### PR TITLE
feat: add CI check for up-to-date generated API files

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -46,6 +46,20 @@ jobs:
           pnpm typecheck &
           pnpm build &
           wait
+      - name: Check generated API spec is up to date
+        run: |
+          # Save current swagger.json with sorted keys for comparison
+          jq --sort-keys . packages/backend/src/generated/swagger.json > /tmp/swagger-before.json
+
+          pnpm generate-api
+
+          # Compare swagger.json with sorted keys (ignores non-deterministic property ordering)
+          jq --sort-keys . packages/backend/src/generated/swagger.json > /tmp/swagger-after.json
+          if ! diff /tmp/swagger-before.json /tmp/swagger-after.json; then
+            echo "::error::Generated API spec is out of date. Run 'pnpm generate-api' and commit the changes."
+            exit 1
+          fi
+          echo "Generated API spec is up to date."
       - name: Run unit tests
         run: pnpm test
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

1. Adds a CI check to ensure generated API files are up to date. The workflow now runs `pnpm generate-api` and fails if there are uncommitted changes in the generated files, prompting developers to run the command locally.

![CleanShot 2026-01-27 at 18.40.13@2x.png](https://app.graphite.com/user-attachments/assets/80ee2421-8892-4add-aa04-a61fba941f05.png)

