### PR TITLE
fix: map hover opacity

### DIFF
--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -843,17 +843,23 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     layer.bindTooltip(tooltipHtml);
                     layer.bindPopup(popupHtml);
 
+                    // Determine the correct base and hover opacity for this region
+                    const baseOpacity = regionEntry
+                        ? fillOpacityWithData
+                        : fillOpacityNoData;
+                    const hoverOpacity = hasBaseMap ? 0.9 : 1;
+
                     layer.on({
                         mouseover: () => {
                             layer.setStyle({
                                 weight: 2,
-                                fillOpacity: hasBaseMap ? 0.9 : 1,
+                                fillOpacity: hoverOpacity,
                             });
                         },
                         mouseout: () => {
                             layer.setStyle({
                                 weight: 1,
-                                fillOpacity: fillOpacityWithData,
+                                fillOpacity: baseOpacity,
                             });
                         },
                         popupopen: (e) => {
@@ -888,6 +894,7 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                 handlePopupCopyClick,
                 hasBaseMap,
                 fillOpacityWithData,
+                fillOpacityNoData,
             ],
         );
 


### PR DESCRIPTION
### Description:

When hovering on area maps, the styles werent being properly reset on mouse out. 

**Before**
![Kapture 2026-01-27 at 19 09 28](https://github.com/user-attachments/assets/fa4b1b88-aec7-4d9f-920f-7a321bacc0c0)

**After**
![Kapture 2026-01-27 at 19 05 12](https://github.com/user-attachments/assets/3323dc72-3864-42e8-823f-4b4777dafbec)
