### PR TITLE
feat: add dbt-athena adapter

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -114,7 +114,8 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-databricks~=1.9.0" \
     "dbt-trino~=1.9.0" \
     "dbt-clickhouse~=1.9.0" \
-    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \ 
+    "dbt-athena~=1.9.0" \
+    && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \
     && python3 -m venv /usr/local/dbt1.10 \
     && /usr/local/dbt1.10/bin/pip install \
     "dbt-core~=1.10.0" \
@@ -125,6 +126,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-databricks~=1.10.0" \
     "dbt-trino~=1.10.0" \
     "dbt-clickhouse~=1.9.0" \
+    "dbt-athena~=1.10.0" \
     && ln -s /usr/local/dbt1.10/bin/dbt /usr/local/bin/dbt1.10 \
     && python3 -m venv /usr/local/dbt1.11 \
     && /usr/local/dbt1.11/bin/pip install \
@@ -136,6 +138,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-databricks~=1.11.0" \
     "dbt-trino~=1.10.0" \
     "dbt-clickhouse~=1.9.0" \
+    "dbt-athena~=1.10.0" \
     && ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11
 
 # -----------------------------

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -117,6 +117,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-databricks~=1.9.0" \
     "dbt-trino~=1.9.0" \
     "dbt-clickhouse~=1.9.0" \
+    "dbt-athena~=1.9.0" \
     && ln -s /usr/local/dbt1.9/bin/dbt /usr/local/bin/dbt1.9 \
     && python3 -m venv /usr/local/dbt1.10 \
     && /usr/local/dbt1.10/bin/pip install \
@@ -128,6 +129,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-databricks~=1.10.0" \
     "dbt-trino~=1.10.0" \
     "dbt-clickhouse~=1.9.0" \
+    "dbt-athena~=1.10.0" \
     && ln -s /usr/local/dbt1.10/bin/dbt /usr/local/bin/dbt1.10 \
     && python3 -m venv /usr/local/dbt1.11 \
     && /usr/local/dbt1.11/bin/pip install \
@@ -139,6 +141,7 @@ RUN --mount=type=cache,target=/root/.cache/pip \
     "dbt-databricks~=1.11.0" \
     "dbt-trino~=1.10.0" \
     "dbt-clickhouse~=1.9.0" \
+    "dbt-athena~=1.10.0" \
     && ln -s /usr/local/dbt1.11/bin/dbt /usr/local/bin/dbt1.11
 
 # -----------------------------

--- a/flake.nix
+++ b/flake.nix
@@ -43,7 +43,7 @@
           dbtVersions = {
             dbt1_4 = {
               dbtCoreVersion = "1.4.9";
-              dbtAliasName = "dbt";
+              dbtAliasName = "dbt1.4";
               adapterVersions = {
                 postgres = "1.4.9";
                 redshift = "1.4.1";
@@ -117,6 +117,35 @@
                 databricks = "1.9.0";
                 trino = "1.9.0";
                 clickhouse = "1.9.0";
+                athena = "1.9.0";
+              };
+            };
+            dbt1_10 = {
+              dbtCoreVersion = "1.10.0";
+              dbtAliasName = "dbt1.10";
+              adapterVersions = {
+                postgres = "1.10.0";
+                redshift = "1.10.0";
+                snowflake = "1.10.0";
+                bigquery = "1.10.0";
+                databricks = "1.10.0";
+                trino = "1.10.0";
+                clickhouse = "1.9.0";
+                athena = "1.10.0";
+              };
+            };
+            dbt1_11 = {
+              dbtCoreVersion = "1.11.0";
+              dbtAliasName = "dbt1.11";
+              adapterVersions = {
+                postgres = "1.10.0";
+                redshift = "1.10.0";
+                snowflake = "1.11.0";
+                bigquery = "1.11.0";
+                databricks = "1.11.0";
+                trino = "1.10.0";
+                clickhouse = "1.9.0";
+                athena = "1.10.0";
               };
             };
           };
@@ -165,6 +194,7 @@
                   "dbt-databricks~=${adapterVersions.databricks}" \
                   "dbt-trino~=${adapterVersions.trino}" \
                   "dbt-clickhouse~=${adapterVersions.clickhouse}" \
+                  ${pkgs.lib.optionalString (adapterVersions ? athena) "\"dbt-athena~=${adapterVersions.athena}\""} \
                   "pytz" \
                   "psycopg2-binary==2.9.10" \
                   --disable-pip-version-check --no-warn-script-location || { echo "Failed to install adapters"; exit 1; }
@@ -253,6 +283,9 @@
 
               # This single variable now expands to all the setup scripts
               ${dbtSetupScripts}
+
+              # Create 'dbt' alias pointing to dbt1.9 (default version)
+              ln -sf "dbt1.9" "${dbtAliasesDir}/dbt"
 
               # Add the alias directory to the PATH to make dbt commands directly available
               export PATH="$PWD/${dbtAliasesDir}:$PATH"


### PR DESCRIPTION
### Description:

Add dbt-athena adapter to Docker images and Nix development environment. This PR:

- Adds dbt-athena v1.9.0 to dbt 1.8 environment
- Adds dbt-athena v1.9.0 to dbt 1.9 environment
- Adds dbt-athena v1.10.0 to dbt 1.10 environment
- Updates flake.nix to include dbt-athena in all environments
- Adds dbt1.10 and dbt.1.11configuration to flake.nix
- Changes dbt1.4 alias name from "dbt" to "dbt1.4"
- Sets dbt1.9 as the default version for the "dbt" command