### PR TITLE
fix: include dashboard space in chart validation queries

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -22,6 +22,7 @@ import {
     isDashboardValidationError,
     isExploreError,
     isSqlTableCalculation,
+    isTableValidationError,
     isTemplateTableCalculation,
     isValidationTargetValid,
     OrganizationMemberRole,
@@ -923,6 +924,16 @@ export class ValidationService extends BaseService {
         // Filter private content to developers
         return Promise.all(
             validations.map(async (validation) => {
+                // Table validations are project-level, not space-specific
+                // Anyone with project access can see them
+                if (
+                    !isDashboardValidationError(validation) &&
+                    !isChartValidationError(validation) &&
+                    isTableValidationError(validation)
+                ) {
+                    return validation;
+                }
+
                 const isDeleted =
                     (isDashboardValidationError(validation) &&
                         !validation.dashboardUuid) ||


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2734/validation-errors-with-private-content-when-chart-is-saved-in


  Problem: Charts saved within dashboards (not directly in a space) were showing as "Private content"  
  in the validation page, even when the user had access to the dashboard's space.                      
                                                                                                       
  Root cause:                                                                                          
  1. In the database, charts saved within dashboards have space_id = NULL in the saved_charts table -  
  they inherit their space from the dashboard                                                          
  2. The ValidationModel.get() query was only joining to the chart's direct space, so space_uuid was   
  NULL for charts in dashboards                                                                        
  3. In hidePrivateContent(), when space_uuid is NULL/undefined, the code can't find the space in      
  allowedSpaceUuids, so it returns "Private content"    

Summary:                                                                                             
  - Table validations: Now show actual names (fixed by ValidationService change)                       
  - Chart validations: Have spaceUuid populated, but showing "Private content" because the session user
   doesn't have access to those specific spaces - this is correct/expected behavior                    
                                                                                                       
  Both changes were needed:                                                                            
  1. ValidationService.ts - Let table validations through (they're project-level, not space-specific)  
  2. ValidationModel.ts - Get spaceUuid for charts saved in dashboards via COALESCE

- Before

<img width="1025" height="479" alt="Screenshot from 2026-01-28 08-50-40" src="https://github.com/user-attachments/assets/37c68086-4970-40b9-b6cd-b655e0ec6f75" />


- After

<img width="1042" height="310" alt="image" src="https://github.com/user-attachments/assets/7c06338e-0542-4b54-94cf-ce6abb7779a9" />

After fix, but without giving access user to the space (only table validation errors will appear)

<img width="1028" height="370" alt="image" src="https://github.com/user-attachments/assets/6cff2e68-8d2b-4122-a2da-8ac6461b5084" />


### Description:
This PR fixes validation errors for charts that are saved in dashboards by properly tracking their space association. Previously, charts saved in dashboards weren't correctly linked to the dashboard's space, causing validation errors to be missing space context.

The changes:
1. Add joins from saved charts through dashboard tiles to dashboards to find the associated space
2. Use COALESCE to prioritize direct space association but fall back to dashboard space when needed
3. Add special handling for table validations which are project-level and should be visible to anyone with project access