### PR TITLE
fix: ignore timezone when formatting date values with expressions

### DIFF
--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -444,6 +444,7 @@ export function formatValueWithExpression(expression: string, value: unknown) {
             return formatWithExpression(
                 expression,
                 moment(sanitizedValue).toDate(),
+                { ignoreTimezone: true },
             );
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2727: Using date format shifts my x-axis labels](https://linear.app/lightdash/issue/PROD-2727/using-date-format-shifts-my-x-axis-labels)

Closes: [PROD-2726: Chart tooltips convert timestamps differently than x-axis](https://linear.app/lightdash/issue/PROD-2726/chart-tooltips-convert-timestamps-differently-than-x-axis)

### Description:

Add `ignoreTimezone: true` option to `formatWithExpression` when formatting date values to ensure consistent date formatting regardless of timezone settings.

This code explains the issue and the fix:

```ts
import { format } from "numfmt";
import dayjs from "dayjs";
import utc from "dayjs/plugin/utc";
dayjs.extend(utc);

const date = new Date("2024-11-01T00:00:00Z");

console.log({
  dateISO: date.toISOString(),
  dateLocal: `${date.toLocaleDateString()} ${date.toLocaleTimeString()}`,
  formattedISO: dayjs.utc(date).format("D MMM YYYY HH:mm:ss"),
  formattedLocal: dayjs(date).format("D MMM YYYY HH:mm:ss"),
  numfmt_current: format("d mmm yyyy HH:mm:ss", date), // current impl
  // https://github.com/borgar/numfmt/issues/6
  numfmt_fixed: format("d mmm yyyy HH:mm:ss", date, { ignoreTimezone: true }),
});

// {
//   dateISO: "2024-11-01T00:00:00.000Z",
//   dateLocal: "10/31/2024 7:00:00 PM",
//   formattedISO: "1 Nov 2024 00:00:00",
//   formattedLocal: "31 Oct 2024 19:00:00",
//   numfmt_current: "31 Oct 2024 19:00:00",
//   numfmt_fixed: "1 Nov 2024 00:00:00",
// }
```
