### PR TITLE
fix: prevent line breaks in SuboptimalState description

### DIFF
--- a/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
+++ b/packages/frontend/src/components/common/SuboptimalState/SuboptimalState.tsx
@@ -64,18 +64,17 @@ const SuboptimalState: FC<Props> = ({
             )}
             {description && (
                 <Box c="dimmed" fz="xs" maw={400} mt={title ? -10 : 0}>
-                    {typeof description === 'string' ? (
-                        <Text
-                            size="xs"
-                            className={
-                                adaptive ? classes.description : undefined
-                            }
-                        >
-                            {description}
-                        </Text>
-                    ) : (
-                        description
-                    )}
+                    <Text
+                        size="xs"
+                        className={adaptive ? classes.description : undefined}
+                        style={
+                            // Prevent line breaks in the description
+                            // Can be custom using: SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE
+                            { whiteSpace: 'pre-wrap' }
+                        }
+                    >
+                        {description}
+                    </Text>
                 </Box>
             )}
             {action && action}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2754/access-error-pop-ups-dynamic-content-does-not-populate

Using
```
 export SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE="
You don't have access to the {snowflakeTable} table. To fix this:
1) Go to Sailpoint (on your Okta dashboard)
2) 'Request Center' > 'Request for myself'
3) Search for 'Snowflake' > 'Select'
4) Search for 'ANALYTICS_DB_{snowflakeSchema}' > Request"
```
- Before

<img width="746" height="777" alt="Screenshot from 2026-01-28 15-23-26" src="https://github.com/user-attachments/assets/07a184a1-dac1-4c89-a612-f63d1b12fd6e" />

- After

<img width="746" height="777" alt="Screenshot from 2026-01-28 15-23-41" src="https://github.com/user-attachments/assets/43e42975-1b67-4eaa-94e9-949b34df0225" />

### Description:
Updated the `SuboptimalState` component to handle descriptions consistently by wrapping all descriptions in a `Text` component with `whiteSpace: 'pre-wrap'` style. This ensures proper text formatting and prevents unwanted line breaks, particularly for error messages like `SNOWFLAKE_UNAUTHORIZED_ERROR_MESSAGE`.