### PR TITLE
feat: add OpenAI zero data retention option

### DIFF
--- a/packages/backend/src/config/aiConfigSchema.ts
+++ b/packages/backend/src/config/aiConfigSchema.ts
@@ -28,6 +28,7 @@ export const aiCopilotConfigSchema = z
                         .default(DEFAULT_OPENAI_EMBEDDING_MODEL),
                     baseUrl: z.string().optional(),
                     availableModels: z.array(z.string()).optional(),
+                    zeroDataRetention: z.boolean().default(false),
                 })
                 .optional(),
             azure: z

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -219,6 +219,7 @@ export const lightdashConfigMock: LightdashConfig = {
                     apiKey: 'mock_api_key',
                     modelName: 'gpt-4.1-2025-04-14',
                     embeddingModelName: 'text-embedding-3-small',
+                    zeroDataRetention: false,
                 },
             },
             verifiedAnswerSimilarityThreshold: 0.6,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -711,6 +711,8 @@ export const getAiConfig = () => ({
                   availableModels: getArrayFromCommaSeparatedList(
                       'OPENAI_AVAILABLE_MODELS',
                   ),
+                  zeroDataRetention:
+                      process.env.OPENAI_ZERO_DATA_RETENTION === 'true',
               }
             : undefined,
         anthropic:

--- a/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/tests/agent.integration.test.ts
@@ -46,6 +46,7 @@ describeOrSkip.concurrent('agent integration tests', () => {
             apiKey: process.env.OPENAI_API_KEY!,
             modelName: 'gpt-4.1',
             embeddingModelName: 'text-embedding-3-small',
+            zeroDataRetention: false,
         },
         getModelPreset('openai', 'gpt-4.1')!,
     );

--- a/packages/backend/src/ee/services/ai/models/openai-gpt.ts
+++ b/packages/backend/src/ee/services/ai/models/openai-gpt.ts
@@ -40,6 +40,12 @@ export const getOpenaiGptmodel = (
                     reasoningSummary: 'auto',
                     reasoningEffort,
                 }),
+                // ZDR: use encrypted reasoning items instead of server-stored IDs
+                ...(config.zeroDataRetention &&
+                    reasoningEnabled && {
+                        store: false,
+                        include: ['reasoning.encrypted_content'],
+                    }),
             },
         },
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2775: OpenAI Zero Data Retention (ZDR) Incompatibility with Reasoning Models](https://linear.app/lightdash/issue/PROD-2775/openai-zero-data-retention-zdr-incompatibility-with-reasoning-models)

### Description:
Added support for OpenAI Zero Data Retention (ZDR) mode through a new configuration option. This allows users to enable encrypted reasoning content instead of server-stored IDs when using OpenAI models, enhancing privacy options.

The implementation includes:
- New `zeroDataRetention` boolean flag in the OpenAI config schema (defaults to false)
- Environment variable support via `OPENAI_ZERO_DATA_RETENTION`
- Configuration for encrypted reasoning content when ZDR is enabled