### PR TITLE
fix: conditional formatting range input re-rendering on every change

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingList.tsx
@@ -9,7 +9,8 @@ import {
 } from '@lightdash/common';
 import { Accordion } from '@mantine/core';
 import { produce } from 'immer';
-import { useCallback, useMemo } from 'react';
+import { useCallback, useEffect, useMemo, useRef } from 'react';
+import { v4 as uuidv4 } from 'uuid';
 import { isTableVisualizationConfig } from '../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
 import { AddButton } from '../common/AddButton';
@@ -63,6 +64,15 @@ const ConditionalFormattingList = ({}) => {
         });
     }, [chartConfig, fieldsForConditionalFormatting]);
 
+    const configIdsRef = useRef<string[]>([]);
+    // Ensure we have best effort stable IDs for each config (generates new IDs for new configs)
+    // This prevents focus loss when editing and ensures correct item deletion.
+    useEffect(() => {
+        while (configIdsRef.current.length < activeConfigs.length) {
+            configIdsRef.current.push(uuidv4());
+        }
+    }, [activeConfigs.length]);
+
     const handleAdd = useCallback(() => {
         if (!chartConfig) return;
 
@@ -83,6 +93,8 @@ const ConditionalFormattingList = ({}) => {
     const handleRemove = useCallback(
         (index: number) => {
             if (!chartConfig) return;
+
+            configIdsRef.current.splice(index, 1);
 
             const { onSetConditionalFormattings } = chartConfig;
 
@@ -136,7 +148,7 @@ const ConditionalFormattingList = ({}) => {
                 >
                     {activeConfigs.map((conditionalFormatting, index) => (
                         <ConditionalFormattingItem
-                            key={JSON.stringify(conditionalFormatting)}
+                            key={configIdsRef.current[index] ?? index}
                             isOpen={openItems.includes(`${index}`)}
                             addNewItem={addNewItem}
                             removeItem={removeItem}


### PR DESCRIPTION
### Description:
Fixed re-renders when editing conditional formatting by using a best effort stable key instead of a stringified object.
The previous approach caused unnecessary re-renders because the key would change whenever the conditional formatting object was modified - this would cause the input to go out of focus whenever the state updated which meant the user input could be cut.

Relates to: https://github.com/lightdash/lightdash/pull/17421

**Before**

https://github.com/user-attachments/assets/8a41e895-e09a-4ee8-89bb-991f32cc9f63


**After**

https://github.com/user-attachments/assets/b34fa8cb-baa3-4af1-a6e4-0619743934ca

