### PR TITLE
fix: pivot sorting with mix column types

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1254,9 +1254,9 @@ SELECT * FROM group_by_query LIMIT 50`);
             expect(result).toContain(
                 'SELECT "category", "date" FROM original_query group by "category", "date"',
             );
-            // Should calculate total_columns correctly (no multiplier when 1 value column)
+            // Should calculate total_columns correctly using subquery approach
             expect(result).toContain(
-                'COUNT(DISTINCT "category") AS total_columns',
+                'SELECT COUNT(*) * 1 AS total_columns FROM (SELECT DISTINCT "category" FROM filtered_rows) AS distinct_groups',
             );
         });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19767, PROD-2762

### Description:

Fixes an issue in pivot table sorting where not all warehouses can handle concatenating mixed types. We were using CONCAT to count the unique columns (after pivot) but it wasn't working right in redshift. 

**Before, we were using concat**
```
 COUNT(DISTINCT CONCAT('col1', "col1", '-', 'col2', "col2"))
```

**NOW - with this PR** we use a subquery
```
  total_columns AS (
    SELECT
        COUNT(*) * 1 AS total_columns
    FROM (
        SELECT DISTINCT
            "orders_order_date_month"
        FROM filtered_rows
    ) AS distinct_groups
)  
```

To test:
- Make a pivoted table
- Sort by a metric
- The fist values column shout be sorted

This is a bit of a blind fix -- we dont have a redshift repro. But we were thinking about doing this anyway. 
