### PR TITLE
fix: allow `upsertDashboardAsCode` with orphan charts

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -400,22 +400,19 @@ export class CoderService extends BaseService {
             if (isAnyChartTile(tile)) {
                 const { chartSlug } = tile.properties;
                 const chartInfo = chartSlugToInfo.get(chartSlug);
-
-                if (!chartInfo) {
-                    throw new NotFoundError(
-                        `Chart with slug ${chartSlug} not found`,
-                    );
-                }
+                const isSqlChart =
+                    chartInfo?.isSql ??
+                    tile.type === DashboardTileTypes.SQL_CHART;
 
                 // Use the correct property name based on chart type
-                if (chartInfo.isSql) {
+                if (isSqlChart) {
                     return {
                         ...tile,
                         uuid: uuidv4(),
                         type: DashboardTileTypes.SQL_CHART,
                         properties: {
                             ...tile.properties,
-                            savedSqlUuid: chartInfo.uuid,
+                            savedSqlUuid: chartInfo?.uuid ?? null,
                         },
                     } as DashboardTileWithSlug;
                 }
@@ -426,7 +423,7 @@ export class CoderService extends BaseService {
                     type: DashboardTileTypes.SAVED_CHART,
                     properties: {
                         ...tile.properties,
-                        savedChartUuid: chartInfo.uuid,
+                        savedChartUuid: chartInfo?.uuid ?? null,
                     },
                 } as DashboardTileWithSlug;
             }


### PR DESCRIPTION
### Description:
While exploring our CLI with the local development environment, I noticed that doing a simple download followed by an upload (without any changes) ends up in an error:

> [!CAUTION] 
> Error upserting dashboards:
	"Scheduled delivery edge cases blub" (slug: "scheduled-delivery-edge-cases")
	Chart with slug null not found

Imo throwing an error in this case doesn't make too much sense, especially given the fact that the frontend also allows updating in this scenario. So in a way this just makes the CLI behave exactly like the frontend.

I made sure to test with both normal charts and sql charts. With the fix, I'm able to make changes (e.g. the title) to the dashboard, without any issues, despite the orphan tiles:
<img width="1651" height="1293" alt="image" src="https://github.com/user-attachments/assets/1693209c-4aab-4e0d-8f51-cb7aaff3c2d5" />
