### PR TITLE
fix: validate spotlight owner type in project config

### DIFF
--- a/packages/common/src/compiler/lightdashProjectConfig.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.ts
@@ -11,6 +11,16 @@ type SpotlightConfigArgs = {
     owner?: string;
 };
 
+const validateOwner = (owner: unknown): string | null => {
+    if (typeof owner === 'string') return owner;
+    if (owner === undefined)
+        // eslint-disable-next-line no-console
+        console.warn(
+            `Invalid spotlight owner: expected string, got ${typeof owner}`,
+        );
+    return null;
+};
+
 /**
  * Get the spotlight configuration for a resource
  */
@@ -27,13 +37,15 @@ export const getSpotlightConfigurationForResource = ({
         return {};
     }
 
+    const validatedOwner = validateOwner(owner);
+
     return {
         spotlight: {
             visibility,
             categories,
             ...(filterBy ? { filterBy } : {}),
             ...(segmentBy ? { segmentBy } : {}),
-            ...(owner ? { owner } : {}),
+            ...(validatedOwner ? { owner: validatedOwner } : {}),
         },
     };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-226: TypeError: ownerEmail.toLowerCase is not a function](https://linear.app/lightdash/issue/ZAP-226/typeerror-owneremailtolowercase-is-not-a-function)

### Description:

Added validation for the spotlight owner field to ensure it's a string. If the owner is undefined, a warning is logged to the console. This prevents invalid owner types from being included in the spotlight configuration.
