### PR TITLE
fix: remove file-level ACLs in s3 uploads

### DIFF
--- a/packages/backend/src/clients/Aws/S3Client.ts
+++ b/packages/backend/src/clients/Aws/S3Client.ts
@@ -53,7 +53,6 @@ export class S3Client extends S3BaseClient {
                 Key: fileId,
                 Body: file,
                 ContentType: fileOpts.contentType,
-                ACL: 'private',
                 ContentDisposition: createContentDispositionHeader(
                     fileOpts.attachmentDownloadName || fileId,
                 ),
@@ -193,7 +192,6 @@ export class S3Client extends S3BaseClient {
                 Key: fileId,
                 Body: buffer,
                 ContentType: `application/jsonl`,
-                ACL: 'private',
                 ContentDisposition: createContentDispositionHeader(fileId),
             },
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19792, PROD-2796

### Description:

The problem:
- Self-hosted customers are seeing an error when exporting dashboards "The bucket does not allow ACLs". It looks like this is because we still have a couple legacy uploads that set ACL: 'private', but GCP (and AWS) security policies now suggest setting uniformBucketLevelAccess, which disables ACLs.

**Solution**
- remove the ACL: 'private' settings from our s3 uploads. Our newer uploads dont include it anyway, and it's frowned upon by GCP and AWS.

**Also**
- We are reviewing security settings on Lightdash buckets to make sure they are in line with current GCP recommendations
