### PR TITLE
feat: add `inherit_parent_permissions` column to spaces

### DIFF
--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -13,6 +13,7 @@ export type DbSpace = {
     slug: string;
     parent_space_uuid: string | null;
     path: string;
+    inherit_parent_permissions: boolean;
 };
 
 export type CreateDbSpace = Pick<
@@ -24,6 +25,7 @@ export type CreateDbSpace = Pick<
     | 'slug'
     | 'parent_space_uuid'
     | 'path'
+    | 'inherit_parent_permissions'
 >;
 
 export type UpdateDbSpace = Partial<Pick<DbSpace, 'name' | 'is_private'>>;

--- a/packages/backend/src/database/migrations/20260129134608_add_inherit_parent_permissions_to_spaces.ts
+++ b/packages/backend/src/database/migrations/20260129134608_add_inherit_parent_permissions_to_spaces.ts
@@ -1,0 +1,29 @@
+import { Knex } from 'knex';
+
+const SpacesTableName = 'spaces';
+// NOTE: this new column will ultimately replace `is_private`.
+// During the transition phase we'll need both.
+const columnName = 'inherit_parent_permissions';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.boolean(columnName).notNullable().defaultTo(true);
+    });
+
+    // Set initial values:
+    // - Root spaces (parent_space_uuid IS NULL): inherit = !is_private
+    //   (private spaces have their own permissions, public spaces inherit from project)
+    // - Child spaces (parent_space_uuid IS NOT NULL): inherit = true
+    //   (child spaces always inherit right now)
+    await knex.raw(`
+        UPDATE ${SpacesTableName}
+        SET ${columnName} = NOT is_private
+        WHERE parent_space_uuid IS NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.dropColumn(columnName);
+    });
+}

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -246,6 +246,7 @@ export async function seed(knex: Knex): Promise<void> {
             slug: spaceSlug,
             parent_space_uuid: null,
             path: getLtreePathFromSlug(spaceSlug),
+            inherit_parent_permissions: true,
         })
         .returning(['space_id', 'space_uuid']);
 

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -135,6 +135,7 @@ export const spaceEntry: SpaceTable['base'] = {
     search_vector: '',
     parent_space_uuid: null,
     path: 'space-name',
+    inherit_parent_permissions: true,
 };
 export const savedChartEntry: SavedChartTable['base'] = {
     saved_query_id: 0,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -514,6 +514,7 @@ export class ProjectModel {
                     slug,
                     parent_space_uuid: null,
                     path,
+                    inherit_parent_permissions: true,
                 });
             }
 

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -56,6 +56,7 @@ export const space: SpaceTable['base'] = {
     search_vector: '',
     parent_space_uuid: null,
     path: 'space-name',
+    inherit_parent_permissions: false,
 };
 
 export const publicSpace: Space = {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-152/add-inheritance-flag-to-spaces-schema

### Description:
This is the first building block to implement the new permission model for nested spaces.
The idea is to phase out `is_private` and ultimately replace it with the new column `inherit_parent_permissions`, to allow every space to toggle inheritance on or off.

With this PR we continue to only support inheritance for nested spaces (for now).

### Scenarios tested

- Migration of current data
  - ALL child spaces have `inherit_parent_permissions` = `true` as this is the only scenario support at the time
  - Root spaces have `inherit_parent_permissions` = `!is_private` as private root spaces do not inherit, while public root spaces inherit (from project).
- Creating a new space follows the same logic as the migration of existing data
- Updating a root space permission also updates the `inherit_parent_permissions`
- Moving a root space to become a child space sets `inherit_parent_permissions` to `true`.
