### PR TITLE
fix: map zoom-button contrast in dark mode

### DIFF
--- a/packages/frontend/src/components/SimpleMap/SimpleMap.module.css
+++ b/packages/frontend/src/components/SimpleMap/SimpleMap.module.css
@@ -98,7 +98,7 @@
 
     @mixin dark {
         background-color: alpha(var(--mantine-color-dark-6), 0.8) !important;
-        color: var(--mantine-color-ldGray-4) !important;
+        color: var(--mantine-color-ldGray-8) !important;
     }
 }
 
@@ -110,7 +110,7 @@
 
     @mixin dark {
         background-color: alpha(var(--mantine-color-dark-5), 0.95) !important;
-        color: var(--mantine-color-ldGray-2) !important;
+        color: var(--mantine-color-white) !important;
     }
 }
 


### PR DESCRIPTION
### Description:

Small style fix for map buttons in dark mode.

**Before (boring-bad-sad)**
<img width="586" height="515" alt="Screenshot 2026-01-29 at 15 50 44" src="https://github.com/user-attachments/assets/a64fd3f6-88a6-41bf-b0db-9c6c819af708" />


**After (this patch)**
<img width="678" height="515" alt="Screenshot 2026-01-29 at 15 40 15" src="https://github.com/user-attachments/assets/96b86fee-cf1a-41cf-9a4f-f6265b0e4f3a" />

