### PR TITLE
feat: display current project info in CLI commands

### DIFF
--- a/packages/cli/src/globalState.ts
+++ b/packages/cli/src/globalState.ts
@@ -1,4 +1,5 @@
 import ora from 'ora';
+import { Config } from './config';
 import * as styles from './styles';
 
 type PromptAnswer = {
@@ -62,6 +63,12 @@ class GlobalState {
         if (this.verbose) {
             this.log(styles.debug(message));
         }
+    }
+
+    logProjectInfo(config: Config) {
+        const projectUuid = config.context?.project;
+
+        this.log(`\n${styles.success('Using project:')} ${projectUuid}\n`);
     }
 }
 

--- a/packages/cli/src/handlers/dbt/refresh.ts
+++ b/packages/cli/src/handlers/dbt/refresh.ts
@@ -101,6 +101,9 @@ export const refreshHandler = async (options: RefreshHandlerOptions) => {
     }
     const projectUuid = config.context.project;
 
+    // Log current project info
+    GlobalState.logProjectInfo(config);
+
     const project = await getProject(projectUuid);
 
     if (project.dbtConnection.type === DbtProjectType.NONE) {

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -279,6 +279,11 @@ export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
     const config = await getConfig();
     let projectUuid: string;
 
+    // Log current project info if not creating a new one
+    if (options.create === undefined) {
+        GlobalState.logProjectInfo(config);
+    }
+
     if (options.create !== undefined) {
         const project = await createNewProject(executionId, options);
         if (!project) {

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -480,6 +480,15 @@ export const downloadHandler = async (
         );
     }
 
+    // Log current project info
+    if (options.project) {
+        console.error(
+            `\n${styles.success('Downloading from project:')} ${projectId}\n`,
+        );
+    } else {
+        GlobalState.logProjectInfo(config);
+    }
+
     // Fetch project details to get project name for folder structure
     const project = await lightdashApi<Project>({
         method: 'GET',
@@ -857,6 +866,15 @@ export const uploadHandler = async (
         throw new Error(
             'No project selected. Run lightdash config set-project',
         );
+    }
+
+    // Log current project info
+    if (options.project) {
+        console.error(
+            `\n${styles.success('Uploading to project:')} ${projectId}\n`,
+        );
+    } else {
+        GlobalState.logProjectInfo(config);
     }
 
     let changes: Record<string, number> = {};

--- a/packages/cli/src/handlers/generateExposures.ts
+++ b/packages/cli/src/handlers/generateExposures.ts
@@ -48,6 +48,9 @@ export const generateExposuresHandler = async (
         ),
     );
 
+    // Log current project info
+    GlobalState.logProjectInfo(config);
+
     const spinner = GlobalState.startSpinner(
         `  Generating Lightdash exposures .yml for project ${styles.bold(
             config.context.projectName || config.context.project,

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -370,9 +370,22 @@ export const startPreviewHandler = async (
     }
 
     const projectName = options.name;
+    const config = await getConfig();
+
+    // Log current source project info if copying content
+    if (!options.skipCopyContent && config.context?.project) {
+        console.error(
+            `\n${styles.success('Source project for content:')} ${styles.bold(
+                config.context.projectName || config.context.project,
+            )}\n`,
+        );
+    }
 
     const previewProject = await getPreviewProject(projectName);
     if (previewProject) {
+        console.error(
+            `\n${styles.success('Updating preview project:')} ${styles.bold(projectName)}\n`,
+        );
         await setPreviewProject(previewProject.projectUuid, projectName);
         await LightdashAnalytics.track({
             event: 'start_preview.update',
@@ -384,7 +397,6 @@ export const startPreviewHandler = async (
         });
 
         // Update
-        console.error(`Updating project preview ${projectName}`);
         const explores = await compile(options);
         await deploy(explores, {
             ...options,
@@ -397,7 +409,9 @@ export const startPreviewHandler = async (
             core.setOutput('project_uuid', previewProject.projectUuid);
         }
     } else {
-        const config = await getConfig();
+        console.error(
+            `\n${styles.success('Creating preview project:')} ${styles.bold(projectName)}\n`,
+        );
 
         if (!config.context?.project) {
             console.error(
@@ -422,7 +436,6 @@ export const startPreviewHandler = async (
         }
 
         // Create
-        console.error(`Creating new project preview ${projectName}`);
         const results = await createProject({
             ...options,
             name: projectName,

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -91,6 +91,15 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
         );
     }
 
+    // Log current project info
+    if (options.project) {
+        console.error(
+            `\n${styles.success('Renaming in project:')} ${projectUuid}\n`,
+        );
+    } else {
+        GlobalState.logProjectInfo(config);
+    }
+
     const isValidInput = (input: string): boolean => /^[a-z_]+$/.test(input);
 
     if (!isValidInput(options.from) || !isValidInput(options.to)) {

--- a/packages/cli/src/handlers/validate.ts
+++ b/packages/cli/src/handlers/validate.ts
@@ -89,6 +89,9 @@ export const validateHandler = async (options: ValidateHandlerOptions) => {
 
     const config = await getConfig();
 
+    // Log current project info
+    GlobalState.logProjectInfo(config);
+
     const explores = await compile(options);
     GlobalState.debug(`> Compiled ${explores.length} explores`);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-2777

### Description:

Added project information logging to CLI commands to improve user experience. Now users can clearly see which project they are working with when running commands like deploy, download, upload, validate, refresh, generate-exposures, and preview. This helps prevent accidental operations on the wrong project.

The implementation adds a new `logProjectInfo` method to the GlobalState class that displays the current project UUID in a consistent format across all commands.