### PR TITLE
feat: add bulk edit modal for filter values

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -85,6 +85,11 @@ export enum FeatureFlags {
      * inherit permissions from their root space.
      */
     NestedSpacesPermissions = 'nested-spaces-permissions',
+
+    /**
+     * Enable bulk edit modal for filter string autocomplete
+     */
+    FilterBulkEdit = 'filter-bulk-edit',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/BulkEditValuesModal.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BulkEditValuesModal.tsx
@@ -1,0 +1,115 @@
+import { SegmentedControl, Stack, Text, Textarea } from '@mantine-8/core';
+import { IconList } from '@tabler/icons-react';
+import uniq from 'lodash/uniq';
+import { useCallback, useEffect, useState, type FC } from 'react';
+import MantineModal from '../../MantineModal';
+
+type Separator = 'newline' | 'comma';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    values: string[];
+    onApply: (values: string[]) => void;
+    isNumberField?: boolean;
+};
+
+const serializeValues = (vals: string[], sep: Separator): string => {
+    const sepChar = sep === 'newline' ? '\n' : ', ';
+    return vals.join(sepChar);
+};
+
+const parseValues = (
+    text: string,
+    sep: Separator,
+    isNumberField?: boolean,
+): string[] => {
+    const regex = sep === 'newline' ? /\n/ : /\s*,\s*/;
+    const values = text
+        .split(regex)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+    if (isNumberField) {
+        return values.filter((v) => !isNaN(parseFloat(v)));
+    }
+    return values;
+};
+
+const BulkEditValuesModal: FC<Props> = ({
+    opened,
+    onClose,
+    values,
+    onApply,
+    isNumberField,
+}) => {
+    const [separator, setSeparator] = useState<Separator>('newline');
+    const [text, setText] = useState('');
+
+    // Sync text when modal opens or values change while open
+    useEffect(() => {
+        if (opened) {
+            setText(serializeValues(values, separator));
+        }
+    }, [opened, values, separator]);
+
+    const handleSeparatorChange = useCallback(
+        (newSep: string) => {
+            const parsed = parseValues(text, separator, isNumberField);
+            setSeparator(newSep as Separator);
+            setText(serializeValues(parsed, newSep as Separator));
+        },
+        [text, separator, isNumberField],
+    );
+
+    const handleApply = useCallback(() => {
+        const parsed = parseValues(text, separator, isNumberField);
+        onApply(uniq(parsed));
+        onClose();
+    }, [text, separator, isNumberField, onApply, onClose]);
+
+    const valueCount = uniq(parseValues(text, separator, isNumberField)).length;
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Edit filter values"
+            icon={IconList}
+            size="xl"
+            onConfirm={handleApply}
+            confirmLabel="Apply"
+        >
+            <Stack gap="md">
+                <SegmentedControl
+                    size="xs"
+                    radius="md"
+                    data={[
+                        { value: 'newline', label: 'One per line' },
+                        { value: 'comma', label: 'Comma-separated' },
+                    ]}
+                    value={separator}
+                    onChange={handleSeparatorChange}
+                />
+                <Textarea
+                    autoFocus
+                    minRows={10}
+                    maxRows={20}
+                    autosize
+                    value={text}
+                    onChange={(e) => setText(e.currentTarget.value)}
+                    placeholder={
+                        separator === 'newline'
+                            ? 'Enter one value per line'
+                            : 'Enter values separated by commas'
+                    }
+                />
+                <Text size="xs" c="dimmed">
+                    {valueCount} {valueCount === 1 ? 'value' : 'values'}
+                </Text>
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export default BulkEditValuesModal;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2418: I want an option to upload a CSV of values for filters](https://linear.app/lightdash/issue/PROD-2418/i-want-an-option-to-upload-a-csv-of-values-for-filters)

### Description:
Added a bulk edit modal for filter values, allowing users to edit multiple filter values at once. The modal supports both newline and comma-separated input formats, and includes validation for number fields.

The feature is behind the new `FilterBulkEdit` feature flag and appears as a "Bulk edit values" option in the filter menu for compatible filter operators (equals, not equals, include, not include, starts with, ends with).
