### PR TITLE
feat: move "Add period comparison" to top of menu dropdown

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -110,6 +110,47 @@ const ContextMenu: FC<ContextMenuProps> = ({
         const itemFieldId = getItemId(item);
         return (
             <>
+                {isMetric(item) && !isPopAdditionalMetric ? (
+                    <>
+                        <Tooltip
+                            disabled={!hasExistingPopForMetric}
+                            label="This metric already has a period comparison"
+                        >
+                            <Menu.Item
+                                icon={<MantineIcon icon={IconTimelineEvent} />}
+                                rightSection={
+                                    <Box ml="sm">
+                                        <BetaBadge tooltipLabel="" />
+                                    </Box>
+                                }
+                                sx={
+                                    hasExistingPopForMetric
+                                        ? {
+                                              opacity: 0.5,
+                                              cursor: 'not-allowed',
+                                          }
+                                        : undefined
+                                }
+                                onClick={() => {
+                                    if (hasExistingPopForMetric) return;
+                                    dispatch(
+                                        explorerActions.togglePeriodOverPeriodComparisonModal(
+                                            {
+                                                metric: item,
+                                                itemsMap: itemsMap,
+                                            },
+                                        ),
+                                    );
+                                }}
+                            >
+                                Add period comparison
+                            </Menu.Item>
+                        </Tooltip>
+
+                        <Menu.Divider />
+                    </>
+                ) : null}
+
                 {isFilterableField(item) && !isPopAdditionalMetric && (
                     <>
                         <Menu.Item
@@ -175,47 +216,6 @@ const ContextMenu: FC<ContextMenuProps> = ({
                     >
                         Edit custom metric
                     </Menu.Item>
-                ) : null}
-
-                {isMetric(item) && !isPopAdditionalMetric ? (
-                    <>
-                        <Tooltip
-                            disabled={!hasExistingPopForMetric}
-                            label="This metric already has a period comparison"
-                        >
-                            <Menu.Item
-                                icon={<MantineIcon icon={IconTimelineEvent} />}
-                                rightSection={
-                                    <Box ml="sm">
-                                        <BetaBadge tooltipLabel="" />
-                                    </Box>
-                                }
-                                sx={
-                                    hasExistingPopForMetric
-                                        ? {
-                                              opacity: 0.5,
-                                              cursor: 'not-allowed',
-                                          }
-                                        : undefined
-                                }
-                                onClick={() => {
-                                    if (hasExistingPopForMetric) return;
-                                    dispatch(
-                                        explorerActions.togglePeriodOverPeriodComparisonModal(
-                                            {
-                                                metric: item,
-                                                itemsMap: itemsMap,
-                                            },
-                                        ),
-                                    );
-                                }}
-                            >
-                                Add period comparison
-                            </Menu.Item>
-                        </Tooltip>
-
-                        <Menu.Divider />
-                    </>
                 ) : null}
 
                 <Menu.Item


### PR DESCRIPTION
The period comparison option was easy to miss near the bottom of the dropdown. Moving it to the top improves discoverability.

Slack thread: https://lightdash.slack.com/archives/C09UGKWHGR5/p1769700725790329?thread_ts=1769700451.304869&cid=C09UGKWHGR5

https://claude.ai/code/session_01QXp1WetAmySE696VorvyYv

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

<img width="670" height="678" alt="image" src="https://github.com/user-attachments/assets/40cf7f78-0a38-4d04-831b-b2539f810eb4" />
