### PR TITLE
fix: normalize quarter filter values to start of quarter

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
@@ -11,7 +11,7 @@ import { MonthPicker, type MonthPickerProps } from '@mantine/dates';
 import { useDisclosure } from '@mantine/hooks';
 import dayjs from 'dayjs';
 import quarterOfYear from 'dayjs/plugin/quarterOfYear';
-import { type FC, useCallback, useState } from 'react';
+import { type FC, useCallback, useEffect, useState } from 'react';
 
 dayjs.extend(quarterOfYear);
 
@@ -58,19 +58,32 @@ const FilterQuarterPicker: FC<Props> = ({
         return quarter ? quarter.months : [0, 1, 2];
     };
 
-    const handleMonthSelect = (date: Date | null) => {
-        if (!date) return;
+    const getStartOfQuarter = useCallback(
+        (date: Date): Date => dayjs(date).startOf('quarter').toDate(),
+        [],
+    );
 
-        // Use dayjs for date handling
-        const dateObj = dayjs(date);
-        const year = dateObj.year();
-        setSelectedYear(year);
+    const handleMonthSelect = useCallback(
+        (date: Date | null) => {
+            if (!date) return;
 
-        const quarterDate = dateObj.startOf('quarter');
+            const startOfQuarter = getStartOfQuarter(date);
+            setSelectedYear(dayjs(startOfQuarter).year());
+            onChange?.(startOfQuarter);
+            close();
+        },
+        [close, onChange, getStartOfQuarter],
+    );
 
-        onChange?.(quarterDate.toDate());
-        close();
-    };
+    // Normalize value to start of quarter if needed
+    useEffect(() => {
+        if (!value) return;
+
+        const startOfQuarter = getStartOfQuarter(value);
+        if (value.getTime() !== startOfQuarter.getTime()) {
+            onChange?.(startOfQuarter);
+        }
+    }, [value, getStartOfQuarter, onChange]);
 
     const getMonthControlProps = useCallback(
         (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2806: Quarter filter shows wrong results after switching dimensions](https://linear.app/lightdash/issue/PROD-2806/quarter-filter-shows-wrong-results-after-switching-dimensions)

Reproduction/testing steps described in the above ticket

## Summary

Enhances the `FilterQuarterPicker` component to properly normalize date values to the start of a quarter. This ensures consistent behavior when selecting dates and prevents issues with incorrect quarter boundaries.
