### PR TITLE
Fix Period-over-Period metric naming and configuration locking

### DIFF
--- a/packages/common/src/types/periodOverPeriodComparison.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.ts
@@ -56,8 +56,11 @@ export const isSupportedPeriodOverPeriodGranularity = (
     granularity: TimeFrames,
 ) => validPeriodOverPeriodGranularities.includes(granularity);
 
-export const buildPopAdditionalMetricName = (baseMetricName: string) =>
-    `${baseMetricName}__pop`;
+export const buildPopAdditionalMetricName = (
+    baseMetricName: string,
+    granularity: TimeFrames,
+    periodOffset: number,
+) => `${baseMetricName}__pop_${granularity}_${periodOffset}`;
 
 export const getPopPeriodLabel = (
     granularity: TimeFrames,
@@ -92,7 +95,11 @@ export const buildPopAdditionalMetric = ({
     periodOffset: number;
 }): { additionalMetric: AdditionalMetric; metricId: string } => {
     const baseMetricId = getItemId(metric);
-    const popName = buildPopAdditionalMetricName(metric.name);
+    const popName = buildPopAdditionalMetricName(
+        metric.name,
+        granularity,
+        periodOffset,
+    );
     const popMetricId = getItemId({ table: metric.table, name: popName });
 
     const additionalMetric: AdditionalMetric = {

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -1,5 +1,4 @@
 import {
-    buildPopAdditionalMetricName,
     DimensionType,
     getItemId,
     getItemLabelWithoutTableName,
@@ -101,9 +100,12 @@ const ContextMenu: FC<ContextMenuProps> = ({
     // Check if a PoP metric already exists for this base metric
     const hasExistingPopForMetric = useMemo(() => {
         if (!item || !isMetric(item)) return false;
-        const expectedPopName = buildPopAdditionalMetricName(item.name);
-        const expectedPopId = `${item.table}_${expectedPopName}`;
-        return additionalMetrics?.some((am) => getItemId(am) === expectedPopId);
+        const itemId = getItemId(item);
+        return additionalMetrics?.some(
+            (am) =>
+                isPeriodOverPeriodAdditionalMetric(am) &&
+                am.baseMetricId === itemId,
+        );
     }, [item, additionalMetrics]);
 
     if (item && isField(item)) {


### PR DESCRIPTION
### Description:

This PR fixes several issues with Period-over-Period (PoP) comparison functionality:

**Changes:**

1. **Enhanced PoP metric naming** - Updated `buildPopAdditionalMetricName()` to include granularity and periodOffset in the metric name, making it unique per configuration. This prevents metric ID collisions when using different PoP settings.

2. **Configuration locking** - Added logic to detect existing PoP configurations and lock the modal to those settings. Since the backend requires all PoP metrics in a query to use matching configurations, users must now remove existing PoP comparisons before changing settings.

3. **UI improvements**:
   - Added an informational alert explaining the configuration sharing requirement
   - Disabled time dimension and period offset inputs when an existing PoP config is detected
   - Made the time dimension field non-clearable when locked to existing config

4. **Improved PoP metric detection** - Updated `ColumnHeaderContextMenu.tsx` to use `isPeriodOverPeriodAdditionalMetric()` and check `baseMetricId` instead of relying on metric name patterns, making the detection more robust.

**Why:**
- Prevents metric ID collisions and query errors when using different PoP configurations
- Provides clear UX guidance about the backend constraint
- Makes the code more maintainable by using type-safe helper functions

https://claude.ai/code/session_01U8Kv7bNn1PMKSGGpmM1j7u