### PR TITLE
chore: add `NESTED_SPACES_PERMISSIONS_ENABLED` feature flag

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -307,4 +307,7 @@ export const lightdashConfigMock: LightdashConfig = {
     maps: {
         enabled: false,
     },
+    nestedSpacesPermissions: {
+        enabled: false,
+    },
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1011,6 +1011,9 @@ export type LightdashConfig = {
     maps: {
         enabled: boolean | undefined;
     };
+    nestedSpacesPermissions: {
+        enabled: boolean;
+    };
 };
 
 export type SlackConfig = {
@@ -1820,6 +1823,9 @@ export const parseConfig = (): LightdashConfig => {
                 process.env.LIGHTDASH_MAPS_ENABLED === 'true'
                     ? true
                     : undefined,
+        },
+        nestedSpacesPermissions: {
+            enabled: process.env.NESTED_SPACES_PERMISSIONS_ENABLED === 'true',
         },
     };
 };

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -44,6 +44,8 @@ export class FeatureFlagModel {
             [FeatureFlags.Maps]: this.getMapsEnabled.bind(this),
             [FeatureFlags.ShowExecutionTime]:
                 this.getShowExecutionTimeEnabled.bind(this),
+            [FeatureFlags.NestedSpacesPermissions]:
+                this.getNestedSpacesPermissionsEnabled.bind(this),
         };
     }
 
@@ -239,6 +241,15 @@ export class FeatureFlagModel {
         return {
             id: featureFlagId,
             enabled,
+        };
+    }
+
+    private async getNestedSpacesPermissionsEnabled({
+        featureFlagId,
+    }: FeatureFlagLogicArgs) {
+        return {
+            id: featureFlagId,
+            enabled: this.lightdashConfig.nestedSpacesPermissions.enabled,
         };
     }
 }

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -78,6 +78,13 @@ export enum FeatureFlags {
      * When enabled, uses VisualizationProvider + echarts instead of recharts
      */
     MetricsCatalogEchartsVisualization = 'metrics-catalog-echarts-visualization',
+
+    /**
+     * Enable nested spaces to define their own permissions as well as extending
+     * their parent permissions. When disabled (default), all nested spaces
+     * inherit permissions from their root space.
+     */
+    NestedSpacesPermissions = 'nested-spaces-permissions',
 }
 
 export type FeatureFlag = {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-161/add-feature-flag-env

### Description:
Adding a new feature flag `NESTED_SPACES_PERMISSIONS_ENABLED` to allow testing of nested space permissions. Defaults to false to keep the original functionality until we're confident to release it.
