### PR TITLE
feat: allow multiple pop metrics from same metric but diff config

### DIFF
--- a/packages/common/src/types/periodOverPeriodComparison.test.ts
+++ b/packages/common/src/types/periodOverPeriodComparison.test.ts
@@ -1,0 +1,99 @@
+import {
+    getPopComparisonConfigKey,
+    hashPopComparisonConfigKeyToSuffix,
+} from './periodOverPeriodComparison';
+import { TimeFrames } from './timeFrames';
+
+describe('periodOverPeriodComparison helpers', () => {
+    test('getPopComparisonConfigKey is deterministic for same inputs', () => {
+        const a = getPopComparisonConfigKey({
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+        });
+        const b = getPopComparisonConfigKey({
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+        });
+        expect(a).toEqual(b);
+    });
+
+    test('getPopComparisonConfigKey changes when any field changes', () => {
+        const base = getPopComparisonConfigKey({
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+        });
+
+        expect(
+            getPopComparisonConfigKey({
+                timeDimensionId: 'orders_order_date_month',
+                granularity: TimeFrames.MONTH,
+                periodOffset: 2,
+            }),
+        ).not.toEqual(base);
+
+        expect(
+            getPopComparisonConfigKey({
+                timeDimensionId: 'orders_order_date_week',
+                granularity: TimeFrames.MONTH,
+                periodOffset: 1,
+            }),
+        ).not.toEqual(base);
+
+        expect(
+            getPopComparisonConfigKey({
+                timeDimensionId: 'orders_order_date_month',
+                granularity: TimeFrames.WEEK,
+                periodOffset: 1,
+            }),
+        ).not.toEqual(base);
+    });
+
+    test('hashPopComparisonConfigKeyToSuffix is deterministic and fixed length', () => {
+        const key = getPopComparisonConfigKey({
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+        });
+
+        const a = hashPopComparisonConfigKeyToSuffix(key);
+        const b = hashPopComparisonConfigKeyToSuffix(key);
+
+        expect(a).toEqual(b);
+        expect(a).toHaveLength(8);
+        expect(a).toMatch(/^[0-9a-z]{8}$/);
+    });
+
+    test('hashPopComparisonConfigKeyToSuffix differs for different config keys', () => {
+        const k1 = getPopComparisonConfigKey({
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+        });
+        const k2 = getPopComparisonConfigKey({
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 2,
+        });
+        expect(k1).not.toEqual(k2);
+        expect(hashPopComparisonConfigKeyToSuffix(k1)).not.toEqual(
+            hashPopComparisonConfigKeyToSuffix(k2),
+        );
+    });
+
+    test('getPopComparisonConfigKey is delimiter-safe (timeDimensionId can contain "|")', () => {
+        const normal = getPopComparisonConfigKey({
+            timeDimensionId: 'orders_order_date_month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+        });
+        const withPipe = getPopComparisonConfigKey({
+            timeDimensionId: 'orders|order_date|month',
+            granularity: TimeFrames.MONTH,
+            periodOffset: 1,
+        });
+        expect(withPipe).not.toEqual(normal);
+    });
+});

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -1,5 +1,4 @@
 import {
-    buildPopAdditionalMetricName,
     DimensionType,
     getItemId,
     getItemLabelWithoutTableName,
@@ -16,7 +15,7 @@ import {
     isTimeBasedDimension,
     type TableCalculation,
 } from '@lightdash/common';
-import { ActionIcon, Box, Group, Menu, Text, Tooltip } from '@mantine/core';
+import { ActionIcon, Box, Group, Menu, Text } from '@mantine/core';
 import {
     IconChevronDown,
     IconFilter,
@@ -98,54 +97,32 @@ const ContextMenu: FC<ContextMenuProps> = ({
     const isPopAdditionalMetric =
         isPeriodOverPeriodAdditionalMetric(additionalMetric);
 
-    // Check if a PoP metric already exists for this base metric
-    const hasExistingPopForMetric = useMemo(() => {
-        if (!item || !isMetric(item)) return false;
-        const expectedPopName = buildPopAdditionalMetricName(item.name);
-        const expectedPopId = `${item.table}_${expectedPopName}`;
-        return additionalMetrics?.some((am) => getItemId(am) === expectedPopId);
-    }, [item, additionalMetrics]);
-
     if (item && isField(item)) {
         const itemFieldId = getItemId(item);
         return (
             <>
                 {isMetric(item) && !isPopAdditionalMetric ? (
                     <>
-                        <Tooltip
-                            disabled={!hasExistingPopForMetric}
-                            label="This metric already has a period comparison"
+                        <Menu.Item
+                            icon={<MantineIcon icon={IconTimelineEvent} />}
+                            rightSection={
+                                <Box ml="sm">
+                                    <BetaBadge tooltipLabel="" />
+                                </Box>
+                            }
+                            onClick={() => {
+                                dispatch(
+                                    explorerActions.togglePeriodOverPeriodComparisonModal(
+                                        {
+                                            metric: item,
+                                            itemsMap: itemsMap,
+                                        },
+                                    ),
+                                );
+                            }}
                         >
-                            <Menu.Item
-                                icon={<MantineIcon icon={IconTimelineEvent} />}
-                                rightSection={
-                                    <Box ml="sm">
-                                        <BetaBadge tooltipLabel="" />
-                                    </Box>
-                                }
-                                sx={
-                                    hasExistingPopForMetric
-                                        ? {
-                                              opacity: 0.5,
-                                              cursor: 'not-allowed',
-                                          }
-                                        : undefined
-                                }
-                                onClick={() => {
-                                    if (hasExistingPopForMetric) return;
-                                    dispatch(
-                                        explorerActions.togglePeriodOverPeriodComparisonModal(
-                                            {
-                                                metric: item,
-                                                itemsMap: itemsMap,
-                                            },
-                                        ),
-                                    );
-                                }}
-                            >
-                                Add period comparison
-                            </Menu.Item>
-                        </Tooltip>
+                            Add period comparison
+                        </Menu.Item>
 
                         <Menu.Divider />
                     </>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  N/A

### Description:
This PR enhances period-over-period (PoP) comparison functionality by supporting multiple PoP configurations in a single query. Users can now add multiple comparisons for the same metric with different time dimensions or offsets (e.g., compare to previous month AND two months ago).

Key changes:
- Refactored the MetricQueryBuilder to handle multiple PoP configurations
- Updated the PoP metric ID generation to include configuration details in the name
- Improved the UI to prevent duplicate configurations and provide better feedback
- Removed the limitation that only allowed one PoP configuration per query
- Added validation to ensure each comparison's time dimension is selected

![Screenshot 2026-01-29 at 17.34.34.png](https://app.graphite.com/user-attachments/assets/2e9be355-3806-4643-835b-d694e3bb8725.png)

![Screenshot 2026-01-29 at 17.31.15.png](https://app.graphite.com/user-attachments/assets/634d92e5-2314-497e-a434-58588a30ae1b.png)

