### PR TITLE
feat: introduce drivers in models to define relationships in canvas

### DIFF
--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -139,6 +139,7 @@ export type DbMetricsTreeEdge = {
     created_at: Date;
     created_by_user_uuid: string | null;
     project_uuid: string;
+    source: 'yaml' | 'ui';
 };
 
 export type DbMetricsTreeEdgeIn = Pick<
@@ -147,6 +148,7 @@ export type DbMetricsTreeEdgeIn = Pick<
     | 'target_metric_catalog_search_uuid'
     | 'created_by_user_uuid'
     | 'project_uuid'
+    | 'source'
 >;
 
 export type DbMetricsTreeEdgeDelete = Pick<

--- a/packages/backend/src/database/migrations/20260130091416_add_source_to_metrics_tree_edge.ts
+++ b/packages/backend/src/database/migrations/20260130091416_add_source_to_metrics_tree_edge.ts
@@ -1,0 +1,24 @@
+import { Knex } from 'knex';
+
+const METRICS_TREE_EDGES_TABLE = 'metrics_tree_edges';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+        // source: 'yaml' for YAML-defined edges, 'ui' for UI-created edges
+        table
+            .string('source')
+            .notNullable()
+            .defaultTo('ui')
+            .comment('Source of the edge: yaml or ui');
+    });
+    await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+        table.index(['project_uuid', 'source']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(METRICS_TREE_EDGES_TABLE, (table) => {
+        table.dropIndex(['project_uuid', 'source']);
+        table.dropColumn('source');
+    });
+}

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -367,8 +367,9 @@ export class CatalogService<
             'uuid',
         );
 
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         const projectYamlTags = await this.tagsModel.getYamlTags(projectUuid);
 
@@ -600,8 +601,8 @@ export class CatalogService<
                             target_metric_catalog_search_uuid:
                                 targetCatalogItem.catalogSearchUuid,
                             created_by_user_uuid: edge.createdByUserUuid,
-                            created_at: edge.createdAt,
                             project_uuid: projectUuid,
+                            source: 'ui' as const,
                         },
                     ];
                 }
@@ -618,8 +619,9 @@ export class CatalogService<
         catalogSearch: ApiCatalogSearch,
         context: CatalogSearchContext,
     ): Promise<KnexPaginatedData<(CatalogField | CatalogTable)[]>> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -674,8 +676,9 @@ export class CatalogService<
         // Right now we return the full cached explore based on name
         // We could extract some data to only return what we need instead
         // to make this request more lightweight
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -760,8 +763,9 @@ export class CatalogService<
         projectUuid: string,
         table: string,
     ): Promise<CatalogAnalytics> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -846,8 +850,9 @@ export class CatalogService<
         }: ApiCatalogSearch = {},
         sortArgs?: ApiSort,
     ): Promise<KnexPaginatedData<CatalogField[]>> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -941,8 +946,9 @@ export class CatalogService<
             throw new NotFoundError('Tag not found');
         }
 
-        const catalogSearch =
-            await this.catalogModel.getCatalogItem(catalogSearchUuid);
+        const catalogSearch = await this.catalogModel.getCatalogItem(
+            catalogSearchUuid,
+        );
 
         if (!catalogSearch) {
             throw new NotFoundError('Catalog search not found');
@@ -1023,8 +1029,9 @@ export class CatalogService<
         catalogSearchUuid: string,
         icon: CatalogItemIcon | null,
     ): Promise<void> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1065,8 +1072,9 @@ export class CatalogService<
         userAttributes?: UserAttributeValueMap;
         addDefaultTimeDimension?: boolean;
     }): Promise<MetricWithAssociatedTimeDimension[]> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1207,8 +1215,9 @@ export class CatalogService<
         projectUuid: string,
         metricUuids: string[],
     ) {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1277,8 +1286,9 @@ export class CatalogService<
         projectUuid: string,
         edgePayload: ApiMetricsTreeEdgePayload,
     ) {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1299,6 +1309,7 @@ export class CatalogService<
             target_metric_catalog_search_uuid: targetCatalogSearchUuid,
             created_by_user_uuid: user.userUuid,
             project_uuid: projectUuid,
+            source: 'ui',
         });
     }
 
@@ -1308,8 +1319,9 @@ export class CatalogService<
         context: CatalogSearchContext,
         tableName?: string,
     ): Promise<MetricWithAssociatedTimeDimension[]> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
         if (
             user.ability.cannot(
                 'view',
@@ -1334,8 +1346,9 @@ export class CatalogService<
                 type: CatalogType.Field,
                 filter: CatalogFilter.Metrics,
             },
-            tablesConfiguration:
-                await this.projectModel.getTablesConfiguration(projectUuid),
+            tablesConfiguration: await this.projectModel.getTablesConfiguration(
+                projectUuid,
+            ),
         });
 
         const filteredMetrics = allCatalogMetrics.data.filter(
@@ -1362,8 +1375,9 @@ export class CatalogService<
         tableName: string,
         context: CatalogSearchContext,
     ): Promise<CompiledDimension[]> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1394,8 +1408,9 @@ export class CatalogService<
                 type: CatalogType.Field,
                 filter: CatalogFilter.Dimensions,
             },
-            tablesConfiguration:
-                await this.projectModel.getTablesConfiguration(projectUuid),
+            tablesConfiguration: await this.projectModel.getTablesConfiguration(
+                projectUuid,
+            ),
         });
 
         const allDimensions = catalogDimensions.data
@@ -1412,8 +1427,9 @@ export class CatalogService<
         tableName: string,
         context: CatalogSearchContext,
     ): Promise<CompiledDimension[]> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1444,8 +1460,9 @@ export class CatalogService<
                 type: CatalogType.Field,
                 filter: CatalogFilter.Dimensions,
             },
-            tablesConfiguration:
-                await this.projectModel.getTablesConfiguration(projectUuid),
+            tablesConfiguration: await this.projectModel.getTablesConfiguration(
+                projectUuid,
+            ),
         });
 
         const allDimensions = catalogDimensions.data
@@ -1461,8 +1478,9 @@ export class CatalogService<
         projectUuid: string,
         edgePayload: ApiMetricsTreeEdgePayload,
     ) {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1488,8 +1506,9 @@ export class CatalogService<
         user: SessionUser,
         projectUuid: string,
     ): Promise<boolean> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(
@@ -1508,8 +1527,9 @@ export class CatalogService<
         user: SessionUser,
         projectUuid: string,
     ): Promise<CatalogOwner[]> {
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
+        const { organizationUuid } = await this.projectModel.getSummary(
+            projectUuid,
+        );
 
         if (
             user.ability.cannot(

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -373,6 +373,13 @@
                                                         "required": ["owner"]
                                                     }
                                                 ]
+                                            },
+                                            "drivers": {
+                                                "type": "array",
+                                                "items": {
+                                                    "type": "string"
+                                                },
+                                                "description": "Array of metrics that drive this metric. Use 'metric_name' for same-table or 'table.metric_name' for cross-table."
                                             }
                                         },
                                         "required": ["type", "sql"]
@@ -925,6 +932,13 @@
                                                                     ]
                                                                 }
                                                             ]
+                                                        },
+                                                        "drivers": {
+                                                            "type": "array",
+                                                            "items": {
+                                                                "type": "string"
+                                                            },
+                                                            "description": "Array of metrics that drive this metric. Use 'metric_name' for same-table or 'table.metric_name' for cross-table."
                                                         }
                                                     },
                                                     "required": ["type"]

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -242,6 +242,7 @@ export type DbtColumnLightdashMetric = {
         segment_by?: string[]; // dimension IDs allowlist
         owner?: string; // metric owner email
     };
+    drivers?: string[]; // metrics that drive this metric (same-table: 'name', cross-table: 'table.name')
     ai_hint?: string | string[];
 } & DbtLightdashFieldTags;
 
@@ -613,6 +614,7 @@ export const convertModelMetric = ({
             segmentBy: metric.spotlight?.segment_by,
             owner,
         }),
+        ...(metric.drivers ? { drivers: metric.drivers } : {}),
         ...(metric.ai_hint ? { aiHint: convertToAiHints(metric.ai_hint) } : {}),
     };
 };

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -67,14 +67,14 @@ export enum NumberSeparator {
 }
 type CompactConfig = {
     compact: Compact;
-    alias: Array<(typeof CompactAlias)[number]>;
+    alias: Array<typeof CompactAlias[number]>;
     orderOfMagnitude: number;
     convertFn: (value: number) => number;
     label: string;
     suffix: string;
 };
 
-export type CompactOrAlias = Compact | (typeof CompactAlias)[number];
+export type CompactOrAlias = Compact | typeof CompactAlias[number];
 
 export const CompactConfigMap: Record<Compact, CompactConfig> = {
     [Compact.THOUSANDS]: {
@@ -284,7 +284,7 @@ export interface CustomFormat {
     type: CustomFormatType;
     round?: number | undefined;
     separator?: NumberSeparator;
-    currency?: (typeof currencies)[number] | undefined;
+    currency?: typeof currencies[number] | undefined;
     compact?: CompactOrAlias | undefined;
     prefix?: string | undefined;
     suffix?: string | undefined;
@@ -765,6 +765,7 @@ export interface Metric extends Field {
         segmentBy?: string[]; // dimension IDs allowlist
         owner?: string; // metric owner email
     };
+    drivers?: string[]; // metrics that drive this metric (same-table: 'name', cross-table: 'table.name')
     aiHint?: string | string[];
 }
 


### PR DESCRIPTION
Closes: ZAP-204

### Description:

Added support for YAML-defined metric relationships through a new `drivers` property in metric definitions. This allows users to define metric dependencies directly in YAML files, which are then automatically synchronized to the metrics tree.

The implementation includes:

- New `source` field in the `metrics_tree_edges` table to track whether edges were created via YAML or UI
- Migration script to add the source column and appropriate indexes
- Logic to synchronize YAML-defined edges during project indexing
- Schema updates to support the new `drivers` property in metrics
- Conflict resolution that prioritizes YAML-defined edges over UI-created ones

This feature enables data teams to version-control their metric relationships alongside metric definitions, making it easier to maintain a consistent metrics framework.