### PR TITLE
chore: add initial frontend

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/DisableInheritanceConfirmModal.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/DisableInheritanceConfirmModal.tsx
@@ -1,0 +1,115 @@
+import { type SpaceShare } from '@lightdash/common';
+import { Avatar, Group, List, Stack, Text } from '@mantine/core';
+import { IconArrowRight } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineModal from '../MantineModal';
+import { getInitials, getUserNameOrEmail } from './Utils';
+
+interface DisableInheritanceConfirmModalProps {
+    opened: boolean;
+    onClose: () => void;
+    onConfirm: () => void;
+    inheritedPermissions: SpaceShare[];
+    inheritanceSource: string;
+    isLoading?: boolean;
+}
+
+const DisableInheritanceConfirmModal: FC<
+    DisableInheritanceConfirmModalProps
+> = ({
+    opened,
+    onClose,
+    onConfirm,
+    inheritedPermissions,
+    inheritanceSource,
+    isLoading = false,
+}) => {
+    const hasInheritedPermissions = inheritedPermissions.length > 0;
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Switch to explicit permissions?"
+            icon={IconArrowRight}
+            size="md"
+            onConfirm={onConfirm}
+            confirmLabel="Switch to Explicit"
+            confirmLoading={isLoading}
+            confirmDisabled={isLoading}
+        >
+            <Stack spacing="md">
+                <Text fz="sm">
+                    Turning off inheritance will stop this space from
+                    automatically receiving permission changes from{' '}
+                    {inheritanceSource}.
+                </Text>
+
+                {hasInheritedPermissions ? (
+                    <>
+                        <Text fz="sm">
+                            The following inherited permissions will be copied
+                            as direct permissions on this space:
+                        </Text>
+                        <List spacing="xs" size="sm" withPadding>
+                            {inheritedPermissions
+                                .slice(0, 5)
+                                .map((permission) => (
+                                    <List.Item key={permission.userUuid}>
+                                        <Group spacing="xs">
+                                            <Avatar
+                                                size="xs"
+                                                radius="xl"
+                                                color="blue"
+                                            >
+                                                {getInitials(
+                                                    permission.userUuid,
+                                                    permission.firstName,
+                                                    permission.lastName,
+                                                    permission.email,
+                                                )}
+                                            </Avatar>
+                                            <Text span fz="sm">
+                                                {getUserNameOrEmail(
+                                                    permission.userUuid,
+                                                    permission.firstName,
+                                                    permission.lastName,
+                                                    permission.email,
+                                                )}
+                                            </Text>
+                                            <Text span fz="sm" c="ldGray.6">
+                                                ({permission.role})
+                                            </Text>
+                                            {permission.inheritedFrom && (
+                                                <Text span fz="xs" c="ldGray.5">
+                                                    - from{' '}
+                                                    {permission.inheritedFrom}
+                                                </Text>
+                                            )}
+                                        </Group>
+                                    </List.Item>
+                                ))}
+                            {inheritedPermissions.length > 5 && (
+                                <List.Item>
+                                    <Text fz="sm" c="ldGray.6">
+                                        ...and {inheritedPermissions.length - 5}{' '}
+                                        more
+                                    </Text>
+                                </List.Item>
+                            )}
+                        </List>
+                        <Text fz="sm" c="ldGray.6">
+                            You can modify these permissions after switching.
+                        </Text>
+                    </>
+                ) : (
+                    <Text fz="sm" c="ldGray.6">
+                        This space has no inherited permissions to copy.
+                    </Text>
+                )}
+            </Stack>
+        </MantineModal>
+    );
+};
+
+export default DisableInheritanceConfirmModal;

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -252,7 +252,8 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 };
             });
 
-        return [...usersSet, ...(groupsSet ?? [])].filter(
+        // Groups first to encourage their usage (more scalable than individual users)
+        return [...(groupsSet ?? []), ...usersSet].filter(
             (item): item is SelectItem => item !== null,
         );
     }, [
@@ -279,7 +280,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
                 clearable
                 clearSearchOnChange
                 clearSearchOnBlur
-                placeholder="Select users to share this space with"
+                placeholder="Add groups or users..."
                 nothingFound="No users found"
                 searchValue={searchQuery}
                 onSearchChange={setSearchQuery}

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceInheritanceToggle.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceInheritanceToggle.tsx
@@ -1,0 +1,131 @@
+import { type Space } from '@lightdash/common';
+import { Avatar, Group, Stack, Switch, Text, Tooltip } from '@mantine/core';
+import {
+    IconFolder,
+    IconFolderOpen,
+    IconInfoCircle,
+} from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import { useProject } from '../../../hooks/useProject';
+import { useUpdateMutation } from '../../../hooks/useSpaces';
+import MantineIcon from '../MantineIcon';
+import DisableInheritanceConfirmModal from './DisableInheritanceConfirmModal';
+
+interface ShareSpaceInheritanceToggleProps {
+    space: Space;
+    projectUuid: string;
+}
+
+export const ShareSpaceInheritanceToggle: FC<
+    ShareSpaceInheritanceToggleProps
+> = ({ space, projectUuid }) => {
+    const { data: project } = useProject(projectUuid);
+    const { mutate: updateSpace, isLoading } = useUpdateMutation(
+        projectUuid,
+        space.uuid,
+    );
+    const [confirmModalOpen, setConfirmModalOpen] = useState(false);
+
+    const isRootSpace = !space.parentSpaceUuid;
+    const parentSpaceName =
+        space.breadcrumbs && space.breadcrumbs.length > 1
+            ? space.breadcrumbs[space.breadcrumbs.length - 2]?.name
+            : null;
+
+    const handleToggleChange = (checked: boolean) => {
+        if (checked) {
+            // Turning inheritance ON - just update
+            updateSpace({
+                name: space.name,
+                inheritParentPermissions: true,
+            });
+        } else {
+            // Turning inheritance OFF - show confirmation modal
+            setConfirmModalOpen(true);
+        }
+    };
+
+    const handleConfirmDisableInheritance = () => {
+        updateSpace({
+            name: space.name,
+            inheritParentPermissions: false,
+        });
+        setConfirmModalOpen(false);
+    };
+
+    const inheritanceSource = isRootSpace
+        ? `project "${project?.name ?? 'Project'}"`
+        : `parent space "${parentSpaceName ?? 'Parent'}"`;
+
+    return (
+        <>
+            <Group position="apart">
+                <Group spacing="sm">
+                    <Avatar
+                        radius="xl"
+                        color={
+                            space.inheritParentPermissions ? 'blue' : 'orange'
+                        }
+                    >
+                        <MantineIcon
+                            icon={
+                                space.inheritParentPermissions
+                                    ? IconFolderOpen
+                                    : IconFolder
+                            }
+                        />
+                    </Avatar>
+
+                    <Stack spacing={2}>
+                        <Group spacing="xs">
+                            <Text fw={600} fz="sm">
+                                Inherit permissions
+                            </Text>
+                            <Tooltip
+                                label={
+                                    space.inheritParentPermissions
+                                        ? `This space uses permissions from ${inheritanceSource}. Changes to parent permissions automatically apply here.`
+                                        : 'This space has its own explicit permissions that you can customize independently.'
+                                }
+                                multiline
+                                maw={300}
+                                withinPortal
+                            >
+                                <MantineIcon
+                                    icon={IconInfoCircle}
+                                    size={14}
+                                    color="gray"
+                                />
+                            </Tooltip>
+                        </Group>
+                        <Text c="ldGray.6" fz="xs">
+                            {space.inheritParentPermissions
+                                ? `Permissions flow from ${inheritanceSource}`
+                                : 'Using explicit permissions for this space'}
+                        </Text>
+                    </Stack>
+                </Group>
+
+                <Switch
+                    checked={space.inheritParentPermissions}
+                    onChange={(e) =>
+                        handleToggleChange(e.currentTarget.checked)
+                    }
+                    disabled={isLoading}
+                    size="md"
+                />
+            </Group>
+
+            <DisableInheritanceConfirmModal
+                opened={confirmModalOpen}
+                onClose={() => setConfirmModalOpen(false)}
+                onConfirm={handleConfirmDisableInheritance}
+                inheritedPermissions={space.access.filter(
+                    (a) => !a.hasDirectAccess,
+                )}
+                inheritanceSource={inheritanceSource}
+                isLoading={isLoading}
+            />
+        </>
+    );
+};

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -66,7 +66,8 @@ export interface CreateSpaceModalBody
 
 export interface DeleteSpaceModalBody
     extends Pick<CreateSpaceModalBody, 'data' | 'form'>,
-        Pick<ActionModalProps, 'title' | 'icon'> {
+        Pick<ActionModalProps, 'title' | 'icon' | 'projectUuid'> {
+    spaceUuid: string | undefined;
     isLoading: boolean;
     handleSubmit: (values: Space) => void;
     onClose: () => void;
@@ -140,6 +141,8 @@ const SpaceModal: FC<ActionModalProps> = ({
                 form={form}
                 handleSubmit={handleSubmit}
                 isLoading={isLoading}
+                projectUuid={projectUuid}
+                spaceUuid={data?.uuid}
             />
         );
     }

--- a/packages/frontend/src/hooks/useSpaceDeleteImpact.ts
+++ b/packages/frontend/src/hooks/useSpaceDeleteImpact.ts
@@ -1,0 +1,36 @@
+import { type ApiError, type SpaceDeleteImpact } from '@lightdash/common';
+import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
+
+const getSpaceDeleteImpact = async (
+    projectUuid: string,
+    spaceUuid: string,
+): Promise<SpaceDeleteImpact> => {
+    const response = await fetch(
+        `/api/v1/projects/${projectUuid}/spaces/${spaceUuid}/delete-impact`,
+    );
+    const data = await response.json();
+    if (!response.ok) {
+        throw data;
+    }
+    return data.results;
+};
+
+/**
+ * Hook to fetch the delete impact for a space.
+ * Use `enabled` option for lazy loading (e.g., when delete modal opens).
+ */
+export const useSpaceDeleteImpact = (
+    projectUuid: string | undefined,
+    spaceUuid: string | undefined,
+    queryOptions?: Omit<
+        UseQueryOptions<SpaceDeleteImpact, ApiError>,
+        'queryKey' | 'queryFn'
+    >,
+) =>
+    useQuery<SpaceDeleteImpact, ApiError>({
+        queryKey: ['space-delete-impact', projectUuid, spaceUuid],
+        queryFn: () => getSpaceDeleteImpact(projectUuid!, spaceUuid!),
+        enabled:
+            !!projectUuid && !!spaceUuid && (queryOptions?.enabled ?? true),
+        ...queryOptions,
+    });

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -397,3 +397,42 @@ export const useDeleteSpaceGroupAccessMutation = (
         },
     );
 };
+
+const clearAllSpaceAccess = async (projectUuid: string, spaceUuid: string) =>
+    lightdashApi<Space>({
+        url: `/projects/${projectUuid}/spaces/${spaceUuid}/access`,
+        method: 'DELETE',
+        body: undefined,
+    });
+
+export const useClearAllSpaceAccessMutation = (
+    projectUuid: string,
+    spaceUuid: string,
+) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+
+    return useMutation<Space, ApiError, void>(
+        () => clearAllSpaceAccess(projectUuid, spaceUuid),
+        {
+            mutationKey: ['space_clear_access', projectUuid, spaceUuid],
+            onSuccess: async (data) => {
+                await queryClient.refetchQueries(['spaces', projectUuid]);
+                queryClient.setQueryData(
+                    ['space', projectUuid, spaceUuid],
+                    data,
+                );
+
+                showToastSuccess({
+                    title: `Success! All direct permissions cleared.`,
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: `Failed to clear space permissions`,
+                    apiError: error,
+                });
+            },
+        },
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [https://linear.app/lightdash/issue/GLITCH-156/enable-sharing-ui-for-nested-spaces](https://linear.app/lightdash/issue/GLITCH-156/enable-sharing-ui-for-nested-spaces)

Closes: [https://linear.app/lightdash/issue/GLITCH-158/handle-breadcrumbs-for-hidden-parent-spaces](https://linear.app/lightdash/issue/GLITCH-158/handle-breadcrumbs-for-hidden-parent-spaces)

Relates to: [https://linear.app/lightdash/issue/GLITCH-155/unify-root-space-publicprivate-with-inheritance-model](https://linear.app/lightdash/issue/GLITCH-155/unify-root-space-publicprivate-with-inheritance-model)

### Description:

This PR adds space permission inheritance controls to the Share Space modal, allowing users to toggle between inherited and explicit permissions for spaces.

Key changes:

- Added a new inheritance toggle switch at the top of the Share Space modal
- Created a confirmation modal when disabling inheritance that shows which permissions will be copied
- Reorganized the permissions display to clearly separate inherited (read-only) from explicit permissions
- Added a "Clear all" button to remove all explicit permissions at once
- Improved the delete space modal to show more detailed impact information about nested spaces
- Updated the breadcrumb navigation to indicate spaces where the user doesn't have access