### PR TITLE
feat: add validation for custom metric filters

### DIFF
--- a/packages/backend/src/ee/services/ai/tools/runQuery.ts
+++ b/packages/backend/src/ee/services/ai/tools/runQuery.ts
@@ -31,6 +31,7 @@ import { toModelOutput } from '../utils/toModelOutput';
 import { toolErrorHandler } from '../utils/toolErrorHandler';
 import {
     validateAxisFields,
+    validateCustomMetricFilters,
     validateCustomMetricsDefinition,
     validateFieldEntityType,
     validateFilterRules,
@@ -92,6 +93,7 @@ export const validateRunQueryTool = (
     );
 
     validateCustomMetricsDefinition(explore, queryTool.customMetrics);
+    validateCustomMetricFilters(explore, queryTool.customMetrics);
     validateFilterRules(
         explore,
         filterRules,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added validation for custom metric filters in the AI agent's query tool. This ensures that when custom metrics with filters are used, the filter fields exist in the explore and the filter rules are valid. The validation checks each filter in custom metrics, converts field references to field IDs, and validates the filter rules against the corresponding fields.
