### PR TITLE
feat: add Notify Support button to the error toast

### DIFF
--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,7 +1,8 @@
-import type { ApiErrorDetail } from '@lightdash/common';
+import { type ApiErrorDetail, LightdashMode } from '@lightdash/common';
 import {
     ActionIcon,
     Anchor,
+    Button,
     CopyButton,
     Group,
     Modal,
@@ -10,10 +11,38 @@ import {
     Tooltip,
     useMantineTheme,
 } from '@mantine/core';
-import { IconCheck, IconCopy } from '@tabler/icons-react';
+import { modals } from '@mantine/modals';
+import { IconCheck, IconCopy, IconSpeakerphone } from '@tabler/icons-react';
 import MantineIcon from '../../components/common/MantineIcon';
 import { SnowflakeFormInput } from '../../components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs';
+import SupportDrawerContent from '../../providers/SupportDrawer/SupportDrawerContent';
 import { useGoogleLoginPopup } from '../gdrive/useGdrive';
+import useHealth from '../health/useHealth';
+
+const CopyErrorButton = ({
+    value,
+    color,
+}: {
+    value: string;
+    color: string;
+}) => (
+    <CopyButton value={value}>
+        {({ copied, copy }) => (
+            <Tooltip
+                label={copied ? 'Copied' : 'Copy error'}
+                withArrow
+                position="right"
+            >
+                <ActionIcon size="xs" onClick={copy} variant="transparent">
+                    <MantineIcon
+                        color={color}
+                        icon={copied ? IconCheck : IconCopy}
+                    />
+                </ActionIcon>
+            </Tooltip>
+        )}
+    </CopyButton>
+);
 
 const GoogleSheetsReauthMessage = ({ message }: { message: string }) => {
     const { mutate: openLoginPopup } = useGoogleLoginPopup('gdrive');
@@ -41,6 +70,13 @@ const ApiErrorDisplay = ({
 }) => {
     const theme = useMantineTheme();
     const isDark = theme.colorScheme === 'dark';
+    const health = useHealth();
+    const isCloudCustomer = health.data?.mode === LightdashMode.CLOUD_BETA;
+    const isDevelopment = health.data?.mode === LightdashMode.DEV;
+    const isNotMultiTenantCloud = !(
+        health.data?.siteUrl === 'https://app.lightdash.cloud' ||
+        health.data?.siteUrl === 'https://eu1.lightdash.cloud'
+    );
 
     switch (apiError.name) {
         case 'GoogleSheetsScopeError':
@@ -78,47 +114,79 @@ const ApiErrorDisplay = ({
         default:
             break;
     }
-    return apiError.sentryEventId || apiError.sentryTraceId ? (
-        <Stack spacing="xxs">
-            <Text mb={0}>{apiError.message}</Text>
-            <Text mb={0} weight="bold">
-                Contact support with the following information:
-            </Text>
-            <Group spacing="xxs" align="flex-start">
-                <Text mb={0} weight="bold">
-                    Error ID: {apiError.sentryEventId || 'n/a'}
-                    <br />
-                    Trace ID: {apiError.sentryTraceId || 'n/a'}
-                </Text>
-                <CopyButton
-                    value={`Error ID: ${
-                        apiError.sentryEventId || 'n/a'
-                    } Trace ID: ${apiError.sentryTraceId || 'n/a'}`}
-                >
-                    {({ copied, copy }) => (
-                        <Tooltip
-                            label={copied ? 'Copied' : 'Copy error ID'}
-                            withArrow
-                            position="right"
-                        >
-                            <ActionIcon
-                                size="xs"
-                                onClick={copy}
-                                variant={'transparent'}
-                            >
+    const showSupportButton =
+        (isCloudCustomer && isNotMultiTenantCloud) || isDevelopment;
+
+    if (apiError.sentryEventId || apiError.sentryTraceId) {
+        // Cloud/dev: show button only, no IDs
+        if (showSupportButton) {
+            return (
+                <Stack spacing="xxs" align="start">
+                    <Text mb={0} color="red.6">
+                        {apiError.message}
+                    </Text>
+                    <Group spacing="xs">
+                        <Button
+                            size="xs"
+                            compact
+                            variant="outline"
+                            color="red.6"
+                            leftIcon={
                                 <MantineIcon
-                                    color={isDark ? 'white' : 'gray.7'}
-                                    icon={copied ? IconCheck : IconCopy}
+                                    color="red.6"
+                                    icon={IconSpeakerphone}
                                 />
-                            </ActionIcon>
-                        </Tooltip>
-                    )}
-                </CopyButton>
-            </Group>
-        </Stack>
-    ) : (
-        <span>{apiError.message}</span>
-    );
+                            }
+                            onClick={() => {
+                                modals.open({
+                                    title: 'Share with Lightdash Support',
+                                    size: 'lg',
+                                    children: <SupportDrawerContent />,
+                                    yOffset: 100,
+                                    zIndex: 1000,
+                                });
+                            }}
+                        >
+                            <Text color="red.6" weight="lighter">
+                                Notify support
+                            </Text>
+                        </Button>
+                        <CopyErrorButton
+                            value={`${apiError.message}\nError ID: ${
+                                apiError.sentryEventId || 'n/a'
+                            }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`}
+                            color="red.6"
+                        />
+                    </Group>
+                </Stack>
+            );
+        }
+
+        // Self-hosted: show IDs with copy button
+        return (
+            <Stack spacing="xxs">
+                <Text mb={0}>{apiError.message}</Text>
+                <Text mb={0} weight="bold">
+                    Contact support with the following information:
+                </Text>
+                <Group spacing="xxs" align="flex-start">
+                    <Text mb={0} weight="bold">
+                        Error ID: {apiError.sentryEventId || 'n/a'}
+                        <br />
+                        Trace ID: {apiError.sentryTraceId || 'n/a'}
+                    </Text>
+                    <CopyErrorButton
+                        value={`${apiError.message}\nError ID: ${
+                            apiError.sentryEventId || 'n/a'
+                        }\nTrace ID: ${apiError.sentryTraceId || 'n/a'}`}
+                        color={isDark ? 'white' : 'gray.7'}
+                    />
+                </Group>
+            </Stack>
+        );
+    }
+
+    return <span>{apiError.message}</span>;
 };
 
 export default ApiErrorDisplay;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Improved error display in the API error component by adding a "Notify support" button for cloud customers and development environments. For cloud users, the error IDs are now hidden and replaced with a direct support button, while self-hosted users still see the error and trace IDs with copy functionality. This makes it easier for cloud users to get help when encountering errors.
