### PR TITLE
fix: respect global spotlight default_visibility in preview

### DIFF
--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -446,7 +446,9 @@ export class ExploreCompiler {
         }
 
         const spotlightVisibility =
-            meta.spotlight?.visibility ?? spotlightConfig?.default_visibility;
+            meta.spotlight?.visibility ??
+            spotlightConfig?.default_visibility ??
+            'show';
 
         const spotlightCategories = getCategoriesFromResource(
             'explore',

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -552,7 +552,9 @@ export const convertModelMetric = ({
 }: ConvertModelMetricArgs): Metric => {
     const groups = convertToGroups(metric.groups, metric.group_label);
     const spotlightVisibility =
-        metric.spotlight?.visibility ?? spotlightConfig?.default_visibility;
+        metric.spotlight?.visibility ??
+        spotlightConfig?.default_visibility ??
+        'show';
     const metricCategories = Array.from(
         new Set([...modelCategories, ...(metric.spotlight?.categories || [])]),
     );


### PR DESCRIPTION
Closes: #19858

### Description:

- When running `lightdash preview` with global Spotlight visibility set to hide in `lightdash.config.yml`, metrics were still appearing in Spotlight. 
- This fix ensures the compiler always applies the project’s default visibility (show or hide) to metrics and explores, so a global “hide” setting is respected and those items no longer show in Spotlight during preview.