### PR TITLE
fix: missing borders in canvas nodes

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/CollapsedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/CollapsedNode.tsx
@@ -22,14 +22,12 @@ const CollapsedNode: React.FC<NodeProps<CollapsedNodeData>> = ({
             miw={150}
             fz="xs"
             p="xs"
-            bg="white"
             sx={(theme) => ({
-                '&[data-with-border]': {
-                    borderRadius: theme.radius.md,
-                    border: `1px dashed ${
-                        selected ? theme.colors.blue[5] : theme.colors.ldGray[3]
-                    }`,
-                },
+                backgroundColor: theme.colors.background[0],
+                borderRadius: theme.radius.md,
+                border: `1px dashed ${
+                    selected ? theme.colors.blue[5] : theme.colors.ldGray[3]
+                }`,
             })}
         >
             <Group position="apart">
@@ -51,7 +49,7 @@ const CollapsedNode: React.FC<NodeProps<CollapsedNodeData>> = ({
                     <MantineIcon
                         icon={IconInfoCircle}
                         size={12}
-                        color="ldDark.3"
+                        color="ldGray.7"
                     />
                 </Tooltip>
             </Group>

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
@@ -133,13 +133,11 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
             p="md"
             fz={14}
             sx={(theme) => ({
-                '&[data-with-border]': {
-                    backgroundColor: theme.colors.background[0],
-                    borderRadius: theme.radius.md,
-                    border: `1px solid ${
-                        selected ? theme.colors.blue[5] : theme.colors.ldGray[3]
-                    }`,
-                },
+                backgroundColor: theme.colors.background[0],
+                borderRadius: theme.radius.md,
+                border: `1px solid ${
+                    selected ? theme.colors.blue[5] : theme.colors.ldGray[3]
+                }`,
             })}
         >
             <Handle


### PR DESCRIPTION
### Description:
Fixed border and background color for spotlight canvas nodes. This was caused because Mantine's defaults changed during dark mode implementation.

_ignore the edge's arrows, working on that 👀_

#### After

![CleanShot 2026-02-02 at 12.14.42@2x.png](https://app.graphite.com/user-attachments/assets/6d6cf0c5-ac37-45d7-bf1e-330937142437.png)

![CleanShot 2026-02-02 at 12.14.36@2x.png](https://app.graphite.com/user-attachments/assets/0f5f5323-9a61-403b-ac89-4cdfa4acaf5d.png)

#### Before

![CleanShot 2026-02-02 at 12.14.53@2x.png](https://app.graphite.com/user-attachments/assets/91eb83cb-1a91-49ad-a4bb-0f493b4d646a.png)

![CleanShot 2026-02-02 at 12.14.47@2x.png](https://app.graphite.com/user-attachments/assets/9e13da2a-08ee-426c-aa10-07ddd34adf04.png)

