### PR TITLE
fix: invalidate tags, owner and metric-tree  queries after catalog indexing

### DIFF
--- a/packages/frontend/src/features/catalog/hooks/useIndexCatalogJob.ts
+++ b/packages/frontend/src/features/catalog/hooks/useIndexCatalogJob.ts
@@ -11,8 +11,9 @@ import { getSchedulerJobStatus } from '../../scheduler/hooks/useScheduler';
 const getIndexCatalogCompleteJob = async (
     jobId: string,
 ): Promise<ApiJobStatusResponse['results']> => {
-    const job =
-        await getSchedulerJobStatus<ApiJobStatusResponse['results']>(jobId);
+    const job = await getSchedulerJobStatus<ApiJobStatusResponse['results']>(
+        jobId,
+    );
 
     if (job.status === SchedulerJobStatus.COMPLETED) {
         return job;
@@ -55,6 +56,15 @@ export const useIndexCatalogJob = (
                     exact: false,
                 });
                 await queryClient.invalidateQueries(['catalog'], {
+                    exact: false,
+                });
+                await queryClient.invalidateQueries(['project-tags'], {
+                    exact: false,
+                });
+                await queryClient.invalidateQueries(['metrics-tree'], {
+                    exact: false,
+                });
+                await queryClient.invalidateQueries(['metric-owners'], {
                     exact: false,
                 });
                 onSuccess(job);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Invalidate additional query caches after catalog indexing completes. This ensures that project tags, metrics tree, and metric owners data are refreshed when a catalog job finishes successfully.
