### PR TITLE
feat: add directional arrows between connected metrics

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
@@ -2,15 +2,24 @@ import { useMantineTheme } from '@mantine/core';
 import { BaseEdge, getSimpleBezierPath, type EdgeProps } from '@xyflow/react';
 import type { FC } from 'react';
 
+const ARROW_SIZE = 8;
+
 const DefaultEdge: FC<EdgeProps> = ({
     sourceX,
     sourceY,
     targetX,
     targetY,
     selected,
+    id,
     ...props
 }) => {
     const theme = useMantineTheme();
+    const strokeColor = selected
+        ? theme.colors.blue[4]
+        : theme.colors.ldGray[3];
+
+    const markerId = `arrow-${id}`;
+
     const [edgePath] = getSimpleBezierPath({
         sourceX,
         sourceY,
@@ -19,15 +28,33 @@ const DefaultEdge: FC<EdgeProps> = ({
     });
 
     return (
-        <BaseEdge
-            {...props}
-            path={edgePath}
-            style={{
-                stroke: selected
-                    ? theme.colors.blue[4]
-                    : theme.colors.ldGray[3],
-            }}
-        />
+        <>
+            <defs>
+                <marker
+                    id={markerId}
+                    markerWidth={ARROW_SIZE}
+                    markerHeight={ARROW_SIZE}
+                    refX={ARROW_SIZE}
+                    refY={ARROW_SIZE / 2}
+                    orient="auto"
+                    markerUnits="strokeWidth"
+                >
+                    <path
+                        d={`M0,0 L0,${ARROW_SIZE} L${ARROW_SIZE},${ARROW_SIZE / 2} z`}
+                        fill={strokeColor}
+                    />
+                </marker>
+            </defs>
+            <BaseEdge
+                {...props}
+                id={id}
+                path={edgePath}
+                style={{
+                    stroke: strokeColor,
+                }}
+                markerEnd={`url(#${markerId})`}
+            />
+        </>
     );
 };
 


### PR DESCRIPTION
Closes: ZAP-207

### Description:
Added directional arrows between metrics to indicate the flow of the relationship

![CleanShot 2026-02-02 at 12.56.47@2x.png](https://app.graphite.com/user-attachments/assets/ceaf4896-1e6e-40a4-ac18-8751796cadf4.png)

