### PR TITLE
feat: add bubble size info to map legend

### DIFF
--- a/packages/frontend/src/components/SimpleMap/MapLegend.tsx
+++ b/packages/frontend/src/components/SimpleMap/MapLegend.tsx
@@ -1,10 +1,18 @@
-import { Box, Group, Text } from '@mantine-8/core';
+import { Box, Group, Stack, Text } from '@mantine-8/core';
 import { type FC } from 'react';
 import GradientBar from '../common/GradientBar';
 // eslint-disable-next-line css-modules/no-unused-class
 import classes from './SimpleMap.module.css';
 
-type MapLegendProps = {
+type BubbleSizeInfo = {
+    minSize: number;
+    maxSize: number;
+    formattedMin: string;
+    formattedMax: string;
+    label?: string;
+};
+
+type ColorInfo = {
     colors: string[];
     formattedMin: string;
     formattedMax: string;
@@ -12,34 +20,83 @@ type MapLegendProps = {
     opacity?: number;
 };
 
-const MapLegend: FC<MapLegendProps> = ({
-    colors,
-    formattedMin,
-    formattedMax,
-    label,
-    opacity,
-}) => {
+type MapLegendProps = {
+    color?: ColorInfo;
+    bubbleSize?: BubbleSizeInfo;
+};
+
+const MapLegend: FC<MapLegendProps> = ({ color, bubbleSize }) => {
     return (
         <Box className={classes.legend}>
-            {label && (
-                <Text fz="xs" fw={500} c="ldGray.7" mb={4}>
-                    {label}
-                </Text>
-            )}
-            <GradientBar
-                colors={colors}
-                height={12}
-                borderRadius={4}
-                opacity={opacity}
-            />
-            <Group justify="space-between">
-                <Text span fz="xs" c="ldGray.6">
-                    {formattedMin}
-                </Text>
-                <Text span fz="xs" c="ldGray.6">
-                    {formattedMax}
-                </Text>
-            </Group>
+            <Stack gap="sm">
+                {/* Color legend */}
+                {color && (
+                    <Box>
+                        {color.label && (
+                            <Text fz="xs" fw={500} c="ldGray.7" mb={4}>
+                                {color.label}
+                            </Text>
+                        )}
+                        <GradientBar
+                            colors={color.colors}
+                            height={12}
+                            borderRadius={4}
+                            opacity={color.opacity}
+                        />
+                        <Group justify="space-between">
+                            <Text span fz="xs" c="ldGray.6">
+                                {color.formattedMin}
+                            </Text>
+                            <Text span fz="xs" c="ldGray.6">
+                                {color.formattedMax}
+                            </Text>
+                        </Group>
+                    </Box>
+                )}
+
+                {/* Bubble size legend */}
+                {bubbleSize && (
+                    <Box>
+                        {bubbleSize.label && (
+                            <Text fz="xs" fw={500} c="ldGray.7" mb={4}>
+                                {bubbleSize.label}
+                            </Text>
+                        )}
+                        <Group
+                            gap="md"
+                            justify="space-between"
+                            align="flex-end"
+                        >
+                            <Stack gap={2} align="center">
+                                <Box
+                                    w={bubbleSize.minSize * 2}
+                                    h={bubbleSize.minSize * 2}
+                                    style={{
+                                        borderRadius: '50%',
+                                        border: '1.5px solid var(--mantine-color-ldGray-5)',
+                                    }}
+                                />
+                                <Text fz="xs" c="ldGray.6">
+                                    {bubbleSize.formattedMin}
+                                </Text>
+                            </Stack>
+                            <Stack gap={2} align="center">
+                                <Box
+                                    w={bubbleSize.maxSize * 2}
+                                    h={bubbleSize.maxSize * 2}
+                                    style={{
+                                        borderRadius: '50%',
+                                        border: '1.5px solid var(--mantine-color-ldGray-5)',
+                                    }}
+                                />
+                                <Text fz="xs" c="ldGray.6">
+                                    {bubbleSize.formattedMax}
+                                </Text>
+                            </Stack>
+                        </Group>
+                    </Box>
+                )}
+            </Stack>
         </Box>
     );
 };

--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -1031,15 +1031,45 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                             })
                         )}
                     </MapContainer>
-                    {mapConfig.showLegend && mapConfig.valueRange && (
-                        <MapLegend
-                            colors={mapConfig.colors.scale}
-                            formattedMin={mapConfig.valueRange.formattedMin}
-                            formattedMax={mapConfig.valueRange.formattedMax}
-                            label={mapConfig.valueFieldLabel ?? undefined}
-                            opacity={fillOpacityWithData}
-                        />
-                    )}
+                    {mapConfig.showLegend &&
+                        (mapConfig.valueRange || mapConfig.sizeRange) && (
+                            <MapLegend
+                                color={
+                                    mapConfig.valueRange
+                                        ? {
+                                              colors: mapConfig.colors.scale,
+                                              formattedMin:
+                                                  mapConfig.valueRange
+                                                      .formattedMin,
+                                              formattedMax:
+                                                  mapConfig.valueRange
+                                                      .formattedMax,
+                                              label:
+                                                  mapConfig.valueFieldLabel ??
+                                                  undefined,
+                                              opacity: fillOpacityWithData,
+                                          }
+                                        : undefined
+                                }
+                                bubbleSize={
+                                    mapConfig.sizeRange
+                                        ? {
+                                              minSize: mapConfig.minBubbleSize,
+                                              maxSize: mapConfig.maxBubbleSize,
+                                              formattedMin:
+                                                  mapConfig.sizeRange
+                                                      .formattedMin,
+                                              formattedMax:
+                                                  mapConfig.sizeRange
+                                                      .formattedMax,
+                                              label:
+                                                  mapConfig.sizeFieldLabel ??
+                                                  undefined,
+                                          }
+                                        : undefined
+                                }
+                            />
+                        )}
                 </div>
             );
         }
@@ -1102,11 +1132,13 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                     </MapContainer>
                     {mapConfig.showLegend && mapConfig.valueRange && (
                         <MapLegend
-                            colors={mapConfig.colors.scale}
-                            formattedMin={mapConfig.valueRange.formattedMin}
-                            formattedMax={mapConfig.valueRange.formattedMax}
-                            label={mapConfig.valueFieldLabel ?? undefined}
-                            opacity={fillOpacityWithData}
+                            color={{
+                                colors: mapConfig.colors.scale,
+                                formattedMin: mapConfig.valueRange.formattedMin,
+                                formattedMax: mapConfig.valueRange.formattedMax,
+                                label: mapConfig.valueFieldLabel ?? undefined,
+                                opacity: fillOpacityWithData,
+                            }}
                         />
                     )}
                 </div>

--- a/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
+++ b/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
@@ -61,7 +61,13 @@ export type LeafletMapConfig = {
     };
     minBubbleSize: number;
     maxBubbleSize: number;
-    sizeRange: { min: number; max: number } | null;
+    sizeRange: {
+        min: number;
+        max: number;
+        formattedMin: string;
+        formattedMax: string;
+    } | null;
+    sizeFieldLabel: string | null;
     heatmapConfig: {
         radius: number;
         blur: number;
@@ -340,18 +346,25 @@ const useLeafletMapConfig = ({
             formattedMin: string;
             formattedMax: string;
         } | null = null;
-        let sizeRange: { min: number; max: number } | null = null;
+        let sizeRange: {
+            min: number;
+            max: number;
+            formattedMin: string;
+            formattedMax: string;
+        } | null = null;
         if (scatterData && scatterData.length > 0) {
             // Single pass to find min/max for both value and size
             let minPoint: (ScatterPoint & { value: number }) | null = null;
             let maxPoint: (ScatterPoint & { value: number }) | null = null;
-            let minSize = scatterData[0].sizeValue;
-            let maxSize = scatterData[0].sizeValue;
+            let minSizePoint = scatterData[0];
+            let maxSizePoint = scatterData[0];
 
             for (const point of scatterData) {
-                // Track size range
-                if (point.sizeValue < minSize) minSize = point.sizeValue;
-                if (point.sizeValue > maxSize) maxSize = point.sizeValue;
+                // Track size range (keep the point reference for formatted values)
+                if (point.sizeValue < minSizePoint.sizeValue)
+                    minSizePoint = point;
+                if (point.sizeValue > maxSizePoint.sizeValue)
+                    maxSizePoint = point;
 
                 // Track value range (only for numeric values)
                 if (point.value !== null) {
@@ -375,10 +388,21 @@ const useLeafletMapConfig = ({
                 };
             }
 
-            sizeRange = {
-                min: Math.min(minSize, 0),
-                max: Math.max(maxSize, 1),
-            };
+            // Only set sizeRange when sizeFieldId is set
+            if (sizeFieldId) {
+                const formattedMinSize =
+                    minSizePoint.rowData[sizeFieldId]?.value?.formatted ??
+                    String(minSizePoint.sizeValue);
+                const formattedMaxSize =
+                    maxSizePoint.rowData[sizeFieldId]?.value?.formatted ??
+                    String(maxSizePoint.sizeValue);
+                sizeRange = {
+                    min: Math.min(minSizePoint.sizeValue, 0),
+                    max: Math.max(maxSizePoint.sizeValue, 1),
+                    formattedMin: formattedMinSize,
+                    formattedMax: formattedMaxSize,
+                };
+            }
         } else if (regionData && regionData.length > 0 && valueFieldId) {
             // Single pass to find min/max values and their regions
             let minRegion = regionData[0];
@@ -407,6 +431,17 @@ const useLeafletMapConfig = ({
                 valueFieldLabel = valueItem.label;
             } else if ('name' in valueItem) {
                 valueFieldLabel = (valueItem as { name: string }).name;
+            }
+        }
+
+        // Get size field label for legend
+        let sizeFieldLabel: string | null = null;
+        if (sizeFieldId && itemsMap?.[sizeFieldId]) {
+            const sizeItem = itemsMap[sizeFieldId];
+            if ('label' in sizeItem) {
+                sizeFieldLabel = sizeItem.label;
+            } else if ('name' in sizeItem) {
+                sizeFieldLabel = (sizeItem as { name: string }).name;
             }
         }
 
@@ -467,6 +502,7 @@ const useLeafletMapConfig = ({
             minBubbleSize: minBubbleSize ?? 2,
             maxBubbleSize: maxBubbleSize ?? 8,
             sizeRange,
+            sizeFieldLabel,
             heatmapConfig: {
                 radius: heatmapConfig?.radius ?? 25,
                 blur: heatmapConfig?.blur ?? 15,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19872, PROD-2839 

### Description:

Adds bubble size info to map legend

<img width="155" height="158" alt="Screenshot 2026-02-02 at 12 28 28" src="https://github.com/user-attachments/assets/91c2780d-c2fd-4cdc-bbce-76acd2587f59" />

