### PR TITLE
chore: remove unused npm overrides and yarn resolutions

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,18 +8,12 @@
         "packages/*",
         "packages/frontend/sdk"
     ],
-    "resolutions": {
-        "react-is": "19.2.0",
-        "@types/react": "19.2.2",
-        "@types/react-dom": "19.2.2",
-        "typescript": "5.5.4"
-    },
-    "overrides": {
-        "@mantine/core@8.0.0>@mantine/hooks": "$@mantine-8/hooks",
-        "echarts-for-react@3.0.1": "$echarts-6"
-    },
     "pnpm": {
         "overrides": {
+            "react-is": "19.2.0",
+            "@types/react": "19.2.2",
+            "@types/react-dom": "19.2.2",
+            "typescript": "5.5.4",
             "linkifyjs": "^4.3.2",
             "axios": "^1.12.0",
             "form-data@2.5.3": "2.5.5",


### PR DESCRIPTION
## Summary

- Remove npm `overrides` field (we use pnpm, not npm)
- Merge yarn `resolutions` into `pnpm.overrides`

## Problem

The npm `overrides` field was causing `npx` commands to crash with:
```
TypeError: Invalid comparator: file:8.0.0>@mantine/hooks
```

This is a [known npm bug](https://github.com/npm/cli/issues/5955) with scoped packages in overrides.

## Why these fields are unnecessary

| Field | Used by | Status |
|-------|---------|--------|
| `overrides` | npm | Ignored - we use pnpm |
| `resolutions` | yarn | Ignored - we use pnpm |
| `pnpm.overrides` | pnpm | ✓ Active |

The Mantine/echarts peer dependency patching that `overrides` was attempting is already handled by `.pnpmfile.cjs`.

## Test plan

- [x] `pnpm install --frozen-lockfile` works (lockfile unchanged)
- [x] Mantine v8 still resolves hooks to v8.0.0
- [x] Mantine v6 still resolves hooks to v6.0.22

🤖 Generated with [Claude Code](https://claude.ai/claude-code)