### PR TITLE
feat: add Google Sheets scope error handling and re-authentication UI

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -8,6 +8,7 @@ import {
     getErrorMessage,
     getItemLabel,
     getItemLabelWithoutTableName,
+    GoogleSheetsScopeError,
     GoogleSheetsTransientError,
     isDimension,
     isField,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -8,6 +8,7 @@ import {
     ForbiddenError,
     getTimezoneLabel,
     getTzMinutesOffset,
+    GoogleSheetsScopeError,
     GoogleSheetsTransientError,
     InvalidUser,
     isChartCreateScheduler,
@@ -476,6 +477,14 @@ export class SchedulerService extends BaseService {
                 }
                 if (error instanceof GoogleSheetsTransientError) {
                     throw error; // Allow transient errors to propagate for retry
+                }
+                if (error instanceof GoogleSheetsScopeError) {
+                    throw error; // Allow scope errors to propagate for frontend re-auth handling
+                }
+                if (error instanceof NotFoundError) {
+                    throw new GoogleSheetsScopeError(
+                        `Google sheet not found or you don't have permission to access it.`,
+                    );
                 }
                 throw new MissingConfigError(
                     'Unable to validate Google Sheets file. Please ensure you have connected your Google account.',

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1569,10 +1569,13 @@ export class UserService extends BaseService {
                         if (
                             scopes.includes(
                                 'https://www.googleapis.com/auth/drive.file',
-                            ) &&
-                            scopes.includes(
-                                'https://www.googleapis.com/auth/spreadsheets',
                             )
+                            // This scope is now optional
+                            // Not grating this scope will prevent users from overwritting
+                            // existing sheets that were not created by this app, throwing GoogleSheetsScopeError on scheduler
+                            /* scopes.includes(
+                                'https://www.googleapis.com/auth/spreadsheets',
+                            ) */
                         ) {
                             resolve(accessToken);
                         }

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -428,6 +428,23 @@ export class UnexpectedGoogleSheetsError extends LightdashError {
     }
 }
 
+/* This specific error will be used in the frontend
+to show a "Re-authenticate" button in the UI for Google Sheets scope issues
+*/
+export class GoogleSheetsScopeError extends LightdashError {
+    constructor(
+        message = 'Unable to validate Google Sheets file. Please re-authenticate with Google to grant the required permissions.',
+        data: { [key: string]: AnyType } = {},
+    ) {
+        super({
+            message,
+            name: 'GoogleSheetsScopeError',
+            statusCode: 403,
+            data,
+        });
+    }
+}
+
 export class GoogleSheetsTransientError extends LightdashError {
     constructor(
         message = 'Unexpected error in Google Sheets API',

--- a/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
+++ b/packages/frontend/src/hooks/toaster/ApiErrorDisplay.tsx
@@ -1,6 +1,7 @@
 import type { ApiErrorDetail } from '@lightdash/common';
 import {
     ActionIcon,
+    Anchor,
     CopyButton,
     Group,
     Modal,
@@ -12,6 +13,24 @@ import {
 import { IconCheck, IconCopy } from '@tabler/icons-react';
 import MantineIcon from '../../components/common/MantineIcon';
 import { SnowflakeFormInput } from '../../components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs';
+import { useGoogleLoginPopup } from '../gdrive/useGdrive';
+
+const GoogleSheetsReauthMessage = ({ message }: { message: string }) => {
+    const { mutate: openLoginPopup } = useGoogleLoginPopup('gdrive');
+
+    return (
+        <Text mb={0}>
+            {message}{' '}
+            <Anchor
+                component="button"
+                type="button"
+                onClick={() => openLoginPopup()}
+            >
+                Re-authenticate with Google
+            </Anchor>
+        </Text>
+    );
+};
 
 const ApiErrorDisplay = ({
     apiError,
@@ -24,6 +43,8 @@ const ApiErrorDisplay = ({
     const isDark = theme.colorScheme === 'dark';
 
     switch (apiError.name) {
+        case 'GoogleSheetsScopeError':
+            return <GoogleSheetsReauthMessage message={apiError.message} />;
         case 'SnowflakeTokenError':
             return (
                 <>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2802/reduce-google-drive-permission-scope-for-sheets-exportsync

List of changes: 

- remove requirement for `spreadsheet` scope in the backend -> This makes now the scope optional
- Add new error code, so when an error is triggered, the user can relogin from the error popup.

Note: if the `access to all files` is not granted, then Lightdash will not be able to write on existing files, but we can create new and update files uploaded within lightdash. 


<img width="601" height="598" alt="Screenshot from 2026-02-02 13-52-04" src="https://github.com/user-attachments/assets/7c7080be-9f32-4731-af4f-699ea7160a24" />

I still can select existing spreadsheets.

<img width="701" height="473" alt="Screenshot from 2026-02-02 13-31-47" src="https://github.com/user-attachments/assets/2721587c-68e2-4b40-b28e-f909c0891416" />

Before

<img width="517" height="157" alt="Screenshot from 2026-02-02 13-55-54" src="https://github.com/user-attachments/assets/3307944b-22fe-4e37-91eb-e88f19ba92ec" />

After

<img width="454" height="104" alt="image" src="https://github.com/user-attachments/assets/7008b006-bfab-4177-8149-4f0903bcda5c" />


AFter reauth: 
<img width="1113" height="694" alt="Screenshot from 2026-02-02 14-01-27" src="https://github.com/user-attachments/assets/4d138a33-a338-4963-9d87-9fd049d8d4a5" />


### Description:
Improves Google Sheets integration by handling scope errors more gracefully. When a user doesn't have sufficient permissions to access a Google Sheet, the system now throws a specific `GoogleSheetsScopeError` instead of a generic error.

Added a new UI component that displays a "Re-authenticate with Google" button when these permission errors occur, allowing users to easily grant the necessary permissions without having to navigate through settings.

Made the spreadsheets scope optional, which allows the app to work with more limited permissions, though users will be prompted to re-authenticate if they try to overwrite existing sheets not created by the app.