### PR TITLE
chore: warn if metric owner prop is not valid

### DIFF
--- a/packages/common/src/compiler/lightdashProjectConfig.ts
+++ b/packages/common/src/compiler/lightdashProjectConfig.ts
@@ -13,11 +13,12 @@ type SpotlightConfigArgs = {
 
 const validateOwner = (owner: unknown): string | null => {
     if (typeof owner === 'string') return owner;
-    if (owner === undefined)
+    if (owner !== undefined) {
         // eslint-disable-next-line no-console
         console.warn(
             `Invalid spotlight owner: expected string, got ${typeof owner}`,
         );
+    }
     return null;
 };
 


### PR DESCRIPTION


### Description:
We were logging warnings when compiling projects with metrics with no owners:

![CleanShot 2026-02-02 at 15.30.53@2x.png](https://app.graphite.com/user-attachments/assets/20db68ed-f449-48ca-9131-93c4465b5c53.png)

undefined is a valid case, will be transformed to null, we should log when a different value is found instead
