### PR TITLE
feat: add unified /docker-dev command for local development

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -1,4 +1,4 @@
-Start the Lightdash development environment. Automatically detects current state and runs setup/migrations as needed.
+Manage Docker dev environment. Args: (none) = start, `reset` = reset db, `stop` = stop services.
 
 ## Arguments
 


### PR DESCRIPTION
## Summary
- Add `/docker-dev` command that consolidates all Docker development environment operations
- Supports three modes:
  - **No arguments**: Auto-detect state and run what's needed (fresh setup, migrations, or just start)
  - **`reset`**: Force reset database and rebuild dbt models
  - **`stop`**: Stop Docker services (preserves data volumes)

This single command encapsulates the entire Docker-based local development workflow with intelligent state detection, making it easy for developers to manage their local environment without remembering complex command sequences.

## Features
- **Smart state detection**: Automatically checks Docker services, env files, dependencies, migrations, seeds, and dbt models
- **Incremental setup**: Only runs steps that are needed based on current state
- **Reset capability**: Full database reset with dbt model rebuild when needed
- **Clean shutdown**: Stop services while preserving data volumes

## Test plan
- [x] Run `/docker-dev` on fresh environment - verifies full setup flow
- [x] Run `/docker-dev` when already set up - verifies quick start
- [x] Run `/docker-dev stop` - verifies services stop correctly
- [x] Run `/docker-dev reset` - verifies database reset and dbt rebuild

🤖 Generated with [Claude Code](https://claude.ai/code)