### PR TITLE
feat: use AsyncQueryService for metrics tree queries

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -859,6 +859,7 @@ export class ServiceRepository
                     lightdashConfig: this.context.lightdashConfig,
                     catalogModel: this.models.getCatalogModel(),
                     projectService: this.getProjectService(),
+                    asyncQueryService: this.getAsyncQueryService(),
                     catalogService: this.getCatalogService(),
                     projectModel: this.models.getProjectModel(),
                 }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the MetricsExplorerService to use AsyncQueryService for executing metric queries instead of ProjectService. This change adds AsyncQueryService as a dependency to MetricsExplorerService and replaces calls to `projectService.runMetricExplorerQuery()` with `asyncQueryService.executeMetricQueryAndGetResults()`, providing the appropriate context for metrics explorer queries.
