### PR TITLE
feat: allow setting no-data color in scatter maps

### DIFF
--- a/packages/frontend/src/components/SimpleMap/index.tsx
+++ b/packages/frontend/src/components/SimpleMap/index.tsx
@@ -1007,16 +1007,11 @@ const SimpleMap: FC<SimpleMapProps> = memo(
                             scatterColorScale &&
                             scatterData.map((point, idx) => {
                                 const radius = sizeScale(point.sizeValue);
-                                // Use interpolated color for numeric values, middle of scale for non-numeric
+                                // Use interpolated color for numeric values, noDataColor for non-numeric
                                 const color =
                                     point.value !== null
                                         ? scatterColorScale(point.value)
-                                        : mapConfig.colors.scale[
-                                              Math.floor(
-                                                  mapConfig.colors.scale
-                                                      .length / 2,
-                                              )
-                                          ];
+                                        : mapConfig.noDataColor;
 
                                 return (
                                     <MapMarker

--- a/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/MapConfig/MapDisplayConfig.tsx
@@ -293,7 +293,7 @@ export const Display: FC = memo(() => {
                             />
                         </>
                     )}
-                    {isAreaMap && (
+                    {(isAreaMap || isScatterMap) && (
                         <Config.Group>
                             <Config.Label>No data color</Config.Label>
                             <ColorSelector

--- a/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
+++ b/packages/frontend/src/hooks/leaflet/useLeafletMapConfig.ts
@@ -278,7 +278,12 @@ const useLeafletMapConfig = ({
                             ? row[valueFieldId]?.value.raw
                             : 1;
                         const numericValue = Number(rawValue);
-                        const isNumeric = !isNaN(numericValue);
+                        // Check for null/undefined/empty explicitly since Number(null) = 0, Number('') = 0
+                        const isNumeric =
+                            rawValue !== null &&
+                            rawValue !== undefined &&
+                            rawValue !== '' &&
+                            !isNaN(numericValue);
                         const value = isNumeric ? numericValue : null;
                         const displayValue = valueFieldId
                             ? (row[valueFieldId]?.value.formatted ??


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19883, PROD-2840

### Description:

Allow setting no data color on scatter maps

<img width="1188" height="522" alt="Screenshot 2026-02-02 at 16 40 09" src="https://github.com/user-attachments/assets/87ef2c05-7ccc-4584-9b83-bba099a531bf" />

