### PR TITLE
feat: increase tree node spacing in metrics canvas

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
@@ -127,7 +127,7 @@ const getNodeLayout = (
     const treeGraph = new Dagre.graphlib.Graph().setDefaultEdgeLabel(
         () => ({}),
     );
-    treeGraph.setGraph({ rankdir: 'TB' });
+    treeGraph.setGraph({ rankdir: 'TB', ranksep: 100 });
 
     // Main padding
     const mainPadding = 8;


### PR DESCRIPTION
### Description:
Increased the vertical spacing between nodes in the metrics catalog canvas by setting the `ranksep` parameter to 100 in the Dagre graph layout configuration. This provides better visual separation between nodes in the tree graph.

#### After
![CleanShot 2026-02-02 at 16.46.16@2x.png](https://app.graphite.com/user-attachments/assets/1eeb0a35-c2d3-4231-b838-ed6e2582f760.png)

#### Before
![CleanShot 2026-02-02 at 16.46.31@2x.png](https://app.graphite.com/user-attachments/assets/8531fd73-49f3-4a8f-b778-e6112f56af52.png)


