### PR TITLE
feat: allow csv import filter values

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.module.css
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.module.css
@@ -1,0 +1,45 @@
+.moreValuesPill {
+    cursor: pointer;
+}
+
+.dropdownRefresh {
+    cursor: pointer;
+    border-top: 1px solid var(--mantine-color-ldGray-2);
+    position: sticky;
+    bottom: calc(var(--mantine-spacing-xs) / 2);
+    z-index: 10;
+    background-color: light-dark(
+        var(--mantine-color-white),
+        var(--mantine-color-dark-6)
+    );
+    box-shadow: 0 -1px 0 0 var(--mantine-color-ldGray-2);
+    padding-top: var(--mantine-spacing-xs);
+    border-radius: 0;
+    margin-top: var(--mantine-spacing-xs);
+}
+
+.dropdownRefresh:hover {
+    background-color: var(--mantine-color-ldGray-1);
+}
+
+.multiSelectInput {
+    max-height: 350px;
+    overflow-y: auto;
+}
+
+.rightSectionGroup {
+    margin-right: var(--mantine-spacing-xs);
+    margin-top: calc(var(--mantine-spacing-xs) / 2);
+    justify-content: flex-end;
+    align-items: flex-start;
+}
+
+/* Custom selected state for dropdown items when values are truncated */
+/* This ensures hidden values (beyond display limit) still show as selected */
+.multiSelectItemSelected {
+    background-color: var(--mantine-color-blue-6);
+    color: var(--mantine-color-white);
+    &:hover {
+        background-color: var(--mantine-color-blue-7) !important;
+    }
+}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
@@ -1,0 +1,262 @@
+import {
+    DimensionType,
+    FieldType,
+    type FilterableItem,
+} from '@lightdash/common';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import FilterStringAutoComplete from './FilterStringAutoComplete';
+
+// Mock the hooks
+vi.mock('../useFiltersContext', () => ({
+    default: vi.fn(() => ({
+        projectUuid: 'test-project-uuid',
+        getAutocompleteFilterGroup: vi.fn(() => undefined),
+        parameterValues: {},
+    })),
+}));
+
+vi.mock('../../../../hooks/useFieldValues', () => ({
+    MAX_AUTOCOMPLETE_RESULTS: 100,
+    useFieldValues: vi.fn(() => ({
+        isInitialLoading: false,
+        results: new Set<string>(),
+        refreshedAt: new Date(),
+        refetch: vi.fn(),
+        error: null,
+        isError: false,
+    })),
+}));
+
+vi.mock('../../../../hooks/health/useHealth', () => ({
+    default: vi.fn(() => ({
+        data: { hasCacheAutocompleResults: false },
+    })),
+}));
+
+const mockField: FilterableItem = {
+    name: 'test_field',
+    type: DimensionType.STRING,
+    table: 'test_table',
+    tableLabel: 'Test Table',
+    label: 'Test Field',
+    fieldType: FieldType.DIMENSION,
+    sql: 'test_field',
+    hidden: false,
+};
+
+const createValues = (count: number) =>
+    Array.from({ length: count }, (_, i) => `value-${i}`);
+
+describe('FilterStringAutoComplete', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('truncation behavior', () => {
+        it('shows "+N more" pill when values exceed inline limit', async () => {
+            const values = createValues(100);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            // Should show the "+50 more" pill
+            expect(screen.getByText('+50 more')).toBeInTheDocument();
+        });
+
+        it('shows all values when below inline limit', async () => {
+            const values = createValues(10);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            // Should not show "+N more" pill
+            expect(screen.queryByText(/more$/)).not.toBeInTheDocument();
+
+            // All values should be visible
+            values.forEach((value) => {
+                expect(screen.getByText(value)).toBeInTheDocument();
+            });
+        });
+    });
+
+    describe('data preservation in truncated mode', () => {
+        it('preserves hidden values when removing a displayed value', async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const values = createValues(100);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            // Find the remove button on the first value pill (it's aria-hidden, so we query by class)
+            const firstValuePill = screen.getByText('value-0');
+            // eslint-disable-next-line testing-library/no-node-access
+            const pillContainer = firstValuePill.closest(
+                '.mantine-MultiSelect-value',
+            );
+            // eslint-disable-next-line testing-library/no-node-access
+            const removeButton = pillContainer?.querySelector('button');
+
+            expect(removeButton).toBeTruthy();
+            await user.click(removeButton!);
+
+            // onChange should be called with 99 values (all except value-0)
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalled();
+            });
+
+            const calledWith = onChange.mock.calls[0][0];
+            expect(calledWith).toHaveLength(99);
+            expect(calledWith).not.toContain('value-0');
+            // Hidden values should be preserved
+            expect(calledWith).toContain('value-50');
+            expect(calledWith).toContain('value-99');
+        });
+
+        it('preserves hidden values when adding a new value via keyboard', async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            const values = createValues(60);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={['new-suggestion']}
+                    onChange={onChange}
+                />,
+            );
+
+            // Focus on the input using fireEvent (bypasses pointer-events check)
+            const input = screen.getByRole('searchbox');
+            fireEvent.focus(input);
+
+            // Type a new value and press Enter
+            await user.type(input, 'brand-new-value{Enter}');
+
+            await waitFor(() => {
+                expect(onChange).toHaveBeenCalled();
+            });
+
+            const calledWith = onChange.mock.calls[0][0];
+            // Should have original 60 + 1 new = 61 values
+            expect(calledWith).toHaveLength(61);
+            expect(calledWith).toContain('brand-new-value');
+            // Hidden values should be preserved
+            expect(calledWith).toContain('value-50');
+            expect(calledWith).toContain('value-59');
+        });
+    });
+
+    describe('summary mode', () => {
+        it('shows summary text input when values exceed summary threshold', async () => {
+            const values = createValues(600);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            // Should show summary text
+            expect(
+                screen.getByDisplayValue('600 values selected'),
+            ).toBeInTheDocument();
+
+            // Should show "Manage values" button
+            expect(
+                screen.getByRole('button', { name: 'Manage values' }),
+            ).toBeInTheDocument();
+        });
+    });
+
+    describe('manage values modal', () => {
+        it('opens modal when clicking "+N more" pill', async () => {
+            const values = createValues(100);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            // Click the "+50 more" pill - use fireEvent to bypass pointer-events check
+            const morePill = screen.getByText('+50 more');
+            fireEvent.mouseDown(morePill);
+
+            // Modal should open
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Manage filter values'),
+                ).toBeInTheDocument();
+            });
+        });
+
+        it('opens modal from summary mode manage values button', async () => {
+            const user = userEvent.setup({ pointerEventsCheck: 0 });
+            // Use > 500 values to trigger summary mode
+            const values = createValues(600);
+            const onChange = vi.fn();
+
+            renderWithProviders(
+                <FilterStringAutoComplete
+                    filterId="test-filter"
+                    field={mockField}
+                    values={values}
+                    suggestions={[]}
+                    onChange={onChange}
+                />,
+            );
+
+            // In summary mode, there's a visible "Manage values" button
+            const manageButton = screen.getByRole('button', {
+                name: 'Manage values',
+            });
+            await user.click(manageButton);
+
+            // Modal should open
+            await waitFor(() => {
+                expect(
+                    screen.getByText('Manage filter values'),
+                ).toBeInTheDocument();
+            });
+        });
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.utils.test.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.utils.test.ts
@@ -1,0 +1,269 @@
+import { describe, expect, it } from 'vitest';
+import {
+    computeDisplayValues,
+    computeHiddenCount,
+    INLINE_RENDER_LIMIT,
+    isValueSelected,
+    mergeWithHiddenValues,
+    MORE_VALUES_TOKEN,
+    wasTokenRemoved,
+} from './FilterStringAutoComplete.utils';
+
+describe('FilterStringAutoComplete utils', () => {
+    describe('computeHiddenCount', () => {
+        it('returns 0 when values are below limit', () => {
+            const values = Array.from({ length: 30 }, (_, i) => `value-${i}`);
+            expect(computeHiddenCount(values)).toBe(0);
+        });
+
+        it('returns 0 when values are exactly at limit', () => {
+            const values = Array.from(
+                { length: INLINE_RENDER_LIMIT },
+                (_, i) => `value-${i}`,
+            );
+            expect(computeHiddenCount(values)).toBe(0);
+        });
+
+        it('returns correct count when values exceed limit', () => {
+            const values = Array.from({ length: 100 }, (_, i) => `value-${i}`);
+            expect(computeHiddenCount(values)).toBe(50);
+        });
+
+        it('handles empty array', () => {
+            expect(computeHiddenCount([])).toBe(0);
+        });
+    });
+
+    describe('computeDisplayValues', () => {
+        it('returns all values when below limit', () => {
+            const values = ['a', 'b', 'c'];
+            expect(computeDisplayValues(values)).toEqual(['a', 'b', 'c']);
+        });
+
+        it('returns all values for singleValue mode regardless of count', () => {
+            const values = Array.from({ length: 100 }, (_, i) => `value-${i}`);
+            expect(computeDisplayValues(values, true)).toEqual(values);
+        });
+
+        it('truncates and adds token when exceeding limit', () => {
+            const values = Array.from({ length: 100 }, (_, i) => `value-${i}`);
+            const result = computeDisplayValues(values);
+
+            expect(result).toHaveLength(INLINE_RENDER_LIMIT + 1);
+            expect(result[INLINE_RENDER_LIMIT]).toBe(MORE_VALUES_TOKEN);
+            expect(result.slice(0, INLINE_RENDER_LIMIT)).toEqual(
+                values.slice(0, INLINE_RENDER_LIMIT),
+            );
+        });
+
+        it('returns all values when exactly at limit', () => {
+            const values = Array.from(
+                { length: INLINE_RENDER_LIMIT },
+                (_, i) => `value-${i}`,
+            );
+            expect(computeDisplayValues(values)).toEqual(values);
+        });
+    });
+
+    describe('mergeWithHiddenValues', () => {
+        const createValues = (count: number) =>
+            Array.from({ length: count }, (_, i) => `value-${i}`);
+
+        it('returns cleaned values when not truncated', () => {
+            const allValues = ['a', 'b', 'c'];
+            const displayValues = ['a', 'b', 'c'];
+            const updatedValues = ['a', 'c', 'd']; // removed b, added d
+
+            expect(
+                mergeWithHiddenValues(updatedValues, displayValues, allValues),
+            ).toEqual(['a', 'c', 'd']);
+        });
+
+        it('preserves hidden values when adding a new value', () => {
+            // 100 values total, display shows first 50 + token
+            const allValues = createValues(100);
+            const displayValues = [
+                ...allValues.slice(0, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+            ];
+            // User adds 'new-value' to the displayed values
+            const updatedValues = [
+                ...allValues.slice(0, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+                'new-value',
+            ];
+
+            const result = mergeWithHiddenValues(
+                updatedValues,
+                displayValues,
+                allValues,
+            );
+
+            // Should have: first 50 + 'new-value' + hidden 50 = 101 values
+            expect(result).toHaveLength(101);
+            // First 50 should be preserved
+            expect(result.slice(0, INLINE_RENDER_LIMIT)).toEqual(
+                allValues.slice(0, INLINE_RENDER_LIMIT),
+            );
+            // new-value should be at position 50
+            expect(result[INLINE_RENDER_LIMIT]).toBe('new-value');
+            // Hidden values (50-99) should be preserved at the end
+            expect(result.slice(INLINE_RENDER_LIMIT + 1)).toEqual(
+                allValues.slice(INLINE_RENDER_LIMIT),
+            );
+        });
+
+        it('preserves hidden values when removing a displayed value', () => {
+            const allValues = createValues(100);
+            const displayValues = [
+                ...allValues.slice(0, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+            ];
+            // User removes value-0 from displayed values
+            const updatedValues = [
+                ...allValues.slice(1, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+            ];
+
+            const result = mergeWithHiddenValues(
+                updatedValues,
+                displayValues,
+                allValues,
+            );
+
+            // Should have: 49 displayed + 50 hidden = 99 values
+            expect(result).toHaveLength(99);
+            // value-0 should be gone
+            expect(result).not.toContain('value-0');
+            // Hidden values should be preserved
+            expect(result.slice(INLINE_RENDER_LIMIT - 1)).toEqual(
+                allValues.slice(INLINE_RENDER_LIMIT),
+            );
+        });
+
+        it('filters out the MORE_VALUES_TOKEN from result', () => {
+            const allValues = createValues(100);
+            const displayValues = [
+                ...allValues.slice(0, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+            ];
+            const updatedValues = [...displayValues];
+
+            const result = mergeWithHiddenValues(
+                updatedValues,
+                displayValues,
+                allValues,
+            );
+
+            expect(result).not.toContain(MORE_VALUES_TOKEN);
+        });
+
+        it('handles removing multiple displayed values', () => {
+            const allValues = createValues(100);
+            const displayValues = [
+                ...allValues.slice(0, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+            ];
+            // Remove first 5 values
+            const updatedValues = [
+                ...allValues.slice(5, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+            ];
+
+            const result = mergeWithHiddenValues(
+                updatedValues,
+                displayValues,
+                allValues,
+            );
+
+            // Should have: 45 displayed + 50 hidden = 95 values
+            expect(result).toHaveLength(95);
+            // First 5 should be gone
+            expect(result).not.toContain('value-0');
+            expect(result).not.toContain('value-4');
+            // value-5 should be first
+            expect(result[0]).toBe('value-5');
+        });
+
+        it('handles edge case with exactly INLINE_RENDER_LIMIT + 1 values', () => {
+            const allValues = createValues(INLINE_RENDER_LIMIT + 1);
+            const displayValues = [
+                ...allValues.slice(0, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+            ];
+            const updatedValues = [
+                ...allValues.slice(0, INLINE_RENDER_LIMIT),
+                MORE_VALUES_TOKEN,
+                'new-value',
+            ];
+
+            const result = mergeWithHiddenValues(
+                updatedValues,
+                displayValues,
+                allValues,
+            );
+
+            // First 50 + new-value + 1 hidden = 52 values
+            expect(result).toHaveLength(INLINE_RENDER_LIMIT + 2);
+            expect(result).toContain('new-value');
+            expect(result).toContain(`value-${INLINE_RENDER_LIMIT}`);
+        });
+    });
+
+    describe('isValueSelected', () => {
+        it('returns true for values in the array', () => {
+            const values = ['a', 'b', 'c'];
+            expect(isValueSelected('b', values)).toBe(true);
+        });
+
+        it('returns false for values not in the array', () => {
+            const values = ['a', 'b', 'c'];
+            expect(isValueSelected('d', values)).toBe(false);
+        });
+
+        it('returns false for MORE_VALUES_TOKEN', () => {
+            const values = [MORE_VALUES_TOKEN, 'a', 'b'];
+            expect(isValueSelected(MORE_VALUES_TOKEN, values)).toBe(false);
+        });
+
+        it('returns true for hidden values (beyond display limit)', () => {
+            const values = Array.from({ length: 100 }, (_, i) => `value-${i}`);
+            // value-75 is in the hidden portion
+            expect(isValueSelected('value-75', values)).toBe(true);
+        });
+    });
+
+    describe('wasTokenRemoved', () => {
+        it('returns true when token was removed and there are hidden values', () => {
+            const displayValues = ['a', 'b', MORE_VALUES_TOKEN];
+            const updatedValues = ['a', 'b'];
+            expect(wasTokenRemoved(displayValues, updatedValues, 10)).toBe(
+                true,
+            );
+        });
+
+        it('returns false when token is still present', () => {
+            const displayValues = ['a', 'b', MORE_VALUES_TOKEN];
+            const updatedValues = ['a', 'b', MORE_VALUES_TOKEN, 'c'];
+            expect(wasTokenRemoved(displayValues, updatedValues, 10)).toBe(
+                false,
+            );
+        });
+
+        it('returns false when there were no hidden values', () => {
+            const displayValues = ['a', 'b', MORE_VALUES_TOKEN];
+            const updatedValues = ['a', 'b'];
+            expect(wasTokenRemoved(displayValues, updatedValues, 0)).toBe(
+                false,
+            );
+        });
+
+        it('returns false when token was never present', () => {
+            const displayValues = ['a', 'b'];
+            const updatedValues = ['a'];
+            expect(wasTokenRemoved(displayValues, updatedValues, 10)).toBe(
+                false,
+            );
+        });
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.utils.ts
@@ -1,0 +1,99 @@
+export const INLINE_RENDER_LIMIT = 50;
+export const SUMMARY_MODE_THRESHOLD = 500;
+export const MORE_VALUES_TOKEN = '__lightdash_more_values__';
+
+/**
+ * Computes display values for the MultiSelect component.
+ * When there are more than INLINE_RENDER_LIMIT values, truncates to first N items
+ * and appends a token representing the hidden items.
+ */
+export const computeDisplayValues = (
+    values: string[],
+    singleValue?: boolean,
+): string[] => {
+    if (singleValue) return values;
+    const hiddenCount = Math.max(values.length - INLINE_RENDER_LIMIT, 0);
+    if (hiddenCount <= 0) return values;
+    return [...values.slice(0, INLINE_RENDER_LIMIT), MORE_VALUES_TOKEN];
+};
+
+/**
+ * Computes the hidden count (values beyond the display limit).
+ */
+export const computeHiddenCount = (values: string[]): number =>
+    Math.max(values.length - INLINE_RENDER_LIMIT, 0);
+
+/**
+ * Handles value changes from the MultiSelect, preserving hidden values when truncated.
+ *
+ * When values are truncated (>50 items), the MultiSelect only sees the first 50.
+ * This function ensures that:
+ * 1. Hidden values are preserved when adding new values
+ * 2. If a user removes a displayed value, it's also removed from hidden if present
+ * 3. Data loss is prevented when interacting with truncated lists
+ *
+ * @param updatedValues - The new values from MultiSelect onChange
+ * @param displayValues - The values currently shown in MultiSelect (truncated + token)
+ * @param allValues - The full list of all values (including hidden)
+ * @returns The merged list preserving hidden values
+ */
+export const mergeWithHiddenValues = (
+    updatedValues: string[],
+    displayValues: string[],
+    allValues: string[],
+): string[] => {
+    const hiddenCount = computeHiddenCount(allValues);
+
+    // Remove the token from the updated values
+    const cleaned = updatedValues.filter((v) => v !== MORE_VALUES_TOKEN);
+
+    // If not truncated, just return cleaned values
+    if (hiddenCount <= 0) {
+        return cleaned;
+    }
+
+    // Get hidden values (beyond display limit)
+    const hiddenValues = allValues.slice(INLINE_RENDER_LIMIT);
+
+    // Find which displayed values were removed
+    const displayedWithoutToken = displayValues.filter(
+        (v) => v !== MORE_VALUES_TOKEN,
+    );
+    const removedFromDisplayed = displayedWithoutToken.filter(
+        (v) => !cleaned.includes(v),
+    );
+
+    // Filter hidden values to exclude any that were removed
+    const finalHidden = hiddenValues.filter(
+        (v) => !removedFromDisplayed.includes(v),
+    );
+
+    // Merge displayed values with preserved hidden values
+    return [...cleaned, ...finalHidden];
+};
+
+/**
+ * Checks if a value is selected, considering the full values array.
+ * This is used to fix the dropdown selection state for hidden values.
+ */
+export const isValueSelected = (
+    itemValue: string,
+    allValues: string[],
+): boolean => {
+    if (itemValue === MORE_VALUES_TOKEN) return false;
+    return allValues.includes(itemValue);
+};
+
+/**
+ * Determines if the "more values" token was removed (user pressed backspace on truncated list).
+ * In this case, we should open the manage values modal instead of removing values.
+ */
+export const wasTokenRemoved = (
+    displayValues: string[],
+    updatedValues: string[],
+    hiddenCount: number,
+): boolean => {
+    const hadToken = displayValues.includes(MORE_VALUES_TOKEN);
+    const hasToken = updatedValues.includes(MORE_VALUES_TOKEN);
+    return hadToken && !hasToken && hiddenCount > 0;
+};

--- a/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.module.css
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.module.css
@@ -1,0 +1,42 @@
+.container {
+    border: 1px solid var(--mantine-color-ldGray-4);
+    border-radius: var(--mantine-radius-md);
+}
+
+.header {
+    padding: var(--mantine-spacing-sm);
+    border-bottom: 1px solid var(--mantine-color-ldGray-4);
+    background-color: var(--mantine-color-ldGray-0);
+    border-radius: var(--mantine-radius-md);
+    border-bottom-left-radius: 0;
+    border-bottom-right-radius: 0;
+}
+
+.headerRow {
+    align-items: center;
+    gap: var(--mantine-spacing-sm);
+}
+
+.headerSearch {
+    flex: 1;
+}
+
+.scrollContainer {
+    height: 360px;
+    overflow: auto;
+}
+
+.virtualInner {
+    position: relative;
+    width: 100%;
+}
+
+.row {
+    position: absolute;
+    left: 0;
+    right: 0;
+}
+
+.emptyState {
+    height: 100%;
+}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.test.tsx
@@ -1,0 +1,105 @@
+import { screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import { ManageFilterValuesModal } from './ManageFilterValuesModal';
+import { parseDelimitedValues } from './ManageFilterValuesModal.utils';
+
+describe('ManageFilterValuesModal', () => {
+    it('applies unique values and closes', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        const onClose = vi.fn();
+
+        renderWithProviders(
+            <ManageFilterValuesModal
+                opened
+                onClose={onClose}
+                values={['alpha', 'alpha', 'beta']}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+        expect(onChange).toHaveBeenCalledWith(['alpha', 'beta']);
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('clears all values and shows empty state', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        const onClose = vi.fn();
+
+        renderWithProviders(
+            <ManageFilterValuesModal
+                opened
+                onClose={onClose}
+                values={['alpha', 'beta']}
+                onChange={onChange}
+            />,
+        );
+
+        const clearAllButton = screen.getByRole('button', {
+            name: 'Clear all',
+        });
+        await user.click(clearAllButton);
+
+        expect(await screen.findByText('No values yet')).toBeInTheDocument();
+        expect(clearAllButton).toBeDisabled();
+    });
+
+    it('does not apply changes when cancelled', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        const onClose = vi.fn();
+
+        renderWithProviders(
+            <ManageFilterValuesModal
+                opened
+                onClose={onClose}
+                values={['alpha', 'beta']}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByRole('button', { name: 'Clear all' }));
+        await user.click(screen.getByRole('button', { name: 'Cancel' }));
+
+        expect(onChange).not.toHaveBeenCalled();
+        expect(onClose).toHaveBeenCalledTimes(1);
+    });
+
+    it('applies only selected values', async () => {
+        const user = userEvent.setup();
+        const onChange = vi.fn();
+        const onClose = vi.fn();
+
+        renderWithProviders(
+            <ManageFilterValuesModal
+                opened
+                onClose={onClose}
+                values={['alpha', 'beta']}
+                onChange={onChange}
+            />,
+        );
+
+        await user.click(screen.getByLabelText('Select all shown'));
+        await user.click(screen.getByRole('button', { name: 'Apply' }));
+
+        expect(onChange).toHaveBeenCalledWith([]);
+    });
+
+    it('parses delimited values with optional header', () => {
+        expect(parseDelimitedValues('value\nalpha\nbeta\nbeta\n')).toEqual([
+            'alpha',
+            'beta',
+            'beta',
+        ]);
+        expect(parseDelimitedValues('values,alpha, beta')).toEqual([
+            'alpha',
+            'beta',
+        ]);
+        expect(parseDelimitedValues('alpha\tbeta')).toEqual(['alpha', 'beta']);
+    });
+});

--- a/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.tsx
@@ -1,0 +1,328 @@
+import {
+    Box,
+    Button,
+    Center,
+    Checkbox,
+    FileButton,
+    getDefaultZIndex,
+    Group,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import {
+    IconClearAll,
+    IconFileUpload,
+    IconSettings,
+} from '@tabler/icons-react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import uniq from 'lodash/uniq';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import MantineIcon from '../../MantineIcon';
+import MantineModal from '../../MantineModal';
+import classes from './ManageFilterValuesModal.module.css';
+import { parseDelimitedValues } from './ManageFilterValuesModal.utils';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    values: string[];
+    onChange: (values: string[]) => void;
+    title?: string;
+};
+
+export const ManageFilterValuesModal: FC<Props> = ({
+    opened,
+    onClose,
+    values,
+    onChange,
+    title = 'Manage values',
+}) => {
+    const scrollRef = useRef<HTMLDivElement | null>(null);
+    const originalValuesRef = useRef<string[]>([]);
+
+    const valuesNormalized = useMemo(() => uniq(values), [values]);
+    const [draftValues, setDraftValues] = useState<string[]>([]);
+    const [search, setSearch] = useState('');
+    const [selected, setSelected] = useState<Set<string>>(new Set());
+
+    const workingValues = useMemo(() => uniq(draftValues), [draftValues]);
+    const filteredValues = useMemo(() => {
+        const q = search.trim().toLowerCase();
+        if (q.length === 0) return workingValues;
+        return workingValues.filter((v) => v.toLowerCase().includes(q));
+    }, [search, workingValues]);
+    const shownCount = filteredValues.length;
+    const selectedCount = selected.size;
+    const isAllShownSelected = shownCount > 0 && selectedCount === shownCount;
+    const isSomeShownSelected = selectedCount > 0 && selectedCount < shownCount;
+
+    const virtualizer = useVirtualizer({
+        count: filteredValues.length,
+        getScrollElement: () => scrollRef.current,
+        estimateSize: () => 36,
+        overscan: 8,
+    });
+
+    // Initialize a draft snapshot when opening the modal.
+    useEffect(() => {
+        if (!opened) return;
+        originalValuesRef.current = valuesNormalized;
+        setDraftValues(valuesNormalized);
+        setSearch('');
+        setSelected(new Set(valuesNormalized));
+    }, [opened, valuesNormalized]);
+
+    // Ensure the virtualizer measures after open/layout changes.
+    useEffect(() => {
+        if (!opened) return;
+        const raf = requestAnimationFrame(() => {
+            virtualizer.measure();
+        });
+        return () => cancelAnimationFrame(raf);
+    }, [opened, virtualizer, filteredValues.length]);
+
+    const handleClearAll = useCallback(() => {
+        setDraftValues([]);
+        setSelected(new Set());
+    }, []);
+
+    const handleCancel = useCallback(() => {
+        setDraftValues([]);
+        setSearch('');
+        setSelected(new Set());
+        onClose();
+    }, [onClose]);
+
+    const handleApply = useCallback(() => {
+        const selectedValues = workingValues.filter((value) =>
+            selected.has(value),
+        );
+        onChange(selectedValues);
+        onClose();
+    }, [onChange, onClose, selected, workingValues]);
+
+    const handleCsvFileChange = useCallback(async (file: File | null) => {
+        if (!file) return;
+
+        const text = await file.text();
+        const parsedUnique = uniq(parseDelimitedValues(text));
+        if (parsedUnique.length === 0) return;
+
+        // Append to the current draft by default
+        setDraftValues((prev) => uniq([...prev, ...parsedUnique]));
+    }, []);
+
+    const toggleSelected = useCallback((value: string) => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            if (next.has(value)) next.delete(value);
+            else next.add(value);
+            return next;
+        });
+    }, []);
+
+    const selectAllVisible = useCallback(() => {
+        setSelected((prev) => {
+            const next = new Set(prev);
+            filteredValues.forEach((v) => next.add(v));
+            return next;
+        });
+    }, [filteredValues]);
+
+    const clearSelection = useCallback(() => {
+        setSelected(new Set());
+    }, []);
+
+    const isClearAllDisabled = workingValues.length === 0;
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={handleCancel}
+            onCancel={handleCancel}
+            title={title}
+            icon={IconSettings}
+            size="lg"
+            cancelLabel="Cancel"
+            confirmLabel="Apply"
+            onConfirm={handleApply}
+            modalRootProps={{ zIndex: getDefaultZIndex('modal') + 1000 }}
+            leftActions={
+                <Tooltip label="Clear all values">
+                    <Button
+                        variant="default"
+                        leftSection={<MantineIcon icon={IconClearAll} />}
+                        onClick={handleClearAll}
+                        disabled={isClearAllDisabled}
+                    >
+                        Clear all
+                    </Button>
+                </Tooltip>
+            }
+        >
+            <Stack gap="sm">
+                <Group gap="xs" justify="space-between" align="center">
+                    <Text fw={500}>
+                        {workingValues.length.toLocaleString()} values
+                        <Text span c="dimmed" size="xs" ta="center" maw={300}>
+                            {' '}
+                            ({selected.size.toLocaleString()} selected)
+                        </Text>
+                    </Text>
+
+                    <FileButton
+                        onChange={handleCsvFileChange}
+                        accept=".csv,.txt,text/csv,text/plain"
+                        inputProps={{ 'aria-label': 'Import CSV file' }}
+                    >
+                        {(props) => (
+                            <Button
+                                {...props}
+                                size="xs"
+                                variant="light"
+                                leftSection={
+                                    <MantineIcon icon={IconFileUpload} />
+                                }
+                            >
+                                Import CSV
+                            </Button>
+                        )}
+                    </FileButton>
+                </Group>
+
+                <Box className={classes.container}>
+                    <Group className={classes.header} wrap="nowrap">
+                        <Group className={classes.headerRow} wrap="nowrap">
+                            <Checkbox
+                                size="xs"
+                                aria-label="Select all shown"
+                                checked={isAllShownSelected}
+                                indeterminate={isSomeShownSelected}
+                                onChange={() => {
+                                    if (isAllShownSelected) {
+                                        clearSelection();
+                                    } else {
+                                        selectAllVisible();
+                                    }
+                                }}
+                            />
+                            <Text fw={500}>Selections</Text>
+                        </Group>
+                        <Box className={classes.headerSearch}>
+                            <TextInput
+                                size="xs"
+                                placeholder="Search values…"
+                                value={search}
+                                onChange={(e) =>
+                                    setSearch(e.currentTarget.value)
+                                }
+                            />
+                        </Box>
+                    </Group>
+
+                    <Box ref={scrollRef} className={classes.scrollContainer}>
+                        {filteredValues.length === 0 ? (
+                            <Center className={classes.emptyState}>
+                                <Stack gap="xs" align="center">
+                                    <Text fw={500}>
+                                        {workingValues.length === 0
+                                            ? 'No values yet'
+                                            : 'No matches'}
+                                    </Text>
+                                    <Text
+                                        c="dimmed"
+                                        size="xs"
+                                        ta="center"
+                                        maw={300}
+                                    >
+                                        {workingValues.length === 0
+                                            ? 'Import a CSV to populate this filter, then you can review and remove items here.'
+                                            : 'Try a different search.'}
+                                    </Text>
+                                    <FileButton
+                                        onChange={handleCsvFileChange}
+                                        accept=".csv,.txt,text/csv,text/plain"
+                                        inputProps={{
+                                            'aria-label': 'Import CSV file',
+                                        }}
+                                    >
+                                        {(props) => (
+                                            <Button
+                                                {...props}
+                                                size="xs"
+                                                variant="default"
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconFileUpload}
+                                                    />
+                                                }
+                                            >
+                                                Import CSV
+                                            </Button>
+                                        )}
+                                    </FileButton>
+                                </Stack>
+                            </Center>
+                        ) : (
+                            <Box
+                                className={classes.virtualInner}
+                                h={virtualizer.getTotalSize()}
+                            >
+                                {virtualizer
+                                    .getVirtualItems()
+                                    .map((virtualRow) => {
+                                        const value =
+                                            filteredValues[virtualRow.index];
+                                        if (value === undefined) return null;
+                                        const checked = selected.has(value);
+                                        return (
+                                            <Box
+                                                key={value}
+                                                className={classes.row}
+                                                style={{
+                                                    transform: `translateY(${virtualRow.start}px)`,
+                                                    height: `${virtualRow.size}px`,
+                                                }}
+                                            >
+                                                <Group
+                                                    h={36}
+                                                    gap="xs"
+                                                    px="sm"
+                                                    wrap="nowrap"
+                                                >
+                                                    <Checkbox
+                                                        checked={checked}
+                                                        aria-label={`Select ${value}`}
+                                                        onChange={() =>
+                                                            toggleSelected(
+                                                                value,
+                                                            )
+                                                        }
+                                                    />
+                                                    <Text
+                                                        size="sm"
+                                                        lineClamp={1}
+                                                    >
+                                                        {value}
+                                                    </Text>
+                                                </Group>
+                                            </Box>
+                                        );
+                                    })}
+                            </Box>
+                        )}
+                    </Box>
+                </Box>
+            </Stack>
+        </MantineModal>
+    );
+};

--- a/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.utils.ts
@@ -1,0 +1,18 @@
+export const parseDelimitedValues = (raw: string): string[] => {
+    const parsed = raw
+        .replace(/\r\n/g, '\n')
+        .replace(/\t/g, ',')
+        .split(/,|\n/)
+        .map((s) => s.trim())
+        .filter((s) => s.length > 0);
+
+    if (
+        parsed.length > 1 &&
+        (parsed[0].toLowerCase() === 'value' ||
+            parsed[0].toLowerCase() === 'values')
+    ) {
+        return parsed.slice(1);
+    }
+
+    return parsed;
+};

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.module.css
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.module.css
@@ -30,3 +30,12 @@
         border-bottom-right-radius: 0px;
     }
 }
+
+.additionalValuesList {
+    @mixin light {
+        background-color: var(--mantine-color-ldDark-8);
+    }
+    @mixin dark {
+        background-color: var(--mantine-color-ldDark-1);
+    }
+}

--- a/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
+++ b/packages/frontend/src/features/dashboardFilters/ActiveFilters/Filter.tsx
@@ -10,8 +10,10 @@ import {
     Badge,
     Box,
     Button,
+    HoverCard,
     Indicator,
     Popover,
+    ScrollArea,
     Text,
     Tooltip,
 } from '@mantine-8/core';
@@ -372,25 +374,49 @@ const Filter: FC<Props> = ({
                                                         : filterRuleLabels?.value}
                                                 </Text>
                                                 {truncatedValuesDisplay.hasMore && (
-                                                    <Tooltip
+                                                    <HoverCard
                                                         withinPortal
                                                         position="bottom"
-                                                        label={
-                                                            <Box>
-                                                                <Text
-                                                                    fz="xs"
-                                                                    fw={500}
-                                                                    c="dimmed"
-                                                                >
-                                                                    Additional
-                                                                    values (
-                                                                    {
-                                                                        truncatedValuesDisplay
-                                                                            .additionalValues
-                                                                            .length
-                                                                    }
-                                                                    )
-                                                                </Text>
+                                                        classNames={{
+                                                            dropdown:
+                                                                classes.additionalValuesList,
+                                                        }}
+                                                    >
+                                                        <HoverCard.Target>
+                                                            <Badge
+                                                                size="sm"
+                                                                variant="light"
+                                                                color="gray"
+                                                                ml={4}
+                                                            >
+                                                                +
+                                                                {
+                                                                    truncatedValuesDisplay
+                                                                        .additionalValues
+                                                                        .length
+                                                                }
+                                                            </Badge>
+                                                        </HoverCard.Target>
+                                                        <HoverCard.Dropdown>
+                                                            <Text
+                                                                fz="xs"
+                                                                fw={500}
+                                                                c="ldGray.5"
+                                                            >
+                                                                Additional
+                                                                values (
+                                                                {
+                                                                    truncatedValuesDisplay
+                                                                        .additionalValues
+                                                                        .length
+                                                                }
+                                                                )
+                                                            </Text>
+                                                            <ScrollArea.Autosize
+                                                                mah={200}
+                                                                type="always"
+                                                                scrollbars="y"
+                                                            >
                                                                 {truncatedValuesDisplay.additionalValues.map(
                                                                     (
                                                                         val,
@@ -401,6 +427,7 @@ const Filter: FC<Props> = ({
                                                                                 idx
                                                                             }
                                                                             fz="xs"
+                                                                            c="white"
                                                                         >
                                                                             •{' '}
                                                                             {
@@ -409,23 +436,9 @@ const Filter: FC<Props> = ({
                                                                         </Text>
                                                                     ),
                                                                 )}
-                                                            </Box>
-                                                        }
-                                                    >
-                                                        <Badge
-                                                            size="sm"
-                                                            variant="light"
-                                                            color="gray"
-                                                            ml={4}
-                                                        >
-                                                            +
-                                                            {
-                                                                truncatedValuesDisplay
-                                                                    .additionalValues
-                                                                    .length
-                                                            }
-                                                        </Badge>
-                                                    </Tooltip>
+                                                            </ScrollArea.Autosize>
+                                                        </HoverCard.Dropdown>
+                                                    </HoverCard>
                                                 )}
                                             </>
                                         )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2418](https://linear.app/lightdash/issue/PROD-2418/i-want-an-option-to-upload-a-csv-of-values-for-filters)

### Description:
Enhances the filter string autocomplete component with improved handling for large value sets:

- Added a "Manage Values" modal for bulk editing filter values
- Implemented CSV import functionality for easily adding multiple values
- Created a summary view for filters with more than 500 values
- Limited inline display to 50 values with a "+X more" pill for better performance
- Added a sticky "Refresh" button at the bottom of dropdown results
- Improved UI with hover actions and better visual organization


https://github.com/user-attachments/assets/fb8f20ed-87c6-4132-9503-40850efdc438

