### PR TITLE
fix: check for parentPath existence in isLightdashContentFile

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -159,6 +159,7 @@ const writeContent = async (
 
 const isLightdashContentFile = (folder: string, entry: Dirent) =>
     entry.isFile() &&
+    entry.parentPath &&
     entry.parentPath.endsWith(path.sep + folder) &&
     entry.name.endsWith('.yml') &&
     !entry.name.endsWith('.language.map.yml');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Added a null check for `entry.parentPath` in the `isLightdashContentFile` function to prevent potential errors when processing directory entries that might not have a defined parent path.