### PR TITLE
fix: respect metric order in pivoted table

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -921,7 +921,8 @@ export const convertSqlPivotedRowsToPivotData = ({
     // Get unique base metrics from valuesColumns, preserving order
     const baseMetricsArray = filteredValuesColumns
         .map((col) => col.referenceField)
-        .filter((field, index, self) => self.indexOf(field) === index);
+        .filter((field, index, self) => self.indexOf(field) === index)
+        .sort((a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b));
 
     const headerValueTypes = getHeaderValueTypes({
         metricsAsRows: pivotConfig.metricsAsRows,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19838, #19919

### Description:

When using 'metrics as rows', the pivoted table viz was not respecting the order specified by users in the results table. Now it does. 

Test steps:
- Pivot a table
- Use metrics as rows
- Order in the pivot table (vertical) should match order in the results table (horizontal)


![Kapture 2026-02-02 at 18 42 41](https://github.com/user-attachments/assets/e6767de9-5196-4015-90b1-3a2fe1a24503)
