### PR TITLE
style: mantine migration part 1

### DIFF
--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -1,4 +1,4 @@
-import { Stack } from '@mantine/core';
+import { Stack } from '@mantine-8/core';
 import { useMemo, type FC } from 'react';
 import { Navigate, useParams, useRoutes, type RouteObject } from 'react-router';
 import CompilationHistory from '../components/CompilationHistory';
@@ -100,7 +100,7 @@ const ProjectSettings: FC = () => {
         <>
             <DocumentTitle title="Project Settings" />
 
-            <Stack spacing="xl">
+            <Stack gap="xl">
                 <PageBreadcrumbs
                     items={[
                         {

--- a/packages/frontend/src/pages/ViewSqlChart.tsx
+++ b/packages/frontend/src/pages/ViewSqlChart.tsx
@@ -10,7 +10,7 @@ import {
     SegmentedControl,
     Stack,
     Text,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconChartHistogram, IconTable } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState } from 'react';
 import { Provider } from 'react-redux';
@@ -117,55 +117,48 @@ const ViewSqlChart = () => {
             withFullHeight
             header={<Header mode="view" />}
         >
-            <Paper
-                shadow="none"
-                radius={0}
-                px="md"
-                pb={0}
-                pt="sm"
-                sx={{
-                    flex: 1,
-                }}
-            >
+            <Paper shadow="none" radius={0} px="md" pb={0} pt="sm" flex={1}>
                 <Stack h="100%">
-                    <Group position="apart">
-                        <Group position="apart">
+                    <Group justify="space-between">
+                        <Group justify="space-between">
                             <SegmentedControl
-                                styles={(theme) => ({
-                                    root: {
-                                        backgroundColor: theme.colors.ldGray[2],
-                                    },
-                                })}
-                                size="sm"
+                                color="ldGray.9"
+                                size="xs"
                                 radius="md"
                                 disabled={isChartResultsLoading}
                                 data={[
                                     {
                                         value: TabOption.CHART,
                                         label: (
-                                            <Group spacing="xs" noWrap>
+                                            <Group gap="xs" wrap="nowrap">
                                                 <MantineIcon
                                                     icon={IconChartHistogram}
                                                 />
-                                                <Text>Chart</Text>
+                                                <Text fz="sm" fw={500}>
+                                                    Chart
+                                                </Text>
                                             </Group>
                                         ),
                                     },
                                     {
                                         value: TabOption.RESULTS,
                                         label: (
-                                            <Group spacing="xs" noWrap>
+                                            <Group gap="xs" wrap="nowrap">
                                                 <MantineIcon icon={IconTable} />
-                                                <Text>Results</Text>
+                                                <Text fz="sm" fw={500}>
+                                                    Results
+                                                </Text>
                                             </Group>
                                         ),
                                     },
                                 ]}
                                 value={activeTab}
-                                onChange={(val: TabOption) => setActiveTab(val)}
+                                onChange={(value: string) =>
+                                    setActiveTab(value as TabOption)
+                                }
                             />
                         </Group>
-                        <Group position="apart">
+                        <Group justify="space-between">
                             <Parameters
                                 isEditMode={false}
                                 parameters={projectParameters}
@@ -235,13 +228,7 @@ const ViewSqlChart = () => {
                     )}
 
                     {chartData && !isChartLoading && (
-                        <Box
-                            h="100%"
-                            sx={{
-                                position: 'relative',
-                                flex: 1,
-                            }}
-                        >
+                        <Box h="100%" pos="relative" flex={1}>
                             <ConditionalVisibility
                                 isVisible={activeTab === TabOption.CHART}
                             >

--- a/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
+++ b/packages/frontend/src/providers/SupportDrawer/SupportDrawerContent.tsx
@@ -8,7 +8,7 @@ import {
     Stack,
     Text,
     Textarea,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { modals } from '@mantine/modals';
 import { IconIdOff } from '@tabler/icons-react';
 import html2canvas from 'html2canvas-pro';
@@ -108,7 +108,7 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
     }, [includeImage, screenshot, allowAccess, moreDetails, showToastSuccess]);
 
     return (
-        <Stack spacing="xs">
+        <Stack gap="xs">
             <Checkbox
                 label="Include this image"
                 checked={screenshotError ? false : includeImage}
@@ -126,12 +126,7 @@ const SupportDrawerContent: FC<SupportDrawerContentProps> = () => {
                 />
             ) : (
                 <Paper p="lg" withBorder h={200}>
-                    <Stack
-                        h="100%"
-                        align="center"
-                        justify="center"
-                        spacing="xs"
-                    >
+                    <Stack h="100%" align="center" justify="center" gap="xs">
                         {screenshotError ? (
                             <>
                                 <MantineIcon icon={IconIdOff} color="ldGray" />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->



### Description:
Migrated from Mantine v6 to Mantine v8 by updating import paths and component props:

- Updated imports from `@mantine/core` to `@mantine-8/core`
- Changed `spacing` prop to `gap` on Stack components
- Updated Group component props from `position="apart"` to `justify="space-between"`
- Replaced `noWrap` with `wrap="nowrap"` on Group components
- Simplified styling by using shorthand props (e.g., `flex`, `pos`) instead of `sx` objects
- Updated SegmentedControl styling and onChange handler typing
- Enhanced text styling with explicit font size and weight props