### PR TITLE
fix: add missing check when filtering scheduler logs

### DIFF
--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -1748,6 +1748,7 @@ export class SchedulerModel {
             .whereRaw(
                 `${SchedulerLogTableName}.job_id = ${SchedulerLogTableName}.job_group`,
             )
+            .whereNot(`${SchedulerLogTableName}.scheduler_uuid`, null)
             .orderBy(`${SchedulerLogTableName}.created_at`, 'asc');
 
         if (!parentJobs || parentJobs.length === 0) {


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Fixes the following error:
```
packages/backend dev: 2026-02-03 08:39:32 [Lightdash] error: Handled error of type NotFoundError on [GET] /api/v1/schedulers/runs/594/logs Scheduler not found
packages/backend dev: 2026-02-03 08:39:32 [Lightdash] error: NotFoundError: Scheduler not found
packages/backend dev:     at SchedulerModel.getScheduler (/usr/app/packages/backend/src/models/SchedulerModel/index.ts:549:19)
packages/backend dev:     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
packages/backend dev:     at async SchedulerService.getRunLogs (/usr/app/packages/backend/src/services/SchedulerService/SchedulerService.ts:1077:27)
packages/backend dev:     at async SchedulerController.getRunLogs (/usr/app/packages/backend/src/controllers/schedulerController.ts:215:22)
packages/backend dev:     at async ExpressTemplateService.apiHandler (/usr/app/node_modules/.pnpm/@tsoa+runtime@6.6.0/node_modules/@tsoa/runtime/src/routeGeneration/templates/express/expressTemplateService.ts:37:20)
packages/backend dev:     at async SchedulerController_getRunLogs (/usr/app/packages/backend/src/generated/routes.ts:35295:17)
```

The error specifically occurs when trying to fetch fetch the scheduler logs for an ad-hoc Google sync. The root cause is that the `scheduler_uuid` is empty for the log with status `scheduled`. Since that's always the first log, the next call fails as the code tries to query the scheduler with uuid `null`.

<img width="1280" height="172" alt="image" src="https://github.com/user-attachments/assets/f9345abb-2a7f-4099-ac10-a4cfe9be5533" />


The quick work around makes sure to skip rows which don't have the `scheduler_uuid`.

### Before:
<img width="1617" height="1062" alt="Before" src="https://github.com/user-attachments/assets/758ed413-3d0a-44af-aa74-b938adc1e29d" />

### After:
<img width="1617" height="1062" alt="After" src="https://github.com/user-attachments/assets/846aa034-fbba-4caa-892b-dd75b6974830" />


### No negative side-effect on scheduled delivery (before and after is the same):
<img width="1617" height="1062" alt="image" src="https://github.com/user-attachments/assets/eda62e67-f24b-434a-9777-713600f7a861" />
