### PR TITLE
feat: implement GitHub repository pagination and improve UI display

### DIFF
--- a/packages/backend/src/services/GithubAppService/GithubAppService.ts
+++ b/packages/backend/src/services/GithubAppService/GithubAppService.ts
@@ -293,9 +293,13 @@ export class GithubAppService extends BaseService {
         const appOctokit = getOctokitRestForApp(installationId);
 
         try {
-            const { data } =
-                await appOctokit.apps.listReposAccessibleToInstallation();
-            return data.repositories.map((repo) => ({
+            // Use pagination to fetch all repositories (default is only 30 per page)
+            // The paginate helper automatically handles the repositories array from the response
+            const repositories = await appOctokit.paginate(
+                'GET /installation/repositories',
+                { per_page: 100 },
+            );
+            return repositories.map((repo) => ({
                 name: repo.name,
                 ownerLogin: repo.owner.login,
                 fullName: repo.full_name,

--- a/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/GithubSettingsPanel/index.tsx
@@ -76,7 +76,7 @@ const GithubSettingsPanel: FC = () => {
             </Box>
 
             <Stack>
-                <Text color="dimmed" fz="xs">
+                <Text c="dimmed" fz="xs">
                     Installing GitHub App allows Lightdash to access your GitHub
                     repositories and create pull requests.
                 </Text>
@@ -91,15 +91,25 @@ const GithubSettingsPanel: FC = () => {
                     </Alert>
                 )}
                 {isValidGithubInstallation && data && data.length > 0 && (
-                    <Text color="dimmed" fz="xs">
-                        Your GitHub integration has access to the following
-                        repositories:
-                        <ul>
-                            {data.map((repo) => (
-                                <li key={repo.fullName}>{repo.fullName}</li>
-                            ))}
-                        </ul>
-                    </Text>
+                    <Stack spacing="xs">
+                        <Text c="dimmed" fz="xs">
+                            Your GitHub integration has access to the following
+                            repositories ({data.length}):
+                        </Text>
+                        <Box mah={200} style={{ overflowY: 'auto' }}>
+                            <Text
+                                component="ul"
+                                fz="xs"
+                                c="dimmed"
+                                m={0}
+                                pl="md"
+                            >
+                                {data.map((repo) => (
+                                    <li key={repo.fullName}>{repo.fullName}</li>
+                                ))}
+                            </Text>
+                        </Box>
+                    </Stack>
                 )}
 
                 {isValidGithubInstallation ? (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2502/github-integration-only-lists-30-repos

Before

<img width="947" height="702" alt="image" src="https://github.com/user-attachments/assets/c18ecb5f-e0e7-4002-90b4-207affb48bb4" />

AFter


<img width="970" height="375" alt="image" src="https://github.com/user-attachments/assets/a37da353-8a24-4f2d-88ec-8a7c025884bf" />

with only 3 repos 

<img width="932" height="234" alt="image" src="https://github.com/user-attachments/assets/48514695-12e7-440c-9277-2473bb5cd0da" />


### Description:
Improved GitHub repository listing by implementing pagination in the GitHub App Service to fetch all repositories instead of just the default 30. The UI has been enhanced to show the total count of repositories and add a scrollable container with a maximum height to handle large numbers of repositories more elegantly.

The changes also include a minor update to the Text component styling, changing from the deprecated `color` prop to the newer `c` prop.