### PR TITLE
feat: support ${TABLE} references in non-aggregate metrics

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -237,7 +237,7 @@ models:
                 - event_id: ">5"
                 - event: "song_played"
             # Example of non-aggregate metric (type: number) with aggregation in SQL
-            # This pattern is common in Looker where type:number measures have
+            # This pattern is common where type:number measures have
             # aggregation functions in their SQL field
             unique_event_count:
               type: number
@@ -248,9 +248,15 @@ models:
               description: "Standard deviation of event IDs using non-aggregate type"
               sql: stddev(${event_id})
             # Example of non-aggregate metric (type: number) that references BOTH
-            # dimensions AND other metrics. This pattern is common in Looker where
+            # dimensions AND other metrics. This pattern is common where
             # type:number measures have SQL like "sum(${dim}) / ${metric}"
             avg_event_id_per_unique:
               type: number
               description: "Average event_id per unique event (combines dimension and metric references)"
               sql: sum(${event_id}) / NULLIF(${unique_event_count}, 0)
+            # Example of non-aggregate metric using ${TABLE} reference
+            # This pattern is common where measures use ${TABLE}.column syntax
+            count_song_played_events:
+              type: number
+              description: "Count of events where event is song_played using TABLE reference"
+              sql: count(case when ${TABLE}.event = 'song_played' then 1 end)

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -143,7 +143,7 @@ test('Should compile with a reference to a metric in a non-aggregate metric', ()
 });
 
 test('Should compile non-aggregate metrics with aggregation in SQL referencing dimensions', () => {
-    // This tests the Looker pattern where type:number metrics have aggregation
+    // This tests the pattern where type:number metrics have aggregation
     // functions in their SQL (e.g., "count(distinct ${user_id})").
     // These should be allowed to reference dimensions.
     expect(
@@ -154,7 +154,7 @@ test('Should compile non-aggregate metrics with aggregation in SQL referencing d
 });
 
 test('Should compile non-aggregate metrics with aggregation in SQL referencing BOTH dimensions AND metrics', () => {
-    // This tests the Looker pattern where type:number metrics have aggregation
+    // This tests the pattern where type:number metrics have aggregation
     // and reference both dimensions and other metrics in the same SQL.
     // For example: "sum(${amount}) / ${user_count}" where amount is a dimension
     // and user_count is a metric.

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -58,7 +58,7 @@ type Reference = {
 /**
  * Regex pattern to detect SQL aggregation functions.
  * Used to allow dimension references in non-aggregate metrics when
- * the SQL itself contains an aggregation function (common Looker pattern).
+ * the SQL itself contains an aggregation function (common pattern).
  *
  * Matches: sum(, count(, avg(, etc. with word boundary to avoid false positives
  * like "summary" matching "sum".
@@ -70,7 +70,7 @@ const SQL_AGGREGATION_FUNCTIONS_PATTERN =
  * Check if the SQL contains any aggregation functions.
  *
  * This is used to determine if a non-aggregate metric with dimension references
- * should be allowed. In Looker, it's common to define metrics as type:number
+ * should be allowed. It's common to define metrics as type:number
  * with aggregation functions in the SQL field. These are valid in Lightdash
  * because the aggregation happens in the SQL itself.
  *
@@ -797,7 +797,7 @@ export class ExploreCompiler {
                 // - Post-calculation metrics can ONLY reference other metrics
                 // - Non-aggregate metrics without aggregation can only reference other metrics
                 // - Non-aggregate metrics that have aggregation in their SQL can
-                //   reference BOTH dimensions AND metrics (common Looker pattern like
+                //   reference BOTH dimensions AND metrics (common pattern like
                 //   type:number with sql: "sum(${dim}) / ${metric}")
                 // - Aggregate metrics can only reference dimensions
                 const isNonAggregate = isNonAggregateMetric(metric);
@@ -842,7 +842,15 @@ export class ExploreCompiler {
                 } else if (hasAggregationInSql) {
                     // Non-aggregate metrics WITH SQL aggregation can reference both
                     // dimensions and metrics - detect based on what the reference actually is
-                    if (isDimensionRef) {
+                    // Handle TABLE reference first (common pattern: ${TABLE}.column)
+                    if (p1 === 'TABLE') {
+                        compiledReference = this.compileDimensionReference(
+                            p1,
+                            tables,
+                            metric.table,
+                            fieldContext,
+                        );
+                    } else if (isDimensionRef) {
                         compiledReference = this.compileDimensionReference(
                             p1,
                             tables,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2868/bug-dollartable-syntax-in-metrics-throws-references-table-which-is

>               sql: count(case when ${TABLE}.event = 'song_played' then 1 end)

Before
<img width="773" height="139" alt="Screenshot from 2026-02-03 12-05-47" src="https://github.com/user-attachments/assets/6f95faf3-0ec8-4fe9-b710-b0d5823b0f06" />


After
<img width="1525" height="866" alt="Screenshot from 2026-02-03 12-10-00" src="https://github.com/user-attachments/assets/a1910229-6db5-4959-9f2b-cafeb7b59d39" />



### Description:
Added support for `${TABLE}` references in non-aggregate metrics with SQL aggregation. This pattern is commonly used in Looker where measures use `${TABLE}.column` syntax. The PR includes:

1. Enhanced the `ExploreCompiler` to handle `${TABLE}` references before checking for dimension or metric references
2. Added an example in the jaffle-shop demo that demonstrates this pattern with a `count_song_played_events` metric