### PR TITLE
fix: default chart legend to scroll

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/index.tsx
@@ -186,10 +186,13 @@ export const Legend: FC<Props> = ({ items }) => {
                             <Group spacing="xs">
                                 <Config.Label>Scroll behavior</Config.Label>
                                 <SegmentedControl
-                                    value={dirtyEchartsConfig?.legend?.type}
+                                    value={
+                                        dirtyEchartsConfig?.legend?.type ??
+                                        'scroll'
+                                    }
                                     data={[
-                                        { label: 'Default', value: 'plain' },
                                         { label: 'Scroll', value: 'scroll' },
+                                        { label: 'Wrap', value: 'plain' },
                                     ]}
                                     onChange={(value) =>
                                         handleChange('type', value)


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19887

### Description:

**Issue**
Chart legends were defaulting to 'Scroll' behavior, instead of the option labeled 'Default'

**Fix**
- Changed the default to Scroll. Should be backwards compatible, and that's what we generally want anyway. 
- Changed the name of 'Default' to 'Wrap'. It's not the default, and that also doesnt mean much. 

<img width="277" height="302" alt="Screenshot 2026-02-03 at 14 32 51" src="https://github.com/user-attachments/assets/91b10359-8c3f-4981-9358-7855af9ebf37" />

