### PR TITLE
feat: allow editors to send scheduled deliveries they didn't create

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulersListItem.tsx
@@ -68,7 +68,15 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
             }),
         );
     }, [user.data, activeProjectUuid, scheduler.createdBy]);
-
+    const userCanCreateScheduledDelivery = useMemo(() => {
+        return user.data?.ability?.can(
+            'create',
+            subject('ScheduledDeliveries', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid: activeProjectUuid,
+            }),
+        );
+    }, [user.data, activeProjectUuid]);
     if (!project) {
         return null;
     }
@@ -97,6 +105,19 @@ const SchedulersListItem: FC<SchedulersListItemProps> = ({
                         </Text>
                     </Group>
                 </Stack>
+                {!userCanManageScheduledDelivery &&
+                    userCanCreateScheduledDelivery && (
+                        <Tooltip withinPortal label="Send now">
+                            <ActionIcon
+                                variant="light"
+                                onClick={() => setIsConfirmSendNowOpen(true)}
+                                radius="md"
+                                color="ldDark.9"
+                            >
+                                <MantineIcon color="ldDark.9" icon={IconSend} />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
                 {userCanManageScheduledDelivery && (
                     <Group wrap="nowrap" gap="xs">
                         <Tooltip


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2849/i-should-be-allowed-to-send-now-from-scheduled-deliveries-even-if-im

Before
<img width="803" height="431" alt="Screenshot from 2026-02-03 15-17-01" src="https://github.com/user-attachments/assets/36578883-b68a-48d9-9882-1caa3418f6ff" />

After

<img width="803" height="431" alt="Screenshot from 2026-02-03 15-23-13" src="https://github.com/user-attachments/assets/0d3cfcd2-1e5f-46a3-83cd-30bb288f8527" />

### Description:
Allow editors to send scheduled deliveries they didn't create themselves by checking for 'create' permissions instead of 'manage' permissions when using the "Send Now" feature. This enables more flexibility for team collaboration on scheduled reports.

Added a "Send Now" button for users who can create but not manage scheduled deliveries, giving editors the ability to trigger immediate delivery of reports without needing full management permissions.