### PR TITLE
feat: prevent deletion of YAML-defined metric tree edges

### DIFF
--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -1586,6 +1586,7 @@ export class CatalogModel {
                 target_metric_catalog_search_uuid: `${MetricsTreeEdgesTableName}.target_metric_catalog_search_uuid`,
                 created_at: `${MetricsTreeEdgesTableName}.created_at`,
                 created_by_user_uuid: `${MetricsTreeEdgesTableName}.created_by_user_uuid`,
+                source: `${MetricsTreeEdgesTableName}.source`,
                 source_metric_name: `source_metric.name`,
                 source_metric_table_name: `source_metric.table_name`,
                 target_metric_name: `target_metric.name`,
@@ -1631,6 +1632,7 @@ export class CatalogModel {
                 createdAt: e.created_at,
                 createdByUserUuid: e.created_by_user_uuid,
                 projectUuid,
+                createdFrom: e.source,
             })),
         };
     }
@@ -1652,6 +1654,7 @@ export class CatalogModel {
                 project_uuid: `${MetricsTreeEdgesTableName}.project_uuid`,
                 created_at: `${MetricsTreeEdgesTableName}.created_at`,
                 created_by_user_uuid: `${MetricsTreeEdgesTableName}.created_by_user_uuid`,
+                source: `${MetricsTreeEdgesTableName}.source`,
                 source_metric_name: `source_metric.name`,
                 source_metric_table_name: `source_metric.table_name`,
                 target_metric_name: `target_metric.name`,
@@ -1683,6 +1686,7 @@ export class CatalogModel {
             createdAt: e.created_at,
             createdByUserUuid: e.created_by_user_uuid,
             projectUuid: e.project_uuid,
+            createdFrom: e.source,
         }));
     }
 

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -121,12 +121,15 @@ export type CatalogMetricsTreeNode = Pick<
     'catalogSearchUuid' | 'name' | 'tableName'
 >;
 
+export type CatalogMetricsTreeEdgeSource = 'ui' | 'yaml';
+
 export type CatalogMetricsTreeEdge = {
     source: CatalogMetricsTreeNode;
     target: CatalogMetricsTreeNode;
     createdAt: Date;
     createdByUserUuid: string | null;
     projectUuid: string;
+    createdFrom: CatalogMetricsTreeEdgeSource;
 };
 
 export type ApiCatalogResults = CatalogItem[];

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
@@ -1,10 +1,20 @@
+import { type CatalogMetricsTreeEdgeSource } from '@lightdash/common';
 import { useMantineTheme } from '@mantine/core';
-import { BaseEdge, getSimpleBezierPath, type EdgeProps } from '@xyflow/react';
+import {
+    BaseEdge,
+    getSimpleBezierPath,
+    type Edge,
+    type EdgeProps,
+} from '@xyflow/react';
 import type { FC } from 'react';
 
 const ARROW_SIZE = 8;
 
-const DefaultEdge: FC<EdgeProps> = ({
+type DefaultEdgeData = Edge<{
+    createdFrom?: CatalogMetricsTreeEdgeSource;
+}>;
+
+const DefaultEdge: FC<EdgeProps<DefaultEdgeData>> = ({
     sourceX,
     sourceY,
     targetX,
@@ -40,7 +50,9 @@ const DefaultEdge: FC<EdgeProps> = ({
                     markerUnits="strokeWidth"
                 >
                     <path
-                        d={`M0,0 L0,${ARROW_SIZE} L${ARROW_SIZE},${ARROW_SIZE / 2} z`}
+                        d={`M0,0 L0,${ARROW_SIZE} L${ARROW_SIZE},${
+                            ARROW_SIZE / 2
+                        } z`}
                         fill={strokeColor}
                     />
                 </marker>


### PR DESCRIPTION
### Description:

Added support for tracking the source of metric tree edges, distinguishing between edges created via UI and those defined in YAML files. This allows the UI to prevent users from deleting YAML-defined edges, displaying a helpful toast message that instructs them to update their YAML files instead.

![CleanShot 2026-02-03 at 16.36.06@2x.png](https://app.graphite.com/user-attachments/assets/8fe85c39-740d-4798-8d65-9c270cf960c5.png)

