### PR TITLE
feat: view compiled sql for metric tree metric total

### DIFF
--- a/packages/backend/src/controllers/metricsExplorerController.ts
+++ b/packages/backend/src/controllers/metricsExplorerController.ts
@@ -1,4 +1,5 @@
 import {
+    ApiCompiledQueryResults,
     ApiErrorPayload,
     MetricExplorerQuery,
     MetricTotalComparisonType,
@@ -108,6 +109,50 @@ export class MetricsExplorerController extends BaseController {
         const results = await this.services
             .getMetricsExplorerService()
             .getMetricTotal(
+                req.user!,
+                projectUuid,
+                explore,
+                metric,
+                timeFrame,
+                granularity,
+                startDate,
+                endDate,
+                body?.comparisonType,
+            );
+
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Compile the metric total query SQL
+     * @summary Compile metric total query
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{explore}/{metric}/compileMetricTotalQuery')
+    @OperationId('compileMetricTotalQuery')
+    async compileMetricTotalQuery(
+        @Path() projectUuid: string,
+        @Path() explore: string,
+        @Path() metric: string,
+        @Request() req: express.Request,
+        @Query() timeFrame: TimeFrames,
+        @Query() granularity: TimeFrames,
+        @Query() startDate: string,
+        @Query() endDate: string,
+        @Body()
+        body?: {
+            comparisonType?: MetricTotalComparisonType;
+        },
+    ): Promise<{ status: 'ok'; results: ApiCompiledQueryResults }> {
+        this.setStatus(200);
+
+        const results = await this.services
+            .getMetricsExplorerService()
+            .compileMetricTotalQuery(
                 req.user!,
                 projectUuid,
                 explore,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7398,7 +7398,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7421,7 +7421,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                chartUsage:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7450,17 +7450,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7489,7 +7489,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7497,7 +7497,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7512,7 +7516,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7520,11 +7524,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7656,7 +7656,7 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7679,7 +7679,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    chartUsage:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7708,17 +7708,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -20374,6 +20374,27 @@ const models: TsoaRoute.Models = {
         enums: ['none', 'previous_period'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCompiledQueryResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                compilationErrors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
+                parameterReferences: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                pivotQuery: { dataType: 'string' },
+                query: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiGroupResponse: {
         dataType: 'refAlias',
         type: {
@@ -21078,27 +21099,6 @@ const models: TsoaRoute.Models = {
     ApiExploreResults: {
         dataType: 'refAlias',
         type: { ref: 'Omit_Explore.unfilteredTables_', validators: {} },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ApiCompiledQueryResults: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                compilationErrors: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                },
-                parameterReferences: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
-                pivotQuery: { dataType: 'string' },
-                query: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiPromoteDashboardResponse: {
@@ -21905,11 +21905,27 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    CatalogMetricsTreeEdgeSource: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['ui'] },
+                { dataType: 'enum', enums: ['yaml'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     CatalogMetricsTreeEdge: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                createdFrom: {
+                    ref: 'CatalogMetricsTreeEdgeSource',
+                    required: true,
+                },
                 projectUuid: { dataType: 'string', required: true },
                 createdByUserUuid: {
                     dataType: 'union',
@@ -41632,6 +41648,111 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'runMetricTotal',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsMetricsExplorerController_compileMetricTotalQuery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        explore: {
+            in: 'path',
+            name: 'explore',
+            required: true,
+            dataType: 'string',
+        },
+        metric: {
+            in: 'path',
+            name: 'metric',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        timeFrame: {
+            in: 'query',
+            name: 'timeFrame',
+            required: true,
+            ref: 'TimeFrames',
+        },
+        granularity: {
+            in: 'query',
+            name: 'granularity',
+            required: true,
+            ref: 'TimeFrames',
+        },
+        startDate: {
+            in: 'query',
+            name: 'startDate',
+            required: true,
+            dataType: 'string',
+        },
+        endDate: {
+            in: 'query',
+            name: 'endDate',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                comparisonType: { ref: 'MetricTotalComparisonType' },
+            },
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/metricsExplorer/:explore/:metric/compileMetricTotalQuery',
+        ...fetchMiddlewares<RequestHandler>(MetricsExplorerController),
+        ...fetchMiddlewares<RequestHandler>(
+            MetricsExplorerController.prototype.compileMetricTotalQuery,
+        ),
+
+        async function MetricsExplorerController_compileMetricTotalQuery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsMetricsExplorerController_compileMetricTotalQuery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<MetricsExplorerController>(
+                        MetricsExplorerController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'compileMetricTotalQuery',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8223,12 +8223,12 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -8236,10 +8236,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8248,8 +8248,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8259,16 +8259,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -8343,12 +8343,12 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "searchRank": {
+                                                                                    "chartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -8356,10 +8356,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8368,8 +8368,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -21152,6 +21152,30 @@
                 "enum": ["none", "previous_period"],
                 "type": "string"
             },
+            "ApiCompiledQueryResults": {
+                "properties": {
+                    "compilationErrors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "parameterReferences": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "pivotQuery": {
+                        "type": "string"
+                    },
+                    "query": {
+                        "type": "string"
+                    }
+                },
+                "required": ["parameterReferences", "query"],
+                "type": "object"
+            },
             "ApiGroupResponse": {
                 "properties": {
                     "results": {
@@ -21854,30 +21878,6 @@
             },
             "ApiExploreResults": {
                 "$ref": "#/components/schemas/Omit_Explore.unfilteredTables_"
-            },
-            "ApiCompiledQueryResults": {
-                "properties": {
-                    "compilationErrors": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "parameterReferences": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
-                    "pivotQuery": {
-                        "type": "string"
-                    },
-                    "query": {
-                        "type": "string"
-                    }
-                },
-                "required": ["parameterReferences", "query"],
-                "type": "object"
             },
             "ApiPromoteDashboardResponse": {
                 "properties": {
@@ -22675,8 +22675,15 @@
             "CatalogMetricsTreeNode": {
                 "$ref": "#/components/schemas/Pick_CatalogField.catalogSearchUuid-or-name-or-tableName_"
             },
+            "CatalogMetricsTreeEdgeSource": {
+                "type": "string",
+                "enum": ["ui", "yaml"]
+            },
             "CatalogMetricsTreeEdge": {
                 "properties": {
+                    "createdFrom": {
+                        "$ref": "#/components/schemas/CatalogMetricsTreeEdgeSource"
+                    },
                     "projectUuid": {
                         "type": "string"
                     },
@@ -22696,6 +22703,7 @@
                     }
                 },
                 "required": [
+                    "createdFrom",
                     "projectUuid",
                     "createdByUserUuid",
                     "createdAt",
@@ -24663,7 +24671,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2410.1",
+        "version": "0.2415.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -35464,6 +35472,121 @@
                 },
                 "description": "Run a metric total query with comparison",
                 "summary": "Run metric total query",
+                "tags": ["Metrics Explorer", "Metrics", "Explorer"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "explore",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "metric",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "timeFrame",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/TimeFrames"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "granularity",
+                        "required": true,
+                        "schema": {
+                            "$ref": "#/components/schemas/TimeFrames"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "startDate",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "endDate",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": false,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "comparisonType": {
+                                        "$ref": "#/components/schemas/MetricTotalComparisonType"
+                                    }
+                                },
+                                "type": "object"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/metricsExplorer/{explore}/{metric}/compileMetricTotalQuery": {
+            "post": {
+                "operationId": "compileMetricTotalQuery",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "#/components/schemas/ApiCompiledQueryResults"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": ["ok"],
+                                            "nullable": false
+                                        }
+                                    },
+                                    "required": ["results", "status"],
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Compile the metric total query SQL",
+                "summary": "Compile metric total query",
                 "tags": ["Metrics Explorer", "Metrics", "Explorer"],
                 "security": [],
                 "parameters": [

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
@@ -26,6 +26,7 @@ import { calculateComparisonValue } from '../../../../../../hooks/useBigNumberCo
 import { useAppSelector } from '../../../../../sqlRunner/store/hooks';
 import { useRunMetricTotal } from '../../../../hooks/useRunMetricExplorerQuery';
 import { useChangeIndicatorStyles } from '../../../../styles/useChangeIndicatorStyles';
+import { MetricDetailPopover } from '../../../MetricDetailPopover';
 
 const ChangeIndicator: FC<{ change: number; formattedChange: string }> = ({
     change,
@@ -94,6 +95,19 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
         },
     });
 
+    const compiledQueryConfig = useMemo(
+        () =>
+            dateRange
+                ? {
+                      timeFrame: data.timeFrame,
+                      granularity: TimeFrames.DAY, // TODO: this should be dynamic
+                      comparisonType: MetricTotalComparisonType.PREVIOUS_PERIOD,
+                      dateRange,
+                  }
+                : undefined,
+        [data.timeFrame, dateRange],
+    );
+
     const change = useMemo(() => {
         const value = totalQuery.data?.value;
         const compareValue = totalQuery.data?.comparisonValue;
@@ -150,24 +164,20 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
                     <Title fz={14} fw={500} c="ldGray.7">
                         {title}
                     </Title>
-                    <Tooltip
-                        label={
-                            <>
-                                <Text size="xs" fw="bold">
-                                    Table:{' '}
-                                    <Text span fw="normal">
-                                        {data.tableName}
-                                    </Text>
-                                </Text>
-                            </>
-                        }
-                    >
-                        <MantineIcon
-                            icon={IconInfoCircle}
-                            size={12}
-                            color="ldGray.7"
-                        />
-                    </Tooltip>
+                    {projectUuid && (
+                        <MetricDetailPopover
+                            projectUuid={projectUuid}
+                            tableName={data.tableName}
+                            metricName={data.metricName}
+                            compiledQueryConfig={compiledQueryConfig}
+                        >
+                            <MantineIcon
+                                icon={IconInfoCircle}
+                                size={12}
+                                color="ldGray.7"
+                            />
+                        </MetricDetailPopover>
+                    )}
                 </Group>
 
                 {totalQuery.isFetching ? (

--- a/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
+++ b/packages/frontend/src/features/metricsCatalog/hooks/useRunMetricExplorerQuery.ts
@@ -1,5 +1,6 @@
 import {
     METRICS_EXPLORER_DATE_FORMAT,
+    type ApiCompiledQueryResults,
     type ApiMetricsExplorerQueryResults,
     type ApiMetricsExplorerTotalResults,
     type FilterRule,
@@ -168,6 +169,32 @@ const postRunMetricTotal = async ({
     });
 };
 
+const postCompileMetricTotalQuery = async ({
+    projectUuid,
+    exploreName,
+    metricName,
+    dateRange,
+    timeFrame,
+    granularity,
+    comparisonType,
+}: RunMetricTotalArgs) => {
+    const queryString = getUrlParams({
+        dateRange,
+        timeFrame,
+        granularity,
+    });
+
+    return lightdashApi<ApiCompiledQueryResults>({
+        url: `/projects/${projectUuid}/metricsExplorer/${exploreName}/${metricName}/compileMetricTotalQuery${
+            queryString ? `?${queryString}` : ''
+        }`,
+        method: 'POST',
+        body: JSON.stringify({
+            comparisonType,
+        }),
+    });
+};
+
 export const useRunMetricTotal = ({
     projectUuid,
     exploreName,
@@ -194,6 +221,44 @@ export const useRunMetricTotal = ({
         ],
         queryFn: () =>
             postRunMetricTotal({
+                projectUuid: projectUuid!,
+                exploreName: exploreName!,
+                metricName: metricName!,
+                dateRange: dateRange!,
+                timeFrame: timeFrame!,
+                granularity: granularity!,
+                comparisonType: comparisonType!,
+            }),
+        ...options,
+    });
+};
+
+export const useCompileMetricTotalQuery = ({
+    projectUuid,
+    exploreName,
+    metricName,
+    dateRange,
+    timeFrame,
+    granularity,
+    comparisonType,
+    options,
+}: Partial<RunMetricTotalArgs> & {
+    options?: UseQueryOptions<ApiCompiledQueryResults>;
+}) => {
+    return useQuery({
+        queryKey: [
+            'compileMetricTotalQuery',
+            projectUuid,
+            exploreName,
+            metricName,
+            dateRange?.[0],
+            dateRange?.[1],
+            timeFrame,
+            granularity,
+            comparisonType,
+        ],
+        queryFn: () =>
+            postCompileMetricTotalQuery({
                 projectUuid: projectUuid!,
                 exploreName: exploreName!,
                 metricName: metricName!,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added a new API endpoint to compile metric total queries, allowing users to see the SQL behind metric calculations. This enhances transparency by exposing the underlying SQL that powers metric totals in the metrics explorer.

The implementation includes:

- New `compileMetricTotalQuery` endpoint in the MetricsExplorerController
- Supporting service method in MetricsExplorerService
- Frontend components to display the compiled SQL in a popover
- Integration with the existing metrics explorer UI to show SQL when viewing metric details
