### PR TITLE
feat: allow switching time frames on metric tree

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -85,6 +85,11 @@ export enum FeatureFlags {
      * inherit permissions from their root space.
      */
     NestedSpacesPermissions = 'nested-spaces-permissions',
+
+    /**
+     * Enable tree/list mode switcher in Metrics Catalog
+     */
+    MetricsCatalogTreeModeSwitcher = 'metrics-catalog-tree-mode-switcher',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/utils/metricsExplorer.test.ts
+++ b/packages/common/src/utils/metricsExplorer.test.ts
@@ -1,0 +1,45 @@
+import dayjs from 'dayjs';
+import { TimeFrames } from '../types/timeFrames';
+import { getDateCalcUtils } from './metricsExplorer';
+
+const formatDate = (date: Date) => dayjs(date).format('YYYY-MM-DD');
+
+describe('getDateCalcUtils', () => {
+    test('day shift', () => {
+        const { back, forward } = getDateCalcUtils(
+            TimeFrames.DAY,
+            TimeFrames.DAY,
+        );
+        const base = new Date('2026-03-31T00:00:00Z');
+        expect(formatDate(back(base))).toBe('2026-03-30');
+        expect(formatDate(forward(base))).toBe('2026-04-01');
+    });
+
+    test('week shift', () => {
+        const { back, forward } = getDateCalcUtils(
+            TimeFrames.WEEK,
+            TimeFrames.WEEK,
+        );
+        const base = new Date('2026-03-31T00:00:00Z');
+        expect(formatDate(back(base))).toBe('2026-03-24');
+        expect(formatDate(forward(base))).toBe('2026-04-07');
+    });
+
+    test('month shift clamps end of month', () => {
+        const { back, forward } = getDateCalcUtils(
+            TimeFrames.MONTH,
+            TimeFrames.MONTH,
+        );
+        const base = new Date('2026-03-31T00:00:00Z');
+        expect(formatDate(back(base))).toBe('2026-02-28');
+        expect(formatDate(forward(new Date('2026-01-31T00:00:00Z')))).toBe(
+            '2026-02-28',
+        );
+    });
+
+    test('year shift clamps leap day', () => {
+        const { back } = getDateCalcUtils(TimeFrames.YEAR, TimeFrames.YEAR);
+        const leap = new Date('2024-02-29T00:00:00Z');
+        expect(formatDate(back(leap))).toBe('2023-02-28');
+    });
+});

--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -107,7 +107,11 @@ export const getFieldIdForDateDimension = (
 export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
     switch (timeFrame) {
         case TimeFrames.MONTH:
-            if (grain && grain !== TimeFrames.DAY) {
+            if (
+                grain &&
+                grain !== TimeFrames.DAY &&
+                grain !== TimeFrames.MONTH
+            ) {
                 throw new Error(
                     `Granularity "${grain}" is not supported yet for this timeframe "${timeFrame}"`,
                 );
@@ -116,6 +120,26 @@ export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
             return {
                 forward: (date: Date) => dayjs(date).add(1, 'month').toDate(),
                 back: (date: Date) => dayjs(date).subtract(1, 'month').toDate(),
+            };
+        case TimeFrames.DAY:
+            if (grain && grain !== TimeFrames.DAY) {
+                throw new Error(
+                    `Granularity "${grain}" is not supported yet for this timeframe "${timeFrame}"`,
+                );
+            }
+            return {
+                forward: (date: Date) => dayjs(date).add(1, 'day').toDate(),
+                back: (date: Date) => dayjs(date).subtract(1, 'day').toDate(),
+            };
+        case TimeFrames.WEEK:
+            if (grain && grain !== TimeFrames.WEEK) {
+                throw new Error(
+                    `Granularity "${grain}" is not supported yet for this timeframe "${timeFrame}"`,
+                );
+            }
+            return {
+                forward: (date: Date) => dayjs(date).add(1, 'week').toDate(),
+                back: (date: Date) => dayjs(date).subtract(1, 'week').toDate(),
             };
         case TimeFrames.YEAR:
             // Handle week shift for previous year comparison and subtract what the amount of weeks is in a year
@@ -139,9 +163,6 @@ export const getDateCalcUtils = (timeFrame: TimeFrames, grain?: TimeFrames) => {
                 forward: (date: Date) => dayjs(date).add(1, 'year').toDate(),
                 back: (date: Date) => dayjs(date).subtract(1, 'year').toDate(),
             };
-        case TimeFrames.DAY:
-        case TimeFrames.WEEK:
-            throw new Error(`Timeframe "${timeFrame}" is not supported yet`);
         default:
             return assertUnimplementedTimeframe(timeFrame);
     }

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/nodes/ExpandedNode.tsx
@@ -28,10 +28,26 @@ import { useRunMetricTotal } from '../../../../hooks/useRunMetricExplorerQuery';
 import { useChangeIndicatorStyles } from '../../../../styles/useChangeIndicatorStyles';
 import { MetricDetailPopover } from '../../../MetricDetailPopover';
 
-const ChangeIndicator: FC<{ change: number; formattedChange: string }> = ({
-    change,
-    formattedChange,
-}) => {
+const getComparisonLabel = (timeFrame: TimeFrames) => {
+    switch (timeFrame) {
+        case TimeFrames.DAY:
+            return 'Current day vs. last day to date';
+        case TimeFrames.WEEK:
+            return 'Current week vs. last week to date';
+        case TimeFrames.MONTH:
+            return 'Current month vs. last month to date';
+        case TimeFrames.YEAR:
+            return 'Current year vs. last year to date';
+        default:
+            return 'Current vs. previous period';
+    }
+};
+
+const ChangeIndicator: FC<{
+    change: number;
+    formattedChange: string;
+    timeFrame: TimeFrames;
+}> = ({ change, formattedChange, timeFrame }) => {
     const { classes } = useChangeIndicatorStyles();
     const indicatorClasses = useMemo(() => {
         if (change === 0) {
@@ -41,7 +57,11 @@ const ChangeIndicator: FC<{ change: number; formattedChange: string }> = ({
     }, [change, classes]);
 
     return (
-        <Tooltip position="bottom" label={'Current vs. Last Month-to-date'}>
+        <Tooltip
+            position="bottom"
+            label={getComparisonLabel(timeFrame)}
+            withinPortal
+        >
             <Badge
                 fz={13}
                 fw={500}
@@ -87,7 +107,7 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
         exploreName: data.tableName,
         metricName: data.metricName,
         timeFrame: data.timeFrame,
-        granularity: TimeFrames.DAY, // TODO: this should be dynamic
+        granularity: data.timeFrame,
         comparisonType: MetricTotalComparisonType.PREVIOUS_PERIOD,
         dateRange,
         options: {
@@ -100,7 +120,7 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
             dateRange
                 ? {
                       timeFrame: data.timeFrame,
-                      granularity: TimeFrames.DAY, // TODO: this should be dynamic
+                      granularity: data.timeFrame,
                       comparisonType: MetricTotalComparisonType.PREVIOUS_PERIOD,
                       dateRange,
                   }
@@ -192,6 +212,7 @@ const ExpandedNode: React.FC<NodeProps<ExpandedNodeData>> = ({
                                 <ChangeIndicator
                                     change={change}
                                     formattedChange={formattedChange}
+                                    timeFrame={data.timeFrame}
                                 />
                             )}
                         </Group>

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/TimeFramePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/TimeFramePicker.tsx
@@ -1,0 +1,60 @@
+import { TimeFrames } from '@lightdash/common';
+import { Select } from '@mantine/core';
+import { IconChevronDown } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import { useSelectStyles } from '../../styles/useSelectStyles';
+
+type TimeFrameOption = {
+    value: TimeFrames;
+    label: string;
+};
+
+const DEFAULT_OPTIONS: TimeFrameOption[] = [
+    { value: TimeFrames.DAY, label: 'Today' },
+    { value: TimeFrames.WEEK, label: 'Current week to date' },
+    { value: TimeFrames.MONTH, label: 'Current month to date' },
+    { value: TimeFrames.YEAR, label: 'Current year to date' },
+];
+
+type Props = {
+    value: TimeFrames;
+    onChange: (value: TimeFrames) => void;
+    options?: TimeFrameOption[];
+    width?: number;
+};
+
+export const TimeFramePicker: FC<Props> = ({
+    value,
+    onChange,
+    options = DEFAULT_OPTIONS,
+    width = 185,
+}) => {
+    const { classes } = useSelectStyles();
+
+    return (
+        <Select
+            w={width}
+            size="xs"
+            radius="md"
+            data={options}
+            value={value}
+            onChange={(val) => {
+                if (val) onChange(val as TimeFrames);
+            }}
+            withinPortal
+            rightSection={
+                <MantineIcon
+                    color="ldGray.7"
+                    icon={IconChevronDown}
+                    size={12}
+                />
+            }
+            classNames={{
+                input: classes.input,
+                item: classes.item,
+                rightSection: classes.rightSection,
+            }}
+        />
+    );
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added support for day, week, and month time frames in the metrics explorer canvas. Users can now select different time frames (Today, Current week to date, Current month to date, Current year to date) from a dropdown in the canvas view. The comparison tooltips now display appropriate labels based on the selected time frame.
