### PR TITLE
fix: add ID to embed dashboard scroll container (regression) 

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -27,6 +27,7 @@ import { EmbedMarkdownTile } from './EmbedMarkdownTile';
 
 // eslint-disable-next-line css-modules/no-unused-class
 import { dashboardCSSVars } from '../../../../../components/common/Dashboard/dashboard.constants';
+// eslint-disable-next-line css-modules/no-unused-class
 import tabStyles from '../../../../../features/dashboardTabs/tabs.module.css';
 import '../../../../../styles/react-grid.css';
 
@@ -317,6 +318,8 @@ const EmbedDashboard: FC<{
 
     return (
         <div
+            // Used by EmbedDashboardExportPdf to temporarily set height:auto for multipage PDF printing
+            id="embed-scroll-container"
             style={
                 containerStyles ?? {
                     height: '100vh',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2878/print-button-in-react-embedded-dashboard-is-only-printing-the-first

Before

<img width="1082" height="733" alt="Screenshot from 2026-02-04 09-09-34" src="https://github.com/user-attachments/assets/2931fb54-2ec2-4f09-958a-09c349053337" />

After 

<img width="1082" height="733" alt="Screenshot from 2026-02-04 09-10-38" src="https://github.com/user-attachments/assets/ede14eba-0196-4acf-af68-7011477f8329" />


### Description:
Added an ID attribute `embed-scroll-container` to the main div in the EmbedDashboard component to enable targeted scrolling functionality for embedded dashboards.