### PR TITLE
perf: optimize chart query to prevent cartesian product explosion

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -255,7 +255,7 @@ jobs:
   build-cypress-e2e-image:
     runs-on: depot-ubuntu-24.04-4
     needs: files-changed
-    if: needs.files-changed.outputs.frontend == 'true' || needs.files-changed.outputs.timezone == 'true'
+    if: needs.files-changed.outputs.frontend == 'true' || needs.files-changed.outputs.timezone == 'true' || needs.files-changed.outputs.backend == 'true'
     name: Build E2E Image
     steps:
       - name: Checkout


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2291/slow-query-findchartsforvalidation


Before

> findChartsForValidation took 2415.598427000001ms with 5658 charts

After


> findChartsForValidation took 1485.7766159999883ms with 5658 charts

### Description:
Optimized chart loading query performance by replacing multiple LEFT JOINs with scalar subqueries to avoid cartesian product issues. The previous implementation joined 6 child tables which caused row explosion (e.g., 5 fields × 2 calculations × 3 metrics = 30+ rows per chart), significantly impacting performance. This change maintains the same functionality while reducing query complexity and improving execution time.