### PR TITLE
fix: prevent filter UI from jumping when editing values

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -7,11 +7,13 @@ import { Select } from '@mantine/core';
 import { type FilterInputsProps } from '.';
 import { getPlaceholderByFilterTypeAndOperator } from '../utils/getPlaceholderByFilterTypeAndOperator';
 import DefaultFilterInputs from './DefaultFilterInputs';
+import { useInitialAutoFocus } from './useInitialAutoFocus';
 
 const BooleanFilterInputs = <T extends BaseFilterRule>(
     props: FilterInputsProps<T>,
 ) => {
     const { rule, onChange, disabled, filterType, popoverProps } = props;
+    const autoFocus = useInitialAutoFocus();
 
     const isFilterRuleDisabled = isFilterRule(rule) && rule.disabled;
 
@@ -34,7 +36,7 @@ const BooleanFilterInputs = <T extends BaseFilterRule>(
                     onDropdownOpen={popoverProps?.onOpen}
                     onDropdownClose={popoverProps?.onClose}
                     disabled={disabled}
-                    autoFocus={true}
+                    autoFocus={autoFocus}
                     initiallyOpened={currentValue === null && !disabled}
                     placeholder={placeholder}
                     data={[

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -27,12 +27,14 @@ import FilterQuarterPicker from './FilterQuarterPicker';
 import FilterUnitOfTimeAutoComplete from './FilterUnitOfTimeAutoComplete';
 import FilterWeekPicker from './FilterWeekPicker';
 import FilterYearPicker from './FilterYearPicker';
+import { useInitialAutoFocus } from './useInitialAutoFocus';
 
 const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
     props: FilterInputsProps<T>,
 ) => {
     const { field, rule, onChange, popoverProps, disabled, filterType } = props;
     const { startOfWeek } = useFiltersContext();
+    const autoFocus = useInitialAutoFocus();
 
     const isTimestamp =
         !field ||
@@ -72,7 +74,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 <FilterWeekPicker
                                     placeholder={placeholder}
                                     disabled={disabled}
-                                    autoFocus={true}
+                                    autoFocus={autoFocus}
                                     value={
                                         rule.values && rule.values[0]
                                             ? parseDate(
@@ -114,7 +116,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                                 // @ts-ignore
                                 placeholder={placeholder}
-                                autoFocus={true}
+                                autoFocus={autoFocus}
                                 popoverProps={popoverProps}
                                 value={
                                     rule.values && rule.values[0]
@@ -146,7 +148,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                             <FilterQuarterPicker
                                 disabled={disabled}
                                 placeholder={placeholder}
-                                autoFocus={true}
+                                autoFocus={autoFocus}
                                 popoverProps={popoverProps}
                                 value={parsedValue}
                                 onChange={(newDate: Date) => {
@@ -166,7 +168,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                                 // @ts-ignore
                                 placeholder={placeholder}
-                                autoFocus={true}
+                                autoFocus={autoFocus}
                                 popoverProps={popoverProps}
                                 value={
                                     rule.values && rule.values[0]
@@ -211,7 +213,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                         // @ts-ignore
                         placeholder={placeholder}
-                        autoFocus={true}
+                        autoFocus={autoFocus}
                         withSeconds
                         // FIXME: mantine v7
                         // mantine does not set the first day of the week based on the locale
@@ -239,7 +241,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     // so we need to do it manually and always pass it as a prop
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     popoverProps={popoverProps}
-                    autoFocus={true}
+                    autoFocus={autoFocus}
                     value={
                         rule.values
                             ? parseDate(
@@ -269,7 +271,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         sx={{ flexShrink: 1, flexGrow: 1 }}
                         placeholder={placeholder}
                         disabled={disabled}
-                        autoFocus={true}
+                        autoFocus={autoFocus}
                         value={isNaN(parsedValue) ? undefined : parsedValue}
                         min={0}
                         onChange={(value) => {
@@ -321,7 +323,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     }
                     showOptionsInPlural={false}
                     showCompletedOptions={false}
-                    autoFocus={!rule.settings?.unitOfTime}
+                    autoFocus={autoFocus && !rule.settings?.unitOfTime}
                     completed={false}
                     withinPortal={popoverProps?.withinPortal}
                     onDropdownOpen={popoverProps?.onOpen}
@@ -342,7 +344,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 return (
                     <FilterDateTimeRangePicker
                         disabled={disabled}
-                        autoFocus={true}
+                        autoFocus={autoFocus}
                         firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                         value={
                             rule.values && rule.values[0] && rule.values[1]
@@ -371,7 +373,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
             return (
                 <FilterDateRangePicker
                     disabled={disabled}
-                    autoFocus={true}
+                    autoFocus={autoFocus}
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     value={
                         rule.values && rule.values[0] && rule.values[1]

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -16,6 +16,7 @@ import FilterMultiStringInput from './FilterMultiStringInput';
 import FilterNumberInput from './FilterNumberInput';
 import FilterNumberRangeInput from './FilterNumberRangeInput';
 import FilterStringAutoComplete from './FilterStringAutoComplete';
+import { useInitialAutoFocus } from './useInitialAutoFocus';
 
 const DefaultFilterInputs = <T extends BaseFilterRule>({
     field,
@@ -26,6 +27,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
     popoverProps,
 }: FilterInputsProps<T>) => {
     const { getField } = useFiltersContext();
+    const autoFocus = useInitialAutoFocus();
     const suggestions = isFilterRule(rule)
         ? getField(rule)?.suggestions
         : undefined;
@@ -60,7 +62,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             limit={FILTER_SELECT_LIMIT}
                             disabled={disabled}
                             placeholder={placeholder}
-                            autoFocus={true}
+                            autoFocus={autoFocus}
                             withinPortal={popoverProps?.withinPortal}
                             onDropdownOpen={popoverProps?.onOpen}
                             onDropdownClose={popoverProps?.onClose}
@@ -78,7 +80,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             filterId={rule.id}
                             disabled={disabled}
                             field={field}
-                            autoFocus={true}
+                            autoFocus={autoFocus}
                             placeholder={placeholder}
                             suggestions={suggestions || []}
                             withinPortal={popoverProps?.withinPortal}
@@ -106,7 +108,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                         return (
                             <FilterNumberInput
                                 disabled={disabled}
-                                autoFocus={true}
+                                autoFocus={autoFocus}
                                 placeholder={placeholder}
                                 value={rule.values?.[0]}
                                 onChange={(newValue) => {
@@ -123,7 +125,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             <TagInput
                                 w="100%"
                                 clearable
-                                autoFocus={true}
+                                autoFocus={autoFocus}
                                 size="xs"
                                 disabled={disabled}
                                 placeholder={placeholder}
@@ -142,7 +144,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                         <TagInput
                             w="100%"
                             clearable
-                            autoFocus={true}
+                            autoFocus={autoFocus}
                             size="xs"
                             disabled={disabled}
                             placeholder={placeholder}
@@ -170,7 +172,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
             return (
                 <FilterNumberInput
                     disabled={disabled}
-                    autoFocus={true}
+                    autoFocus={autoFocus}
                     placeholder={placeholder}
                     value={rule.values?.[0]}
                     onChange={(newValue) => {
@@ -186,7 +188,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
             return (
                 <FilterNumberRangeInput
                     disabled={disabled}
-                    autoFocus={true}
+                    autoFocus={autoFocus}
                     placeholder={placeholder}
                     value={rule.values}
                     onChange={(value) => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/useInitialAutoFocus.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/useInitialAutoFocus.ts
@@ -1,0 +1,19 @@
+import { useRef } from 'react';
+
+/**
+ * Hook that returns true only on the first render (for autoFocus),
+ * and false on subsequent renders to prevent focus jumping.
+ *
+ * This solves the issue where multiple inputs with autoFocus={true}
+ * cause the UI to jump to the last input on every re-render.
+ */
+export const useInitialAutoFocus = (): boolean => {
+    const hasBeenMounted = useRef(false);
+
+    if (!hasBeenMounted.current) {
+        hasBeenMounted.current = true;
+        return true;
+    }
+
+    return false;
+};


### PR DESCRIPTION
Closes: #19705
Fixes #19705

### Description:
Before fixes : [Loom](https://www.loom.com/share/002cac2464e24bc1a1c31ce7c19a0076)


Problem: Editing a filter in a multi-filter panel causes focus to jump to the last filter after each keystroke.
Solution: Created useInitialAutoFocus hook that only triggers autoFocus on initial mount, not on re-renders.


Changes:
Added useInitialAutoFocus.ts hook
Updated DefaultFilterInputs.tsx, BooleanFilterInputs.tsx, DateFilterInputs.tsx to use the hook


After fixes : [Loom](https://www.loom.com/share/daa7b26ad22b472a813773b3051702e7)
