### PR TITLE
fix: clarify user access description in agent settings

### DIFF
--- a/packages/frontend/src/ee/components/UserAccessMultiSelect.tsx
+++ b/packages/frontend/src/ee/components/UserAccessMultiSelect.tsx
@@ -37,8 +37,10 @@ interface UserData {
     roleLabel: string;
 }
 
-interface UserAccessMultiSelectProps
-    extends Omit<MultiSelectProps, 'data' | 'renderOption'> {
+interface UserAccessMultiSelectProps extends Omit<
+    MultiSelectProps,
+    'data' | 'renderOption'
+> {
     projectUuid: string;
     isGroupsEnabled?: boolean;
 }
@@ -216,8 +218,8 @@ export const UserAccessMultiSelect: FC<UserAccessMultiSelectProps> = ({
             }
             description={`Select specific users from this project who can access this agent. ${
                 isGroupsEnabled
-                    ? 'If no users are selected, access will be determined by group settings.'
-                    : ''
+                    ? 'If no users or groups are selected, all users will have access.'
+                    : 'If no users are selected, all users will have access.'
             }`}
             placeholder="Search users"
             data={selectData}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Updated the description text in the UserAccessMultiSelect component to clarify access permissions. For environments with groups enabled, the text now states "If no users or groups are selected, all users will have access" instead of indicating that access would be determined by group settings. For environments without groups, the message now explicitly states "If no users are selected, all users will have access."