### PR TITLE
fix: prevent duplicate data in Trino query results

### DIFF
--- a/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/TrinoWarehouseClient.test.ts
@@ -52,7 +52,12 @@ describe('TrinoWarehouseClient', () => {
         queryResultMock.mockReturnValue({
             next: jest
                 .fn()
-                .mockResolvedValueOnce({ done: false, value: queryResponse })
+                // First chunk: has nextUri indicating more data available
+                .mockResolvedValueOnce({
+                    done: false,
+                    value: { ...queryResponse, nextUri: 'http://trino/next' },
+                })
+                // Second chunk: no nextUri, query complete
                 .mockResolvedValueOnce({ done: true, value: queryResponse }),
         });
         const results = await warehouse.runQuery('fake sql');


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-320/exported-results-limited-to-20000-rows-despite-increasing-csv-limit

[trino-postgres.log](https://github.com/user-attachments/files/25074272/trino-postgres.log)

docs: https://trino.io/docs/current/develop/client-protocol.html


### Description:
Fix duplicate data issue in Trino query results by checking for missing `nextUri` instead of relying on state and row count. This addresses a protocol-specific behavior where some Trino setups (like Honeydew semantic layer) return `done=false` with no `nextUri`, causing the trino-client library to return duplicate data on subsequent calls.

The fix aligns with Trino's protocol documentation which specifies that absence of `nextUri` indicates query completion.