### PR TITLE
feat: return NULL for table calculations with pivot functions

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -22,6 +22,7 @@ import {
     getParsedReference,
     getPopComparisonConfigKey,
     hashPopComparisonConfigKeyToSuffix,
+    hasPivotFunctions,
     IntrinsicUserAttributes,
     isAndFilterGroup,
     isCompiledCustomSqlDimension,
@@ -36,6 +37,7 @@ import {
     lightdashVariablePattern,
     MetricFilterRule,
     parseAllReferences,
+    parseTableCalculationFunctions,
     PivotConfiguration,
     QueryWarning,
     renderFilterRuleSqlFromField,
@@ -793,7 +795,16 @@ export class MetricQueryBuilder {
         const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
         return simpleTableCalcs.map((tableCalculation) => {
             const alias = tableCalculation.name;
-            return `  ${tableCalculation.compiledSql} AS ${fieldQuoteChar}${alias}${fieldQuoteChar}`;
+
+            // Check if table calculation contains pivot functions
+            const functions = parseTableCalculationFunctions(
+                tableCalculation.compiledSql,
+            );
+            // Return NULL for table calculations with pivot functions
+            const tablCalcSql = hasPivotFunctions(functions)
+                ? null
+                : tableCalculation.compiledSql;
+            return `  ${tablCalcSql} AS ${fieldQuoteChar}${alias}${fieldQuoteChar}`;
         });
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
Return NULL for table calculations with pivot functions in SQL queries. This prevents pivot functions (like `pivot_offset` and `pivot_column`) from being included in the SQL query, as they should only be processed client-side after the query results are returned.

The PR adds a check in the table calculation SQL generation to detect pivot functions and return NULL instead of the compiled SQL for those calculations, while preserving normal table calculations.