### PR TITLE
docs(claude): require permission before modifying CLAUDE.local.md

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -103,7 +103,13 @@ echo "DBT_DEMO_DIR=$(pwd)/examples/full-jaffle-shop-demo" >> .env.development.lo
 
 ### Add Local Dev Instructions to CLAUDE.local.md
 
-Append local development instructions to `CLAUDE.local.md` (creates file if it doesn't exist, appends if it does):
+**IMPORTANT: You MUST ask the user for permission before modifying CLAUDE.local.md.** Use AskUserQuestion to confirm:
+
+> "The docker-dev setup can add PM2 commands and debugging instructions to CLAUDE.local.md. This includes PM2 start/stop/restart commands and guidance on using the /debug skill with Spotlight. May I add these instructions?"
+
+**Only proceed with this step after the user confirms.** If declined, skip this step and continue with the remaining setup.
+
+Once permission is granted, append local development instructions to `CLAUDE.local.md` (creates file if it doesn't exist, appends if it does):
 ```bash
 cat >> CLAUDE.local.md << 'EOF'
 # Local Development Environment


### PR DESCRIPTION
## Summary
- The docker-dev skill now asks for user confirmation before adding PM2 commands and debugging instructions to CLAUDE.local.md
- If the user declines, the step is skipped but the remaining setup continues
- Respects user autonomy over local configuration files

## Test plan
- [ ] Run `/docker-dev` when CLAUDE.local.md check fails
- [ ] Verify the permission prompt appears before modifying the file
- [ ] Verify declining skips the step but continues with remaining setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)