### PR TITLE
feat: add pivot_column table calculation function

### DIFF
--- a/packages/common/src/utils/tableCalculationFunctions.ts
+++ b/packages/common/src/utils/tableCalculationFunctions.ts
@@ -358,6 +358,11 @@ export class TableCalculationFunctionCompiler {
                     processedSql = processedSql.replace(func.rawSql, compiled);
                     break;
                 }
+                case TableCalculationFunctionType.PIVOT_COLUMN: {
+                    const compiled = this.compilePivotColumn();
+                    processedSql = processedSql.replace(func.rawSql, compiled);
+                    break;
+                }
                 default:
                     // Not implemented yet
                     break;
@@ -399,5 +404,15 @@ export class TableCalculationFunctionCompiler {
 
         // Build the guarded expression that returns NULL for non-adjacent time periods
         return `CASE WHEN ${windowFunction}(${q}row_index${q}, ${offsetValue}) ${windowClause} = ${q}row_index${q} + (${expectedDiff}) THEN ${windowFunction}(${expression}, ${offsetValue}) ${windowClause} ELSE NULL END`;
+    }
+
+    /**
+     * Compiles a pivot_column function call to return the current column index.
+     * The pivot_column() function returns the index of the current pivot column.
+     * @returns SQL expression that retrieves the column_index value
+     */
+    private compilePivotColumn(): string {
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
+        return `${q}column_index${q}`;
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added support for the `pivot_column()` function in table calculations. This function returns the index of the current pivot column, allowing users to reference the column position in their calculations.

The implementation compiles the function to return the `column_index` value from the SQL context, enabling dynamic behavior based on column position in pivoted tables.