### PR TITLE
fix: added string customDimensions to isStringDimension type guard

### DIFF
--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -121,7 +121,10 @@ export const isStringDimension = (
     if (!item) {
         return false;
     }
-    return isDimension(item) && getItemType(item) === DimensionType.STRING;
+    return (
+        (isDimension(item) || isCustomDimension(item)) &&
+        getItemType(item) === DimensionType.STRING
+    );
 };
 
 export const getItemIcon = (


### PR DESCRIPTION
This Closes: [#19955](https://github.com/lightdash/lightdash/issues/19955)

## Description:
Updated the type guard isStringDimension to recognise custom dimensions as well as normal string dimensions.
This fixes conditional formatting not being available for string-typed custom dimensions.
