### PR TITLE
fix: Include custom dimensions in isStringDimension check

### DIFF
--- a/packages/common/src/utils/item.ts
+++ b/packages/common/src/utils/item.ts
@@ -121,7 +121,10 @@ export const isStringDimension = (
     if (!item) {
         return false;
     }
-    return isDimension(item) && getItemType(item) === DimensionType.STRING;
+    return (
+        (isDimension(item) || isCustomDimension(item)) &&
+        getItemType(item) === DimensionType.STRING
+    );
 };
 
 export const getItemIcon = (


### PR DESCRIPTION
Closes: #19962

## Summary
- Added `isCustomDimension` check alongside `isDimension` in `isStringDimension` function
- Fixes string custom dimensions not appearing in conditional formatting dropdown

## Root Cause
`isStringDimension` gated on `isDimension()`, which fails for `CustomDimension` types since they lack the `fieldType` property.

## Fix
Changed the check from:
`isDimension(item) && getItemType(item) === DimensionType.STRING`

To:
`(isDimension(item) || isCustomDimension(item)) && getItemType(item) === DimensionType.STRING`

<img width="749" height="245" alt="image" src="https://github.com/user-attachments/assets/d8026766-ba84-4196-be8a-e20d4b620711" />
