### PR TITLE
feat: implement `space.inherit_parent_permissions` update functionality

### DIFF
--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -28,7 +28,9 @@ export type CreateDbSpace = Pick<
     | 'inherit_parent_permissions'
 >;
 
-export type UpdateDbSpace = Partial<Pick<DbSpace, 'name' | 'is_private'>>;
+export type UpdateDbSpace = Partial<
+    Pick<DbSpace, 'name' | 'is_private' | 'inherit_parent_permissions'>
+>;
 
 export type SpaceTable = Knex.CompositeTableType<
     DbSpace,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -2566,14 +2566,7 @@ export class SpaceModel {
             .update({
                 name: space.name,
                 is_private: space.isPrivate,
-                ...(space.isPrivate !== undefined && {
-                    // While the feature isn't fully built, we still depend on the `isPrivate`
-                    // and `parent_space_uuid` to set the `inherit_parent_permissions` column
-                    inherit_parent_permissions: this.database.raw(
-                        `CASE WHEN parent_space_uuid IS NULL THEN ? ELSE inherit_parent_permissions END`,
-                        [!space.isPrivate],
-                    ),
-                }),
+                inherit_parent_permissions: space.inheritParentPermissions,
             })
             .where('space_uuid', spaceUuid);
         return this.getFullSpace(spaceUuid, options);

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -61,6 +61,7 @@ export type CreateSpace = {
 export type UpdateSpace = {
     name: string;
     isPrivate?: boolean;
+    inheritParentPermissions?: boolean;
 };
 
 export type SpaceShare = {


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-154/api-toggle-inheritance-and-manage-nested-space-permissions

### Description:
This PR implements the PATCH Space functionality for the new `inherit_parent_permissions` property.

Just like with the create space functionality, it stays backwards compatible with the feature flag off and we're keeping `is_private` / `inherit_space_permissions` in sync.

This makes the following API test pass:
- `should not inherit new parent permissions after breaking inheritance with PATCH`

Other observations:
- The `spaceModel.update` function is only used in one other place, which only updates the name of a space: https://github.com/lightdash/lightdash/blob/daa46e4c5e78fa65ca7d1dc18be48efebb5139bd/packages/backend/src/services/PromoteService/PromoteService.ts#L912-L923
- The `spaceService.updateSpace` function is only used in the updated controller.