### PR TITLE
fix: remove 'edited' trigger from PR workflow

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -2,7 +2,7 @@ name: PR Checks
 
 on:
   pull_request:
-    types: [opened, synchronize, reopened, edited]
+    types: [opened, synchronize, reopened]
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Removed the `edited` event trigger from the PR Checks GitHub workflow. This change ensures that the workflow only runs when a PR is opened, synchronized, or reopened, but not when it's merely edited (such as updating the title or description).