### PR TITLE
chore: update chart value in tests

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -110,7 +110,10 @@ describe('Dashboard', () => {
 
         cy.findAllByText('Loading chart').should('have.length', 0); // Finish loading
 
-        cy.contains('1,961.5').click();
+        cy.get('[data-testid="big-number-value"]')
+            .first()
+            .scrollIntoView()
+            .click();
         cy.contains('View underlying data').click();
 
         cy.get('section[role="dialog"]').within(() => {

--- a/packages/e2e/cypress/e2e/app/dates.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dates.cy.ts
@@ -124,7 +124,7 @@ describe('Date tests', () => {
         cy.get('.react-grid-layout').within(() => {
             cy.contains(`What's our total revenue to date?`)
                 .parents('.react-grid-item')
-                .contains('1,682');
+                .contains('1,961.5');
         });
 
         // Add filter

--- a/packages/e2e/cypress/e2e/app/minimal.cy.ts
+++ b/packages/e2e/cypress/e2e/app/minimal.cy.ts
@@ -60,7 +60,10 @@ describe('Minimal pages', () => {
             );
 
             cy.contains('Payments total revenue');
-            cy.contains('1,682');
+            cy.get('[data-testid="big-number-value"]').should(
+                'contain',
+                '2,397',
+            );
         });
     });
     it('I can view a minimal dashboard', () => {
@@ -82,7 +85,10 @@ describe('Minimal pages', () => {
                 'Lightdash is an open source analytics for your dbt project.',
             ); // markdown
 
-            cy.contains('1,682'); // big number
+            cy.get('[data-testid="big-number-value"]').should(
+                'contain',
+                '1,961.5',
+            );
 
             cy.contains(`What's the average spend per customer?`); // bar chart
             cy.contains('Average order size'); // bar chart

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -285,7 +285,12 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
         >
             <Flex style={{ flexShrink: 1 }} justify="center" align="center">
                 {shouldHideContextMenu ? (
-                    <BigNumberText fz={valueFontSize} fw={600} isHeading>
+                    <BigNumberText
+                        fz={valueFontSize}
+                        fw={600}
+                        isHeading
+                        data-testid="big-number-value"
+                    >
                         {bigNumber}
                     </BigNumberText>
                 ) : (
@@ -298,6 +303,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                             fz={valueFontSize}
                             fw={600}
                             isHeading
+                            data-testid="big-number-value"
                             style={{
                                 cursor: 'pointer',
                             }}


### PR DESCRIPTION
### Description:

Added a `data-testid="big-number-value"` attribute to the BigNumberText component to improve test reliability. Updated the expected revenue values in e2e tests from 1,682 to the current values (1,961.5 and 2,397) to match the actual data. Also improved the dashboard test by using the new data-testid selector instead of relying on text content for more robust test interactions.