### PR TITLE
fix: support CSV quoting and escaping in filter value parsing

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.test.tsx
@@ -102,4 +102,25 @@ describe('ManageFilterValuesModal', () => {
         ]);
         expect(parseDelimitedValues('alpha\tbeta')).toEqual(['alpha', 'beta']);
     });
+
+    it('strips surrounding double quotes from CSV values', () => {
+        expect(parseDelimitedValues('"ID_123","ID_456"')).toEqual([
+            'ID_123',
+            'ID_456',
+        ]);
+        expect(
+            parseDelimitedValues('value\n"ID_123"\n"ID_456"\n"ID_789"'),
+        ).toEqual(['ID_123', 'ID_456', 'ID_789']);
+        expect(parseDelimitedValues('"alpha"\nbeta\n"gamma"')).toEqual([
+            'alpha',
+            'beta',
+            'gamma',
+        ]);
+    });
+
+    it('unescapes doubled quotes inside quoted CSV values', () => {
+        expect(parseDelimitedValues('"value ""with"" quotes"')).toEqual([
+            'value "with" quotes',
+        ]);
+    });
 });

--- a/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.utils.ts
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/ManageFilterValuesModal.utils.ts
@@ -4,6 +4,13 @@ export const parseDelimitedValues = (raw: string): string[] => {
         .replace(/\t/g, ',')
         .split(/,|\n/)
         .map((s) => s.trim())
+        .map((s) =>
+            // Strip surrounding double quotes (standard CSV quoting)
+            // and unescape doubled quotes ("" → ")
+            s.length >= 2 && s.startsWith('"') && s.endsWith('"')
+                ? s.slice(1, -1).replace(/""/g, '"')
+                : s,
+        )
         .filter((s) => s.length > 0);
 
     if (


### PR DESCRIPTION
Closes: [PROD-2892: Allow quote-wrapping on csv import for filter values](https://linear.app/lightdash/issue/PROD-2892/allow-quote-wrapping-on-csv-import-for-filter-values)

### Description:
This PR enhances the `parseDelimitedValues` function to properly handle CSV-formatted input with quoted values and escaped quotes.

**Changes:**
- Added support for stripping surrounding double quotes from CSV values (standard CSV quoting format)
- Added support for unescaping doubled quotes within quoted values (`""` → `"`)
- Added comprehensive test cases covering:
  - CSV values with surrounding quotes: `"ID_123","ID_456"`
  - Mixed quoted and unquoted values across multiple delimiters
  - Escaped quotes within quoted values: `"value ""with"" quotes"` → `value "with" quotes`

**Why:**
This improvement allows users to paste CSV data directly into filter inputs without having to manually remove quotes or handle escaped characters, making the filter input more robust and user-friendly.

https://claude.ai/code/session_01CQwk9KpJpy1r9FkC5PzkW4