### PR TITLE
feat: implement pivot_offset_list and pivot_row table calculation functions

### DIFF
--- a/packages/common/src/utils/tableCalculationFunctions.test.ts
+++ b/packages/common/src/utils/tableCalculationFunctions.test.ts
@@ -611,7 +611,7 @@ describe('tableCalculationFunctions', () => {
                     const functions = parseTableCalculationFunctions(sql);
                     const compiled = compiler.compileFunctions(sql, functions);
                     const expectedSql =
-                        'ARRAY_AGG(revenue) OVER (PARTITION BY "row_index" ORDER BY "column_index")';
+                        'ARRAY_AGG(revenue) OVER (PARTITION BY "row_index" ORDER BY "column_index" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)';
                     expect(compiled).toBe(expectedSql);
                 });
 
@@ -621,7 +621,7 @@ describe('tableCalculationFunctions', () => {
                     const compiled = compiler.compileFunctions(sql, functions);
 
                     const expectedSql =
-                        'ARRAY_AGG(revenue * 100) OVER (PARTITION BY "row_index" ORDER BY "column_index")';
+                        'ARRAY_AGG(revenue * 100) OVER (PARTITION BY "row_index" ORDER BY "column_index" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)';
                     expect(compiled).toBe(expectedSql);
                 });
 
@@ -631,7 +631,7 @@ describe('tableCalculationFunctions', () => {
                     const compiled = compiler.compileFunctions(sql, functions);
 
                     const expectedSql =
-                        'ARRAY_LENGTH(ARRAY_AGG(status) OVER (PARTITION BY "row_index" ORDER BY "column_index"), 1)';
+                        'ARRAY_LENGTH(ARRAY_AGG(status) OVER (PARTITION BY "row_index" ORDER BY "column_index" ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING), 1)';
                     expect(compiled).toBe(expectedSql);
                 });
             });

--- a/packages/common/src/utils/tableCalculationFunctions.ts
+++ b/packages/common/src/utils/tableCalculationFunctions.ts
@@ -613,6 +613,6 @@ export class TableCalculationFunctionCompiler {
         // Array aggregation with window functions doesn't support ORDER BY inside the aggregate
         // We need to use the base array aggregation without ordering and put ORDER BY in the window clause
         const baseAgg = this.warehouseSqlBuilder.buildArrayAgg(expression);
-        return `${baseAgg} OVER (PARTITION BY ${q}row_index${q} ORDER BY ${q}column_index${q})`;
+        return `${baseAgg} OVER (PARTITION BY ${q}row_index${q} ORDER BY ${q}column_index${q} ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)`;
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Implements PostgreSQL support for `pivot_offset_list` and `pivot_row` table calculation functions. 

The `pivot_offset_list` function now returns an array of values from consecutive pivot columns using window functions (LAG/LEAD) with proper array construction. The `pivot_row` function returns all values from the current row across all pivot columns using array aggregation.

Both functions now generate proper SQL syntax instead of returning NULL placeholders, enabling more advanced pivot table calculations.