### PR TITLE
fix: disable image export for maps

### DIFF
--- a/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
+++ b/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
@@ -6,6 +6,7 @@ export const CHART_TYPES_WITHOUT_IMAGE_EXPORT = [
     ChartType.CUSTOM,
     ChartType.BIG_NUMBER,
     ChartType.TABLE,
+    ChartType.MAP,
 ];
 
 export enum DownloadType {


### PR DESCRIPTION
### Description:

Disable image export for maps. Until it works. 

