### PR TITLE
fix: filter dashboard fields by active tab

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
@@ -16,6 +16,7 @@ import FilterConfiguration from './FilterConfiguration';
 
 type Props = {
     isEditMode: boolean;
+    activeTabUuid: string | undefined;
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
@@ -25,6 +26,7 @@ type Props = {
 
 const AddFilterButton: FC<Props> = ({
     isEditMode,
+    activeTabUuid,
     openPopoverId,
     onPopoverOpen,
     onPopoverClose,
@@ -164,6 +166,7 @@ const AddFilterButton: FC<Props> = ({
                         <FilterConfiguration
                             isCreatingNew={true}
                             isEditMode={isEditMode}
+                            activeTabUuid={activeTabUuid}
                             fields={allFilterableFields || []}
                             tiles={dashboardTiles}
                             tabs={dashboardTabs}

--- a/packages/frontend/src/features/dashboardFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/index.tsx
@@ -81,6 +81,7 @@ const DashboardFilters: FC<Props> = ({ isEditMode, activeTabUuid }) => {
         >
             <AddFilterButton
                 isEditMode={isEditMode}
+                activeTabUuid={activeTabUuid}
                 openPopoverId={openPopoverId}
                 onPopoverOpen={handlePopoverOpen}
                 onPopoverClose={handlePopoverClose}


### PR DESCRIPTION
### Description:

This PR implements tab-aware filtering for dashboard filter configuration. When creating or editing a filter, the field dropdown now displays only fields from tiles in the active tab, plus any fields from other tabs that are explicitly targeted in the filter's `tileTargets`.

#### Changes:

1. **AddFilterButton.tsx**: Added `activeTabUuid` prop and passed it down to `FilterConfiguration`

2. **FilterConfiguration/index.tsx**: 
   - Added `activeTabUuid` prop to component interface
   - Implemented `getRelevantTileUuids()` helper function that computes which tiles should be included based on:
     - All tiles from the active tab
     - Any tiles explicitly targeted in the filter rule's `tileTargets`
   - Added `displayedFields` computed state that filters available fields to only show those from relevant tiles
   - Updated SQL columns dropdown to also respect the relevant tiles filter
   - Updated field selection UI to use `displayedFields` instead of all `fields`

3. **index.tsx**: Passed `activeTabUuid` from parent component to `AddFilterButton`

#### Benefits:

- Users see a cleaner, more relevant field list when configuring filters
- Prevents confusion from seeing fields from tiles on other tabs
- Maintains ability to target fields from other tabs if explicitly configured
- Improves UX by reducing cognitive load when working with multi-tab dashboards

https://claude.ai/code/session_01MTxQ6mB2g46b33qcEstopX