### PR TITLE
fix: validate preset exists before displaying in metrics explorer date picker

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/MetricExploreDatePicker.tsx
@@ -159,7 +159,12 @@ export const MetricExploreDatePicker: FC<Props> = ({
                         value={
                             isOpen ||
                             !timeDimensionBaseField ||
-                            !effectiveMatchingPresetLabel
+                            !effectiveMatchingPresetLabel ||
+                            !presets.some(
+                                (p) =>
+                                    p.controlLabel ===
+                                    effectiveMatchingPresetLabel,
+                            )
                                 ? 'custom'
                                 : effectiveMatchingPresetLabel
                         }


### PR DESCRIPTION
## Summary
- Fix crash when changing granularity in MetricExploreDatePicker
- SegmentedControl threw "Cannot read properties of null (reading 'getBoundingClientRect')" when preset label didn't exist in new presets after granularity change
- Added validation to fall back to 'custom' when effectiveMatchingPresetLabel not found in current presets
