### PR TITLE
fix: preserve parameterReferences for saved charts on initial load

### DIFF
--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -132,14 +132,10 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
 
         useEffect(() => {
             if (isError) {
-                // If there's an error, we set the parameter references to an empty array
                 dispatch(explorerActions.setParameterReferences([]));
-            } else {
-                // While there's no parameter references array the request hasn't run, so we set it explicitly to null
+            } else if (parameterReferences?.length) {
                 dispatch(
-                    explorerActions.setParameterReferences(
-                        parameterReferences ?? null,
-                    ),
+                    explorerActions.setParameterReferences(parameterReferences),
                 );
             }
         }, [parameterReferences, dispatch, isError]);


### PR DESCRIPTION
## Summary

- Fixes a bug where the Parameters section was hidden on initial page load for saved charts with parameters

## Root Cause

The `useEffect` that syncs `parameterReferences` from compiled SQL was overwriting saved chart's stored parameter references with an empty array.

The compiled SQL API returns `parameterReferences: []` because parameters are stored metadata, not SQL template variables - so there's nothing to detect in the SQL itself.

## The Fix

Only update `parameterReferences` from compiled SQL if it actually found parameters:

```typescript
useEffect(() => {
    if (isError) {
        dispatch(explorerActions.setParameterReferences([]));
    } else if (parameterReferences?.length) {
        dispatch(explorerActions.setParameterReferences(parameterReferences));
    }
}, [parameterReferences, dispatch, isError]);
```

This prevents overwriting existing values (from saved charts) with empty arrays.

## Test plan

- [ ] Open a saved chart that has parameters
- [ ] Verify the Parameters section is visible on initial page load
- [ ] Verify new (unsaved) queries still detect parameters from compiled SQL

🤖 Generated with [Claude Code](https://claude.ai/code)