### PR TITLE
feat: improve filter selection based on dashboard tab

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
+++ b/packages/frontend/src/components/DashboardTiles/AddTileButton.tsx
@@ -140,7 +140,7 @@ const AddTileButton: FC<Props> = ({
                             leftSection={<MantineIcon icon={IconPlus} />}
                         >
                             <Group gap="xxs">
-                                <Text>New chart</Text>
+                                <Text fz="sm">New chart</Text>
                                 <Tooltip label="Charts generated from here are exclusive to this dashboard">
                                     <MantineIcon
                                         icon={IconInfoCircle}

--- a/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
@@ -16,6 +16,7 @@ import FilterConfiguration from './FilterConfiguration';
 
 type Props = {
     isEditMode: boolean;
+    activeTabUuid: string | undefined;
     openPopoverId: string | undefined;
     onPopoverOpen: (popoverId: string) => void;
     onPopoverClose: () => void;
@@ -25,6 +26,7 @@ type Props = {
 
 const AddFilterButton: FC<Props> = ({
     isEditMode,
+    activeTabUuid,
     openPopoverId,
     onPopoverOpen,
     onPopoverClose,
@@ -164,6 +166,7 @@ const AddFilterButton: FC<Props> = ({
                         <FilterConfiguration
                             isCreatingNew={true}
                             isEditMode={isEditMode}
+                            activeTabUuid={activeTabUuid}
                             fields={allFilterableFields || []}
                             tiles={dashboardTiles}
                             tabs={dashboardTabs}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/FilterFieldSelect.module.css
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/FilterFieldSelect.module.css
@@ -1,0 +1,67 @@
+.sectionHeader {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding: 0 var(--mantine-spacing-sm);
+    font-size: 10px;
+    font-weight: 700;
+    text-transform: uppercase;
+    letter-spacing: 0.6px;
+    border-bottom: 1px solid var(--mantine-color-ldGray-2);
+
+    @mixin light {
+        background-color: var(--mantine-color-ldGray-0);
+        color: var(--mantine-color-ldGray-7);
+    }
+
+    @mixin dark {
+        background-color: var(--mantine-color-dark-6);
+        color: var(--mantine-color-ldGray-3);
+        border-bottom-color: var(--mantine-color-dark-4);
+    }
+}
+
+.sectionHeaderDimmed {
+    composes: sectionHeader;
+}
+
+.groupHeader {
+    display: flex;
+    align-items: center;
+    height: 100%;
+    padding: 0 var(--mantine-spacing-xs);
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 600;
+
+    @mixin light {
+        color: var(--mantine-color-ldGray-7);
+    }
+
+    @mixin dark {
+        color: var(--mantine-color-ldGray-3);
+    }
+}
+
+.dimmedOption {
+    opacity: 0.6;
+}
+
+.option {
+    &:hover,
+    &[data-combobox-selected] {
+        @mixin light {
+            background-color: var(--mantine-color-ldGray-0);
+        }
+
+        @mixin dark {
+            background-color: var(--mantine-color-dark-7);
+        }
+
+        color: inherit;
+    }
+}
+
+.scrollContainer {
+    scrollbar-width: thin;
+    overflow: auto;
+}

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/index.tsx
@@ -1,0 +1,336 @@
+import {
+    getItemId,
+    getItemLabelWithoutTableName,
+    isField,
+    type DashboardTab,
+    type DashboardTile,
+    type FilterableDimension,
+} from '@lightdash/common';
+import {
+    Box,
+    Combobox,
+    Group,
+    InputBase,
+    Text,
+    Tooltip,
+    useCombobox,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine-8/hooks';
+import { IconSearch, IconSelector } from '@tabler/icons-react';
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import FieldIcon from '../../../../components/common/Filters/FieldIcon';
+import MantineIcon from '../../../../components/common/MantineIcon';
+import styles from './FilterFieldSelect.module.css';
+import { useFilterFieldSections } from './useFilterFieldSections';
+
+interface FilterFieldSelectProps {
+    fields: FilterableDimension[];
+    availableTileFilters: Record<string, FilterableDimension[]>;
+    tiles: DashboardTile[];
+    tabs: DashboardTab[];
+    activeTabUuid: string | undefined;
+    selectedField: FilterableDimension | undefined;
+    onChange: (field: FilterableDimension) => void;
+    popoverProps?: {
+        onOpen?: () => void;
+        onClose?: () => void;
+    };
+}
+
+// Flattened virtual list item types
+type VirtualItem =
+    | { type: 'section-header'; label: string; dimmed: boolean }
+    | { type: 'group-header'; label: string; dimmed: boolean }
+    | { type: 'field'; field: FilterableDimension; dimmed: boolean };
+
+const FIELD_HEIGHT = 32;
+const GROUP_HEADER_HEIGHT = 28;
+const SECTION_HEADER_HEIGHT = 30;
+const DROPDOWN_MAX_HEIGHT = 300;
+
+const FilterFieldSelect: FC<FilterFieldSelectProps> = ({
+    fields,
+    availableTileFilters,
+    tiles,
+    tabs,
+    activeTabUuid,
+    selectedField,
+    onChange,
+    popoverProps,
+}) => {
+    const [search, setSearch] = useState('');
+    const [debouncedSearch] = useDebouncedValue(search, 150);
+    const searchRef = useRef<HTMLInputElement>(null);
+    const scrollRef = useRef<HTMLDivElement>(null);
+
+    const combobox = useCombobox({
+        onDropdownOpen: () => {
+            combobox.resetSelectedOption();
+            popoverProps?.onOpen?.();
+        },
+        onDropdownClose: () => {
+            combobox.resetSelectedOption();
+            setSearch('');
+            popoverProps?.onClose?.();
+        },
+    });
+
+    const sections = useFilterFieldSections({
+        fields,
+        availableTileFilters,
+        tiles,
+        tabs,
+        activeTabUuid,
+        search: debouncedSearch,
+    });
+
+    const hasMultipleTabs = tabs.length > 1 && !!activeTabUuid;
+
+    // Flatten sections into virtual items
+    const virtualItems = useMemo((): VirtualItem[] => {
+        const items: VirtualItem[] = [];
+
+        for (const section of sections) {
+            if (hasMultipleTabs && section.label) {
+                items.push({
+                    type: 'section-header',
+                    label: section.label,
+                    dimmed: section.dimmed,
+                });
+            }
+
+            for (const group of section.groups) {
+                items.push({
+                    type: 'group-header',
+                    label: group.tableLabel,
+                    dimmed: section.dimmed,
+                });
+
+                for (const field of group.fields) {
+                    items.push({
+                        type: 'field',
+                        field,
+                        dimmed: section.dimmed,
+                    });
+                }
+            }
+        }
+
+        return items;
+    }, [sections, hasMultipleTabs]);
+
+    const totalFields = virtualItems.filter((i) => i.type === 'field').length;
+
+    const getItemSize = useCallback(
+        (index: number) => {
+            const item = virtualItems[index];
+            if (!item) return FIELD_HEIGHT;
+            switch (item.type) {
+                case 'section-header':
+                    return SECTION_HEADER_HEIGHT;
+                case 'group-header':
+                    return GROUP_HEADER_HEIGHT;
+                case 'field':
+                    return FIELD_HEIGHT;
+            }
+        },
+        [virtualItems],
+    );
+
+    const virtualizer = useVirtualizer({
+        count: virtualItems.length,
+        getScrollElement: () => scrollRef.current,
+        estimateSize: getItemSize,
+        overscan: 10,
+    });
+
+    const handleOptionSubmit = (value: string) => {
+        const field = fields.find((f) => getItemId(f) === value);
+        if (field) {
+            onChange(field);
+        }
+        combobox.closeDropdown();
+    };
+
+    const renderVirtualItem = useCallback(
+        (item: VirtualItem) => {
+            switch (item.type) {
+                case 'section-header':
+                    return (
+                        <div
+                            className={
+                                item.dimmed
+                                    ? styles.sectionHeaderDimmed
+                                    : styles.sectionHeader
+                            }
+                        >
+                            {item.label}
+                        </div>
+                    );
+                case 'group-header':
+                    return (
+                        <div
+                            className={`${styles.groupHeader} ${item.dimmed ? styles.dimmedOption : ''}`}
+                        >
+                            {item.label}
+                        </div>
+                    );
+                case 'field': {
+                    const fieldId = getItemId(item.field);
+                    return (
+                        <Combobox.Option
+                            value={fieldId}
+                            className={`${styles.option} ${item.dimmed ? styles.dimmedOption : ''}`}
+                        >
+                            <Tooltip
+                                disabled={
+                                    !isField(item.field) ||
+                                    !item.field.description
+                                }
+                                label={
+                                    isField(item.field)
+                                        ? item.field.description
+                                        : undefined
+                                }
+                                position="right"
+                                multiline
+                                maw={300}
+                                withinPortal
+                                openDelay={500}
+                            >
+                                <Group gap="xs" wrap="nowrap">
+                                    <FieldIcon item={item.field} size="md" />
+                                    <Text size="xs" truncate="end">
+                                        {getItemLabelWithoutTableName(
+                                            item.field,
+                                        )}
+                                    </Text>
+                                </Group>
+                            </Tooltip>
+                        </Combobox.Option>
+                    );
+                }
+            }
+        },
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [],
+    );
+
+    return (
+        <div>
+            <Text size="sm" mb={4}>
+                Select a dimension to filter{' '}
+                <Text component="span" c="red">
+                    *
+                </Text>
+            </Text>
+
+            <Combobox
+                store={combobox}
+                onOptionSubmit={handleOptionSubmit}
+                withinPortal={false}
+            >
+                <Combobox.Target>
+                    <InputBase
+                        component="button"
+                        type="button"
+                        size="xs"
+                        pointer
+                        onClick={() => combobox.toggleDropdown()}
+                        leftSection={
+                            selectedField ? (
+                                <FieldIcon item={selectedField} />
+                            ) : undefined
+                        }
+                        rightSection={<MantineIcon icon={IconSelector} />}
+                        rightSectionPointerEvents="none"
+                        multiline={false}
+                        data-testid="FilterConfiguration/FieldSelect"
+                    >
+                        {selectedField ? (
+                            <Text size="xs" truncate="end">
+                                {isField(selectedField)
+                                    ? `${selectedField.tableLabel} ${selectedField.label}`
+                                    : getItemLabelWithoutTableName(
+                                          selectedField,
+                                      )}
+                            </Text>
+                        ) : (
+                            <Text size="xs" truncate="end">
+                                Select a filter
+                            </Text>
+                        )}
+                    </InputBase>
+                </Combobox.Target>
+
+                <Combobox.Dropdown p={0}>
+                    <Combobox.Search
+                        ref={searchRef}
+                        value={search}
+                        onChange={(event) =>
+                            setSearch(event.currentTarget.value)
+                        }
+                        placeholder="Search field..."
+                        size="xs"
+                        radius="md"
+                        leftSection={
+                            <MantineIcon icon={IconSearch} color="ldGray.6" />
+                        }
+                        styles={{
+                            input: {
+                                border: `1px solid var(--mantine-color-ldGray-1)`,
+                                borderRadius: 'var(--mantine-radius-sm)',
+                                margin: 2,
+                                width: 'calc(100% - 4px)',
+                            },
+                        }}
+                    />
+                    <Combobox.Options>
+                        {totalFields === 0 ? (
+                            <Combobox.Empty>No matching fields</Combobox.Empty>
+                        ) : (
+                            <Box
+                                mah={DROPDOWN_MAX_HEIGHT}
+                                ref={scrollRef}
+                                className={styles.scrollContainer}
+                            >
+                                <Box
+                                    pos="relative"
+                                    w="100%"
+                                    h={virtualizer.getTotalSize()}
+                                >
+                                    {virtualizer
+                                        .getVirtualItems()
+                                        .map((virtualRow) => {
+                                            const item =
+                                                virtualItems[virtualRow.index];
+                                            if (!item) return null;
+
+                                            return (
+                                                <Box
+                                                    key={virtualRow.key}
+                                                    pos="absolute"
+                                                    top={0}
+                                                    left={0}
+                                                    w="100%"
+                                                    h={virtualRow.size}
+                                                    style={{
+                                                        transform: `translateY(${virtualRow.start}px)`,
+                                                    }}
+                                                >
+                                                    {renderVirtualItem(item)}
+                                                </Box>
+                                            );
+                                        })}
+                                </Box>
+                            </Box>
+                        )}
+                    </Combobox.Options>
+                </Combobox.Dropdown>
+            </Combobox>
+        </div>
+    );
+};
+
+export default FilterFieldSelect;

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/useFilterFieldSections.ts
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/useFilterFieldSections.ts
@@ -1,0 +1,181 @@
+import {
+    getItemId,
+    getItemLabel,
+    getItemLabelWithoutTableName,
+    isCustomDimension,
+    isDimension,
+    isField,
+    isMetric,
+    sortTimeFrames,
+    type DashboardTab,
+    type DashboardTile,
+    type FilterableDimension,
+    type Item,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+
+type FieldGroup = {
+    tableLabel: string;
+    tableName: string;
+    fields: FilterableDimension[];
+};
+
+export type FieldSection = {
+    label: string;
+    groups: FieldGroup[];
+    dimmed: boolean;
+};
+
+const getTypePriority = (i: Item): number => {
+    if (isDimension(i) || isCustomDimension(i)) return 1;
+    if (isMetric(i)) return 2;
+    return 3;
+};
+
+const getGroupKey = (i: Item): string => {
+    if (
+        isDimension(i) &&
+        'timeIntervalBaseDimensionName' in i &&
+        i.timeIntervalBaseDimensionName
+    ) {
+        return i.timeIntervalBaseDimensionName;
+    }
+    return i.name;
+};
+
+const sortFields = (fields: FilterableDimension[]): FilterableDimension[] =>
+    [...fields].sort((a, b) => {
+        // Sort by table label
+        if (isField(a) && isField(b) && a.table !== b.table) {
+            return (a.tableLabel || '').localeCompare(b.tableLabel || '');
+        }
+
+        // Sort by type priority
+        const priorityDiff = getTypePriority(a) - getTypePriority(b);
+        if (priorityDiff !== 0) return priorityDiff;
+
+        // Sort by group
+        const groupComparison = getGroupKey(a).localeCompare(getGroupKey(b));
+        if (groupComparison !== 0) return groupComparison;
+
+        // Within same group, sort time-based dimensions by interval
+        if (
+            isDimension(a) &&
+            isDimension(b) &&
+            'timeInterval' in a &&
+            'timeInterval' in b &&
+            a.timeInterval &&
+            b.timeInterval
+        ) {
+            return sortTimeFrames(a.timeInterval, b.timeInterval);
+        }
+
+        return getItemLabelWithoutTableName(a).localeCompare(
+            getItemLabelWithoutTableName(b),
+        );
+    });
+
+const groupByTable = (fields: FilterableDimension[]): FieldGroup[] => {
+    const groupMap = new Map<string, FieldGroup>();
+
+    for (const field of fields) {
+        const tableName = field.table;
+        const tableLabel = field.tableLabel || field.table;
+
+        const existing = groupMap.get(tableName);
+        if (existing) {
+            existing.fields.push(field);
+        } else {
+            groupMap.set(tableName, { tableLabel, tableName, fields: [field] });
+        }
+    }
+
+    return Array.from(groupMap.values());
+};
+
+const matchesSearch = (field: FilterableDimension, search: string): boolean => {
+    if (!search) return true;
+    const lowerSearch = search.toLowerCase();
+    return (
+        getItemLabel(field).toLowerCase().includes(lowerSearch) ||
+        getItemLabelWithoutTableName(field).toLowerCase().includes(lowerSearch)
+    );
+};
+
+type UseFilterFieldSectionsArgs = {
+    fields: FilterableDimension[];
+    availableTileFilters: Record<string, FilterableDimension[]>;
+    tiles: DashboardTile[];
+    tabs: DashboardTab[];
+    activeTabUuid: string | undefined;
+    search: string;
+};
+
+export const useFilterFieldSections = ({
+    fields,
+    availableTileFilters,
+    tiles,
+    activeTabUuid,
+    tabs,
+    search,
+}: UseFilterFieldSectionsArgs): FieldSection[] => {
+    return useMemo(() => {
+        const filtered = fields.filter((f) => matchesSearch(f, search));
+
+        // No tabs or single tab: return flat section
+        if (!activeTabUuid || tabs.length <= 1) {
+            const sorted = sortFields(filtered);
+            const groups = groupByTable(sorted);
+            return [{ label: '', groups, dimmed: false }];
+        }
+
+        // Multi-tab: split by active tab
+        const activeTabTileUuids = new Set(
+            tiles.filter((t) => t.tabUuid === activeTabUuid).map((t) => t.uuid),
+        );
+
+        const activeTabFieldIds = new Set<string>();
+        for (const [tileUuid, tileFields] of Object.entries(
+            availableTileFilters,
+        )) {
+            if (activeTabTileUuids.has(tileUuid)) {
+                for (const f of tileFields) {
+                    activeTabFieldIds.add(getItemId(f));
+                }
+            }
+        }
+
+        const activeTabFields: FilterableDimension[] = [];
+        const otherFields: FilterableDimension[] = [];
+
+        for (const field of filtered) {
+            if (activeTabFieldIds.has(getItemId(field))) {
+                activeTabFields.push(field);
+            } else {
+                otherFields.push(field);
+            }
+        }
+
+        const sections: FieldSection[] = [];
+
+        if (activeTabFields.length > 0) {
+            const sorted = sortFields(activeTabFields);
+            sections.push({
+                label: 'Fields in this tab',
+                groups: groupByTable(sorted),
+                dimmed: false,
+            });
+        }
+
+        if (otherFields.length > 0) {
+            const sorted = sortFields(otherFields);
+            sections.push({
+                label: 'Other available fields',
+                groups: groupByTable(sorted),
+                dimmed: true,
+            });
+        }
+
+        return sections;
+    }, [fields, availableTileFilters, tiles, activeTabUuid, tabs, search]);
+};

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -34,11 +34,11 @@ import {
 import { IconRotate2, IconSql } from '@tabler/icons-react';
 import { produce } from 'immer';
 import { useCallback, useMemo, useState, type FC } from 'react';
-import FieldSelect from '../../../components/common/FieldSelect';
 import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import FieldLabel from '../../../components/common/Filters/FieldLabel';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import FilterFieldSelect from './FilterFieldSelect';
 import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
 import { DEFAULT_TAB, FilterActions, FilterTabs } from './constants';
@@ -52,6 +52,7 @@ import {
 interface Props {
     tiles: DashboardTile[];
     tabs: DashboardTab[];
+    activeTabUuid?: string;
     field?: FilterableDimension;
     fields?: FilterableDimension[];
     availableTileFilters: Record<string, FilterableDimension[]>;
@@ -81,6 +82,7 @@ const FilterConfiguration: FC<Props> = ({
     isTemporary = false,
     tiles,
     tabs,
+    activeTabUuid,
     field,
     fields,
     availableTileFilters,
@@ -378,29 +380,15 @@ const FilterConfiguration: FC<Props> = ({
                     <Stack spacing="sm">
                         {isCreatingNew ? (
                             !!fields && fields.length > 0 ? (
-                                <FieldSelect
-                                    data-testid="FilterConfiguration/FieldSelect"
-                                    size="xs"
-                                    focusOnRender={true}
-                                    label={
-                                        <Text>
-                                            Select a dimension to filter{' '}
-                                            <Text color="red" span>
-                                                *
-                                            </Text>{' '}
-                                        </Text>
-                                    }
-                                    withinPortal={popoverProps?.withinPortal}
-                                    onDropdownOpen={popoverProps?.onOpen}
-                                    onDropdownClose={popoverProps?.onClose}
-                                    hasGrouping
-                                    item={selectedField}
-                                    items={fields}
-                                    onChange={(newField) => {
-                                        if (!newField) return;
-
-                                        handleChangeField(newField);
-                                    }}
+                                <FilterFieldSelect
+                                    fields={fields}
+                                    availableTileFilters={availableTileFilters}
+                                    tiles={tiles}
+                                    tabs={tabs}
+                                    activeTabUuid={activeTabUuid}
+                                    selectedField={selectedField}
+                                    onChange={handleChangeField}
+                                    popoverProps={popoverProps}
                                 />
                             ) : (
                                 <Select

--- a/packages/frontend/src/features/dashboardFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/index.tsx
@@ -81,6 +81,7 @@ const DashboardFilters: FC<Props> = ({ isEditMode, activeTabUuid }) => {
         >
             <AddFilterButton
                 isEditMode={isEditMode}
+                activeTabUuid={activeTabUuid}
                 openPopoverId={openPopoverId}
                 onPopoverOpen={handlePopoverOpen}
                 onPopoverClose={handlePopoverClose}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [PROD-2874](https://linear.app/lightdash/issue/PROD-2874/dashboard-tab-filters-should-only-show-filters-relevant-to-that-tab)

### Description:
Improved dashboard filter field selection with a new virtualized dropdown component that organizes fields by tab relevance. The new `FilterFieldSelect` component:

- Groups fields by table and separates them into "Fields in this tab" and "Other available fields" sections
- Dims fields that aren't directly related to the active tab
- Uses virtualization for better performance with large field lists
- Maintains proper sorting of fields, including time-based dimensions
- Includes tooltips for field descriptions

Also made a minor UI improvement to the "New chart" text in the AddTileButton by reducing its font size.

[CleanShot 2026-02-05 at 14.53.42.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/ae036ad0-06ba-44e8-9c8f-4035a0e03130.mp4" />](https://app.graphite.com/user-attachments/video/ae036ad0-06ba-44e8-9c8f-4035a0e03130.mp4)

