### PR TITLE
fix: stacking not working with extra metrics

### DIFF
--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -21,6 +21,7 @@ import {
 import {
     BinType,
     CustomDimensionType,
+    DimensionType,
     FieldType,
     MetricType,
     type ItemsMap,
@@ -603,6 +604,125 @@ describe('derivePivotConfigurationFromChart', () => {
                     reference: 'payments_total_revenue',
                     aggregation: VizAggregationOptions.ANY,
                 },
+            ]);
+        });
+    });
+
+    describe('Stacked Bar Chart with Table Calculations', () => {
+        it('does not include metrics as index columns when table calculation is on y-axis', () => {
+            // This tests that metrics used by table calculations but not on the x-axis
+            // are not incorrectly added as index columns, which would break stacking
+            const itemsWithTableCalc: ItemsMap = {
+                ...mockItems,
+                orders_shipping_method: {
+                    sql: '${TABLE}.shipping_method',
+                    name: 'shipping_method',
+                    type: DimensionType.STRING,
+                    fieldType: FieldType.DIMENSION,
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    label: 'Shipping method',
+                    hidden: false,
+                    index: 0,
+                    groups: [],
+                },
+                orders_order_source: {
+                    sql: '${TABLE}.order_source',
+                    name: 'order_source',
+                    type: DimensionType.STRING,
+                    fieldType: FieldType.DIMENSION,
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    label: 'Order source',
+                    hidden: false,
+                    index: 1,
+                    groups: [],
+                },
+                orders_total_order_amount: {
+                    sql: 'SUM(${TABLE}.amount)',
+                    name: 'total_order_amount',
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    label: 'Total order amount',
+                    hidden: false,
+                    index: 0,
+                    filters: [],
+                    groups: [],
+                },
+                _or_total: {
+                    index: 0,
+                    name: '_or_total',
+                    displayName: '% or total',
+                    sql: '${orders.total_order_amount} / sum(${orders.total_order_amount}) over(partition by ${orders.order_source})',
+                },
+            };
+
+            const stackedBarChartConfig: CartesianChartConfig = {
+                type: ChartType.CARTESIAN,
+                config: {
+                    layout: {
+                        xField: 'orders_shipping_method', // dimension on x-axis
+                        yField: ['_or_total'], // table calculation on y-axis (uses the metric)
+                    },
+                    eChartsConfig: { series: [] },
+                },
+            };
+
+            const metricQueryForStackedBar: MetricQuery = {
+                exploreName: 'orders',
+                dimensions: ['orders_shipping_method', 'orders_order_source'],
+                metrics: ['orders_total_order_amount'], // metric used by table calc
+                filters: {},
+                sorts: [
+                    { fieldId: 'orders_shipping_method', descending: false },
+                ],
+                limit: 500,
+                tableCalculations: [
+                    {
+                        name: '_or_total',
+                        displayName: '% or total',
+                        sql: '${orders.total_order_amount} / sum(${orders.total_order_amount}) over(partition by ${orders.order_source})',
+                    },
+                ],
+                additionalMetrics: [],
+                metricOverrides: {},
+            };
+
+            const savedChart: Pick<
+                SavedChartDAO,
+                'chartConfig' | 'pivotConfig'
+            > = {
+                chartConfig: stackedBarChartConfig,
+                pivotConfig: { columns: ['orders_order_source'] }, // pivot on order_source
+            };
+
+            const result = derivePivotConfigurationFromChart(
+                savedChart,
+                metricQueryForStackedBar,
+                itemsWithTableCalc,
+            );
+
+            expect(result).toBeDefined();
+            // The metric (orders_total_order_amount) should NOT be in index columns
+            // Only the x-axis dimension should be an index column
+            expect(result?.indexColumn).toEqual([
+                {
+                    reference: 'orders_shipping_method',
+                    type: VizIndexType.CATEGORY,
+                },
+            ]);
+            // The table calculation should be the value column
+            expect(result?.valuesColumns).toEqual([
+                {
+                    reference: '_or_total',
+                    aggregation: VizAggregationOptions.ANY,
+                },
+            ]);
+            // The pivot dimension should be the groupBy column
+            expect(result?.groupByColumns).toEqual([
+                { reference: 'orders_order_source' },
             ]);
         });
     });

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -142,7 +142,9 @@ const getIndexColumn = (
             }
 
             // Metrics can be used as x-axis in scatter charts, so we need to handle them as index columns
-            if (isMetric(field)) {
+            // Only include metrics if they are explicitly the x-axis field, otherwise they would
+            // incorrectly become index columns and break pivoted charts (e.g., stacked bar charts)
+            if (isMetric(field) && dim === xField) {
                 return {
                     reference: dim,
                     type: VizIndexType.CATEGORY,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #20001 

### Description:
                                                                                                              
  **Summary**                                                                                                                      
Fixes a regression introduced in #19916 where stacked bar charts with pivoted data would display overlapping bars instead of properly stacking them.                                                                                                      
                                                                                                                               
  **The Problem**                                                                                                                  
                                                                                                                               
  PR #19916 added support for scatter charts with metrics on both axes by allowing metrics to become index columns. However,   
  the fix was too broad - it added all metrics to the index columns if they weren't explicitly in valuesColumns.               
                                                                                                                               
  This broke pivoted bar charts in a subtle way. Consider a stacked bar chart with:                                            
  - x-axis: shipping_method (dimension)                                                                                        
  - y-axis: % of total (table calculation that uses total_order_amount metric)                                                 
  - pivot: order_source                                                                                                        
                                                                                                                               
  The metric total_order_amount is in the query (the table calc needs it), but it's not in valuesColumns (only the table calc %
   of total is). So the buggy code added it as an extra index column.                                                          
                                                                                                                               
  Having multiple index columns changes how the pivot groups data - instead of one row per shipping method, you get one row per
   (shipping_method + total_order_amount) combination. This multiplies the data rows and breaks stacking because ECharts places
   the values at different array positions.                                                                                    
                                                                                                                               
  **The Fix**                                                                                                                      
                                                                                                                               
  Only treat a metric as an index column if it's explicitly the x-axis field (the original scatter chart use case)
