### PR TITLE
feat: show current/previous periods in metrics canvas

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/visualization/CanvasTimeFramePicker.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/CanvasTimeFramePicker.module.css
@@ -1,0 +1,74 @@
+/* Select input styles */
+.input {
+    font-weight: 500;
+    font-size: 14px;
+    height: 32px;
+    border-color: var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md) 0 0 var(--mantine-radius-md);
+    box-shadow: var(--mantine-shadow-subtle);
+
+    border-right: none;
+
+    &:hover {
+        background-color: var(--mantine-color-ldGray-0);
+        transition: background-color var(--mantine-transition-duration)
+            var(--mantine-transition-timing-function);
+    }
+
+    &[value=''] {
+        border: 1px dashed var(--mantine-color-ldGray-4);
+    }
+}
+
+/* Dropdown option styles */
+.option {
+    font-size: 14px;
+
+    &[data-combobox-selected='true'] {
+        color: var(--mantine-color-ldGray-7);
+        font-weight: 500;
+        background-color: var(--mantine-color-ldGray-0);
+    }
+
+    &[data-combobox-selected='true']:hover {
+        background-color: var(--mantine-color-ldGray-0);
+    }
+
+    &:hover {
+        background-color: var(--mantine-color-ldGray-0);
+        transition: background-color var(--mantine-transition-duration)
+            var(--mantine-transition-timing-function);
+    }
+}
+
+/* Dropdown container */
+.dropdown {
+    min-width: 300px;
+}
+
+/* Right section (chevron icon) */
+.section {
+    pointer-events: none;
+}
+
+/* Date display */
+.dateDisplay {
+    height: 32px;
+    display: flex;
+    align-items: center;
+    padding: 0 var(--mantine-spacing-sm);
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    background-color: var(--mantine-color-white);
+    white-space: nowrap;
+    color: var(--input-color);
+
+    @mixin dark {
+        background-color: var(--mantine-color-ldGray-0);
+        border-color: var(--mantine-color-ldGray-2);
+    }
+}
+
+.dateDisplayGroupped {
+    border-radius: 0 var(--mantine-radius-md) var(--mantine-radius-md) 0;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/visualization/CanvasTimeFramePicker.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/visualization/CanvasTimeFramePicker.tsx
@@ -3,12 +3,13 @@ import {
     getDefaultMetricTreeNodeDateRange,
     getRollingPeriodDates,
 } from '@lightdash/common';
-import { Select, Tooltip } from '@mantine/core';
-import { IconChevronDown } from '@tabler/icons-react';
+import { Group, Select, Text } from '@mantine-8/core';
+import { clsx } from '@mantine/core';
+import { IconCalendar } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
-import { useSelectStyles } from '../../styles/useSelectStyles';
+import styles from './CanvasTimeFramePicker.module.css';
 import {
     DEFAULT_CANVAS_TIME_OPTIONS,
     type CanvasTimeOption,
@@ -16,10 +17,18 @@ import {
 
 const DATE_FORMAT = 'MMM D, YYYY';
 
-const getCanvasTimeDateLabel = (option: CanvasTimeOption): string => {
+type DateRangeInfo = {
+    currentRange: string;
+    previousRange: string;
+};
+
+const getDateRanges = (option: CanvasTimeOption): DateRangeInfo => {
     if (option.type === 'rolling') {
         const { current, previous } = getRollingPeriodDates(option.rollingDays);
-        return `${previous.start.format(DATE_FORMAT)} - ${previous.end.format(DATE_FORMAT)} / ${current.start.format(DATE_FORMAT)} - ${current.end.format(DATE_FORMAT)}`;
+        return {
+            currentRange: `${current.start.format(DATE_FORMAT)} – ${current.end.format(DATE_FORMAT)}`,
+            previousRange: `${previous.start.format(DATE_FORMAT)} – ${previous.end.format(DATE_FORMAT)}`,
+        };
     }
     const [currentStart, currentEnd] = getDefaultMetricTreeNodeDateRange(
         option.timeFrame,
@@ -27,7 +36,10 @@ const getCanvasTimeDateLabel = (option: CanvasTimeOption): string => {
     const { back } = getDateCalcUtils(option.timeFrame);
     const previousStart = back(currentStart);
     const previousEnd = back(currentEnd);
-    return `${dayjs(currentStart).format(DATE_FORMAT)} - ${dayjs(currentEnd).format(DATE_FORMAT)} / ${dayjs(previousStart).format(DATE_FORMAT)} - ${dayjs(previousEnd).format(DATE_FORMAT)}`;
+    return {
+        currentRange: `${dayjs(currentStart).format(DATE_FORMAT)} – ${dayjs(currentEnd).format(DATE_FORMAT)}`,
+        previousRange: `${dayjs(previousStart).format(DATE_FORMAT)} – ${dayjs(previousEnd).format(DATE_FORMAT)}`,
+    };
 };
 
 const serializeOption = (option: CanvasTimeOption): string =>
@@ -39,52 +51,71 @@ type Props = {
     value: CanvasTimeOption;
     onChange: (value: CanvasTimeOption) => void;
     options?: CanvasTimeOption[];
-    width?: number;
 };
 
 export const CanvasTimeFramePicker: FC<Props> = ({
     value,
     onChange,
     options = DEFAULT_CANVAS_TIME_OPTIONS,
-    width = 185,
 }) => {
-    const { classes } = useSelectStyles();
-
     const selectData = options.map((option) => ({
         value: serializeOption(option),
         label: option.label,
     }));
 
-    const tooltipLabel = useMemo(() => getCanvasTimeDateLabel(value), [value]);
+    const dateRanges = useMemo(() => getDateRanges(value), [value]);
 
     return (
-        <Tooltip label={tooltipLabel} position="bottom" withArrow>
-            <Select
-                w={width}
-                size="xs"
-                radius="md"
-                data={selectData}
-                value={serializeOption(value)}
-                onChange={(val) => {
-                    const selected = options.find(
-                        (opt) => serializeOption(opt) === val,
-                    );
-                    if (selected) onChange(selected);
-                }}
-                withinPortal
-                rightSection={
-                    <MantineIcon
-                        color="ldGray.7"
-                        icon={IconChevronDown}
-                        size={12}
-                    />
-                }
-                classNames={{
-                    input: classes.input,
-                    item: classes.item,
-                    rightSection: classes.rightSection,
-                }}
-            />
-        </Tooltip>
+        <Group gap="xs" wrap="nowrap">
+            <Group gap={0} wrap="nowrap">
+                <Select
+                    size="xs"
+                    data={selectData}
+                    value={serializeOption(value)}
+                    onChange={(val) => {
+                        const selected = options.find(
+                            (opt) => serializeOption(opt) === val,
+                        );
+                        if (selected) onChange(selected);
+                    }}
+                    leftSection={
+                        <MantineIcon
+                            icon={IconCalendar}
+                            color="ldGray.6"
+                            size={14}
+                        />
+                    }
+                    classNames={{
+                        input: styles.input,
+                        option: styles.option,
+                        dropdown: styles.dropdown,
+                        section: styles.section,
+                    }}
+                    withCheckIcon={false}
+                />
+                <Text
+                    size="sm"
+                    c="ldGray.7"
+                    fw={500}
+                    className={clsx(
+                        styles.dateDisplay,
+                        styles.dateDisplayGroupped,
+                    )}
+                >
+                    {dateRanges.currentRange}
+                </Text>
+            </Group>
+            <Text c="ldGray.6" fz={14} fw={500}>
+                compared to
+            </Text>
+            <Text
+                size="sm"
+                c="ldGray.7"
+                fw={500}
+                className={styles.dateDisplay}
+            >
+                {dateRanges.previousRange}
+            </Text>
+        </Group>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Redesigned the CanvasTimeFramePicker component with a more intuitive UI that clearly displays date ranges. The new design shows the current and previous date ranges side by side with "compared to" text between them, replacing the previous tooltip implementation. Added custom styling with a dedicated CSS module file for better visual consistency and user experience.
