### PR TITLE
feat: add callout if filter being applied won't affect current tab

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -51,9 +51,15 @@ describe('Dashboard', () => {
         // Add filter
         cy.contains('Add filter').click();
 
-        cy.findByTestId('FilterConfiguration/FieldSelect')
+        cy.findByTestId('FilterConfiguration/FieldSelect').click();
+        cy.findByTestId('FilterConfiguration/FieldSelectSearch')
             .click()
-            .type('payment method{downArrow}{enter}');
+            .type('payment');
+        cy.wait(200);
+
+        cy.get(
+            '[data-combobox-option="true"][value="payments_payment_method"]',
+        ).click();
         cy.findByPlaceholderText('Start typing to filter results').type(
             'credit_card',
         );
@@ -104,7 +110,7 @@ describe('Dashboard', () => {
 
         cy.findAllByText('Loading chart').should('have.length', 0); // Finish loading
 
-        cy.contains('1,682').click();
+        cy.contains('1,961.5').click();
         cy.contains('View underlying data').click();
 
         cy.get('section[role="dialog"]').within(() => {
@@ -170,10 +176,15 @@ describe('Dashboard', () => {
 
         // Add filter Payment method is credit_card and apply
         cy.contains('Add filter').click();
-        cy.findByTestId('FilterConfiguration/FieldSelect')
+        cy.findByTestId('FilterConfiguration/FieldSelect').click();
+        cy.findByTestId('FilterConfiguration/FieldSelectSearch')
             .click()
-            .type('payment method{downArrow}{enter}');
-        // using force click here because this is a mantine switch and the actual checkbox is hidden
+            .type('payment');
+        cy.wait(200);
+        cy.get(
+            '[data-combobox-option="true"][value="payments_payment_method"]',
+        ).click();
+        // using force click here because this is a     mantine switch and the actual checkbox is hidden
         cy.findByLabelText('Provide default value').click({ force: true });
         cy.findByPlaceholderText('Start typing to filter results').type(
             'credit_card',
@@ -380,9 +391,14 @@ describe('Dashboard', () => {
         // Add filter
         cy.contains('Add filter').click();
 
-        cy.findByTestId('FilterConfiguration/FieldSelect')
+        cy.findByTestId('FilterConfiguration/FieldSelect').click();
+        cy.findByTestId('FilterConfiguration/FieldSelectSearch')
             .click()
-            .type('payment method{downArrow}{enter}');
+            .type('payment');
+        cy.wait(200);
+        cy.get(
+            '[data-combobox-option="true"][value="payments_payment_method"]',
+        ).click();
         cy.findByPlaceholderText('Start typing to filter results').type(
             'credit_card',
         );

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterCoverageSummary.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterCoverageSummary.tsx
@@ -1,0 +1,105 @@
+import type {
+    DashboardFilterRule,
+    DashboardTab,
+    DashboardTile,
+    FilterableDimension,
+} from '@lightdash/common';
+import { Anchor, Text } from '@mantine-8/core';
+import { useMemo, type FC } from 'react';
+import Callout from '../../../components/common/Callout';
+import { doesFilterApplyToAnyTile, getTabsForFilterRule } from './utils';
+
+interface FilterCoverageSummaryProps {
+    draftFilterRule: DashboardFilterRule;
+    tiles: DashboardTile[];
+    tabs: DashboardTab[];
+    activeTabUuid: string | undefined;
+    availableTileFilters: Record<string, FilterableDimension[]>;
+    onNavigateToTilesTab: () => void;
+}
+
+const FilterCoverageSummary: FC<FilterCoverageSummaryProps> = ({
+    draftFilterRule,
+    tiles,
+    tabs,
+    activeTabUuid,
+    availableTileFilters,
+    onNavigateToTilesTab,
+}) => {
+    const sortedTabUuids = useMemo(
+        () => [...tabs].sort((a, b) => a.order - b.order).map((t) => t.uuid),
+        [tabs],
+    );
+
+    const applicableTabs = useMemo(
+        () =>
+            getTabsForFilterRule(
+                draftFilterRule,
+                tiles,
+                sortedTabUuids,
+                availableTileFilters,
+            ),
+        [draftFilterRule, tiles, sortedTabUuids, availableTileFilters],
+    );
+
+    const appliesToAny = useMemo(
+        () =>
+            doesFilterApplyToAnyTile(
+                draftFilterRule,
+                tiles,
+                availableTileFilters,
+            ),
+        [draftFilterRule, tiles, availableTileFilters],
+    );
+
+    if (tabs.length <= 1) return null;
+
+    const appliesToCurrentTab =
+        !activeTabUuid || applicableTabs.includes(activeTabUuid);
+
+    if (appliesToCurrentTab) return null;
+
+    const tabNamesByUuid = new Map(tabs.map((t) => [t.uuid, t.name]));
+
+    if (!appliesToAny) {
+        return (
+            <Callout variant="warning">
+                <Text size="xs">
+                    No charts have a matching field for this filter.{' '}
+                    <Anchor
+                        component="button"
+                        type="button"
+                        size="xs"
+                        onClick={onNavigateToTilesTab}
+                    >
+                        Review tile targets
+                    </Anchor>
+                </Text>
+            </Callout>
+        );
+    }
+
+    const applicableTabNames = applicableTabs
+        .map((uuid) => tabNamesByUuid.get(uuid))
+        .filter(Boolean);
+
+    return (
+        <Callout variant="warning">
+            <Text size="xs">
+                This filter won't affect charts on the current tab. <br /> It
+                applies automatically to:{' '}
+                <strong>{applicableTabNames.join(', ')}</strong>. <br />
+                <Anchor
+                    component="button"
+                    type="button"
+                    size="xs"
+                    onClick={onNavigateToTilesTab}
+                >
+                    Review tile targets and change the filter target
+                </Anchor>
+            </Text>
+        </Callout>
+    );
+};
+
+export default FilterCoverageSummary;

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/FilterFieldSelect/index.tsx
@@ -277,6 +277,7 @@ const FilterFieldSelect: FC<FilterFieldSelectProps> = ({
                         leftSection={
                             <MantineIcon icon={IconSearch} color="ldGray.6" />
                         }
+                        data-testid="FilterConfiguration/FieldSelectSearch"
                         styles={{
                             input: {
                                 border: `1px solid var(--mantine-color-ldGray-1)`,

--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -38,6 +38,7 @@ import FieldIcon from '../../../components/common/Filters/FieldIcon';
 import FieldLabel from '../../../components/common/Filters/FieldLabel';
 import MantineIcon from '../../../components/common/MantineIcon';
 import useDashboardContext from '../../../providers/Dashboard/useDashboardContext';
+import FilterCoverageSummary from './FilterCoverageSummary';
 import FilterFieldSelect from './FilterFieldSelect';
 import FilterSettings from './FilterSettings';
 import TileFilterConfiguration from './TileFilterConfiguration';
@@ -461,6 +462,21 @@ const FilterConfiguration: FC<Props> = ({
                                 popoverProps={popoverProps}
                             />
                         )}
+
+                        {isCreatingNew &&
+                            draftFilterRule &&
+                            tabs.length > 1 && (
+                                <FilterCoverageSummary
+                                    draftFilterRule={draftFilterRule}
+                                    tiles={tiles}
+                                    tabs={tabs}
+                                    activeTabUuid={activeTabUuid}
+                                    availableTileFilters={availableTileFilters}
+                                    onNavigateToTilesTab={() =>
+                                        setSelectedTabId(FilterTabs.TILES)
+                                    }
+                                />
+                            )}
                     </Stack>
                 </Tabs.Panel>
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2874](https://linear.app/lightdash/issue/PROD-2874/dashboard-tab-filters-should-only-show-filters-relevant-to-that-tab)

### Description:

Added a new `FilterCoverageSummary` component to improve the dashboard filter configuration experience. This component displays warning messages when a filter doesn't apply to the current tab but does apply to other tabs, helping users understand filter coverage across dashboard tabs.

The summary shows:
- A warning when the filter won't affect charts on the current tab but applies to other tabs
- A list of tab names where the filter will be applied
- A warning when no charts have a matching field for the filter
- A link to review tile targets and change filter settings

This enhancement is only shown when creating a new filter and when the dashboard has multiple tabs.

![Screenshot 2026-02-05 at 15.05.31.png](https://app.graphite.com/user-attachments/assets/bef18b28-d335-4b44-be94-09b1af460455.png)

