### PR TITLE
feat: use CSS variables for canvas edge styling

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/Canvas.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/Canvas.module.css
@@ -1,0 +1,6 @@
+.reactFlow {
+    --xy-edge-stroke: var(--mantine-color-ldGray-4);
+    --xy-edge-stroke-selected: var(--mantine-color-blue-6);
+    --xy-handle-background-color-default: var(--mantine-color-ldGray-6);
+    --xy-handle-border-color-default: var(--mantine-color-background-0);
+}

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
@@ -1,5 +1,4 @@
 import { type CatalogMetricsTreeEdgeSource } from '@lightdash/common';
-import { useMantineTheme } from '@mantine-8/core';
 import {
     BaseEdge,
     getSimpleBezierPath,
@@ -17,15 +16,9 @@ const DefaultEdge: FC<EdgeProps<DefaultEdgeData>> = ({
     sourceY,
     targetX,
     targetY,
-    selected,
     markerEnd,
     ...props
 }) => {
-    const theme = useMantineTheme();
-    const strokeColor = selected
-        ? theme.colors.blue[4]
-        : theme.colors.ldGray[3];
-
     const [edgePath] = getSimpleBezierPath({
         sourceX,
         sourceY,
@@ -33,16 +26,7 @@ const DefaultEdge: FC<EdgeProps<DefaultEdgeData>> = ({
         targetY,
     });
 
-    return (
-        <BaseEdge
-            {...props}
-            path={edgePath}
-            style={{
-                stroke: strokeColor,
-            }}
-            markerEnd={markerEnd}
-        />
-    );
+    return <BaseEdge {...props} path={edgePath} markerEnd={markerEnd} />;
 };
 
 export default DefaultEdge;

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
@@ -46,6 +46,7 @@ import {
     DEFAULT_CANVAS_TIME_OPTION,
     type CanvasTimeOption,
 } from '../visualization/canvasTimeFramePickerOptions';
+import styles from './Canvas.module.css';
 import MetricsSidebar from './MetricsSidebar';
 import DefaultEdge from './TreeComponents/edges/DefaultEdge';
 import ExpandedNode, {
@@ -191,7 +192,9 @@ const Canvas: FC<Props> = ({ metrics, edges, viewOnly }) => {
                 source: edge.source.catalogSearchUuid,
                 target: edge.target.catalogSearchUuid,
                 type: edge.createdFrom,
-                markerEnd: { type: MarkerType.ArrowClosed },
+                markerEnd: {
+                    type: MarkerType.ArrowClosed,
+                },
             }));
         }
 
@@ -371,7 +374,9 @@ const Canvas: FC<Props> = ({ metrics, edges, viewOnly }) => {
                     addEdge(
                         {
                             ...params,
-                            markerEnd: { type: MarkerType.ArrowClosed },
+                            markerEnd: {
+                                type: MarkerType.ArrowClosed,
+                            },
                         },
                         edg,
                     ),
@@ -514,6 +519,7 @@ const Canvas: FC<Props> = ({ metrics, edges, viewOnly }) => {
             <Panel id="metrics-canvas" order={2}>
                 <Box h="100%">
                     <ReactFlow
+                        className={styles.reactFlow}
                         nodes={currentNodes}
                         edges={currentEdges}
                         fitView


### PR DESCRIPTION

### Description:
Improves the styling of the metrics catalog canvas by moving edge colors to CSS variables. This change:

- Creates a new CSS module for the ReactFlow component with custom variables for edge strokes and handle colors
- Removes the direct theme color references from the DefaultEdge component
- Applies the CSS class to the ReactFlow component
- Cleans up the edge marker end formatting

This approach makes the styling more consistent and maintainable by centralizing the color definitions.