### PR TITLE
chore: add space access resolver common utility

### DIFF
--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -2,6 +2,7 @@ import {
     DirectSpaceAccess,
     DirectSpaceAccessOrigin,
     OrganizationSpaceAccess,
+    ProjectRoleOrigin,
     ProjectSpaceAccess,
 } from '@lightdash/common';
 import { Knex } from 'knex';
@@ -31,75 +32,107 @@ export class SpacePermissionModel {
     async getDirectSpaceAccess(
         spaceUuids: string[],
         filters?: { userUuid?: string },
-    ): Promise<Record<string, DirectSpaceAccess[]>> {
+    ): Promise<
+        Record<
+            string,
+            {
+                access: DirectSpaceAccess[];
+                isPrivate: boolean;
+            }
+        >
+    > {
         return wrapSentryTransaction(
             'SpaceModel.getDirectSpaceAccess',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
-                const spacesDirectAccess: DirectSpaceAccess[] =
-                    await this.database(SpaceUserAccessTableName)
-                        .select({
-                            userUuid: `${SpaceUserAccessTableName}.user_uuid`,
-                            spaceUuid: `${SpaceUserAccessTableName}.space_uuid`,
-                            role: `${SpaceUserAccessTableName}.space_role`,
-                            from: this.database.raw(
-                                `'${DirectSpaceAccessOrigin.USER_ACCESS}'`,
-                            ),
-                        })
-                        .whereIn(
-                            `${SpaceUserAccessTableName}.space_uuid`,
-                            spaceUuids,
-                        )
-                        .modify((qb) => {
-                            if (filters?.userUuid) {
-                                void qb.where(
-                                    `${SpaceUserAccessTableName}.user_uuid`,
-                                    filters.userUuid,
-                                );
-                            }
-                        })
-                        .union(
-                            this.database(SpaceGroupAccessTableName)
-                                .select({
-                                    userUuid: `${UserTableName}.user_uuid`,
-                                    spaceUuid: `${SpaceGroupAccessTableName}.space_uuid`,
-                                    role: `${SpaceGroupAccessTableName}.space_role`,
-                                    from: this.database.raw(
-                                        `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
-                                    ),
-                                })
-                                .innerJoin(
-                                    GroupMembershipTableName,
-                                    `${GroupMembershipTableName}.group_uuid`,
-                                    `${SpaceGroupAccessTableName}.group_uuid`,
-                                )
-                                .innerJoin(
-                                    UserTableName,
-                                    `${GroupMembershipTableName}.user_id`,
-                                    `${UserTableName}.user_id`,
-                                )
-                                .whereIn(
-                                    `${SpaceGroupAccessTableName}.space_uuid`,
-                                    spaceUuids,
-                                )
-                                .modify((qb) => {
-                                    if (filters?.userUuid) {
-                                        void qb.where(
-                                            `${UserTableName}.user_uuid`,
-                                            filters.userUuid,
-                                        );
-                                    }
-                                }),
-                        );
+                const spacesDirectAccess: (DirectSpaceAccess & {
+                    isPrivate: boolean;
+                })[] = await this.database(SpaceUserAccessTableName)
+                    .select({
+                        userUuid: `${SpaceUserAccessTableName}.user_uuid`,
+                        spaceUuid: `${SpaceUserAccessTableName}.space_uuid`,
+                        isPrivate: `${SpaceTableName}.is_private`,
+                        role: `${SpaceUserAccessTableName}.space_role`,
+                        from: this.database.raw(
+                            `'${DirectSpaceAccessOrigin.USER}'`,
+                        ),
+                    })
+                    .innerJoin(
+                        SpaceTableName,
+                        `${SpaceUserAccessTableName}.space_uuid`,
+                        `${SpaceTableName}.space_uuid`,
+                    )
+
+                    .whereIn(
+                        `${SpaceUserAccessTableName}.space_uuid`,
+                        spaceUuids,
+                    )
+                    .modify((qb) => {
+                        if (filters?.userUuid) {
+                            void qb.where(
+                                `${SpaceUserAccessTableName}.user_uuid`,
+                                filters.userUuid,
+                            );
+                        }
+                    })
+                    .union(
+                        this.database(SpaceGroupAccessTableName)
+                            .select({
+                                userUuid: `${UserTableName}.user_uuid`,
+                                spaceUuid: `${SpaceGroupAccessTableName}.space_uuid`,
+                                isPrivate: `${SpaceTableName}.is_private`,
+                                role: `${SpaceGroupAccessTableName}.space_role`,
+                                from: this.database.raw(
+                                    `'${DirectSpaceAccessOrigin.GROUP}'`,
+                                ),
+                            })
+                            .innerJoin(
+                                SpaceTableName,
+                                `${SpaceGroupAccessTableName}.space_uuid`,
+                                `${SpaceTableName}.space_uuid`,
+                            )
+                            .innerJoin(
+                                GroupMembershipTableName,
+                                `${GroupMembershipTableName}.group_uuid`,
+                                `${SpaceGroupAccessTableName}.group_uuid`,
+                            )
+                            .innerJoin(
+                                UserTableName,
+                                `${GroupMembershipTableName}.user_id`,
+                                `${UserTableName}.user_id`,
+                            )
+                            .whereIn(
+                                `${SpaceGroupAccessTableName}.space_uuid`,
+                                spaceUuids,
+                            )
+                            .modify((qb) => {
+                                if (filters?.userUuid) {
+                                    void qb.where(
+                                        `${UserTableName}.user_uuid`,
+                                        filters.userUuid,
+                                    );
+                                }
+                            }),
+                    );
 
                 return spacesDirectAccess.reduce<
-                    Record<string, DirectSpaceAccess[]>
+                    Record<
+                        string,
+                        {
+                            access: DirectSpaceAccess[];
+                            isPrivate: boolean;
+                        }
+                    >
                 >((acc, spaceDirectAccess) => {
                     if (!acc[spaceDirectAccess.spaceUuid]) {
-                        acc[spaceDirectAccess.spaceUuid] = [];
+                        acc[spaceDirectAccess.spaceUuid] = {
+                            access: [],
+                            isPrivate: spaceDirectAccess.isPrivate,
+                        };
                     }
 
-                    acc[spaceDirectAccess.spaceUuid].push(spaceDirectAccess);
+                    const { isPrivate, ...access } = spaceDirectAccess;
+                    acc[spaceDirectAccess.spaceUuid].access.push(access);
                     return acc;
                 }, {});
             },
@@ -115,91 +148,104 @@ export class SpacePermissionModel {
     async getProjectSpaceAccess(
         spaceUuids: string[],
         filters?: { userUuid?: string },
-    ): Promise<Record<string, ProjectSpaceAccess[]>> {
+    ): Promise<
+        Record<string, { access: ProjectSpaceAccess[]; isPrivate: boolean }>
+    > {
         return wrapSentryTransaction(
             'SpaceModel.getProjectAccess',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
-                const projectSpacesAccess: ProjectSpaceAccess[] =
-                    await this.database(SpaceTableName)
-                        .select({
-                            userUuid: `${UserTableName}.user_uuid`,
-                            spaceUuid: `${SpaceTableName}.space_uuid`,
-                            role: `${ProjectMembershipsTableName}.role`,
-                        })
-                        .innerJoin(
-                            ProjectTableName,
-                            `${ProjectTableName}.project_id`,
-                            `${SpaceTableName}.project_id`,
-                        )
-                        .innerJoin(
-                            ProjectMembershipsTableName,
-                            `${ProjectMembershipsTableName}.project_id`,
-                            `${ProjectTableName}.project_id`,
-                        )
-                        .innerJoin(
-                            UserTableName,
-                            `${UserTableName}.user_id`,
-                            `${ProjectMembershipsTableName}.user_id`,
-                        )
-                        .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
-                        .modify((qb) => {
-                            if (filters?.userUuid) {
-                                void qb.where(
-                                    `${UserTableName}.user_uuid`,
-                                    filters.userUuid,
-                                );
-                            }
-                        })
-                        .union(
-                            this.database(SpaceTableName)
-                                .select({
-                                    userUuid: `${UserTableName}.user_uuid`,
-                                    spaceUuid: `${SpaceTableName}.space_uuid`,
-                                    role: `${ProjectGroupAccessTableName}.role`,
-                                })
-                                .innerJoin(
-                                    ProjectTableName,
-                                    `${ProjectTableName}.project_id`,
-                                    `${SpaceTableName}.project_id`,
-                                )
-                                .innerJoin(
-                                    ProjectGroupAccessTableName,
-                                    `${ProjectGroupAccessTableName}.project_uuid`,
-                                    `${ProjectTableName}.project_uuid`,
-                                )
-                                .innerJoin(
-                                    GroupMembershipTableName,
-                                    `${GroupMembershipTableName}.group_uuid`,
-                                    `${ProjectGroupAccessTableName}.group_uuid`,
-                                )
-                                .innerJoin(
-                                    UserTableName,
-                                    `${UserTableName}.user_id`,
-                                    `${GroupMembershipTableName}.user_id`,
-                                )
-                                .whereIn(
-                                    `${SpaceTableName}.space_uuid`,
-                                    spaceUuids,
-                                )
-                                .modify((qb) => {
-                                    if (filters?.userUuid) {
-                                        void qb.where(
-                                            `${UserTableName}.user_uuid`,
-                                            filters.userUuid,
-                                        );
-                                    }
-                                }),
-                        );
+                const projectSpacesAccess: (ProjectSpaceAccess & {
+                    isPrivate: boolean;
+                })[] = await this.database(SpaceTableName)
+                    .select({
+                        userUuid: `${UserTableName}.user_uuid`,
+                        spaceUuid: `${SpaceTableName}.space_uuid`,
+                        isPrivate: `${SpaceTableName}.is_private`,
+                        role: `${ProjectMembershipsTableName}.role`,
+                        from: this.database.raw(`'${ProjectRoleOrigin.USER}'`),
+                    })
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        ProjectMembershipsTableName,
+                        `${ProjectMembershipsTableName}.project_id`,
+                        `${ProjectTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${ProjectMembershipsTableName}.user_id`,
+                    )
+                    .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                    .modify((qb) => {
+                        if (filters?.userUuid) {
+                            void qb.where(
+                                `${UserTableName}.user_uuid`,
+                                filters.userUuid,
+                            );
+                        }
+                    })
+                    .union(
+                        this.database(SpaceTableName)
+                            .select({
+                                userUuid: `${UserTableName}.user_uuid`,
+                                spaceUuid: `${SpaceTableName}.space_uuid`,
+                                role: `${ProjectGroupAccessTableName}.role`,
+                                isPrivate: `${SpaceTableName}.is_private`,
+                                from: this.database.raw(
+                                    `'${ProjectRoleOrigin.GROUP}'`,
+                                ),
+                            })
+                            .innerJoin(
+                                ProjectTableName,
+                                `${ProjectTableName}.project_id`,
+                                `${SpaceTableName}.project_id`,
+                            )
+                            .innerJoin(
+                                ProjectGroupAccessTableName,
+                                `${ProjectGroupAccessTableName}.project_uuid`,
+                                `${ProjectTableName}.project_uuid`,
+                            )
+                            .innerJoin(
+                                GroupMembershipTableName,
+                                `${GroupMembershipTableName}.group_uuid`,
+                                `${ProjectGroupAccessTableName}.group_uuid`,
+                            )
+                            .innerJoin(
+                                UserTableName,
+                                `${UserTableName}.user_id`,
+                                `${GroupMembershipTableName}.user_id`,
+                            )
+                            .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                            .modify((qb) => {
+                                if (filters?.userUuid) {
+                                    void qb.where(
+                                        `${UserTableName}.user_uuid`,
+                                        filters.userUuid,
+                                    );
+                                }
+                            }),
+                    );
 
                 return projectSpacesAccess.reduce<
-                    Record<string, ProjectSpaceAccess[]>
+                    Record<
+                        string,
+                        { access: ProjectSpaceAccess[]; isPrivate: boolean }
+                    >
                 >((acc, projectSpaceAccess) => {
                     if (!acc[projectSpaceAccess.spaceUuid]) {
-                        acc[projectSpaceAccess.spaceUuid] = [];
+                        acc[projectSpaceAccess.spaceUuid] = {
+                            access: [],
+                            isPrivate: projectSpaceAccess.isPrivate,
+                        };
                     }
 
-                    acc[projectSpaceAccess.spaceUuid].push(projectSpaceAccess);
+                    const { isPrivate, ...access } = projectSpaceAccess;
+                    acc[projectSpaceAccess.spaceUuid].access.push(access);
                     return acc;
                 }, {});
             },
@@ -215,58 +261,73 @@ export class SpacePermissionModel {
     async getOrganizationSpaceAccess(
         spaceUuids: string[],
         filters?: { userUuid?: string },
-    ): Promise<Record<string, OrganizationSpaceAccess[]>> {
+    ): Promise<
+        Record<
+            string,
+            { access: OrganizationSpaceAccess[]; isPrivate: boolean }
+        >
+    > {
         return wrapSentryTransaction(
             'SpaceModel.getOrganizationAccess',
             { spaceUuidsCount: spaceUuids.length },
             async () => {
-                const organizationSpacesAccess: OrganizationSpaceAccess[] =
-                    await this.database(SpaceTableName)
-                        .select({
-                            userUuid: `${UserTableName}.user_uuid`,
-                            spaceUuid: `${SpaceTableName}.space_uuid`,
-                            role: `${OrganizationMembershipsTableName}.role`,
-                        })
-                        .innerJoin(
-                            ProjectTableName,
-                            `${ProjectTableName}.project_id`,
-                            `${SpaceTableName}.project_id`,
-                        )
-                        .innerJoin(
-                            OrganizationTableName,
-                            `${OrganizationTableName}.organization_id`,
-                            `${ProjectTableName}.organization_id`,
-                        )
-                        .innerJoin(
-                            OrganizationMembershipsTableName,
-                            `${OrganizationMembershipsTableName}.organization_id`,
-                            `${OrganizationTableName}.organization_id`,
-                        )
-                        .innerJoin(
-                            UserTableName,
-                            `${UserTableName}.user_id`,
-                            `${OrganizationMembershipsTableName}.user_id`,
-                        )
-                        .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
-                        .modify((qb) => {
-                            if (filters?.userUuid) {
-                                void qb.where(
-                                    `${UserTableName}.user_uuid`,
-                                    filters.userUuid,
-                                );
-                            }
-                        });
+                const organizationSpacesAccess: (OrganizationSpaceAccess & {
+                    isPrivate: boolean;
+                })[] = await this.database(SpaceTableName)
+                    .select({
+                        userUuid: `${UserTableName}.user_uuid`,
+                        spaceUuid: `${SpaceTableName}.space_uuid`,
+                        isPrivate: `${SpaceTableName}.is_private`,
+                        role: `${OrganizationMembershipsTableName}.role`,
+                    })
+                    .innerJoin(
+                        ProjectTableName,
+                        `${ProjectTableName}.project_id`,
+                        `${SpaceTableName}.project_id`,
+                    )
+                    .innerJoin(
+                        OrganizationTableName,
+                        `${OrganizationTableName}.organization_id`,
+                        `${ProjectTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        OrganizationMembershipsTableName,
+                        `${OrganizationMembershipsTableName}.organization_id`,
+                        `${OrganizationTableName}.organization_id`,
+                    )
+                    .innerJoin(
+                        UserTableName,
+                        `${UserTableName}.user_id`,
+                        `${OrganizationMembershipsTableName}.user_id`,
+                    )
+                    .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                    .modify((qb) => {
+                        if (filters?.userUuid) {
+                            void qb.where(
+                                `${UserTableName}.user_uuid`,
+                                filters.userUuid,
+                            );
+                        }
+                    });
 
                 return organizationSpacesAccess.reduce<
-                    Record<string, OrganizationSpaceAccess[]>
+                    Record<
+                        string,
+                        {
+                            access: OrganizationSpaceAccess[];
+                            isPrivate: boolean;
+                        }
+                    >
                 >((acc, organizationSpaceAccess) => {
                     if (!acc[organizationSpaceAccess.spaceUuid]) {
-                        acc[organizationSpaceAccess.spaceUuid] = [];
+                        acc[organizationSpaceAccess.spaceUuid] = {
+                            access: [],
+                            isPrivate: organizationSpaceAccess.isPrivate,
+                        };
                     }
 
-                    acc[organizationSpaceAccess.spaceUuid].push(
-                        organizationSpaceAccess,
-                    );
+                    const { isPrivate, ...access } = organizationSpaceAccess;
+                    acc[organizationSpaceAccess.spaceUuid].access.push(access);
                     return acc;
                 }, {});
             },

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -1,22 +1,10 @@
-import { SpaceShare } from '@lightdash/common';
+import {
+    resolveSpaceAccessForCasl,
+    type SpaceAccessForCasl,
+} from '@lightdash/common';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SpacePermissionModel } from '../../models/SpacePermissionModel';
 import { BaseService } from '../BaseService';
-
-type SpaceAccessForCasl = {
-    organizationUuid: string;
-    projectUuid: string;
-    isPrivate: boolean;
-    access: SpaceShare[];
-};
-
-// packages/common/src/authorization/spaceAccessResolver.ts
-// type SpaceAccessContext = {
-//     spaceIsPrivate: boolean;
-//     directAccess: DirectSpaceAccess[];
-//     userProjectRole?: ProjectMemberRole;
-//     userOrgRole?: OrganizationMemberRole;
-// };
 
 export class SpacePermissionService extends BaseService {
     constructor(
@@ -26,33 +14,75 @@ export class SpacePermissionService extends BaseService {
         super();
     }
 
+    /**
+     * Gets the access context for a list of spaces, suitable for CASL authorization checks.
+     * This method fetches permissions from direct space access, project memberships, and
+     * organization memberships, then resolves them into a format suitable for CASL.
+     *
+     * @param spaceUuids - The UUIDs of the spaces to get access context for
+     * @param filters - Optional filters to limit access data (e.g., for a specific user)
+     * @returns A record mapping each space UUID to its resolved access context
+     */
     async getAccessContext(
         spaceUuids: string[],
-        filters?: { userUuid: string },
+        filters?: { userUuid?: string },
     ): Promise<Record<string, SpaceAccessForCasl>> {
-        const spaceRoots = await Promise.all(
-            spaceUuids.map((uuid) =>
-                this.spaceModel
-                    .getSpaceRootFromCacheOrDB(uuid)
-                    .then((r) => r.spaceRoot),
-            ),
+        // Map each space UUID to its root UUID (for nested spaces, access is based on root)
+        const spaceToRoot = await Promise.all(
+            spaceUuids.map(async (uuid) => {
+                const { spaceRoot } =
+                    await this.spaceModel.getSpaceRootFromCacheOrDB(uuid);
+                return { spaceUuid: uuid, rootUuid: spaceRoot };
+            }),
         );
-        const directAccess =
-            await this.spacePermissionModel.getDirectSpaceAccess(
-                spaceRoots,
-                filters,
-            );
-        const [projectAccess, organizationAccess] = await Promise.all([
-            this.spacePermissionModel.getProjectSpaceAccess(
-                spaceRoots,
-                filters,
-            ),
-            this.spacePermissionModel.getOrganizationSpaceAccess(
-                spaceRoots,
-                filters,
-            ),
-        ]);
 
-        throw new Error('Not fully implemented');
+        // Get unique root UUIDs to minimize queries
+        const uniqueRootUuids = [
+            ...new Set(spaceToRoot.map((s) => s.rootUuid)),
+        ];
+
+        // Fetch all access data in parallel
+        const [directAccessBySpace, projectAccessBySpace, orgAccessBySpace] =
+            await Promise.all([
+                this.spacePermissionModel.getDirectSpaceAccess(
+                    uniqueRootUuids,
+                    filters,
+                ),
+                this.spacePermissionModel.getProjectSpaceAccess(
+                    uniqueRootUuids,
+                    filters,
+                ),
+                this.spacePermissionModel.getOrganizationSpaceAccess(
+                    uniqueRootUuids,
+                    filters,
+                ),
+            ]);
+
+        // Resolve access for each original space UUID
+        const result: Record<string, SpaceAccessForCasl> = {};
+
+        for (const { spaceUuid, rootUuid } of spaceToRoot) {
+            const directData = directAccessBySpace[rootUuid];
+            const projectData = projectAccessBySpace[rootUuid];
+            const orgData = orgAccessBySpace[rootUuid];
+
+            // Determine isPrivate from whichever query returned actual data.
+            // All queries for the same space should return the same isPrivate value.
+            // SECURITY: If no query returned data, default to true (deny by default)
+            const isPrivate =
+                directData?.isPrivate ??
+                projectData?.isPrivate ??
+                orgData?.isPrivate ??
+                true;
+
+            result[spaceUuid] = resolveSpaceAccessForCasl({
+                directAccess: directData?.access ?? [],
+                projectAccess: projectData?.access ?? [],
+                organizationAccess: orgData?.access ?? [],
+                isPrivate,
+            });
+        }
+
+        return result;
     }
 }

--- a/packages/common/src/authorization/CLAUDE.md
+++ b/packages/common/src/authorization/CLAUDE.md
@@ -1,0 +1,108 @@
+<summary>
+This module handles authorization for Lightdash using CASL (Code Access Security Layer).
+It defines what actions users can perform based on their roles at organization, project, and space levels.
+
+The key components are:
+
+- **Ability builders**: Create CASL abilities based on user roles
+- **Space access resolver**: Computes effective space roles from multiple access sources
+- **Scope-based abilities**: Support for custom roles with fine-grained permissions
+  </summary>
+
+<howToUse>
+
+## Building User Abilities
+
+Use `getUserAbilityBuilder` to create a CASL ability for a user:
+
+```typescript
+import { getUserAbilityBuilder } from '@lightdash/common';
+
+const builder = getUserAbilityBuilder({
+    user: { role: 'editor', organizationUuid, userUuid },
+    projectProfiles: [{ projectUuid, role: 'editor', userUuid }],
+    permissionsConfig: { pat: { enabled: false, allowedOrgRoles: [] } },
+});
+const ability = builder.build();
+```
+
+## Checking Permissions
+
+Use CASL's `can` method with `subject()` to check permissions:
+
+```typescript
+import { subject } from '@casl/ability';
+
+// Check if user can view a space
+ability.can(
+    'view',
+    subject('Space', {
+        projectUuid,
+        isPrivate: false,
+        access: [{ userUuid, role: 'editor' }],
+    }),
+);
+```
+
+## Resolving Space Access
+
+Use `resolveSpaceAccessForCasl` to compute effective access from raw data:
+
+```typescript
+import { resolveSpaceAccessForCasl } from '@lightdash/common';
+
+const accessForCasl = resolveSpaceAccessForCasl({
+    directAccess, // Direct space user/group access
+    projectAccess, // Project membership access
+    organizationAccess, // Org membership access
+    isPrivate: true,
+});
+// Returns: { isPrivate, access: [{ userUuid, role }] }
+```
+
+</howToUse>
+
+<codeExample>
+
+```mermaid
+flowchart LR
+    subgraph "Raw Access Data"
+        D[Direct Space Access]
+        P[Project Memberships]
+        O[Org Memberships]
+    end
+
+    subgraph "Resolution"
+        R[spaceAccessResolver]
+    end
+
+    subgraph "CASL Check"
+        C[ability.can]
+    end
+
+    D --> R
+    P --> R
+    O --> R
+    R -->|"{ isPrivate, access }"| C
+    C -->|"true/false"| Result
+```
+
+</codeExample>
+
+<importantToKnow>
+- **spaceAccessResolver** computes "what role does user have" - CASL checks "can user do action with that role"
+- Space access is resolved from the **root space** for nested spaces (access is inherited)
+- For **public spaces**: users get access based on their project role (converted to space role)
+- For **private spaces**: users need direct access (user or group) to have any access
+- Role priority: admin > editor > viewer - the resolver returns the highest effective role
+- CASL uses `$elemMatch` to check if a user is in the access array with a specific role
+</importantToKnow>
+
+<links>
+- CASL documentation: https://casl.js.org/v6/en/guide/intro
+- Organization abilities: @/packages/common/src/authorization/organizationMemberAbility.ts
+- Project abilities: @/packages/common/src/authorization/projectMemberAbility.ts
+- Scope-based abilities: @/packages/common/src/authorization/scopeAbilityBuilder.ts
+- Space access resolver: @/packages/common/src/authorization/spaceAccessResolver.ts
+- Backend permission model: @/packages/backend/src/models/SpacePermissionModel.ts
+</links>

--- a/packages/common/src/authorization/spaceAccessResolver.ts
+++ b/packages/common/src/authorization/spaceAccessResolver.ts
@@ -1,0 +1,187 @@
+import {
+    type GroupRole,
+    type OrganizationRole,
+    type ProjectRole,
+    type SpaceGroupAccessRole,
+    ProjectMemberRole,
+} from '../types/projectMemberRole';
+import {
+    type DirectSpaceAccess,
+    type OrganizationSpaceAccess,
+    type ProjectSpaceAccess,
+    type SpaceShare,
+    DirectSpaceAccessOrigin,
+    ProjectRoleOrigin,
+    SpaceMemberRole,
+} from '../types/space';
+import {
+    convertOrganizationRoleToProjectRole,
+    convertProjectRoleToSpaceRole,
+    convertSpaceRoleToProjectRole,
+    getHighestProjectRole,
+    getHighestSpaceRole,
+} from '../utils/projectMemberRole';
+
+export type SpaceAccessContext = {
+    directAccess: DirectSpaceAccess[];
+    projectAccess: ProjectSpaceAccess[];
+    organizationAccess: OrganizationSpaceAccess[];
+    isPrivate: boolean;
+};
+
+export type SpaceAccessForCasl = {
+    isPrivate: boolean;
+    access: Pick<SpaceShare, 'userUuid' | 'role' | 'hasDirectAccess'>[];
+};
+
+/**
+ * Resolves the effective space role for a single user given their various access sources.
+ * This mirrors the logic in SpaceModel._getSpaceAccess.
+ */
+function resolveUserSpaceRole({
+    userUuid,
+    directUserAccess,
+    directGroupAccess,
+    orgAccess,
+    projectAndGroupAccess,
+    isPrivate,
+}: {
+    userUuid: string;
+    directUserAccess: DirectSpaceAccess | undefined;
+    directGroupAccess: DirectSpaceAccess[];
+    orgAccess: OrganizationSpaceAccess[];
+    projectAndGroupAccess: ProjectSpaceAccess[];
+    isPrivate: boolean;
+}): SpaceAccessForCasl['access'][number] | null {
+    // Build role objects for getHighestProjectRole
+    const orgRoles: OrganizationRole[] = orgAccess.map((access) => ({
+        type: 'organization',
+        role: convertOrganizationRoleToProjectRole(access.role),
+    }));
+
+    const projectRoles: (ProjectRole | GroupRole)[] = projectAndGroupAccess.map(
+        (access) => ({
+            type: access.from === ProjectRoleOrigin.GROUP ? 'group' : 'project',
+            role: access.role,
+        }),
+    );
+
+    const spaceGroupRoles: SpaceGroupAccessRole[] = directGroupAccess.map(
+        (access) => ({
+            type: 'space_group',
+            role: convertSpaceRoleToProjectRole(access.role),
+        }),
+    );
+
+    const highestRole = getHighestProjectRole([
+        ...orgRoles,
+        ...projectRoles,
+        ...spaceGroupRoles,
+    ]);
+
+    // No role at all - user has no access
+    if (!highestRole) {
+        return null;
+    }
+
+    const hasDirectAccess =
+        directUserAccess !== undefined || directGroupAccess.length > 0;
+
+    let spaceRole: SpaceMemberRole | undefined;
+
+    if (highestRole.role === ProjectMemberRole.ADMIN) {
+        // Admins always get admin space role
+        spaceRole = SpaceMemberRole.ADMIN;
+    } else if (hasDirectAccess) {
+        // User has direct access - use explicit user role or highest group role
+        spaceRole =
+            directUserAccess?.role ??
+            getHighestSpaceRole(directGroupAccess.map((access) => access.role));
+    } else if (!isPrivate) {
+        // Public space - convert project role to space role
+        spaceRole = convertProjectRoleToSpaceRole(highestRole.role);
+    } else {
+        // Private space with no direct access - no access
+        return null;
+    }
+
+    if (!spaceRole) {
+        return null;
+    }
+
+    return {
+        userUuid,
+        role: spaceRole,
+        hasDirectAccess,
+    };
+}
+
+/**
+ * Resolves space access for CASL authorization checks.
+ *
+ * Takes the raw access data (direct, project, org) and resolves it into the format
+ * needed for CASL ability checks. The input data may already be filtered by userUuid
+ * at the query level if only checking access for a single user.
+ *
+ * This function mirrors the logic in SpaceModel._getSpaceAccess but operates on
+ * pre-fetched data rather than doing the SQL joins itself.
+ */
+export function resolveSpaceAccessForCasl({
+    directAccess,
+    projectAccess,
+    organizationAccess,
+    isPrivate,
+}: SpaceAccessContext): SpaceAccessForCasl {
+    // Get all unique user UUIDs from all access sources
+    const allUserUuids = new Set<string>([
+        ...directAccess.map((a) => a.userUuid),
+        ...projectAccess.map((a) => a.userUuid),
+        ...organizationAccess.map((a) => a.userUuid),
+    ]);
+
+    const resolvedAccess: SpaceAccessForCasl['access'] = [];
+
+    for (const userUuid of allUserUuids) {
+        // Get this user's direct access (user-level)
+        const directUserAccess = directAccess.find(
+            (a) =>
+                a.userUuid === userUuid &&
+                a.from === DirectSpaceAccessOrigin.USER,
+        );
+
+        // Get this user's direct access (group-level)
+        const directGroupAccess = directAccess.filter(
+            (a) =>
+                a.userUuid === userUuid &&
+                a.from === DirectSpaceAccessOrigin.GROUP,
+        );
+
+        // Get this user's org access
+        const orgAccess = organizationAccess.filter(
+            (a) => a.userUuid === userUuid,
+        );
+
+        // Get this user's project access (direct + group)
+        const projectAndGroupAccess = projectAccess.filter(
+            (a) => a.userUuid === userUuid,
+        );
+
+        const resolved = resolveUserSpaceRole({
+            userUuid,
+            directUserAccess,
+            directGroupAccess,
+            orgAccess,
+            projectAndGroupAccess,
+            isPrivate,
+        });
+
+        if (resolved) {
+            resolvedAccess.push(resolved);
+        }
+    }
+
+    return {
+        isPrivate,
+        access: resolvedAccess,
+    };
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -53,6 +53,7 @@ export * from './authorization/parseAccount';
 export * from './authorization/roleToScopeMapping';
 export * from './authorization/scopes';
 export * from './authorization/serviceAccountAbility';
+export * from './authorization/spaceAccessResolver';
 export * from './authorization/types';
 export * from './compiler/compilationReport';
 export * from './compiler/exploreCompiler';

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -7,9 +7,15 @@ import { type SpaceQuery } from './savedCharts';
 
 // Permissions added directly to a space (not inherited from parent/orgs/projects)
 export enum DirectSpaceAccessOrigin {
-    USER_ACCESS = 'user_access',
-    GROUP_ACCESS = 'group_access',
+    USER = 'user_access',
+    GROUP = 'group_access',
 }
+
+export enum ProjectRoleOrigin {
+    USER = 'user_role',
+    GROUP = 'group_role',
+}
+
 export type DirectSpaceAccess = {
     userUuid: string;
     spaceUuid: string;
@@ -27,6 +33,7 @@ export type ProjectSpaceAccess = {
     userUuid: string;
     spaceUuid: string;
     role: ProjectMemberRole;
+    from: ProjectRoleOrigin;
 };
 
 export type Space = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR refactors the space permission model to improve access resolution for CASL authorization. Key changes include:

1. Added a new `SpaceAccessResolver` module in the common package to centralize access resolution logic
2. Enhanced the permission model to include `isPrivate` flag in query results
3. Updated the access origin enums to be more consistent (`USER`, `GROUP` instead of `USER_ACCESS`, etc.)
4. Added a new `ProjectRoleOrigin` enum to track whether project roles come from direct user membership or group membership
5. Implemented the `getAccessContext` method in `SpacePermissionService` to properly resolve space access for CASL

The refactored code provides a more structured approach to resolving space permissions by considering direct access, project access, and organization access together.