### PR TITLE
feat: add soft delete migration for saved_queries

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -322,4 +322,7 @@ export const lightdashConfigMock: LightdashConfig = {
         enabled: false,
         expirationSeconds: 604800,
     },
+    softDelete: {
+        enabled: false,
+    },
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1028,6 +1028,9 @@ export type LightdashConfig = {
     nestedSpacesPermissions: {
         enabled: boolean;
     };
+    softDelete: {
+        enabled: boolean;
+    };
 };
 
 export type SlackConfig = {
@@ -1860,6 +1863,9 @@ export const parseConfig = (): LightdashConfig => {
         },
         nestedSpacesPermissions: {
             enabled: process.env.NESTED_SPACES_PERMISSIONS_ENABLED === 'true',
+        },
+        softDelete: {
+            enabled: process.env.SOFT_DELETE_ENABLED === 'true',
         },
     };
 };

--- a/packages/backend/src/database/entities/savedCharts.ts
+++ b/packages/backend/src/database/entities/savedCharts.ts
@@ -61,6 +61,8 @@ export type SavedChartTable = Knex.CompositeTableType<
             | 'slug'
             | 'views_count'
             | 'first_viewed_at'
+            | 'deleted_at'
+            | 'deleted_by_user_uuid'
         >
     >
 >;
@@ -80,6 +82,8 @@ export type DbSavedChart = {
     slug: string;
     views_count: number;
     first_viewed_at: Date | null;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 export type DbSavedChartVersion = {

--- a/packages/backend/src/database/migrations/20260205132424_add_soft_delete_to_saved_queries.ts
+++ b/packages/backend/src/database/migrations/20260205132424_add_soft_delete_to_saved_queries.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const SavedQueriesTableName = 'saved_queries';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SavedQueriesTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_saved_queries_not_deleted
+        ON ${SavedQueriesTableName} (saved_query_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(`
+        CREATE INDEX idx_saved_queries_deleted
+        ON ${SavedQueriesTableName} (saved_query_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_saved_queries_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_saved_queries_not_deleted');
+    await knex.schema.alterTable(SavedQueriesTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -153,6 +153,8 @@ export const savedChartEntry: SavedChartTable['base'] = {
     search_vector: '',
     views_count: 0,
     first_viewed_at: null,
+    deleted_at: null,
+    deleted_by_user_uuid: null,
 };
 
 export const dashboardEntry: DashboardTable['base'] = {


### PR DESCRIPTION
### Description:
Adds soft delete functionality for saved queries by:

1. Adding a `softDelete` configuration option to `LightdashConfig` with an environment variable toggle (`SOFT_DELETE_ENABLED`)
2. Adding `deleted_at` and `deleted_by_user_uuid` columns to the `saved_queries` table
3. Creating a partial index for efficient queries on non-deleted items
4. Updating type definitions to include the new fields

This change lays the groundwork for implementing soft delete functionality, allowing users to recover accidentally deleted saved queries.