### PR TITLE
feat: soft delete for charts

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -289,11 +289,13 @@ export class AnalyticsModel {
                     `${SpaceTableName}.name as space_name`,
                 )
                 .from(AnalyticsChartViewsTableName)
-                .leftJoin(
-                    SavedChartsTableName,
-                    `${SavedChartsTableName}.saved_query_uuid`,
-                    `${AnalyticsChartViewsTableName}.chart_uuid`,
-                )
+                .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                    this.on(
+                        `${SavedChartsTableName}.saved_query_uuid`,
+                        '=',
+                        `${AnalyticsChartViewsTableName}.chart_uuid`,
+                    ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+                })
                 .leftJoin(
                     UserTableName,
                     `${UserTableName}.user_uuid`,

--- a/packages/backend/src/models/CLAUDE.md
+++ b/packages/backend/src/models/CLAUDE.md
@@ -66,6 +66,66 @@ const user = await userModel.findUserByEmail('john.doe@example.com');
   - Methods that start with `create` validate input and return the created entity
   - Methods that start with `update` modify an entity and return the updated version
   - Methods that start with `delete` remove an entity and typically return void
+
+## Soft Delete Pattern
+
+The `saved_queries` table supports soft delete. When `SOFT_DELETE_ENABLED=true`, charts are soft-deleted (marked with `deleted_at` timestamp) instead of permanently removed.
+
+### Key Points
+
+- Columns: `deleted_at` (timestamp), `deleted_by_user_uuid` (UUID)
+- Partial index: `idx_saved_queries_not_deleted` for fast queries on non-deleted items
+- Feature flag: `lightdashConfig.softDelete.enabled` controls behavior in SavedChartService
+
+### When Modifying Queries
+
+Any query that touches `saved_queries` must filter out soft-deleted records:
+
+**Direct Knex query:**
+```typescript
+const charts = await this.database('saved_queries')
+    .whereNull('deleted_at')  // ADD THIS
+    .where('project_uuid', projectUuid);
+```
+
+**Knex join (simple):**
+```typescript
+.leftJoin(SavedChartsTableName, ...)
+.whereNull(`${SavedChartsTableName}.deleted_at`)  // ADD THIS
+```
+
+**Knex join (function syntax - for join conditions):**
+```typescript
+.leftJoin(SavedChartsTableName, function () {
+    this.on('column1', '=', 'column2')
+        .andOnNull(`${SavedChartsTableName}.deleted_at`);  // ADD THIS
+})
+```
+
+**Raw SQL join:**
+```sql
+-- Add to join condition:
+left join saved_queries sq on sq.saved_query_uuid = ... AND sq.deleted_at IS NULL
+```
+
+**Raw SQL WHERE clause:**
+```sql
+WHERE ... AND sq.deleted_at IS NULL
+```
+
+### Finding Queries That Need Soft Delete Filters
+
+The table is `saved_queries`, exported as `SavedChartsTableName` from entities.
+
+```bash
+# Search for the table name (covers string literals and raw SQL)
+grep -rn "saved_queries" packages/backend/src/models/
+
+# Search for the constant (covers Knex queries using the constant)
+grep -rn "SavedChartsTableName" packages/backend/src/models/
+```
+
+Review each result. If it's a SELECT, JOIN, or subquery that returns chart data, it needs `whereNull('deleted_at')` or `AND deleted_at IS NULL`.
 </importantToKnow>
 
 <links>

--- a/packages/backend/src/models/CommentModel/CommentModel.ts
+++ b/packages/backend/src/models/CommentModel/CommentModel.ts
@@ -125,11 +125,13 @@ export class CommentModel {
                 'dashboard_tile_charts.dashboard_tile_uuid',
                 'dashboard_tiles.dashboard_tile_uuid',
             )
-            .leftJoin(
-                'saved_queries',
-                'saved_queries.saved_query_id',
-                'dashboard_tile_charts.saved_chart_id',
-            )
+            .leftJoin('saved_queries', function nonDeletedChartJoin() {
+                this.on(
+                    'saved_queries.saved_query_id',
+                    '=',
+                    'dashboard_tile_charts.saved_chart_id',
+                ).andOnNull('saved_queries.deleted_at');
+            })
             .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
             .andWhere(
                 `${DashboardTilesTableName}.dashboard_tile_uuid`,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -122,6 +122,7 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                     'dashboard_name', ${DashboardsTableName}.name
                  ) as metadata`),
                 ])
+                .whereNull(`${SavedChartsTableName}.deleted_at`)
                 .where((builder) => {
                     if (filters.projectUuids) {
                         void builder.whereIn(

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -109,6 +109,7 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                                         SELECT count(DISTINCT ${SavedChartsTableName}.saved_query_id)
                                         FROM ${SavedChartsTableName}
                                         WHERE ${SavedChartsTableName}.space_id = ${SpaceTableName}.space_id
+                                        AND ${SavedChartsTableName}.deleted_at IS NULL
                                     ),
                                     'dashboardCount', (
                                         SELECT count(DISTINCT ${DashboardsTableName}.dashboard_id)

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -58,11 +58,13 @@ const getCharts = async (
             'pinned_list.pinned_list_uuid',
             'pinned_chart.pinned_list_uuid',
         )
-        .innerJoin(
-            'saved_queries',
-            'pinned_chart.saved_chart_uuid',
-            'saved_queries.saved_query_uuid',
-        )
+        .innerJoin('saved_queries', function nonDeletedChartJoin() {
+            this.on(
+                'pinned_chart.saved_chart_uuid',
+                '=',
+                'saved_queries.saved_query_uuid',
+            ).andOnNull('saved_queries.deleted_at');
+        })
         .innerJoin('spaces', 'saved_queries.space_id', 'spaces.space_id')
         .leftJoin(
             'users',
@@ -203,11 +205,13 @@ const getAllSpaces = async (
                     `${DashboardsTableName}.space_id`,
                     `${SpaceTableName}.space_id`,
                 )
-                .leftJoin(
-                    SavedChartsTableName,
-                    `${SavedChartsTableName}.space_id`,
-                    `${SpaceTableName}.space_id`,
-                )
+                .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                    this.on(
+                        `${SavedChartsTableName}.space_id`,
+                        '=',
+                        `${SpaceTableName}.space_id`,
+                    ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+                })
                 .whereIn(
                     `${SpaceTableName}.space_uuid`,
                     function getSpacesByPinnedListUuid() {

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -188,11 +188,13 @@ export class SchedulerModel {
                 `${UserTableName}.user_uuid`,
                 `${SchedulerTableName}.created_by`,
             )
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${SchedulerTableName}.saved_chart_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${SchedulerTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(
                 DashboardsTableName,
                 `${DashboardsTableName}.dashboard_uuid`,
@@ -280,11 +282,13 @@ export class SchedulerModel {
                 `${UserTableName}.user_uuid`,
                 `${SchedulerTableName}.created_by`,
             )
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${SchedulerTableName}.saved_chart_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${SchedulerTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(
                 DashboardsTableName,
                 `${DashboardsTableName}.dashboard_uuid`,
@@ -892,11 +896,13 @@ export class SchedulerModel {
                 `${UserTableName}.user_uuid`,
                 `${SchedulerTableName}.created_by`,
             )
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${SchedulerTableName}.saved_chart_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${SchedulerTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(DashboardsTableName, function joinDashboards() {
                 this.on(
                     `${DashboardsTableName}.dashboard_uuid`,
@@ -1146,7 +1152,8 @@ export class SchedulerModel {
             .whereIn('user_uuid', userUuids);
         const charts = await this.database(SavedChartsTableName)
             .select('name', 'saved_query_uuid')
-            .whereIn('saved_query_uuid', chartUuids);
+            .whereIn('saved_query_uuid', chartUuids)
+            .whereNull('deleted_at');
         const dashboards = await this.database(DashboardsTableName)
             .select('name', 'dashboard_uuid')
             .whereIn('dashboard_uuid', dashboardUuids);
@@ -1600,11 +1607,13 @@ export class SchedulerModel {
                 `${UserTableName}.user_uuid`,
                 `${SchedulerTableName}.created_by`,
             )
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${SchedulerTableName}.saved_chart_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${SchedulerTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(
                 DashboardsTableName,
                 `${DashboardsTableName}.dashboard_uuid`,
@@ -1734,11 +1743,13 @@ export class SchedulerModel {
                 `${UserTableName}.user_uuid`,
                 `${SchedulerTableName}.created_by`,
             )
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${SchedulerTableName}.saved_chart_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${SchedulerTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(
                 DashboardsTableName,
                 `${DashboardsTableName}.dashboard_uuid`,
@@ -1842,11 +1853,13 @@ export class SchedulerModel {
                 `${ProjectTableName}.project_uuid`,
                 `${ProjectTableName}.name as project_name`,
             )
-            .innerJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${SchedulerTableName}.saved_chart_uuid`,
-            )
+            .innerJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${SchedulerTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(DashboardsTableName, function joinDashboards() {
                 this.on(
                     `${DashboardsTableName}.dashboard_uuid`,
@@ -1963,11 +1976,13 @@ export class SchedulerModel {
             .select<{ scheduler_uuid: string }[]>(
                 `${SchedulerTableName}.scheduler_uuid`,
             )
-            .innerJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${SchedulerTableName}.saved_chart_uuid`,
-            )
+            .innerJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${SchedulerTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(DashboardsTableName, function joinDashboards() {
                 this.on(
                     `${DashboardsTableName}.dashboard_uuid`,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -320,7 +320,8 @@ export class SpaceModel {
                 ),
             ])
             .orderBy('saved_queries.last_version_updated_at', 'desc')
-            .where('saved_queries.space_id', space.space_id);
+            .where('saved_queries.space_id', space.space_id)
+            .whereNull('saved_queries.deleted_at');
 
         return {
             organizationUuid: space.organization_uuid,
@@ -442,7 +443,8 @@ export class SpaceModel {
                             .from(SavedChartsTableName)
                             .whereRaw(
                                 `${SavedChartsTableName}.space_id = ${SpaceTableName}.space_id`,
-                            ),
+                            )
+                            .whereNull(`${SavedChartsTableName}.deleted_at`),
                         dashboardCount: trx
                             .countDistinct(
                                 `${DashboardsTableName}.dashboard_id`,
@@ -1909,6 +1911,7 @@ export class SpaceModel {
     ): Promise<SpaceQuery[]> {
         let spaceQueriesQuery = this.database(SavedChartsTableName)
             .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
             .leftJoin(
                 SpaceTableName,
                 `${SavedChartsTableName}.space_id`,

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -241,11 +241,13 @@ export class ValidationModel {
         const chartValidationErrorsRows = await this.database(
             ValidationTableName,
         )
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${ValidationTableName}.saved_chart_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${ValidationTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             // Join to chart's direct space (for charts saved directly in a space)
             .leftJoin(
                 SpaceTableName,

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -67,7 +67,7 @@ const analyticsModel = {
 };
 const savedChartModel = {
     get: jest.fn(async () => chart),
-    delete: jest.fn(async () => ({
+    permanentDelete: jest.fn(async () => ({
         uuid: 'chart_uuid',
         projectUuid: 'project_uuid',
     })),
@@ -302,7 +302,7 @@ describe('DashboardService', () => {
 
         await service.update(user, dashboardUuid, updateDashboardTiles);
 
-        expect(savedChartModel.delete).toHaveBeenCalledTimes(1);
+        expect(savedChartModel.permanentDelete).toHaveBeenCalledTimes(1);
         expect(analyticsMock.track).toHaveBeenCalledTimes(2);
         expect(analyticsMock.track).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -187,7 +187,7 @@ export class DashboardService
 
         await Promise.all(
             orphanedCharts.map(async (chart) => {
-                const deletedChart = await this.savedChartModel.delete(
+                const deletedChart = await this.savedChartModel.permanentDelete(
                     chart.uuid,
                 );
                 this.analytics.track({

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -1522,7 +1522,7 @@ export class PromoteService extends BaseService {
                     );
                 await Promise.all(
                     orphanedCharts.map((chart) =>
-                        this.savedChartModel.delete(chart.uuid),
+                        this.savedChartModel.permanentDelete(chart.uuid),
                     ),
                 );
             }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -669,6 +669,7 @@ export class ServiceRepository
             () =>
                 new SavedChartService({
                     analytics: this.context.lightdashAnalytics,
+                    lightdashConfig: this.context.lightdashConfig,
                     projectModel: this.models.getProjectModel(),
                     savedChartModel: this.models.getSavedChartModel(),
                     spaceModel: this.models.getSpaceModel(),

--- a/packages/backend/src/utils/SlugUtils.ts
+++ b/packages/backend/src/utils/SlugUtils.ts
@@ -60,6 +60,8 @@ export const generateUniqueSlugScopedToProject = async (
     let matchingSlugs: string[];
     switch (tableName) {
         case 'saved_queries':
+            // NOTE: no `deleted_at IS NULL` filter here because
+            // we need to check for soft deleted charts as well
             matchingSlugs = await trx(SavedChartsTableName)
                 .leftJoin(
                     DashboardsTableName,


### PR DESCRIPTION
### Description:
Implemented soft delete for charts by adding filters to exclude deleted charts in all queries. When `SOFT_DELETE_ENABLED=true`, charts are marked with a `deleted_at` timestamp instead of being permanently removed.

Key changes:
- Modified all SQL queries that access the `saved_queries` table to filter out soft-deleted records
- Updated join conditions to include `AND deleted_at IS NULL` in raw SQL queries
- Used Knex's `andOnNull` for function-style joins to properly handle soft-deleted charts
- Added `softDelete` method to `SavedChartModel` that sets `deleted_at` and `deleted_by_user_uuid`
- Renamed the existing `delete` method to `permanentDelete` for clarity
- Updated `SavedChartService` to use soft delete when the feature flag is enabled
- Added documentation in CLAUDE.md about the soft delete pattern