### PR TITLE
feat: ui for soft deleted saved_charts

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -324,5 +324,6 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     softDelete: {
         enabled: false,
+        retentionDays: 30,
     },
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1030,6 +1030,7 @@ export type LightdashConfig = {
     };
     softDelete: {
         enabled: boolean;
+        retentionDays: number;
     };
 };
 
@@ -1866,6 +1867,10 @@ export const parseConfig = (): LightdashConfig => {
         },
         softDelete: {
             enabled: process.env.SOFT_DELETE_ENABLED === 'true',
+            retentionDays:
+                getIntegerFromEnvironmentVariable(
+                    'SOFT_DELETE_RETENTION_DAYS',
+                ) ?? 30,
         },
     };
 };

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4578,6 +4578,30 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                deletedAt: { dataType: 'datetime' },
                 slug: { dataType: 'string', required: true },
                 access: {
                     dataType: 'array',
@@ -15876,6 +15900,37 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'string' },
                     required: true,
                 },
+                deletedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -24203,6 +24258,185 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'ItemPayload' },
                     required: true,
                 },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DeletedChartContentSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                organizationUuid: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                spaceName: { dataType: 'string', required: true },
+                spaceUuid: { dataType: 'string', required: true },
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                deletedAt: { dataType: 'datetime', required: true },
+                chartKind: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'ChartKind' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                source: { ref: 'ChartSourceType', required: true },
+                contentType: { ref: 'ContentType.CHART', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DeletedContentSummary: {
+        dataType: 'refAlias',
+        type: { ref: 'DeletedChartContentSummary', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'KnexPaginatedData_DeletedContentSummary-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pagination: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'KnexPaginateArgs' },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                totalResults: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                totalPageCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+                data: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'DeletedContentSummary',
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDeletedContentResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'KnexPaginatedData_DeletedContentSummary-Array_',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DeletedContentItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        source: { ref: 'ChartSourceType', required: true },
+                        contentType: {
+                            ref: 'ContentType.CHART',
+                            required: true,
+                        },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        contentType: {
+                            ref: 'ContentType.DASHBOARD',
+                            required: true,
+                        },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        contentType: {
+                            ref: 'ContentType.SPACE',
+                            required: true,
+                        },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiRestoreContentBody: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                item: { ref: 'DeletedContentItem', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPermanentlyDeleteContentBody: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                item: { ref: 'DeletedContentItem', required: true },
             },
             validators: {},
         },
@@ -49046,6 +49280,211 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'bulkMoveContent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsContentController_listDeletedContent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuids: {
+            in: 'query',
+            name: 'projectUuids',
+            required: true,
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+        pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+        page: { in: 'query', name: 'page', dataType: 'double' },
+        search: { in: 'query', name: 'search', dataType: 'string' },
+        contentTypes: {
+            in: 'query',
+            name: 'contentTypes',
+            dataType: 'array',
+            array: { dataType: 'refEnum', ref: 'ContentType' },
+        },
+        deletedByUserUuids: {
+            in: 'query',
+            name: 'deletedByUserUuids',
+            dataType: 'array',
+            array: { dataType: 'string' },
+        },
+    };
+    app.get(
+        '/api/v2/content/deleted',
+        ...fetchMiddlewares<RequestHandler>(ContentController),
+        ...fetchMiddlewares<RequestHandler>(
+            ContentController.prototype.listDeletedContent,
+        ),
+
+        async function ContentController_listDeletedContent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsContentController_listDeletedContent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ContentController>(ContentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'listDeletedContent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsContentController_restoreContent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiRestoreContentBody',
+        },
+    };
+    app.post(
+        '/api/v2/content/:projectUuid/restore',
+        ...fetchMiddlewares<RequestHandler>(ContentController),
+        ...fetchMiddlewares<RequestHandler>(
+            ContentController.prototype.restoreContent,
+        ),
+
+        async function ContentController_restoreContent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsContentController_restoreContent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ContentController>(ContentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'restoreContent',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsContentController_permanentlyDeleteContent: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiPermanentlyDeleteContentBody',
+        },
+    };
+    app.delete(
+        '/api/v2/content/:projectUuid/permanent',
+        ...fetchMiddlewares<RequestHandler>(ContentController),
+        ...fetchMiddlewares<RequestHandler>(
+            ContentController.prototype.permanentlyDeleteContent,
+        ),
+
+        async function ContentController_permanentlyDeleteContent(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsContentController_permanentlyDeleteContent,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ContentController>(ContentController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'permanentlyDeleteContent',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5012,6 +5012,26 @@
             },
             "SavedChart": {
                 "properties": {
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
                     "slug": {
                         "type": "string"
                     },
@@ -16530,6 +16550,26 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
                     }
                 },
                 "required": [
@@ -24992,6 +25032,192 @@
                     }
                 },
                 "required": ["action", "content"],
+                "type": "object"
+            },
+            "DeletedChartContentSummary": {
+                "properties": {
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "spaceName": {
+                        "type": "string"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "chartKind": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ChartKind"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "source": {
+                        "$ref": "#/components/schemas/ChartSourceType"
+                    },
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentType.CHART"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "organizationUuid",
+                    "projectUuid",
+                    "spaceName",
+                    "spaceUuid",
+                    "deletedBy",
+                    "deletedAt",
+                    "chartKind",
+                    "source",
+                    "contentType",
+                    "description",
+                    "name",
+                    "uuid"
+                ],
+                "type": "object"
+            },
+            "DeletedContentSummary": {
+                "$ref": "#/components/schemas/DeletedChartContentSummary"
+            },
+            "KnexPaginatedData_DeletedContentSummary-Array_": {
+                "properties": {
+                    "pagination": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/KnexPaginateArgs"
+                            },
+                            {
+                                "properties": {
+                                    "totalResults": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "totalPageCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    }
+                                },
+                                "required": ["totalResults", "totalPageCount"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "data": {
+                        "items": {
+                            "$ref": "#/components/schemas/DeletedContentSummary"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["data"],
+                "type": "object"
+            },
+            "ApiDeletedContentResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/KnexPaginatedData_DeletedContentSummary-Array_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "DeletedContentItem": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "source": {
+                                "$ref": "#/components/schemas/ChartSourceType"
+                            },
+                            "contentType": {
+                                "$ref": "#/components/schemas/ContentType.CHART"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["source", "contentType", "uuid"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contentType": {
+                                "$ref": "#/components/schemas/ContentType.DASHBOARD"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["contentType", "uuid"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contentType": {
+                                "$ref": "#/components/schemas/ContentType.SPACE"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["contentType", "uuid"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ApiRestoreContentBody": {
+                "properties": {
+                    "item": {
+                        "$ref": "#/components/schemas/DeletedContentItem"
+                    }
+                },
+                "required": ["item"],
+                "type": "object"
+            },
+            "ApiPermanentlyDeleteContentBody": {
+                "properties": {
+                    "item": {
+                        "$ref": "#/components/schemas/DeletedContentItem"
+                    }
+                },
+                "required": ["item"],
                 "type": "object"
             }
         },
@@ -41502,6 +41728,200 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/ApiContentBulkActionBody_ContentActionMove_"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/content/deleted": {
+            "get": {
+                "operationId": "List deleted content",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDeletedContentResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get deleted content (soft-deleted charts, dashboards, etc.)",
+                "summary": "List deleted content",
+                "tags": ["v2", "Content"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "query",
+                        "name": "projectUuids",
+                        "required": true,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "search",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "contentTypes",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "$ref": "#/components/schemas/ContentType"
+                            }
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "deletedByUserUuids",
+                        "required": false,
+                        "schema": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            }
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v2/content/{projectUuid}/restore": {
+            "post": {
+                "operationId": "Restore content",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Restore a soft-deleted item (chart, dashboard, etc.)",
+                "summary": "Restore content",
+                "tags": ["v2", "Content"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiRestoreContentBody"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/content/{projectUuid}/permanent": {
+            "delete": {
+                "operationId": "Permanently delete content",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Permanently delete a soft-deleted item (chart, dashboard, etc.)",
+                "summary": "Permanently delete content",
+                "tags": ["v2", "Content"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiPermanentlyDeleteContentBody"
                             }
                         }
                     }

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -123,6 +123,10 @@ export const BaseResponse: HealthState = {
     funnelBuilder: {
         enabled: false,
     },
+    softDelete: {
+        enabled: false,
+        retentionDays: 30,
+    },
 };
 
 export const userMock = {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -225,6 +225,10 @@ export class HealthService extends BaseService {
             funnelBuilder: {
                 enabled: this.lightdashConfig.funnelBuilder.enabled,
             },
+            softDelete: {
+                enabled: this.lightdashConfig.softDelete.enabled,
+                retentionDays: this.lightdashConfig.softDelete.retentionDays,
+            },
         };
     }
 

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -341,6 +341,9 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'ScheduledDeliveries', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'DeletedContent', {
+            organizationUuid: member.organizationUuid,
+        });
     },
 };
 

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -276,5 +276,9 @@ export const projectMemberAbilities: Record<
         can('manage', 'ScheduledDeliveries', {
             projectUuid: member.projectUuid,
         });
+
+        can('manage', 'DeletedContent', {
+            projectUuid: member.projectUuid,
+        });
     },
 };

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -96,6 +96,7 @@ const BASE_ROLE_SCOPES = {
         'manage:Space', // All spaces
         'manage:Project', // Required for managing non-private spaces
         'manage:SavedChart', // All saved charts
+        'manage:DeletedContent', // Soft-deleted content management
         'view:AiAgentThread', // All threads in project
         'manage:AiAgentThread', // All threads in project
         'manage:ScheduledDeliveries',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -186,6 +186,14 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:DeletedContent',
+        description:
+            'Manage soft-deleted content (restore, permanently delete)',
+        isEnterprise: false,
+        group: ScopeGroup.CONTENT,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'promote:SavedChart',
         description: 'Promote saved charts to any space',
         isEnterprise: false,

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -32,6 +32,7 @@ export type CaslSubjectNames =
     | 'DashboardCsv'
     | 'DashboardImage'
     | 'DashboardPdf'
+    | 'DeletedContent'
     | 'Explore'
     | 'ExportCsv'
     | 'GoogleSheets'

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -153,6 +153,7 @@ export * from './types/search';
 export * from './types/share';
 export * from './types/slack';
 export * from './types/slackSettings';
+export * from './types/softDelete';
 export * from './types/space';
 export * from './types/spotlightTableConfig';
 export * from './types/sqlRunner';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -448,6 +448,10 @@ export type HealthState = {
     funnelBuilder: {
         enabled: boolean;
     };
+    softDelete: {
+        enabled: boolean;
+        retentionDays: number;
+    };
 };
 
 export enum DBFieldTypes {

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -569,6 +569,13 @@ export type SavedChart = {
     isPrivate: boolean;
     access: SpaceAccess[];
     slug: string;
+    // Soft delete fields (only present when deleted: true option is used)
+    deletedAt?: Date;
+    deletedBy?: {
+        userUuid: string;
+        firstName: string;
+        lastName: string;
+    } | null;
 };
 
 type CreateChartBase = Pick<

--- a/packages/common/src/types/softDelete.ts
+++ b/packages/common/src/types/softDelete.ts
@@ -1,0 +1,61 @@
+import type { ChartSourceType, ContentType } from './content';
+import type { KnexPaginatedData } from './knex-paginate';
+import type { ChartKind } from './savedCharts';
+
+export type DeletedChartContentSummary = {
+    uuid: string;
+    name: string;
+    description: string | null;
+    contentType: ContentType.CHART;
+    source: ChartSourceType;
+    chartKind: ChartKind | null;
+    deletedAt: Date;
+    deletedBy: {
+        userUuid: string;
+        firstName: string;
+        lastName: string;
+    } | null;
+    spaceUuid: string;
+    spaceName: string;
+    projectUuid: string;
+    organizationUuid: string;
+};
+
+// Union type for future extensibility (dashboards, spaces, etc.)
+export type DeletedContentSummary = DeletedChartContentSummary;
+
+export type DeletedContentFilters = {
+    projectUuids: string[];
+    search?: string;
+    contentTypes?: ContentType[];
+    deletedByUserUuids?: string[];
+};
+
+// API types
+export type ApiDeletedContentResponse = {
+    status: 'ok';
+    results: KnexPaginatedData<DeletedContentSummary[]>;
+};
+
+export type DeletedContentItem =
+    | {
+          uuid: string;
+          contentType: ContentType.CHART;
+          source: ChartSourceType;
+      }
+    | {
+          uuid: string;
+          contentType: ContentType.DASHBOARD;
+      }
+    | {
+          uuid: string;
+          contentType: ContentType.SPACE;
+      };
+
+export type ApiRestoreContentBody = {
+    item: DeletedContentItem;
+};
+
+export type ApiPermanentlyDeleteContentBody = {
+    item: DeletedContentItem;
+};

--- a/packages/frontend/src/features/recentlyDeleted/api/deletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/api/deletedContent.ts
@@ -1,0 +1,84 @@
+import {
+    type ContentType,
+    type DeletedContentItem,
+    type DeletedContentSummary,
+    type KnexPaginatedData,
+} from '@lightdash/common';
+import { lightdashApi } from '../../../api';
+
+export type DeletedContentApiParams = {
+    projectUuids: string[];
+    page?: number;
+    pageSize?: number;
+    search?: string;
+    contentTypes?: ContentType[];
+    deletedByUserUuids?: string[];
+};
+
+type DeletedContentApiResponse = KnexPaginatedData<DeletedContentSummary[]>;
+
+export async function getDeletedContent(
+    params: DeletedContentApiParams,
+): Promise<DeletedContentApiResponse> {
+    const searchParams = new URLSearchParams();
+
+    params.projectUuids.forEach((uuid) =>
+        searchParams.append('projectUuids', uuid),
+    );
+
+    if (params.page) {
+        searchParams.set('page', String(params.page));
+    }
+
+    if (params.pageSize) {
+        searchParams.set('pageSize', String(params.pageSize));
+    }
+
+    if (params.search) {
+        searchParams.set('search', params.search);
+    }
+
+    if (params.contentTypes && params.contentTypes.length > 0) {
+        params.contentTypes.forEach((type) =>
+            searchParams.append('contentTypes', type),
+        );
+    }
+
+    if (params.deletedByUserUuids && params.deletedByUserUuids.length > 0) {
+        params.deletedByUserUuids.forEach((uuid) =>
+            searchParams.append('deletedByUserUuids', uuid),
+        );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    return lightdashApi<any>({
+        url: `/content/deleted?${searchParams.toString()}`,
+        method: 'GET',
+        body: undefined,
+        version: 'v2',
+    });
+}
+
+export function restoreDeletedContent(
+    projectUuid: string,
+    item: DeletedContentItem,
+): Promise<undefined> {
+    return lightdashApi<undefined>({
+        url: `/content/${projectUuid}/restore`,
+        method: 'POST',
+        body: JSON.stringify({ item }),
+        version: 'v2',
+    });
+}
+
+export function permanentlyDeleteContent(
+    projectUuid: string,
+    item: DeletedContentItem,
+): Promise<undefined> {
+    return lightdashApi<undefined>({
+        url: `/content/${projectUuid}/permanent`,
+        method: 'DELETE',
+        body: JSON.stringify({ item }),
+        version: 'v2',
+    });
+}

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.module.css
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.module.css
@@ -1,0 +1,21 @@
+.segmentedControl {
+    border: 1px solid var(--mantine-color-ldGray-3);
+    background: var(--mantine-color-background-0);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.indicator {
+    background: var(--mantine-color-indigo-0);
+    border: 1px solid var(--mantine-color-indigo-2);
+
+    @mixin dark {
+        background: var(--mantine-color-indigo-8);
+        border-color: var(--mantine-color-indigo-4);
+    }
+}
+
+.label p {
+    font-size: var(--mantine-font-size-xs);
+    font-weight: 500;
+    color: var(--mantine-color-foreground);
+}

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
@@ -1,0 +1,88 @@
+import { ContentType } from '@lightdash/common';
+import { Box, Divider, SegmentedControl, Text, Tooltip } from '@mantine-8/core';
+import { IconChartBar } from '@tabler/icons-react';
+import type { FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from './ContentTypeFilter.module.css';
+
+type ContentTypeFilterProps = {
+    selectedContentType: 'all' | ContentType.CHART;
+    setSelectedContentType: (value: 'all' | ContentType.CHART) => void;
+};
+
+export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
+    selectedContentType,
+    setSelectedContentType,
+}) => {
+    const iconProps = {
+        style: { display: 'block' },
+        size: 18,
+        stroke: 1.5,
+    };
+
+    const data = [
+        {
+            value: 'all',
+            label: (
+                <Tooltip label="Show all deleted items" withinPortal>
+                    <Box>
+                        <Text fz="xs" fw={500}>
+                            All
+                        </Text>
+                    </Box>
+                </Tooltip>
+            ),
+        },
+        {
+            value: ContentType.CHART,
+            label: (
+                <Tooltip
+                    variant="xs"
+                    label="Show only deleted charts"
+                    withinPortal
+                    maw={200}
+                >
+                    <Box>
+                        <MantineIcon icon={IconChartBar} {...iconProps} />
+                    </Box>
+                </Tooltip>
+            ),
+        },
+        // Future content types can be added here:
+        // {
+        //     value: ContentType.DASHBOARD,
+        //     label: (
+        //         <Tooltip label="Show only deleted dashboards" withinPortal>
+        //             <Box>
+        //                 <MantineIcon icon={IconLayoutDashboard} {...iconProps} />
+        //             </Box>
+        //         </Tooltip>
+        //     ),
+        // },
+    ];
+
+    return (
+        <>
+            <Divider
+                orientation="vertical"
+                w={1}
+                h={20}
+                style={{ alignSelf: 'center' }}
+            />
+            <SegmentedControl
+                size="xs"
+                radius="md"
+                value={selectedContentType}
+                onChange={(value) =>
+                    setSelectedContentType(value as 'all' | ContentType.CHART)
+                }
+                classNames={{
+                    root: classes.segmentedControl,
+                    indicator: classes.indicator,
+                    label: classes.label,
+                }}
+                data={data}
+            />
+        </>
+    );
+};

--- a/packages/frontend/src/features/recentlyDeleted/components/DeletedByFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/DeletedByFilter.tsx
@@ -1,0 +1,211 @@
+import {
+    Badge,
+    Button,
+    Checkbox,
+    Loader,
+    Popover,
+    ScrollArea,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import { IconSearch } from '@tabler/icons-react';
+import { useCallback, useMemo, useRef, useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import classes from '../../../components/SchedulersView/filters/FormatFilter.module.css';
+import { useInfiniteOrganizationUsers } from '../../../hooks/useOrganizationUsers';
+
+const getUserDisplayName = (
+    firstName: string | undefined,
+    lastName: string | undefined,
+    email: string,
+): string => {
+    if (firstName && lastName) {
+        return `${firstName} ${lastName}`;
+    }
+    return email;
+};
+
+interface DeletedByFilterProps {
+    projectUuid: string;
+    selectedUserUuids: string[];
+    onSelectionChange: (userUuids: string[]) => void;
+}
+
+export const DeletedByFilter: FC<DeletedByFilterProps> = ({
+    projectUuid,
+    selectedUserUuids,
+    onSelectionChange,
+}) => {
+    const hasSelectedUsers = selectedUserUuids.length > 0;
+    const [searchValue, setSearchValue] = useState('');
+    const [debouncedSearchValue] = useDebouncedValue(searchValue, 300);
+    const viewportRef = useRef<HTMLDivElement>(null);
+
+    const {
+        data: infiniteUsers,
+        isLoading,
+        isFetching,
+        hasNextPage,
+        fetchNextPage,
+    } = useInfiniteOrganizationUsers(
+        {
+            searchInput: debouncedSearchValue,
+            pageSize: 25,
+            projectUuid,
+        },
+        { keepPreviousData: true },
+    );
+
+    const organizationUsers = useMemo(() => {
+        const allUsers =
+            infiniteUsers?.pages.flatMap((page) => page.data) ?? [];
+        // Deduplicate by userUuid
+        const seen = new Set<string>();
+        return allUsers.filter((user) => {
+            if (seen.has(user.userUuid)) return false;
+            seen.add(user.userUuid);
+            return true;
+        });
+    }, [infiniteUsers]);
+
+    const handleScrollPositionChange = useCallback(
+        ({ y }: { x: number; y: number }) => {
+            if (!viewportRef.current || isFetching || !hasNextPage) return;
+
+            const { scrollHeight, clientHeight } = viewportRef.current;
+            const isNearBottom = y >= scrollHeight - clientHeight - 50;
+
+            if (isNearBottom) {
+                void fetchNextPage();
+            }
+        },
+        [fetchNextPage, hasNextPage, isFetching],
+    );
+
+    const handleCheckboxChange = useCallback(
+        (userUuid: string) => {
+            if (selectedUserUuids.includes(userUuid)) {
+                onSelectionChange(
+                    selectedUserUuids.filter((uuid) => uuid !== userUuid),
+                );
+            } else {
+                onSelectionChange([...selectedUserUuids, userUuid]);
+            }
+        },
+        [selectedUserUuids, onSelectionChange],
+    );
+
+    return (
+        <Popover width={280} position="bottom-start">
+            <Popover.Target>
+                <Tooltip
+                    withinPortal
+                    variant="xs"
+                    label="Filter by user who deleted the item"
+                >
+                    <Button
+                        h={32}
+                        c="foreground"
+                        fw={500}
+                        fz="sm"
+                        variant="default"
+                        radius="md"
+                        px="sm"
+                        className={
+                            hasSelectedUsers
+                                ? classes.filterButtonSelected
+                                : classes.filterButton
+                        }
+                        classNames={{
+                            label: classes.buttonLabel,
+                        }}
+                        rightSection={
+                            hasSelectedUsers ? (
+                                <Badge
+                                    size="xs"
+                                    variant="filled"
+                                    color="indigo.6"
+                                    circle
+                                    styles={{
+                                        root: {
+                                            minWidth: 18,
+                                            height: 18,
+                                            padding: '0 4px',
+                                        },
+                                    }}
+                                >
+                                    {selectedUserUuids.length}
+                                </Badge>
+                            ) : null
+                        }
+                    >
+                        Deleted by
+                    </Button>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown p="sm">
+                <Stack gap="xs">
+                    <Text fz="xs" c="ldGray.9" fw={600}>
+                        Filter by deleted by:
+                    </Text>
+
+                    <TextInput
+                        size="xs"
+                        placeholder="Search users..."
+                        value={searchValue}
+                        onChange={(e) => setSearchValue(e.currentTarget.value)}
+                        leftSection={
+                            <MantineIcon icon={IconSearch} size={14} />
+                        }
+                        rightSection={
+                            isLoading || isFetching ? (
+                                <Loader size="xs" />
+                            ) : null
+                        }
+                    />
+
+                    <ScrollArea.Autosize
+                        mah={200}
+                        type="always"
+                        scrollbars="y"
+                        viewportRef={viewportRef}
+                        onScrollPositionChange={handleScrollPositionChange}
+                    >
+                        <Stack gap="xs">
+                            {organizationUsers.length === 0 && !isLoading && (
+                                <Text fz="xs" c="dimmed">
+                                    No users found
+                                </Text>
+                            )}
+                            {organizationUsers.map((user) => (
+                                <Checkbox
+                                    key={user.userUuid}
+                                    label={getUserDisplayName(
+                                        user.firstName,
+                                        user.lastName,
+                                        user.email,
+                                    )}
+                                    checked={selectedUserUuids.includes(
+                                        user.userUuid,
+                                    )}
+                                    size="xs"
+                                    classNames={{
+                                        body: classes.checkboxBody,
+                                        input: classes.checkboxInput,
+                                        label: classes.checkboxLabel,
+                                    }}
+                                    onChange={() =>
+                                        handleCheckboxChange(user.userUuid)
+                                    }
+                                />
+                            ))}
+                        </Stack>
+                    </ScrollArea.Autosize>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};

--- a/packages/frontend/src/features/recentlyDeleted/components/DeletedContentActionMenu.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/DeletedContentActionMenu.tsx
@@ -1,0 +1,69 @@
+import { type DeletedContentSummary } from '@lightdash/common';
+import { ActionIcon, Menu } from '@mantine-8/core';
+import { IconDotsVertical, IconRestore, IconTrash } from '@tabler/icons-react';
+import { useState, type FC } from 'react';
+import MantineIcon from '../../../components/common/MantineIcon';
+import MantineModal from '../../../components/common/MantineModal';
+
+interface Props {
+    item: DeletedContentSummary;
+    onRestore: () => void;
+    onPermanentlyDelete: () => void;
+    isLoading?: boolean;
+}
+
+const DeletedContentActionMenu: FC<Props> = ({
+    item,
+    onRestore,
+    onPermanentlyDelete,
+    isLoading,
+}) => {
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+
+    return (
+        <>
+            <Menu position="bottom-end" withArrow withinPortal shadow="md">
+                <Menu.Target>
+                    <ActionIcon
+                        variant="subtle"
+                        color="gray"
+                        loading={isLoading}
+                    >
+                        <MantineIcon icon={IconDotsVertical} />
+                    </ActionIcon>
+                </Menu.Target>
+                <Menu.Dropdown>
+                    <Menu.Item
+                        leftSection={<MantineIcon icon={IconRestore} />}
+                        onClick={onRestore}
+                    >
+                        Restore
+                    </Menu.Item>
+                    <Menu.Item
+                        leftSection={<MantineIcon icon={IconTrash} />}
+                        color="red"
+                        onClick={() => setIsDeleteModalOpen(true)}
+                    >
+                        Delete permanently
+                    </Menu.Item>
+                </Menu.Dropdown>
+            </Menu>
+
+            <MantineModal
+                opened={isDeleteModalOpen}
+                onClose={() => setIsDeleteModalOpen(false)}
+                title="Permanently delete item?"
+                variant="delete"
+                resourceType="item"
+                resourceLabel={item.name}
+                onConfirm={() => {
+                    onPermanentlyDelete();
+                    setIsDeleteModalOpen(false);
+                }}
+                confirmLabel="Delete permanently"
+            />
+        </>
+    );
+};
+
+export default DeletedContentActionMenu;

--- a/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
@@ -1,0 +1,553 @@
+import { ContentType, type DeletedContentSummary } from '@lightdash/common';
+import {
+    ActionIcon,
+    Badge,
+    Box,
+    Card,
+    Group,
+    Text,
+    TextInput,
+    Title,
+    Tooltip,
+    useMantineTheme,
+} from '@mantine-8/core';
+import { useDebouncedValue } from '@mantine/hooks';
+import {
+    IconCalendar,
+    IconChartBar,
+    IconClock,
+    IconRefresh,
+    IconSearch,
+    IconTag,
+    IconTextCaption,
+    IconUser,
+    IconX,
+} from '@tabler/icons-react';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_Virtualizer,
+} from 'mantine-react-table';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+    type UIEvent,
+} from 'react';
+import Callout from '../../../components/common/Callout';
+import MantineIcon from '../../../components/common/MantineIcon';
+import useApp from '../../../providers/App/useApp';
+import {
+    useInfiniteDeletedContent,
+    usePermanentlyDeleteContent,
+    useRestoreDeletedContent,
+} from '../hooks/useDeletedContent';
+import { useDeletedContentFilters } from '../hooks/useDeletedContentFilters';
+import { ContentTypeFilter } from './ContentTypeFilter';
+import { DeletedByFilter } from './DeletedByFilter';
+import DeletedContentActionMenu from './DeletedContentActionMenu';
+
+interface Props {
+    projectUuid: string;
+}
+
+const FETCH_SIZE = 50;
+
+const formatDaysRemaining = (
+    deletedAt: Date,
+    retentionDays: number,
+): string => {
+    const deletedDate = new Date(deletedAt);
+    const now = new Date();
+    const diffDays = Math.ceil(
+        (deletedDate.getTime() - now.getTime()) / (1000 * 60 * 60 * 24) +
+            retentionDays,
+    );
+    if (diffDays <= 0) return 'Expired';
+    if (diffDays === 1) return '1 day';
+    return `${diffDays} days`;
+};
+
+const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
+    const theme = useMantineTheme();
+    const tableContainerRef = useRef<HTMLDivElement>(null);
+    const rowVirtualizerInstanceRef =
+        useRef<MRT_Virtualizer<HTMLDivElement, HTMLTableRowElement>>(null);
+
+    const { health, user } = useApp();
+    const retentionDays = health.data?.softDelete?.retentionDays ?? 30;
+
+    const [selectedContentType, setSelectedContentType] = useState<
+        'all' | ContentType.CHART
+    >('all');
+
+    const {
+        search,
+        setSearch,
+        selectedDeletedByUserUuids,
+        setSelectedDeletedByUserUuids,
+        apiFilters,
+    } = useDeletedContentFilters();
+
+    // Debounce filters
+    const debouncedFilters = useMemo(() => {
+        return { search, apiFilters, selectedContentType };
+    }, [search, apiFilters, selectedContentType]);
+
+    const [debouncedSearchAndFilters] = useDebouncedValue(
+        debouncedFilters,
+        300,
+    );
+
+    // Convert selectedContentType to array format for API
+    const contentTypesFilter = useMemo(() => {
+        if (debouncedSearchAndFilters.selectedContentType === 'all') {
+            return debouncedSearchAndFilters.apiFilters.contentTypes;
+        }
+        return [debouncedSearchAndFilters.selectedContentType];
+    }, [debouncedSearchAndFilters]);
+
+    const { data, fetchNextPage, isError, isFetching, isLoading, refetch } =
+        useInfiniteDeletedContent({
+            projectUuids: [projectUuid],
+            pageSize: FETCH_SIZE,
+            search: debouncedSearchAndFilters.search,
+            contentTypes: contentTypesFilter,
+            deletedByUserUuids:
+                debouncedSearchAndFilters.apiFilters.deletedByUserUuids,
+        });
+
+    const flatData = useMemo<DeletedContentSummary[]>(
+        () => data?.pages?.flatMap((page) => page.data) ?? [],
+        [data],
+    );
+
+    const totalDBRowCount = data?.pages?.[0]?.pagination?.totalResults ?? 0;
+    const totalFetched = flatData.length;
+
+    // Workaround for memoization issue with mantine-react-table
+    const [tableData, setTableData] = useState<DeletedContentSummary[]>([]);
+    useEffect(() => {
+        setTableData(flatData);
+    }, [flatData]);
+
+    const { mutate: restoreContent, isLoading: isRestoring } =
+        useRestoreDeletedContent(projectUuid);
+    const { mutate: permanentlyDelete, isLoading: isDeleting } =
+        usePermanentlyDeleteContent(projectUuid);
+
+    const isAdmin = user.data?.ability?.can('manage', 'Organization') ?? false;
+
+    // Fetch more data when scrolling near bottom
+    const fetchMoreOnBottomReached = useCallback(
+        (containerRefElement?: HTMLDivElement | null) => {
+            if (containerRefElement) {
+                const { scrollHeight, scrollTop, clientHeight } =
+                    containerRefElement;
+                if (
+                    scrollHeight - scrollTop - clientHeight < 400 &&
+                    !isFetching &&
+                    totalFetched < totalDBRowCount
+                ) {
+                    void fetchNextPage();
+                }
+            }
+        },
+        [fetchNextPage, isFetching, totalFetched, totalDBRowCount],
+    );
+
+    // Scroll to top when filters change
+    useEffect(() => {
+        if (tableContainerRef.current) {
+            tableContainerRef.current.scrollTop = 0;
+        }
+    }, [debouncedSearchAndFilters]);
+
+    // Check on mount if table needs initial fetch
+    useEffect(() => {
+        fetchMoreOnBottomReached(tableContainerRef.current);
+    }, [fetchMoreOnBottomReached]);
+
+    const columns = useMemo<MRT_ColumnDef<DeletedContentSummary>[]>(
+        () => [
+            {
+                accessorKey: 'name',
+                header: 'Name',
+                size: 300,
+                Header: ({ column }) => (
+                    <Group gap="two" wrap="nowrap">
+                        <MantineIcon icon={IconTextCaption} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Group gap="xs" wrap="nowrap">
+                        <MantineIcon
+                            icon={IconChartBar}
+                            size="md"
+                            color="ldGray.6"
+                        />
+                        <Text fw={600} fz="xs" lineClamp={1}>
+                            {row.original.name}
+                        </Text>
+                    </Group>
+                ),
+            },
+            {
+                accessorKey: 'contentType',
+                header: 'Type',
+                size: 100,
+                Header: ({ column }) => (
+                    <Group gap="two" wrap="nowrap">
+                        <MantineIcon icon={IconTag} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Badge variant="light" size="sm" radius="sm" fw={400}>
+                        {row.original.contentType === ContentType.CHART
+                            ? 'Chart'
+                            : row.original.contentType}
+                    </Badge>
+                ),
+            },
+            ...(isAdmin
+                ? [
+                      {
+                          accessorKey: 'deletedBy',
+                          header: 'Deleted by',
+                          size: 150,
+                          Header: ({
+                              column,
+                          }: {
+                              column: { columnDef: { header: string } };
+                          }) => (
+                              <Group gap="two" wrap="nowrap">
+                                  <MantineIcon
+                                      icon={IconUser}
+                                      color="ldGray.6"
+                                  />
+                                  {column.columnDef.header}
+                              </Group>
+                          ),
+                          Cell: ({
+                              row,
+                          }: {
+                              row: { original: DeletedContentSummary };
+                          }) =>
+                              row.original.deletedBy ? (
+                                  <Text fz="xs" c="ldGray.6">
+                                      {row.original.deletedBy.firstName}{' '}
+                                      {row.original.deletedBy.lastName}
+                                  </Text>
+                              ) : (
+                                  <Text fz="xs" c="ldGray.6">
+                                      Unknown
+                                  </Text>
+                              ),
+                      } as MRT_ColumnDef<DeletedContentSummary>,
+                  ]
+                : []),
+            {
+                accessorKey: 'deletedAt',
+                header: 'Deleted',
+                size: 130,
+                Header: ({ column }) => (
+                    <Group gap="two" wrap="nowrap">
+                        <MantineIcon icon={IconCalendar} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Text fz="xs" c="ldGray.6">
+                        {new Date(row.original.deletedAt).toLocaleDateString()}
+                    </Text>
+                ),
+            },
+            {
+                id: 'daysRemaining',
+                header: 'Days remaining',
+                size: 140,
+                Header: ({ column }) => (
+                    <Group gap="two" wrap="nowrap">
+                        <MantineIcon icon={IconClock} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const remaining = formatDaysRemaining(
+                        row.original.deletedAt,
+                        retentionDays,
+                    );
+                    const isExpired = remaining === 'Expired';
+                    return (
+                        <Text fz="xs" c={isExpired ? 'red' : 'ldGray.6'}>
+                            {remaining}
+                        </Text>
+                    );
+                },
+            },
+            {
+                id: 'actions',
+                header: '',
+                size: 50,
+                enableResizing: false,
+                Cell: ({ row }) => (
+                    <Box
+                        component="div"
+                        onClick={(e: React.MouseEvent<HTMLDivElement>) => {
+                            e.stopPropagation();
+                            e.preventDefault();
+                        }}
+                    >
+                        <DeletedContentActionMenu
+                            item={row.original}
+                            onRestore={() =>
+                                restoreContent({
+                                    uuid: row.original.uuid,
+                                    contentType: row.original.contentType,
+                                    source: row.original.source,
+                                })
+                            }
+                            onPermanentlyDelete={() =>
+                                permanentlyDelete({
+                                    uuid: row.original.uuid,
+                                    contentType: row.original.contentType,
+                                    source: row.original.source,
+                                })
+                            }
+                            isLoading={isRestoring || isDeleting}
+                        />
+                    </Box>
+                ),
+            },
+        ],
+        [
+            isAdmin,
+            retentionDays,
+            restoreContent,
+            permanentlyDelete,
+            isRestoring,
+            isDeleting,
+        ],
+    );
+
+    const table = useMantineReactTable({
+        columns,
+        data: tableData,
+        enableColumnResizing: true,
+        enableRowNumbers: false,
+        enablePagination: false,
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableGlobalFilterModes: false,
+        enableSorting: false,
+        enableRowVirtualization: true,
+        enableTopToolbar: true,
+        enableBottomToolbar: false,
+        mantinePaperProps: {
+            shadow: undefined,
+            style: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableHeadRowProps: {
+            sx: {
+                boxShadow: 'none',
+                'th > div > div:last-child': {
+                    top: -10,
+                    right: -5,
+                },
+                'th > div > div:last-child > .mantine-Divider-root': {
+                    border: 'none',
+                },
+            },
+        },
+        mantineTableContainerProps: {
+            ref: tableContainerRef,
+            style: { maxHeight: 'calc(100dvh - 420px)' },
+            onScroll: (event: UIEvent<HTMLDivElement>) =>
+                fetchMoreOnBottomReached(event.target as HTMLDivElement),
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: Boolean(tableData.length),
+        },
+        mantineTableHeadCellProps: (props) => {
+            const isLastColumn =
+                props.table.getAllColumns().indexOf(props.column) ===
+                props.table.getAllColumns().length - 1;
+
+            const isAnyColumnResizing = props.table
+                .getAllColumns()
+                .some((c) => c.getIsResizing());
+            const canResize = props.column.getCanResize();
+
+            return {
+                bg: 'ldGray.0',
+                h: '3xl',
+                pos: 'relative',
+                style: {
+                    userSelect: 'none',
+                    justifyContent: 'center',
+                    padding: `${theme.spacing.xs} ${theme.spacing.xl}`,
+                    borderTop: `1px solid ${theme.colors.ldGray[2]}`,
+                    borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
+                    borderRight: props.column.getIsResizing()
+                        ? `2px solid ${theme.colors.blue[3]}`
+                        : `1px solid ${
+                              isLastColumn
+                                  ? 'transparent'
+                                  : theme.colors.ldGray[2]
+                          }`,
+                    borderLeft: 'none',
+                },
+                sx: {
+                    '&:hover': canResize
+                        ? {
+                              borderRight: !isAnyColumnResizing
+                                  ? `2px solid ${theme.colors.blue[3]} !important`
+                                  : undefined,
+                              transition: `border-right ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                          }
+                        : {},
+                },
+            };
+        },
+        mantineTableBodyCellProps: () => {
+            return {
+                h: 72,
+                style: {
+                    padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                    borderRight: 'none',
+                    borderLeft: 'none',
+                    borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
+                    borderTop: 'none',
+                },
+            };
+        },
+        renderTopToolbar: () => (
+            <Group
+                justify="space-between"
+                p={`${theme.spacing.sm} ${theme.spacing.md}`}
+                wrap="nowrap"
+            >
+                <Group gap="xs" wrap="nowrap" style={{ flex: 1, minWidth: 0 }}>
+                    <Tooltip withinPortal label="Search by item name">
+                        <TextInput
+                            size="xs"
+                            radius="md"
+                            type="search"
+                            variant="default"
+                            placeholder="Search deleted items..."
+                            value={search ?? ''}
+                            leftSection={
+                                <MantineIcon
+                                    size="md"
+                                    color="ldGray.6"
+                                    icon={IconSearch}
+                                />
+                            }
+                            onChange={(e) =>
+                                setSearch(e.target.value || undefined)
+                            }
+                            rightSection={
+                                search && (
+                                    <ActionIcon
+                                        onClick={() => setSearch(undefined)}
+                                        variant="transparent"
+                                        size="xs"
+                                        color="ldGray.5"
+                                    >
+                                        <MantineIcon icon={IconX} />
+                                    </ActionIcon>
+                                )
+                            }
+                            style={{
+                                minWidth: 200,
+                                maxWidth: 350,
+                                flexShrink: 1,
+                            }}
+                        />
+                    </Tooltip>
+
+                    <ContentTypeFilter
+                        selectedContentType={selectedContentType}
+                        setSelectedContentType={setSelectedContentType}
+                    />
+
+                    {isAdmin && (
+                        <DeletedByFilter
+                            projectUuid={projectUuid}
+                            selectedUserUuids={selectedDeletedByUserUuids}
+                            onSelectionChange={setSelectedDeletedByUserUuids}
+                        />
+                    )}
+                </Group>
+            </Group>
+        ),
+        rowVirtualizerInstanceRef,
+        rowVirtualizerProps: { overscan: 10 },
+        state: {
+            isLoading,
+            showAlertBanner: isError,
+            showProgressBars: isFetching,
+            density: 'md',
+        },
+    });
+
+    if (isError) {
+        return (
+            <Card>
+                <Callout variant="danger">
+                    Failed to load deleted content. Please try again.
+                </Callout>
+            </Card>
+        );
+    }
+
+    return (
+        <>
+            <Card>
+                <Group justify="space-between">
+                    <Box>
+                        <Title order={5}>Recently Deleted</Title>
+                        <Text size="sm" c="dimmed">
+                            Items are permanently deleted after {retentionDays}{' '}
+                            days
+                        </Text>
+                    </Box>
+                    <Tooltip label="Click to refresh the list">
+                        <ActionIcon
+                            onClick={() => refetch()}
+                            variant="subtle"
+                            size="xs"
+                        >
+                            <MantineIcon
+                                icon={IconRefresh}
+                                color="ldGray.6"
+                                stroke={2}
+                            />
+                        </ActionIcon>
+                    </Tooltip>
+                </Group>
+            </Card>
+
+            <MantineReactTable table={table} />
+        </>
+    );
+};
+
+export default RecentlyDeletedPage;

--- a/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
@@ -1,0 +1,111 @@
+import {
+    type ApiError,
+    type ContentType,
+    type DeletedContentItem,
+    type DeletedContentSummary,
+    type KnexPaginatedData,
+} from '@lightdash/common';
+import {
+    useInfiniteQuery,
+    useMutation,
+    useQueryClient,
+} from '@tanstack/react-query';
+import useToaster from '../../../hooks/toaster/useToaster';
+import {
+    getDeletedContent,
+    permanentlyDeleteContent,
+    restoreDeletedContent,
+} from '../api/deletedContent';
+
+const DEFAULT_PAGE_SIZE = 50;
+
+type UseInfiniteDeletedContentParams = {
+    projectUuids: string[];
+    pageSize?: number;
+    search?: string;
+    contentTypes?: ContentType[];
+    deletedByUserUuids?: string[];
+};
+
+export function useInfiniteDeletedContent(
+    params: UseInfiniteDeletedContentParams,
+) {
+    return useInfiniteQuery<
+        KnexPaginatedData<DeletedContentSummary[]>,
+        ApiError
+    >({
+        queryKey: [
+            'deletedContent',
+            params.projectUuids,
+            params.pageSize,
+            params.search,
+            params.contentTypes,
+            params.deletedByUserUuids,
+        ],
+        queryFn: async ({ pageParam = 1 }) => {
+            return getDeletedContent({
+                projectUuids: params.projectUuids,
+                page: pageParam as number,
+                pageSize: params.pageSize ?? DEFAULT_PAGE_SIZE,
+                search: params.search,
+                contentTypes: params.contentTypes,
+                deletedByUserUuids: params.deletedByUserUuids,
+            });
+        },
+        getNextPageParam: (_lastGroup, groups) => {
+            const currentPage = groups.length;
+            const totalPages = _lastGroup.pagination?.totalPageCount ?? 0;
+            return currentPage < totalPages ? currentPage + 1 : undefined;
+        },
+        keepPreviousData: true,
+        refetchOnWindowFocus: false,
+    });
+}
+
+export function useRestoreDeletedContent(projectUuid: string) {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<undefined, ApiError, DeletedContentItem>({
+        mutationFn: (item) => restoreDeletedContent(projectUuid, item),
+        onSuccess: () => {
+            showToastSuccess({
+                title: 'Content restored',
+                subtitle: 'The item has been restored successfully.',
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['deletedContent'],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to restore content',
+                apiError: error,
+            });
+        },
+    });
+}
+
+export function usePermanentlyDeleteContent(projectUuid: string) {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+
+    return useMutation<undefined, ApiError, DeletedContentItem>({
+        mutationFn: (item) => permanentlyDeleteContent(projectUuid, item),
+        onSuccess: () => {
+            showToastSuccess({
+                title: 'Content permanently deleted',
+                subtitle: 'The item has been permanently deleted.',
+            });
+            void queryClient.invalidateQueries({
+                queryKey: ['deletedContent'],
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to delete content',
+                apiError: error,
+            });
+        },
+    });
+}

--- a/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContentFilters.ts
+++ b/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContentFilters.ts
@@ -1,0 +1,130 @@
+import type { ContentType } from '@lightdash/common';
+import { useCallback, useMemo, useState } from 'react';
+import { useSearchParams } from 'react-router';
+
+export type DeletedContentFiltersState = {
+    search: string | undefined;
+    selectedContentTypes: ContentType[];
+    selectedDeletedByUserUuids: string[];
+};
+
+const DEFAULT_FILTERS: DeletedContentFiltersState = {
+    search: undefined,
+    selectedContentTypes: [],
+    selectedDeletedByUserUuids: [],
+};
+
+export const useDeletedContentFilters = () => {
+    const [searchParams, setSearchParams] = useSearchParams();
+
+    const initialSearch = searchParams.get('search') ?? undefined;
+    const initialContentTypes =
+        (searchParams.get('contentTypes')?.split(',').filter(Boolean) as
+            | ContentType[]
+            | undefined) ?? [];
+    const initialDeletedBy =
+        searchParams.get('deletedBy')?.split(',').filter(Boolean) ?? [];
+
+    const [search, setSearchState] = useState<string | undefined>(
+        initialSearch,
+    );
+    const [selectedContentTypes, setSelectedContentTypesState] =
+        useState<ContentType[]>(initialContentTypes);
+    const [selectedDeletedByUserUuids, setSelectedDeletedByUserUuidsState] =
+        useState<string[]>(initialDeletedBy);
+
+    const setSearch = useCallback(
+        (newSearch: string | undefined) => {
+            setSearchState(newSearch);
+            const newParams = new URLSearchParams(searchParams);
+            if (newSearch) {
+                newParams.set('search', newSearch);
+            } else {
+                newParams.delete('search');
+            }
+            setSearchParams(newParams);
+        },
+        [searchParams, setSearchParams],
+    );
+
+    const setSelectedContentTypes = useCallback(
+        (types: ContentType[]) => {
+            setSelectedContentTypesState(types);
+            const newParams = new URLSearchParams(searchParams);
+            if (types.length > 0) {
+                newParams.set('contentTypes', types.join(','));
+            } else {
+                newParams.delete('contentTypes');
+            }
+            setSearchParams(newParams);
+        },
+        [searchParams, setSearchParams],
+    );
+
+    const setSelectedDeletedByUserUuids = useCallback(
+        (uuids: string[]) => {
+            setSelectedDeletedByUserUuidsState(uuids);
+            const newParams = new URLSearchParams(searchParams);
+            if (uuids.length > 0) {
+                newParams.set('deletedBy', uuids.join(','));
+            } else {
+                newParams.delete('deletedBy');
+            }
+            setSearchParams(newParams);
+        },
+        [searchParams, setSearchParams],
+    );
+
+    const resetFilters = useCallback(() => {
+        setSearchState(DEFAULT_FILTERS.search);
+        setSelectedContentTypesState(DEFAULT_FILTERS.selectedContentTypes);
+        setSelectedDeletedByUserUuidsState(
+            DEFAULT_FILTERS.selectedDeletedByUserUuids,
+        );
+
+        const newParams = new URLSearchParams(searchParams);
+        newParams.delete('search');
+        newParams.delete('contentTypes');
+        newParams.delete('deletedBy');
+        setSearchParams(newParams);
+    }, [searchParams, setSearchParams]);
+
+    const hasActiveFilters = useMemo(() => {
+        return (
+            search !== DEFAULT_FILTERS.search ||
+            selectedContentTypes.length !==
+                DEFAULT_FILTERS.selectedContentTypes.length ||
+            selectedDeletedByUserUuids.length !==
+                DEFAULT_FILTERS.selectedDeletedByUserUuids.length
+        );
+    }, [search, selectedContentTypes, selectedDeletedByUserUuids]);
+
+    const apiFilters = useMemo(() => {
+        return {
+            search,
+            contentTypes:
+                selectedContentTypes.length > 0
+                    ? selectedContentTypes
+                    : undefined,
+            deletedByUserUuids:
+                selectedDeletedByUserUuids.length > 0
+                    ? selectedDeletedByUserUuids
+                    : undefined,
+        };
+    }, [search, selectedContentTypes, selectedDeletedByUserUuids]);
+
+    return {
+        search,
+        selectedContentTypes,
+        selectedDeletedByUserUuids,
+
+        apiFilters,
+
+        setSearch,
+        setSelectedContentTypes,
+        setSelectedDeletedByUserUuids,
+
+        resetFilters,
+        hasActiveFilters,
+    };
+};

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -16,14 +16,19 @@ import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import SettingsEmbed from '../ee/features/embed/SettingsEmbed';
 import { ProjectChangesets } from '../features/changesets/components/ProjectChangesets';
+import RecentlyDeletedPage from '../features/recentlyDeleted/components/RecentlyDeletedPage';
 import { useProject } from '../hooks/useProject';
+import useApp from '../providers/App/useApp';
 
 const ProjectSettings: FC = () => {
     const { projectUuid } = useParams<{
         projectUuid: string;
     }>();
 
+    const { health } = useApp();
     const { isInitialLoading, data: project, error } = useProject(projectUuid);
+
+    const isSoftDeleteEnabled = health.data?.softDelete?.enabled ?? false;
 
     const routes = useMemo<RouteObject[]>(() => {
         if (!projectUuid) {
@@ -64,6 +69,16 @@ const ProjectSettings: FC = () => {
                 path: `/dataOps`,
                 element: <DataOps projectUuid={projectUuid} />,
             },
+            ...(isSoftDeleteEnabled
+                ? [
+                      {
+                          path: `/recentlyDeleted`,
+                          element: (
+                              <RecentlyDeletedPage projectUuid={projectUuid} />
+                          ),
+                      },
+                  ]
+                : []),
             {
                 path: `/parameters`,
                 element: <ProjectParameters projectUuid={projectUuid} />,
@@ -81,7 +96,7 @@ const ProjectSettings: FC = () => {
                 element: <SettingsEmbed projectUuid={projectUuid} />,
             },
         ];
-    }, [projectUuid]);
+    }, [projectUuid, isSoftDeleteEnabled]);
     const routesElements = useRoutes(routes);
 
     if (error) {

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -19,6 +19,7 @@ import {
     IconRefresh,
     IconReportAnalytics,
     IconTableOptions,
+    IconTrash,
     IconUserCircle,
     IconUserCode,
     IconUserPlus,
@@ -455,6 +456,12 @@ const Settings: FC = () => {
             ) &&
             !matchPath(
                 {
+                    path: '/generalSettings/projectManagement/:projectUuid/recentlyDeleted',
+                },
+                location.pathname,
+            ) &&
+            !matchPath(
+                {
                     path: '/generalSettings/customRoles',
                 },
                 location.pathname,
@@ -519,7 +526,9 @@ const Settings: FC = () => {
                                     exact
                                     to="/generalSettings/profile"
                                     label="Profile"
-                                    leftSection={<MantineIcon icon={IconUserCircle} />}
+                                    leftSection={
+                                        <MantineIcon icon={IconUserCircle} />
+                                    }
                                 />
                                 {allowPasswordAuthentication && (
                                     <RouterNavLink
@@ -530,7 +539,9 @@ const Settings: FC = () => {
                                         }
                                         exact
                                         to="/generalSettings/password"
-                                        leftSection={<MantineIcon icon={IconLock} />}
+                                        leftSection={
+                                            <MantineIcon icon={IconLock} />
+                                        }
                                     />
                                 )}
                                 <RouterNavLink
@@ -572,7 +583,9 @@ const Settings: FC = () => {
                                         label="Personal access tokens"
                                         exact
                                         to="/generalSettings/personalAccessTokens"
-                                        leftSection={<MantineIcon icon={IconKey} />}
+                                        leftSection={
+                                            <MantineIcon icon={IconKey} />
+                                        }
                                     />
                                 )}
                             </Box>
@@ -665,7 +678,9 @@ const Settings: FC = () => {
                                         label="Integrations"
                                         exact
                                         to="/generalSettings/integrations"
-                                        leftSection={<MantineIcon icon={IconPlug} />}
+                                        leftSection={
+                                            <MantineIcon icon={IconPlug} />
+                                        }
                                     />
                                 )}
 
@@ -928,6 +943,17 @@ const Settings: FC = () => {
                                             }
                                         />
                                     ) : null}
+
+                                    {health?.softDelete?.enabled && (
+                                        <RouterNavLink
+                                            label="Recently deleted"
+                                            exact
+                                            to={`/generalSettings/projectManagement/${project.projectUuid}/recentlyDeleted`}
+                                            leftSection={
+                                                <MantineIcon icon={IconTrash} />
+                                            }
+                                        />
+                                    )}
                                 </Box>
                             ) : null}
                         </Stack>

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -123,6 +123,10 @@ export default function mockHealthResponse(
         funnelBuilder: {
             enabled: false,
         },
+        softDelete: {
+            enabled: false,
+            retentionDays: 30,
+        },
         ...overrides,
     };
 }


### PR DESCRIPTION
### Description:
This PR adds a "Recently Deleted" feature that allows users to view, restore, and permanently delete soft-deleted content. The implementation includes:

- Backend API endpoints for listing, restoring, and permanently deleting content
- A new "Recently Deleted" page in project settings with filtering capabilities
- Configuration for retention period (default 30 days)
- Permission controls so admins can manage all deleted content while regular users can only manage their own

The UI provides a table view of deleted items with details like deletion date, days remaining before permanent deletion, and action buttons for restore/delete operations.