### PR TITLE
feat: soft delete for dashboards

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -29,6 +29,8 @@ export type DbDashboard = {
     slug: string;
     views_count: number;
     first_viewed_at: Date | null;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 type DbDashboardVersion = {
@@ -82,6 +84,8 @@ export type DashboardTable = Knex.CompositeTableType<
             | 'first_viewed_at'
             | 'space_id'
             | 'slug'
+            | 'deleted_at'
+            | 'deleted_by_user_uuid'
         >
     >
 >;

--- a/packages/backend/src/database/migrations/20260205192030_add_soft_delete_to_dashboards.ts
+++ b/packages/backend/src/database/migrations/20260205192030_add_soft_delete_to_dashboards.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const DashboardsTableName = 'dashboards';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DashboardsTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_dashboards_not_deleted
+        ON ${DashboardsTableName} (dashboard_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(`
+        CREATE INDEX idx_dashboards_deleted
+        ON ${DashboardsTableName} (dashboard_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_dashboards_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_dashboards_not_deleted');
+    await knex.schema.alterTable(DashboardsTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}

--- a/packages/backend/src/ee/models/EmbedModel.ts
+++ b/packages/backend/src/ee/models/EmbedModel.ts
@@ -49,7 +49,8 @@ export class EmbedModel {
 
         const dashboards = await this.database('dashboards')
             .select()
-            .whereIn('dashboard_uuid', embed.dashboard_uuids);
+            .whereIn('dashboard_uuid', embed.dashboard_uuids)
+            .whereNull('deleted_at');
 
         const validDashboardUuids = dashboards.map(
             (dashboard) => dashboard.dashboard_uuid,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2032,6 +2032,30 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
+                deletedAt: { dataType: 'datetime' },
                 config: { ref: 'DashboardConfig' },
                 slug: { dataType: 'string', required: true },
                 access: {
@@ -7353,11 +7377,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7536,7 +7560,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7544,11 +7568,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7563,7 +7583,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7571,7 +7591,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7835,11 +7859,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7854,11 +7878,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7873,11 +7897,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7892,11 +7916,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7911,11 +7935,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16031,6 +16055,37 @@ const models: TsoaRoute.Models = {
                         { dataType: 'enum', enums: [null] },
                     ],
                     required: true,
+                },
+                deletedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
                 },
                 dashboardVersionId: { dataType: 'double', required: true },
                 tiles: {
@@ -24322,9 +24377,66 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DeletedDashboardContentSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                organizationUuid: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                spaceName: { dataType: 'string', required: true },
+                spaceUuid: { dataType: 'string', required: true },
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                deletedAt: { dataType: 'datetime', required: true },
+                contentType: { ref: 'ContentType.DASHBOARD', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DeletedContentSummary: {
         dataType: 'refAlias',
-        type: { ref: 'DeletedChartContentSummary', validators: {} },
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'DeletedChartContentSummary' },
+                { ref: 'DeletedDashboardContentSummary' },
+            ],
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'KnexPaginatedData_DeletedContentSummary-Array_': {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2169,6 +2169,26 @@
             },
             "Dashboard": {
                 "properties": {
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
                     "config": {
                         "$ref": "#/components/schemas/DashboardConfig"
                     },
@@ -8235,19 +8255,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -8299,16 +8306,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -16684,6 +16691,26 @@
                                 "format": "date-time"
                             }
                         ],
+                        "nullable": true
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
                         "nullable": true
                     },
                     "dashboardVersionId": {
@@ -25109,8 +25136,77 @@
                 ],
                 "type": "object"
             },
+            "DeletedDashboardContentSummary": {
+                "properties": {
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "spaceName": {
+                        "type": "string"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentType.DASHBOARD"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "organizationUuid",
+                    "projectUuid",
+                    "spaceName",
+                    "spaceUuid",
+                    "deletedBy",
+                    "deletedAt",
+                    "contentType",
+                    "description",
+                    "name",
+                    "uuid"
+                ],
+                "type": "object"
+            },
             "DeletedContentSummary": {
-                "$ref": "#/components/schemas/DeletedChartContentSummary"
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/DeletedChartContentSummary"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DeletedDashboardContentSummary"
+                    }
+                ]
             },
             "KnexPaginatedData_DeletedContentSummary-Array_": {
                 "properties": {
@@ -25237,7 +25333,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2454.2",
+        "version": "0.2455.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -216,8 +216,8 @@ SELECT
   dv.dashboard_uuid as uuid, 
   d.name
 FROM public.analytics_dashboard_views dv
-  left join dashboards d  on d.dashboard_uuid  = dv.dashboard_uuid 
-  left join spaces s on s.space_id  = d.space_id 
+  left join dashboards d  on d.dashboard_uuid  = dv.dashboard_uuid AND d.deleted_at IS NULL
+  left join spaces s on s.space_id  = d.space_id
   left join projects on projects.project_id = s.project_id
 where projects.project_uuid = '${projectUuid}'
 group by dv.dashboard_uuid, d.name
@@ -236,10 +236,10 @@ WITH RankedResults AS (
       ROW_NUMBER() OVER (PARTITION BY u.first_name ORDER BY COUNT(dv.dashboard_uuid) DESC) AS rank
   FROM public.analytics_dashboard_views dv
   LEFT JOIN users u ON u.user_uuid = dv.user_uuid
-  LEFT JOIN dashboards d ON dv.dashboard_uuid = d.dashboard_uuid
-  left join spaces s on s.space_id  = d.space_id 
+  LEFT JOIN dashboards d ON dv.dashboard_uuid = d.dashboard_uuid AND d.deleted_at IS NULL
+  left join spaces s on s.space_id  = d.space_id
   left join projects on projects.project_id = s.project_id
-  WHERE projects.project_uuid = '${projectUuid}' 
+  WHERE projects.project_uuid = '${projectUuid}'
     AND u.user_uuid IS NOT NULL
   GROUP BY u.user_uuid, u.first_name, u.last_name, d."name"
 )
@@ -342,15 +342,15 @@ LEFT JOIN users cu ON cu.user_uuid = first_version.updated_by_user_uuid
 LEFT JOIN spaces s ON s.space_id = d.space_id
 LEFT JOIN projects p ON p.project_id = s.project_id
 LEFT JOIN analytics_dashboard_views adv ON adv.dashboard_uuid = d.dashboard_uuid
-WHERE p.project_uuid = ?
-GROUP BY 
-  d.name, 
+WHERE p.project_uuid = ? AND d.deleted_at IS NULL
+GROUP BY
+  d.name,
   d.created_at,
-  d.dashboard_uuid, 
+  d.dashboard_uuid,
   first_version.updated_by_user_uuid,
   cu.first_name,
   cu.last_name
-ORDER BY 
+ORDER BY
   MAX(adv.timestamp) ASC NULLS FIRST,
   COUNT(adv.dashboard_uuid) ASC,
   d.created_at ASC

--- a/packages/backend/src/models/CommentModel/CommentModel.ts
+++ b/packages/backend/src/models/CommentModel/CommentModel.ts
@@ -114,12 +114,13 @@ export class CommentModel {
                 '=',
                 `${DashboardTilesTableName}.dashboard_version_id`,
             )
-            .join(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_id`,
-                '=',
-                `${DashboardVersionsTableName}.dashboard_id`,
-            )
+            .join(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_id`,
+                    '=',
+                    `${DashboardVersionsTableName}.dashboard_id`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .leftJoin(
                 'dashboard_tile_charts',
                 'dashboard_tile_charts.dashboard_tile_uuid',
@@ -201,6 +202,7 @@ export class CommentModel {
                 `${DashboardVersionsTableName}.dashboard_id`,
             )
             .where('dashboard_uuid', dashboardUuid)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
             .orderBy(`${DashboardVersionsTableName}.created_at`, 'desc')
             .limit(1)
             .first();

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -32,6 +32,7 @@ type SpaceContentRow = SummaryContentRow<{
 export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
     {
         shouldQueryBeIncluded: (filters: ContentFilters) => {
+            if (filters.deleted) return false; // Spaces don't support soft delete
             if (filters.contentTypes?.includes(ContentType.SPACE)) {
                 return true;
             }
@@ -103,6 +104,10 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                     knex.raw(`null as last_updated_by_user_last_name`),
                     knex.raw(`0 as views`),
                     knex.raw(`null as first_viewed_at`),
+                    knex.raw(`NULL::timestamp as deleted_at`),
+                    knex.raw(`NULL as deleted_by_user_uuid`),
+                    knex.raw(`NULL as deleted_by_user_first_name`),
+                    knex.raw(`NULL as deleted_by_user_last_name`),
                     knex.raw(
                         `json_build_object(
                                     'chartCount', (
@@ -115,6 +120,7 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                                         SELECT count(DISTINCT ${DashboardsTableName}.dashboard_id)
                                         FROM ${DashboardsTableName}
                                         WHERE ${DashboardsTableName}.space_id = ${SpaceTableName}.space_id
+                                        AND ${DashboardsTableName}.deleted_at IS NULL
                                     ),
                                     'parentSpaceUuid', ${SpaceTableName}.parent_space_uuid,
                                     'path', ${SpaceTableName}.path,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -28,6 +28,7 @@ type SelectSavedSql = SummaryContentRow<{
 export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> =
     {
         shouldQueryBeIncluded: (filters: ContentFilters) => {
+            if (filters.deleted) return false; // SQL charts don't support soft delete
             const contentTypeMatch =
                 !filters.contentTypes ||
                 filters.contentTypes?.includes(ContentType.CHART);
@@ -44,8 +45,13 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                 .from(SavedSqlTableName)
                 .leftJoin(
                     DashboardsTableName,
-                    `${DashboardsTableName}.dashboard_uuid`,
-                    `${SavedSqlTableName}.dashboard_uuid`,
+                    function nonDeletedDashboardJoin() {
+                        this.on(
+                            `${DashboardsTableName}.dashboard_uuid`,
+                            '=',
+                            `${SavedSqlTableName}.dashboard_uuid`,
+                        ).andOnNull(`${DashboardsTableName}.deleted_at`);
+                    },
                 )
                 .innerJoin(
                     SpaceTableName,
@@ -106,9 +112,13 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                     knex.raw(
                         `${SavedSqlTableName}.first_viewed_at::timestamp as first_viewed_at`,
                     ),
+                    knex.raw(`NULL::timestamp as deleted_at`),
+                    knex.raw(`NULL as deleted_by_user_uuid`),
+                    knex.raw(`NULL as deleted_by_user_first_name`),
+                    knex.raw(`NULL as deleted_by_user_last_name`),
                     knex.raw(`json_build_object(
                     'source','${ChartSourceType.SQL}',
-                    'chart_kind', ${SavedSqlTableName}.last_version_chart_kind, 
+                    'chart_kind', ${SavedSqlTableName}.last_version_chart_kind,
                     'dashboard_uuid', ${DashboardsTableName}.dashboard_uuid,
                     'dashboard_name', ${DashboardsTableName}.name
                 ) as metadata`),

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -26,6 +26,8 @@ export type ContentFilters = {
     space?: {
         rootSpaces: boolean;
     };
+    deleted?: boolean;
+    deletedByUserUuids?: string[];
 };
 
 export type ContentArgs = {
@@ -59,6 +61,10 @@ export type SummaryContentRow<
     last_updated_by_user_last_name: string | null;
     views: number;
     first_viewed_at: Date | null;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
+    deleted_by_user_first_name: string | null;
+    deleted_by_user_last_name: string | null;
     metadata: T;
 };
 

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -169,6 +169,8 @@ export const dashboardEntry: DashboardTable['base'] = {
     search_vector: '',
     views_count: 0,
     first_viewed_at: null,
+    deleted_at: null,
+    deleted_by_user_uuid: null,
 };
 
 export const dashboardVersionEntry: DashboardVersionTable['base'] = {

--- a/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.test.ts
@@ -431,7 +431,7 @@ describe('DashboardModel', () => {
             .delete(queryMatcher(DashboardsTableName, [dashboardUuid]))
             .response([]);
 
-        await model.delete(dashboardUuid);
+        await model.permanentDelete(dashboardUuid);
         expect(tracker.history.delete).toHaveLength(1);
     });
 

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -122,11 +122,13 @@ export class SavedSqlModel {
     }) {
         return this.database
             .from(SavedSqlTableName)
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedSqlTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedSqlTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .innerJoin(SpaceTableName, function spaceJoin() {
                 this.on(
                     `${SpaceTableName}.space_id`,

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -195,11 +195,13 @@ export class SchedulerModel {
                     `${SchedulerTableName}.saved_chart_uuid`,
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SchedulerTableName}.dashboard_uuid`,
-            );
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SchedulerTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            });
     }
 
     private async getSchedulersWithTargets(
@@ -289,11 +291,13 @@ export class SchedulerModel {
                     `${SchedulerTableName}.saved_chart_uuid`,
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SchedulerTableName}.dashboard_uuid`,
-            );
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SchedulerTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            });
         // Apply search query if present
         if (searchQuery) {
             baseQuery = getColumnMatchRegexQuery(baseQuery, searchQuery, [
@@ -409,8 +413,13 @@ export class SchedulerModel {
             // Join to get the dashboard that the chart belongs to (if any)
             .leftJoin(
                 { [dashboardChartsJoinTable]: DashboardsTableName },
-                `${dashboardChartsJoinTable}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
+                function nonDeletedDashboardJoin() {
+                    this.on(
+                        `${dashboardChartsJoinTable}.dashboard_uuid`,
+                        '=',
+                        `${SavedChartsTableName}.dashboard_uuid`,
+                    ).andOnNull(`${dashboardChartsJoinTable}.deleted_at`);
+                },
             )
             .innerJoin(SpaceTableName, function joinSpaces() {
                 this.on(
@@ -903,12 +912,14 @@ export class SchedulerModel {
                     `${SchedulerTableName}.saved_chart_uuid`,
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
-            .leftJoin(DashboardsTableName, function joinDashboards() {
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
                 this.on(
                     `${DashboardsTableName}.dashboard_uuid`,
                     '=',
                     `${SavedChartsTableName}.dashboard_uuid`,
-                ).andOnNotNull(`${SavedChartsTableName}.dashboard_uuid`);
+                )
+                    .andOnNotNull(`${SavedChartsTableName}.dashboard_uuid`)
+                    .andOnNull(`${DashboardsTableName}.deleted_at`);
             })
             .leftJoin(SpaceTableName, function joinSpaces() {
                 this.on(
@@ -949,11 +960,13 @@ export class SchedulerModel {
                 `${UserTableName}.user_uuid`,
                 `${SchedulerTableName}.created_by`,
             )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SchedulerTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SchedulerTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .leftJoin(
                 SpaceTableName,
                 `${SpaceTableName}.space_id`,
@@ -1156,7 +1169,8 @@ export class SchedulerModel {
             .whereNull('deleted_at');
         const dashboards = await this.database(DashboardsTableName)
             .select('name', 'dashboard_uuid')
-            .whereIn('dashboard_uuid', dashboardUuids);
+            .whereIn('dashboard_uuid', dashboardUuids)
+            .whereNull('deleted_at');
 
         return {
             pagination: {
@@ -1614,11 +1628,13 @@ export class SchedulerModel {
                     `${SchedulerTableName}.saved_chart_uuid`,
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SchedulerTableName}.dashboard_uuid`,
-            );
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SchedulerTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            });
 
         // Wrap runsQuery as a subquery so we can filter/sort on computed columns like run_status
         // (WHERE clause can't reference SELECT aliases, so we need an outer query)
@@ -1750,11 +1766,13 @@ export class SchedulerModel {
                     `${SchedulerTableName}.saved_chart_uuid`,
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SchedulerTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SchedulerTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .where(`${SchedulerLogTableName}.job_id`, runId)
             .whereRaw(
                 `${SchedulerLogTableName}.job_id = ${SchedulerLogTableName}.job_group`,
@@ -1860,12 +1878,14 @@ export class SchedulerModel {
                     `${SchedulerTableName}.saved_chart_uuid`,
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
-            .leftJoin(DashboardsTableName, function joinDashboards() {
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
                 this.on(
                     `${DashboardsTableName}.dashboard_uuid`,
                     '=',
                     `${SavedChartsTableName}.dashboard_uuid`,
-                ).andOnNotNull(`${SavedChartsTableName}.dashboard_uuid`);
+                )
+                    .andOnNotNull(`${SavedChartsTableName}.dashboard_uuid`)
+                    .andOnNull(`${DashboardsTableName}.deleted_at`);
             })
             .innerJoin(SpaceTableName, function joinSpaces() {
                 this.on(
@@ -1894,14 +1914,17 @@ export class SchedulerModel {
         // Query schedulers for dashboards
         const dashboardSchedulersQuery = this.database(SchedulerTableName)
             .count('*')
-            .select<
-                ProjectCountRow[]
-            >(`${ProjectTableName}.project_uuid`, `${ProjectTableName}.name as project_name`)
-            .innerJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SchedulerTableName}.dashboard_uuid`,
+            .select<ProjectCountRow[]>(
+                `${ProjectTableName}.project_uuid`,
+                `${ProjectTableName}.name as project_name`,
             )
+            .innerJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SchedulerTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .innerJoin(
                 SpaceTableName,
                 `${SpaceTableName}.space_id`,
@@ -1983,12 +2006,14 @@ export class SchedulerModel {
                     `${SchedulerTableName}.saved_chart_uuid`,
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
-            .leftJoin(DashboardsTableName, function joinDashboards() {
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
                 this.on(
                     `${DashboardsTableName}.dashboard_uuid`,
                     '=',
                     `${SavedChartsTableName}.dashboard_uuid`,
-                ).andOnNotNull(`${SavedChartsTableName}.dashboard_uuid`);
+                )
+                    .andOnNotNull(`${SavedChartsTableName}.dashboard_uuid`)
+                    .andOnNull(`${DashboardsTableName}.deleted_at`);
             })
             .innerJoin(SpaceTableName, function joinSpaces() {
                 this.on(
@@ -2013,14 +2038,16 @@ export class SchedulerModel {
 
         // Dashboard schedulers
         const dashboardSchedulerUuids = await this.database(SchedulerTableName)
-            .select<
-                { scheduler_uuid: string }[]
-            >(`${SchedulerTableName}.scheduler_uuid`)
-            .innerJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SchedulerTableName}.dashboard_uuid`,
+            .select<{ scheduler_uuid: string }[]>(
+                `${SchedulerTableName}.scheduler_uuid`,
             )
+            .innerJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SchedulerTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .innerJoin(
                 SpaceTableName,
                 `${SpaceTableName}.space_id`,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -267,11 +267,13 @@ export class SpaceModel {
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
             )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .select<
                 {
                     saved_query_uuid: string;
@@ -452,7 +454,8 @@ export class SpaceModel {
                             .from(DashboardsTableName)
                             .whereRaw(
                                 `${DashboardsTableName}.space_id = ${SpaceTableName}.space_id`,
-                            ),
+                            )
+                            .whereNull(`${DashboardsTableName}.deleted_at`),
                         slug: `${SpaceTableName}.slug`,
                         parentSpaceUuid: `${SpaceTableName}.parent_space_uuid`,
                         path: `${SpaceTableName}.path`,
@@ -644,6 +647,7 @@ export class SpaceModel {
             ])
             .distinctOn(`${DashboardVersionsTableName}.dashboard_id`)
             .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
             .orderBy([
                 {
                     column: `dashboard_id`,
@@ -1942,11 +1946,13 @@ export class SpaceModel {
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
             )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .select<
                 {
                     saved_query_uuid: string;

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -10,6 +10,7 @@ import {
 
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { SlackClient } from '../../clients/Slack/SlackClient';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
@@ -48,7 +49,7 @@ const dashboardModel = {
 
     update: jest.fn(async () => dashboard),
 
-    delete: jest.fn(async () => dashboard),
+    permanentDelete: jest.fn(async () => dashboard),
 
     addVersion: jest.fn(async () => dashboard),
 
@@ -116,6 +117,7 @@ describe('DashboardService', () => {
     const projectUuid = 'projectUuid';
     const { uuid: dashboardUuid } = dashboard;
     const service = new DashboardService({
+        lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
         dashboardModel: dashboardModel as unknown as DashboardModel,
         spaceModel: spaceModel as unknown as SpaceModel,
@@ -313,8 +315,10 @@ describe('DashboardService', () => {
     test('should delete dashboard', async () => {
         await service.delete(user, dashboardUuid);
 
-        expect(dashboardModel.delete).toHaveBeenCalledTimes(1);
-        expect(dashboardModel.delete).toHaveBeenCalledWith(dashboardUuid);
+        expect(dashboardModel.permanentDelete).toHaveBeenCalledTimes(1);
+        expect(dashboardModel.permanentDelete).toHaveBeenCalledWith(
+            dashboardUuid,
+        );
         expect(analyticsMock.track).toHaveBeenCalledTimes(1);
         expect(analyticsMock.track).toHaveBeenCalledWith(
             expect.objectContaining({

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -341,6 +341,7 @@ export class ServiceRepository
             'dashboardService',
             () =>
                 new DashboardService({
+                    lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
                     dashboardModel: this.models.getDashboardModel(),
                     spaceModel: this.models.getSpaceModel(),

--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -196,6 +196,12 @@ export type Dashboard = {
     access: SpaceAccess[] | null;
     slug: string;
     config?: DashboardConfig;
+    deletedAt?: Date;
+    deletedBy?: {
+        userUuid: string;
+        firstName: string;
+        lastName: string;
+    } | null;
 };
 
 export enum DashboardSummaryTone {

--- a/packages/common/src/types/softDelete.ts
+++ b/packages/common/src/types/softDelete.ts
@@ -21,8 +21,26 @@ export type DeletedChartContentSummary = {
     organizationUuid: string;
 };
 
-// Union type for future extensibility (dashboards, spaces, etc.)
-export type DeletedContentSummary = DeletedChartContentSummary;
+export type DeletedDashboardContentSummary = {
+    uuid: string;
+    name: string;
+    description: string | null;
+    contentType: ContentType.DASHBOARD;
+    deletedAt: Date;
+    deletedBy: {
+        userUuid: string;
+        firstName: string;
+        lastName: string;
+    } | null;
+    spaceUuid: string;
+    spaceName: string;
+    projectUuid: string;
+    organizationUuid: string;
+};
+
+export type DeletedContentSummary =
+    | DeletedChartContentSummary
+    | DeletedDashboardContentSummary;
 
 export type DeletedContentFilters = {
     projectUuids: string[];

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
@@ -1,13 +1,18 @@
 import { ContentType } from '@lightdash/common';
 import { Box, Divider, SegmentedControl, Text, Tooltip } from '@mantine-8/core';
-import { IconChartBar } from '@tabler/icons-react';
+import { IconChartBar, IconLayoutDashboard } from '@tabler/icons-react';
 import type { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import classes from './ContentTypeFilter.module.css';
 
+type DeletedContentTypeFilter =
+    | 'all'
+    | ContentType.CHART
+    | ContentType.DASHBOARD;
+
 type ContentTypeFilterProps = {
-    selectedContentType: 'all' | ContentType.CHART;
-    setSelectedContentType: (value: 'all' | ContentType.CHART) => void;
+    selectedContentType: DeletedContentTypeFilter;
+    setSelectedContentType: (value: DeletedContentTypeFilter) => void;
 };
 
 export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
@@ -48,17 +53,19 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
                 </Tooltip>
             ),
         },
-        // Future content types can be added here:
-        // {
-        //     value: ContentType.DASHBOARD,
-        //     label: (
-        //         <Tooltip label="Show only deleted dashboards" withinPortal>
-        //             <Box>
-        //                 <MantineIcon icon={IconLayoutDashboard} {...iconProps} />
-        //             </Box>
-        //         </Tooltip>
-        //     ),
-        // },
+        {
+            value: ContentType.DASHBOARD,
+            label: (
+                <Tooltip label="Show only deleted dashboards" withinPortal>
+                    <Box>
+                        <MantineIcon
+                            icon={IconLayoutDashboard}
+                            {...iconProps}
+                        />
+                    </Box>
+                </Tooltip>
+            ),
+        },
     ];
 
     return (
@@ -74,7 +81,7 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
                 radius="md"
                 value={selectedContentType}
                 onChange={(value) =>
-                    setSelectedContentType(value as 'all' | ContentType.CHART)
+                    setSelectedContentType(value as DeletedContentTypeFilter)
                 }
                 classNames={{
                     root: classes.segmentedControl,


### PR DESCRIPTION
### Description:
This PR adds soft delete functionality for dashboards, allowing users to recover accidentally deleted dashboards within a retention period. When a dashboard is deleted, it's now marked with `deleted_at` and `deleted_by_user_uuid` instead of being permanently removed.

Key changes:
- Added `deleted_at` and `deleted_by_user_uuid` columns to the dashboards table
- Created a partial index to optimize queries for non-deleted dashboards
- Updated dashboard queries to filter out soft-deleted dashboards by default
- Added dashboard restore functionality in the recently deleted UI
- Implemented cascade soft-delete for dashboard-scoped charts
- Added support for viewing deleted dashboards in the "Recently Deleted" page

This extends the existing soft delete functionality that was previously only available for charts.