### PR TITLE
feat: soft delete for saved sql

### DIFF
--- a/packages/backend/src/database/entities/savedSql.ts
+++ b/packages/backend/src/database/entities/savedSql.ts
@@ -21,6 +21,8 @@ export type DbSavedSql = {
     views_count: number;
     first_viewed_at: Date | null;
     last_viewed_at: Date | null;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 type InsertSqlBase = Pick<
@@ -54,6 +56,8 @@ type UpdateSql = Partial<
         | 'views_count'
         | 'first_viewed_at'
         | 'last_viewed_at'
+        | 'deleted_at'
+        | 'deleted_by_user_uuid'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260206064344_add_soft_delete_to_saved_sql.ts
+++ b/packages/backend/src/database/migrations/20260206064344_add_soft_delete_to_saved_sql.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const SavedSqlTableName = 'saved_sql';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SavedSqlTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_saved_sql_not_deleted
+        ON ${SavedSqlTableName} (saved_sql_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(`
+        CREATE INDEX idx_saved_sql_deleted
+        ON ${SavedSqlTableName} (saved_sql_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_saved_sql_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_saved_sql_not_deleted');
+    await knex.schema.alterTable(SavedSqlTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -951,11 +951,13 @@ export class DashboardModel {
                     `${DashboardTilesTableName}.dashboard_version_id`,
                 );
             })
-            .leftJoin(
-                SavedSqlTableName,
-                `${DashboardTileSqlChartTableName}.saved_sql_uuid`,
-                `${SavedSqlTableName}.saved_sql_uuid`,
-            )
+            .leftJoin(SavedSqlTableName, function nonDeletedSavedSqlJoin() {
+                this.on(
+                    `${DashboardTileSqlChartTableName}.saved_sql_uuid`,
+                    '=',
+                    `${SavedSqlTableName}.saved_sql_uuid`,
+                ).andOnNull(`${SavedSqlTableName}.deleted_at`);
+            })
             .leftJoin(SavedChartsTableName, function savedChartsJoin() {
                 this.on(
                     `${DashboardTileChartTableName}.saved_chart_id`,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1789,6 +1789,7 @@ export class ProjectModel {
                 .leftJoin('spaces', 'saved_sql.space_uuid', 'spaces.space_uuid')
                 .whereIn('saved_sql.space_uuid', spaceUuids)
                 .andWhere('spaces.project_id', projectId)
+                .whereNull('saved_sql.deleted_at')
                 .select<DbSavedSql[]>('saved_sql.*');
 
             Logger.info(
@@ -1859,6 +1860,7 @@ export class ProjectModel {
                 .leftJoin('spaces', 'dashboards.space_id', 'spaces.space_id')
                 .where('spaces.project_id', projectId)
                 .andWhere('saved_sql.space_uuid', null)
+                .whereNull('saved_sql.deleted_at')
                 .select<DbSavedSql[]>('saved_sql.*');
 
             Logger.info(
@@ -2382,7 +2384,8 @@ export class ProjectModel {
                         .update({
                             dashboard_uuid: newDashboardUuid,
                         })
-                        .where('saved_sql_uuid', chart.saved_sql_uuid);
+                        .where('saved_sql_uuid', chart.saved_sql_uuid)
+                        .whereNull('deleted_at');
                 },
             );
             await Promise.all(updateSavedSQLInDashboards);

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -119,6 +119,7 @@ export class SavedSqlModel {
         uuid?: string;
         slugs?: string[];
         projectUuid?: string;
+        deleted?: boolean;
     }) {
         return this.database
             .from(SavedSqlTableName)
@@ -195,6 +196,14 @@ export class SavedSqlModel {
                 `${SpaceTableName}.path`,
             ])
             .where((builder) => {
+                if (options.deleted) {
+                    void builder.whereNotNull(
+                        `${SavedSqlTableName}.deleted_at`,
+                    );
+                } else {
+                    void builder.whereNull(`${SavedSqlTableName}.deleted_at`);
+                }
+
                 if (options.uuid) {
                     void builder.where(
                         `${SavedSqlTableName}.saved_sql_uuid`,
@@ -234,8 +243,16 @@ export class SavedSqlModel {
             .orderBy(`${SavedSqlVersionsTableName}.created_at`, 'desc');
     }
 
-    async getBySlug(projectUuid: string, slug: string) {
-        const results = await this.find({ slugs: [slug], projectUuid });
+    async getBySlug(
+        projectUuid: string,
+        slug: string,
+        options?: { deleted?: boolean },
+    ) {
+        const results = await this.find({
+            slugs: [slug],
+            projectUuid,
+            deleted: options?.deleted,
+        });
         const [result] = results;
         if (!result) {
             throw new NotFoundError('Saved sql not found');
@@ -243,7 +260,10 @@ export class SavedSqlModel {
         return SavedSqlModel.convertSelectSavedSql(result);
     }
 
-    async getByUuid(uuid: string, options: { projectUuid?: string }) {
+    async getByUuid(
+        uuid: string,
+        options: { projectUuid?: string; deleted?: boolean },
+    ) {
         const results = await this.find({ uuid, ...options });
         const [result] = results;
         if (!result) {
@@ -310,7 +330,7 @@ export class SavedSqlModel {
                     created_by_user_uuid: userUuid,
                     project_uuid: projectUuid,
                     space_uuid: data.spaceUuid,
-                    dashboard_uuid: null,
+                    dashboard_uuid: null, // TODO: if we start using dashboard_uuid, implement cascade soft delete in DashboardModel (like saved_queries)
                 },
                 ['saved_sql_uuid', 'slug'],
             );
@@ -359,6 +379,38 @@ export class SavedSqlModel {
     async delete(uuid: string) {
         await this.database(SavedSqlTableName)
             .where('saved_sql_uuid', uuid)
+            .delete();
+    }
+
+    async softDelete(savedSqlUuid: string, userUuid: string): Promise<void> {
+        const updateCount = await this.database(SavedSqlTableName)
+            .update({
+                deleted_at: new Date(),
+                deleted_by_user_uuid: userUuid,
+            })
+            .where('saved_sql_uuid', savedSqlUuid)
+            .whereNull('deleted_at');
+        if (updateCount !== 1) {
+            throw new NotFoundError('Saved sql not found');
+        }
+    }
+
+    async restore(savedSqlUuid: string): Promise<void> {
+        const updateCount = await this.database(SavedSqlTableName)
+            .update({
+                deleted_at: null,
+                deleted_by_user_uuid: null,
+            })
+            .where('saved_sql_uuid', savedSqlUuid)
+            .whereNotNull('deleted_at');
+        if (updateCount !== 1) {
+            throw new NotFoundError('Saved sql not found');
+        }
+    }
+
+    async permanentDelete(savedSqlUuid: string): Promise<void> {
+        await this.database(SavedSqlTableName)
+            .where('saved_sql_uuid', savedSqlUuid)
             .delete();
     }
 

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -594,6 +594,7 @@ export class SearchModel {
                 { lastUpdatedByUserUuid: 'updated_by_user.user_uuid' },
                 { search_rank: searchRankRawSql },
             )
+            .whereNull(`${tableName}.deleted_at`)
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereRaw(searchFilterSql)
             .orderBy('search_rank', 'desc');
@@ -996,6 +997,7 @@ export class SearchModel {
                 ),
                 this.database.raw('? as chart_source', ['sql']),
             )
+            .whereNull(`${SavedSqlTableName}.deleted_at`)
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereRaw(savedSqlSearchFilterSql);
 

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1788,6 +1788,7 @@ export class SpaceModel {
                 `${DashboardsTableName}.dashboard_uuid`,
                 `${chartTable}.dashboard_uuid`,
             )
+            .whereNull(`${chartTable}.deleted_at`)
             .select<
                 {
                     uuid: string;

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -387,9 +387,9 @@ export class ContentService extends BaseService {
                             item.uuid,
                         );
                     case ChartSourceType.SQL:
-                        // TODO: Implement SQL chart restore
-                        throw new NotFoundError(
-                            'SQL chart restore not yet supported',
+                        return this.savedSqlService.restoreSqlChart(
+                            user,
+                            item.uuid,
                         );
                     default:
                         return assertUnreachable(
@@ -439,9 +439,9 @@ export class ContentService extends BaseService {
                             item.uuid,
                         );
                     case ChartSourceType.SQL:
-                        // TODO: Implement SQL chart permanent delete
-                        throw new NotFoundError(
-                            'SQL chart permanent delete not yet supported',
+                        return this.savedSqlService.permanentlyDeleteSqlChart(
+                            user,
+                            item.uuid,
                         );
                     default:
                         return assertUnreachable(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -969,6 +969,7 @@ export class ServiceRepository
             'savedSqlService',
             () =>
                 new SavedSqlService({
+                    lightdashConfig: this.context.lightdashConfig,
                     analytics: this.context.lightdashAnalytics,
                     projectModel: this.models.getProjectModel(),
                     spaceModel: this.models.getSpaceModel(),


### PR DESCRIPTION
### Description:
Adds soft delete functionality to SQL charts, allowing users to delete and restore SQL charts similar to other content types. This includes:

- Added `deleted_at` and `deleted_by_user_uuid` columns to the `saved_sql` table
- Created a migration with a partial index for efficient queries on non-deleted items
- Updated the SQL chart content configuration to support filtering by deleted status
- Modified dashboard and project models to exclude deleted SQL charts from queries
- Implemented soft delete, restore, and permanent delete methods in the SavedSqlModel
- Added support for these operations in ContentService and SavedSqlService
- Updated search functionality to exclude deleted SQL charts from results

This completes the soft delete implementation across all content types in the application.