### PR TITLE
fix: react canvas attribution bg dark mode

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/Canvas.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/Canvas.module.css
@@ -3,4 +3,5 @@
     --xy-edge-stroke-selected: var(--mantine-color-blue-6);
     --xy-handle-background-color-default: var(--mantine-color-ldGray-6);
     --xy-handle-border-color-default: var(--mantine-color-background-0);
+    --xy-attribution-background-color: var(--mantine-color-background-0);
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
