### PR TITLE
fix: increase metric detail popover width and add max height to SQL display

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.module.css
@@ -10,6 +10,7 @@
     overflow-y: auto;
     font-size: var(--mantine-font-size-xs);
     white-space: pre-wrap;
+    max-height: 300px;
 }
 
 .compiledToggle {

--- a/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.tsx
@@ -130,7 +130,7 @@ const MetricDetailContent: FC<MetricDetailContentProps> = ({
     const sqlToShow = showCompiled ? metric.compiledSql : metric.sql;
 
     return (
-        <Stack gap="xs" w={compiledQueryConfig ? 360 : 300}>
+        <Stack gap="xs" w={compiledQueryConfig ? 400 : 300}>
             <Group gap="xs" wrap="nowrap" justify="space-between">
                 <Group gap="xs" wrap="nowrap">
                     <MantineIcon icon={IconTable} color="gray.6" size={14} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Improves the metric detail popover by adding a max height of 300px to prevent overly large popups and increases the width from 360px to 400px when compiled query config is present to provide more space for content.
