### PR TITLE
feat: improve value label to include metric/series

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3607,6 +3607,9 @@ const models: TsoaRoute.Models = {
                 label: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        showSeriesName: { dataType: 'boolean' },
+                        showLabel: { dataType: 'boolean' },
+                        showValue: { dataType: 'boolean' },
                         showOverlappingLabels: { dataType: 'boolean' },
                         position: {
                             dataType: 'union',
@@ -13030,6 +13033,9 @@ const models: TsoaRoute.Models = {
                         dataType: 'nestedObjectLiteral',
                         nestedProperties: {
                             whichYAxis: { ref: 'AxisSide' },
+                            showSeriesName: { dataType: 'boolean' },
+                            showLabel: { dataType: 'boolean' },
+                            showValue: { dataType: 'boolean' },
                             valueLabelPosition: {
                                 ref: 'ValueLabelPositionOptions',
                             },
@@ -17390,7 +17396,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17400,7 +17406,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17410,7 +17416,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17423,7 +17429,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -17846,7 +17852,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17856,7 +17862,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17866,7 +17872,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17879,7 +17885,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -3993,6 +3993,15 @@
                     },
                     "label": {
                         "properties": {
+                            "showSeriesName": {
+                                "type": "boolean"
+                            },
+                            "showLabel": {
+                                "type": "boolean"
+                            },
+                            "showValue": {
+                                "type": "boolean"
+                            },
                             "showOverlappingLabels": {
                                 "type": "boolean"
                             },
@@ -13451,6 +13460,15 @@
                                 "whichYAxis": {
                                     "$ref": "#/components/schemas/AxisSide"
                                 },
+                                "showSeriesName": {
+                                    "type": "boolean"
+                                },
+                                "showLabel": {
+                                    "type": "boolean"
+                                },
+                                "showValue": {
+                                    "type": "boolean"
+                                },
                                 "valueLabelPosition": {
                                     "$ref": "#/components/schemas/ValueLabelPositionOptions"
                                 },
@@ -18282,22 +18300,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiChartAsCodeListResponse": {
@@ -18652,22 +18670,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -24693,7 +24711,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2430.3",
+        "version": "0.2433.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -337,7 +337,8 @@ export type Series = {
         position?: 'left' | 'top' | 'right' | 'bottom' | 'inside';
         showOverlappingLabels?: boolean;
         showValue?: boolean; // Show the metric value (default: true when labels are shown)
-        showSeriesName?: boolean; // Show the series/pivot name (e.g., "United States")
+        showLabel?: boolean; // Show the legend/pivot name (e.g., "United States") or metric name for non-pivoted
+        showSeriesName?: boolean; // Show the metric field name (e.g., "Revenue")
     };
     hidden?: boolean;
     areaStyle?: Record<string, unknown>;

--- a/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartSeries.tsx
@@ -32,6 +32,7 @@ type ConfigurableSeries = {
     | 'valueLabelPosition'
     | 'whichYAxis'
     | 'showValue'
+    | 'showLabel'
     | 'showSeriesName'
 >;
 
@@ -68,6 +69,7 @@ export const CartesianChartSeries = ({
             const seriesValueLabelPosition = foundSeries?.valueLabelPosition;
             const seriesWhichYAxis = foundSeries?.whichYAxis;
             const seriesShowValue = foundSeries?.showValue;
+            const seriesShowLabel = foundSeries?.showLabel;
             const seriesShowSeriesName = foundSeries?.showSeriesName;
 
             const config = {
@@ -79,6 +81,7 @@ export const CartesianChartSeries = ({
                 valueLabelPosition: seriesValueLabelPosition,
                 whichYAxis: seriesWhichYAxis,
                 showValue: seriesShowValue,
+                showLabel: seriesShowLabel,
                 showSeriesName: seriesShowSeriesName,
             };
 
@@ -159,6 +162,15 @@ export const CartesianChartSeries = ({
         dispatch(
             actions.setSeriesShowValue({
                 showValue,
+                reference,
+            }),
+        );
+    };
+
+    const handleShowLabelChange = (reference: string, showLabel: boolean) => {
+        dispatch(
+            actions.setSeriesShowLabel({
+                showLabel,
                 reference,
             }),
         );
@@ -280,6 +292,7 @@ export const CartesianChartSeries = ({
                                                   s.valueLabelPosition
                                               }
                                               showValue={s.showValue}
+                                              showLabel={s.showLabel}
                                               showSeriesName={s.showSeriesName}
                                               selectedChartType={
                                                   selectedChartType
@@ -293,6 +306,9 @@ export const CartesianChartSeries = ({
                                               }
                                               onShowValueChange={
                                                   handleShowValueChange
+                                              }
+                                              onShowLabelChange={
+                                                  handleShowLabelChange
                                               }
                                               onShowSeriesNameChange={
                                                   handleShowSeriesNameChange
@@ -316,6 +332,7 @@ export const CartesianChartSeries = ({
                                   whichYAxis,
                                   valueLabelPosition,
                                   showValue,
+                                  showLabel,
                                   showSeriesName,
                               },
                               index,
@@ -330,6 +347,7 @@ export const CartesianChartSeries = ({
                                   whichYAxis={whichYAxis}
                                   valueLabelPosition={valueLabelPosition}
                                   showValue={showValue}
+                                  showLabel={showLabel}
                                   showSeriesName={showSeriesName}
                                   selectedChartType={selectedChartType}
                                   onColorChange={onColorChange}
@@ -340,6 +358,7 @@ export const CartesianChartSeries = ({
                                       handleValueLabelPositionChange
                                   }
                                   onShowValueChange={handleShowValueChange}
+                                  onShowLabelChange={handleShowLabelChange}
                                   onShowSeriesNameChange={
                                       handleShowSeriesNameChange
                                   }

--- a/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartValueLabelConfig.tsx
@@ -1,5 +1,14 @@
 import { ValueLabelPositionOptions } from '@lightdash/common';
-import { Box, Checkbox, Group, Select, Stack, Text } from '@mantine/core';
+import {
+    ActionIcon,
+    Box,
+    Checkbox,
+    Group,
+    Popover,
+    Select,
+    Stack,
+    Text,
+} from '@mantine/core';
 import {
     IconArrowDown,
     IconArrowLeft,
@@ -8,6 +17,7 @@ import {
     IconClearAll,
     IconEyeOff,
     IconLayoutAlignCenter,
+    IconSettings,
 } from '@tabler/icons-react';
 import capitalize from 'lodash/capitalize';
 import { forwardRef, type ComponentPropsWithoutRef, type FC } from 'react';
@@ -48,9 +58,11 @@ const ValueLabelIcon: FC<{
 type Props = {
     valueLabelPosition: ValueLabelPositionOptions | undefined;
     showValue?: boolean;
+    showLabel?: boolean;
     showSeriesName?: boolean;
     onChangeValueLabelPosition: (value: ValueLabelPositionOptions) => void;
     onChangeShowValue?: (value: boolean) => void;
+    onChangeShowLabel?: (value: boolean) => void;
     onChangeShowSeriesName?: (value: boolean) => void;
 };
 
@@ -73,58 +85,25 @@ export const CartesianChartValueLabelConfig: FC<Props> = ({
     onChangeValueLabelPosition,
     valueLabelPosition,
     showValue = true,
+    showLabel = false,
     showSeriesName = false,
     onChangeShowValue,
+    onChangeShowLabel,
     onChangeShowSeriesName,
 }) => {
     const isVisible =
         valueLabelPosition &&
         valueLabelPosition !== ValueLabelPositionOptions.HIDDEN;
 
-    return (
-        <Stack spacing="xs" sx={{ flex: 1 }}>
-            <Select
-                radius="md"
-                data={Object.values(ValueLabelPositionOptions).map(
-                    (option) => ({
-                        value: option,
-                        label: capitalize(option),
-                    }),
-                )}
-                itemComponent={ValueLabelItem}
-                icon={<ValueLabelIcon position={valueLabelPosition} />}
-                value={valueLabelPosition}
-                onChange={(value) =>
-                    value &&
-                    onChangeValueLabelPosition(
-                        value as ValueLabelPositionOptions,
-                    )
-                }
-                styles={(theme) => ({
-                    root: {
-                        flex: 1,
-                    },
-                    input: {
-                        fontWeight: 500,
-                        borderColor: theme.colors.ldGray[2],
-                    },
-                    item: {
-                        '&[data-selected="true"]': {
-                            color: theme.colors.ldGray[7],
-                            fontWeight: 500,
-                            backgroundColor: theme.colors.ldGray[2],
-                        },
-                        '&[data-selected="true"]:hover': {
-                            backgroundColor: theme.colors.ldGray[3],
-                        },
-                        '&:hover': {
-                            backgroundColor: theme.colors.ldGray[1],
-                        },
-                    },
-                })}
-            />
-            {isVisible && onChangeShowValue && onChangeShowSeriesName && (
-                <Group spacing="md">
+    const popoverTarget = isVisible && onChangeShowValue && (
+        <Popover position="bottom-end" shadow="md" withinPortal>
+            <Popover.Target>
+                <ActionIcon variant="subtle" size="xs">
+                    <MantineIcon icon={IconSettings} color="ldGray.6" />
+                </ActionIcon>
+            </Popover.Target>
+            <Popover.Dropdown>
+                <Stack spacing="xs">
                     <Checkbox
                         size="xs"
                         checked={showValue}
@@ -133,16 +112,73 @@ export const CartesianChartValueLabelConfig: FC<Props> = ({
                         }
                         label="Show value"
                     />
-                    <Checkbox
-                        size="xs"
-                        checked={showSeriesName}
-                        onChange={(e) =>
-                            onChangeShowSeriesName(e.currentTarget.checked)
-                        }
-                        label="Show series name"
-                    />
-                </Group>
-            )}
-        </Stack>
+                    {onChangeShowLabel && (
+                        <Checkbox
+                            size="xs"
+                            checked={showLabel}
+                            onChange={(e) =>
+                                onChangeShowLabel(e.currentTarget.checked)
+                            }
+                            label="Show label"
+                        />
+                    )}
+                    {onChangeShowSeriesName && (
+                        <Checkbox
+                            size="xs"
+                            checked={showSeriesName}
+                            onChange={(e) =>
+                                onChangeShowSeriesName(
+                                    e.currentTarget.checked,
+                                )
+                            }
+                            label="Show metric name"
+                        />
+                    )}
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+
+    return (
+        <Select
+            radius="md"
+            data={Object.values(ValueLabelPositionOptions).map((option) => ({
+                value: option,
+                label: capitalize(option),
+            }))}
+            itemComponent={ValueLabelItem}
+            icon={<ValueLabelIcon position={valueLabelPosition} />}
+            rightSection={popoverTarget || undefined}
+            rightSectionProps={{ style: { pointerEvents: 'all' } }}
+            value={valueLabelPosition}
+            onChange={(value) =>
+                value &&
+                onChangeValueLabelPosition(
+                    value as ValueLabelPositionOptions,
+                )
+            }
+            styles={(theme) => ({
+                root: {
+                    flex: 1,
+                },
+                input: {
+                    fontWeight: 500,
+                    borderColor: theme.colors.ldGray[2],
+                },
+                item: {
+                    '&[data-selected="true"]': {
+                        color: theme.colors.ldGray[7],
+                        fontWeight: 500,
+                        backgroundColor: theme.colors.ldGray[2],
+                    },
+                    '&[data-selected="true"]:hover': {
+                        backgroundColor: theme.colors.ldGray[3],
+                    },
+                    '&:hover': {
+                        backgroundColor: theme.colors.ldGray[1],
+                    },
+                },
+            })}
+        />
     );
 };

--- a/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/SingleSeriesConfiguration.tsx
@@ -32,6 +32,7 @@ type SingleSeriesConfigurationProps = {
     whichYAxis?: number;
     valueLabelPosition: ValueLabelPositionOptions | undefined;
     showValue?: boolean;
+    showLabel?: boolean;
     showSeriesName?: boolean;
     selectedChartType: ChartKind;
     onColorChange: (reference: string, color: string) => void;
@@ -46,6 +47,7 @@ type SingleSeriesConfigurationProps = {
         position: ValueLabelPositionOptions,
     ) => void;
     onShowValueChange?: (reference: string, showValue: boolean) => void;
+    onShowLabelChange?: (reference: string, showLabel: boolean) => void;
     onShowSeriesNameChange?: (
         reference: string,
         showSeriesName: boolean,
@@ -61,6 +63,7 @@ export const SingleSeriesConfiguration = ({
     whichYAxis = 0,
     valueLabelPosition,
     showValue = true,
+    showLabel = false,
     showSeriesName = false,
     selectedChartType,
     onColorChange,
@@ -69,6 +72,7 @@ export const SingleSeriesConfiguration = ({
     onAxisChange,
     onValueLabelPositionChange,
     onShowValueChange,
+    onShowLabelChange,
     onShowSeriesNameChange,
 }: SingleSeriesConfigurationProps) => {
     return (
@@ -194,6 +198,7 @@ export const SingleSeriesConfiguration = ({
                             ValueLabelPositionOptions.HIDDEN
                         }
                         showValue={showValue}
+                        showLabel={showLabel}
                         showSeriesName={showSeriesName}
                         onChangeValueLabelPosition={(position) =>
                             onValueLabelPositionChange(reference, position)
@@ -201,6 +206,12 @@ export const SingleSeriesConfiguration = ({
                         onChangeShowValue={
                             onShowValueChange
                                 ? (value) => onShowValueChange(reference, value)
+                                : undefined
+                        }
+                        onChangeShowLabel={
+                            onShowLabelChange
+                                ? (value) =>
+                                      onShowLabelChange(reference, value)
                                 : undefined
                         }
                         onChangeShowSeriesName={

--- a/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
+++ b/packages/frontend/src/components/DataViz/store/cartesianChartBaseSlice.ts
@@ -454,6 +454,25 @@ export const cartesianChartConfigSlice = createSlice({
                 };
             }
         },
+        setSeriesShowLabel: (
+            { fieldConfig, display },
+            action: PayloadAction<{
+                reference: string;
+                showLabel: boolean;
+            }>,
+        ) => {
+            if (!fieldConfig) return;
+            display = display || {};
+            display.yAxis = display.yAxis || [];
+            display.series = display.series || {};
+
+            if (action.payload.reference !== undefined) {
+                display.series[action.payload.reference] = {
+                    ...display.series[action.payload.reference],
+                    showLabel: action.payload.showLabel,
+                };
+            }
+        },
         setSeriesShowSeriesName: (
             { fieldConfig, display },
             action: PayloadAction<{

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/SingleSeriesConfiguration.tsx
@@ -11,6 +11,7 @@ import {
     Checkbox,
     Collapse,
     Group,
+    Popover,
     Select,
     Stack,
 } from '@mantine/core';
@@ -20,6 +21,7 @@ import {
     IconChevronUp,
     IconEye,
     IconEyeOff,
+    IconSettings,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
 import type useCartesianChartConfig from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
@@ -220,6 +222,94 @@ const SingleSeriesConfiguration: FC<Props> = ({
                                 { value: 'right', label: 'Right' },
                                 { value: 'inside', label: 'Inside' },
                             ]}
+                            rightSection={
+                                series.label?.show ? (
+                                    <Popover
+                                        position="bottom-end"
+                                        shadow="md"
+                                        withinPortal
+                                    >
+                                        <Popover.Target>
+                                            <ActionIcon
+                                                variant="subtle"
+                                                size="xs"
+                                            >
+                                                <MantineIcon
+                                                    icon={IconSettings}
+                                                    color="gray.6"
+                                                />
+                                            </ActionIcon>
+                                        </Popover.Target>
+                                        <Popover.Dropdown>
+                                            <Stack spacing="xs">
+                                                <Checkbox
+                                                    size="xs"
+                                                    checked={
+                                                        series.label
+                                                            ?.showValue ?? true
+                                                    }
+                                                    label="Show value"
+                                                    onChange={() => {
+                                                        updateSingleSeries({
+                                                            ...series,
+                                                            label: {
+                                                                ...series.label,
+                                                                showValue: !(
+                                                                    series.label
+                                                                        ?.showValue ??
+                                                                    true
+                                                                ),
+                                                            },
+                                                        });
+                                                    }}
+                                                />
+                                                <Checkbox
+                                                    size="xs"
+                                                    checked={
+                                                        series.label
+                                                            ?.showLabel ?? false
+                                                    }
+                                                    label="Show label"
+                                                    onChange={() => {
+                                                        updateSingleSeries({
+                                                            ...series,
+                                                            label: {
+                                                                ...series.label,
+                                                                showLabel:
+                                                                    !series
+                                                                        .label
+                                                                        ?.showLabel,
+                                                            },
+                                                        });
+                                                    }}
+                                                />
+                                                <Checkbox
+                                                    size="xs"
+                                                    checked={
+                                                        series.label
+                                                            ?.showSeriesName ??
+                                                        false
+                                                    }
+                                                    label="Show metric name"
+                                                    onChange={() => {
+                                                        updateSingleSeries({
+                                                            ...series,
+                                                            label: {
+                                                                ...series.label,
+                                                                showSeriesName:
+                                                                    !series
+                                                                        .label
+                                                                        ?.showSeriesName,
+                                                            },
+                                                        });
+                                                    }}
+                                                />
+                                            </Stack>
+                                        </Popover.Dropdown>
+                                    </Popover>
+                                ) : undefined
+                            }
+                            rightSectionProps={{ style: { pointerEvents: 'all' } }}
                             onChange={(value) => {
                                 updateSingleSeries({
                                     ...series,
@@ -232,6 +322,9 @@ const SingleSeriesConfiguration: FC<Props> = ({
                                                   showValue:
                                                       series.label?.showValue ??
                                                       true,
+                                                  showLabel:
+                                                      series.label?.showLabel ??
+                                                      false,
                                                   showSeriesName:
                                                       series.label
                                                           ?.showSeriesName ??
@@ -241,39 +334,6 @@ const SingleSeriesConfiguration: FC<Props> = ({
                             }}
                         />
                     </Group>
-                    {series.label?.show && (
-                        <Group spacing="xs">
-                            <Checkbox
-                                checked={series.label?.showValue ?? true}
-                                label="Show value"
-                                onChange={() => {
-                                    updateSingleSeries({
-                                        ...series,
-                                        label: {
-                                            ...series.label,
-                                            showValue: !(
-                                                series.label?.showValue ?? true
-                                            ),
-                                        },
-                                    });
-                                }}
-                            />
-                            <Checkbox
-                                checked={series.label?.showSeriesName ?? false}
-                                label="Show series name"
-                                onChange={() => {
-                                    updateSingleSeries({
-                                        ...series,
-                                        label: {
-                                            ...series.label,
-                                            showSeriesName:
-                                                !series.label?.showSeriesName,
-                                        },
-                                    });
-                                }}
-                            />
-                        </Group>
-                    )}
                     {(type === CartesianSeriesType.LINE ||
                         type === CartesianSeriesType.AREA) && (
                         <Group spacing="xs">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19938

### Description:
Added new label configuration options for chart series to provide more control over what appears in data labels:

- Added `showLabel` option to display the legend/pivot name (e.g., "United States")
- Enhanced `showSeriesName` to display the metric field name (e.g., "Revenue")
- Improved the label formatting logic to handle combinations of these options
- Updated UI to include these options in a popover menu accessible from the label position dropdown
- Reorganized the label configuration UI to be more compact and intuitive

These changes allow users to create more informative data labels with combinations like "United States (Revenue): 17,000" where each component can be toggled on/off.