### PR TITLE
fix: update compilation history URL path

### DIFF
--- a/packages/frontend/src/components/JobDetailsDrawer/ProjectCompileLog.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/ProjectCompileLog.tsx
@@ -37,7 +37,7 @@ const ProjectCompileLog: FC<ProjectCompileLogProps> = ({
                     rightSection={<MantineIcon icon={IconExternalLink} />}
                     component="a"
                     target="_blank"
-                    href={`/generalSettings/${projectUuid}/compilationHistory`}
+                    href={`/generalSettings/projectManagement/${projectUuid}/compilationHistory`}
                 >
                     See history
                 </Button>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the URL path for the compilation history link in the ProjectCompileLog component to include the "projectManagement" segment in the path.
