### PR TITLE
style: fix compilation drawer patting

### DIFF
--- a/packages/frontend/src/components/JobDetailsDrawer/index.tsx
+++ b/packages/frontend/src/components/JobDetailsDrawer/index.tsx
@@ -36,6 +36,7 @@ import {
 } from '../../hooks/useRefreshServer';
 import useActiveJob from '../../providers/ActiveJob/useActiveJob';
 import MantineIcon from '../common/MantineIcon';
+import { NAVBAR_HEIGHT } from '../common/Page/constants';
 import ProjectCompileLog from './ProjectCompileLog';
 
 dayjs.extend(duration);
@@ -136,6 +137,11 @@ const JobDetailsDrawer: FC = () => {
             position="right"
             opened={isJobsDrawerOpen}
             onClose={() => setIsJobsDrawerOpen(false)}
+            styles={{
+                inner: {
+                    paddingTop: NAVBAR_HEIGHT,
+                },
+            }}
             title={
                 <Group noWrap align="center" spacing="xs">
                     <DrawerIcon job={activeJob} />


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Adds padding to the top of the JobDetailsDrawer to account for the navbar height. This ensures the drawer content doesn't overlap with the navbar when opened.

The change imports the NAVBAR_HEIGHT constant and applies it as paddingTop to the drawer's inner styles.