### PR TITLE
fix: align help circle icon properly with inline-flex

### DIFF
--- a/packages/frontend/src/components/DocumentationHelpButton.tsx
+++ b/packages/frontend/src/components/DocumentationHelpButton.tsx
@@ -31,14 +31,11 @@ const DocumentationHelpButton: FC<Props> = ({
             target="_blank"
             rel="noreferrer"
             color="dimmed"
+            display="inline-flex"
+            style={{ verticalAlign: 'middle' }}
             {...anchorProps}
         >
-            <MantineIcon
-                icon={IconHelpCircle}
-                size="md"
-                display="inline"
-                {...iconProps}
-            />
+            <MantineIcon icon={IconHelpCircle} size="md" {...iconProps} />
         </Anchor>
     </Tooltip>
 );

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
@@ -82,8 +82,6 @@ export const EmptyStateNoColumns = () => {
                     Pick a metric & select its dimensions{' '}
                     <DocumentationHelpButton
                         href={ExploreDocumentationUrl}
-                        pos="relative"
-                        top={2}
                         iconProps={{ size: 'lg' }}
                     />
                 </>
@@ -164,11 +162,7 @@ export const EmptyStateNoTableData: FC<{ description: React.ReactNode }> = ({
             description={
                 <>
                     {description}{' '}
-                    <DocumentationHelpButton
-                        href={ExploreDocumentationUrl}
-                        pos="relative"
-                        top={2}
-                    />
+                    <DocumentationHelpButton href={ExploreDocumentationUrl} />
                 </>
             }
         >
@@ -186,11 +180,7 @@ export const NoTableSelected = () => (
             <>
                 To run a query, first select the table that you would like to
                 explore.{' '}
-                <DocumentationHelpButton
-                    href={ExploreDocumentationUrl}
-                    pos="relative"
-                    top={2}
-                />
+                <DocumentationHelpButton href={ExploreDocumentationUrl} />
             </>
         }
     />

--- a/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectForm.tsx
@@ -52,11 +52,7 @@ export const ProjectForm: FC<Props> = ({
                     {warehouse && getWarehouseIcon(warehouse)}
                     <Flex align="center" gap={2}>
                         <Title order={5}>Warehouse connection</Title>
-                        <DocumentationHelpButton
-                            href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#warehouse-connection"
-                            pos="relative"
-                            top="2px"
-                        />
+                        <DocumentationHelpButton href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project#warehouse-connection" />
                     </Flex>
 
                     {health.data?.staticIp && (
@@ -81,11 +77,7 @@ export const ProjectForm: FC<Props> = ({
 
                     <Flex align="center" gap={2}>
                         <Title order={5}>dbt connection</Title>
-                        <DocumentationHelpButton
-                            href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project"
-                            pos="relative"
-                            top="2px"
-                        />
+                        <DocumentationHelpButton href="https://docs.lightdash.com/get-started/setup-lightdash/connect-project" />
                     </Flex>
                 </div>
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/CustomVis/CustomVisConfig.tsx
@@ -233,11 +233,7 @@ export const ConfigTabs: React.FC = memo(() => {
                         <Config.Heading>
                             <Flex justify="space-between" gap="xs">
                                 <Text>Vega-Lite JSON</Text>
-                                <DocumentationHelpButton
-                                    pos="relative"
-                                    top="2px"
-                                    href="https://docs.lightdash.com/references/custom-charts#custom-charts"
-                                />
+                                <DocumentationHelpButton href="https://docs.lightdash.com/references/custom-charts#custom-charts" />
                             </Flex>
                         </Config.Heading>
 

--- a/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerModal.tsx
@@ -102,17 +102,9 @@ const SchedulersModal: FC<
                 icon={isThresholdAlert ? IconBell : IconSend}
                 headerActions={
                     isThresholdAlert ? (
-                        <DocumentationHelpButton
-                            href="https://docs.lightdash.com/guides/how-to-create-alerts"
-                            pos="relative"
-                            top="2px"
-                        />
+                        <DocumentationHelpButton href="https://docs.lightdash.com/guides/how-to-create-alerts" />
                     ) : (
-                        <DocumentationHelpButton
-                            href="https://docs.lightdash.com/guides/how-to-create-scheduled-deliveries"
-                            pos="relative"
-                            top="2px"
-                        />
+                        <DocumentationHelpButton href="https://docs.lightdash.com/guides/how-to-create-scheduled-deliveries" />
                     )
                 }
                 modalBodyProps={{ bg: 'background' }}


### PR DESCRIPTION
Use display: inline-flex and verticalAlign: middle on the DocumentationHelpButton anchor to properly align the icon with surrounding text instead of relying on hacky position offsets.

Removes pos="relative" top={2} workarounds from all callers.

https://claude.ai/code/session_01KhCseYFGbkNQzLr7JH5ETK

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
