### PR TITLE
fix: add venv/bin to PATH for PM2 api and scheduler processes

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -32,6 +32,13 @@ const localEnv = dotenv.config({ path: localEnvPath }).parsed || {};
 // Merge: local overrides base
 const env = { ...baseEnv, ...localEnv };
 
+// Add venv/bin to PATH for dbt access
+const venvBinPath = path.join(__dirname, 'venv', 'bin');
+const envWithPath = {
+    ...env,
+    PATH: `${venvBinPath}:${process.env.PATH}`,
+};
+
 module.exports = {
     apps: [
         // ─────────────────────────────────────────────────────────────────
@@ -44,7 +51,7 @@ module.exports = {
             node_args: '--import tsx --inspect=0.0.0.0:9229',
             cwd: path.join(__dirname, 'packages/backend'),
             env: {
-                ...env,
+                ...envWithPath,
                 LIGHTDASH_MODE: 'development',
                 HEADLESS: 'true',
                 NODE_ENV: 'development',
@@ -67,7 +74,7 @@ module.exports = {
             node_args: '--import tsx',
             cwd: path.join(__dirname, 'packages/backend'),
             env: {
-                ...env,
+                ...envWithPath,
                 NODE_ENV: 'development',
                 SENTRY_SPOTLIGHT: 'http://localhost:8969/stream',
                 // Override PORT to avoid conflict with API (which uses 8080)


### PR DESCRIPTION
## Summary
- PM2-managed backend processes (API server and scheduler) couldn't find `dbt` because the project's Python `venv/bin` wasn't on their PATH
- Prepends `venv/bin` to the PATH environment variable for both `lightdash-api` and `lightdash-scheduler` process configs

## Test plan
- [ ] Run `pnpm pm2:start` and verify dbt commands work from the API server (e.g. project sync triggers dbt)

🤖 Generated with [Claude Code](https://claude.com/claude-code)