### PR TITLE
fix: remove comment from ChartAsCode type

### DIFF
--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -30,7 +30,7 @@ export type ChartAsCode = Pick<
     | 'pivotConfig'
     | 'slug'
     | 'updatedAt' // Not modifiable by user, but useful to know if it has been updated
-    | 'parameters' // Parameter values for charts migrated from Looker
+    | 'parameters'
 > & {
     dashboardSlug: string | undefined;
     version: number;


### PR DESCRIPTION
## Summary
- Removes the `// Parameter values for charts migrated from Looker` comment from the `parameters` field in the `ChartAsCode` type

## Test plan
- [ ] No runtime changes — comment-only removal

🤖 Generated with [Claude Code](https://claude.com/claude-code)