### PR TITLE
refactor: improve ProjectSwitcher dropdown with ScrollArea component

### DIFF
--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.module.css
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.module.css
@@ -1,7 +1,6 @@
 .dropdown {
     min-width: 250px;
-    max-height: 450px;
-    overflow: auto;
+    overflow: visible;
 }
 
 .groupHeader {
@@ -28,11 +27,7 @@
 }
 
 .searchHeader {
-    position: sticky;
-    top: 0;
-    background-color: var(--mantine-color-gray-9);
     padding: var(--mantine-spacing-sm);
-    box-shadow: 0 2px 8px var(--mantine-color-gray-9);
     border-bottom: 1px solid var(--mantine-color-dark-4);
 }
 
@@ -45,15 +40,6 @@
     }
 }
 
-.projectsScroll {
-    max-height: 200px;
-    overflow: auto;
-}
-
 .stickyFooter {
-    position: sticky;
-    bottom: 0;
-    background-color: var(--mantine-color-gray-9);
-    /* fixes scroll overlap */
-    box-shadow: 0 4px var(--mantine-color-gray-9);
+    border-top: 1px solid var(--mantine-color-dark-4);
 }

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -13,6 +13,7 @@ import {
     Group,
     Highlight,
     Menu,
+    ScrollArea,
     Stack,
     Text,
     TextInput,
@@ -49,7 +50,7 @@ const MENU_TEXT_PROPS = {
     fw: 500,
 };
 
-type GroupState = 'expanded' | 'collapsed' | 'filtered';
+type GroupState = 'expanded' | 'collapsed';
 
 interface GroupStates {
     base: GroupState;
@@ -214,27 +215,11 @@ const ProjectSwitcher = () => {
     const [debouncedSearchQuery] = useDebouncedValue(searchQuery, 300);
 
     const handleGroupToggle = useCallback((groupType: 'base' | 'preview') => {
-        setGroupStates((prev) => {
-            const currentState = prev[groupType];
-
-            // Cycle through states: expanded -> collapsed -> filtered -> expanded
-            switch (currentState) {
-                case 'expanded':
-                    return { ...prev, [groupType]: 'collapsed' };
-                case 'collapsed':
-                    // Enter filter mode: this group filtered, other collapsed
-                    if (groupType === 'base') {
-                        return { base: 'filtered', preview: 'collapsed' };
-                    } else {
-                        return { base: 'collapsed', preview: 'filtered' };
-                    }
-                case 'filtered':
-                    // Back to default: both expanded
-                    return { base: 'expanded', preview: 'expanded' };
-                default:
-                    return prev;
-            }
-        });
+        setGroupStates((prev) => ({
+            ...prev,
+            [groupType]:
+                prev[groupType] === 'collapsed' ? 'expanded' : 'collapsed',
+        }));
     }, []);
 
     const routeMatches =
@@ -381,7 +366,7 @@ const ProjectSwitcher = () => {
             previewProjects: preview,
             shouldShowBase: showBase && base.length > 0,
             shouldShowPreview: showPreview && preview.length > 0,
-            showSearchInput: base.length + preview.length > 2,
+            showSearchInput: availableProjects.length > 2,
         };
     }, [
         activeProjectUuid,
@@ -492,7 +477,7 @@ const ProjectSwitcher = () => {
                                     isVisible={shouldShowBase}
                                 />
                                 <Collapse in={shouldShowBase}>
-                                    <Box className={classes.projectsScroll}>
+                                    <ScrollArea.Autosize mah={200}>
                                         <Stack gap={0}>
                                             {baseProjects.map((item) => (
                                                 <ProjectItem
@@ -511,10 +496,11 @@ const ProjectSwitcher = () => {
                                                 />
                                             ))}
                                         </Stack>
-                                    </Box>
+                                    </ScrollArea.Autosize>
                                 </Collapse>
                             </Box>
                         )}
+                        {}
 
                         {/* Preview Projects Group */}
                         {!isLoadingProjects && previewProjects.length > 0 && (
@@ -531,7 +517,7 @@ const ProjectSwitcher = () => {
                                     isVisible={shouldShowPreview}
                                 />
                                 <Collapse in={shouldShowPreview}>
-                                    <Box className={classes.projectsScroll}>
+                                    <ScrollArea.Autosize mah={200}>
                                         <Stack gap={0}>
                                             {previewProjects.map((item) => (
                                                 <ProjectItem
@@ -550,7 +536,7 @@ const ProjectSwitcher = () => {
                                                 />
                                             ))}
                                         </Stack>
-                                    </Box>
+                                    </ScrollArea.Autosize>
                                 </Collapse>
                             </Box>
                         )}
@@ -578,9 +564,6 @@ const ProjectSwitcher = () => {
 
                     {userCanCreatePreview && (
                         <Box className={classes.stickyFooter}>
-                            {(baseProjects.length > 0 ||
-                                previewProjects.length > 0) && <Menu.Divider />}
-
                             <Menu.Item
                                 onClick={(
                                     e: React.MouseEvent<HTMLButtonElement>,


### PR DESCRIPTION
### Description:
Improves the ProjectSwitcher dropdown UI by:

- Replacing fixed height scrollable containers with `ScrollArea.Autosize` components for better scrolling experience
- Simplifying the group toggle logic by removing the 'filtered' state
- Fixing overflow issues by making the dropdown overflow visible
- Replacing sticky positioning with simple borders for headers and footers
- Improving the search visibility logic to show search when there are more than 2 available projects

[CleanShot 2026-02-06 at 14.18.54.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/2bff232f-6be6-4d95-8d46-74ed1d12c1bb.mp4" />](https://app.graphite.com/user-attachments/video/2bff232f-6be6-4d95-8d46-74ed1d12c1bb.mp4)

