### PR TITLE
style: fix empty state help documentation icon

### DIFF
--- a/packages/frontend/src/components/DocumentationHelpButton.tsx
+++ b/packages/frontend/src/components/DocumentationHelpButton.tsx
@@ -30,7 +30,7 @@ const DocumentationHelpButton: FC<Props> = ({
             role="button"
             target="_blank"
             rel="noreferrer"
-            color="dimmed"
+            c="dimmed"
             {...anchorProps}
         >
             <MantineIcon

--- a/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ExplorerResultsNonIdealStates.tsx
@@ -179,7 +179,7 @@ export const EmptyStateNoTableData: FC<{ description: React.ReactNode }> = ({
 
 export const NoTableSelected = () => (
     <EmptyState
-        maw={500}
+        maw={520}
         icon={<NoTableIcon />}
         title="Select a table"
         description={

--- a/packages/frontend/src/components/common/MantineIcon/index.tsx
+++ b/packages/frontend/src/components/common/MantineIcon/index.tsx
@@ -24,6 +24,7 @@ export interface MantineIconProps extends Omit<TablerIconsProps, 'ref'> {
     stroke?: MantineIconSize;
     color?: MantineColor;
     fill?: MantineColor;
+    display?: 'block' | 'inline' | 'none';
 }
 
 /** Mantine color keywords that map directly to --mantine-color-{name}. */
@@ -62,22 +63,32 @@ function toColorVar(color: MantineColor): string {
 }
 
 function toSizeValue(size: MantineIconSize): string | number {
-    return typeof size === 'string'
-        ? `var(--mantine-spacing-${size})`
-        : size;
+    return typeof size === 'string' ? `var(--mantine-spacing-${size})` : size;
 }
 
 const MantineIcon = forwardRef<SVGSVGElement, MantineIconProps>(
-    ({ icon: TablerIcon, size = 'md', stroke, color, fill, ...rest }, ref) => {
+    (
+        {
+            icon: TablerIcon,
+            size = 'md',
+            stroke,
+            color,
+            fill,
+            display = 'block',
+            ...rest
+        },
+        ref,
+    ) => {
         const sizeValue = toSizeValue(size);
 
         return (
             <TablerIcon
                 ref={ref}
                 aria-hidden
+                display={display}
                 {...rest}
                 style={{
-                    display: 'block',
+                    display,
                     width: sizeValue,
                     height: sizeValue,
                     ...(color && { color: toColorVar(color) }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
This PR updates several UI components to align with Mantine's latest API:

1. Changed `color` prop to `c` in `DocumentationHelpButton` to match Mantine's current API
2. Increased the maximum width of the "No Table Selected" empty state from 500px to 520px
3. Enhanced the `MantineIcon` component to support a configurable `display` prop with options for 'block', 'inline', or 'none', defaulting to 'block'