### PR TITLE
style: migrate 10 components from mantine/core to mantine-8/core

### DIFF
--- a/packages/frontend/src/components/CronInput/FrequencySelect.module.css
+++ b/packages/frontend/src/components/CronInput/FrequencySelect.module.css
@@ -1,0 +1,3 @@
+.select {
+    align-self: start;
+}

--- a/packages/frontend/src/components/CronInput/FrequencySelect.tsx
+++ b/packages/frontend/src/components/CronInput/FrequencySelect.tsx
@@ -1,6 +1,7 @@
-import { Select } from '@mantine/core';
+import { Select } from '@mantine-8/core';
 import React, { type FC } from 'react';
 import { Frequency } from './cronInputUtils';
+import styles from './FrequencySelect.module.css';
 
 type FrequencyItem = {
     value: Frequency;
@@ -33,17 +34,16 @@ const FrequencyItems: Array<FrequencyItem> = [
 const FrequencySelect: FC<{
     disabled?: boolean;
     value: Frequency;
-    onChange: (value: Frequency) => void;
+    onChange: (value: Frequency | null | string) => void;
 }> = ({ disabled, value, onChange }) => {
     return (
         <Select
+            className={styles.select}
             data={FrequencyItems}
             value={value}
-            withinPortal
             disabled={disabled}
             onChange={onChange}
             w={110}
-            sx={{ alignSelf: 'start' }}
         />
     );
 };

--- a/packages/frontend/src/components/CronInput/index.tsx
+++ b/packages/frontend/src/components/CronInput/index.tsx
@@ -41,9 +41,11 @@ export const CronInternalInputs: FC<
     }, [frequency, value]);
 
     const onFrequencyChange = useCallback(
-        (newFrequency: Frequency) => {
-            setFrequency(newFrequency);
-            onChange(getFrequencyCronExpression(newFrequency, value));
+        (newFrequency: Frequency | null | string) => {
+            setFrequency(newFrequency as Frequency);
+            onChange(
+                getFrequencyCronExpression(newFrequency as Frequency, value),
+            );
         },
         [onChange, value],
     );

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.module.css
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.module.css
@@ -1,0 +1,10 @@
+.markdownContainer {
+    flex: 1;
+    overflow: auto;
+
+    :global(.wmde-markdown) {
+        font-size: 14px;
+        background-color: transparent;
+        font-family: var(--mantine-font-family);
+    }
+}

--- a/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardMarkdownTile.tsx
@@ -2,8 +2,7 @@ import {
     MARKDOWN_TILE_CLASS,
     type DashboardMarkdownTile,
 } from '@lightdash/common';
-import { Menu } from '@mantine-8/core';
-import { Text, useMantineTheme } from '@mantine/core';
+import { Box, Menu, useMantineColorScheme } from '@mantine-8/core';
 import { IconCopy } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import React, { useCallback, useMemo, useState, type FC } from 'react';
@@ -15,6 +14,7 @@ import useDashboardStorage from '../../hooks/dashboard/useDashboardStorage';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import MantineIcon from '../common/MantineIcon';
 import TileBase from './TileBase/index';
+import styles from './DashboardMarkdownTile.module.css';
 
 export type Props = Pick<
     React.ComponentProps<typeof TileBase>,
@@ -24,7 +24,7 @@ export type Props = Pick<
 };
 
 const MarkdownTile: FC<Props> = (props) => {
-    const theme = useMantineTheme();
+    const { colorScheme } = useMantineColorScheme();
 
     const {
         tile: {
@@ -104,20 +104,8 @@ const MarkdownTile: FC<Props> = (props) => {
             }
             {...props}
         >
-            <Text
-                className="non-draggable"
-                component="div"
-                sx={{
-                    flex: 1,
-                    overflow: 'auto',
-                    '.wmde-markdown': {
-                        fontSize: '14px',
-                        backgroundColor: 'transparent',
-                        fontFamily: theme.fontFamily,
-                    },
-                }}
-            >
-                <div data-color-mode={theme.colorScheme}>
+            <Box className={`non-draggable ${styles.markdownContainer}`}>
+                <div data-color-mode={colorScheme}>
                     <MarkdownPreview
                         className={MARKDOWN_TILE_CLASS}
                         source={content}
@@ -126,7 +114,7 @@ const MarkdownTile: FC<Props> = (props) => {
                         ]}
                     />
                 </div>
-            </Text>
+            </Box>
         </TileBase>
     );
 };

--- a/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
+++ b/packages/frontend/src/components/Explorer/ExplorePanel/index.tsx
@@ -50,7 +50,7 @@ import ExploreTree from '../ExploreTree';
 import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
 import ExploreYamlModal from '../ExploreYamlModal';
-import WarningsHoverCardContent from '../WarningsHoverCard';
+import WarningsHoverCardContent from '../WarningsHoverCardContent';
 import { useIsGitProject } from '../WriteBackModal/hooks';
 import { VisualizationConfigPortalId } from './constants';
 

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -20,7 +20,7 @@ import {
 import React from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { TableItemDetailPreview } from '../ExploreTree/TableTree/ItemDetailPreview';
-import WarningsHoverCardContent from '../WarningsHoverCard';
+import WarningsHoverCardContent from '../WarningsHoverCardContent';
 
 type ExploreNavLinkProps = {
     explore: SummaryExplore;

--- a/packages/frontend/src/components/Explorer/WarningsHoverCardContent.module.css
+++ b/packages/frontend/src/components/Explorer/WarningsHoverCardContent.module.css
@@ -1,0 +1,11 @@
+.warningsList {
+    overflow: auto;
+}
+
+.warningBox {
+    border-radius: 4px;
+}
+
+.warningText {
+    word-break: break-word;
+}

--- a/packages/frontend/src/components/Explorer/WarningsHoverCardContent.tsx
+++ b/packages/frontend/src/components/Explorer/WarningsHoverCardContent.tsx
@@ -1,6 +1,7 @@
 import { type InlineError } from '@lightdash/common';
-import { Box, Stack, Text } from '@mantine/core';
+import { Box, Stack, Text } from '@mantine-8/core';
 import type { FC } from 'react';
+import styles from './WarningsHoverCardContent.module.css';
 
 type WarningsHoverCardContentProps = {
     type: 'warnings' | 'errors';
@@ -19,17 +20,15 @@ const WarningsHoverCardContent: FC<WarningsHoverCardContentProps> = ({
         <Text fz="sm" fw={600} mb="xs">
             Compilation {type} ({warnings.length})
         </Text>
-        <Stack spacing="xs" sx={{ maxHeight: 250, overflow: 'auto' }}>
+        <Stack className={styles.warningsList} gap="xs" mah={250}>
             {warnings.map((warning, idx) => (
                 <Box
+                    className={styles.warningBox}
                     key={idx}
                     p="xs"
-                    sx={(theme) => ({
-                        backgroundColor: theme.colors.ldGray[0],
-                        borderRadius: 4,
-                    })}
+                    bg="ldGray.0"
                 >
-                    <Text fz="xs" sx={{ wordBreak: 'break-word' }}>
+                    <Text className={styles.warningText} fz="xs">
                         {warning.message}
                     </Text>
                 </Box>

--- a/packages/frontend/src/components/ExportResults/ExportResults.module.css
+++ b/packages/frontend/src/components/ExportResults/ExportResults.module.css
@@ -1,0 +1,3 @@
+.downloadButton {
+    align-self: end;
+}

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -9,16 +9,16 @@ import {
     Alert,
     Box,
     Button,
+    Group,
     NumberInput,
     SegmentedControl,
     Stack,
     Text,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { notifications } from '@mantine/notifications';
 import { IconTableExport } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
 import { memo, useState, type FC, type ReactNode } from 'react';
-
 import { pollJobStatus } from '../../features/scheduler/hooks/useScheduler';
 import useHealth from '../../hooks/health/useHealth';
 import useToaster from '../../hooks/toaster/useToaster';
@@ -26,6 +26,7 @@ import { scheduleDownloadQuery } from '../../hooks/useQueryResults';
 import useUser from '../../hooks/user/useUser';
 import { Can } from '../../providers/Ability';
 import MantineIcon from '../common/MantineIcon';
+import styles from './ExportResults.module.css';
 import { Limit } from './types';
 
 type ExportCsvRenderProps = {
@@ -182,12 +183,15 @@ const ExportResults: FC<ExportResultsProps> = memo(
 
         return (
             <Box>
-                <Stack spacing={0} miw={300}>
+                <Stack gap={0} miw={300}>
                     <Stack p={renderDialogActions ? 'md' : 0}>
-                        <Stack spacing="xs">
-                            <Text fw={500}>File format</Text>
+                        <Group gap="xs">
+                            <Text fw={500} fz="sm">
+                                File format
+                            </Text>
                             <SegmentedControl
-                                size={'xs'}
+                                size="xs"
+                                radius="md"
                                 value={fileType}
                                 onChange={(value) =>
                                     setFileType(value as DownloadFileType)
@@ -203,12 +207,15 @@ const ExportResults: FC<ExportResultsProps> = memo(
                                     },
                                 ]}
                             />
-                        </Stack>
+                        </Group>
 
-                        <Stack spacing="xs">
-                            <Text fw={500}>Values</Text>
+                        <Group gap="xs">
+                            <Text fw={500} fz="sm">
+                                Values
+                            </Text>
                             <SegmentedControl
-                                size={'xs'}
+                                size="xs"
+                                radius="md"
                                 value={format}
                                 onChange={(value) => setFormat(value)}
                                 data={[
@@ -219,8 +226,8 @@ const ExportResults: FC<ExportResultsProps> = memo(
                                     { label: 'Raw', value: Values.RAW },
                                 ]}
                             />
-                        </Stack>
-                        <Stack spacing="xs">
+                        </Group>
+                        <Stack gap="xs">
                             <Can
                                 I="manage"
                                 this={subject('ChangeCsvResults', {
@@ -230,10 +237,13 @@ const ExportResults: FC<ExportResultsProps> = memo(
                                 })}
                             >
                                 {!hideLimitSelection ? (
-                                    <Stack spacing="xs">
-                                        <Text fw={500}>Limit</Text>
+                                    <Group gap="xs">
+                                        <Text fw={500} fz="sm">
+                                            Limit
+                                        </Text>
                                         <SegmentedControl
-                                            size={'xs'}
+                                            size="xs"
+                                            radius="md"
                                             value={limit}
                                             onChange={(value) =>
                                                 setLimit(value as Limit)
@@ -253,23 +263,26 @@ const ExportResults: FC<ExportResultsProps> = memo(
                                                 },
                                             ]}
                                         />
-                                    </Stack>
+                                        {limit === Limit.CUSTOM && (
+                                            <NumberInput
+                                                size="xs"
+                                                min={1}
+                                                w={70}
+                                                radius="md"
+                                                allowDecimal={false}
+                                                required
+                                                value={customLimit}
+                                                onChange={(value) =>
+                                                    setCustomLimit(
+                                                        Number(value),
+                                                    )
+                                                }
+                                            />
+                                        )}
+                                    </Group>
                                 ) : null}
                             </Can>
 
-                            {limit === Limit.CUSTOM && (
-                                <NumberInput
-                                    w="100%"
-                                    size="xs"
-                                    min={1}
-                                    precision={0}
-                                    required
-                                    value={customLimit}
-                                    onChange={(value) =>
-                                        setCustomLimit(Number(value))
-                                    }
-                                />
-                            )}
                             {/* Pivot table specific warnings */}
                             {isPivotTable && (
                                 <Alert color="gray" p="xs">
@@ -298,14 +311,12 @@ const ExportResults: FC<ExportResultsProps> = memo(
 
                     {!renderDialogActions ? (
                         <Button
+                            className={styles.downloadButton}
                             loading={isExporting}
-                            sx={{
-                                alignSelf: 'end',
-                            }}
                             size="xs"
                             mt="sm"
-                            leftIcon={<MantineIcon icon={IconTableExport} />}
-                            onClick={exportMutation}
+                            leftSection={<MantineIcon icon={IconTableExport} />}
+                            onClick={() => exportMutation()}
                             data-testid="chart-export-results-button"
                         >
                             Download

--- a/packages/frontend/src/components/MinimalDashboardTabs/MinimalDashboardTabs.module.css
+++ b/packages/frontend/src/components/MinimalDashboardTabs/MinimalDashboardTabs.module.css
@@ -1,0 +1,4 @@
+.menuDropdown {
+    overflow-y: auto;
+    border-radius: var(--mantine-radius-md);
+}

--- a/packages/frontend/src/components/MinimalDashboardTabs/index.tsx
+++ b/packages/frontend/src/components/MinimalDashboardTabs/index.tsx
@@ -7,7 +7,7 @@ import {
     Text,
     Title,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import {
     IconChevronDown,
     IconChevronLeft,
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from 'react-router';
 import { useIsTruncated } from '../../hooks/useIsTruncated';
 import MantineIcon from '../common/MantineIcon';
+import styles from './MinimalDashboardTabs.module.css';
 
 const MinimalDashboardTabs = ({
     tabs,
@@ -30,10 +31,10 @@ const MinimalDashboardTabs = ({
     const activeTab = tabs.find((tab) => tab.uuid === activeTabId) ?? tabs[0];
 
     return (
-        <Group p="xs" bg="background" sx={{ gap: '10px' }} position="apart">
+        <Group p="xs" bg="background" gap={10} justify="space-between">
             <ActionIcon
                 size="md"
-                color="blue.6"
+                color="gray"
                 onClick={() => {
                     if (activeTab.prevUrl) {
                         void navigate(activeTab.prevUrl);
@@ -43,13 +44,8 @@ const MinimalDashboardTabs = ({
             >
                 <MantineIcon icon={IconChevronLeft} size="lg" />
             </ActionIcon>
-            <Group position="center" sx={{ flexGrow: 1 }}>
-                <Tooltip
-                    disabled={!isTruncated}
-                    label={activeTab.name}
-                    withinPortal
-                    variant="xs"
-                >
+            <Group justify="center" flex={1}>
+                <Tooltip disabled={!isTruncated} label={activeTab.name}>
                     <Menu shadow="md">
                         <Menu.Target>
                             <Button
@@ -57,28 +53,19 @@ const MinimalDashboardTabs = ({
                                 variant="subtle"
                                 color="ldGray.8"
                                 radius="md"
-                                rightIcon={
+                                rightSection={
                                     <MantineIcon icon={IconChevronDown} />
                                 }
                             >
-                                <Title
-                                    ref={ref}
-                                    order={6}
-                                    fw={500}
-                                    truncate
-                                    maw="50vw"
-                                >
-                                    {activeTab.name}
+                                <Title ref={ref} order={6} fw={500} maw="50vw">
+                                    <Text truncate="end">{activeTab.name}</Text>
                                 </Title>
                             </Button>
                         </Menu.Target>
                         <Menu.Dropdown
+                            className={styles.menuDropdown}
                             w={200}
                             mah={200}
-                            sx={(theme) => ({
-                                overflowY: 'auto',
-                                borderRadius: theme.radius.md,
-                            })}
                         >
                             {tabs.map((tab) => (
                                 <Menu.Item
@@ -93,7 +80,7 @@ const MinimalDashboardTabs = ({
                                                 ? 500
                                                 : 400
                                         }
-                                        truncate
+                                        truncate="end"
                                         maw="160px"
                                     >
                                         {tab.name}
@@ -106,7 +93,7 @@ const MinimalDashboardTabs = ({
             </Group>
             <ActionIcon
                 size="md"
-                color="blue.6"
+                color="gray"
                 onClick={() => {
                     if (activeTab.nextUrl) {
                         void navigate(activeTab.nextUrl);

--- a/packages/frontend/src/components/NavBar/index.module.css
+++ b/packages/frontend/src/components/NavBar/index.module.css
@@ -3,7 +3,7 @@
     top: 0;
     left: 0;
     right: 0;
-    z-index: 1000;
+    z-index: var(--mantine-zIndex-max);
 }
 
 .header {

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -1,5 +1,5 @@
 import { ResourceViewItemType, type PinnedItems } from '@lightdash/common';
-import { Card, Group, Text } from '@mantine/core';
+import { Card, Group, Text } from '@mantine-8/core';
 import { IconPin } from '@tabler/icons-react';
 import { type FC } from 'react';
 import usePinnedItemsContext from '../../providers/PinnedItems/usePinnedItemsContext';
@@ -40,26 +40,21 @@ const PinnedItemsPanel: FC<Props> = ({ pinnedItems, isEnabled }) => {
     ) : ((userCanManage && pinnedItems.length <= 0) || !pinnedItems) &&
       isEnabled ? (
         // FIXME: update width with Mantine widths
-        <Card
-            withBorder
-            sx={(theme) => ({
-                backgroundColor: theme.colors.ldGray[1],
-            })}
-        >
-            <Group position="apart">
-                <Group position="center" spacing="xxs" my="xs" ml="xs">
+        <Card withBorder bg="ldGray.1">
+            <Group justify="space-between">
+                <Group justify="center" gap="xxs" my="xs" ml="xs">
                     <MantineIcon
                         icon={IconPin}
-                        size="lg"
+                        size={20}
                         color="ldGray.7"
                         fill="ldGray.1"
                     />
-                    <Text fw={600} color="ldGray.7">
-                        No Pinned items.
+                    <Text fw={600} c="ldGray.8" fz="sm">
+                        No pinned items.
                     </Text>
-                    <Text color="ldGray.7">
+                    <Text c="ldGray.7" fz="sm">
                         Pin items to the top of the homepage to guide users to
-                        relevant content!
+                        relevant content.
                     </Text>
                 </Group>
                 <MantineLinkButton

--- a/packages/frontend/src/features/comments/components/CommentDetail.module.css
+++ b/packages/frontend/src/features/comments/components/CommentDetail.module.css
@@ -1,0 +1,3 @@
+.commentText {
+    word-break: break-word;
+}

--- a/packages/frontend/src/features/comments/components/CommentDetail.tsx
+++ b/packages/frontend/src/features/comments/components/CommentDetail.tsx
@@ -3,17 +3,19 @@ import {
     ActionIcon,
     Avatar,
     Box,
+    getDefaultZIndex,
     Grid,
     Group,
     Menu,
     Text,
     Tooltip,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useHover } from '@mantine/hooks';
 import { IconDotsVertical, IconMessage, IconTrash } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getNameInitials } from '../utils';
+import styles from './CommentDetail.module.css';
 import { CommentTimestamp } from './CommentTimestamp';
 
 type Props = {
@@ -51,17 +53,21 @@ export const CommentDetail: FC<Props> = ({
                     </Avatar>
                 </Grid.Col>
                 <Grid.Col span={18}>
-                    <Group position="apart">
-                        <Group spacing="xs">
+                    <Group justify="space-between">
+                        <Group gap="xs">
                             <Text fz="xs" fw={600}>
                                 {comment.user.name}
                             </Text>
                             <CommentTimestamp timestamp={comment.createdAt} />
                         </Group>
 
-                        <Group spacing="two" opacity={hovered ? 1 : 0}>
+                        <Group gap="two" opacity={hovered ? 1 : 0}>
                             {canReply && onReply && (
-                                <Tooltip label="Reply">
+                                <Tooltip
+                                    label="Reply"
+                                    withinPortal
+                                    zIndex={getDefaultZIndex('popover') + 1}
+                                >
                                     <ActionIcon
                                         size="xs"
                                         onClick={() => onReply()}
@@ -73,7 +79,12 @@ export const CommentDetail: FC<Props> = ({
                                 </Tooltip>
                             )}
                             {canRemove && (
-                                <Menu position="right" withArrow>
+                                <Menu
+                                    position="right"
+                                    withArrow
+                                    withinPortal
+                                    zIndex={getDefaultZIndex('popover') + 1}
+                                >
                                     <Menu.Target>
                                         <ActionIcon
                                             size="xs"
@@ -89,7 +100,7 @@ export const CommentDetail: FC<Props> = ({
                                         <Menu.Item
                                             p="xs"
                                             fz="xs"
-                                            icon={
+                                            leftSection={
                                                 <MantineIcon
                                                     color="red"
                                                     icon={IconTrash}
@@ -105,13 +116,11 @@ export const CommentDetail: FC<Props> = ({
                         </Group>
                     </Group>
                     <Box
+                        className={styles.commentText}
                         dangerouslySetInnerHTML={{
                             __html: sanitizedCommentTextHtml,
                         }}
                         fz="xs"
-                        sx={{
-                            wordBreak: 'break-word',
-                        }}
                     />
                 </Grid.Col>
             </Grid>

--- a/packages/frontend/src/features/comments/components/CommentForm.module.css
+++ b/packages/frontend/src/features/comments/components/CommentForm.module.css
@@ -1,0 +1,3 @@
+.submitButton {
+    align-self: flex-end;
+}

--- a/packages/frontend/src/features/comments/components/CommentForm.tsx
+++ b/packages/frontend/src/features/comments/components/CommentForm.tsx
@@ -1,5 +1,5 @@
 import { type Comment } from '@lightdash/common';
-import { Avatar, Button, Grid, Group, Skeleton, Stack } from '@mantine/core';
+import { Avatar, Button, Grid, Group, Skeleton, Stack } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
 import { type Editor, type JSONContent } from '@tiptap/react';
 import { useMemo, useState, type FC } from 'react';
@@ -9,6 +9,7 @@ import useDashboardContext from '../../../providers/Dashboard/useDashboardContex
 import { type SuggestionsItem } from '../types';
 import { getNameInitials } from '../utils';
 import { LazyCommentWithMentions } from './CommentWithMentions/LazyCommentWithMentions';
+import styles from './CommentForm.module.css';
 
 type Props = {
     userName: string;
@@ -86,7 +87,7 @@ export const CommentForm: FC<Props> = ({
 
     return (
         <form onSubmit={handleSubmit}>
-            <Stack spacing="xs" mt="xs">
+            <Stack gap="xs" mt="xs">
                 <Grid columns={20}>
                     <Grid.Col span={2}>
                         <Avatar radius="xl" size="sm" color="ldGray.6">
@@ -102,16 +103,15 @@ export const CommentForm: FC<Props> = ({
                                 onUpdate={setEditor}
                             />
                         ) : (
-                            <Skeleton h={30} w={'100%'} />
+                            <Skeleton h={30} w="100%" />
                         )}
                     </Grid.Col>
                 </Grid>
-                <Group position="right" spacing="xs">
+                <Group justify="flex-end" gap="xs">
                     {onCancel && (
                         <Button
-                            compact
                             variant="default"
-                            size="xs"
+                            size="compact-xs"
                             onClick={onCancel}
                         >
                             Cancel
@@ -119,12 +119,9 @@ export const CommentForm: FC<Props> = ({
                     )}
 
                     <Button
-                        compact
+                        className={styles.submitButton}
                         loading={isSubmitting}
-                        size="xs"
-                        sx={{
-                            alignSelf: 'flex-end',
-                        }}
+                        size="compact-xs"
                         type="submit"
                     >
                         {mode === 'reply' ? 'Reply' : 'Add comment'}

--- a/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardCommentAndReplies.tsx
@@ -1,5 +1,5 @@
 import { type Comment } from '@lightdash/common';
-import { Box, Button, Collapse, Divider, Stack } from '@mantine/core';
+import { Box, Button, Collapse, Divider, Stack } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import { useCallback, useState, type FC } from 'react';
 import useApp from '../../../providers/App/useApp';
@@ -57,7 +57,7 @@ export const DashboardCommentAndReplies: FC<Props> = ({
     }, [isRepliesOpen, comment.commentId, toggleReplies]);
 
     return (
-        <Stack spacing="two" ref={targetRef}>
+        <Stack gap="two" ref={targetRef}>
             <CommentDetail
                 comment={comment}
                 canReply={canCreateDashboardComments}
@@ -74,8 +74,7 @@ export const DashboardCommentAndReplies: FC<Props> = ({
                         labelPosition="right"
                         label={
                             <Button
-                                compact
-                                size="xs"
+                                size="compact-xs"
                                 variant="subtle"
                                 fz="xs"
                                 onClick={toggleReplies}
@@ -89,7 +88,7 @@ export const DashboardCommentAndReplies: FC<Props> = ({
                     />
 
                     <Collapse in={isRepliesOpen}>
-                        <Stack spacing="xs">
+                        <Stack gap="xs">
                             {comment.replies.map((reply) => (
                                 <CommentDetail
                                     key={reply.commentId}

--- a/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
+++ b/packages/frontend/src/features/comments/components/DashboardTileComments.tsx
@@ -8,7 +8,7 @@ import {
     Stack,
     Text,
     type PopoverProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { useScrollIntoView } from '@mantine/hooks';
 import { IconMessage } from '@tabler/icons-react';
 import { useCallback, useMemo, useRef, useState, type FC } from 'react';
@@ -175,8 +175,8 @@ export const DashboardTileComments: FC<
                     id="comments-stack"
                     ref={scrollableRef}
                     p="sm"
-                    spacing="xs"
-                    sx={{
+                    gap="xs"
+                    style={{
                         maxHeight: COMMENTS_LIST_MAX_HEIGHT,
                         overflowY: 'auto',
                     }}
@@ -220,7 +220,7 @@ export const DashboardTileComments: FC<
                     offset={4}
                     color={indicatorColor}
                     styles={{
-                        common: {
+                        indicator: {
                             fontSize: 11,
                             padding: 0,
                         },
@@ -228,6 +228,8 @@ export const DashboardTileComments: FC<
                 >
                     <ActionIcon
                         size="sm"
+                        variant="light"
+                        color="gray"
                         onClick={() => {
                             if (openedComments) {
                                 onClose?.();

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.module.css
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.module.css
@@ -1,0 +1,71 @@
+.errorsTitle {
+    color: var(--mantine-color-red-9);
+
+    @mixin dark {
+        color: var(--mantine-color-red-4);
+    }
+}
+
+.toggleButton {
+    background-color: var(--mantine-color-red-1);
+    border: 1px solid var(--mantine-color-red-2);
+
+    @mixin dark {
+        background-color: color-mix(in srgb, var(--mantine-color-red-9) 40%, black);
+        border-color: var(--mantine-color-red-9);
+    }
+}
+
+.toggleButtonText {
+    color: var(--mantine-color-red-9);
+
+    @mixin dark {
+        color: var(--mantine-color-red-1);
+    }
+}
+
+.collapseContainer {
+    max-height: 155px;
+    overflow: auto;
+    display: flex;
+    flex-direction: column;
+}
+
+.errorItem {
+    width: 100%;
+    border: 1px solid var(--mantine-color-red-2);
+    border-radius: 4px;
+    padding: var(--mantine-spacing-xs);
+    background-color: var(--mantine-color-red-0);
+
+    @mixin dark {
+        border-color: var(--mantine-color-red-9);
+        background-color: color-mix(in srgb, var(--mantine-color-red-9) 30%, black);
+    }
+}
+
+.errorItemTitle {
+    color: var(--mantine-color-red-9);
+
+    @mixin dark {
+        color: var(--mantine-color-red-2);
+    }
+}
+
+.markdownPreview {
+    background-color: transparent;
+    color: var(--mantine-color-red-9);
+    font-size: 12px;
+
+    @mixin dark {
+        color: var(--mantine-color-red-2);
+    }
+}
+
+.closeButton {
+    color: var(--mantine-color-red-9);
+
+    @mixin dark {
+        color: var(--mantine-color-red-4);
+    }
+}

--- a/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
+++ b/packages/frontend/src/hooks/toaster/MultipleToastBody.tsx
@@ -1,13 +1,14 @@
 import {
     ActionIcon,
+    Box,
     Button,
     Collapse,
     Group,
     Stack,
     Text,
     Title,
-    useMantineTheme,
-} from '@mantine/core';
+    useMantineColorScheme,
+} from '@mantine-8/core';
 import { IconChevronDown, IconChevronUp, IconX } from '@tabler/icons-react';
 import MarkdownPreview from '@uiw/react-markdown-preview';
 import { useState, type ReactNode } from 'react';
@@ -15,6 +16,7 @@ import rehypeExternalLinks from 'rehype-external-links';
 import MantineIcon from '../../components/common/MantineIcon';
 import ApiErrorDisplay from './ApiErrorDisplay';
 import { type NotificationData } from './types';
+import styles from './MultipleToastBody.module.css';
 
 const MultipleToastBody = ({
     toastsData,
@@ -24,34 +26,25 @@ const MultipleToastBody = ({
     toastsData: NotificationData[];
     onCloseError?: (errorData: NotificationData) => void;
 }) => {
-    const theme = useMantineTheme();
-    const isDark = theme.colorScheme === 'dark';
+    const { colorScheme } = useMantineColorScheme();
+    const isDark = colorScheme === 'dark';
     const [listCollapsed, setListCollapsed] = useState(true);
 
     return (
-        <Stack spacing="xs" align="stretch">
+        <Stack gap="xs" align="stretch">
             <Group>
-                <Title order={6} color={isDark ? 'red.4' : 'red.9'}>
+                <Title
+                    className={styles.errorsTitle}
+                    order={6}
+                >
                     Errors
                 </Title>
                 <Button
-                    size="xs"
-                    compact
+                    className={styles.toggleButton}
+                    size="compact-xs"
                     variant="outline"
                     color={isDark ? 'red.4' : 'red.8'}
-                    styles={{
-                        root: {
-                            backgroundColor: isDark
-                                ? theme.fn.darken(theme.colors.red[9], 0.6)
-                                : theme.colors.red[1],
-                            border: `1px solid ${
-                                isDark
-                                    ? theme.colors.red[9]
-                                    : theme.colors.red[2]
-                            }`,
-                        },
-                    }}
-                    rightIcon={
+                    rightSection={
                         <MantineIcon
                             color={isDark ? 'red.4' : 'red.8'}
                             icon={
@@ -61,92 +54,66 @@ const MultipleToastBody = ({
                     }
                     onClick={() => setListCollapsed(!listCollapsed)}
                 >
-                    <Text color={isDark ? 'red.1' : 'red.9'}>{`${
+                    <Text className={styles.toggleButtonText}>{`${
                         listCollapsed ? 'Show' : 'Hide'
                     } ${toastsData.length}`}</Text>
                 </Button>
             </Group>
 
-            <Collapse
-                in={!listCollapsed}
-                style={{
-                    maxHeight: 155,
-                    overflow: 'auto',
-                    display: 'flex',
-                    flexDirection: 'column',
-                }}
-            >
-                <Stack spacing="xs" pb="sm">
-                    {toastsData.map((toastData, index) => (
-                        <Group
-                            key={`${toastData.subtitle}-${index}`}
-                            position="apart"
-                            spacing="xxs"
-                            noWrap
-                            sx={{
-                                width: '100%',
-                                border: `1px solid ${
-                                    isDark
-                                        ? theme.colors.red[9]
-                                        : theme.colors.red[2]
-                                }`,
-                                borderRadius: '4px',
-                                padding: theme.spacing.xs,
-                                backgroundColor: isDark
-                                    ? theme.fn.darken(theme.colors.red[9], 0.7)
-                                    : theme.colors.red[0],
-                            }}
-                        >
-                            {toastData.apiError ? (
-                                <ApiErrorDisplay
-                                    apiError={toastData.apiError}
-                                    onClose={() => onCloseError?.(toastData)}
-                                />
-                            ) : (
-                                <>
-                                    {toastData.title && (
-                                        <Title
-                                            order={6}
-                                            color={isDark ? 'red.2' : 'red.9'}
-                                        >
-                                            {toastData.title}
-                                        </Title>
-                                    )}
-                                    {toastData.subtitle && (
-                                        <MarkdownPreview
-                                            source={toastData.subtitle.toString()}
-                                            rehypePlugins={[
-                                                [
-                                                    rehypeExternalLinks,
-                                                    { target: '_blank' },
-                                                ],
-                                            ]}
-                                            style={{
-                                                backgroundColor: 'transparent',
-                                                color: isDark
-                                                    ? theme.colors.red[2]
-                                                    : theme.colors.red[9],
-                                                fontSize: '12px',
-                                            }}
-                                        />
-                                    )}
-                                </>
-                            )}
-
-                            <ActionIcon
-                                variant="transparent"
-                                size="xs"
-                                onClick={() => onCloseError?.(toastData)}
+            <Box className={styles.collapseContainer}>
+                <Collapse in={!listCollapsed}>
+                    <Stack gap="xs" pb="sm">
+                        {toastsData.map((toastData, index) => (
+                            <Group
+                                className={styles.errorItem}
+                                key={`${toastData.subtitle}-${index}`}
+                                justify="space-between"
+                                gap="xxs"
+                                wrap="nowrap"
                             >
-                                <MantineIcon
-                                    icon={IconX}
-                                    color={isDark ? 'red.4' : 'red.9'}
-                                />
-                            </ActionIcon>
-                        </Group>
-                    ))}
-                </Stack>
-            </Collapse>
+                                {toastData.apiError ? (
+                                    <ApiErrorDisplay
+                                        apiError={toastData.apiError}
+                                        onClose={() => onCloseError?.(toastData)}
+                                    />
+                                ) : (
+                                    <>
+                                        {toastData.title && (
+                                            <Title
+                                                className={styles.errorItemTitle}
+                                                order={6}
+                                            >
+                                                {toastData.title}
+                                            </Title>
+                                        )}
+                                        {toastData.subtitle && (
+                                            <MarkdownPreview
+                                                className={styles.markdownPreview}
+                                                source={toastData.subtitle.toString()}
+                                                rehypePlugins={[
+                                                    [
+                                                        rehypeExternalLinks,
+                                                        { target: '_blank' },
+                                                    ],
+                                                ]}
+                                            />
+                                        )}
+                                    </>
+                                )}
+
+                                <ActionIcon
+                                    className={styles.closeButton}
+                                    variant="transparent"
+                                    size="xs"
+                                    onClick={() => onCloseError?.(toastData)}
+                                >
+                                    <MantineIcon icon={IconX} />
+                                </ActionIcon>
+                            </Group>
+                        ))}
+                    </Stack>
+                </Collapse>
+            </Box>
         </Stack>
     );
 };

--- a/packages/frontend/src/pages/JoinOrganization.module.css
+++ b/packages/frontend/src/pages/JoinOrganization.module.css
@@ -1,0 +1,9 @@
+.disabledAnchor {
+    color: var(--mantine-color-ldGray-6);
+    pointer-events: none;
+
+    &:hover {
+        text-decoration: none;
+        color: var(--mantine-color-ldGray-6);
+    }
+}

--- a/packages/frontend/src/pages/JoinOrganization.tsx
+++ b/packages/frontend/src/pages/JoinOrganization.tsx
@@ -9,7 +9,7 @@ import {
     Stack,
     Text,
     Title,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useEffect, type FC } from 'react';
 import { useNavigate } from 'react-router';
@@ -22,6 +22,7 @@ import useAllowedOrganizations from '../hooks/user/useAllowedOrganizations';
 import { useJoinOrganizationMutation } from '../hooks/user/useJoinOrganizationMutation';
 import { useDeleteUserMutation } from '../hooks/user/useUserDeleteMutation';
 import useApp from '../providers/App/useApp';
+import styles from './JoinOrganization.module.css';
 
 const JoinOrganizationPage: FC = () => {
     const { health, user } = useApp();
@@ -96,22 +97,22 @@ const JoinOrganizationPage: FC = () => {
                     <Box mx="auto" my="lg">
                         <LightdashLogo />
                     </Box>
-                    <Card p="xl" radius="xs" withBorder shadow="xs">
-                        <Stack justify="center" spacing="md" mb="xs">
+                    <Card p="xl" radius="md" withBorder>
+                        <Stack justify="center" gap="md" mb="xs">
                             <Title order={3} ta="center">
                                 Join a workspace
                             </Title>
-                            <Text color="ldGray.6" ta="center">
+                            <Text c="ldGray.6" ta="center">
                                 The workspaces below are open to anyone with a{' '}
                                 <Text span fw={600}>
-                                    @{emailDomain}:
+                                    @{emailDomain}
                                 </Text>{' '}
                                 domain
                             </Text>
                             {allowedOrgs?.map((org) => (
                                 <Card key={org.organizationUuid} withBorder>
-                                    <Group position="apart">
-                                        <Group spacing="md">
+                                    <Group justify="space-between">
+                                        <Group gap="md">
                                             <Avatar
                                                 size="md"
                                                 radius="xl"
@@ -119,8 +120,8 @@ const JoinOrganizationPage: FC = () => {
                                             >
                                                 {org.name[0]?.toUpperCase()}
                                             </Avatar>
-                                            <Stack spacing="two">
-                                                <Text truncate fw={600}>
+                                            <Stack gap="two">
+                                                <Text truncate="end" fw={600}>
                                                     {org.name}
                                                 </Text>
                                                 <Text fz="xs" c="gray">
@@ -142,22 +143,11 @@ const JoinOrganizationPage: FC = () => {
                         </Stack>
                     </Card>
                     <Anchor
+                        className={disabled ? styles.disabledAnchor : undefined}
                         component="button"
                         onClick={() => createOrg({ name: '' })}
-                        disabled={disabled}
                         ta="center"
                         size="sm"
-                        sx={(theme) =>
-                            disabled
-                                ? {
-                                      color: theme.colors.ldGray[6],
-                                      '&:hover': {
-                                          textDecoration: 'none',
-                                          color: theme.colors.ldGray[6],
-                                      },
-                                  }
-                                : {}
-                        }
                     >
                         Create a new workspace
                     </Anchor>


### PR DESCRIPTION
Migrate the following components to Mantine 8:

1. FrequencySelect - sx → CSS module
2. DashboardMarkdownTile - useMantineTheme → useMantineColorScheme, sx → CSS module
3. ExportResults - spacing → gap, leftIcon → leftSection, precision → allowDecimal
4. MinimalDashboardTabs - spacing → gap, position → justify, rightIcon → rightSection
5. PinnedItemsPanel - sx → bg, position → justify, spacing → gap, color → c
6. WarningsHoverCard - spacing → gap, sx → CSS module
7. CommentDetail - position → justify, spacing → gap, icon → leftSection
8. CommentForm - spacing → gap, position → justify, compact → size="compact-xs"
9. MultipleToastBody - useMantineTheme → useMantineColorScheme, styles → CSS module
10. JoinOrganization - spacing → gap, position → justify, color → c

Slack thread: https://lightdash.slack.com/archives/C0AD7R21BLG/p1770385714597039?thread_ts=1770378514.545599&cid=C0AD7R21BLG

https://claude.ai/code/session_01AdB1eKRixZR79jLd2tdK9S

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
