### PR TITLE
fix: dashboard cache reset time on invalidation

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardRefreshButton.tsx
@@ -60,6 +60,7 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
             isFetching,
             invalidateDashboardRelatedQueries,
             invalidateDashboardResultsQueries,
+            removeDashboardResultsQueries,
         } = useDashboardRefresh();
 
         const clearCacheAndFetch = useDashboardContext(
@@ -70,12 +71,18 @@ export const DashboardRefreshButton: FC<DashboardRefreshButtonProps> = memo(
         const isOneAtLeastFetching = isFetching > 0;
 
         const invalidateAndSetRefreshTime = useCallback(async () => {
+            // Remove old cached results before refreshing so stale data
+            // doesn't persist when navigating away and back (SPA navigation).
+            // Without this, old cache entries keyed with invalidateCache:false
+            // survive and are served when DashboardProvider remounts.
+            removeDashboardResultsQueries();
             clearCacheAndFetch();
             await invalidateDashboardRelatedQueries();
             await invalidateDashboardResultsQueries();
 
             setLastRefreshTime(new Date());
         }, [
+            removeDashboardResultsQueries,
             clearCacheAndFetch,
             invalidateDashboardRelatedQueries,
             invalidateDashboardResultsQueries,

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -366,6 +366,20 @@ export const useUpdateDashboard = (
                     'dashboards-containing-chart',
                 ]);
                 await queryClient.resetQueries(['saved_dashboard_query', id]);
+                // Remove stale chart results so navigating back doesn't
+                // show old cache timestamps after a save
+                queryClient.removeQueries({
+                    predicate: (query) => {
+                        const firstKey =
+                            typeof query.queryKey === 'string'
+                                ? query.queryKey
+                                : query.queryKey?.[0];
+                        return (
+                            firstKey === 'dashboard_chart_ready_query' ||
+                            firstKey === 'savedSqlChartResults'
+                        );
+                    },
+                });
                 await queryClient.invalidateQueries(['content']);
                 const onlyUpdatedName: boolean =
                     Object.keys(variables).length === 1 &&

--- a/packages/frontend/src/hooks/dashboard/useDashboardRefresh.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardRefresh.ts
@@ -59,10 +59,17 @@ export const useDashboardRefresh = () => {
         });
     }, [queryClient]);
 
+    const removeDashboardResultsQueries = useCallback(() => {
+        queryClient.removeQueries({
+            predicate: dashboardResultsQueryPredicate,
+        });
+    }, [queryClient]);
+
     return useMemo(
         () => ({
             invalidateDashboardRelatedQueries,
             invalidateDashboardResultsQueries,
+            removeDashboardResultsQueries,
             isFetching:
                 isFetchingDashboardRelatedQueries +
                 isFetchingDashboardResultsQueries,
@@ -70,6 +77,7 @@ export const useDashboardRefresh = () => {
         [
             invalidateDashboardRelatedQueries,
             invalidateDashboardResultsQueries,
+            removeDashboardResultsQueries,
             isFetchingDashboardRelatedQueries,
             isFetchingDashboardResultsQueries,
         ],


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2904: Dashboard cache timestamp not updating after manual refresh or save in SPA navigation](https://linear.app/lightdash/issue/PROD-2904/dashboard-cache-timestamp-not-updating-after-manual-refresh-or-save-in)

### Description:

Fix stale dashboard data persisting after refresh or save operations. This PR adds a new `removeDashboardResultsQueries` function that explicitly removes cached query results before refreshing dashboards, preventing old data from being shown when navigating away and back to a dashboard. 

The fix addresses two specific scenarios:
1. When refreshing a dashboard, old cached results with `invalidateCache:false` were surviving and being served when the DashboardProvider remounted
2. After saving a dashboard, stale chart results could show outdated timestamps when navigating back to the dashboard
