### PR TITLE
fix: add `end` to RouterNavLink and address profile route

### DIFF
--- a/packages/frontend/src/components/common/RouterNavLink.tsx
+++ b/packages/frontend/src/components/common/RouterNavLink.tsx
@@ -9,9 +9,9 @@ import {
 
 type RouterNavLinkProps = Omit<NavLinkProps, 'component' | 'active'> & {
     exact?: boolean;
-} & Omit<ReactRouterNavLinkProps, 'component'>;
+} & Omit<ReactRouterNavLinkProps, 'component' | 'end'>;
 
-const RouterNavLink: FC<RouterNavLinkProps> = (props) => {
+const RouterNavLink: FC<RouterNavLinkProps> = ({ exact, ...props }) => {
     const location = useLocation();
     const exactMatch = useMatch(props.to.toString());
     const isPartialMatch = location.pathname.startsWith(props.to.toString());
@@ -19,7 +19,10 @@ const RouterNavLink: FC<RouterNavLinkProps> = (props) => {
         <NavLink
             {...props}
             component={ReactRouterNavLink}
-            active={props.exact ? !!exactMatch : isPartialMatch}
+            active={exact ? !!exactMatch : isPartialMatch}
+            // Pass 'end' to React Router's NavLink to sync its active state
+            // When end=true, NavLink only matches exact paths (no partial matching)
+            end={exact}
         />
     );
 };

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -517,7 +517,7 @@ const Settings: FC = () => {
                                 </Title>
                                 <RouterNavLink
                                     exact
-                                    to="/generalSettings"
+                                    to="/generalSettings/profile"
                                     label="Profile"
                                     leftSection={<MantineIcon icon={IconUserCircle} />}
                                 />


### PR DESCRIPTION
### Description:
This PR fixes the `RouterNavLink` component to properly synchronize its active state with React Router's `NavLink` component.

**Changes:**
- Updated the type definition to exclude the `end` prop from `ReactRouterNavLinkProps` to avoid conflicts, since we're managing it explicitly
- Destructured the `exact` prop from the component props for cleaner usage
- Added the `end` prop to React Router's `NavLink`, mapping it to the `exact` prop value
- Added clarifying comments explaining the `end` prop behavior

**Why:**
React Router v6's `NavLink` uses the `end` prop to control whether it matches exact paths only. By passing `end={exact}`, we ensure that the internal React Router NavLink's active state matches our custom active state logic, preventing inconsistencies between the two.

This fix ensures that when `exact` is true, only exact path matches trigger the active state, and when false, partial path matches are allowed.

https://claude.ai/code/session_019uBJZLRSo8XuqRk4Uuqd39