### PR TITLE
style: mantine migration part 5

### DIFF
--- a/packages/frontend/src/components/common/Filters/FieldLabel.tsx
+++ b/packages/frontend/src/components/common/Filters/FieldLabel.tsx
@@ -7,7 +7,7 @@ import {
     type Field,
     type TableCalculation,
 } from '@lightdash/common';
-import { Text } from '@mantine/core';
+import { Text } from '@mantine-8/core';
 import { type FC } from 'react';
 
 interface FieldLabelProps {

--- a/packages/frontend/src/components/common/ResourceView/ContentTypeFilter.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ContentTypeFilter.tsx
@@ -1,5 +1,5 @@
 import { ContentType } from '@lightdash/common';
-import { Center, SegmentedControl, Text } from '@mantine/core';
+import { Center, SegmentedControl, Text } from '@mantine-8/core';
 import { type FC } from 'react';
 
 interface OptionProps {
@@ -9,7 +9,7 @@ interface OptionProps {
 
 const ContentTypeSelectOption = ({ label }: OptionProps) => (
     <Center px={'xxs'}>
-        <Text size="sm" color="ldGray.7">
+        <Text fz="sm" c="ldGray.7">
             {label}
         </Text>
     </Center>

--- a/packages/frontend/src/components/common/ResourceView/ResourceAccessInfo.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceAccessInfo.tsx
@@ -1,5 +1,5 @@
 import { type ResourceViewSpaceItem } from '@lightdash/common';
-import { Group, Text, Tooltip } from '@mantine/core';
+import { Group, Text, Tooltip } from '@mantine-8/core';
 import { IconLock, IconUser, IconUsers } from '@tabler/icons-react';
 import React, { useMemo } from 'react';
 import MantineIcon from '../MantineIcon';
@@ -50,19 +50,19 @@ const ResourceAccessInfo: React.FC<ResourceAccessInfoProps> = ({
             // Hack the tooltip to never open when `withTooltip` is false
             opened={withTooltip ? undefined : false}
             label={
-                <Text lineClamp={1} fz="xs" fw={600} color="white">
+                <Text lineClamp={1} fz="xs" fw={600} c="white">
                     {getResourceAccessLabel(item)}
                 </Text>
             }
         >
-            <Group spacing={4}>
+            <Group gap={4}>
                 <MantineIcon
                     icon={Icon}
                     color={styles.color}
                     size={styles.size}
                 />
 
-                <Text size={styles.size} color={styles.color}>
+                <Text fz={styles.size} c={styles.color}>
                     {status}
                 </Text>
             </Group>

--- a/packages/frontend/src/components/common/ResourceView/ResourceAttributeCount.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceAttributeCount.tsx
@@ -1,7 +1,6 @@
-import React from 'react';
-
-import { Flex, Text, Tooltip } from '@mantine/core';
+import { Flex, Text, Tooltip } from '@mantine-8/core';
 import { type Icon as IconType } from '@tabler/icons-react';
+import React from 'react';
 import MantineIcon from '../MantineIcon';
 
 const ResourceAttributeCount: React.FC<{
@@ -19,7 +18,7 @@ const ResourceAttributeCount: React.FC<{
                 <MantineIcon icon={Icon} color="ldGray.6" size={14} />
             )}
 
-            <Text size={14} color="ldGray.6" fz="xs">
+            <Text fz="xs" c="ldGray.6">
                 {count}
             </Text>
         </Flex>

--- a/packages/frontend/src/components/common/ResourceView/ResourceLastEdited.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceLastEdited.tsx
@@ -2,7 +2,7 @@ import {
     type ResourceViewChartItem,
     type ResourceViewDashboardItem,
 } from '@lightdash/common';
-import { Text, Tooltip } from '@mantine/core';
+import { Text, Tooltip } from '@mantine-8/core';
 import dayjs from 'dayjs';
 import type { FC } from 'react';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
@@ -25,13 +25,13 @@ const ResourceLastEdited: FC<ResourceLastEditedProps> = ({
                 position="top-start"
                 label={dayjs(updatedAt).format('YYYY-MM-DD HH:mm:ss')}
             >
-                <Text fz={12} fw={500} color="ldGray.7">
+                <Text fz={12} fw={500} c="ldGray.7">
                     {timeAgo}
                 </Text>
             </Tooltip>
 
             {user && user.firstName ? (
-                <Text fz={12} color="ldGray.6">
+                <Text fz={12} c="ldGray.6">
                     by {user.firstName} {user.lastName}
                 </Text>
             ) : null}

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -17,8 +17,10 @@ import ResourceViewActionMenu, {
 } from '../ResourceActionMenu';
 import { getResourceViewsSinceWhenDescription } from '../resourceUtils';
 
-interface ResourceViewGridChartItemProps
-    extends Pick<ResourceViewActionMenuCommonProps, 'onAction'> {
+interface ResourceViewGridChartItemProps extends Pick<
+    ResourceViewActionMenuCommonProps,
+    'onAction'
+> {
     item: ResourceViewChartItem;
     allowDelete?: boolean;
     dragIcon: ReactNode;
@@ -68,6 +70,9 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
                 <Tooltip
                     label={item.data.description}
                     position="top"
+                    variant="xs"
+                    maw={400}
+                    multiline
                     disabled={!item.data.description}
                 >
                     <Text lineClamp={2} fz="sm" fw={600}>

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -17,8 +17,10 @@ import ResourceViewActionMenu, {
 } from '../ResourceActionMenu';
 import { getResourceViewsSinceWhenDescription } from '../resourceUtils';
 
-interface ResourceViewGridDashboardItemProps
-    extends Pick<ResourceViewActionMenuCommonProps, 'onAction'> {
+interface ResourceViewGridDashboardItemProps extends Pick<
+    ResourceViewActionMenuCommonProps,
+    'onAction'
+> {
     item: ResourceViewDashboardItem;
     allowDelete?: boolean;
     dragIcon: ReactNode;
@@ -66,6 +68,9 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
                 <ResourceIcon item={item} />
                 <Tooltip
                     position="top"
+                    maw={400}
+                    multiline
+                    variant="xs"
                     label={item.data.description}
                     disabled={!item.data.description}
                 >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #ISSUE_NUMBER

### Description:
This PR updates the Mantine imports from `@mantine/core` to `@mantine-8/core` across several components in the ResourceView and Filters directories. It also updates Mantine component props to match the v8 API:

- Changed `color` prop to `c` for Text components
- Changed `size` prop to `fz` for Text components
- Changed `spacing` prop to `gap` for Group components
- Added new Tooltip props (`variant`, `maw`, `multiline`) to improve description tooltips in ResourceViewGridChartItem and ResourceViewGridDashboardItem

These changes are part of the migration to Mantine v8.