### PR TITLE
style: mantine migration part 6

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/MultiValuePastePopover.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/MultiValuePastePopover.tsx
@@ -1,4 +1,4 @@
-import { Button, Flex, Popover, Text } from '@mantine/core';
+import { Button, Flex, Popover, Text } from '@mantine-8/core';
 import { useCallback, type FC, type PropsWithChildren } from 'react';
 
 type Props = {
@@ -35,13 +35,13 @@ const MultiValuePastePopUp: FC<PropsWithChildren<Props>> = ({
         >
             <Popover.Target>{children}</Popover.Target>
             <Popover.Dropdown>
-                <Text weight={500}>
+                <Text fw={500} fz="sm">
                     Multiple comma-separated values detected:
                 </Text>
-                <Text>
+                <Text fz="sm">
                     Would you like to add them as single or multiple values?
                 </Text>
-                <Flex mt="xl" align={'center'} gap={'sm'} justify={'flex-end'}>
+                <Flex mt="xl" align="center" gap="sm" justify="flex-end">
                     <Button
                         variant="light"
                         size="sm"

--- a/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/DashboardList.tsx
@@ -1,4 +1,4 @@
-import { Anchor, Box, List, Loader, Text } from '@mantine/core';
+import { Anchor, Box, List, Loader, Text } from '@mantine-8/core';
 import { type FC } from 'react';
 import { useDashboardsContainingChart } from '../../../hooks/dashboard/useDashboards';
 
@@ -15,7 +15,7 @@ export const DashboardList: FC<Props> = ({ resourceItemId, projectUuid }) => {
     return (
         <Box>
             {relatedDashboards ? (
-                <Text fw={600} fz="xs" color="ldGray.6">
+                <Text fw={600} fz="xs" c="ldGray.6">
                     Used in {relatedDashboards?.length ?? 0} dashboard
                     {relatedDashboards?.length === 1 ? '' : 's'}
                     {relatedDashboards && relatedDashboards.length > 0
@@ -35,6 +35,7 @@ export const DashboardList: FC<Props> = ({ resourceItemId, projectUuid }) => {
                                 onClick={(
                                     e: React.MouseEvent<HTMLAnchorElement>,
                                 ) => e.stopPropagation()}
+                                fz="xs"
                             >
                                 {name}
                             </Anchor>

--- a/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.module.css
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.module.css
@@ -1,0 +1,3 @@
+.preLineText {
+    white-space: pre-line;
+}

--- a/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
+++ b/packages/frontend/src/components/common/ResourceInfoPopup/ResourceInfoPopup.tsx
@@ -1,9 +1,10 @@
-import { Group, HoverCard, Stack, Text, Tooltip } from '@mantine/core';
+import { Group, HoverCard, Stack, Text, Tooltip } from '@mantine-8/core';
 import { IconEye, IconInfoCircle } from '@tabler/icons-react';
 import dayjs from 'dayjs';
 import { type FC } from 'react';
 import MantineIcon from '../MantineIcon';
 import { DashboardList } from './DashboardList';
+import styles from './ResourceInfoPopup.module.css';
 
 type Props = {
     resourceUuid: string;
@@ -32,21 +33,15 @@ export const ResourceInfoPopup: FC<Props> = ({
     if (!viewStats && !description && !withChartData) return null;
 
     return (
-        <HoverCard
-            offset={-1}
-            position="bottom"
-            withArrow
-            shadow="md"
-            withinPortal
-        >
+        <HoverCard offset={-1} position="bottom" shadow="md" withinPortal>
             <HoverCard.Target>
                 <MantineIcon icon={IconInfoCircle} color="ldGray.6" />
             </HoverCard.Target>
             <HoverCard.Dropdown maw={300}>
-                <Stack spacing="xs">
+                <Stack gap="xs">
                     {viewStats && viewStats > 0 ? (
-                        <Stack spacing="two">
-                            <Text fz="xs" fw={600} color="ldGray.6">
+                        <Stack gap="two">
+                            <Text fz="xs" fw={600} c="ldGray.6">
                                 Views:
                             </Text>
                             <Tooltip
@@ -54,7 +49,7 @@ export const ResourceInfoPopup: FC<Props> = ({
                                 label={label}
                                 disabled={!viewStats || !firstViewedAt}
                             >
-                                <Group spacing="two">
+                                <Group gap="two">
                                     <MantineIcon size={12} icon={IconEye} />
                                     <Text fz="xs">{viewStats || '0'}</Text>
                                 </Group>
@@ -63,11 +58,11 @@ export const ResourceInfoPopup: FC<Props> = ({
                     ) : null}
 
                     {description && (
-                        <Stack spacing="two">
-                            <Text fz="xs" fw={600} color="ldGray.6">
+                        <Stack gap="two">
+                            <Text fz="xs" fw={600} c="ldGray.6">
                                 Description:{' '}
                             </Text>
-                            <Text fz="xs" style={{ whiteSpace: 'pre-line' }}>
+                            <Text fz="xs" className={styles.preLineText}>
                                 {description}
                             </Text>
                         </Stack>

--- a/packages/frontend/src/components/common/Table/ImageCell.tsx
+++ b/packages/frontend/src/components/common/Table/ImageCell.tsx
@@ -1,5 +1,5 @@
 import { type Dimension } from '@lightdash/common';
-import { Tooltip } from '@mantine/core';
+import { Tooltip } from '@mantine-8/core';
 import { IconPhotoOff } from '@tabler/icons-react';
 import { useState } from 'react';
 import MantineIcon from '../MantineIcon';

--- a/packages/frontend/src/components/common/Table/ScrollableTable/CellTooltip.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/CellTooltip.tsx
@@ -1,4 +1,4 @@
-import { Portal, Tooltip, type TooltipProps } from '@mantine/core';
+import { Portal, Tooltip, type TooltipProps } from '@mantine-8/core';
 import { type FC } from 'react';
 
 type CellTooltipProps = Omit<TooltipProps, 'children'> & {

--- a/packages/frontend/src/components/common/TagInput/TagInputRightSection/TagInputRightSection.tsx
+++ b/packages/frontend/src/components/common/TagInput/TagInputRightSection/TagInputRightSection.tsx
@@ -1,5 +1,4 @@
-import { CloseButton } from '@mantine/core';
-import { type MantineSize } from '@mantine/styles';
+import { CloseButton, type MantineSize } from '@mantine-8/core';
 import React from 'react';
 
 export interface TagInputRightSectionProps {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Update Mantine imports from `@mantine/core` to `@mantine-8/core` across multiple components and update component props to match the new Mantine v8 API:

- Replace `color` prop with `c` for Text components
- Replace `spacing` prop with `gap` for Stack and Group components
- Move inline styles to CSS modules for better maintainability (e.g., `white-space: pre-line` in ResourceInfoPopup)
- Update import for CloseButton to include MantineSize type from the same package