### PR TITLE
feat: soft delete for scheduled deliveries

### DIFF
--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -38,6 +38,8 @@ export type SchedulerDb = {
     notification_frequency: string | null;
     selected_tabs: string[] | null;
     include_links: boolean;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 export type ChartSchedulerDb = SchedulerDb & {
@@ -76,7 +78,7 @@ export type SchedulerTable = Knex.CompositeTableType<
     SchedulerDb,
     Omit<
         ChartSchedulerDb | DashboardSchedulerDB,
-        'scheduler_uuid' | 'created_at'
+        'scheduler_uuid' | 'created_at' | 'deleted_at' | 'deleted_by_user_uuid'
     >,
     | Pick<
           SchedulerDb,
@@ -98,6 +100,7 @@ export type SchedulerTable = Knex.CompositeTableType<
     | Pick<SchedulerDb, 'updated_at' | 'enabled'>
     | Pick<SchedulerDb, 'created_by' | 'updated_at'>
     | Pick<SchedulerDb, 'cron'>
+    | Pick<SchedulerDb, 'deleted_at' | 'deleted_by_user_uuid'>
 >;
 
 export type SchedulerSlackTargetTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20260206092529_add_soft_delete_to_scheduler.ts
+++ b/packages/backend/src/database/migrations/20260206092529_add_soft_delete_to_scheduler.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const SchedulerTableName = 'scheduler';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SchedulerTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_scheduler_not_deleted
+        ON ${SchedulerTableName} (scheduler_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items
+    await knex.raw(`
+        CREATE INDEX idx_scheduler_deleted
+        ON ${SchedulerTableName} (scheduler_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_scheduler_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_scheduler_not_deleted');
+    await knex.schema.alterTable(SchedulerTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -759,6 +759,9 @@ export class SchedulerService extends BaseService {
             projectUuid,
             userUuid: user.userUuid,
         });
+
+        // Always hard-delete: UI scheduler deletion is permanent.
+        // Soft delete only happens via cascade from chart/dashboard soft-delete.
         await this.schedulerModel.deleteScheduler(schedulerUuid);
         await this.schedulerModel.deleteScheduledLogs(schedulerUuid);
 


### PR DESCRIPTION
### Description:
Adds soft delete functionality to schedulers, allowing them to be marked as deleted without permanently removing them from the database. This includes:

- Added `deleted_at` and `deleted_by_user_uuid` columns to the scheduler table
- Created partial indexes for efficient querying of deleted and non-deleted schedulers
- Updated scheduler queries to filter out soft-deleted records
- Implemented cascade soft delete/restore when charts or dashboards are soft deleted/restored
- Added methods for soft deleting and restoring schedulers

This change ensures that when a chart or dashboard is soft deleted, its associated schedulers are also soft deleted, maintaining data consistency while preserving historical information.