### PR TITLE
feat: soft delete space

### DIFF
--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -14,6 +14,8 @@ export type DbSpace = {
     parent_space_uuid: string | null;
     path: string;
     inherit_parent_permissions: boolean;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 export type CreateDbSpace = Pick<
@@ -35,7 +37,7 @@ export type UpdateDbSpace = Partial<
 export type SpaceTable = Knex.CompositeTableType<
     DbSpace,
     CreateDbSpace,
-    UpdateDbSpace
+    UpdateDbSpace | Pick<DbSpace, 'deleted_at' | 'deleted_by_user_uuid'>
 >;
 export const SpaceTableName = 'spaces';
 

--- a/packages/backend/src/database/migrations/20260206163809_add_soft_delete_to_spaces.ts
+++ b/packages/backend/src/database/migrations/20260206163809_add_soft_delete_to_spaces.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const SpacesTableName = 'spaces';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable();
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_spaces_not_deleted
+        ON ${SpacesTableName} (space_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(`
+        CREATE INDEX idx_spaces_deleted
+        ON ${SpacesTableName} (space_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_spaces_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_spaces_not_deleted');
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14222,6 +14222,36 @@ const models: TsoaRoute.Models = {
                 path: { dataType: 'string', required: true },
                 chartCount: { dataType: 'double', required: true },
                 dashboardCount: { dataType: 'double', required: true },
+                deletedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -15890,6 +15920,37 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                deletedAt: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'datetime' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 tableName: { dataType: 'string', required: true },
                 metricQuery: { ref: 'MetricQuery', required: true },
                 pivotConfig: {
@@ -15923,37 +15984,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'array',
                     array: { dataType: 'string' },
                     required: true,
-                },
-                deletedAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'datetime' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                deletedBy: {
-                    dataType: 'union',
-                    subSchemas: [
-                        {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                lastName: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                firstName: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                userUuid: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                            },
-                        },
-                        { dataType: 'enum', enums: [null] },
-                        { dataType: 'undefined' },
-                    ],
                 },
             },
             validators: {},
@@ -16737,6 +16767,24 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        deletedBy: {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        deletedAt: { dataType: 'datetime' },
                         dashboardCount: { dataType: 'double', required: true },
                         chartCount: { dataType: 'double', required: true },
                         access: {
@@ -24427,6 +24475,56 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DeletedSpaceContentSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                organizationUuid: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                spaceName: { dataType: 'string', required: true },
+                spaceUuid: { dataType: 'string', required: true },
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                deletedAt: { dataType: 'datetime', required: true },
+                contentType: { ref: 'ContentType.SPACE', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DeletedContentSummary: {
         dataType: 'refAlias',
         type: {
@@ -24434,6 +24532,7 @@ const models: TsoaRoute.Models = {
             subSchemas: [
                 { ref: 'DeletedChartContentSummary' },
                 { ref: 'DeletedDashboardContentSummary' },
+                { ref: 'DeletedSpaceContentSummary' },
             ],
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -14648,6 +14648,25 @@
                     "dashboardCount": {
                         "type": "number",
                         "format": "double"
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object"
                     }
                 },
                 "required": [
@@ -16522,6 +16541,26 @@
                     "updatedByUser": {
                         "$ref": "#/components/schemas/UpdatedByUser"
                     },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
                     "tableName": {
                         "type": "string"
                     },
@@ -16557,26 +16596,6 @@
                             "type": "string"
                         },
                         "type": "array"
-                    },
-                    "deletedAt": {
-                        "type": "string",
-                        "format": "date-time"
-                    },
-                    "deletedBy": {
-                        "properties": {
-                            "lastName": {
-                                "type": "string"
-                            },
-                            "firstName": {
-                                "type": "string"
-                            },
-                            "userUuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": ["lastName", "firstName", "userUuid"],
-                        "type": "object",
-                        "nullable": true
                     }
                 },
                 "required": [
@@ -17552,6 +17571,29 @@
                     },
                     {
                         "properties": {
+                            "deletedBy": {
+                                "properties": {
+                                    "lastName": {
+                                        "type": "string"
+                                    },
+                                    "firstName": {
+                                        "type": "string"
+                                    },
+                                    "userUuid": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "lastName",
+                                    "firstName",
+                                    "userUuid"
+                                ],
+                                "type": "object"
+                            },
+                            "deletedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
                             "dashboardCount": {
                                 "type": "number",
                                 "format": "double"
@@ -25198,6 +25240,68 @@
                 ],
                 "type": "object"
             },
+            "DeletedSpaceContentSummary": {
+                "properties": {
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "spaceName": {
+                        "type": "string"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentType.SPACE"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "organizationUuid",
+                    "projectUuid",
+                    "spaceName",
+                    "spaceUuid",
+                    "deletedBy",
+                    "deletedAt",
+                    "contentType",
+                    "description",
+                    "name",
+                    "uuid"
+                ],
+                "type": "object"
+            },
             "DeletedContentSummary": {
                 "anyOf": [
                     {
@@ -25205,6 +25309,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/DeletedDashboardContentSummary"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DeletedSpaceContentSummary"
                     }
                 ]
             },

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -311,7 +311,8 @@ export class AnalyticsModel {
                     `${ProjectTableName}.project_id`,
                     `${SpaceTableName}.project_id`,
                 )
-                .where(`${ProjectTableName}.project_uuid`, projectUuid);
+                .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                .whereNull(`${SpaceTableName}.deleted_at`);
 
             const dashboardViews = trx
                 .select<RawViewType[]>(
@@ -347,7 +348,8 @@ export class AnalyticsModel {
                     `${ProjectTableName}.project_id`,
                     `${SpaceTableName}.project_id`,
                 )
-                .where(`${ProjectTableName}.project_uuid`, projectUuid);
+                .where(`${ProjectTableName}.project_uuid`, projectUuid)
+                .whereNull(`${SpaceTableName}.deleted_at`);
 
             return chartViews
                 .union(dashboardViews)

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
@@ -165,6 +165,9 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                             [`%${filters.search.toLowerCase()}%`],
                         );
                     }
+
+                    // Exclude dashboards in deleted spaces
+                    void builder.whereNull(`${SpaceTableName}.deleted_at`);
                 }),
         shouldRowBeConverted: (value): value is SummaryContentRow =>
             value.content_type === ContentType.DASHBOARD,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -174,6 +174,9 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                             [`%${filters.search.toLowerCase()}%`],
                         );
                     }
+
+                    // Exclude charts in deleted spaces
+                    void builder.whereNull(`${SpaceTableName}.deleted_at`);
                 }),
         shouldRowBeConverted: (value): value is SelectSavedChart => {
             const contentTypeMatch = value.content_type === ContentType.CHART;

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -166,6 +166,9 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                             [`%${filters.search.toLowerCase()}%`],
                         );
                     }
+
+                    // Exclude SQL charts in deleted spaces
+                    void builder.whereNull(`${SpaceTableName}.deleted_at`);
                 }),
         shouldRowBeConverted: (value): value is SelectSavedSql => {
             const contentTypeMatch = value.content_type === ContentType.CHART;

--- a/packages/backend/src/models/ContentModel/ContentModel.ts
+++ b/packages/backend/src/models/ContentModel/ContentModel.ts
@@ -192,6 +192,11 @@ export class ContentModel {
                     ...base,
                     contentType: ContentType.DASHBOARD,
                 };
+            case ContentType.SPACE:
+                return {
+                    ...base,
+                    contentType: ContentType.SPACE,
+                };
             default:
                 throw new Error(
                     `Unexpected content type in deleted results: ${row.content_type}`,

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -136,6 +136,8 @@ export const spaceEntry: SpaceTable['base'] = {
     parent_space_uuid: null,
     path: 'space-name',
     inherit_parent_permissions: true,
+    deleted_at: null,
+    deleted_by_user_uuid: null,
 };
 export const savedChartEntry: SavedChartTable['base'] = {
     saved_query_id: 0,

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -566,11 +566,11 @@ export class DashboardModel {
                         .leftJoin(
                             SpaceTableName,
                             'dashboards.space_id',
-                            'spaces.space_id',
+                            `${SpaceTableName}.space_id`,
                         )
                         .leftJoin(
                             ProjectTableName,
-                            'spaces.project_id',
+                            `${SpaceTableName}.project_id`,
                             'projects.project_id',
                         )
                         .leftJoin(
@@ -664,7 +664,7 @@ export class DashboardModel {
                 })
                 .leftJoin(
                     'projects',
-                    'spaces.project_id',
+                    `${SpaceTableName}.project_id`,
                     'projects.project_id',
                 )
                 .where('projects.project_uuid', projectUuid);
@@ -1156,7 +1156,7 @@ export class DashboardModel {
         const dashboardId = await this.database.transaction(async (trx) => {
             const [space] = await trx(SpaceTableName)
                 .where('space_uuid', spaceUuid)
-                .select('spaces.*')
+                .select(`${SpaceTableName}.*`)
                 .limit(1);
             if (!space) {
                 throw new NotFoundError('Space not found');

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -38,7 +38,7 @@ const getCharts = async (
         .select({
             project_uuid: 'pinned_list.project_uuid',
             pinned_list_uuid: 'pinned_list.pinned_list_uuid',
-            space_uuid: 'spaces.space_uuid',
+            space_uuid: `${SpaceTableName}.space_uuid`,
             saved_chart_uuid: 'pinned_chart.saved_chart_uuid',
             updated_by_user_first_name: 'users.first_name',
             updated_by_user_last_name: 'users.last_name',
@@ -65,13 +65,18 @@ const getCharts = async (
                 'saved_queries.saved_query_uuid',
             ).andOnNull('saved_queries.deleted_at');
         })
-        .innerJoin('spaces', 'saved_queries.space_id', 'spaces.space_id')
+        .innerJoin(
+            SpaceTableName,
+            'saved_queries.space_id',
+            `${SpaceTableName}.space_id`,
+        )
         .leftJoin(
             'users',
             'saved_queries.last_version_updated_by_user_uuid',
             'users.user_uuid',
         )
-        .whereIn('spaces.space_uuid', allowedSpaceUuids)
+        .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+        .whereNull(`${SpaceTableName}.deleted_at`)
         .andWhere('pinned_list.pinned_list_uuid', pinnedListUuid)
         .andWhere('pinned_list.project_uuid', projectUuid)
         .orderBy('pinned_chart.order', 'asc')) as Record<string, AnyType>[];
@@ -122,7 +127,11 @@ const getDashboards = async (
                 'dashboards.dashboard_uuid',
             ).andOnNull('dashboards.deleted_at');
         })
-        .innerJoin('spaces', 'dashboards.space_id', 'spaces.space_id')
+        .innerJoin(
+            SpaceTableName,
+            'dashboards.space_id',
+            `${SpaceTableName}.space_id`,
+        )
         .innerJoin(
             knex('dashboard_versions')
                 .distinctOn('dashboard_id')
@@ -138,13 +147,14 @@ const getDashboards = async (
             'dv.dashboard_id',
         )
         .leftJoin('users', 'dv.updated_by_user_uuid', 'users.user_uuid')
-        .whereIn('spaces.space_uuid', allowedSpaceUuids)
+        .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+        .whereNull(`${SpaceTableName}.deleted_at`)
         .andWhere('pinned_list.pinned_list_uuid', pinnedListUuid)
         .andWhere('pinned_list.project_uuid', projectUuid)
         .select(
             'pinned_list.project_uuid',
             'pinned_list.pinned_list_uuid',
-            'spaces.space_uuid',
+            `${SpaceTableName}.space_uuid`,
             'pinned_dashboard.dashboard_uuid',
             'users.user_uuid as updated_by_user_uuid',
             'pinned_dashboard.order',

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -798,7 +798,7 @@ export class SavedChartModel {
                 ).andOnNull(`${DashboardsTableName}.deleted_at`);
             })
             .joinRaw(
-                `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+                `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id) AND ${SpaceTableName}.deleted_at IS NULL`,
             )
             .innerJoin(
                 ProjectTableName,
@@ -1560,7 +1560,10 @@ export class SavedChartModel {
                 }
 
                 if (filters.spaceUuids) {
-                    void query.whereIn('spaces.space_uuid', filters.spaceUuids);
+                    void query.whereIn(
+                        `${SpaceTableName}.space_uuid`,
+                        filters.spaceUuids,
+                    );
                 }
                 if (filters.slug) {
                     void query.where('saved_queries.slug', filters.slug);
@@ -1612,8 +1615,8 @@ export class SavedChartModel {
                 uuid: 'saved_queries.saved_query_uuid',
                 name: 'saved_queries.name',
                 description: 'saved_queries.description',
-                spaceUuid: 'spaces.space_uuid',
-                spaceName: 'spaces.name',
+                spaceUuid: `${SpaceTableName}.space_uuid`,
+                spaceName: `${SpaceTableName}.name`,
                 projectUuid: 'projects.project_uuid',
                 organizationUuid: 'organizations.organization_uuid',
                 pinnedListUuid: `${PinnedListTableName}.pinned_list_uuid`,
@@ -1630,9 +1633,13 @@ export class SavedChartModel {
                 `${SavedChartsTableName}.dashboard_uuid`,
             )
             .joinRaw(
-                `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id)`,
+                `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id) AND ${SpaceTableName}.deleted_at IS NULL`,
             )
-            .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
+            .leftJoin(
+                'projects',
+                `${SpaceTableName}.project_id`,
+                'projects.project_id',
+            )
             .leftJoin(
                 OrganizationTableName,
                 'organizations.organization_id',
@@ -1666,7 +1673,7 @@ export class SavedChartModel {
             .select({
                 uuid: 'saved_queries.saved_query_uuid',
                 name: 'saved_queries.name',
-                spaceUuid: 'spaces.space_uuid',
+                spaceUuid: `${SpaceTableName}.space_uuid`,
                 tableName: `${SavedChartVersionsTableName}.explore_name`,
                 projectUuid: 'projects.project_uuid',
                 organizationUuid: 'organizations.organization_uuid',
@@ -1692,7 +1699,11 @@ export class SavedChartModel {
                 'saved_queries.saved_query_id',
                 'saved_queries_versions.saved_query_id',
             )
-            .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
+            .leftJoin(
+                'projects',
+                `${SpaceTableName}.project_id`,
+                'projects.project_id',
+            )
             .leftJoin(
                 OrganizationTableName,
                 'organizations.organization_id',
@@ -1707,7 +1718,8 @@ export class SavedChartModel {
                                            order by ${SavedChartVersionsTableName}.created_at desc
                                            limit 1)`),
             )
-            .whereNull(`${SavedChartsTableName}.deleted_at`);
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`);
 
         if (charts.length === 0) {
             throw new NotFoundError('Saved queries not found');
@@ -1753,7 +1765,11 @@ export class SavedChartModel {
                     `${SavedChartsTableName}.space_id`,
                 );
             })
-            .leftJoin('projects', 'spaces.project_id', 'projects.project_id')
+            .leftJoin(
+                'projects',
+                `${SpaceTableName}.project_id`,
+                'projects.project_id',
+            )
             .leftJoin(
                 UserTableName,
                 `${SavedChartVersionsTableName}.updated_by_user_uuid`,
@@ -1769,7 +1785,8 @@ export class SavedChartModel {
                                            order by ${SavedChartVersionsTableName}.created_at desc
                                            limit 1)`),
             )
-            .whereNull(`${SavedChartsTableName}.deleted_at`);
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`);
     }
 
     async findChartsWithCustomFields(projectUuid: string): Promise<

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -452,6 +452,14 @@ export class SchedulerModel {
                 `${SpaceTableName}.project_id`,
             );
 
+        // Exclude schedulers for content in deleted spaces
+        schedulerCharts = schedulerCharts.whereNull(
+            `${SpaceTableName}.deleted_at`,
+        );
+        schedulerDashboards = schedulerDashboards.whereNull(
+            `${SpaceTableName}.deleted_at`,
+        );
+
         if (projectUuid) {
             schedulerCharts = schedulerCharts.where(
                 `${ProjectTableName}.project_uuid`,
@@ -1000,7 +1008,8 @@ export class SchedulerModel {
                 `${ProjectTableName}.project_id`,
                 `${SpaceTableName}.project_id`,
             )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid);
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNull(`${SpaceTableName}.deleted_at`);
         if (schedulerUuids?.length) {
             schedulerCharts = schedulerCharts.whereIn(
                 `${SchedulerTableName}.scheduler_uuid`,
@@ -1040,7 +1049,8 @@ export class SchedulerModel {
                 `${ProjectTableName}.project_id`,
                 `${SpaceTableName}.project_id`,
             )
-            .where(`${ProjectTableName}.project_uuid`, projectUuid);
+            .where(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNull(`${SpaceTableName}.deleted_at`);
         if (schedulerUuids?.length) {
             schedulerDashboards = schedulerDashboards.whereIn(
                 `${SchedulerTableName}.scheduler_uuid`,
@@ -1970,6 +1980,7 @@ export class SchedulerModel {
             )
             .where(`${SchedulerTableName}.created_by`, userUuid)
             .whereNotNull(`${SchedulerTableName}.saved_chart_uuid`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .groupBy(
                 `${ProjectTableName}.project_uuid`,
                 `${ProjectTableName}.name`,
@@ -2002,6 +2013,7 @@ export class SchedulerModel {
             )
             .where(`${SchedulerTableName}.created_by`, userUuid)
             .whereNotNull(`${SchedulerTableName}.dashboard_uuid`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .groupBy(
                 `${ProjectTableName}.project_uuid`,
                 `${ProjectTableName}.name`,
@@ -2100,6 +2112,7 @@ export class SchedulerModel {
             )
             .where(`${SchedulerTableName}.created_by`, fromUserUuid)
             .whereNotNull(`${SchedulerTableName}.saved_chart_uuid`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .whereIn(`${ProjectTableName}.project_uuid`, projectUuids);
 
         // Dashboard schedulers
@@ -2127,6 +2140,7 @@ export class SchedulerModel {
             )
             .where(`${SchedulerTableName}.created_by`, fromUserUuid)
             .whereNotNull(`${SchedulerTableName}.dashboard_uuid`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .whereIn(`${ProjectTableName}.project_uuid`, projectUuids);
 
         const allSchedulerUuids = [

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -342,6 +342,7 @@ export class ContentService extends BaseService {
         const contentTypes = filters.contentTypes ?? [
             ContentType.CHART,
             ContentType.DASHBOARD,
+            ContentType.SPACE,
         ];
 
         return this.contentModel.findDeletedContents(
@@ -400,8 +401,7 @@ export class ContentService extends BaseService {
             case ContentType.DASHBOARD:
                 return this.dashboardService.restoreDashboard(user, item.uuid);
             case ContentType.SPACE:
-                // TODO: Implement space restore
-                throw new NotFoundError('Space restore not yet supported');
+                return this.spaceService.restoreSpace(user, item.uuid);
             default:
                 return assertUnreachable(item, 'Unknown content type');
         }
@@ -455,9 +455,9 @@ export class ContentService extends BaseService {
                     item.uuid,
                 );
             case ContentType.SPACE:
-                // TODO: Implement space permanent delete
-                throw new NotFoundError(
-                    'Space permanent delete not yet supported',
+                return this.spaceService.permanentlyDeleteSpace(
+                    user,
+                    item.uuid,
                 );
             default:
                 return assertUnreachable(item, 'Unknown content type');

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -57,6 +57,8 @@ export const space: SpaceTable['base'] = {
     parent_space_uuid: null,
     path: 'space-name',
     inherit_parent_permissions: false,
+    deleted_at: null,
+    deleted_by_user_uuid: null,
 };
 
 export const publicSpace: Space = {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -778,11 +778,14 @@ export class ServiceRepository
             () =>
                 new SpaceService({
                     analytics: this.context.lightdashAnalytics,
+                    lightdashConfig: this.context.lightdashConfig,
                     projectModel: this.models.getProjectModel(),
                     spaceModel: this.models.getSpaceModel(),
                     pinnedListModel: this.models.getPinnedListModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    savedChartService: this.getSavedChartService(),
+                    dashboardService: this.getDashboardService(),
                 }),
         );
     }

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -7,10 +7,14 @@ import {
 import knex from 'knex';
 import { getTracker, MockClient, Tracker } from 'knex-mock-client';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { SpaceTableName } from '../../database/entities/spaces';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SpaceModel } from '../../models/SpaceModel';
+import { DashboardService } from '../DashboardService/DashboardService';
+import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import { SpacePermissionService } from './SpacePermissionService';
 import { SpaceService } from './SpaceService';
 import {
@@ -31,11 +35,14 @@ describe('SpaceService', () => {
     beforeEach(() => {
         service = new SpaceService({
             analytics: analyticsMock,
+            lightdashConfig: lightdashConfigMock,
             projectModel: {} as ProjectModel,
             spaceModel: new SpaceModel({ database: db }),
             pinnedListModel: {} as PinnedListModel,
             featureFlagModel: {} as FeatureFlagModel,
             spacePermissionService: {} as SpacePermissionService,
+            savedChartService: {} as SavedChartService,
+            dashboardService: {} as DashboardService,
         });
     });
 
@@ -77,7 +84,7 @@ describe('SpaceService', () => {
                 const testUser = createTestUser(user);
                 const testSpace = createTestSpace(space);
 
-                tracker.on.select('spaces').response([
+                tracker.on.select(SpaceTableName).response([
                     createSpaceAccessResponse({
                         ...user,
                         ...access,
@@ -119,7 +126,7 @@ describe('SpaceService', () => {
                 const testUser = createTestUser(user);
                 const testSpace = createTestSpace(space);
 
-                tracker.on.select('spaces').response([
+                tracker.on.select(SpaceTableName).response([
                     createSpaceAccessResponse({
                         ...user,
                         ...access,
@@ -252,7 +259,7 @@ describe('SpaceService', () => {
                     const testUser = createTestUser(user);
                     const testSpace = createTestSpace(space);
 
-                    tracker.on.select('spaces').response([
+                    tracker.on.select(SpaceTableName).response([
                         createSpaceAccessResponse({
                             ...user,
                             ...access,
@@ -428,7 +435,7 @@ describe('SpaceService', () => {
                     const testUser = createTestUser(user);
                     const testSpace = createTestSpace(space);
 
-                    tracker.on.select('spaces').response([
+                    tracker.on.select(SpaceTableName).response([
                         createSpaceAccessResponse({
                             ...user,
                             ...access,
@@ -618,7 +625,7 @@ describe('SpaceService', () => {
                         isPrivate: space.isPrivate,
                     });
 
-                    tracker.on.select('spaces').response([response]);
+                    tracker.on.select(SpaceTableName).response([response]);
 
                     const result = await service._userCanActionSpace(
                         testUser,
@@ -672,7 +679,7 @@ describe('SpaceService', () => {
                         isPrivate: space.isPrivate,
                     });
 
-                    tracker.on.select('spaces').response([response]);
+                    tracker.on.select(SpaceTableName).response([response]);
 
                     const result = await service._userCanActionSpace(
                         testUser,
@@ -821,7 +828,7 @@ describe('SpaceService', () => {
                         projectGroupRoles: user.projectGroupRoles || [],
                     });
 
-                    tracker.on.select('spaces').response([response]);
+                    tracker.on.select(SpaceTableName).response([response]);
 
                     const result = await service._userCanActionSpace(
                         testUser,

--- a/packages/common/src/types/softDelete.ts
+++ b/packages/common/src/types/softDelete.ts
@@ -38,9 +38,27 @@ export type DeletedDashboardContentSummary = {
     organizationUuid: string;
 };
 
+export type DeletedSpaceContentSummary = {
+    uuid: string;
+    name: string;
+    description: string | null;
+    contentType: ContentType.SPACE;
+    deletedAt: Date;
+    deletedBy: {
+        userUuid: string;
+        firstName: string;
+        lastName: string;
+    } | null;
+    spaceUuid: string;
+    spaceName: string;
+    projectUuid: string;
+    organizationUuid: string;
+};
+
 export type DeletedContentSummary =
     | DeletedChartContentSummary
-    | DeletedDashboardContentSummary;
+    | DeletedDashboardContentSummary
+    | DeletedSpaceContentSummary;
 
 export type DeletedContentFilters = {
     projectUuids: string[];

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -93,6 +93,12 @@ export type SpaceSummary = Pick<
     access: string[];
     chartCount: number;
     dashboardCount: number;
+    deletedAt?: Date;
+    deletedBy?: {
+        userUuid: string;
+        firstName: string;
+        lastName: string;
+    };
 };
 
 export type CreateSpace = {

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
@@ -1,6 +1,10 @@
 import { ContentType } from '@lightdash/common';
 import { Box, Divider, SegmentedControl, Text, Tooltip } from '@mantine-8/core';
-import { IconChartBar, IconLayoutDashboard } from '@tabler/icons-react';
+import {
+    IconChartBar,
+    IconFolder,
+    IconLayoutDashboard,
+} from '@tabler/icons-react';
 import type { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import classes from './ContentTypeFilter.module.css';
@@ -8,7 +12,8 @@ import classes from './ContentTypeFilter.module.css';
 type DeletedContentTypeFilter =
     | 'all'
     | ContentType.CHART
-    | ContentType.DASHBOARD;
+    | ContentType.DASHBOARD
+    | ContentType.SPACE;
 
 type ContentTypeFilterProps = {
     selectedContentType: DeletedContentTypeFilter;
@@ -62,6 +67,16 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
                             icon={IconLayoutDashboard}
                             {...iconProps}
                         />
+                    </Box>
+                </Tooltip>
+            ),
+        },
+        {
+            value: ContentType.SPACE,
+            label: (
+                <Tooltip label="Show only deleted spaces" withinPortal>
+                    <Box>
+                        <MantineIcon icon={IconFolder} {...iconProps} />
                     </Box>
                 </Tooltip>
             ),

--- a/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
@@ -20,6 +20,7 @@ import {
     IconCalendar,
     IconChartBar,
     IconClock,
+    IconFolder,
     IconLayoutDashboard,
     IconRefresh,
     IconSearch,
@@ -87,7 +88,7 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
     const retentionDays = health.data?.softDelete.retentionDays;
 
     const [selectedContentType, setSelectedContentType] = useState<
-        'all' | ContentType.CHART | ContentType.DASHBOARD
+        'all' | ContentType.CHART | ContentType.DASHBOARD | ContentType.SPACE
     >('all');
 
     const {
@@ -196,6 +197,8 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                 return IconChartBar;
                             case ContentType.DASHBOARD:
                                 return IconLayoutDashboard;
+                            case ContentType.SPACE:
+                                return IconFolder;
                             default:
                                 return assertUnreachable(
                                     row.original,
@@ -234,6 +237,8 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                 return 'Chart';
                             case ContentType.DASHBOARD:
                                 return 'Dashboard';
+                            case ContentType.SPACE:
+                                return 'Space';
                             default:
                                 return assertUnreachable(
                                     row.original,
@@ -355,6 +360,12 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                             contentType: item.contentType,
                                         });
                                         break;
+                                    case ContentType.SPACE:
+                                        restoreContent({
+                                            uuid: item.uuid,
+                                            contentType: item.contentType,
+                                        });
+                                        break;
                                     default:
                                         assertUnreachable(
                                             item,
@@ -373,6 +384,12 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                         });
                                         break;
                                     case ContentType.DASHBOARD:
+                                        permanentlyDelete({
+                                            uuid: item.uuid,
+                                            contentType: item.contentType,
+                                        });
+                                        break;
+                                    case ContentType.SPACE:
                                         permanentlyDelete({
                                             uuid: item.uuid,
                                             contentType: item.contentType,


### PR DESCRIPTION
### Description:
Adds soft delete functionality to spaces, allowing users to recover deleted spaces and their content. This includes:

- Added `deleted_at` and `deleted_by_user_uuid` columns to the spaces table
- Created database indexes for efficient queries on deleted/non-deleted spaces
- Implemented cascade deletion for child spaces, charts, and dashboards
- Added space restoration that recovers all cascade-deleted content
- Updated content queries to exclude items in deleted spaces
- Added spaces to the "Recently Deleted" page with proper filtering