### PR TITLE
fix: remove allowed-tools from debug skill to fix invocation error

### DIFF
--- a/.claude/skills/debug/SKILL.md
+++ b/.claude/skills/debug/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: debug
 description: Debug the Lightdash app using PM2 logs, Spotlight traces, and browser automation. Use when investigating issues, tracking down bugs, understanding request flow, or correlating frontend actions with backend behavior.
-allowed-tools: Bash, Read, mcp__spotlight__search_traces, mcp__spotlight__get_traces, mcp__spotlight__search_errors, mcp__spotlight__search_logs, mcp__chrome-devtools__*
 ---
 
 # Debugging Lightdash


### PR DESCRIPTION
## Summary
- Removes `allowed-tools` from the debug skill's SKILL.md frontmatter
- The `allowed-tools` field causes the Skill tool to require a sub-agent model invocation, which fails with `"Skill debug cannot be used with Skill tool due to disable-model-invocation"`
- Without `allowed-tools`, the skill content injects directly into the conversation, avoiding the error

## Test plan
- [ ] Start a new Claude Code session and invoke `/debug` — should load without error

🤖 Generated with [Claude Code](https://claude.com/claude-code)