### PR TITLE
chore(devx): add configurable MinIO file expiration policy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,6 +11,7 @@ services:
             - MINIO_ROOT_USER=minioadmin
             - MINIO_ROOT_PASSWORD=minioadmin
             - MINIO_DEFAULT_BUCKETS=default
+            - MINIO_EXPIRATION_DAYS=${MINIO_EXPIRATION_DAYS:-1}
     lightdash:
         platform: linux/amd64
         image: lightdash/lightdash:latest

--- a/docker/init-minio.sh
+++ b/docker/init-minio.sh
@@ -18,6 +18,14 @@ for bucket in $MINIO_DEFAULT_BUCKETS; do
     if ! mc mb -p local/"$bucket" 2>/dev/null; then
       echo "Bucket '$bucket' already exists or could not be created"
     fi
+    
+    # Configure lifecycle policy to auto-delete files after MINIO_EXPIRATION_DAYS days (default: 1 day)
+    EXPIRATION_DAYS="${MINIO_EXPIRATION_DAYS:-1}"
+    if [ "$EXPIRATION_DAYS" -gt 0 ] 2>/dev/null; then
+      echo "Setting lifecycle policy for bucket '$bucket': expire after $EXPIRATION_DAYS day(s)"
+      mc ilm rule add --expire-days "$EXPIRATION_DAYS" local/"$bucket" 2>/dev/null || \
+        echo "Could not set lifecycle policy for bucket '$bucket' (may already exist)"
+    fi
   fi
 done
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added configurable auto-deletion of files in MinIO buckets through a lifecycle policy. Files will expire after a configurable number of days (default: 1 day) using the new `MINIO_EXPIRATION_DAYS` environment variable.