### PR TITLE
chore: migrate `CatalogService` to new `SpacePermissionService

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -856,7 +856,7 @@ export class ServiceRepository
                     spaceModel: this.models.getSpaceModel(),
                     tagsModel: this.models.getTagsModel(),
                     changesetModel: this.models.getChangesetModel(),
-                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new

### Description:
Migrating the CatalogService to use the new SpacePermissionService.
Added a small API test since the existing ones didn't really test the "access permissions".
