### PR TITLE
fix: default time interval "undefined" in metric

### DIFF
--- a/packages/common/src/utils/metricsExplorer.ts
+++ b/packages/common/src/utils/metricsExplorer.ts
@@ -521,12 +521,22 @@ export const getDefaultTimeDimension = (
 ): DefaultTimeDimension | undefined => {
     // Priority 1: Use metric-level default time dimension if defined in yml
     if (metric.defaultTimeDimension) {
-        return metric.defaultTimeDimension;
+        return {
+            field: metric.defaultTimeDimension.field,
+            interval:
+                metric.defaultTimeDimension.interval ??
+                DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
+        };
     }
 
     // Priority 2: Use model-level default time dimension if defined in yml
     if (table?.defaultTimeDimension) {
-        return table.defaultTimeDimension;
+        return {
+            field: table.defaultTimeDimension.field,
+            interval:
+                table.defaultTimeDimension.interval ??
+                DEFAULT_METRICS_EXPLORER_TIME_INTERVAL,
+        };
     }
 
     // Priority 3: Use the only time dimension if there's exactly one


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [ZAP-231: Error: Unknown time interval: "undefined"](https://linear.app/lightdash/issue/ZAP-231/error-unknown-time-interval-undefined)

### Description:

Ensures that the default time interval is applied when a default time dimension is specified in the metric or table configuration but doesn't include an interval. This change adds fallback logic to use the `DEFAULT_METRICS_EXPLORER_TIME_INTERVAL` when the interval is not explicitly defined in the configuration.
