### PR TITLE
fix: tiles and page header styles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -8,10 +8,7 @@
     box-shadow: unset;
 
     border: 1px solid
-        light-dark(
-            var(--mantine-color-ldGray-2),
-            lighten(var(--mantine-color-ldDark-2), 0.05)
-        ) !important;
+        light-dark(var(--mantine-color-ldGray-2), var(--mantine-color-ldDark-2)) !important;
 
     &[data-with-transparent-border='true'] {
         border: 1px solid transparent !important;

--- a/packages/frontend/src/components/common/Page/PageHeader.module.css
+++ b/packages/frontend/src/components/common/Page/PageHeader.module.css
@@ -1,5 +1,5 @@
 .root {
-    z-index: 1;
+    z-index: 2;
     display: flex;
     flex-direction: row;
     align-items: center;

--- a/packages/frontend/src/components/common/Table/Tr.module.css
+++ b/packages/frontend/src/components/common/Table/Tr.module.css
@@ -2,14 +2,14 @@
     &[data-odd='true'] {
         background-color: alpha(
             var(--mantine-color-ldGray-1),
-            light-dark(0.3, 0.1)
+            light-dark(0.3, 0.5)
         );
     }
 
     &:hover {
         background-color: alpha(
             var(--mantine-color-ldGray-1),
-            light-dark(0.7, 0.2)
+            light-dark(0.7, 0.7)
         ) !important;
     }
 


### PR DESCRIPTION
### Description:
This PR improves UI styling for better contrast and visibility:

1. Simplified the border styling in TileBase by removing the lighten function, using the standard ldDark-2 color
2. Increased the z-index of PageHeader from 1 to 2 to ensure proper layering
3. Enhanced table row visibility by adjusting background opacity:
   - Increased dark mode opacity for odd rows from 0.1 to 0.5
   - Increased dark mode hover opacity from 0.2 to 0.7

These changes improve the visual hierarchy and readability of the dashboard interface.