### PR TITLE
fix: make Slack artifact action IDs unique with UUID

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -82,7 +82,7 @@ export function getReferencedArtifactsBlocks(
                         text: `📊 ${title}`,
                         emoji: true,
                     },
-                    action_id: 'view_artifact',
+                    action_id: `view_artifact_${artifact.artifactUuid}`,
                 };
             }),
         },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the `action_id` in Slack blocks to include the artifact UUID, changing from a generic `view_artifact` to a specific `view_artifact_${artifact.artifactUuid}`. This ensures each artifact button has a unique identifier, which helps with proper tracking and handling of user interactions.
