### PR TITLE
chore: fail cli upload on unspported NodeJS versions

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -196,6 +196,13 @@ const readCodeFiles = async <T extends ChartAsCode | DashboardAsCode>(
 
     GlobalState.log(`Reading ${folder} from ${baseDir}`);
 
+    const [major, minor] = process.versions.node.split('.').map(Number);
+    if (major < 20 || (major === 20 && minor < 12)) {
+        throw new Error(
+            `Node.js v20.12.0 or later is required for this command (current: ${process.version}).`,
+        );
+    }
+
     try {
         const allEntries = await fs.readdir(baseDir, {
             recursive: true,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-2912/cli-upload-silently-finds-0-files-on-older-nodejs-versions

### Description:
The `Dirent` `parentPath` is only supported since NodeJS 20.12+. Since it's a rename of `path`, I tried to fall back to it to also support older NodeJS versions, however there's a [bug](https://github.com/nodejs/node/issues/48858) in some early NodeJS 20.x versions regarding `readdir` which cause the same silent failure in the bug description as well.

So the safest approach is to simply fail based on the NodeJS version, to make sure both `readdir` and `parentPath` are working/present.

### Before:

<img width="1466" height="280" alt="Screenshot 2026-02-09 at 10 37 50" src="https://github.com/user-attachments/assets/0a733fd8-1ca8-413e-9d46-5e2b73833996" />

### After:

<img width="1466" height="556" alt="Screenshot 2026-02-09 at 10 37 18" src="https://github.com/user-attachments/assets/b6a316aa-c4b5-44de-bb77-ee951440bc4f" />

