### PR TITLE
feat: display time dimension in metric detail popover

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricDetailPopover.tsx
@@ -1,4 +1,5 @@
 import {
+    friendlyName,
     type MetricExplorerDateRange,
     type MetricTotalComparisonType,
     type MetricWithAssociatedTimeDimension,
@@ -175,6 +176,28 @@ const MetricDetailContent: FC<MetricDetailContentProps> = ({
                     {sqlToShow}
                 </Prism>
             </Box>
+
+            {metric.timeDimension && (
+                <>
+                    <Divider />
+                    <Group justify="space-between" gap="xs">
+                        <Text size="xs" c="dimmed" fw={500} mb={4}>
+                            Time dimension
+                        </Text>
+                        <Tooltip
+                            label={`${metric.timeDimension.table}.${metric.timeDimension.field}`}
+                            withinPortal
+                        >
+                            <Text size="xs">
+                                {metric.timeDimension.table !== metric.table &&
+                                    `${friendlyName(metric.timeDimension.table)} `}
+                                {friendlyName(metric.timeDimension.field)} (
+                                {friendlyName(metric.timeDimension.interval)})
+                            </Text>
+                        </Tooltip>
+                    </Group>
+                </>
+            )}
 
             {compiledQueryConfig && (
                 <CompiledQuerySection


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added time dimension information to the Metric Detail Popover. This enhancement displays the time dimension's table, field, and interval in a user-friendly format, with a tooltip showing the full table.field path. The time dimension section only appears when a metric has an associated time dimension.
