### PR TITLE
fix: add correct `startOfWeek` default values per adapter

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -77,7 +77,7 @@ export const ExpectedInTheCurrentFilterSQL: Record<UnitOfTime, string> = {
     [UnitOfTime.minutes]: `((customers.created) >= ('2020-04-04 06:12:00') AND (customers.created) <= ('2020-04-04 06:12:59'))`,
     [UnitOfTime.hours]: `((customers.created) >= ('2020-04-04 06:00:00') AND (customers.created) <= ('2020-04-04 06:59:59'))`,
     [UnitOfTime.days]: `((customers.created) >= ('2020-04-04 00:00:00') AND (customers.created) <= ('2020-04-04 23:59:59'))`,
-    [UnitOfTime.weeks]: `((customers.created) >= ('2020-03-29 00:00:00') AND (customers.created) <= ('2020-04-04 23:59:59'))`,
+    [UnitOfTime.weeks]: `((customers.created) >= ('2020-03-30 00:00:00') AND (customers.created) <= ('2020-04-05 23:59:59'))`,
     [UnitOfTime.months]: `((customers.created) >= ('2020-04-01 00:00:00') AND (customers.created) <= ('2020-04-30 23:59:59'))`,
     [UnitOfTime.quarters]: `((customers.created) >= ('2020-04-01 00:00:00') AND (customers.created) <= ('2020-06-30 23:59:59'))`,
     [UnitOfTime.years]: `((customers.created) >= ('2020-01-01 00:00:00') AND (customers.created) <= ('2020-12-31 23:59:59'))`,
@@ -89,7 +89,7 @@ export const TrinoExpectedInTheCurrentFilterSQL: Record<UnitOfTime, string> = {
     [UnitOfTime.minutes]: `((customers.created) >= CAST('2020-04-04 06:12:00' AS timestamp) AND (customers.created) <= CAST('2020-04-04 06:12:59' AS timestamp))`,
     [UnitOfTime.hours]: `((customers.created) >= CAST('2020-04-04 06:00:00' AS timestamp) AND (customers.created) <= CAST('2020-04-04 06:59:59' AS timestamp))`,
     [UnitOfTime.days]: `((customers.created) >= CAST('2020-04-04 00:00:00' AS timestamp) AND (customers.created) <= CAST('2020-04-04 23:59:59' AS timestamp))`,
-    [UnitOfTime.weeks]: `((customers.created) >= CAST('2020-03-29 00:00:00' AS timestamp) AND (customers.created) <= CAST('2020-04-04 23:59:59' AS timestamp))`,
+    [UnitOfTime.weeks]: `((customers.created) >= CAST('2020-03-30 00:00:00' AS timestamp) AND (customers.created) <= CAST('2020-04-05 23:59:59' AS timestamp))`,
     [UnitOfTime.months]: `((customers.created) >= CAST('2020-04-01 00:00:00' AS timestamp) AND (customers.created) <= CAST('2020-04-30 23:59:59' AS timestamp))`,
     [UnitOfTime.quarters]: `((customers.created) >= CAST('2020-04-01 00:00:00' AS timestamp) AND (customers.created) <= CAST('2020-06-30 23:59:59' AS timestamp))`,
     [UnitOfTime.years]: `((customers.created) >= CAST('2020-01-01 00:00:00' AS timestamp) AND (customers.created) <= CAST('2020-12-31 23:59:59' AS timestamp))`,
@@ -138,7 +138,7 @@ export const ExpectedInTheNextCompleteFilterSQL: Record<UnitOfTime, string> = {
     [UnitOfTime.minutes]: `((customers.created) >= ('2020-04-04 06:13:00') AND (customers.created) < ('2020-04-04 06:14:00'))`,
     [UnitOfTime.hours]: `((customers.created) >= ('2020-04-04 07:00:00') AND (customers.created) < ('2020-04-04 08:00:00'))`,
     [UnitOfTime.days]: `((customers.created) >= ('2020-04-05 00:00:00') AND (customers.created) < ('2020-04-06 00:00:00'))`,
-    [UnitOfTime.weeks]: `((customers.created) >= ('2020-04-05 00:00:00') AND (customers.created) < ('2020-04-12 00:00:00'))`,
+    [UnitOfTime.weeks]: `((customers.created) >= ('2020-04-06 00:00:00') AND (customers.created) < ('2020-04-13 00:00:00'))`,
     [UnitOfTime.months]: `((customers.created) >= ('2020-05-01 00:00:00') AND (customers.created) < ('2020-06-01 00:00:00'))`,
     [UnitOfTime.quarters]: `((customers.created) >= ('2020-07-01 00:00:00') AND (customers.created) < ('2020-10-01 00:00:00'))`,
     [UnitOfTime.years]: `((customers.created) >= ('2021-01-01 00:00:00') AND (customers.created) < ('2022-01-01 00:00:00'))`,
@@ -153,7 +153,7 @@ export const TrinoExpectedInTheNextCompleteFilterSQL: Record<
     [UnitOfTime.minutes]: `((customers.created) >= CAST('2020-04-04 06:13:00' AS timestamp) AND (customers.created) < CAST('2020-04-04 06:14:00' AS timestamp))`,
     [UnitOfTime.hours]: `((customers.created) >= CAST('2020-04-04 07:00:00' AS timestamp) AND (customers.created) < CAST('2020-04-04 08:00:00' AS timestamp))`,
     [UnitOfTime.days]: `((customers.created) >= CAST('2020-04-05 00:00:00' AS timestamp) AND (customers.created) < CAST('2020-04-06 00:00:00' AS timestamp))`,
-    [UnitOfTime.weeks]: `((customers.created) >= CAST('2020-04-05 00:00:00' AS timestamp) AND (customers.created) < CAST('2020-04-12 00:00:00' AS timestamp))`,
+    [UnitOfTime.weeks]: `((customers.created) >= CAST('2020-04-06 00:00:00' AS timestamp) AND (customers.created) < CAST('2020-04-13 00:00:00' AS timestamp))`,
     [UnitOfTime.months]: `((customers.created) >= CAST('2020-05-01 00:00:00' AS timestamp) AND (customers.created) < CAST('2020-06-01 00:00:00' AS timestamp))`,
     [UnitOfTime.quarters]: `((customers.created) >= CAST('2020-07-01 00:00:00' AS timestamp) AND (customers.created) < CAST('2020-10-01 00:00:00' AS timestamp))`,
     [UnitOfTime.years]: `((customers.created) >= CAST('2021-01-01 00:00:00' AS timestamp) AND (customers.created) < CAST('2022-01-01 00:00:00' AS timestamp))`,
@@ -266,9 +266,9 @@ export const InTheLast1CompletedWeekFilter = {
     },
 };
 
-export const InTheLast1CompletedWeekFilterSQL = `((customers.created) >= ('2020-03-22') AND (customers.created) < ('2020-03-29'))`;
+export const InTheLast1CompletedWeekFilterSQL = `((customers.created) >= ('2020-03-23') AND (customers.created) < ('2020-03-30'))`;
 
-export const TrinoInTheLast1CompletedWeekFilterSQL = `((customers.created) >= CAST('2020-03-22' AS timestamp) AND (customers.created) < CAST('2020-03-29' AS timestamp))`;
+export const TrinoInTheLast1CompletedWeekFilterSQL = `((customers.created) >= CAST('2020-03-23' AS timestamp) AND (customers.created) < CAST('2020-03-30' AS timestamp))`;
 
 export const InTheLast1MonthFilter = {
     ...InTheLast1WeekFilter,

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -27,7 +27,32 @@ import { convertToBooleanValue } from '../utils/booleanConverter';
 import { formatDate } from '../utils/formatting';
 import { getItemId } from '../utils/item';
 import { getMomentDateWithCustomStartOfWeek } from '../utils/time';
-import { type WeekDay } from '../utils/timeFrames';
+import { WeekDay } from '../utils/timeFrames';
+
+/**
+ * Returns the default week start day for a given warehouse adapter.
+ * This ensures JavaScript-side week boundary calculations match the warehouse.
+ *
+ * References:
+ * - PostgreSQL: https://www.postgresql.org/docs/current/functions-datetime.html (ISO 8601 weeks start on Monday)
+ * - Snowflake: https://docs.snowflake.com/en/sql-reference/functions-date-time (WEEK_START=0 defaults to Monday)
+ * - Redshift: https://docs.aws.amazon.com/redshift/latest/dg/r_DATE_TRUNC.html (truncates week to Monday)
+ * - Databricks: https://docs.databricks.com/aws/en/sql/language-manual/functions/date_trunc (WEEK truncates to Monday)
+ * - Trino: https://trino.io/docs/current/functions/datetime.html (ISO 8601 weeks start on Monday)
+ * - BigQuery: https://docs.cloud.google.com/bigquery/docs/reference/standard-sql/date_functions (WEEK is equivalent to WEEK(SUNDAY))
+ * - ClickHouse: https://clickhouse.com/docs/sql-reference/functions/date-time-functions (toStartOfWeek default mode=0 is Sunday)
+ */
+const getDefaultStartOfWeek = (
+    adapterType: SupportedDbtAdapter | WarehouseTypes,
+): WeekDay => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+        case SupportedDbtAdapter.CLICKHOUSE:
+            return WeekDay.SUNDAY;
+        default:
+            return WeekDay.MONDAY;
+    }
+};
 
 // NOTE: This function requires a complete date as input.
 // It produces a timezoneless string which is implied to be in UTC.
@@ -220,6 +245,11 @@ export const renderDateFilterSql = (
     dateFormatter: (date: Date) => string = formatDate,
     startOfWeek: WeekDay | null | undefined = undefined,
 ): string => {
+    // When startOfWeek is not explicitly configured, use the warehouse's default
+    // to ensure JS-side week boundaries match the warehouse's DATE_TRUNC behavior.
+    const effectiveStartOfWeek =
+        startOfWeek ?? getDefaultStartOfWeek(adapterType);
+
     const castValue = (value: string): string => {
         switch (adapterType) {
             case SupportedDbtAdapter.TRINO:
@@ -272,19 +302,19 @@ export const renderDateFilterSql = (
 
             if (completed) {
                 const completedDate = moment(
-                    getMomentDateWithCustomStartOfWeek(startOfWeek)
+                    getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                         .startOf(unitOfTime)
                         .format(unitOfTimeFormat[unitOfTime]),
                 ).toDate();
                 const untilDate = dateFormatter(
-                    getMomentDateWithCustomStartOfWeek(startOfWeek)
+                    getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                         .startOf(unitOfTime)
                         .toDate(),
                 );
                 return `${not}((${dimensionSql}) >= ${castValue(
                     dateFormatter(
                         getMomentDateWithCustomStartOfWeek(
-                            startOfWeek,
+                            effectiveStartOfWeek,
                             completedDate,
                         )
                             .subtract(filter.values?.[0], unitOfTime)
@@ -293,11 +323,13 @@ export const renderDateFilterSql = (
                 )} AND (${dimensionSql}) < ${castValue(untilDate)})`;
             }
             const untilDate = dateFormatter(
-                getMomentDateWithCustomStartOfWeek(startOfWeek).toDate(),
+                getMomentDateWithCustomStartOfWeek(
+                    effectiveStartOfWeek,
+                ).toDate(),
             );
             return `${not}((${dimensionSql}) >= ${castValue(
                 dateFormatter(
-                    getMomentDateWithCustomStartOfWeek(startOfWeek)
+                    getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                         .subtract(filter.values?.[0], unitOfTime)
                         .toDate(),
                 ),
@@ -310,12 +342,15 @@ export const renderDateFilterSql = (
 
             if (completed) {
                 const fromDate = moment(
-                    getMomentDateWithCustomStartOfWeek(startOfWeek)
+                    getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                         .add(1, unitOfTime)
                         .startOf(unitOfTime),
                 ).toDate();
                 const toDate = dateFormatter(
-                    getMomentDateWithCustomStartOfWeek(startOfWeek, fromDate)
+                    getMomentDateWithCustomStartOfWeek(
+                        effectiveStartOfWeek,
+                        fromDate,
+                    )
                         .add(filter.values?.[0], unitOfTime)
                         .toDate(),
                 );
@@ -324,10 +359,12 @@ export const renderDateFilterSql = (
                 )} AND (${dimensionSql}) < ${castValue(toDate)})`;
             }
             const fromDate = dateFormatter(
-                getMomentDateWithCustomStartOfWeek(startOfWeek).toDate(),
+                getMomentDateWithCustomStartOfWeek(
+                    effectiveStartOfWeek,
+                ).toDate(),
             );
             const toDate = dateFormatter(
-                getMomentDateWithCustomStartOfWeek(startOfWeek)
+                getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                     .add(filter.values?.[0], unitOfTime)
                     .toDate(),
             );
@@ -340,14 +377,14 @@ export const renderDateFilterSql = (
                 filter.settings?.unitOfTime || UnitOfTime.days;
 
             const fromDate = dateFormatter(
-                getMomentDateWithCustomStartOfWeek(startOfWeek)
+                getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                     .tz(timezone)
                     .startOf(unitOfTime)
                     .utc()
                     .toDate(),
             );
             const untilDate = dateFormatter(
-                getMomentDateWithCustomStartOfWeek(startOfWeek)
+                getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                     .tz(timezone)
                     .endOf(unitOfTime)
                     .utc()
@@ -364,14 +401,14 @@ export const renderDateFilterSql = (
                 filter.settings?.unitOfTime || UnitOfTime.days;
 
             const fromDate = dateFormatter(
-                getMomentDateWithCustomStartOfWeek(startOfWeek)
+                getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                     .tz(timezone)
                     .startOf(unitOfTime)
                     .utc()
                     .toDate(),
             );
             const untilDate = dateFormatter(
-                getMomentDateWithCustomStartOfWeek(startOfWeek)
+                getMomentDateWithCustomStartOfWeek(effectiveStartOfWeek)
                     .tz(timezone)
                     .endOf(unitOfTime)
                     .utc()


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2905/date-trunc-week-filter-excludes-last-day-of-range-when-using-custom

### Description
When using "completed weeks" filters (e.g., "in the last X completed weeks"), the WHERE clause date boundaries were computed using moment.js's default week start (Sunday). Most warehouses default to Monday for `DATE_TRUNC('WEEK', ...)`, causing the final Sunday of the range to be excluded from results.

This adds a warehouse-aware default so that when `startOfWeek` is not explicitly configured, the JavaScript boundary calculation matches the warehouse's native behavior. No change when `startOfWeek` is explicitly set by the user.

**Root cause**: `getMomentDateWithCustomStartOfWeek(undefined)` fell back to Sunday (moment.js default) instead of the warehouse's default (Monday for most).

**Fix**: Resolve `startOfWeek` to the warehouse's default at the top of `renderDateFilterSql` via `startOfWeek ?? getDefaultStartOfWeek(adapterType)`.

### Testing:
Using Snowflake with "auto" start of the week setting.

#### Before:
Note that the query filters for "date >= Sunday and date < Sunday", meaning that it's using Sunday as a default while we internally assume Monday.

<img width="2659" height="1138" alt="Before" src="https://github.com/user-attachments/assets/76003117-d3ca-4703-9ce2-1c6ac693a8b3" />

#### After:
Now it's correctly filtering "date >= Monday and date < Monday".
<img width="2659" height="1138" alt="After" src="https://github.com/user-attachments/assets/327ab516-021a-43e2-bdf1-496687a1fb93" />

#### After with custom start of week -> Wednesday:
Filter uses Wednesday values correctly as it's explicitly set.

<img width="2659" height="1138" alt="image" src="https://github.com/user-attachments/assets/5da6c0c5-4638-4dc3-abf8-1c3a4b94d3bc" />
