### PR TITLE
fix: exclude deleted charts from queries

### DIFF
--- a/packages/backend/src/ee/models/EmbedModel.ts
+++ b/packages/backend/src/ee/models/EmbedModel.ts
@@ -58,7 +58,8 @@ export class EmbedModel {
 
         const charts = await this.database('saved_queries')
             .select()
-            .whereIn('saved_query_uuid', embed.chart_uuids);
+            .whereIn('saved_query_uuid', embed.chart_uuids)
+            .whereNull('deleted_at');
 
         const validChartUuids = charts.map((chart) => chart.saved_query_uuid);
 

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1964,6 +1964,7 @@ export class ProjectModel {
                 .leftJoin('spaces', 'saved_queries.space_id', 'spaces.space_id')
                 .whereIn('saved_queries.space_id', spaceIds)
                 .andWhere('spaces.project_id', projectId)
+                .whereNull('saved_queries.deleted_at')
                 .select<DbSavedChart[]>('saved_queries.*');
 
             Logger.info(
@@ -2013,6 +2014,7 @@ export class ProjectModel {
                 .leftJoin('spaces', 'dashboards.space_id', 'spaces.space_id')
                 .where('spaces.project_id', projectId)
                 .andWhere('saved_queries.space_id', null)
+                .whereNull('saved_queries.deleted_at')
                 .select<DbSavedChart[]>('saved_queries.*');
 
             Logger.info(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Exclude soft-deleted charts from embed and project queries by adding `whereNull('deleted_at')` conditions to the relevant database queries. This prevents deleted charts from appearing in embeds and project chart listings.
