### PR TITLE
fix: column naming bug in SQL runner

### DIFF
--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -173,11 +173,14 @@ export const isPivotChartLayout = (
         return false;
     }
 
-    if (!('y' in obj) && !('groupBy' in obj) && !('x' in obj)) {
-        return false;
+    // PivotChartLayout.y is always an array of { reference, aggregation }.
+    // A VizColumnsConfig could have a column named "y" but its value would be
+    // a VizColumnConfig object (with label, frozen, visible), never an array.
+    if ('y' in obj && Array.isArray(obj.y)) {
+        return true;
     }
 
-    return true;
+    return false;
 };
 
 export type VizCartesianChartOptions = {


### PR DESCRIPTION
Fixes the a SQL runner type guard that was causing tables to be treated as charts if the had columns named 'x' or 'y'. 
