### PR TITLE
fix: filter on raw date column even when zoom is applied

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2391,6 +2391,7 @@ export class ProjectService extends BaseService {
             parameterDefinitions: availableParameterDefinitions,
             pivotConfiguration,
             continueOnError,
+            originalExplore: dateZoom ? explore : undefined,
         });
 
         return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-2875/date-range-filters-break-when-date-zoom-granularity-is-changed

## Description:
When date zoom changes granularity, `updateExploreWithDateZoom` modifies the dimension's `compiledSql` to use `DATE_TRUNC`. This modified explore was passed to `MetricQueryBuilder`, where filter compilation looked up the dimension and used the truncated `compiledSql` in the WHERE clause - producing incorrect comparisons like `WHERE DATE_TRUNC('month', col) >= '2024-09-01'` instead of `WHERE col >= '2024-09-01'`.


## Testing:
In my test scenario I have a day filter `between 2025-02-19 and 2025-02-24`. The total order amount is $125. Note that this amount shouldn't change with any zoom changed, it should only ever change the visual representation. However, in the bugged version it becomes wrong.

### Before:
- Zoom: day
<img width="2659" height="1138" alt="Before-day" src="https://github.com/user-attachments/assets/a492bcb0-6e04-4bc3-92b0-850b873400d5" />

- Zoom: week
<img width="2659" height="1138" alt="Before-week" src="https://github.com/user-attachments/assets/7bfc6d21-ad38-4b53-a65c-d75c72a05882" />

- Zoom: month
<img width="2659" height="1138" alt="Before-month" src="https://github.com/user-attachments/assets/73d1ced1-22be-4210-bd6f-7116a355e035" />


### After:
- Zoom: day
<img width="2659" height="1138" alt="After-day" src="https://github.com/user-attachments/assets/2b37e6ac-76d4-453e-b9dd-40e6a8391095" />


- Zoom: week
<img width="2659" height="1138" alt="After-week" src="https://github.com/user-attachments/assets/e12ae32b-3d26-41d3-99b3-307afeccce45" />


- Zoom: month
<img width="2659" height="1138" alt="After-month" src="https://github.com/user-attachments/assets/6b5c6ccc-e3da-46ab-82e1-3157faa647d4" />


