### PR TITLE
fix: stacked bar range is cropped when reference line is applied

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1761,14 +1761,18 @@ const getEchartAxes = ({
         max?: number,
     ) => {
         if (axisType === 'value') {
+            // For bar charts (allowFirstAxisDefaultRange === false), we should NOT use
+            // reference line values to set the axis bounds. This prevents the axis from
+            // being forced to scale to a reference line that's outside the data range.
+            // See: https://github.com/lightdash/lightdash/issues/19822
             const initialBottomAxisMin =
                 xAxisConfiguration?.[0]?.min ??
-                referenceLineMinX ??
+                (allowFirstAxisDefaultRange ? referenceLineMinX : undefined) ??
                 maybeGetAxisDefaultMinValue(allowFirstAxisDefaultRange);
 
             const initialBottomAxisMax =
                 xAxisConfiguration?.[0]?.max ??
-                referenceLineMaxX ??
+                (allowFirstAxisDefaultRange ? referenceLineMaxX : undefined) ??
                 maybeGetAxisDefaultMaxValue(allowFirstAxisDefaultRange);
 
             // Apply offset to the min and max values of the axis
@@ -1851,19 +1855,28 @@ const getEchartAxes = ({
                 : bottomAxisBounds.max
             : undefined;
 
+    // For bar charts (allowFirstAxisDefaultRange === false), we should NOT use
+    // reference line values to set the axis bounds. This prevents the axis from
+    // being forced to scale to a reference line that's outside the data range,
+    // which would compress the bars and make the chart misleading.
+    // See: https://github.com/lightdash/lightdash/issues/19822
     const maxYAxisValue =
         leftAxisType === 'value'
             ? shouldStack100 && !validCartesianConfig.layout.flipAxes
                 ? 100 // For 100% stacking without flipped axes, max is always 100
                 : yAxisConfiguration?.[0]?.max ||
-                  referenceLineMaxLeftY ||
+                  (allowFirstAxisDefaultRange
+                      ? referenceLineMaxLeftY
+                      : undefined) ||
                   maybeGetAxisDefaultMaxValue(allowFirstAxisDefaultRange)
             : undefined;
 
     const minYAxisValue =
         leftAxisType === 'value'
             ? yAxisConfiguration?.[0]?.min ||
-              referenceLineMinLeftY ||
+              (allowFirstAxisDefaultRange
+                  ? referenceLineMinLeftY
+                  : undefined) ||
               maybeGetAxisDefaultMinValue(allowFirstAxisDefaultRange)
             : undefined;
 
@@ -2081,7 +2094,9 @@ const getEchartAxes = ({
                 min:
                     rightAxisType === 'value'
                         ? yAxisConfiguration?.[1]?.min ||
-                          referenceLineMinRightY ||
+                          (allowSecondAxisDefaultRange
+                              ? referenceLineMinRightY
+                              : undefined) ||
                           maybeGetAxisDefaultMinValue(
                               allowSecondAxisDefaultRange,
                           )
@@ -2089,7 +2104,9 @@ const getEchartAxes = ({
                 max:
                     rightAxisType === 'value'
                         ? yAxisConfiguration?.[1]?.max ||
-                          referenceLineMaxRightY ||
+                          (allowSecondAxisDefaultRange
+                              ? referenceLineMaxRightY
+                              : undefined) ||
                           maybeGetAxisDefaultMaxValue(
                               allowSecondAxisDefaultRange,
                           )


### PR DESCRIPTION
Closes: [PROD-2814](https://linear.app/lightdash/issue/PROD-2814/stacked-bar-chart-reference-line-forces-y-axis-max-value)

When a reference line is added to a stacked bar chart with a value higher than the data maximum, the Y-axis was being forced to scale to include the reference line value. This compressed the bars and made the chart visually misleading.

The fix ensures that reference line min/max values are NOT used to set axis bounds for bar charts. Instead, the axis scales naturally to the data range, and reference lines outside the data range will be positioned at the edge.

For line/scatter charts (where allowFirstAxisDefaultRange is true), the existing behavior is preserved - the axis will expand to show reference lines.

Fixes #19822

Slack thread: https://lightdash.slack.com/archives/C0AD7R21BLG/p1770645418418709?thread_ts=1770645378.889849&cid=C0AD7R21BLG

https://claude.ai/code/session_01PNZDVJKuzFXqikY9M7GeEq

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to ECharts axis bound selection logic; risk is limited to potential edge-case differences in how axis min/max are chosen for mixed-series charts.
> 
> **Overview**
> Fixes stacked bar axis scaling when reference lines are outside the data range by **only applying reference-line min/max to axis bounds when default-range expansion is allowed**.
> 
> This gates reference-line-driven bounds for the primary X/Y axes and the secondary (right) Y axis behind `allowFirstAxisDefaultRange`/`allowSecondAxisDefaultRange`, so bar charts keep a data-driven scale while line/scatter behavior remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1d37f90a1f05fbe4f9150eacd55639de54871d1d. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->