### PR TITLE
chore: move 'CommentService' to new 'SpacePermissionService'

### DIFF
--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -6,8 +6,6 @@ import {
     ForbiddenError,
     LightdashUser,
     SessionUser,
-    SpaceShare,
-    SpaceSummary,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
@@ -15,19 +13,18 @@ import { CommentModel } from '../../models/CommentModel/CommentModel';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { NotificationsModel } from '../../models/NotificationsModel/NotificationsModel';
-import { SpaceModel } from '../../models/SpaceModel';
 import { UserModel } from '../../models/UserModel';
 import { BaseService } from '../BaseService';
-import { hasViewAccessToSpace } from '../SpaceService/SpaceService';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 
 type CommentServiceArguments = {
     analytics: LightdashAnalytics;
     dashboardModel: DashboardModel;
-    spaceModel: SpaceModel;
     commentModel: CommentModel;
     notificationsModel: NotificationsModel;
     userModel: UserModel;
     featureFlagModel: FeatureFlagModel;
+    spacePermissionService: SpacePermissionService;
 };
 
 export class CommentService extends BaseService {
@@ -35,8 +32,6 @@ export class CommentService extends BaseService {
 
     dashboardModel: DashboardModel;
 
-    spaceModel: SpaceModel;
-
     commentModel: CommentModel;
 
     notificationsModel: NotificationsModel;
@@ -45,50 +40,42 @@ export class CommentService extends BaseService {
 
     featureFlagModel: FeatureFlagModel;
 
+    spacePermissionService: SpacePermissionService;
+
     constructor({
         analytics,
         dashboardModel,
-        spaceModel,
         commentModel,
         notificationsModel,
         userModel,
         featureFlagModel,
+        spacePermissionService,
     }: CommentServiceArguments) {
         super();
         this.analytics = analytics;
         this.dashboardModel = dashboardModel;
-        this.spaceModel = spaceModel;
         this.commentModel = commentModel;
         this.notificationsModel = notificationsModel;
         this.userModel = userModel;
         this.featureFlagModel = featureFlagModel;
+        this.spacePermissionService = spacePermissionService;
     }
 
     async hasDashboardSpaceAccess(
         user: SessionUser,
         spaceUuid: string,
     ): Promise<boolean> {
-        let space: Omit<SpaceSummary, 'userAccess'>;
-        let spaceAccess: SpaceShare[];
-
         try {
-            space = await this.spaceModel.getSpaceSummary(spaceUuid);
-            const nestedPermissionsFlag = await this.featureFlagModel.get({
+            return await this.spacePermissionService.can(
+                'view',
                 user,
-                featureFlagId: FeatureFlags.NestedSpacesPermissions,
-            });
-            spaceAccess = await this.spaceModel.getUserSpaceAccess(
-                user.userUuid,
                 spaceUuid,
-                { useInheritedAccess: nestedPermissionsFlag.enabled },
             );
         } catch (e) {
             Sentry.captureException(e);
             console.error(e);
             return false;
         }
-
-        return hasViewAccessToSpace(user, space, spaceAccess);
     }
 
     private async isFeatureEnabled(

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -283,11 +283,11 @@ export class ServiceRepository
                 new CommentService({
                     analytics: this.context.lightdashAnalytics,
                     dashboardModel: this.models.getDashboardModel(),
-                    spaceModel: this.models.getSpaceModel(),
                     commentModel: this.models.getCommentModel(),
                     notificationsModel: this.models.getNotificationsModel(),
                     userModel: this.models.getUserModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new

### Description:
Refactored `CommentService` to use `SpacePermissionService` for access control instead of directly using `SpaceModel`. This change removes the direct dependency on `SpaceModel` and simplifies the permission checking logic by leveraging the dedicated permission service.

The PR updates the `hasDashboardSpaceAccess` method to use the `can` method from `SpacePermissionService` rather than implementing the permission logic directly.