### PR TITLE
chore: move 'ContentService' to new 'SpacePermissionService'

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -970,7 +970,7 @@ export class ServiceRepository
                     dashboardService: this.getDashboardService(),
                     savedChartService: this.getSavedChartService(),
                     savedSqlService: this.getSavedSqlService(),
-                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new

### Description:
Refactored ContentService to use SpacePermissionService for checking space access permissions instead of directly using FeatureFlagModel. This change replaces the manual permission checking logic with a call to the dedicated `getAccessibleSpaceUuids` method from SpacePermissionService, simplifying the code and improving maintainability.