### PR TITLE
chore:  move 'PinningService' to new 'SpacePermissionService'

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -527,7 +527,7 @@ export class ServiceRepository
                     resourceViewItemModel:
                         this.models.getResourceViewItemModel(),
                     projectModel: this.models.getProjectModel(),
-                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new

### Description:
Refactored the PinningService to use SpacePermissionService for checking space access permissions instead of directly using FeatureFlagModel. This change removes the direct dependency on feature flags and simplifies the permission checking logic by leveraging the dedicated SpacePermissionService.

The PR replaces the manual space access verification with a call to `getAccessibleSpaceUuids()` method, which provides a cleaner and more maintainable approach to handling space permissions.