### PR TITLE
chore: move 'SearchService' to 'SpacePermissionService'

### DIFF
--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -699,7 +699,7 @@ export class ServiceRepository
                     searchModel: this.models.getSearchModel(),
                     spaceModel: this.models.getSpaceModel(),
                     userAttributesModel: this.models.getUserAttributesModel(),
-                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new

### Description:
Refactored the SearchService to use SpacePermissionService for access control instead of directly checking space permissions. This change removes the dependency on FeatureFlagModel and simplifies the permission checking logic by leveraging the SpacePermissionService's `can` method.
