### PR TITLE
style: reduce font size of access token descriptions in table

### DIFF
--- a/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
+++ b/packages/frontend/src/components/UserSettings/AccessTokensPanel/TokensTable.tsx
@@ -58,7 +58,9 @@ const TokenItem: FC<{
         <>
             <Table.Tr>
                 <Table.Td>
-                    <Text fw={500}>{description}</Text>
+                    <Text fw={500} size="sm">
+                        {description}
+                    </Text>
                 </Table.Td>
                 <Table.Td>
                     <Group align="center" justify="flex-start" gap="xs">


### PR DESCRIPTION
### Description:
Updated the token description text in the AccessTokensPanel TokensTable to use a smaller font size (`size="sm"`). This improves the visual hierarchy and makes better use of space in the tokens table by de-emphasizing the description text while keeping it readable.

The change applies the `size="sm"` prop to the Text component displaying the token description, making it more compact and visually consistent with typical table layouts.

https://claude.ai/code/session_01CiUry3U5dkNaKMqzx4Jjao

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pure UI styling change confined to a single table cell; no logic, data, or security behavior is affected.
> 
> **Overview**
> Updates the Access Tokens table to render token descriptions with a smaller font (`Text size="sm"`) to better match table density and visual hierarchy.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 70f5dcf60bc450fa8a0690ad2291cca704f8a771. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->