### PR TITLE
chore: invert use_sql_pivot_results feature flag

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1566,7 +1566,7 @@ export const parseConfig = (): LightdashConfig => {
                     'LIGHTDASH_QUERY_MAX_PAGE_SIZE',
                 ) || 2500, // Defaults to default limit * 5
             useSqlPivotResults: process.env.USE_SQL_PIVOT_RESULTS
-                ? process.env.USE_SQL_PIVOT_RESULTS === 'true'
+                ? process.env.USE_SQL_PIVOT_RESULTS !== 'false'
                 : undefined,
             showExecutionTime: process.env.SHOW_EXECUTION_TIME
                 ? process.env.SHOW_EXECUTION_TIME === 'true'

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -123,8 +123,9 @@ export class FeatureFlagModel {
                           throwOnTimeout: false,
                           timeoutMilliseconds: 500,
                       },
+                      true,
                   )
-                : false);
+                : true);
         return {
             id: featureFlagId,
             enabled,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR changes the default behavior for SQL pivot results and feature flags. 

For SQL pivot results, the logic is inverted to enable the feature by default unless explicitly set to 'false'. Previously, it was only enabled when explicitly set to 'true'.

Similarly, for posthog feature flags, the default value is now set to 'true' instead of 'false', making features enabled by default unless specified otherwise.