### PR TITLE
fix: add user to membership via invite link if set up

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -46,6 +46,8 @@ import {
     PasswordLoginTableName,
 } from '../database/entities/passwordLogins';
 import { DbPersonalAccessToken } from '../database/entities/personalAccessTokens';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
 import {
     RolesTableName,
     ScopedRolesTableName,
@@ -494,9 +496,9 @@ export class UserModel {
     > {
         const projectMemberships = await this.database('project_memberships')
             .leftJoin(
-                'projects',
+                ProjectTableName,
                 'project_memberships.project_id',
-                'projects.project_id',
+                `${ProjectTableName}.project_id`,
             )
             .leftJoin('users', 'project_memberships.user_id', 'users.user_id')
             .select('*')
@@ -1006,6 +1008,39 @@ export class UserModel {
             await Promise.all(projectMemberships);
         });
         return this.getUserDetailsByUuid(userUuid);
+    }
+
+    async addProjectMemberships(
+        userUuid: string,
+        projects: { [projectUuid: string]: ProjectMemberRole },
+    ): Promise<void> {
+        const [user] = await this.database(UserTableName)
+            .where('user_uuid', userUuid)
+            .select('user_id');
+        if (!user) {
+            throw new NotFoundError('Cannot find user');
+        }
+
+        const projectMemberships = Object.entries(projects).map(
+            async ([projectUuid, projectRole]) => {
+                const [project] = await this.database(ProjectTableName)
+                    .select('project_id')
+                    .where('project_uuid', projectUuid);
+
+                if (project) {
+                    await this.database(ProjectMembershipsTableName)
+                        .insert({
+                            project_id: project.project_id,
+                            role: projectRole,
+                            user_id: user.user_id,
+                        })
+                        .onConflict(['project_id', 'user_id'])
+                        .ignore();
+                }
+            },
+        );
+
+        await Promise.all(projectMemberships);
     }
 
     async getRefreshToken(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2924](https://linear.app/lightdash/issue/PROD-2924/org-level-member-role-overrides-higher-project-roles-causing)

### Description:
Adds automatic project membership assignment for users who register with an email domain that matches the organization's allowed email domains configuration. When a user registers with a matching email domain, they are automatically added to the projects specified in the allowed email domains settings with the designated roles.

The implementation includes:
- A new `addProjectMemberships` method in the UserModel to assign users to projects
- Logic in the UserService to check email domains and apply default project memberships during user registration
- Proper table name constants for project-related database operations

This enhancement streamlines the onboarding process for new users from trusted domains by automatically granting them access to relevant projects.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes user onboarding/permissions by automatically granting project access on invite acceptance; mistakes in domain/project config or role mapping could grant unintended access, though failures are contained and activation still succeeds.
> 
> **Overview**
> When a user activates via an invite link, the backend now *optionally* auto-adds them to projects defined in the organization’s allowed email domain configuration (including per-project roles), so invited members get expected project access immediately.
> 
> This introduces `UserModel.addProjectMemberships` to upsert `project_memberships` (ignoring conflicts) and updates `activateUserFromInvite` to look up allowed domains for the user’s org and apply those memberships in a best-effort `try/catch` that won’t block activation. It also replaces hardcoded project table names in `getUserProjectRoles` with the shared `ProjectTableName` constant.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 21b18be128c7ca9ea8f099f63427b8fce9a14004. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->