### PR TITLE
fix: handle Snowflake Schema-level errors in custom error messages

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -1092,25 +1092,32 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
     ): string {
         let formattedMessage = customTemplate;
 
-        // Extract table information from the original error message
-        // Pattern matches: Object 'DATABASE.SCHEMA.TABLE' does not exist or not authorized
-        const tableMatch = originalMessage.match(
+        const objectMatch = originalMessage.match(
             /Object '([^']+)' does not exist or not authorized/i,
         );
 
-        if (tableMatch) {
-            const fullTableName = tableMatch[1];
-            const parts = fullTableName.split('.');
+        const schemaMatch = originalMessage.match(
+            /Schema '([^']+)' does not exist or not authorized/i,
+        );
+
+        if (objectMatch) {
+            const parts = objectMatch[1].split('.');
 
             if (parts.length >= 3) {
-                const snowflakeTable = parts[parts.length - 1]; // Last part is table name
-                const snowflakeSchema = parts[parts.length - 2]; // Second to last is schema
+                const snowflakeTable = parts[parts.length - 1];
+                const snowflakeSchema = parts[parts.length - 2];
 
-                // Replace variables in the custom message
                 formattedMessage = formattedMessage
                     .replace(/\{snowflakeTable\}/g, snowflakeTable)
                     .replace(/\{snowflakeSchema\}/g, snowflakeSchema);
             }
+        } else if (schemaMatch) {
+            const parts = schemaMatch[1].split('.');
+            const snowflakeSchema = parts[parts.length - 1];
+
+            formattedMessage = formattedMessage
+                .replace(/\{snowflakeTable\}/g, snowflakeSchema)
+                .replace(/\{snowflakeSchema\}/g, snowflakeSchema);
         }
 
         return formattedMessage;


### PR DESCRIPTION
## Summary

- Handle `Schema '...' does not exist or not authorized` errors in addition to `Object '...'` errors in Snowflake custom error messages
- When a schema-level error is matched, extract the schema name and use it for both `{snowflakeTable}` and `{snowflakeSchema}` template placeholders
- Previously, schema-level errors left raw template variables visible to end users

Fixes SPK-330

## Test plan

- [x] Added test: schema-level error extracts schema name and replaces both placeholders
- [x] Added test: schema errors with different DB.SCHEMA formats
- [x] Existing Object-level error tests still pass (15/15)

🤖 Generated with [Claude Code](https://claude.com/claude-code)