### PR TITLE
feat: add persistent download file database and service

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -194,6 +194,10 @@ import {
     OrganizationAllowedEmailDomainsTableName,
 } from '../database/entities/organizationsAllowedEmailDomains';
 import {
+    PersistentDownloadFileTable,
+    PersistentDownloadFileTableName,
+} from '../database/entities/persistentDownloadFile';
+import {
     ProjectGroupAccessTable,
     ProjectGroupAccessTableName,
 } from '../database/entities/projectGroupAccess';
@@ -392,6 +396,7 @@ declare module 'knex/types/tables' {
         [SavedChartCustomDimensionsTableName]: SavedChartCustomDimensionsTable;
         [SavedChartCustomSqlDimensionsTableName]: SavedChartCustomSqlDimensionsTable;
         [DownloadFileTableName]: DownloadFileTable;
+        [PersistentDownloadFileTableName]: PersistentDownloadFileTable;
         [DownloadAuditTableName]: DownloadAuditTable;
         [GithubAppInstallationTableName]: GithubAppInstallationTable;
         [GitlabAppInstallationTableName]: GitlabAppInstallationTable;

--- a/packages/backend/src/database/entities/persistentDownloadFile.ts
+++ b/packages/backend/src/database/entities/persistentDownloadFile.ts
@@ -1,0 +1,23 @@
+import { Knex } from 'knex';
+
+export const PersistentDownloadFileTableName = 'persistent_download_files';
+
+export type DbPersistentDownloadFile = {
+    nanoid: string;
+    s3_key: string;
+    file_type: string;
+    organization_uuid: string;
+    project_uuid: string | null;
+    created_by_user_uuid: string | null;
+    created_at: Date;
+};
+
+type CreatePersistentDownloadFile = Omit<
+    DbPersistentDownloadFile,
+    'created_at'
+>;
+
+export type PersistentDownloadFileTable = Knex.CompositeTableType<
+    DbPersistentDownloadFile,
+    CreatePersistentDownloadFile
+>;

--- a/packages/backend/src/database/migrations/20260209120000_create_persistent_download_files.ts
+++ b/packages/backend/src/database/migrations/20260209120000_create_persistent_download_files.ts
@@ -1,0 +1,42 @@
+import { Knex } from 'knex';
+
+const PersistentDownloadFilesTableName = 'persistent_download_files';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(PersistentDownloadFilesTableName))) {
+        await knex.schema.createTable(
+            PersistentDownloadFilesTableName,
+            (tableBuilder) => {
+                tableBuilder.text('nanoid').primary();
+                tableBuilder.text('s3_key').notNullable();
+                tableBuilder.text('file_type').notNullable();
+                tableBuilder
+                    .uuid('organization_uuid')
+                    .notNullable()
+                    .references('organization_uuid')
+                    .inTable('organizations')
+                    .onDelete('CASCADE');
+                tableBuilder
+                    .uuid('project_uuid')
+                    .nullable()
+                    .references('project_uuid')
+                    .inTable('projects')
+                    .onDelete('SET NULL');
+                tableBuilder
+                    .uuid('created_by_user_uuid')
+                    .nullable()
+                    .references('user_uuid')
+                    .inTable('users')
+                    .onDelete('SET NULL');
+                tableBuilder
+                    .timestamp('created_at', { useTz: true })
+                    .notNullable()
+                    .defaultTo(knex.fn.now());
+            },
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(PersistentDownloadFilesTableName);
+}

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -28,6 +28,7 @@ import { OrganizationMemberProfileModel } from './OrganizationMemberProfileModel
 import { OrganizationModel } from './OrganizationModel';
 import { OrganizationWarehouseCredentialsModel } from './OrganizationWarehouseCredentialsModel';
 import { PasswordResetLinkModel } from './PasswordResetLinkModel';
+import { PersistentDownloadFileModel } from './PersistentDownloadFileModel';
 import { PinnedListModel } from './PinnedListModel';
 import { ProjectCompileLogModel } from './ProjectCompileLogModel';
 import { ProjectModel } from './ProjectModel/ProjectModel';
@@ -64,6 +65,7 @@ export type ModelManifest = {
     dashboardModel: DashboardModel;
     downloadFileModel: DownloadFileModel;
     downloadAuditModel: DownloadAuditModel;
+    persistentDownloadFileModel: PersistentDownloadFileModel;
     emailModel: EmailModel;
     githubAppInstallationsModel: GithubAppInstallationsModel;
     gitlabAppInstallationsModel: GitlabAppInstallationsModel;
@@ -249,6 +251,16 @@ export class ModelRepository
         return this.getModel(
             'downloadAuditModel',
             () => new DownloadAuditModel({ database: this.database }),
+        );
+    }
+
+    public getPersistentDownloadFileModel(): PersistentDownloadFileModel {
+        return this.getModel(
+            'persistentDownloadFileModel',
+            () =>
+                new PersistentDownloadFileModel({
+                    database: this.database,
+                }),
         );
     }
 

--- a/packages/backend/src/models/PersistentDownloadFileModel.ts
+++ b/packages/backend/src/models/PersistentDownloadFileModel.ts
@@ -1,0 +1,49 @@
+import { NotFoundError } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    DbPersistentDownloadFile,
+    PersistentDownloadFileTableName,
+} from '../database/entities/persistentDownloadFile';
+
+type PersistentDownloadFileModelArguments = {
+    database: Knex;
+};
+
+export class PersistentDownloadFileModel {
+    private database: Knex;
+
+    constructor(args: PersistentDownloadFileModelArguments) {
+        this.database = args.database;
+    }
+
+    async create(data: {
+        nanoid: string;
+        s3Key: string;
+        fileType: string;
+        organizationUuid: string;
+        projectUuid: string | null;
+        createdByUserUuid: string | null;
+    }): Promise<void> {
+        await this.database(PersistentDownloadFileTableName).insert({
+            nanoid: data.nanoid,
+            s3_key: data.s3Key,
+            file_type: data.fileType,
+            organization_uuid: data.organizationUuid,
+            project_uuid: data.projectUuid,
+            created_by_user_uuid: data.createdByUserUuid,
+        });
+    }
+
+    async get(nanoid: string): Promise<DbPersistentDownloadFile> {
+        const row = await this.database(PersistentDownloadFileTableName)
+            .where('nanoid', nanoid)
+            .select('*')
+            .first();
+
+        if (row === undefined) {
+            throw new NotFoundError('Cannot find file');
+        }
+
+        return row;
+    }
+}

--- a/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
+++ b/packages/backend/src/services/PersistentDownloadFileService/PersistentDownloadFileService.ts
@@ -1,0 +1,67 @@
+import { ForbiddenError } from '@lightdash/common';
+import { nanoid } from 'nanoid';
+import { S3Client } from '../../clients/Aws/S3Client';
+import { LightdashConfig } from '../../config/parseConfig';
+import { PersistentDownloadFileModel } from '../../models/PersistentDownloadFileModel';
+import { BaseService } from '../BaseService';
+
+type PersistentDownloadFileServiceArguments = {
+    lightdashConfig: LightdashConfig;
+    persistentDownloadFileModel: PersistentDownloadFileModel;
+    s3Client: S3Client;
+};
+
+export class PersistentDownloadFileService extends BaseService {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly persistentDownloadFileModel: PersistentDownloadFileModel;
+
+    private readonly s3Client: S3Client;
+
+    constructor({
+        lightdashConfig,
+        persistentDownloadFileModel,
+        s3Client,
+    }: PersistentDownloadFileServiceArguments) {
+        super();
+        this.lightdashConfig = lightdashConfig;
+        this.persistentDownloadFileModel = persistentDownloadFileModel;
+        this.s3Client = s3Client;
+    }
+
+    async createPersistentUrl(data: {
+        s3Key: string;
+        fileType: string;
+        organizationUuid: string;
+        projectUuid: string | null;
+        createdByUserUuid: string | null;
+    }): Promise<string> {
+        const fileNanoid = nanoid();
+        await this.persistentDownloadFileModel.create({
+            nanoid: fileNanoid,
+            s3Key: data.s3Key,
+            fileType: data.fileType,
+            organizationUuid: data.organizationUuid,
+            projectUuid: data.projectUuid,
+            createdByUserUuid: data.createdByUserUuid,
+        });
+
+        return new URL(
+            `/api/v1/file/${fileNanoid}`,
+            this.lightdashConfig.siteUrl,
+        ).href;
+    }
+
+    async getSignedUrl(
+        fileNanoid: string,
+        userOrganizationUuid: string,
+    ): Promise<string> {
+        const file = await this.persistentDownloadFileModel.get(fileNanoid);
+
+        if (userOrganizationUuid !== file.organization_uuid) {
+            throw new ForbiddenError('You do not have access to this file');
+        }
+
+        return this.s3Client.getFileUrl(file.s3_key);
+    }
+}

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -31,6 +31,7 @@ import { NotificationsService } from './NotificationsService/NotificationsServic
 import { OAuthService } from './OAuthService/OAuthService';
 import { OrganizationService } from './OrganizationService/OrganizationService';
 import { PermissionsService } from './PermissionsService/PermissionsService';
+import { PersistentDownloadFileService } from './PersistentDownloadFileService/PersistentDownloadFileService';
 import { PersonalAccessTokenService } from './PersonalAccessTokenService';
 import { PinningService } from './PinningService/PinningService';
 import { PivotTableService } from './PivotTableService/PivotTableService';
@@ -77,6 +78,7 @@ interface ServiceManifest {
     oauthService: OAuthService;
 
     organizationService: OrganizationService;
+    persistentDownloadFileService: PersistentDownloadFileService;
     personalAccessTokenService: PersonalAccessTokenService;
     pinningService: PinningService;
     pivotTableService: PivotTableService;
@@ -498,6 +500,19 @@ export class ServiceRepository
             () =>
                 new PermissionsService({
                     dashboardModel: this.models.getDashboardModel(),
+                }),
+        );
+    }
+
+    public getPersistentDownloadFileService(): PersistentDownloadFileService {
+        return this.getService(
+            'persistentDownloadFileService',
+            () =>
+                new PersistentDownloadFileService({
+                    lightdashConfig: this.context.lightdashConfig,
+                    persistentDownloadFileModel:
+                        this.models.getPersistentDownloadFileModel(),
+                    s3Client: this.clients.getS3Client(),
                 }),
         );
     }


### PR DESCRIPTION
Closes: PROD-2636

### Description

This is PR 1/3 in the persistent download URLs stack.

Introduces the persistent download file infrastructure: database table, entity types, model, and service. This is the foundation for stable download URLs that survive IAM credential rotation.

**Problem:** S3 pre-signed URLs expire when IAM credentials rotate, causing `ExpiredToken` errors for users clicking download links in scheduled deliveries (Slack, email).

**Solution:** Store a mapping of stable nanoid → S3 key in the database. Instead of returning raw S3 URLs, return `/api/v1/file/{nanoid}` URLs that generate fresh signed URLs on each access.

### Changes

- **Migration:** `persistent_download_files` table with nanoid PK, s3_key, file_type, organization_uuid, project_uuid, created_by_user_uuid
- **Entity:** Type definitions for the new table
- **Model:** `PersistentDownloadFileModel` with `create()` and `get()` methods
- **Service:** `PersistentDownloadFileService` with `createPersistentUrl()` and `getSignedUrl()`
- **Registrations:** Added to `ModelRepository` and `ServiceRepository`

### Stack

1. **This PR** — Database, model, and service layer
2. #20124 — HTTP endpoint (`GET /api/v1/file/{fileId}`)
3. #20125 — Feature flag gating and public expiring links