### PR TITLE
feat: add limit option to embedded dashboard chart exports

### DIFF
--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -306,6 +306,7 @@ export class EmbedController extends BaseController {
             | 'invalidateCache'
             | 'dateZoom'
             | 'parameters'
+            | 'limit'
         >,
     ): Promise<{
         status: 'ok';
@@ -326,6 +327,7 @@ export class EmbedController extends BaseController {
                 dashboardSorts: body.dashboardSorts,
                 parameters: body.parameters,
                 pivotResults: body.pivotResults,
+                limit: body.limit,
             });
 
         return {

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -934,6 +934,7 @@ export class EmbedService extends BaseService {
         dashboardSorts,
         parameters,
         pivotResults,
+        limit,
     }: {
         account: AnonymousAccount;
         projectUuid: string;
@@ -946,6 +947,7 @@ export class EmbedService extends BaseService {
         | 'invalidateCache'
         | 'dateZoom'
         | 'parameters'
+        | 'limit'
     >): Promise<ApiExecuteAsyncDashboardChartQueryResults> {
         const { dashboardUuids, allowAllDashboards, user } =
             await this.embedModel.get(projectUuid);
@@ -1031,7 +1033,7 @@ export class EmbedService extends BaseService {
             dashboardFilters: appliedDashboardFilters,
             dateZoom,
             invalidateCache,
-            limit: undefined,
+            limit,
             context: QueryExecutionContext.EMBED,
             parameters: combinedParameters,
             pivotResults,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -94,6 +94,7 @@ import {
     type DashboardChartReadyQuery,
 } from '../../hooks/dashboard/useDashboardChartReadyQuery';
 import useDashboardFiltersForTile from '../../hooks/dashboard/useDashboardFiltersForTile';
+import { useEmbedDashboardChartDownload } from '../../hooks/dashboard/useEmbedDashboardChartDownload';
 import { uploadGsheet } from '../../hooks/gdrive/useGdrive';
 import { useOrganization } from '../../hooks/organization/useOrganization';
 import useToaster from '../../hooks/toaster/useToaster';
@@ -1627,14 +1628,10 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         [],
     );
 
-    // For minimal tiles, we can reuse the existing queryUuid from dashboardChartReadyQuery
-    const getDownloadQueryUuid = useCallback(
-        async (_limit: number | null): Promise<string> => {
-            // The query has already been executed by dashboardChartReadyQuery
-            // We can simply return the queryUuid
-            return dashboardChartReadyQuery.executeQueryResponse.queryUuid;
-        },
-        [dashboardChartReadyQuery.executeQueryResponse.queryUuid],
+    const { getDownloadQueryUuid } = useEmbedDashboardChartDownload(
+        tileUuid,
+        projectUuid,
+        dashboardChartReadyQuery.executeQueryResponse.queryUuid,
     );
 
     const chartKind = useMemo(
@@ -1761,6 +1758,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     projectUuid={projectUuid!}
                     totalResults={resultsData.totalResults}
                     getDownloadQueryUuid={getDownloadQueryUuid}
+                    forceShowLimitSelection
                     showTableNames={
                         isTableChartConfig(chart.chartConfig.config)
                             ? (chart.chartConfig.config.showTableNames ?? false)

--- a/packages/frontend/src/components/ExportResults/index.tsx
+++ b/packages/frontend/src/components/ExportResults/index.tsx
@@ -53,6 +53,7 @@ export type ExportResultsProps = {
     chartName?: string;
     pivotConfig?: PivotConfig;
     hideLimitSelection?: boolean;
+    forceShowLimitSelection?: boolean;
     renderDialogActions?: (renderProps: ExportCsvRenderProps) => ReactNode;
 };
 
@@ -70,6 +71,7 @@ const ExportResults: FC<ExportResultsProps> = memo(
         chartName,
         pivotConfig,
         hideLimitSelection = false,
+        forceShowLimitSelection = false,
         renderDialogActions,
     }) => {
         const { showToastError, showToastInfo, showToastWarning } =
@@ -228,15 +230,8 @@ const ExportResults: FC<ExportResultsProps> = memo(
                             />
                         </Group>
                         <Stack gap="xs">
-                            <Can
-                                I="manage"
-                                this={subject('ChangeCsvResults', {
-                                    organizationUuid:
-                                        user.data?.organizationUuid,
-                                    projectUuid: projectUuid,
-                                })}
-                            >
-                                {!hideLimitSelection ? (
+                            {!hideLimitSelection &&
+                                (forceShowLimitSelection ? (
                                     <Group gap="xs">
                                         <Text fw={500} fz="sm">
                                             Limit
@@ -280,8 +275,60 @@ const ExportResults: FC<ExportResultsProps> = memo(
                                             />
                                         )}
                                     </Group>
-                                ) : null}
-                            </Can>
+                                ) : (
+                                    <Can
+                                        I="manage"
+                                        this={subject('ChangeCsvResults', {
+                                            organizationUuid:
+                                                user.data?.organizationUuid,
+                                            projectUuid: projectUuid,
+                                        })}
+                                    >
+                                        <Group gap="xs">
+                                            <Text fw={500} fz="sm">
+                                                Limit
+                                            </Text>
+                                            <SegmentedControl
+                                                size="xs"
+                                                radius="md"
+                                                value={limit}
+                                                onChange={(value) =>
+                                                    setLimit(value as Limit)
+                                                }
+                                                data={[
+                                                    {
+                                                        label: 'Results in Table',
+                                                        value: Limit.TABLE,
+                                                    },
+                                                    {
+                                                        label: 'All Results',
+                                                        value: Limit.ALL,
+                                                    },
+                                                    {
+                                                        label: 'Custom...',
+                                                        value: Limit.CUSTOM,
+                                                    },
+                                                ]}
+                                            />
+                                            {limit === Limit.CUSTOM && (
+                                                <NumberInput
+                                                    size="xs"
+                                                    min={1}
+                                                    w={70}
+                                                    radius="md"
+                                                    allowDecimal={false}
+                                                    required
+                                                    value={customLimit}
+                                                    onChange={(value) =>
+                                                        setCustomLimit(
+                                                            Number(value),
+                                                        )
+                                                    }
+                                                />
+                                            )}
+                                        </Group>
+                                    </Can>
+                                ))}
 
                             {/* Pivot table specific warnings */}
                             {isPivotTable && (

--- a/packages/frontend/src/hooks/dashboard/useEmbedDashboardChartDownload.ts
+++ b/packages/frontend/src/hooks/dashboard/useEmbedDashboardChartDownload.ts
@@ -1,0 +1,84 @@
+import {
+    QueryHistoryStatus,
+    type ApiExecuteAsyncDashboardChartQueryResults,
+} from '@lightdash/common';
+import { useCallback, useMemo } from 'react';
+import { lightdashApi } from '../../api';
+import { Limit } from '../../components/ExportResults/types';
+import { pollForResults } from '../../features/queryRunner/executeQuery';
+import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
+import useDashboardFiltersForTile from './useDashboardFiltersForTile';
+
+export const useEmbedDashboardChartDownload = (
+    tileUuid: string,
+    projectUuid: string | undefined,
+    originalQueryUuid: string,
+) => {
+    const dashboardFilters = useDashboardFiltersForTile(tileUuid);
+    const chartSort = useDashboardContext((c) => c.chartSort);
+    const parameters = useDashboardContext((c) => c.parameterValues);
+    const dashboardSorts = useMemo(
+        () => chartSort[tileUuid] || [],
+        [chartSort, tileUuid],
+    );
+    const dateZoomGranularity = useDashboardContext(
+        (c) => c.dateZoomGranularity,
+    );
+
+    const getDownloadQueryUuid = useCallback(
+        async (limit: number | null, limitType: Limit): Promise<string> => {
+            if (!projectUuid) {
+                throw new Error('Missing required parameters');
+            }
+
+            // When limiting to the table, use the original query uuid
+            if (limitType === Limit.TABLE) {
+                return originalQueryUuid;
+            }
+
+            // Execute a new query with the specified limit via embed endpoint
+            const executeQueryResponse =
+                await lightdashApi<ApiExecuteAsyncDashboardChartQueryResults>({
+                    url: `/embed/${projectUuid}/query/dashboard-tile`,
+                    method: 'POST',
+                    body: JSON.stringify({
+                        tileUuid,
+                        dashboardFilters: dashboardFilters || {},
+                        dashboardSorts: dashboardSorts || [],
+                        dateZoom: dateZoomGranularity
+                            ? { granularity: dateZoomGranularity }
+                            : undefined,
+                        limit,
+                        invalidateCache: false,
+                        parameters,
+                    }),
+                });
+
+            const results = await pollForResults(
+                projectUuid,
+                executeQueryResponse.queryUuid,
+            );
+
+            if (results.status === QueryHistoryStatus.ERROR) {
+                throw new Error(results.error || 'Error executing query');
+            }
+
+            if (results.status !== QueryHistoryStatus.READY) {
+                throw new Error('Unexpected query status');
+            }
+
+            return executeQueryResponse.queryUuid;
+        },
+        [
+            projectUuid,
+            tileUuid,
+            dashboardFilters,
+            dashboardSorts,
+            dateZoomGranularity,
+            parameters,
+            originalQueryUuid,
+        ],
+    );
+
+    return { getDownloadQueryUuid };
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/19024

Now the UI and functionality matches the export from other export modals. 

I don't think we need to add a new flag or permission check to enable "all results" on embedding. 


### Not embed
<img width="742" height="341" alt="Screenshot from 2026-02-10 10-04-34" src="https://github.com/user-attachments/assets/77d44e6f-f93f-4b7e-8201-7f04811dfa70" />

<img width="742" height="341" alt="Screenshot from 2026-02-10 10-05-58" src="https://github.com/user-attachments/assets/7f7a45a0-20ca-40f5-99f9-111bb9aaf7ab" />

### Embed 

Before:
<img width="742" height="341" alt="Screenshot from 2026-02-10 09-32-45" src="https://github.com/user-attachments/assets/60a19635-ca42-4896-a347-5c1c6445f99b" />

After:

<img width="742" height="341" alt="Screenshot from 2026-02-10 10-08-02" src="https://github.com/user-attachments/assets/083e09ab-3312-4e1b-affb-d22bc19e9f7f" />

<img width="742" height="341" alt="Screenshot from 2026-02-10 10-08-30" src="https://github.com/user-attachments/assets/c506f125-5a02-48c0-a3cc-4f92e00d375b" />
<img width="1012" height="529" alt="Screenshot from 2026-02-10 10-08-48" src="https://github.com/user-attachments/assets/baeff351-4675-4011-bc87-d777c2d4f9cf" />



### Description:
Adds support for custom row limits when exporting data from embedded dashboard charts. This enhancement allows users to specify the number of rows to include in exports, with options for using the table's current limit, all results, or a custom limit.

The implementation includes:
- Adding a `limit` parameter to the embed controller and service
- Creating a new `useEmbedDashboardChartDownload` hook to handle limit-specific queries
- Updating the export UI to show limit selection options in embedded contexts
- Adding a `forceShowLimitSelection` prop to make limit controls visible in embedded views