### PR TITLE
feat: add toggle to show/hide org members without project roles

### DIFF
--- a/packages/frontend/src/components/ProjectAccess/ProjectAccessRowV2.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccessRowV2.tsx
@@ -233,13 +233,28 @@ const ProjectAccessRowV2: FC<Props> = ({
                     <Group spacing="xs">
                         <Tooltip
                             disabled={hasProjectRole}
+                            multiline
+                            w={isMember && !hasProjectRole ? 280 : undefined}
                             label={
-                                <Text>
-                                    User inherits this role from{' '}
-                                    <Text span fw={600}>
-                                        {highestRoleType}
+                                isMember && !hasProjectRole ? (
+                                    <Text>
+                                        <Text fw={600}>
+                                            Members have no access to this
+                                            project.
+                                        </Text>
+                                        <Text>
+                                            Assign a project role to grant them
+                                            visibility.
+                                        </Text>
                                     </Text>
-                                </Text>
+                                ) : (
+                                    <Text>
+                                        User inherits this role from{' '}
+                                        <Text span fw={600}>
+                                            {highestRoleType}
+                                        </Text>
+                                    </Text>
+                                )
                             }
                         >
                             <Select
@@ -252,7 +267,7 @@ const ProjectAccessRowV2: FC<Props> = ({
                                         ? [
                                               {
                                                   value: 'member',
-                                                  label: 'member',
+                                                  label: 'member (no project access)',
                                                   group: 'Organization role',
                                               },
                                               ...organizationRoles,


### PR DESCRIPTION
Closes: #20132

### Description:
This PR improves the Project Access UI by adding a toggle to show/hide organization members who don't have explicit project roles.

**Changes:**
- Added a `showMembersOnly` state to filter users based on their project role assignment
- Implemented filtering logic to hide org-level members without direct project roles by default
- Added a switch toggle that appears when there are hidden members, allowing users to show them
- Added an info tooltip explaining that members have no project access by default
- Updated the role selection dropdown to clarify that "member" means "no project access"
- Enhanced tooltips in `ProjectAccessRowV2` to provide better context for members without project roles
- Updated the search/filter reset logic to account for the new filter state

**Benefits:**
- Cleaner default view focusing on users with actual project roles
- Users can still access the full member list when needed
- Better UX with clear explanations of member access levels
- Improved discoverability of why certain members don't have project visibility

https://claude.ai/code/session_012KT39WnGLyMfjGES4vMe67