### PR TITLE
fix: add user to membership via invite link if set up

### DIFF
--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -46,10 +46,9 @@ import {
     PasswordLoginTableName,
 } from '../database/entities/passwordLogins';
 import { DbPersonalAccessToken } from '../database/entities/personalAccessTokens';
-import {
-    RolesTableName,
-    ScopedRolesTableName,
-} from '../database/entities/roles';
+import { ProjectMembershipsTableName } from '../database/entities/projectMemberships';
+import { ProjectTableName } from '../database/entities/projects';
+import { ScopedRolesTableName } from '../database/entities/roles';
 import {
     DbUser,
     DbUserIn,
@@ -494,9 +493,9 @@ export class UserModel {
     > {
         const projectMemberships = await this.database('project_memberships')
             .leftJoin(
-                'projects',
+                ProjectTableName,
                 'project_memberships.project_id',
-                'projects.project_id',
+                `${ProjectTableName}.project_id`,
             )
             .leftJoin('users', 'project_memberships.user_id', 'users.user_id')
             .select('*')
@@ -1006,6 +1005,39 @@ export class UserModel {
             await Promise.all(projectMemberships);
         });
         return this.getUserDetailsByUuid(userUuid);
+    }
+
+    async addProjectMemberships(
+        userUuid: string,
+        projects: { [projectUuid: string]: ProjectMemberRole },
+    ): Promise<void> {
+        const [user] = await this.database(UserTableName)
+            .where('user_uuid', userUuid)
+            .select('user_id');
+        if (!user) {
+            throw new NotFoundError('Cannot find user');
+        }
+
+        const projectMemberships = Object.entries(projects).map(
+            async ([projectUuid, projectRole]) => {
+                const [project] = await this.database(ProjectTableName)
+                    .select('project_id')
+                    .where('project_uuid', projectUuid);
+
+                if (project) {
+                    await this.database(ProjectMembershipsTableName)
+                        .insert({
+                            project_id: project.project_id,
+                            role: projectRole,
+                            user_id: user.user_id,
+                        })
+                        .onConflict(['project_id', 'user_id'])
+                        .ignore();
+                }
+            },
+        );
+
+        await Promise.all(projectMemberships);
     }
 
     async getRefreshToken(

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -37,6 +37,7 @@ import {
     OrganizationMemberRole,
     ParameterError,
     PasswordReset,
+    ProjectMemberRole,
     RegisterOrActivateUser,
     SessionUser,
     SnowflakeAuthenticationType,
@@ -285,6 +286,51 @@ export class UserService extends BaseService {
             activateUser,
         );
         await this.inviteLinkModel.deleteByCode(inviteLink.inviteCode);
+
+        // Apply default project memberships from allowed email domains config.
+        // Wrapped in try-catch because the user is already activated and the
+        // invite link is deleted — a failure here must not break activation.
+        try {
+            if (
+                user.organizationUuid &&
+                user.role === OrganizationMemberRole.MEMBER
+            ) {
+                const allowedEmailDomains =
+                    await this.organizationAllowedEmailDomainsModel.findAllowedEmailDomains(
+                        user.organizationUuid,
+                    );
+                if (allowedEmailDomains) {
+                    const emailDomain = getEmailDomain(userEmail);
+                    if (
+                        allowedEmailDomains.emailDomains.some(
+                            (domain) =>
+                                domain.toLowerCase() === emailDomain,
+                        ) &&
+                        allowedEmailDomains.projects.length > 0
+                    ) {
+                        const projectMemberships =
+                            allowedEmailDomains.projects.reduce<
+                                Record<string, ProjectMemberRole>
+                            >(
+                                (acc, project) => ({
+                                    ...acc,
+                                    [project.projectUuid]: project.role,
+                                }),
+                                {},
+                            );
+                        await this.userModel.addProjectMemberships(
+                            user.userUuid,
+                            projectMemberships,
+                        );
+                    }
+                }
+            }
+        } catch (e) {
+            this.logger.warn(
+                `Failed to apply default project memberships for invited user ${user.userUuid}: ${e}`,
+            );
+        }
+
         this.identifyUser(user);
         this.analytics.track({
             event: 'user.created',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Revert of the revert: `Fix: revert "fix: add user to membership via invite link if set up (#20120)" (#20129)`
Related: #20120 & #20129
No issues with this

### Description:
Adds functionality to automatically assign project memberships to users when they are activated via an invite link, based on their email domain. This feature leverages the existing allowed email domains configuration to determine which projects a new user should be added to.

The implementation includes:
- A new `addProjectMemberships` method in the UserModel to handle adding users to multiple projects
- Logic in the UserService to check if the user's email domain matches any allowed domains and assign appropriate project roles
- Error handling to ensure user activation succeeds even if project membership assignment fails

This enhancement streamlines the onboarding process by automatically granting new users access to relevant projects based on their organizational email domain.