### PR TITLE
chore: update access check in getSpace

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -2208,7 +2208,7 @@ export class SpaceModel {
 
     async getFullSpace(
         spaceUuid: string,
-        options: { useInheritedAccess: boolean },
+        options?: { useInheritedAccess: boolean },
     ): Promise<Space> {
         const space = await this.get(spaceUuid);
         const { spaceRoot: rootSpaceUuid } =
@@ -2221,7 +2221,7 @@ export class SpaceModel {
         // If useInheritedAccess is true, use getEffectiveSpaceAccess which resolves
         // permissions through the inheritance chain. Otherwise, use the root space's
         // direct access only (legacy behavior).
-        const access = options.useInheritedAccess
+        const access = options?.useInheritedAccess
             ? await this.getEffectiveSpaceAccess(spaceUuid)
             : ((await this._getSpaceAccess([rootSpaceUuid]))[rootSpaceUuid] ??
               []);

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -760,6 +760,7 @@ export class ServiceRepository
                     spaceModel: this.models.getSpaceModel(),
                     pinnedListModel: this.models.getPinnedListModel(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -11,6 +11,7 @@ import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SpaceModel } from '../../models/SpaceModel';
+import { SpacePermissionService } from './SpacePermissionService';
 import { SpaceService } from './SpaceService';
 import {
     createSpaceAccessResponse,
@@ -34,6 +35,7 @@ describe('SpaceService', () => {
             spaceModel: new SpaceModel({ database: db }),
             pinnedListModel: {} as PinnedListModel,
             featureFlagModel: {} as FeatureFlagModel,
+            spacePermissionService: {} as SpacePermissionService,
         });
     });
 


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new

### Description:

Use space permissions service to check access in `SpaceService.getSpace()`. There are many more instances of old access in the space service. This is a start. 

Also started to remove reliance on `useInheritedAccess` for access checks. 

Might need more test coverage.
