### PR TITLE
feat: add metrics trees and nodes tables

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -145,6 +145,10 @@ import {
     CatalogTagsTableName,
     type MetricsTreeEdgesTable,
     MetricsTreeEdgesTableName,
+    type MetricsTreeNodesTable,
+    MetricsTreeNodesTableName,
+    type MetricsTreesTable,
+    MetricsTreesTableName,
 } from '../database/entities/catalog';
 import {
     DashboardTileCommentsTable,
@@ -422,6 +426,8 @@ declare module 'knex/types/tables' {
         [CatalogTagsTableName]: CatalogTagsTable;
         [ServiceAccountsTableName]: ServiceAccountTable;
         [MetricsTreeEdgesTableName]: MetricsTreeEdgesTable;
+        [MetricsTreesTableName]: MetricsTreesTable;
+        [MetricsTreeNodesTableName]: MetricsTreeNodesTable;
         [SpotlightTableConfigTableName]: SpotlightTableConfigTable;
         [OrganizationColorPaletteTableName]: OrganizationColorPaletteTable;
         [OrganizationWarehouseCredentialsTableName]: OrganizationWarehouseCredentialsTable;

--- a/packages/backend/src/database/entities/catalog.ts
+++ b/packages/backend/src/database/entities/catalog.ts
@@ -162,3 +162,75 @@ export type MetricsTreeEdgesTable = Knex.CompositeTableType<
 >;
 
 export const MetricsTreeEdgesTableName = 'metrics_tree_edges';
+
+// --- Metrics Trees ---
+
+export const MetricsTreesTableName = 'metrics_trees';
+
+export type DbMetricsTree = {
+    metrics_tree_uuid: string;
+    project_uuid: string;
+    slug: string;
+    name: string;
+    description: string | null;
+    source: 'yaml' | 'ui';
+    created_by_user_uuid: string | null;
+    updated_by_user_uuid: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbMetricsTreeIn = Pick<
+    DbMetricsTree,
+    | 'project_uuid'
+    | 'slug'
+    | 'name'
+    | 'description'
+    | 'source'
+    | 'created_by_user_uuid'
+>;
+
+export type DbMetricsTreeUpdate = Pick<
+    DbMetricsTree,
+    'name' | 'description' | 'updated_at' | 'updated_by_user_uuid'
+>;
+
+export type MetricsTreesTable = Knex.CompositeTableType<
+    DbMetricsTree,
+    DbMetricsTreeIn,
+    Partial<DbMetricsTreeUpdate>
+>;
+
+// --- Metrics Tree Nodes ---
+
+export const MetricsTreeNodesTableName = 'metrics_tree_nodes';
+
+export type DbMetricsTreeNode = {
+    metrics_tree_uuid: string;
+    catalog_search_uuid: string;
+    x_position: number | null;
+    y_position: number | null;
+    source: 'yaml' | 'ui';
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbMetricsTreeNodeIn = Pick<
+    DbMetricsTreeNode,
+    | 'metrics_tree_uuid'
+    | 'catalog_search_uuid'
+    | 'x_position'
+    | 'y_position'
+    | 'source'
+>;
+
+export type DbMetricsTreeNodeUpdate = Pick<
+    DbMetricsTreeNode,
+    'x_position' | 'y_position'
+>;
+
+export type MetricsTreeNodesTable = Knex.CompositeTableType<
+    DbMetricsTreeNode,
+    DbMetricsTreeNodeIn,
+    Partial<DbMetricsTreeNodeUpdate>
+>;

--- a/packages/backend/src/database/migrations/20260210095213_add_metrics_tree_and_tree_nodes_tables.ts
+++ b/packages/backend/src/database/migrations/20260210095213_add_metrics_tree_and_tree_nodes_tables.ts
@@ -1,0 +1,89 @@
+import { Knex } from 'knex';
+
+const METRICS_TREES_TABLE = 'metrics_trees';
+const METRICS_TREE_NODES_TABLE = 'metrics_tree_nodes';
+const PROJECTS_TABLE = 'projects';
+const USERS_TABLE = 'users';
+const CATALOG_SEARCH_TABLE = 'catalog_search';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(METRICS_TREES_TABLE, (table) => {
+        table.uuid('metrics_tree_uuid').primary().defaultTo(knex.fn.uuid());
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable(PROJECTS_TABLE)
+            .onDelete('CASCADE');
+        table.string('slug', 255).notNullable();
+        table.string('name', 255).notNullable();
+        table.text('description').nullable();
+        table
+            .string('source', 10)
+            .notNullable()
+            .defaultTo('ui')
+            .comment('Source of the tree: yaml or ui');
+        table
+            .uuid('created_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL');
+        table
+            .uuid('updated_by_user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable(USERS_TABLE)
+            .onDelete('SET NULL');
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.unique(['project_uuid', 'slug']);
+        table.index('project_uuid');
+        table.index(['project_uuid', 'source']);
+    });
+
+    await knex.schema.createTable(METRICS_TREE_NODES_TABLE, (table) => {
+        table
+            .uuid('metrics_tree_uuid')
+            .notNullable()
+            .references('metrics_tree_uuid')
+            .inTable(METRICS_TREES_TABLE)
+            .onDelete('CASCADE');
+        table
+            .uuid('catalog_search_uuid')
+            .notNullable()
+            .references('catalog_search_uuid')
+            .inTable(CATALOG_SEARCH_TABLE)
+            .onDelete('CASCADE');
+        table.double('x_position').nullable();
+        table.double('y_position').nullable();
+        table
+            .string('source', 10)
+            .notNullable()
+            .defaultTo('ui')
+            .comment('Source of the node: yaml or ui');
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.primary(['metrics_tree_uuid', 'catalog_search_uuid']);
+        table.index('metrics_tree_uuid');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(METRICS_TREE_NODES_TABLE);
+    await knex.schema.dropTableIfExists(METRICS_TREES_TABLE);
+}

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -121,7 +121,10 @@ export type CatalogMetricsTreeNode = Pick<
     'catalogSearchUuid' | 'name' | 'tableName'
 >;
 
-export type CatalogMetricsTreeEdgeSource = 'ui' | 'yaml';
+export type MetricsTreeSource = 'ui' | 'yaml';
+
+/** @deprecated Use MetricsTreeSource instead */
+export type CatalogMetricsTreeEdgeSource = MetricsTreeSource;
 
 export type CatalogMetricsTreeEdge = {
     source: CatalogMetricsTreeNode;
@@ -129,7 +132,89 @@ export type CatalogMetricsTreeEdge = {
     createdAt: Date;
     createdByUserUuid: string | null;
     projectUuid: string;
-    createdFrom: CatalogMetricsTreeEdgeSource;
+    createdFrom: MetricsTreeSource;
+};
+
+// --- Saved Metrics Trees ---
+
+export type MetricsTree = {
+    metricsTreeUuid: string;
+    projectUuid: string;
+    slug: string;
+    name: string;
+    description: string | null;
+    source: MetricsTreeSource;
+    createdByUserUuid: string | null;
+    updatedByUserUuid: string | null;
+    createdAt: Date;
+    updatedAt: Date;
+};
+
+export type MetricsTreeSummary = MetricsTree & {
+    nodeCount: number;
+};
+
+export type MetricsTreeNodePosition = {
+    catalogSearchUuid: string;
+    xPosition: number | null;
+    yPosition: number | null;
+};
+
+export type MetricsTreeNode = MetricsTreeNodePosition & {
+    name: string;
+    tableName: string;
+    source: MetricsTreeSource;
+};
+
+export type MetricsTreeWithDetails = MetricsTree & {
+    nodes: MetricsTreeNode[];
+    edges: CatalogMetricsTreeEdge[];
+};
+
+// --- Saved Metrics Trees API Types ---
+
+export type ApiCreateMetricsTreePayload = {
+    name: string;
+    slug?: string;
+    description?: string;
+    nodeUuids: string[];
+};
+
+export type ApiUpdateMetricsTreePayload = {
+    name?: string;
+    description?: string;
+};
+
+export type ApiAddMetricsTreeNodesPayload = {
+    nodes: Array<{
+        catalogSearchUuid: string;
+        xPosition?: number;
+        yPosition?: number;
+    }>;
+};
+
+export type ApiUpdateMetricsTreeNodePositionsPayload = {
+    positions: MetricsTreeNodePosition[];
+};
+
+export type ApiGetMetricsTreesResponse = {
+    status: 'ok';
+    results: MetricsTreeSummary[];
+};
+
+export type ApiGetMetricsTreeResponse = {
+    status: 'ok';
+    results: MetricsTreeWithDetails;
+};
+
+export type ApiCreateMetricsTreeResponse = {
+    status: 'ok';
+    results: MetricsTree;
+};
+
+export type ApiGetUnassignedMetricsResponse = {
+    status: 'ok';
+    results: CatalogMetricsTreeNode[];
 };
 
 export type ApiCatalogResults = CatalogItem[];

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/TreeComponents/edges/DefaultEdge.tsx
@@ -1,4 +1,4 @@
-import { type CatalogMetricsTreeEdgeSource } from '@lightdash/common';
+import { type MetricsTreeSource } from '@lightdash/common';
 import {
     BaseEdge,
     getSimpleBezierPath,
@@ -8,7 +8,7 @@ import {
 import type { FC } from 'react';
 
 type DefaultEdgeData = Edge<{
-    createdFrom?: CatalogMetricsTreeEdgeSource;
+    createdFrom?: MetricsTreeSource;
 }>;
 
 const DefaultEdge: FC<EdgeProps<DefaultEdgeData>> = ({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: ZAP-234, ZAP-236, ZAP-235

### Description:
This PR adds database support for saved metrics trees by introducing two new tables: `metrics_trees` and `metrics_tree_nodes`. 

The changes include:
- Creating database migration for the new tables with appropriate schema definitions
- Adding TypeScript type definitions for the new tables in the backend
- Registering the new tables with Knex
- Defining API types for metrics tree operations in the common package
- Renaming `CatalogMetricsTreeEdgeSource` to `MetricsTreeSource` (with backward compatibility)

These changes will enable storing and managing metrics trees, which can be created from either the UI or YAML files, along with their associated nodes and positions.