### PR TITLE
feat: add API endpoint to list saved metrics trees

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -15,6 +15,7 @@ import {
     type ApiGetAllMetricsTreeEdges,
     type ApiGetMetricsTree,
     type ApiGetMetricsTreePayload,
+    type ApiGetMetricsTreesResponse,
     type ApiMetricsTreeEdgePayload,
     type ApiMetricsWithAssociatedTimeDimensionResponse,
     type ApiSort,
@@ -661,6 +662,38 @@ export class CatalogController extends BaseController {
     }
 
     // --- Saved Metrics Trees ---
+
+    /**
+     * List saved metrics trees for a project
+     * @summary List metrics trees
+     * @param projectUuid
+     * @param page Page number (1-indexed)
+     * @param pageSize Number of trees per page
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/metrics/trees')
+    @OperationId('getMetricsTrees')
+    async getMetricsTrees(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() page?: number,
+        @Query() pageSize?: number,
+    ): Promise<ApiGetMetricsTreesResponse> {
+        this.setStatus(200);
+
+        const paginateArgs: KnexPaginateArgs | undefined =
+            page && pageSize ? { page, pageSize } : undefined;
+
+        const results = await this.services
+            .getCatalogService()
+            .getMetricsTrees(req.user!, projectUuid, paginateArgs);
+
+        return {
+            status: 'ok',
+            results,
+        };
+    }
 
     /**
      * Create a new saved metrics tree with nodes and edges

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -32,6 +32,7 @@ import {
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type MetricsTree,
+    type MetricsTreeSummary,
     type SessionUser,
     type TablesConfiguration,
     type Tag,
@@ -50,6 +51,7 @@ import {
     getDbCatalogColumnFromCatalogProperty,
     type DbCatalog,
     type DbCatalogTagsMigrateIn,
+    type DbMetricsTree,
     type DbMetricsTreeEdge,
     type DbMetricsTreeEdgeDelete,
     type DbMetricsTreeEdgeIn,
@@ -1737,6 +1739,48 @@ export class CatalogModel {
     }
 
     // --- Saved Metrics Trees ---
+
+    async getMetricsTrees(
+        projectUuid: string,
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<MetricsTreeSummary[]>> {
+        const query = this.database(MetricsTreesTableName)
+            .select<(DbMetricsTree & { node_count: number })[]>(
+                `${MetricsTreesTableName}.*`,
+                this.database.raw(
+                    `COALESCE(COUNT(${MetricsTreeNodesTableName}.catalog_search_uuid), 0)::int as node_count`,
+                ),
+            )
+            .leftJoin(
+                MetricsTreeNodesTableName,
+                `${MetricsTreesTableName}.metrics_tree_uuid`,
+                `${MetricsTreeNodesTableName}.metrics_tree_uuid`,
+            )
+            .where(`${MetricsTreesTableName}.project_uuid`, projectUuid)
+            .groupBy(`${MetricsTreesTableName}.metrics_tree_uuid`)
+            .orderBy(`${MetricsTreesTableName}.updated_at`, 'desc');
+
+        const result = await KnexPaginate.paginate(query, paginateArgs);
+
+        return {
+            data: (
+                result.data as (DbMetricsTree & { node_count: number })[]
+            ).map((row) => ({
+                metricsTreeUuid: row.metrics_tree_uuid,
+                projectUuid: row.project_uuid,
+                slug: row.slug,
+                name: row.name,
+                description: row.description,
+                source: row.source,
+                createdByUserUuid: row.created_by_user_uuid,
+                updatedByUserUuid: row.updated_by_user_uuid,
+                createdAt: row.created_at,
+                updatedAt: row.updated_at,
+                nodeCount: row.node_count,
+            })),
+            pagination: result.pagination,
+        };
+    }
 
     async createMetricsTree(
         tree: DbMetricsTreeIn,

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -47,6 +47,7 @@ import {
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type MetricsTree,
+    type MetricsTreeSummary,
 } from '@lightdash/common';
 import { uniqBy } from 'lodash';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
@@ -1529,6 +1530,26 @@ export class CatalogService<
     }
 
     // --- Saved Metrics Trees ---
+
+    async getMetricsTrees(
+        user: SessionUser,
+        projectUuid: string,
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<MetricsTreeSummary[]>> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+
+        if (
+            user.ability.cannot(
+                'view',
+                subject('MetricsTree', { projectUuid, organizationUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        return this.catalogModel.getMetricsTrees(projectUuid, paginateArgs);
+    }
 
     async createMetricsTree(
         user: SessionUser,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -51,6 +51,7 @@ import {
     type ApiCatalogAnalyticsResults,
     type ApiCatalogMetadataResults,
     type ApiGetMetricsTree,
+    type ApiGetMetricsTreesResponse,
     type ApiMetricsCatalog,
 } from './catalog';
 import { type ApiGetChangeResponse } from './changeset';
@@ -808,6 +809,7 @@ type ApiResults =
     | ApiDashboardAsCodeListResponse['results']
     | ApiChartAsCodeUpsertResponse['results']
     | ApiGetMetricsTree['results']
+    | ApiGetMetricsTreesResponse['results']
     | ApiMetricsExplorerTotalResults['results']
     | ApiGetSpotlightTableConfig['results']
     | ApiCalculateSubtotalsResponse['results']

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -208,7 +208,7 @@ export type ApiUpdateMetricsTreeNodePositionsPayload = {
 
 export type ApiGetMetricsTreesResponse = {
     status: 'ok';
-    results: MetricsTreeSummary[];
+    results: KnexPaginatedData<MetricsTreeSummary[]>;
 };
 
 export type ApiGetMetricsTreeResponse = {


### PR DESCRIPTION
### Description:
Adds a new API endpoint to list saved metrics trees for a project. The implementation includes:

- New controller method `getMetricsTrees` in `CatalogController` to handle GET requests to `/metrics/trees`
- Database query in `CatalogModel` to fetch metrics trees with node counts
- Service method in `CatalogService` to handle authorization and call the model
- Updated type definition in `catalog.ts` for the API response

This endpoint supports pagination through optional `page` and `pageSize` query parameters and returns metrics trees ordered by most recently updated.