### PR TITLE
refactor: replace sessionStorage with Redux for dashboard editing state

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -4,6 +4,7 @@ import {
     type CreateChartInDashboard,
     type CreateDashboardChartTile,
     type CreateSavedChartVersion,
+    type DashboardTile,
 } from '@lightdash/common';
 import {
     Button,
@@ -133,7 +134,9 @@ export const SaveToDashboard: FC<Props> = ({
                     : selectedDashboard?.tiles;
 
             setUnsavedDashboardTiles(
-                appendNewTilesToBottom(existingTiles || [], [newTile]),
+                appendNewTilesToBottom(existingTiles || [], [
+                    newTile as DashboardTile,
+                ]),
             );
 
             clearIsEditingDashboardChart();

--- a/packages/frontend/src/features/dashboard/store/dashboardEditingSlice.ts
+++ b/packages/frontend/src/features/dashboard/store/dashboardEditingSlice.ts
@@ -1,0 +1,79 @@
+import {
+    type CreateDashboardChartTile,
+    type DashboardFilters,
+    type DashboardTab,
+    type DashboardTile,
+} from '@lightdash/common';
+import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export interface DashboardEditingState {
+    dashboardName: string | null;
+    dashboardUuid: string | null;
+    unsavedTiles: DashboardTile[] | CreateDashboardChartTile[] | null;
+    unsavedFilters: DashboardFilters | null;
+    tabs: DashboardTab[] | null;
+    hasChanges: boolean;
+    activeTabUuid: string | null;
+}
+
+const initialState: DashboardEditingState = {
+    dashboardName: null,
+    dashboardUuid: null,
+    unsavedTiles: null,
+    unsavedFilters: null,
+    tabs: null,
+    hasChanges: false,
+    activeTabUuid: null,
+};
+
+export const dashboardEditingSlice = createSlice({
+    name: 'dashboardEditing',
+    initialState,
+    reducers: {
+        storeDashboard(
+            state,
+            action: PayloadAction<{
+                dashboardName: string;
+                dashboardUuid: string;
+                unsavedTiles: DashboardTile[];
+                unsavedFilters: DashboardFilters | null;
+                tabs: DashboardTab[] | null;
+                hasChanges: boolean;
+                activeTabUuid: string | null;
+            }>,
+        ) {
+            state.dashboardName = action.payload.dashboardName;
+            state.dashboardUuid = action.payload.dashboardUuid;
+            state.unsavedTiles = action.payload.unsavedTiles;
+            state.unsavedFilters = action.payload.unsavedFilters;
+            state.tabs = action.payload.tabs;
+            state.hasChanges = action.payload.hasChanges;
+            state.activeTabUuid = action.payload.activeTabUuid;
+        },
+        setChartInfo(
+            state,
+            action: PayloadAction<{
+                name: string;
+                dashboardUuid: string;
+            }>,
+        ) {
+            state.dashboardName = action.payload.name;
+            state.dashboardUuid = action.payload.dashboardUuid;
+        },
+        clearChartInfo(state) {
+            state.dashboardName = null;
+            state.dashboardUuid = null;
+        },
+        clearAll() {
+            return initialState;
+        },
+        setUnsavedTiles(
+            state,
+            action: PayloadAction<DashboardTile[] | CreateDashboardChartTile[]>,
+        ) {
+            state.unsavedTiles = action.payload;
+        },
+    },
+});
+
+export const dashboardEditingActions = dashboardEditingSlice.actions;

--- a/packages/frontend/src/features/dashboard/store/index.ts
+++ b/packages/frontend/src/features/dashboard/store/index.ts
@@ -1,0 +1,18 @@
+// FIXES ts2742 issue with configureStore
+// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
+import type * as rtk from '@reduxjs/toolkit';
+import { configureStore } from '@reduxjs/toolkit';
+import { dashboardEditingSlice } from './dashboardEditingSlice';
+
+export const dashboardEditingStore = configureStore({
+    reducer: {
+        [dashboardEditingSlice.name]: dashboardEditingSlice.reducer,
+    },
+    devTools: process.env.NODE_ENV === 'development',
+});
+
+export type DashboardEditingRootState = ReturnType<
+    typeof dashboardEditingStore.getState
+>;
+
+export { dashboardEditingActions } from './dashboardEditingSlice';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Replaces session storage with Redux for dashboard editing state management. This change moves dashboard editing state (tiles, filters, tabs, etc.) from browser session storage to a Redux store, providing better type safety and state management. The implementation includes a new `dashboardEditingSlice` with actions for storing, updating, and clearing dashboard state, along with corresponding hooks to access this state.

The PR also fixes a type casting issue in `SaveToDashboard.tsx` by explicitly casting `newTile` to `DashboardTile`.