### PR TITLE
fix: filter stuck jobs without jobUuid before updating Lightdash jobs table

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1242,7 +1242,13 @@ export class SchedulerClient {
             lockedAt: Date;
             lockedBy: string;
             runAt: Date;
-            payload: Record<string, unknown>;
+            payload: {
+                jobUuid?: string;
+                schedulerUuid?: string;
+                projectUuid?: string;
+                organizationUuid?: string;
+                userUuid?: string;
+            };
         }[]
     > {
         const graphileClient = await this.graphileUtils;
@@ -1268,7 +1274,7 @@ export class SchedulerClient {
                 locked_at: Date;
                 locked_by: string;
                 run_at: Date;
-                payload: Record<string, unknown> | null;
+                payload: Record<string, string | undefined> | null;
             }) => ({
                 id: row.id,
                 taskIdentifier: row.task_identifier,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1426,9 +1426,7 @@ export class SchedulerService extends BaseService {
             jobsToLog.map(({ job, durationMinutes }) =>
                 this.schedulerModel.logSchedulerJob({
                     task: job.taskIdentifier as SchedulerTaskName,
-                    schedulerUuid: job.payload.schedulerUuid as
-                        | string
-                        | undefined,
+                    schedulerUuid: job.payload.schedulerUuid,
                     jobId: job.id,
                     scheduledTime: job.runAt,
                     status: SchedulerJobStatus.ERROR,
@@ -1436,24 +1434,22 @@ export class SchedulerService extends BaseService {
                         error: 'This job took longer than expected and was stopped after 1 hour—please try again. If the issue persists, contact support.',
                         lockedAt: job.lockedAt.toISOString(),
                         lockedBy: job.lockedBy,
-                        projectUuid: job.payload.projectUuid as
-                            | string
-                            | undefined,
-                        organizationUuid: job.payload.organizationUuid as
-                            | string
-                            | undefined,
-                        createdByUserUuid: job.payload.userUuid as
-                            | string
-                            | undefined,
+                        projectUuid: job.payload.projectUuid,
+                        organizationUuid: job.payload.organizationUuid,
+                        createdByUserUuid: job.payload.userUuid,
                     },
                 }),
             ),
         );
 
         // Update Lightdash job status to ERROR for compile project jobs
+        // Only compile/createProject tasks have a jobUuid in their payload
+        const stuckJobUuids = jobsToLog
+            .map(({ job }) => job.payload.jobUuid)
+            .filter((uuid): uuid is string => typeof uuid === 'string');
         await Promise.all(
-            jobsToLog.map(({ job }) =>
-                this.jobModel.update(job.payload.jobUuid as string, {
+            stuckJobUuids.map((jobUuid) =>
+                this.jobModel.update(jobUuid, {
                     jobStatus: JobStatusType.ERROR,
                 }),
             ),


### PR DESCRIPTION
## Summary
- Filter stuck Graphile Worker jobs to only those with a `jobUuid` in their payload before calling `JobModel.update()`
- Only compile/createProject tasks create records in the Lightdash `jobs` table — other tasks (scheduled deliveries, Google Sheets uploads, notifications) don't have `jobUuid`, causing `Undefined binding` Knex errors

## Sentry Issue
Fixes [LIGHTDASH-BACKEND-BK7](https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-BK7) — 146 events, 32 users since Jan 9

## Test plan
- [ ] Verify `checkForStuckJobs` no longer throws when processing stuck jobs without `jobUuid`
- [ ] Verify stuck compile project jobs still get their status updated to ERROR
- [ ] Verify stuck non-compile jobs (deliveries, gsheets) are still failed in the Graphile queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)