### PR TITLE
fix: filter stuck jobs without jobUuid before updating Lightdash jobs table

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1451,8 +1451,12 @@ export class SchedulerService extends BaseService {
         );
 
         // Update Lightdash job status to ERROR for compile project jobs
+        // Only compile/createProject tasks have a jobUuid in their payload
+        const jobsWithLightdashJob = jobsToLog.filter(
+            ({ job }) => typeof job.payload.jobUuid === 'string',
+        );
         await Promise.all(
-            jobsToLog.map(({ job }) =>
+            jobsWithLightdashJob.map(({ job }) =>
                 this.jobModel.update(job.payload.jobUuid as string, {
                     jobStatus: JobStatusType.ERROR,
                 }),


### PR DESCRIPTION
## Summary
- Filter stuck Graphile Worker jobs to only those with a `jobUuid` in their payload before calling `JobModel.update()`
- Only compile/createProject tasks create records in the Lightdash `jobs` table — other tasks (scheduled deliveries, Google Sheets uploads, notifications) don't have `jobUuid`, causing `Undefined binding` Knex errors

## Sentry Issue
Fixes [LIGHTDASH-BACKEND-BK7](https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-BK7) — 146 events, 32 users since Jan 9

## Test plan
- [ ] Verify `checkForStuckJobs` no longer throws when processing stuck jobs without `jobUuid`
- [ ] Verify stuck compile project jobs still get their status updated to ERROR
- [ ] Verify stuck non-compile jobs (deliveries, gsheets) are still failed in the Graphile queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)