### PR TITLE
refactor: type getRecentRunningJobs payload and remove unsafe casts

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1242,7 +1242,13 @@ export class SchedulerClient {
             lockedAt: Date;
             lockedBy: string;
             runAt: Date;
-            payload: Record<string, unknown>;
+            payload: {
+                jobUuid?: string;
+                schedulerUuid?: string;
+                projectUuid?: string;
+                organizationUuid?: string;
+                userUuid?: string;
+            };
         }[]
     > {
         const graphileClient = await this.graphileUtils;
@@ -1268,7 +1274,7 @@ export class SchedulerClient {
                 locked_at: Date;
                 locked_by: string;
                 run_at: Date;
-                payload: Record<string, unknown> | null;
+                payload: Record<string, string | undefined> | null;
             }) => ({
                 id: row.id,
                 taskIdentifier: row.task_identifier,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1426,9 +1426,7 @@ export class SchedulerService extends BaseService {
             jobsToLog.map(({ job, durationMinutes }) =>
                 this.schedulerModel.logSchedulerJob({
                     task: job.taskIdentifier as SchedulerTaskName,
-                    schedulerUuid: job.payload.schedulerUuid as
-                        | string
-                        | undefined,
+                    schedulerUuid: job.payload.schedulerUuid,
                     jobId: job.id,
                     scheduledTime: job.runAt,
                     status: SchedulerJobStatus.ERROR,
@@ -1436,15 +1434,9 @@ export class SchedulerService extends BaseService {
                         error: 'This job took longer than expected and was stopped after 1 hour—please try again. If the issue persists, contact support.',
                         lockedAt: job.lockedAt.toISOString(),
                         lockedBy: job.lockedBy,
-                        projectUuid: job.payload.projectUuid as
-                            | string
-                            | undefined,
-                        organizationUuid: job.payload.organizationUuid as
-                            | string
-                            | undefined,
-                        createdByUserUuid: job.payload.userUuid as
-                            | string
-                            | undefined,
+                        projectUuid: job.payload.projectUuid,
+                        organizationUuid: job.payload.organizationUuid,
+                        createdByUserUuid: job.payload.userUuid,
                     },
                 }),
             ),
@@ -1452,12 +1444,12 @@ export class SchedulerService extends BaseService {
 
         // Update Lightdash job status to ERROR for compile project jobs
         // Only compile/createProject tasks have a jobUuid in their payload
-        const jobsWithLightdashJob = jobsToLog.filter(
-            ({ job }) => typeof job.payload.jobUuid === 'string',
-        );
+        const stuckJobUuids = jobsToLog
+            .map(({ job }) => job.payload.jobUuid)
+            .filter((uuid): uuid is string => typeof uuid === 'string');
         await Promise.all(
-            jobsWithLightdashJob.map(({ job }) =>
-                this.jobModel.update(job.payload.jobUuid as string, {
+            stuckJobUuids.map((jobUuid) =>
+                this.jobModel.update(jobUuid, {
                     jobStatus: JobStatusType.ERROR,
                 }),
             ),


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` payload type in `getRecentRunningJobs()` with a typed interface declaring optional fields (`jobUuid`, `schedulerUuid`, `projectUuid`, etc.)
- Remove all `as string | undefined` casts in `checkForStuckJobs` — the types now express optionality directly
- Replace the `as string` cast on `jobUuid` with a type predicate filter (`(uuid): uuid is string =>`) that TypeScript can verify at compile time

## Context
The original bug ([LIGHTDASH-BACKEND-BK7](https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-BK7)) was hidden by an `as string` cast that silenced the compiler. This ensures TypeScript would catch similar issues in the future.

## Test plan
- [ ] Verify typecheck passes with no new errors
- [ ] No runtime behavior change — this is a types-only refactor on top of the bug fix in #20155

🤖 Generated with [Claude Code](https://claude.com/claude-code)