### PR TITLE
refactor: type getRecentRunningJobs payload and remove redundant casts

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1242,7 +1242,13 @@ export class SchedulerClient {
             lockedAt: Date;
             lockedBy: string;
             runAt: Date;
-            payload: Record<string, unknown>;
+            payload: {
+                jobUuid?: string;
+                schedulerUuid?: string;
+                projectUuid?: string;
+                organizationUuid?: string;
+                userUuid?: string;
+            };
         }[]
     > {
         const graphileClient = await this.graphileUtils;
@@ -1268,7 +1274,7 @@ export class SchedulerClient {
                 locked_at: Date;
                 locked_by: string;
                 run_at: Date;
-                payload: Record<string, unknown> | null;
+                payload: Record<string, string | undefined> | null;
             }) => ({
                 id: row.id,
                 taskIdentifier: row.task_identifier,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1426,9 +1426,7 @@ export class SchedulerService extends BaseService {
             jobsToLog.map(({ job, durationMinutes }) =>
                 this.schedulerModel.logSchedulerJob({
                     task: job.taskIdentifier as SchedulerTaskName,
-                    schedulerUuid: job.payload.schedulerUuid as
-                        | string
-                        | undefined,
+                    schedulerUuid: job.payload.schedulerUuid,
                     jobId: job.id,
                     scheduledTime: job.runAt,
                     status: SchedulerJobStatus.ERROR,
@@ -1436,15 +1434,9 @@ export class SchedulerService extends BaseService {
                         error: 'This job took longer than expected and was stopped after 1 hour—please try again. If the issue persists, contact support.',
                         lockedAt: job.lockedAt.toISOString(),
                         lockedBy: job.lockedBy,
-                        projectUuid: job.payload.projectUuid as
-                            | string
-                            | undefined,
-                        organizationUuid: job.payload.organizationUuid as
-                            | string
-                            | undefined,
-                        createdByUserUuid: job.payload.userUuid as
-                            | string
-                            | undefined,
+                        projectUuid: job.payload.projectUuid,
+                        organizationUuid: job.payload.organizationUuid,
+                        createdByUserUuid: job.payload.userUuid,
                     },
                 }),
             ),


### PR DESCRIPTION
## Summary
- Replace `Record<string, unknown>` payload type in `getRecentRunningJobs()` with a typed interface declaring optional fields (`jobUuid`, `schedulerUuid`, `projectUuid`, etc.)
- Remove all redundant `as string | undefined` casts in `checkForStuckJobs` — the types now express optionality directly
- The unsafe `as string` cast on `jobUuid` is intentionally left to be fixed in #20158

## Context
The `as string` cast on `payload.jobUuid` hid [LIGHTDASH-BACKEND-BK7](https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-BK7). With proper types, the cast now visibly narrows `string | undefined` to `string` — making the bug obvious and fixable in the next PR.

## Test plan
- [ ] Verify typecheck passes with no new errors
- [ ] No runtime behavior change — pure types refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)