### PR TITLE
fix: filter stuck jobs without jobUuid before updating Lightdash jobs table

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1443,9 +1443,13 @@ export class SchedulerService extends BaseService {
         );
 
         // Update Lightdash job status to ERROR for compile project jobs
+        // Only compile/createProject tasks have a jobUuid in their payload
+        const stuckJobUuids = jobsToLog
+            .map(({ job }) => job.payload.jobUuid)
+            .filter((uuid): uuid is string => typeof uuid === 'string');
         await Promise.all(
-            jobsToLog.map(({ job }) =>
-                this.jobModel.update(job.payload.jobUuid as string, {
+            stuckJobUuids.map((jobUuid) =>
+                this.jobModel.update(jobUuid, {
                     jobStatus: JobStatusType.ERROR,
                 }),
             ),


### PR DESCRIPTION
## Summary
- Filter stuck Graphile Worker jobs to only those with a `jobUuid` in their payload before calling `JobModel.update()`
- Replace the unsafe `as string` cast with a type predicate filter (`(uuid): uuid is string =>`) that TypeScript can verify at compile time
- Only compile/createProject tasks create records in the Lightdash `jobs` table — other tasks (scheduled deliveries, Google Sheets uploads, notifications) don't have `jobUuid`, causing `Undefined binding` Knex errors

## Sentry Issue
Fixes [LIGHTDASH-BACKEND-BK7](https://lightdash.sentry.io/issues/LIGHTDASH-BACKEND-BK7) — 146 events, 32 users since Jan 9

## Test plan
- [ ] Verify `checkForStuckJobs` no longer throws when processing stuck jobs without `jobUuid`
- [ ] Verify stuck compile project jobs still get their status updated to ERROR
- [ ] Verify stuck non-compile jobs (deliveries, gsheets) are still failed in the Graphile queue

🤖 Generated with [Claude Code](https://claude.com/claude-code)