### PR TITLE
feat: add API endpoint to get metrics tree details

### DIFF
--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -51,6 +51,7 @@ import {
     type ApiCatalogAnalyticsResults,
     type ApiCatalogMetadataResults,
     type ApiGetMetricsTree,
+    type ApiGetMetricsTreeResponse,
     type ApiGetMetricsTreesResponse,
     type ApiMetricsCatalog,
 } from './catalog';
@@ -809,6 +810,7 @@ type ApiResults =
     | ApiDashboardAsCodeListResponse['results']
     | ApiChartAsCodeUpsertResponse['results']
     | ApiGetMetricsTree['results']
+    | ApiGetMetricsTreeResponse['results']
     | ApiGetMetricsTreesResponse['results']
     | ApiMetricsExplorerTotalResults['results']
     | ApiGetSpotlightTableConfig['results']

--- a/packages/common/src/types/catalog.ts
+++ b/packages/common/src/types/catalog.ts
@@ -123,9 +123,6 @@ export type CatalogMetricsTreeNode = Pick<
 
 export type MetricsTreeSource = 'ui' | 'yaml';
 
-/** @deprecated Use MetricsTreeSource instead */
-export type CatalogMetricsTreeEdgeSource = MetricsTreeSource;
-
 export type CatalogMetricsTreeEdge = {
     source: CatalogMetricsTreeNode;
     target: CatalogMetricsTreeNode;


### PR DESCRIPTION
### Description:
Added a new API endpoint to get details of a saved metrics tree by UUID. This endpoint returns the complete tree structure including nodes and edges with their positions and metadata.

The implementation includes:
- New controller method `getMetricsTreeDetails` in `catalogController.ts`
- New model method `getMetricsTreeByUuid` in `CatalogModel.ts` to fetch tree metadata with hydrated catalog data
- New service method in `CatalogService.ts` with proper authorization checks
- Updated type definitions in the common package