### PR TITLE
chore: rename SpaceAccessForCasl to SpaceAccessContextForCasl and move SpaceAccess into space types

### DIFF
--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -10,7 +10,7 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SpacePermissionModel } from '../../models/SpacePermissionModel';
 import { BaseService } from '../BaseService';
 
-type SpaceAccessForCasl = {
+type SpaceAccessContextForCasl = {
     organizationUuid: string;
     projectUuid: string;
     isPrivate: boolean;
@@ -41,7 +41,7 @@ export class SpacePermissionService extends BaseService {
             ? spaceUuids
             : [spaceUuids];
 
-        const accessContext = await this.getAccessContext(spaceUuidsArray, {
+        const accessContext = await this.getSpacesCaslContext(spaceUuidsArray, {
             userUuid: actor.userUuid,
         });
 
@@ -62,7 +62,7 @@ export class SpacePermissionService extends BaseService {
         actor: Pick<SessionUser, 'ability' | 'userUuid'>,
         spaceUuids: string[],
     ): Promise<string[]> {
-        const accessContext = await this.getAccessContext(spaceUuids, {
+        const accessContext = await this.getSpacesCaslContext(spaceUuids, {
             userUuid: actor.userUuid,
         });
 
@@ -79,10 +79,10 @@ export class SpacePermissionService extends BaseService {
      * @param filters - The filters to apply to the access context
      * @returns The access context for the given space uuids
      */
-    private async getAccessContext(
+    private async getSpacesCaslContext(
         spaceUuidsArg: string[],
         filters?: { userUuid?: string },
-    ): Promise<Record<string, SpaceAccessForCasl>> {
+    ): Promise<Record<string, SpaceAccessContextForCasl>> {
         const uniqueSpaceUuids = [...new Set(spaceUuidsArg)];
 
         // Getting the root space uuids since for nested spaces that's what is used
@@ -117,7 +117,10 @@ export class SpacePermissionService extends BaseService {
                 this.spacePermissionModel.getSpaceInfo(uniqueRootSpaceUuids),
             ]);
 
-        const rootSpaceAccessContext: Record<string, SpaceAccessForCasl> = {};
+        const rootSpaceAccessContext: Record<
+            string,
+            SpaceAccessContextForCasl
+        > = {};
         for (const rootSpaceUuid of uniqueRootSpaceUuids) {
             const space = spaceInfo[rootSpaceUuid];
             if (!space) {

--- a/packages/common/src/authorization/space/spaceAccessResolver.ts
+++ b/packages/common/src/authorization/space/spaceAccessResolver.ts
@@ -12,8 +12,8 @@ import {
     type DirectSpaceAccess,
     type OrganizationSpaceAccess,
     type ProjectSpaceAccess,
+    type SpaceAccess,
     type SpaceAccessInput,
-    type SpaceShare,
 } from '../../types/space';
 import {
     convertOrganizationRoleToProjectRole,
@@ -22,16 +22,6 @@ import {
     getHighestProjectRole,
     getHighestSpaceRole,
 } from '../../utils/projectMemberRole';
-
-export type SpaceAccess = Pick<
-    SpaceShare,
-    | 'userUuid'
-    | 'role'
-    | 'hasDirectAccess'
-    | 'inheritedFrom'
-    | 'projectRole'
-    | 'inheritedRole'
->;
 
 const getUserOrganizationRole = (
     organizationAccess: OrganizationSpaceAccess[],

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -127,6 +127,18 @@ export type SpaceShare = {
         | undefined;
 };
 
+// Lightweight version of SpaceShare without user metadata (firstName, lastName, email).
+// Used for CASL permission checks where only the role/access data matters.
+export type SpaceAccess = Pick<
+    SpaceShare,
+    | 'userUuid'
+    | 'role'
+    | 'hasDirectAccess'
+    | 'inheritedFrom'
+    | 'projectRole'
+    | 'inheritedRole'
+>;
+
 export type SpaceGroup = {
     groupUuid: string;
     groupName: string;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR refactors space permission types and methods to improve clarity and consistency:

1. Renamed `SpaceAccessForCasl` to `SpaceAccessContextForCasl` to better reflect its purpose
2. Renamed `getAccessContext` to `getSpacesCaslContext` for more precise naming
3. Moved the `SpaceAccess` type from the resolver file to the common types file
4. Added documentation for the `SpaceAccess` type, clarifying it's a lightweight version of `SpaceShare` without user metadata

These changes make the code more maintainable by using more descriptive names and organizing types in a more logical way.