### PR TITLE
feat: add navigation links to recently deleted items in toast notifications

### DIFF
--- a/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
@@ -1,15 +1,17 @@
 import {
+    ContentType,
     type ApiError,
-    type ContentType,
     type DeletedContentItem,
     type DeletedContentSummary,
     type KnexPaginatedData,
 } from '@lightdash/common';
+import { IconArrowRight } from '@tabler/icons-react';
 import {
     useInfiniteQuery,
     useMutation,
     useQueryClient,
 } from '@tanstack/react-query';
+import { useNavigate } from 'react-router';
 import useToaster from '../../../hooks/toaster/useToaster';
 import {
     getDeletedContent,
@@ -64,14 +66,35 @@ export function useInfiniteDeletedContent(
 
 export function useRestoreDeletedContent(projectUuid: string) {
     const queryClient = useQueryClient();
+    const navigate = useNavigate();
     const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<undefined, ApiError, DeletedContentItem>({
         mutationFn: (item) => restoreDeletedContent(projectUuid, item),
-        onSuccess: () => {
+        onSuccess: (_data, item) => {
             showToastSuccess({
                 title: 'Content restored',
                 subtitle: 'The item has been restored successfully.',
+                action:
+                    item.contentType === ContentType.CHART
+                        ? {
+                              children: 'Go to chart',
+                              icon: IconArrowRight,
+                              onClick: () =>
+                                  navigate(
+                                      `/projects/${projectUuid}/saved/${item.uuid}`,
+                                  ),
+                          }
+                        : item.contentType === ContentType.DASHBOARD
+                          ? {
+                                children: 'Go to dashboard',
+                                icon: IconArrowRight,
+                                onClick: () =>
+                                    navigate(
+                                        `/projects/${projectUuid}/dashboards/${item.uuid}`,
+                                    ),
+                            }
+                          : undefined,
             });
             void queryClient.invalidateQueries({
                 queryKey: ['deletedContent'],

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
@@ -6,6 +6,7 @@ import {
     type SqlChart,
     type UpdateSqlChart,
 } from '@lightdash/common';
+import { IconArrowRight } from '@tabler/icons-react';
 import {
     useMutation,
     useQuery,
@@ -15,6 +16,7 @@ import {
 import { useNavigate } from 'react-router';
 import { lightdashApi } from '../../../api';
 import useToaster from '../../../hooks/toaster/useToaster';
+import useApp from '../../../providers/App/useApp';
 
 export type GetSavedSqlChartParams = {
     projectUuid: string;
@@ -153,6 +155,9 @@ export const useDeleteSqlChartMutation = (
     savedSqlUuid: string,
 ) => {
     const queryClient = useQueryClient();
+    const navigate = useNavigate();
+    const { health } = useApp();
+    const isSoftDeleteEnabled = health.data?.softDelete.enabled ?? false;
     const { showToastSuccess, showToastApiError } = useToaster();
 
     return useMutation<{ savedSqlUuid: string }, ApiError>(
@@ -171,6 +176,16 @@ export const useDeleteSqlChartMutation = (
 
                 showToastSuccess({
                     title: `Success! SQL chart deleted`,
+                    action: isSoftDeleteEnabled
+                        ? {
+                              children: 'Go to recently deleted',
+                              icon: IconArrowRight,
+                              onClick: () =>
+                                  navigate(
+                                      `/generalSettings/projectManagement/${projectUuid}/recentlyDeleted`,
+                                  ),
+                          }
+                        : undefined,
                 });
             },
             onError: ({ error }) => {

--- a/packages/frontend/src/hooks/useContent.ts
+++ b/packages/frontend/src/hooks/useContent.ts
@@ -19,6 +19,7 @@ import {
 } from '@tanstack/react-query';
 import { useNavigate } from 'react-router';
 import { lightdashApi } from '../api';
+import useApp from '../providers/App/useApp';
 import useToaster from './toaster/useToaster';
 
 export type ContentArgs = {
@@ -138,6 +139,8 @@ export const useContentAction = (
     const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
+    const { health } = useApp();
+    const isSoftDeleteEnabled = health.data?.softDelete.enabled ?? false;
 
     return useMutation<ApiSuccessEmpty, ApiError, ApiContentActionBody>({
         mutationFn: (body) => {
@@ -181,6 +184,16 @@ export const useContentAction = (
                 case 'delete':
                     return showToastSuccess({
                         title: `Successfully deleted ${item.contentType}.`,
+                        action: isSoftDeleteEnabled
+                            ? {
+                                  children: 'Go to recently deleted',
+                                  icon: IconArrowRight,
+                                  onClick: () =>
+                                      navigate(
+                                          `/generalSettings/projectManagement/${projectUuid}/recentlyDeleted`,
+                                      ),
+                              }
+                            : undefined,
                     });
 
                 default:
@@ -212,6 +225,8 @@ export const useContentBulkAction = (
     const { showToastSuccess, showToastApiError } = useToaster();
     const queryClient = useQueryClient();
     const navigate = useNavigate();
+    const { health } = useApp();
+    const isSoftDeleteEnabled = health.data?.softDelete.enabled ?? false;
 
     return useMutation<ApiSuccessEmpty, ApiError, ApiContentBulkActionBody>({
         mutationFn: (body) => {
@@ -257,6 +272,16 @@ export const useContentBulkAction = (
                         title: `Successfully deleted ${content.length} ${
                             content.length === 1 ? 'item' : 'items'
                         }.`,
+                        action: isSoftDeleteEnabled
+                            ? {
+                                  children: 'Go to recently deleted',
+                                  icon: IconArrowRight,
+                                  onClick: () =>
+                                      navigate(
+                                          `/generalSettings/projectManagement/${projectUuid}/recentlyDeleted`,
+                                      ),
+                              }
+                            : undefined,
                     });
 
                 default:

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -17,6 +17,7 @@ import {
 } from '@tanstack/react-query';
 import { useNavigate, useParams } from 'react-router';
 import { lightdashApi } from '../api';
+import useApp from '../providers/App/useApp';
 import { convertDateFilters } from '../utils/dateFilter';
 import useToaster from './toaster/useToaster';
 import useSearchParams from './useSearchParams';
@@ -194,6 +195,10 @@ export const useChartVersionRollbackMutation = (
 
 export const useSavedQueryDeleteMutation = () => {
     const queryClient = useQueryClient();
+    const navigate = useNavigate();
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { health } = useApp();
+    const isSoftDeleteEnabled = health.data?.softDelete.enabled ?? false;
     const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(
         async (data) => {
@@ -213,6 +218,17 @@ export const useSavedQueryDeleteMutation = () => {
 
                 showToastSuccess({
                     title: `Success! Chart was deleted.`,
+                    action:
+                        isSoftDeleteEnabled && projectUuid
+                            ? {
+                                  children: 'Go to recently deleted',
+                                  icon: IconArrowRight,
+                                  onClick: () =>
+                                      navigate(
+                                          `/generalSettings/projectManagement/${projectUuid}/recentlyDeleted`,
+                                      ),
+                              }
+                            : undefined,
                 });
             },
             onError: ({ error }) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added "Go to" action buttons in toast notifications after deleting or restoring content. When users delete charts, dashboards, or SQL charts, they now see a "Go to recently deleted" button in the success toast that navigates them to the Recently Deleted page. Similarly, when restoring content from the Recently Deleted page, users see a "Go to chart/dashboard" button that takes them directly to the restored item.
