### PR TITLE
fix: invalidate deletedContent queries after deletion

### DIFF
--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
@@ -173,6 +173,7 @@ export const useDeleteSqlChartMutation = (
                     'most-popular-and-recently-updated',
                 ]);
                 await queryClient.invalidateQueries(['content']);
+                await queryClient.invalidateQueries(['deletedContent']);
 
                 showToastSuccess({
                     title: `Success! SQL chart deleted`,

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -593,6 +593,7 @@ export const useDashboardDeleteMutation = () => {
                 'most-popular-and-recently-updated',
             ]);
             await queryClient.invalidateQueries(['content']);
+            await queryClient.invalidateQueries(['deletedContent']);
             showToastSuccess({
                 title: `Deleted! Dashboard was deleted.`,
                 action:

--- a/packages/frontend/src/hooks/useContent.ts
+++ b/packages/frontend/src/hooks/useContent.ts
@@ -182,6 +182,7 @@ export const useContentAction = (
                     });
 
                 case 'delete':
+                    await queryClient.invalidateQueries(['deletedContent']);
                     return showToastSuccess({
                         title: `Successfully deleted ${item.contentType}.`,
                         action: isSoftDeleteEnabled
@@ -268,6 +269,7 @@ export const useContentBulkAction = (
                     });
 
                 case 'delete':
+                    await queryClient.invalidateQueries(['deletedContent']);
                     return showToastSuccess({
                         title: `Successfully deleted ${content.length} ${
                             content.length === 1 ? 'item' : 'items'

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -215,6 +215,7 @@ export const useSavedQueryDeleteMutation = () => {
                     'most-popular-and-recently-updated',
                 ]);
                 await queryClient.invalidateQueries(['content']);
+                await queryClient.invalidateQueries(['deletedContent']);
 
                 showToastSuccess({
                     title: `Success! Chart was deleted.`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Invalidate deletedContent queries when content is deleted to ensure the deleted items list is updated correctly. This fix ensures that when users delete SQL charts, dashboards, or other content, the deleted items view is immediately refreshed with the latest data.
