### PR TITLE
fix: dashboard chart deletion modal

### DIFF
--- a/packages/frontend/src/components/common/modal/DeleteChartTileThatBelongsToDashboardModal.tsx
+++ b/packages/frontend/src/components/common/modal/DeleteChartTileThatBelongsToDashboardModal.tsx
@@ -1,6 +1,5 @@
 import { type ModalProps } from '@mantine-8/core';
 import { type FC } from 'react';
-import useApp from '../../../providers/App/useApp';
 import Callout from '../Callout';
 import MantineModal from '../MantineModal';
 
@@ -17,22 +16,6 @@ const DeleteChartTileThatBelongsToDashboardModal: FC<Props> = ({
     onConfirm,
     className,
 }) => {
-    const { health } = useApp();
-    const softDeleteEnabled = health.data?.softDelete.enabled;
-    const retentionDays = health.data?.softDelete.retentionDays;
-
-    const description = softDeleteEnabled
-        ? `This chart will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
-        : undefined;
-
-    const calloutTitle = softDeleteEnabled
-        ? 'This chart was created from within the dashboard.'
-        : 'This change cannot be undone.';
-
-    const calloutContent = softDeleteEnabled
-        ? 'Removing the tile will also delete the chart. It can be restored from Recently deleted.'
-        : 'This chart was created from within the dashboard, so removing the tile will also result in the permanent deletion of the chart.';
-
     return (
         <MantineModal
             opened={opened}
@@ -41,15 +24,13 @@ const DeleteChartTileThatBelongsToDashboardModal: FC<Props> = ({
             variant="delete"
             resourceType="chart"
             resourceLabel={name}
-            description={description}
             modalRootProps={{ className }}
             onConfirm={onConfirm}
         >
-            <Callout
-                variant={softDeleteEnabled ? 'warning' : 'danger'}
-                title={calloutTitle}
-            >
-                {calloutContent}
+            <Callout variant="warning" title="This change cannot be undone.">
+                This chart was created from within the dashboard, so removing
+                the tile will also result in the permanent deletion of the
+                chart.
             </Callout>
         </MantineModal>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

The modal now always shows a warning callout with a fixed message about permanent deletion, rather than conditionally changing the message based on soft delete settings.
