### PR TITLE
fix: prevent chart create modal flicker when saving to dashboard

### DIFF
--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToDashboard.tsx
@@ -87,9 +87,11 @@ export const SaveToDashboard: FC<Props> = ({
     const { showToastSuccess } = useToaster();
     const navigate = useNavigate();
 
-    const { mutateAsync: createChart } = useCreateMutation();
+    const { mutateAsync: createChart } = useCreateMutation({
+        redirectOnSuccess: false,
+        showToastOnSuccess: false,
+    });
     const {
-        clearIsEditingDashboardChart,
         getUnsavedDashboardTiles,
         setUnsavedDashboardTiles,
         getDashboardActiveTabUuid,
@@ -135,8 +137,6 @@ export const SaveToDashboard: FC<Props> = ({
             setUnsavedDashboardTiles(
                 appendNewTilesToBottom(existingTiles || [], [newTile]),
             );
-
-            clearIsEditingDashboardChart();
             void navigate(
                 activeTabUuid
                     ? `/projects/${projectUuid}/dashboards/${dashboardUuid}/edit/tabs/${activeTabUuid}`
@@ -152,7 +152,6 @@ export const SaveToDashboard: FC<Props> = ({
             createChart,
             setUnsavedDashboardTiles,
             unsavedDashboardTiles,
-            clearIsEditingDashboardChart,
             navigate,
             projectUuid,
             showToastSuccess,

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/index.tsx
@@ -1,6 +1,6 @@
 import { type CreateSavedChartVersion } from '@lightdash/common';
 import { IconChartBar } from '@tabler/icons-react';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { useParams } from 'react-router';
 import useDashboardStorage from '../../../../hooks/dashboard/useDashboardStorage';
 import MantineModal, { type MantineModalProps } from '../../MantineModal';
@@ -8,8 +8,10 @@ import { SaveToDashboard } from './SaveToDashboard';
 import { SaveToSpaceOrDashboard } from './SaveToSpaceOrDashboard';
 import { type ChartMetadata } from './types';
 
-interface ChartCreateModalProps
-    extends Pick<MantineModalProps, 'opened' | 'onClose'> {
+interface ChartCreateModalProps extends Pick<
+    MantineModalProps,
+    'opened' | 'onClose'
+> {
     savedData: CreateSavedChartVersion;
     defaultSpaceUuid?: string;
     onConfirm: (savedData: CreateSavedChartVersion) => void;
@@ -33,7 +35,15 @@ const ChartCreateModal: FC<ChartCreateModalProps> = ({
     const [spaceUuid] = useState(defaultSpaceUuid);
 
     const { getEditingDashboardInfo } = useDashboardStorage();
-    const editingDashboardInfo = getEditingDashboardInfo();
+    const [editingDashboardInfo, setEditingDashboardInfo] = useState(() =>
+        getEditingDashboardInfo(),
+    );
+
+    useEffect(() => {
+        if (opened) {
+            setEditingDashboardInfo(getEditingDashboardInfo());
+        }
+    }, [opened, getEditingDashboardInfo]);
 
     const saveMode = useMemo(() => {
         if (editingDashboardInfo.name && editingDashboardInfo.dashboardUuid) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

This PR fixes a transient UI flicker in the chart save flow when saving directly to a dashboard.

`ChartCreateModal` derived its mode from live `sessionStorage` on each render. In `SaveToDashboard`, we were clearing dashboard-edit storage before navigation, and the create mutation also had its own redirect behavior. Together, this could briefly switch modal content before route transition.

Flicker on save on 10s:

[CleanShot 2026-02-11 at 12.38.38.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/bb1bda58-b847-43cb-ac2e-d13bf02b76bd.mp4" />](https://app.graphite.com/user-attachments/video/bb1bda58-b847-43cb-ac2e-d13bf02b76bd.mp4)

This fix:

1. `SaveToDashboard` now uses `useCreateMutation({ redirectOnSuccess: false, showToastOnSuccess: false })` so this flow has a single, explicit navigation path.
2. Removed `clearIsEditingDashboardChart()` from the `SaveToDashboard` submit handler.
3. `ChartCreateModal` now snapshots dashboard editing context when the modal opens and derives `saveMode` from that snapshot (instead of live storage reads).
