### PR TITLE
feat: support user attributes in filter values

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -2214,6 +2214,82 @@ export const METRIC_QUERY_WITH_DATE_FILTER: CompiledMetricQuery = {
     compiledCustomDimensions: [],
 };
 
+// Filter with user attribute value (e.g., ${lightdash.user.email}) in filter values
+export const METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE: CompiledMetricQuery =
+    {
+        exploreName: 'table1',
+        dimensions: ['table1_dim1'],
+        metrics: [],
+        filters: {
+            dimensions: {
+                id: 'root',
+                and: [
+                    {
+                        id: '1',
+                        target: {
+                            fieldId: 'table1_shared',
+                        },
+                        operator: FilterOperator.EQUALS,
+                        values: ['${lightdash.user.email}'],
+                    },
+                ],
+            },
+        },
+        sorts: [{ fieldId: 'table1_dim1', descending: true }],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+export const METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE_SQL = `SELECT "table1".dim1 AS "table1_dim1"
+                                             FROM "db"."schema"."table1" AS "table1"
+
+                                             WHERE ((
+                                                 ("table1".shared) IN ('mock@lightdash.com')
+                                                 ))
+                                             GROUP BY 1
+                                             ORDER BY "table1_dim1" DESC LIMIT 10`;
+
+// Filter with custom user attribute value (e.g., ${lightdash.attribute.country}) in filter values
+export const METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE: CompiledMetricQuery =
+    {
+        exploreName: 'table1',
+        dimensions: ['table1_dim1'],
+        metrics: [],
+        filters: {
+            dimensions: {
+                id: 'root',
+                and: [
+                    {
+                        id: '1',
+                        target: {
+                            fieldId: 'table1_shared',
+                        },
+                        operator: FilterOperator.EQUALS,
+                        values: ['${lightdash.attribute.country}'],
+                    },
+                ],
+            },
+        },
+        sorts: [{ fieldId: 'table1_dim1', descending: true }],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+export const METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE_SQL = `SELECT "table1".dim1 AS "table1_dim1"
+                                             FROM "db"."schema"."table1" AS "table1"
+
+                                             WHERE ((
+                                                 ("table1".shared) IN ('EU')
+                                                 ))
+                                             GROUP BY 1
+                                             ORDER BY "table1_dim1" DESC LIMIT 10`;
+
 // Expected: SELECT uses DATE_TRUNC (zoomed), but WHERE uses raw column
 export const METRIC_QUERY_WITH_DATE_ZOOM_FILTER_SQL = `SELECT
   DATE_TRUNC('month', "orders".created_at) AS "orders_created_at",

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -56,6 +56,8 @@ import {
     METRIC_QUERY_WITH_ADDITIONAL_METRIC_SQL,
     METRIC_QUERY_WITH_CUSTOM_DIMENSION,
     METRIC_QUERY_WITH_CUSTOM_SQL_DIMENSION,
+    METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
+    METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE_SQL,
     METRIC_QUERY_WITH_DATE_FILTER,
     METRIC_QUERY_WITH_DATE_ZOOM_FILTER_SQL,
     METRIC_QUERY_WITH_DAY_OF_WEEK_NAME_SORT,
@@ -89,6 +91,8 @@ import {
     METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER_SQL,
     METRIC_QUERY_WITH_TABLE_REFERENCE,
     METRIC_QUERY_WITH_TABLE_REFERENCE_SQL,
+    METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE,
+    METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE_SQL,
     QUERY_BUILDER_UTC_TIMEZONE,
     warehouseClientMock,
 } from './MetricQueryBuilder.mock';
@@ -431,6 +435,62 @@ describe('Query builder', () => {
                 }).query,
             ),
         ).toStrictEqual(replaceWhitespace(METRIC_QUERY_WITH_SQL_FILTER));
+    });
+
+    test('Should replace intrinsic user attributes in filter values', () => {
+        expect(
+            replaceWhitespace(
+                buildQuery({
+                    explore: EXPLORE,
+                    compiledMetricQuery:
+                        METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE,
+                    warehouseSqlBuilder: warehouseClientMock,
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                }).query,
+            ),
+        ).toStrictEqual(
+            replaceWhitespace(
+                METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE_SQL,
+            ),
+        );
+    });
+
+    test('Should replace custom user attributes in filter values', () => {
+        expect(
+            replaceWhitespace(
+                buildQuery({
+                    explore: EXPLORE,
+                    compiledMetricQuery:
+                        METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
+                    warehouseSqlBuilder: warehouseClientMock,
+                    userAttributes: {
+                        country: ['EU'],
+                    },
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                }).query,
+            ),
+        ).toStrictEqual(
+            replaceWhitespace(
+                METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE_SQL,
+            ),
+        );
+    });
+
+    test('Should throw error if user attribute in filter value is missing', () => {
+        expect(
+            () =>
+                buildQuery({
+                    explore: EXPLORE,
+                    compiledMetricQuery:
+                        METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
+                    warehouseSqlBuilder: warehouseClientMock,
+                    userAttributes: {},
+                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+                }).query,
+        ).toThrow(ForbiddenError);
     });
 
     it('buildQuery with custom dimension bin number', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -954,8 +954,13 @@ export class MetricQueryBuilder {
                         this.args.parameters ?? {},
                         this.args.warehouseSqlBuilder,
                     );
-
-                    return replacedSql;
+                    // Replace user attribute references (e.g., ${lightdash.user.email})
+                    // Raw replacement is safe because the filter compiler handles quoting
+                    return replaceUserAttributesRaw(
+                        replacedSql,
+                        this.args.intrinsicUserAttributes,
+                        this.args.userAttributes ?? {},
+                    );
                 }
                 return value;
             }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related: https://linear.app/lightdash/issue/PROD-2812/convert-looker-user-attributesemail-to-dollarlightdashuseremail

<img width="1511" height="982" alt="image" src="https://github.com/user-attachments/assets/12e03797-bf07-4fe3-86ab-0c8aae5fac72" />

Out of scope: 

- Autocomplete UI

TODO: 

- [ ] Update docs

### Description:
Added support for user attribute references in filter values. This allows users to create filters that reference their own attributes (e.g., `${lightdash.user.email}`) or custom attributes (e.g., `${lightdash.attribute.country}`).

The implementation:
- Adds test cases for both intrinsic and custom user attributes in filter values
- Extends the filter value processing to replace user attribute references
- Adds error handling for missing user attributes
- Includes mock data and SQL examples for validation

test-frontend test-backend