### PR TITLE
fix: use share URLs for "Explore from here" functionality

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -314,6 +314,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     asyncQueryService: repository.getAsyncQueryService(),
                     catalogService: repository.getCatalogService(),
                     projectService: repository.getProjectService(),
+                    shareService: repository.getShareService(),
                     userAttributesModel: models.getUserAttributesModel(),
                     searchModel: models.getSearchModel(),
                     spaceService: repository.getSpaceService(),

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -63,6 +63,7 @@ import { CatalogService } from '../../../services/CatalogService/CatalogService'
 import { CsvService } from '../../../services/CsvService/CsvService';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
+import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
 import {
     doesExploreMatchRequiredAttributes,
@@ -117,6 +118,7 @@ type McpServiceArguments = {
     catalogService: CatalogService;
     projectModel: ProjectModel;
     projectService: ProjectService;
+    shareService: ShareService;
     userAttributesModel: UserAttributesModel;
     searchModel: SearchModel;
     spaceService: SpaceService;
@@ -157,6 +159,8 @@ export class McpService extends BaseService {
 
     private mcpContextModel: McpContextModel;
 
+    private shareService: ShareService;
+
     private featureFlagService: FeatureFlagService;
 
     private mcpServer: McpServer;
@@ -169,6 +173,7 @@ export class McpService extends BaseService {
         asyncQueryService,
         catalogService,
         projectService,
+        shareService,
         userAttributesModel,
         searchModel,
         spaceService,
@@ -182,6 +187,7 @@ export class McpService extends BaseService {
         this.asyncQueryService = asyncQueryService;
         this.catalogService = catalogService;
         this.projectService = projectService;
+        this.shareService = shareService;
         this.userAttributesModel = userAttributesModel;
         this.searchModel = searchModel;
         this.projectModel = projectModel;
@@ -925,7 +931,15 @@ export class McpService extends BaseService {
                     const exploreParams = `?create_saved_chart_version=${encodeURIComponent(
                         JSON.stringify(exploreConfigState),
                     )}&isExploreFromHere=true`;
-                    const exploreUrl = `${this.lightdashConfig.siteUrl}${explorePath}${exploreParams}`;
+
+                    const { user: mcpUser } = (extra as McpProtocolContext)
+                        .authInfo!.extra;
+                    const shareUrl = await this.shareService.createShareUrl(
+                        mcpUser,
+                        explorePath,
+                        exploreParams,
+                    );
+                    const exploreUrl = `${this.lightdashConfig.siteUrl}/share/${shareUrl.nanoid}`;
 
                     return {
                         content: [

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiChartQuickOptions.tsx
@@ -15,12 +15,13 @@ import {
     IconTableShortcut,
     IconTerminal2,
 } from '@tabler/icons-react';
-import { Fragment, useMemo } from 'react';
+import { Fragment, useCallback, useMemo } from 'react';
 import { Link } from 'react-router';
 import MantineIcon from '../../../../../components/common/MantineIcon';
 import MantineModal from '../../../../../components/common/MantineModal';
 import { SaveToSpaceOrDashboard } from '../../../../../components/common/modal/ChartCreateModal/SaveToSpaceOrDashboard';
 import { useVisualizationContext } from '../../../../../components/LightdashVisualization/useVisualizationContext';
+import { useCreateShareMutation } from '../../../../../hooks/useShare';
 import useApp from '../../../../../providers/App/useApp';
 import useTracking from '../../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../../types/Events';
@@ -115,7 +116,7 @@ export const AiChartQuickOptions = ({
     };
 
     const openInExploreUrl = useMemo(() => {
-        if (isDisabled) return '';
+        if (isDisabled) return undefined;
         return getOpenInExploreUrl({
             metricQuery,
             projectUuid,
@@ -132,7 +133,15 @@ export const AiChartQuickOptions = ({
         pivotDimensions,
     ]);
 
-    const onClickExplore = () => {
+    const { mutateAsync: createShareUrl } = useCreateShareMutation();
+
+    const handleExploreFromHere = useCallback(async () => {
+        if (!openInExploreUrl) return;
+        const shareUrl = await createShareUrl({
+            path: openInExploreUrl.pathname,
+            params: `?${openInExploreUrl.search}`,
+        });
+        window.open(`/share/${shareUrl.nanoid}`, '_blank');
         if (
             user?.data?.userUuid &&
             user?.data?.organizationUuid &&
@@ -153,7 +162,18 @@ export const AiChartQuickOptions = ({
                 },
             });
         }
-    };
+    }, [
+        openInExploreUrl,
+        createShareUrl,
+        user?.data?.userUuid,
+        user?.data?.organizationUuid,
+        projectUuid,
+        agentUuid,
+        metricQuery?.exploreName,
+        track,
+        message.threadUuid,
+        message.uuid,
+    ]);
 
     const handleVerifyToggle = () => {
         if (!artifactData) return;
@@ -239,12 +259,9 @@ export const AiChartQuickOptions = ({
                     )}
 
                     <Menu.Item
-                        component={Link}
-                        to={openInExploreUrl}
-                        target="_blank"
                         leftSection={<MantineIcon icon={IconExternalLink} />}
                         disabled={isDisabled}
-                        onClick={onClickExplore}
+                        onClick={handleExploreFromHere}
                     >
                         Explore from here
                     </Menu.Item>

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/ExploreFromHereButton.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/ExploreFromHereButton.tsx
@@ -1,10 +1,10 @@
 import { type CreateSavedChartVersion } from '@lightdash/common';
 import { Button, Tooltip } from '@mantine-8/core';
 import { IconExternalLink } from '@tabler/icons-react';
-import { useMemo, type FC } from 'react';
-import { Link } from 'react-router';
+import { useCallback, useMemo, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../../../hooks/useExplorerRoute';
+import { useCreateShareMutation } from '../../../../hooks/useShare';
 
 type Props = {
     projectUuid: string | undefined;
@@ -26,6 +26,18 @@ export const ExploreFromHereButton: FC<Props> = ({
         );
     }, [projectUuid, unsavedChartVersion]);
 
+    const { mutateAsync: createShareUrl, isLoading: isCreatingShareUrl } =
+        useCreateShareMutation();
+
+    const handleExploreFromHere = useCallback(async () => {
+        if (!openInExploreUrl) return;
+        const shareUrl = await createShareUrl({
+            path: openInExploreUrl.pathname,
+            params: `?${openInExploreUrl.search}`,
+        });
+        window.open(`/share/${shareUrl.nanoid}`, '_blank');
+    }, [createShareUrl, openInExploreUrl]);
+
     const isEnabled = Boolean(openInExploreUrl && canExplore);
 
     return (
@@ -34,32 +46,17 @@ export const ExploreFromHereButton: FC<Props> = ({
             position="bottom"
             disabled={!isEnabled}
         >
-            {isEnabled ? (
-                <Button
-                    component={Link}
-                    to={openInExploreUrl!}
-                    target="_blank"
-                    rel="noreferrer"
-                    variant="default"
-                    size="xs"
-                    radius="md"
-                    leftSection={<MantineIcon icon={IconExternalLink} />}
-                >
-                    Explore from here
-                </Button>
-            ) : (
-                <Button
-                    component="button"
-                    type="button"
-                    variant="default"
-                    size="xs"
-                    radius="md"
-                    leftSection={<MantineIcon icon={IconExternalLink} />}
-                    disabled
-                >
-                    Explore from here
-                </Button>
-            )}
+            <Button
+                variant="default"
+                size="xs"
+                radius="md"
+                leftSection={<MantineIcon icon={IconExternalLink} />}
+                disabled={!isEnabled}
+                loading={isCreatingShareUrl}
+                onClick={handleExploreFromHere}
+            >
+                Explore from here
+            </Button>
         </Tooltip>
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/4137

### Description:

Use share URLs for "Explore from here" links to prevent 431 error when the url is too big. This PR modifies the behavior of "Explore from here" buttons across the application to generate share URLs instead of direct links.

The changes affect:

- Underlying data modal
- AI chart quick options
- Metrics catalog explore button
- MCP service for external tool integrations