### PR TITLE
chore: enable metrics catalog tree mode switcher by default

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -81,10 +81,6 @@ export enum FeatureFlags {
     NestedSpacesPermissions = 'nested-spaces-permissions',
 
     /**
-     * Enable tree/list mode switcher in Metrics Catalog
-     */
-    MetricsCatalogTreeModeSwitcher = 'metrics-catalog-tree-mode-switcher',
-    /**
      * Enable admin change notifications for critical configuration changes
      */
     AdminChangeNotifications = 'admin-change-notifications',

--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/index.tsx
@@ -1,6 +1,5 @@
 import Dagre from '@dagrejs/dagre';
 import {
-    FeatureFlags,
     TimeFrames,
     type CatalogField,
     type CatalogMetricsTreeEdge,
@@ -40,7 +39,6 @@ import {
 import { Panel, PanelGroup } from 'react-resizable-panels';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useToaster from '../../../../hooks/toaster/useToaster';
-import { useClientFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import useTracking from '../../../../providers/Tracking/useTracking';
 import { EventName } from '../../../../types/Events';
 import { useAppSelector } from '../../../sqlRunner/store/hooks';
@@ -143,9 +141,6 @@ const getNodeLayout = (
 const Canvas: FC<Props> = ({ metrics, edges, viewOnly }) => {
     const { track } = useTracking();
     const theme = useMantineTheme();
-    const isTreeModeSwitcherEnabled = useClientFeatureFlag(
-        FeatureFlags.MetricsCatalogTreeModeSwitcher,
-    );
     const [userUuid, projectUuid, organizationUuid] = useAppSelector(
         ({ metricsCatalog }) => [
             metricsCatalog.user?.userUuid,
@@ -579,16 +574,10 @@ const Canvas: FC<Props> = ({ metrics, edges, viewOnly }) => {
                                 <Text fz={14} fw={500} c="ldGray.6">
                                     Canvas mode:
                                 </Text>
-                                {isTreeModeSwitcherEnabled ? (
-                                    <CanvasTimeFramePicker
-                                        value={canvasTimeOption}
-                                        onChange={setCanvasTimeOption}
-                                    />
-                                ) : (
-                                    <Text span fw={500} c="ldGray.7">
-                                        Current month to date
-                                    </Text>
-                                )}
+                                <CanvasTimeFramePicker
+                                    value={canvasTimeOption}
+                                    onChange={setCanvasTimeOption}
+                                />
                             </Group>
                         </ReactFlowPanel>
                         {!viewOnly && (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Removes the `MetricsCatalogTreeModeSwitcher` feature flag and enables the Canvas Time Frame Picker by default in the Metrics Catalog. This change removes the conditional rendering that was previously controlled by the feature flag, making the time frame picker permanently available to all users.
