### PR TITLE
chore: migrate SavedChartService to use SpacePermissionService

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -4565,6 +4565,57 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Record_string.ParameterValue_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_SpaceShare.userUuid-or-role-or-hasDirectAccess-or-inheritedFrom-or-projectRole-or-inheritedRole_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    userUuid: { dataType: 'string', required: true },
+                    role: { ref: 'SpaceMemberRole', required: true },
+                    hasDirectAccess: { dataType: 'boolean', required: true },
+                    inheritedFrom: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'enum', enums: ['organization'] },
+                            { dataType: 'enum', enums: ['project'] },
+                            { dataType: 'enum', enums: ['group'] },
+                            { dataType: 'enum', enums: ['space_group'] },
+                            { dataType: 'enum', enums: ['parent_space'] },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                    projectRole: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'ProjectMemberRole' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                    inheritedRole: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'ProjectMemberRole' },
+                            { ref: 'OrganizationMemberRole' },
+                            { dataType: 'undefined' },
+                        ],
+                        required: true,
+                    },
+                },
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceAccess: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'Pick_SpaceShare.userUuid-or-role-or-hasDirectAccess-or-inheritedFrom-or-projectRole-or-inheritedRole_',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SavedChart: {
         dataType: 'refAlias',
         type: {
@@ -4573,7 +4624,7 @@ const models: TsoaRoute.Models = {
                 slug: { dataType: 'string', required: true },
                 access: {
                     dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'SpaceShare' },
+                    array: { dataType: 'refAlias', ref: 'SpaceAccess' },
                     required: true,
                 },
                 isPrivate: { dataType: 'boolean', required: true },
@@ -9260,6 +9311,13 @@ const models: TsoaRoute.Models = {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
                     type: { ref: 'WarehouseTypes.SNOWFLAKE', required: true },
+                    role: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     account: { dataType: 'string', required: true },
                     requireUserCredentials: {
                         dataType: 'union',
@@ -9272,13 +9330,6 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { ref: 'SnowflakeAuthenticationType' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    role: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'string' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -9504,17 +9555,17 @@ const models: TsoaRoute.Models = {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
                     type: { ref: 'WarehouseTypes.POSTGRES', required: true },
-                    requireUserCredentials: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'boolean' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
                     role: {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    requireUserCredentials: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'boolean' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -9659,6 +9710,7 @@ const models: TsoaRoute.Models = {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
                     type: { ref: 'WarehouseTypes.BIGQUERY', required: true },
+                    project: { dataType: 'string', required: true },
                     requireUserCredentials: {
                         dataType: 'union',
                         subSchemas: [
@@ -9696,7 +9748,6 @@ const models: TsoaRoute.Models = {
                         ],
                         required: true,
                     },
-                    project: { dataType: 'string', required: true },
                     dataset: { dataType: 'string', required: true },
                     priority: {
                         dataType: 'union',
@@ -17887,7 +17938,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17897,7 +17948,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -17907,7 +17958,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -17920,7 +17971,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5022,6 +5022,48 @@
             "ParametersValuesMap": {
                 "$ref": "#/components/schemas/Record_string.ParameterValue_"
             },
+            "Pick_SpaceShare.userUuid-or-role-or-hasDirectAccess-or-inheritedFrom-or-projectRole-or-inheritedRole_": {
+                "properties": {
+                    "userUuid": {
+                        "type": "string"
+                    },
+                    "role": {
+                        "$ref": "#/components/schemas/SpaceMemberRole"
+                    },
+                    "hasDirectAccess": {
+                        "type": "boolean"
+                    },
+                    "inheritedFrom": {
+                        "type": "string",
+                        "enum": [
+                            "organization",
+                            "project",
+                            "group",
+                            "space_group",
+                            "parent_space"
+                        ]
+                    },
+                    "projectRole": {
+                        "$ref": "#/components/schemas/ProjectMemberRole"
+                    },
+                    "inheritedRole": {
+                        "anyOf": [
+                            {
+                                "$ref": "#/components/schemas/ProjectMemberRole"
+                            },
+                            {
+                                "$ref": "#/components/schemas/OrganizationMemberRole"
+                            }
+                        ]
+                    }
+                },
+                "required": ["userUuid", "role", "hasDirectAccess"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "SpaceAccess": {
+                "$ref": "#/components/schemas/Pick_SpaceShare.userUuid-or-role-or-hasDirectAccess-or-inheritedFrom-or-projectRole-or-inheritedRole_"
+            },
             "SavedChart": {
                 "properties": {
                     "slug": {
@@ -5029,7 +5071,7 @@
                     },
                     "access": {
                         "items": {
-                            "$ref": "#/components/schemas/SpaceShare"
+                            "$ref": "#/components/schemas/SpaceAccess"
                         },
                         "type": "array"
                     },
@@ -9705,6 +9747,9 @@
                     "type": {
                         "$ref": "#/components/schemas/WarehouseTypes.SNOWFLAKE"
                     },
+                    "role": {
+                        "type": "string"
+                    },
                     "account": {
                         "type": "string"
                     },
@@ -9713,9 +9758,6 @@
                     },
                     "authenticationType": {
                         "$ref": "#/components/schemas/SnowflakeAuthenticationType"
-                    },
-                    "role": {
-                        "type": "string"
                     },
                     "database": {
                         "type": "string"
@@ -9865,11 +9907,11 @@
                     "type": {
                         "$ref": "#/components/schemas/WarehouseTypes.POSTGRES"
                     },
-                    "requireUserCredentials": {
-                        "type": "boolean"
-                    },
                     "role": {
                         "type": "string"
+                    },
+                    "requireUserCredentials": {
+                        "type": "boolean"
                     },
                     "schema": {
                         "type": "string"
@@ -9960,6 +10002,9 @@
                     "type": {
                         "$ref": "#/components/schemas/WarehouseTypes.BIGQUERY"
                     },
+                    "project": {
+                        "type": "string"
+                    },
                     "requireUserCredentials": {
                         "type": "boolean"
                     },
@@ -9981,9 +10026,6 @@
                     "timeoutSeconds": {
                         "type": "number",
                         "format": "double"
-                    },
-                    "project": {
-                        "type": "string"
                     },
                     "dataset": {
                         "type": "string"
@@ -18685,22 +18727,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -24956,7 +24998,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2453.0",
+        "version": "0.2453.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -661,7 +661,7 @@ export class ServiceRepository
                     permissionsService: this.getPermissionsService(),
                     googleDriveClient: this.clients.getGoogleDriveClient(),
                     userService: this.getUserService(),
-                    featureFlagModel: this.models.getFeatureFlagModel(),
+                    spacePermissionService: this.getSpacePermissionService(),
                 }),
         );
     }

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -74,6 +74,27 @@ export class SpacePermissionService extends BaseService {
     }
 
     /**
+     * Returns the CASL context for a space (organizationUuid, projectUuid, isPrivate, access)
+     * without performing any permission checks. Callers use this to build their own
+     * `subject(...)` checks when the resource type is not Space.
+     */
+    async getSpaceAccessContext(
+        userUuid: string,
+        spaceUuid: string,
+    ): Promise<SpaceAccessContextForCasl> {
+        const accessContext = await this.getSpacesCaslContext([spaceUuid], {
+            userUuid,
+        });
+        const ctx = accessContext[spaceUuid];
+        if (!ctx) {
+            throw new NotFoundError(
+                `Couldn't find access context for space ${spaceUuid}`,
+            );
+        }
+        return ctx;
+    }
+
+    /**
      * Gets the access context for a list of space uuids so we can check against CASL
      * @param spaceUuidsArg - The space uuids to get the access context for
      * @param filters - The filters to apply to the access context

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -9,7 +9,7 @@ import { type MetricQuery, type MetricQueryRequest } from './metricQuery';
 import { type ParametersValuesMap } from './parameters';
 import type { SchedulerAndTargets } from './scheduler';
 // eslint-disable-next-line import/no-cycle
-import { type SpaceShare } from './space';
+import { type SpaceAccess } from './space';
 import { type LightdashUser, type UpdatedByUser } from './user';
 import { type ValidationSummary } from './validation';
 
@@ -567,7 +567,7 @@ export type SavedChart = {
     dashboardName: string | null;
     colorPalette: string[];
     isPrivate: boolean;
-    access: SpaceShare[];
+    access: SpaceAccess[];
     slug: string;
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new](https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new)

### Description:

This PR introduces a new `SpaceAccess` type to replace `SpaceShare` in the SavedChart service.
It refactors the SavedChartService to use the SpacePermissionService for access control instead of directly accessing the SpaceModel.
This change improves code organization by centralizing space permission logic and removes the dependency on the FeatureFlagModel for nested permissions.

The PR also updates the generated routes and swagger files to reflect these type changes, ensuring API documentation remains in sync with the implementation.