### PR TITLE
chore: use table name constants instead of hardcoded strings

### DIFF
--- a/packages/backend/src/ee/models/EmbedModel.ts
+++ b/packages/backend/src/ee/models/EmbedModel.ts
@@ -1,5 +1,7 @@
 import { Embed, NotFoundError, UpdateEmbed } from '@lightdash/common';
 import { Knex } from 'knex';
+import { DashboardsTableName } from '../../database/entities/dashboards';
+import { SavedChartsTableName } from '../../database/entities/savedCharts';
 
 type Dependencies = {
     database: Knex;
@@ -47,7 +49,7 @@ export class EmbedModel {
             );
         }
 
-        const dashboards = await this.database('dashboards')
+        const dashboards = await this.database(DashboardsTableName)
             .select()
             .whereIn('dashboard_uuid', embed.dashboard_uuids)
             .whereNull('deleted_at');
@@ -56,7 +58,7 @@ export class EmbedModel {
             (dashboard) => dashboard.dashboard_uuid,
         );
 
-        const charts = await this.database('saved_queries')
+        const charts = await this.database(SavedChartsTableName)
             .select()
             .whereIn('saved_query_uuid', embed.chart_uuids)
             .whereNull('deleted_at');

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -15,6 +15,7 @@ import {
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
+import { SavedSqlTableName } from '../database/entities/savedSql';
 import { SpaceTableName } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
 import {
@@ -108,7 +109,7 @@ export class AnalyticsModel {
                 chart_uuid: chartUuid,
                 user_uuid: userUuid,
             }); */
-            await trx(`saved_sql`)
+            await trx(SavedSqlTableName)
                 .update({
                     views_count: trx.raw(
                         'views_count + 1',

--- a/packages/backend/src/models/CLAUDE.md
+++ b/packages/backend/src/models/CLAUDE.md
@@ -82,19 +82,22 @@ The `saved_queries` table supports soft delete. When `SOFT_DELETE_ENABLED=true`,
 Any query that touches `saved_queries` must filter out soft-deleted records:
 
 **Direct Knex query:**
+
 ```typescript
-const charts = await this.database('saved_queries')
-    .whereNull('deleted_at')  // ADD THIS
+const charts = await this.database(SavedChartsTableName)
+    .whereNull('deleted_at') // ADD THIS
     .where('project_uuid', projectUuid);
 ```
 
 **Knex join (simple):**
+
 ```typescript
 .leftJoin(SavedChartsTableName, ...)
 .whereNull(`${SavedChartsTableName}.deleted_at`)  // ADD THIS
 ```
 
 **Knex join (function syntax - for join conditions):**
+
 ```typescript
 .leftJoin(SavedChartsTableName, function () {
     this.on('column1', '=', 'column2')
@@ -103,12 +106,14 @@ const charts = await this.database('saved_queries')
 ```
 
 **Raw SQL join:**
+
 ```sql
 -- Add to join condition:
-left join saved_queries sq on sq.saved_query_uuid = ... AND sq.deleted_at IS NULL
+left join ${SavedChartsTableName} sq on sq.saved_query_uuid = ... AND sq.deleted_at IS NULL
 ```
 
 **Raw SQL WHERE clause:**
+
 ```sql
 WHERE ... AND sq.deleted_at IS NULL
 ```

--- a/packages/backend/src/models/CommentModel/CommentModel.ts
+++ b/packages/backend/src/models/CommentModel/CommentModel.ts
@@ -14,6 +14,7 @@ import {
     DashboardVersionsTableName,
     DashboardsTableName,
 } from '../../database/entities/dashboards';
+import { SavedChartsTableName } from '../../database/entities/savedCharts';
 import { DbUser, UserTableName } from '../../database/entities/users';
 
 type CommentModelArguments = {
@@ -126,12 +127,12 @@ export class CommentModel {
                 'dashboard_tile_charts.dashboard_tile_uuid',
                 'dashboard_tiles.dashboard_tile_uuid',
             )
-            .leftJoin('saved_queries', function nonDeletedChartJoin() {
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
                 this.on(
-                    'saved_queries.saved_query_id',
+                    `${SavedChartsTableName}.saved_query_id`,
                     '=',
                     'dashboard_tile_charts.saved_chart_id',
-                ).andOnNull('saved_queries.deleted_at');
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
             .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
             .andWhere(
@@ -140,7 +141,7 @@ export class CommentModel {
             )
             .select(
                 `${DashboardTilesTableName}.dashboard_tile_uuid`,
-                `saved_queries.saved_query_uuid`,
+                `${SavedChartsTableName}.saved_query_uuid`,
             )
             .first();
 

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
@@ -147,7 +147,7 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                         `last_version.dashboard_version_id`,
                         knex.raw(`(select dashboard_version_id
                                            from dashboard_versions
-                                           where dashboard_id = dashboards.dashboard_id
+                                           where dashboard_id = ${DashboardsTableName}.dashboard_id
                                            order by dashboard_versions.created_at desc
                                            limit 1)`),
                     );
@@ -155,7 +155,7 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                         `first_version.dashboard_version_id`,
                         knex.raw(`(select dashboard_version_id
                                             from dashboard_versions
-                                            where dashboard_id = dashboards.dashboard_id
+                                            where dashboard_id = ${DashboardsTableName}.dashboard_id
                                             order by dashboard_versions.created_at asc
                                             limit 1)`),
                     );

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -556,8 +556,8 @@ export class DashboardModel {
                 .with(cteName, (qb) => {
                     void qb
                         .select({
-                            dashboard_uuid: 'dashboards.dashboard_uuid',
-                            name: 'dashboards.name',
+                            dashboard_uuid: `${DashboardsTableName}.dashboard_uuid`,
+                            name: `${DashboardsTableName}.name`,
                             dashboard_version_id: this.database.raw(
                                 'MAX(dashboard_versions.dashboard_version_id)',
                             ),
@@ -565,7 +565,7 @@ export class DashboardModel {
                         .from(DashboardsTableName)
                         .leftJoin(
                             SpaceTableName,
-                            'dashboards.space_id',
+                            `${DashboardsTableName}.space_id`,
                             `${SpaceTableName}.space_id`,
                         )
                         .leftJoin(
@@ -581,8 +581,8 @@ export class DashboardModel {
                         .where('projects.project_uuid', projectUuid)
                         .whereNull(`${DashboardsTableName}.deleted_at`)
                         .groupBy(
-                            'dashboards.dashboard_uuid',
-                            'dashboards.name',
+                            `${DashboardsTableName}.dashboard_uuid`,
+                            `${DashboardsTableName}.name`,
                         );
                 })
                 .select({
@@ -591,7 +591,7 @@ export class DashboardModel {
                     filters: `${DashboardViewsTableName}.filters`,
                     parameters: `${DashboardViewsTableName}.parameters`,
                     chartUuids: this.database.raw(
-                        "COALESCE(ARRAY_AGG(DISTINCT saved_queries.saved_query_uuid) FILTER (WHERE saved_queries.saved_query_uuid IS NOT NULL), '{}')",
+                        `COALESCE(ARRAY_AGG(DISTINCT ${SavedChartsTableName}.saved_query_uuid) FILTER (WHERE ${SavedChartsTableName}.saved_query_uuid IS NOT NULL), '{}')`,
                     ),
                 })
                 .from(cteName)
@@ -1503,7 +1503,7 @@ export class DashboardModel {
                 firstName: `${UserTableName}.first_name`,
                 lastName: `${UserTableName}.last_name`,
                 chartUuids: this.database.raw(
-                    'ARRAY_AGG(DISTINCT saved_queries.saved_query_uuid) FILTER (WHERE saved_queries.saved_query_uuid IS NOT NULL)',
+                    `ARRAY_AGG(DISTINCT ${SavedChartsTableName}.saved_query_uuid) FILTER (WHERE ${SavedChartsTableName}.saved_query_uuid IS NOT NULL)`,
                 ),
             })
             .orderBy([

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -42,37 +42,36 @@ const getCharts = async (
             saved_chart_uuid: 'pinned_chart.saved_chart_uuid',
             updated_by_user_first_name: 'users.first_name',
             updated_by_user_last_name: 'users.last_name',
-            updated_by_user_uuid:
-                'saved_queries.last_version_updated_by_user_uuid',
+            updated_by_user_uuid: `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
             order: 'pinned_chart.order',
-            chart_kind: `saved_queries.last_version_chart_kind`,
-            name: 'saved_queries.name',
-            description: 'saved_queries.description',
-            updated_at: 'saved_queries.last_version_updated_at',
-            views: 'saved_queries.views_count',
-            first_viewed_at: 'saved_queries.first_viewed_at',
-            slug: 'saved_queries.slug',
+            chart_kind: `${SavedChartsTableName}.last_version_chart_kind`,
+            name: `${SavedChartsTableName}.name`,
+            description: `${SavedChartsTableName}.description`,
+            updated_at: `${SavedChartsTableName}.last_version_updated_at`,
+            views: `${SavedChartsTableName}.views_count`,
+            first_viewed_at: `${SavedChartsTableName}.first_viewed_at`,
+            slug: `${SavedChartsTableName}.slug`,
         })
         .innerJoin(
             'pinned_chart',
             'pinned_list.pinned_list_uuid',
             'pinned_chart.pinned_list_uuid',
         )
-        .innerJoin('saved_queries', function nonDeletedChartJoin() {
+        .innerJoin(SavedChartsTableName, function nonDeletedChartJoin() {
             this.on(
                 'pinned_chart.saved_chart_uuid',
                 '=',
-                'saved_queries.saved_query_uuid',
-            ).andOnNull('saved_queries.deleted_at');
+                `${SavedChartsTableName}.saved_query_uuid`,
+            ).andOnNull(`${SavedChartsTableName}.deleted_at`);
         })
         .innerJoin(
             SpaceTableName,
-            'saved_queries.space_id',
+            `${SavedChartsTableName}.space_id`,
             `${SpaceTableName}.space_id`,
         )
         .leftJoin(
             'users',
-            'saved_queries.last_version_updated_by_user_uuid',
+            `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
             'users.user_uuid',
         )
         .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
@@ -120,16 +119,16 @@ const getDashboards = async (
             'pinned_list.pinned_list_uuid',
             'pinned_dashboard.pinned_list_uuid',
         )
-        .innerJoin('dashboards', function nonDeletedDashboardJoin() {
+        .innerJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
             this.on(
                 'pinned_dashboard.dashboard_uuid',
                 '=',
-                'dashboards.dashboard_uuid',
-            ).andOnNull('dashboards.deleted_at');
+                `${DashboardsTableName}.dashboard_uuid`,
+            ).andOnNull(`${DashboardsTableName}.deleted_at`);
         })
         .innerJoin(
             SpaceTableName,
-            'dashboards.space_id',
+            `${DashboardsTableName}.space_id`,
             `${SpaceTableName}.space_id`,
         )
         .innerJoin(
@@ -143,7 +142,7 @@ const getDashboards = async (
                     'updated_by_user_uuid',
                 )
                 .as('dv'),
-            'dashboards.dashboard_id',
+            `${DashboardsTableName}.dashboard_id`,
             'dv.dashboard_id',
         )
         .leftJoin('users', 'dv.updated_by_user_uuid', 'users.user_uuid')
@@ -160,10 +159,10 @@ const getDashboards = async (
             'pinned_dashboard.order',
         )
         .max({
-            name: 'dashboards.name',
-            views: 'dashboards.views_count',
-            first_viewed_at: 'dashboards.first_viewed_at',
-            description: 'dashboards.description',
+            name: `${DashboardsTableName}.name`,
+            views: `${DashboardsTableName}.views_count`,
+            first_viewed_at: `${DashboardsTableName}.first_viewed_at`,
+            description: `${DashboardsTableName}.description`,
             updated_at: 'dv.updated_at',
             updated_by_user_first_name: 'users.first_name',
             updated_by_user_last_name: 'users.last_name',

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -36,16 +36,9 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { DatabaseError } from 'pg';
-import {
-    DashboardsTableName,
-    DbDashboard,
-} from '../../database/entities/dashboards';
-import { OrganizationTableName } from '../../database/entities/organizations';
+import { DashboardsTableName } from '../../database/entities/dashboards';
 import { ProjectTableName } from '../../database/entities/projects';
-import {
-    DbSavedChart,
-    SavedChartsTableName,
-} from '../../database/entities/savedCharts';
+import { SavedChartsTableName } from '../../database/entities/savedCharts';
 import {
     SchedulerDb,
     SchedulerEmailTargetDb,
@@ -59,7 +52,7 @@ import {
     SchedulerTableName,
 } from '../../database/entities/scheduler';
 import { SpaceTableName } from '../../database/entities/spaces';
-import { DbUser, UserTableName } from '../../database/entities/users';
+import { UserTableName } from '../../database/entities/users';
 import KnexPaginate from '../../database/pagination';
 import { getColumnMatchRegexQuery } from '../SearchModel/utils/search';
 

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -358,11 +358,11 @@ export class SearchModel {
             .whereIn('dashboard_uuid', dashboardUuids)
             .whereNull('deleted_at');
 
-        const tileChartsQuery = this.database('dashboards')
-            .whereNull('dashboards.deleted_at')
+        const tileChartsQuery = this.database(DashboardsTableName)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
             .join(
                 'dashboard_versions',
-                'dashboards.dashboard_id',
+                `${DashboardsTableName}.dashboard_id`,
                 'dashboard_versions.dashboard_id',
             )
             .join(
@@ -389,7 +389,7 @@ export class SearchModel {
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
             .select(
-                'dashboards.dashboard_uuid',
+                `${DashboardsTableName}.dashboard_uuid`,
                 { uuid: `${SavedChartsTableName}.saved_query_uuid` },
                 `${SavedChartsTableName}.name`,
                 `${SavedChartsTableName}.description`,
@@ -398,12 +398,12 @@ export class SearchModel {
                 },
                 `${SavedChartsTableName}.views_count`,
             )
-            .whereIn('dashboards.dashboard_uuid', dashboardUuids)
+            .whereIn(`${DashboardsTableName}.dashboard_uuid`, dashboardUuids)
             .whereRaw(
                 `dashboard_versions.dashboard_version_id = (
                         SELECT MAX(dashboard_version_id)
                         FROM dashboard_versions dv2
-                        WHERE dv2.dashboard_id = dashboards.dashboard_id
+                        WHERE dv2.dashboard_id = ${DashboardsTableName}.dashboard_id
                     )`,
             );
 
@@ -1039,7 +1039,9 @@ export class SearchModel {
             }>()
             .from(savedChartsSubquery.as('saved_charts'))
             .unionAll(
-                this.database.select().from(savedSqlSubquery.as('saved_sql')),
+                this.database
+                    .select()
+                    .from(savedSqlSubquery.as(SavedSqlTableName)),
             );
 
         const results = await this.database

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -236,7 +236,7 @@ export class SpaceModel {
         userUuid: string,
     ): Promise<Space> {
         const space = await this.getFirstAccessibleSpace(projectUuid, userUuid);
-        const savedQueries = await this.database('saved_queries')
+        const savedQueries = await this.database(SavedChartsTableName)
             .leftJoin(
                 SpaceTableName,
                 `${SavedChartsTableName}.space_id`,
@@ -321,9 +321,9 @@ export class SpaceModel {
                     `${SpaceModel.getRootSpaceIsPrivateQuery()} AS is_private`,
                 ),
             ])
-            .orderBy('saved_queries.last_version_updated_at', 'desc')
-            .where('saved_queries.space_id', space.space_id)
-            .whereNull('saved_queries.deleted_at');
+            .orderBy(`${SavedChartsTableName}.last_version_updated_at`, 'desc')
+            .where(`${SavedChartsTableName}.space_id`, space.space_id)
+            .whereNull(`${SavedChartsTableName}.deleted_at`);
 
         return {
             organizationUuid: space.organization_uuid,
@@ -2048,7 +2048,7 @@ export class SpaceModel {
                         (
                             SELECT json_agg(validations.*)
                             FROM validations
-                            WHERE validations.saved_chart_uuid = saved_queries.saved_query_uuid
+                            WHERE validations.saved_chart_uuid = ${SavedChartsTableName}.saved_query_uuid
                             AND validations.job_id IS NULL
                         ), '[]'
                     ) as validation_errors
@@ -2074,7 +2074,7 @@ export class SpaceModel {
                           ]
                         : [
                               {
-                                  column: `saved_queries.last_version_updated_at`,
+                                  column: `${SavedChartsTableName}.last_version_updated_at`,
                                   order: 'desc',
                               },
                           ],

--- a/packages/backend/src/utils/CLAUDE.md
+++ b/packages/backend/src/utils/CLAUDE.md
@@ -17,7 +17,11 @@ const encrypted = encryption.encrypt('sensitive data');
 const decrypted = encryption.decrypt(encrypted);
 
 // Generate unique slugs
-const slug = await generateUniqueSlug(trx, 'saved_queries', 'My Chart Name');
+const slug = await generateUniqueSlug(
+    trx,
+    SavedChartsTableName,
+    'My Chart Name',
+);
 
 // Adjust cron expressions for timezone
 const adjustedCron = getAdjustedCronByOffset('0 9 * * *', 120); // +2 hours
@@ -37,7 +41,7 @@ await database('organizations').update({ jwt_secret: encryptedSecret });
 const chartSlug = await generateUniqueSlugScopedToProject(
     trx,
     projectUuid,
-    'saved_queries',
+    SavedChartsTableName,
     'Weekly Sales Report',
 );
 


### PR DESCRIPTION
### Description:
This PR replaces hardcoded table name strings with imported table name constants throughout the codebase. The changes primarily affect:

- Replaced `'saved_queries'` with `SavedChartsTableName`
- Replaced `'saved_sql'` with `SavedSqlTableName`
- Replaced `'dashboards'` with `DashboardsTableName`

This improves code maintainability by centralizing table name definitions and reduces the risk of typos in table references. It also makes the code more consistent with our existing patterns for database entity references.