### PR TITLE
feat: added wide table for testing sum_distinct feat

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/data/raw_order_items.csv
+++ b/examples/full-jaffle-shop-demo/dbt/data/raw_order_items.csv
@@ -1,0 +1,27 @@
+id,order_id,product_name,quantity,unit_price
+1,1,Classic Jaffle,2,8.50
+2,1,Maple Syrup,1,4.00
+3,2,Belgian Waffle,1,12.00
+4,2,Fresh Berries,2,5.00
+5,3,Cheese Jaffle,1,9.50
+6,4,Deluxe Waffle Stack,1,18.00
+7,4,Whipped Cream,2,2.50
+8,4,Hot Chocolate,1,4.50
+9,5,Ham & Cheese Jaffle,1,11.00
+10,5,Orange Juice,1,3.50
+11,6,Nutella Waffle,1,13.00
+12,7,Classic Jaffle,3,8.50
+13,8,Breakfast Platter,1,22.00
+14,8,Coffee,2,3.50
+15,9,Veggie Jaffle,1,10.00
+16,9,Sweet Potato Waffle,1,14.00
+17,9,Iced Latte,1,5.00
+18,10,Premium Waffle Feast,1,28.00
+19,11,Bacon Jaffle,1,12.00
+20,11,Hash Browns,1,4.00
+21,12,Kids Waffle,1,7.00
+22,13,Chicken Jaffle,1,13.00
+23,13,Side Salad,2,4.50
+24,14,Gourmet Jaffle Combo,1,24.00
+25,15,Waffle Ice Cream Sundae,2,15.00
+26,15,Espresso,2,3.00

--- a/examples/full-jaffle-shop-demo/dbt/models/customer_order_payments.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/customer_order_payments.sql
@@ -1,0 +1,63 @@
+-- Wide table joining customers, orders, order line items, and payments
+-- This creates a compound fanout from two one-to-many relationships:
+--   orders -> line_items (1:N)
+--   orders -> payments (1:N)
+-- Result: line_items × payments rows per order
+--
+-- Use sum_distinct metrics to deduplicate aggregations at different grains:
+--   - Order-level metrics: dedupe by order_id
+--   - Line item metrics: dedupe by line_item_id (or order_id + line_item_id if not globally unique)
+--   - Payment metrics: no dedup needed at payment grain, but need order_id for order-level
+
+with customers as (
+    select * from {{ ref('stg_customers') }}
+),
+
+orders as (
+    select * from {{ ref('stg_orders') }}
+),
+
+order_items as (
+    select
+        id as line_item_id,
+        order_id,
+        product_name,
+        quantity,
+        unit_price,
+        quantity * unit_price as line_item_total
+    from {{ ref('raw_order_items') }}
+),
+
+payments as (
+    select * from {{ ref('stg_payments') }}
+)
+
+-- Cross join line items and payments for the same order creates the fanout
+select
+    -- Customer grain (dedupe by customer_id)
+    c.customer_id,
+    c.first_name,
+    c.last_name,
+
+    -- Order grain (dedupe by order_id)
+    o.order_id,
+    o.order_date,
+    o.status as order_status,
+    o.shipping_cost,
+
+    -- Line item grain (dedupe by line_item_id)
+    li.line_item_id,
+    li.product_name,
+    li.quantity,
+    li.unit_price,
+    li.line_item_total,
+
+    -- Payment grain
+    p.payment_id,
+    p.payment_method,
+    p.amount as payment_amount
+
+from orders o
+inner join order_items li on o.order_id = li.order_id
+inner join payments p on o.order_id = p.order_id
+left join customers c on o.customer_id = c.customer_id

--- a/examples/full-jaffle-shop-demo/dbt/models/customer_order_payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/customer_order_payments.yml
@@ -1,0 +1,202 @@
+version: 2
+models:
+  - name: customer_order_payments
+    description: >
+      Wide table joining customers, orders, order line items, and payments.
+
+      **Compound Fanout**: This table joins two one-to-many relationships through orders:
+      - orders → line_items (1:N)
+      - orders → payments (1:N)
+
+      Result: Each order with M line items and N payments produces M × N rows.
+
+      Example: Order #9 has 3 line items and 2 payments = 6 rows in this table.
+
+      **Deduplication with sum_distinct**:
+      - Order-level metrics (shipping_cost): dedupe by `order_id`
+      - Line item metrics (line_item_total): dedupe by `line_item_id`
+      - Payment metrics (payment_amount): dedupe by `payment_id`
+    config:
+      tags: ["core", "wide-table", "fanout-demo"]
+      meta:
+        primary_key: [order_id, line_item_id, payment_id]
+
+    columns:
+      # Customer grain columns
+      - name: customer_id
+        description: Unique identifier for the customer
+        config:
+          meta:
+            metrics:
+              unique_customers:
+                type: count_distinct
+                description: Count of unique customers
+
+      - name: first_name
+        description: Customer's first name
+
+      - name: last_name
+        description: Customer's last name
+
+      # Order grain columns
+      - name: order_id
+        description: Unique identifier for the order. Use as distinct_key for order-level aggregations.
+        tests:
+          - not_null
+        config:
+          meta:
+            metrics:
+              unique_orders:
+                type: count_distinct
+                description: Count of unique orders
+
+      - name: order_date
+        description: Date the order was placed
+        config:
+          meta:
+            dimension:
+              type: date
+
+      - name: order_status
+        description: Current status of the order
+
+      - name: shipping_cost
+        description: >
+          Shipping cost for the order. Duplicated across all line_item × payment combinations
+          for this order. Use sum_distinct with order_id to get correct totals.
+        config:
+          meta:
+            dimension:
+              format: usd
+              round: 2
+            metrics:
+              total_shipping_cost_deduped:
+                type: sum_distinct
+                sql: ${shipping_cost}
+                distinct_keys: [order_id]
+                description: >
+                  Total shipping costs correctly deduped by order_id. Each order's shipping
+                  cost is summed once, regardless of line items or payment methods.
+                format: usd
+                round: 2
+              total_shipping_cost_inflated:
+                type: sum
+                sql: ${shipping_cost}
+                description: >
+                  Inflated sum - shipping cost counted once per (line_item × payment) combination.
+                  For an order with 3 items and 2 payments, shipping is counted 6 times!
+                format: usd
+                round: 2
+
+      # Line item grain columns
+      - name: line_item_id
+        description: >
+          Unique identifier for the line item. Use as distinct_key for line-item-level aggregations.
+        tests:
+          - not_null
+        config:
+          meta:
+            metrics:
+              unique_line_items:
+                type: count_distinct
+                description: Count of unique line items
+
+      - name: product_name
+        description: Name of the product in this line item
+
+      - name: quantity
+        description: Quantity of this product ordered
+
+      - name: unit_price
+        description: Price per unit
+        config:
+          meta:
+            dimension:
+              format: usd
+              round: 2
+
+      - name: line_item_total
+        description: >
+          Total for this line item (quantity × unit_price). Duplicated across all payments
+          for this order. Use sum_distinct with line_item_id to get correct totals.
+        config:
+          meta:
+            dimension:
+              format: usd
+              round: 2
+            metrics:
+              total_line_item_revenue_deduped:
+                type: sum_distinct
+                sql: ${line_item_total}
+                distinct_keys: [line_item_id]
+                description: >
+                  Total line item revenue correctly deduped. Each line item's total is
+                  summed once, regardless of how many payments the order has.
+                format: usd
+                round: 2
+              total_line_item_revenue_inflated:
+                type: sum
+                sql: ${line_item_total}
+                description: >
+                  Inflated sum - line item totals counted once per payment on the order.
+                  An order with 2 payments doubles all line item amounts!
+                format: usd
+                round: 2
+
+      # Payment grain columns
+      - name: payment_id
+        description: Unique identifier for the payment
+        tests:
+          - not_null
+        config:
+          meta:
+            metrics:
+              unique_payments:
+                type: count_distinct
+                description: Count of unique payments
+
+      - name: payment_method
+        description: Payment method used (credit_card, coupon, bank_transfer, gift_card)
+
+      - name: payment_amount
+        description: >
+          Amount of this individual payment. Duplicated across all line items for this order.
+          Use sum_distinct with payment_id to get correct totals.
+        config:
+          meta:
+            dimension:
+              format: usd
+              round: 2
+            metrics:
+              total_payment_amount_deduped:
+                type: sum_distinct
+                sql: ${payment_amount}
+                distinct_keys: [payment_id]
+                description: >
+                  Total payment amount correctly deduped. Each payment is summed once,
+                  regardless of how many line items the order has.
+                format: usd
+                round: 2
+              total_payment_amount_inflated:
+                type: sum
+                sql: ${payment_amount}
+                description: >
+                  Inflated sum - payment amounts counted once per line item on the order.
+                  An order with 3 line items triples all payment amounts!
+                format: usd
+                round: 2
+              # Multi-key deduplication example:
+              # This metric sums payment amounts but dedupes by BOTH order_id and payment_method.
+              # Use case: "Total paid by each payment method per order" when analyzing across
+              # the line_item dimension. If an order has 3 items and 1 credit card payment,
+              # without multi-key dedup the credit card amount would be counted 3 times.
+              total_payment_by_method_per_order:
+                type: sum_distinct
+                sql: ${payment_amount}
+                distinct_keys: [order_id, payment_method]
+                description: >
+                  Total payment amount deduped by order + payment method combination.
+                  Useful when you want to analyze payment methods but your query includes
+                  line items. Each (order, payment_method) combination is counted once.
+                format: usd
+                round: 2


### PR DESCRIPTION

Closes: N/A

### Description:
Added a wide model to test out the sum_distinct logic. Here customers, orders, payments and line_items have been joined into one wide model. If you want to correctly work out metrics from any of these models, you would need a way to dedupe them which should be handled by sum_distinct. Note I haven't tested the models locally as I haven't got my profiles.yml set up for postgres. 

test-frontend