### PR TITLE
feat: add IAM role authentication for Athena warehouse connections

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -282,6 +282,9 @@ export const lightdashConfigMock: LightdashConfig = {
     organizationWarehouseCredentials: {
         enabled: false,
     },
+    athenaWarehouseIamRoleAuth: {
+        enabled: false,
+    },
     googleCloudPlatform: {
         projectId: 'test-project-id',
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -915,6 +915,9 @@ export type LightdashConfig = {
     organizationWarehouseCredentials: {
         enabled: boolean;
     };
+    athenaWarehouseIamRoleAuth: {
+        enabled: boolean;
+    };
     github: {
         appName: string;
         redirectDomain: string;
@@ -1777,6 +1780,9 @@ export const parseConfig = (): LightdashConfig => {
             enabled:
                 process.env.ORGANIZATION_WAREHOUSE_CREDENTIALS_ENABLED ===
                 'true',
+        },
+        athenaWarehouseIamRoleAuth: {
+            enabled: process.env.ATHENA_WAREHOUSE_IAM_ROLE_AUTH === 'true',
         },
         github: {
             appName: process.env.GITHUB_APP_NAME || 'lightdash-app-dev',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -9981,6 +9981,11 @@ const models: TsoaRoute.Models = {
         enums: ['athena'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AthenaAuthenticationType: {
+        dataType: 'refEnum',
+        enums: ['access_key', 'iam_role'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_CreateAthenaCredentials.Exclude_keyofCreateAthenaCredentials.SensitiveCredentialsFieldNames__':
         {
             dataType: 'refAlias',
@@ -9992,6 +9997,13 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'boolean' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    authenticationType: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'AthenaAuthenticationType' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -10541,8 +10553,9 @@ const models: TsoaRoute.Models = {
                 numRetries: { dataType: 'double' },
                 threads: { dataType: 'double' },
                 workGroup: { dataType: 'string' },
-                secretAccessKey: { dataType: 'string', required: true },
-                accessKeyId: { dataType: 'string', required: true },
+                secretAccessKey: { dataType: 'string' },
+                accessKeyId: { dataType: 'string' },
+                authenticationType: { ref: 'AthenaAuthenticationType' },
                 s3DataDir: { dataType: 'string' },
                 s3StagingDir: { dataType: 'string', required: true },
                 schema: { dataType: 'string', required: true },
@@ -11795,8 +11808,20 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 type: { ref: 'WarehouseTypes.ATHENA', required: true },
-                accessKeyId: { dataType: 'string', required: true },
-                secretAccessKey: { dataType: 'string', required: true },
+                accessKeyId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                secretAccessKey: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10195,6 +10195,10 @@
                 "enum": ["athena"],
                 "type": "string"
             },
+            "AthenaAuthenticationType": {
+                "enum": ["access_key", "iam_role"],
+                "type": "string"
+            },
             "Pick_CreateAthenaCredentials.Exclude_keyofCreateAthenaCredentials.SensitiveCredentialsFieldNames__": {
                 "properties": {
                     "type": {
@@ -10202,6 +10206,9 @@
                     },
                     "requireUserCredentials": {
                         "type": "boolean"
+                    },
+                    "authenticationType": {
+                        "$ref": "#/components/schemas/AthenaAuthenticationType"
                     },
                     "database": {
                         "type": "string"
@@ -10947,6 +10954,9 @@
                     "accessKeyId": {
                         "type": "string"
                     },
+                    "authenticationType": {
+                        "$ref": "#/components/schemas/AthenaAuthenticationType"
+                    },
                     "s3DataDir": {
                         "type": "string"
                     },
@@ -10967,8 +10977,6 @@
                     }
                 },
                 "required": [
-                    "secretAccessKey",
-                    "accessKeyId",
                     "s3StagingDir",
                     "schema",
                     "database",
@@ -12243,7 +12251,7 @@
                         "type": "string"
                     }
                 },
-                "required": ["type", "accessKeyId", "secretAccessKey"],
+                "required": ["type"],
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
@@ -24682,7 +24690,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2451.0",
+        "version": "0.2451.2",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1,6 +1,7 @@
 import {
     AlreadyExistsError,
     AnyType,
+    AthenaAuthenticationType,
     BigqueryAuthenticationType,
     ChangesetUtils,
     CompiledTable,
@@ -192,7 +193,11 @@ export class ProjectModel {
             // BigQuery ADC authentication does not require credentials to be set
             (incompleteConfig.type === WarehouseTypes.BIGQUERY &&
                 incompleteConfig.authenticationType ===
-                    BigqueryAuthenticationType.ADC)
+                    BigqueryAuthenticationType.ADC) ||
+            // Athena IAM role authentication should not merge old access keys
+            (incompleteConfig.type === WarehouseTypes.ATHENA &&
+                incompleteConfig.authenticationType ===
+                    AthenaAuthenticationType.IAM_ROLE)
         ) {
             return incompleteConfig;
         }

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -109,6 +109,7 @@ export const BaseResponse: HealthState = {
     },
     isServiceAccountEnabled: false,
     isOrganizationWarehouseCredentialsEnabled: false,
+    isAthenaWarehouseIamRoleAuthEnabled: false,
     isCustomRolesEnabled: false,
     embedding: { enabled: false, events: undefined },
     ai: {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -197,6 +197,8 @@ export class HealthService extends BaseService {
                 this.lightdashConfig.serviceAccount.enabled,
             isOrganizationWarehouseCredentialsEnabled:
                 this.lightdashConfig.organizationWarehouseCredentials.enabled,
+            isAthenaWarehouseIamRoleAuthEnabled:
+                this.lightdashConfig.athenaWarehouseIamRoleAuth.enabled,
             isCustomRolesEnabled:
                 this.isEnterpriseEnabled() &&
                 this.lightdashConfig.customRoles.enabled,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -15,6 +15,7 @@ import {
     assertEmbeddedAuth,
     assertIsAccountWithOrg,
     assertUnreachable,
+    AthenaAuthenticationType,
     BigqueryAuthenticationType,
     CacheMetadata,
     calculateCompilationReport,
@@ -1836,6 +1837,22 @@ export class ProjectService extends BaseService {
                             authenticationType,
                             `Unknown authentication type: ${authenticationType}`,
                         );
+                }
+                break;
+            case WarehouseTypes.ATHENA:
+                const athenaAuthenticationType =
+                    project.warehouseConnection.authenticationType ??
+                    AthenaAuthenticationType.ACCESS_KEY;
+
+                if (
+                    athenaAuthenticationType ===
+                        AthenaAuthenticationType.ACCESS_KEY &&
+                    (!project.warehouseConnection.accessKeyId ||
+                        !project.warehouseConnection.secretAccessKey)
+                ) {
+                    throw new ParameterError(
+                        'Athena access key authentication requires accessKeyId and secretAccessKey',
+                    );
                 }
                 break;
             default:

--- a/packages/cli/src/dbt/targets/athena.test.ts
+++ b/packages/cli/src/dbt/targets/athena.test.ts
@@ -1,0 +1,69 @@
+import {
+    AthenaAuthenticationType,
+    ParseError,
+    WarehouseTypes,
+} from '@lightdash/common';
+import { convertAthenaSchema } from './athena';
+
+describe('convertAthenaSchema', () => {
+    test('should parse access key authentication when keys are present', () => {
+        const target = {
+            type: 'athena',
+            region_name: 'us-east-1',
+            database: 'AwsDataCatalog',
+            schema: 'default',
+            s3_staging_dir: 's3://test-results/',
+            aws_access_key_id: 'AKIATEST',
+            aws_secret_access_key: 'SECRETTEST',
+        };
+
+        expect(convertAthenaSchema(target)).toEqual({
+            type: WarehouseTypes.ATHENA,
+            region: 'us-east-1',
+            database: 'AwsDataCatalog',
+            schema: 'default',
+            s3StagingDir: 's3://test-results/',
+            s3DataDir: undefined,
+            authenticationType: AthenaAuthenticationType.ACCESS_KEY,
+            accessKeyId: 'AKIATEST',
+            secretAccessKey: 'SECRETTEST',
+            workGroup: undefined,
+            threads: undefined,
+            numRetries: undefined,
+        });
+    });
+
+    test('should parse iam role authentication when keys are missing', () => {
+        const target = {
+            type: 'athena',
+            region_name: 'us-east-1',
+            database: 'AwsDataCatalog',
+            schema: 'default',
+            s3_staging_dir: 's3://test-results/',
+        };
+
+        expect(convertAthenaSchema(target)).toEqual({
+            type: WarehouseTypes.ATHENA,
+            region: 'us-east-1',
+            database: 'AwsDataCatalog',
+            schema: 'default',
+            s3StagingDir: 's3://test-results/',
+            s3DataDir: undefined,
+            authenticationType: AthenaAuthenticationType.IAM_ROLE,
+            accessKeyId: undefined,
+            secretAccessKey: undefined,
+            workGroup: undefined,
+            threads: undefined,
+            numRetries: undefined,
+        });
+    });
+
+    test('should throw parse error for invalid Athena target', () => {
+        expect(() =>
+            convertAthenaSchema({
+                type: 'athena',
+                region_name: 'us-east-1',
+            }),
+        ).toThrow(ParseError);
+    });
+});

--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    AthenaAuthenticationType,
     CreateSnowflakeCredentials,
     CreateWarehouseCredentials,
     DatabricksAuthenticationType,
@@ -184,6 +185,7 @@ function getMockCredentials(
         case SupportedDbtAdapter.ATHENA:
             return {
                 type: WarehouseTypes.ATHENA,
+                authenticationType: AthenaAuthenticationType.ACCESS_KEY,
                 region: '',
                 database: '',
                 schema: '',

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -321,6 +321,7 @@ export type HealthState = {
     hasMicrosoftTeams: boolean;
     isServiceAccountEnabled: boolean;
     isOrganizationWarehouseCredentialsEnabled: boolean;
+    isAthenaWarehouseIamRoleAuthEnabled: boolean;
     latest: {
         version?: string;
     };

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -89,6 +89,11 @@ export enum DatabricksAuthenticationType {
     OAUTH_U2M = 'oauth_u2m',
 }
 
+export enum AthenaAuthenticationType {
+    ACCESS_KEY = 'access_key',
+    IAM_ROLE = 'iam_role',
+}
+
 export type CreateDatabricksCredentials = {
     type: WarehouseTypes.DATABRICKS;
     catalog?: string;
@@ -186,8 +191,9 @@ export type CreateAthenaCredentials = {
     schema: string;
     s3StagingDir: string;
     s3DataDir?: string;
-    accessKeyId: string;
-    secretAccessKey: string;
+    authenticationType?: AthenaAuthenticationType;
+    accessKeyId?: string;
+    secretAccessKey?: string;
     workGroup?: string;
     threads?: number;
     numRetries?: number;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
@@ -1,4 +1,5 @@
 import {
+    AthenaAuthenticationType,
     BigqueryAuthenticationType,
     DatabricksAuthenticationType,
     WarehouseTypes,
@@ -145,6 +146,7 @@ export const ClickhouseDefaultValues: CreateClickhouseCredentials = {
 
 export const AthenaDefaultValues: CreateAthenaCredentials = {
     type: WarehouseTypes.ATHENA,
+    authenticationType: AthenaAuthenticationType.ACCESS_KEY,
     region: '',
     database: 'AwsDataCatalog',
     schema: '',

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -106,6 +106,7 @@ export default function mockHealthResponse(
         },
         isServiceAccountEnabled: false,
         isOrganizationWarehouseCredentialsEnabled: false,
+        isAthenaWarehouseIamRoleAuthEnabled: false,
         isCustomRolesEnabled: false,
         embedding: {
             enabled: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2950: Support IAM authentication for AWS Athena integration](https://linear.app/lightdash/issue/PROD-2950/support-iam-authentication-for-aws-athena-integration)

### Description:

This PR adds support for IAM role authentication for Amazon Athena. It introduces a new authentication type enum `AthenaAuthenticationType` with two options: `ACCESS_KEY` (default) and `IAM_ROLE`.

When IAM role authentication is selected, Lightdash will use the IAM role associated with the runtime environment (EC2 instance, ECS task, Lambda function, etc.) instead of requiring AWS access keys to be provided. This is more secure as it eliminates the need to store AWS credentials.

The feature is controlled by a new environment variable `ATHENA_WAREHOUSE_IAM_ROLE_AUTH` which enables the IAM role authentication option in the UI. When enabled, users can choose between access key and IAM role authentication methods when configuring Athena connections.
