### PR TITLE
fix: use bcc for admin change notification emails

### DIFF
--- a/packages/backend/src/clients/EmailClient/CLAUDE.md
+++ b/packages/backend/src/clients/EmailClient/CLAUDE.md
@@ -1,0 +1,10 @@
+# EmailClient
+
+## Multi-Recipient Email Privacy
+
+When sending emails to multiple recipients, you must explicitly decide whether to use `to` or `bcc`:
+
+- **`to`**: All recipients can see every other recipient's email address. Use only when recipients should be aware of each other (e.g., a shared thread where visibility is intentional).
+- **`bcc`**: Recipients cannot see each other. Use when the recipient list should not be disclosed (e.g., admin notifications, bulk alerts).
+
+Always ask the user/engineer which behavior is intended before choosing. Never default to `to` for multi-recipient emails without confirming that recipient visibility is acceptable.

--- a/packages/backend/src/clients/EmailClient/EmailClient.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.ts
@@ -794,7 +794,7 @@ export default class EmailClient {
             payload.type === AdminNotificationType.CONNECTION_SETTINGS_CHANGE;
 
         return this.sendEmail({
-            to: recipients,
+            bcc: recipients,
             subject: `[Lightdash] ${
                 subjectMap[payload.type]
             } - ${projectContext}`,


### PR DESCRIPTION
## Summary
- Admin change notification emails were using the `to` field, which disclosed all recipient email addresses to every other recipient
- Switched to `bcc` so admin emails are hidden from each other
- Added a `CLAUDE.md` to the EmailClient directory reminding engineers to explicitly choose `to` vs `bcc` when sending to multiple recipients

## Test plan
- [x] Unit tests pass (`pnpm -F backend test:dev:nowatch` — 180 tests, 13 suites)
- [x] Triggered an admin role change via the v2 roles API locally
- [x] Verified in Mailpit that the email has `To: null`, `Cc: null`, and recipients only in `Bcc`

🤖 Generated with [Claude Code](https://claude.com/claude-code)