### PR TITLE
fix: create dashboard modal colors

### DIFF
--- a/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardCreateModal.tsx
@@ -8,7 +8,6 @@ import {
     Textarea,
     type ModalProps,
 } from '@mantine-8/core';
-import { MantineProvider, useMantineColorScheme } from '@mantine/core';
 import { useForm } from '@mantine/form';
 import { IconLayoutDashboard, IconPlus } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, type FC } from 'react';
@@ -17,6 +16,7 @@ import { useModalSteps } from '../../../hooks/useModalSteps';
 import { useSpaceManagement } from '../../../hooks/useSpaceManagement';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import useApp from '../../../providers/App/useApp';
+import Mantine8Provider from '../../../providers/Mantine8Provider';
 import MantineIcon from '../MantineIcon';
 import MantineModal from '../MantineModal';
 import SaveToSpaceForm from './ChartCreateModal/SaveToSpaceForm';
@@ -42,7 +42,6 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
     ...modalProps
 }) => {
     const { user } = useApp();
-    const { colorScheme } = useMantineColorScheme();
     const { mutateAsync: createDashboard, isLoading: isCreatingDashboard } =
         useCreateMutation(projectUuid);
 
@@ -182,7 +181,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
     if (isLoadingSpaces || !spaces) return null;
 
     return (
-        <MantineProvider inherit theme={{ colorScheme }}>
+        <Mantine8Provider>
             <MantineModal
                 {...modalProps}
                 title="Create Dashboard"
@@ -270,7 +269,7 @@ const DashboardCreateModal: FC<DashboardCreateModalProps> = ({
                     )}
                 </form>
             </MantineModal>
-        </MantineProvider>
+        </Mantine8Provider>
     );
 };
 


### PR DESCRIPTION
### Description:
Replaced direct usage of `MantineProvider` with the custom `Mantine8Provider` component in the `DashboardCreateModal`. 

Navbar is hardcoded to be dark mode, so we need to update this component to read from app provider instead of inherit from parent

#### Before

![CleanShot 2026-02-11 at 18.19.26@2x.png](https://app.graphite.com/user-attachments/assets/1916b546-81ee-4abf-99a8-9d1e79dec26d.png)

#### After

[CleanShot 2026-02-11 at 18.17.47.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/54326dbd-00b2-4c68-9e6c-78dd5c5d5d7d.mp4" />](https://app.graphite.com/user-attachments/video/54326dbd-00b2-4c68-9e6c-78dd5c5d5d7d.mp4)

