### PR TITLE
fix: should be able to export table viz on chart view

### DIFF
--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadMenu.tsx
@@ -21,7 +21,10 @@ import {
 } from '../CollapsableCard/constants';
 import MantineIcon from '../MantineIcon';
 import ChartDownloadOptions from './ChartDownloadOptions';
-import { CHART_TYPES_WITHOUT_IMAGE_EXPORT } from './chartDownloadUtils';
+import {
+    CHART_TYPES_WITHOUT_DATA_EXPORT,
+    CHART_TYPES_WITHOUT_IMAGE_EXPORT,
+} from './chartDownloadUtils';
 
 export type ChartDownloadMenuProps = {
     getDownloadQueryUuid: (
@@ -86,6 +89,9 @@ const ChartDownloadMenu: React.FC<ChartDownloadMenuProps> = memo(
 
         if (
             CHART_TYPES_WITHOUT_IMAGE_EXPORT.includes(
+                visualizationConfig.chartType,
+            ) &&
+            CHART_TYPES_WITHOUT_DATA_EXPORT.includes(
                 visualizationConfig.chartType,
             )
         ) {

--- a/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
+++ b/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
@@ -9,6 +9,10 @@ export const CHART_TYPES_WITHOUT_IMAGE_EXPORT = [
     ChartType.MAP,
 ];
 
+export const CHART_TYPES_WITHOUT_DATA_EXPORT: ChartType[] = Object.values(
+    ChartType,
+).filter((type) => type !== ChartType.TABLE);
+
 export enum DownloadType {
     JPEG = 'JPEG',
     PNG = 'PNG',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/19606

### Description:
Fixed image export for table visualizations by adding a check to ensure tables can be exported as CSV or XSLS on chart view page.

**Before**

![CleanShot 2026-02-11 at 18.34.33.png](https://app.graphite.com/user-attachments/assets/93e624aa-1767-4155-a302-feaab750dba8.png)

**After**

![CleanShot 2026-02-11 at 18.34.02.png](https://app.graphite.com/user-attachments/assets/e05dd00d-174a-4fe4-9f57-82789ab4896d.png)

