### PR TITLE
feat: add soft delete migration for dashboards

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -29,6 +29,8 @@ export type DbDashboard = {
     slug: string;
     views_count: number;
     first_viewed_at: Date | null;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 type DbDashboardVersion = {
@@ -82,6 +84,8 @@ export type DashboardTable = Knex.CompositeTableType<
             | 'first_viewed_at'
             | 'space_id'
             | 'slug'
+            | 'deleted_at'
+            | 'deleted_by_user_uuid'
         >
     >
 >;

--- a/packages/backend/src/database/migrations/20260205192030_add_soft_delete_to_dashboards.ts
+++ b/packages/backend/src/database/migrations/20260205192030_add_soft_delete_to_dashboards.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const DashboardsTableName = 'dashboards';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(DashboardsTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_dashboards_not_deleted
+        ON ${DashboardsTableName} (dashboard_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(`
+        CREATE INDEX idx_dashboards_deleted
+        ON ${DashboardsTableName} (dashboard_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_dashboards_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_dashboards_not_deleted');
+    await knex.schema.alterTable(DashboardsTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -169,6 +169,9 @@ export const dashboardEntry: DashboardTable['base'] = {
     search_vector: '',
     views_count: 0,
     first_viewed_at: null,
+
+    deleted_at: null,
+    deleted_by_user_uuid: null,
 };
 
 export const dashboardVersionEntry: DashboardVersionTable['base'] = {


### PR DESCRIPTION
### Description:
Added soft delete functionality to dashboards by:
- Adding `deleted_at` and `deleted_by_user_uuid` columns to the dashboards table
- Creating a new migration file to implement these changes
- Adding partial indexes for efficient queries on both deleted and non-deleted dashboards
- Updating type definitions to include the new fields

This change will enable users to recover accidentally deleted dashboards and provide a "Recently Deleted" view.