### PR TITLE
feat: add soft delete migration for scheduled deliveries

### DIFF
--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -38,6 +38,8 @@ export type SchedulerDb = {
     notification_frequency: string | null;
     selected_tabs: string[] | null;
     include_links: boolean;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 export type ChartSchedulerDb = SchedulerDb & {
@@ -76,7 +78,7 @@ export type SchedulerTable = Knex.CompositeTableType<
     SchedulerDb,
     Omit<
         ChartSchedulerDb | DashboardSchedulerDB,
-        'scheduler_uuid' | 'created_at'
+        'scheduler_uuid' | 'created_at' | 'deleted_at' | 'deleted_by_user_uuid'
     >,
     | Pick<
           SchedulerDb,
@@ -98,6 +100,7 @@ export type SchedulerTable = Knex.CompositeTableType<
     | Pick<SchedulerDb, 'updated_at' | 'enabled'>
     | Pick<SchedulerDb, 'created_by' | 'updated_at'>
     | Pick<SchedulerDb, 'cron'>
+    | Pick<SchedulerDb, 'deleted_at' | 'deleted_by_user_uuid'>
 >;
 
 export type SchedulerSlackTargetTable = Knex.CompositeTableType<

--- a/packages/backend/src/database/migrations/20260206092529_add_soft_delete_to_scheduler.ts
+++ b/packages/backend/src/database/migrations/20260206092529_add_soft_delete_to_scheduler.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const SchedulerTableName = 'scheduler';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SchedulerTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_scheduler_not_deleted
+        ON ${SchedulerTableName} (scheduler_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items
+    await knex.raw(`
+        CREATE INDEX idx_scheduler_deleted
+        ON ${SchedulerTableName} (scheduler_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_scheduler_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_scheduler_not_deleted');
+    await knex.schema.alterTable(SchedulerTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}


### PR DESCRIPTION
### Description:
Added soft delete functionality to the scheduler table by introducing two new columns: `deleted_at` and `deleted_by_user_uuid`. Created partial indexes to optimize queries for both deleted and non-deleted items, ensuring efficient data retrieval. Updated the scheduler entity type definitions to include these new fields.