### PR TITLE
feat: add soft delete migration for spaces

### DIFF
--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -14,6 +14,8 @@ export type DbSpace = {
     parent_space_uuid: string | null;
     path: string;
     inherit_parent_permissions: boolean;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 export type CreateDbSpace = Pick<
@@ -35,7 +37,7 @@ export type UpdateDbSpace = Partial<
 export type SpaceTable = Knex.CompositeTableType<
     DbSpace,
     CreateDbSpace,
-    UpdateDbSpace
+    UpdateDbSpace | Pick<DbSpace, 'deleted_at' | 'deleted_by_user_uuid'>
 >;
 export const SpaceTableName = 'spaces';
 

--- a/packages/backend/src/database/migrations/20260206163809_add_soft_delete_to_spaces.ts
+++ b/packages/backend/src/database/migrations/20260206163809_add_soft_delete_to_spaces.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const SpacesTableName = 'spaces';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable();
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_spaces_not_deleted
+        ON ${SpacesTableName} (space_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(`
+        CREATE INDEX idx_spaces_deleted
+        ON ${SpacesTableName} (space_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_spaces_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_spaces_not_deleted');
+    await knex.schema.alterTable(SpacesTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -136,6 +136,9 @@ export const spaceEntry: SpaceTable['base'] = {
     parent_space_uuid: null,
     path: 'space-name',
     inherit_parent_permissions: true,
+
+    deleted_at: null,
+    deleted_by_user_uuid: null,
 };
 export const savedChartEntry: SavedChartTable['base'] = {
     saved_query_id: 0,

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -57,6 +57,8 @@ export const space: SpaceTable['base'] = {
     parent_space_uuid: null,
     path: 'space-name',
     inherit_parent_permissions: false,
+    deleted_at: null,
+    deleted_by_user_uuid: null,
 };
 
 export const publicSpace: Space = {


### PR DESCRIPTION
### Description:
Adds soft delete functionality to spaces by introducing `deleted_at` and `deleted_by_user_uuid` fields to the spaces table. This change includes:

- New database migration to add the soft delete columns
- Creation of two partial indexes for efficient querying of both deleted and non-deleted spaces
- Updated type definitions in the spaces entity
- Updated mock data to include the new fields

This will enable users to recover accidentally deleted spaces and provide better visibility into deletion history.