### PR TITLE
feat: soft delete for scheduled deliveries

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -759,6 +759,9 @@ export class SchedulerService extends BaseService {
             projectUuid,
             userUuid: user.userUuid,
         });
+
+        // Always hard-delete: UI scheduler deletion is permanent.
+        // Soft delete only happens via cascade from chart/dashboard soft-delete.
         await this.schedulerModel.deleteScheduler(schedulerUuid);
         await this.schedulerModel.deleteScheduledLogs(schedulerUuid);
 


### PR DESCRIPTION
### Description:
Implements soft delete functionality for schedulers, ensuring they are properly handled when associated charts or dashboards are deleted. This includes:

- Adding `whereNull('deleted_at')` filters to all scheduler queries to exclude soft-deleted records
- Implementing `softDelete`, `softDeleteByChartUuid`, and `softDeleteByDashboardUuid` methods in the SchedulerModel
- Adding `restore` methods to restore soft-deleted schedulers
- Updating the DashboardService and SavedChartService to cascade soft delete/restore operations to associated schedulers
- Maintaining hard delete behavior for direct scheduler deletions through the UI

This ensures that when a chart or dashboard is soft-deleted, its associated schedulers are also soft-deleted, and when restored, the schedulers are restored as well.