### PR TITLE
feat: add soft delete migration for saved sql

### DIFF
--- a/packages/backend/src/database/entities/savedSql.ts
+++ b/packages/backend/src/database/entities/savedSql.ts
@@ -21,6 +21,8 @@ export type DbSavedSql = {
     views_count: number;
     first_viewed_at: Date | null;
     last_viewed_at: Date | null;
+    deleted_at: Date | null;
+    deleted_by_user_uuid: string | null;
 };
 
 type InsertSqlBase = Pick<
@@ -54,6 +56,8 @@ type UpdateSql = Partial<
         | 'views_count'
         | 'first_viewed_at'
         | 'last_viewed_at'
+        | 'deleted_at'
+        | 'deleted_by_user_uuid'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260206064344_add_soft_delete_to_saved_sql.ts
+++ b/packages/backend/src/database/migrations/20260206064344_add_soft_delete_to_saved_sql.ts
@@ -1,0 +1,33 @@
+import { Knex } from 'knex';
+
+const SavedSqlTableName = 'saved_sql';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SavedSqlTableName, (table) => {
+        table.timestamp('deleted_at', { useTz: false }).nullable();
+        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+    });
+
+    // Partial index for fast queries on non-deleted items
+    await knex.raw(`
+        CREATE INDEX idx_saved_sql_not_deleted
+        ON ${SavedSqlTableName} (saved_sql_uuid)
+        WHERE deleted_at IS NULL
+    `);
+
+    // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(`
+        CREATE INDEX idx_saved_sql_deleted
+        ON ${SavedSqlTableName} (saved_sql_uuid)
+        WHERE deleted_at IS NOT NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.raw('DROP INDEX IF EXISTS idx_saved_sql_deleted');
+    await knex.raw('DROP INDEX IF EXISTS idx_saved_sql_not_deleted');
+    await knex.schema.alterTable(SavedSqlTableName, (table) => {
+        table.dropColumn('deleted_at');
+        table.dropColumn('deleted_by_user_uuid');
+    });
+}


### PR DESCRIPTION
### Description:
Added soft delete functionality to saved SQL queries by:
- Adding `deleted_at` and `deleted_by_user_uuid` columns to the `saved_sql` table
- Creating partial indexes to optimize queries for both deleted and non-deleted items
- Updating TypeScript types to include the new fields

This change enables users to recover accidentally deleted SQL queries and provides better tracking of deletion actions.