### PR TITLE
chore: add Athena warehouse IAM role auth environment variable to docker compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -112,6 +112,7 @@ services:
             - TURBO_API=${TURBO_API}
             - SIGNUP_URL=${SIGNUP_URL}
             - HELP_MENU_URL=${HELP_MENU_URL}
+            - ATHENA_WAREHOUSE_IAM_ROLE_AUTH=${ATHENA_WAREHOUSE_IAM_ROLE_AUTH}
         volumes:
             - '${DBT_PROJECT_DIR}:/usr/app/dbt'
         ports:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added `ATHENA_WAREHOUSE_IAM_ROLE_AUTH` environment variable to the Docker Compose configuration to support IAM role-based authentication for Athena warehouse connections.
