### PR TITLE
fix: dashboard header overlays filters in edit mode

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/Dashboard.module.css
+++ b/packages/frontend/src/components/common/Dashboard/Dashboard.module.css
@@ -1,5 +1,5 @@
 .stickyHeader {
-    position: sticky;
+    position: sticky !important;
     top: 0;
     z-index: var(--dashboard-header-zindex);
     background-color: var(--mantine-color-body);

--- a/packages/frontend/src/components/common/Page/PageHeader.module.css
+++ b/packages/frontend/src/components/common/Page/PageHeader.module.css
@@ -1,4 +1,5 @@
 .root {
+    position: relative;
     z-index: 2;
     display: flex;
     flex-direction: row;

--- a/packages/frontend/src/components/common/Page/PageHeader.tsx
+++ b/packages/frontend/src/components/common/Page/PageHeader.tsx
@@ -10,7 +10,6 @@ type Props = PropsWithChildren<{
 const PageHeader: FC<Props> = ({ cardProps, children }) => (
     <Card
         component={Flex}
-        pos="relative"
         h={PAGE_HEADER_HEIGHT}
         px="lg"
         py="md"


### PR DESCRIPTION
Closes: #20213

### Description:
Fixed Dashboard header positioning on edit mode, from relative to sticky