### PR TITLE
feat: add option to save warehouse credentials separately

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -285,6 +285,9 @@ export const lightdashConfigMock: LightdashConfig = {
     athenaWarehouseIamRoleAuth: {
         enabled: false,
     },
+    saveCredentialsForm: {
+        enabled: false,
+    },
     googleCloudPlatform: {
         projectId: 'test-project-id',
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -922,6 +922,9 @@ export type LightdashConfig = {
     athenaWarehouseIamRoleAuth: {
         enabled: boolean;
     };
+    saveCredentialsForm: {
+        enabled: boolean;
+    };
     github: {
         appName: string;
         redirectDomain: string;
@@ -1797,6 +1800,9 @@ export const parseConfig = (): LightdashConfig => {
         },
         athenaWarehouseIamRoleAuth: {
             enabled: process.env.ATHENA_WAREHOUSE_IAM_ROLE_AUTH === 'true',
+        },
+        saveCredentialsForm: {
+            enabled: process.env.SAVE_CREDENTIALS_FORM_ENABLED === 'true',
         },
         github: {
             appName: process.env.GITHUB_APP_NAME || 'lightdash-app-dev',

--- a/packages/backend/src/models/OrganizationWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/OrganizationWarehouseCredentialsModel.ts
@@ -38,7 +38,7 @@ export class OrganizationWarehouseCredentialsModel {
     }
 
     // eslint-disable-next-line class-methods-use-this
-    private stripSensitiveCredentials(
+    public static stripSensitiveCredentials(
         credentials: CreateWarehouseCredentials,
     ): WarehouseCredentials {
         const strippedCredentials: Record<string, unknown> = { ...credentials };
@@ -67,7 +67,10 @@ export class OrganizationWarehouseCredentialsModel {
             warehouseType: data.warehouse_type as WarehouseTypes,
             createdAt: data.created_at,
             createdByUserUuid: data.created_by_user_uuid,
-            credentials: this.stripSensitiveCredentials(fullCredentials),
+            credentials:
+                OrganizationWarehouseCredentialsModel.stripSensitiveCredentials(
+                    fullCredentials,
+                ),
         } as OrganizationWarehouseCredentials;
     }
 

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -43,6 +43,28 @@ projectRouter.patch(
     },
 );
 
+projectRouter.put(
+    '/warehouse-credentials',
+    allowApiKeyAuthentication,
+    isAuthenticated,
+    unauthorisedInDemo,
+    async (req, res, next) => {
+        req.services
+            .getProjectService()
+            .updateWarehouseCredentials(
+                getObjectValue(req.params, 'projectUuid'),
+                req.account!,
+                { warehouseConnection: req.body.warehouseConnection },
+            )
+            .then(() => {
+                res.json({
+                    status: 'ok',
+                });
+            })
+            .catch(next);
+    },
+);
+
 projectRouter.get(
     '/search/:query',
     allowApiKeyAuthentication,

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -110,6 +110,7 @@ export const BaseResponse: HealthState = {
     isServiceAccountEnabled: false,
     isOrganizationWarehouseCredentialsEnabled: false,
     isAthenaWarehouseIamRoleAuthEnabled: false,
+    isSaveCredentialsFormEnabled: false,
     isCustomRolesEnabled: false,
     embedding: { enabled: false, events: undefined },
     ai: {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -199,6 +199,8 @@ export class HealthService extends BaseService {
                 this.lightdashConfig.organizationWarehouseCredentials.enabled,
             isAthenaWarehouseIamRoleAuthEnabled:
                 this.lightdashConfig.athenaWarehouseIamRoleAuth.enabled,
+            isSaveCredentialsFormEnabled:
+                this.lightdashConfig.saveCredentialsForm.enabled,
             isCustomRolesEnabled:
                 this.isEnterpriseEnabled() &&
                 this.lightdashConfig.customRoles.enabled,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -324,6 +324,7 @@ export type HealthState = {
     isServiceAccountEnabled: boolean;
     isOrganizationWarehouseCredentialsEnabled: boolean;
     isAthenaWarehouseIamRoleAuthEnabled: boolean;
+    isSaveCredentialsFormEnabled: boolean;
     latest: {
         version?: string;
     };

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -233,6 +233,7 @@ export enum SnowflakeAuthenticationType {
     PRIVATE_KEY = 'private_key',
     SSO = 'sso',
     EXTERNAL_BROWSER = 'external_browser',
+    NONE = 'none',
 }
 
 export type CreateSnowflakeCredentials = {

--- a/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
+++ b/packages/frontend/src/components/ProjectConnection/UpdateProjectConnection.tsx
@@ -9,7 +9,11 @@ import {
 import { Alert, Anchor, Box, Button, Card, Flex } from '@mantine/core';
 import { IconExclamationCircle, IconExternalLink } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useProject, useUpdateMutation } from '../../hooks/useProject';
+import {
+    useProject,
+    useUpdateMutation,
+    useUpdateWarehouseCredentialsMutation,
+} from '../../hooks/useProject';
 import { useProjectCompileLogs } from '../../hooks/useProjectCompileLogs';
 import { useAbilityContext } from '../../providers/Ability/useAbilityContext';
 import useApp from '../../providers/App/useApp';
@@ -84,7 +88,17 @@ const UpdateProjectConnection: FC<{
         validateInputOnBlur: true,
     });
 
+    const showSaveCredentials = !!health.data?.isSaveCredentialsFormEnabled;
+    const {
+        mutate: updateWarehouseCredentials,
+        isLoading: isSavingCredentials,
+    } = useUpdateWarehouseCredentialsMutation(projectUuid);
+
     const { track } = useTracking();
+
+    const handleSaveCredentials = () => {
+        updateWarehouseCredentials(form.values.warehouse);
+    };
 
     const handleSubmit = async ({
         name,
@@ -182,15 +196,28 @@ const UpdateProjectConnection: FC<{
                                 </Button>
                             )}
                         </Box>
-                        <Button
-                            type="submit"
-                            loading={isSaving}
-                            disabled={isDisabled}
-                        >
-                            {project.dbtConnection?.type === DbtProjectType.NONE
-                                ? 'Save and test'
-                                : 'Test & deploy project'}
-                        </Button>
+                        <Flex gap="sm">
+                            {showSaveCredentials && (
+                                <Button
+                                    variant="default"
+                                    loading={isSavingCredentials}
+                                    disabled={isDisabled}
+                                    onClick={handleSaveCredentials}
+                                >
+                                    Save credentials
+                                </Button>
+                            )}
+                            <Button
+                                type="submit"
+                                loading={isSaving}
+                                disabled={isDisabled}
+                            >
+                                {project.dbtConnection?.type ===
+                                DbtProjectType.NONE
+                                    ? 'Save and test'
+                                    : 'Test & deploy project'}
+                            </Button>
+                        </Flex>
                     </Card>
                 </FormContainer>
             </form>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/util.ts
@@ -6,3 +6,4 @@ export const PRIVATE_KEY_LABEL = `Service Account (JSON key file)`;
 export const PASSWORD_LABEL = `Password`;
 export const EXTERNAL_BROWSER_LABEL = `External Browser`;
 export const PERSONAL_ACCESS_TOKEN_LABEL = `Personal Access Token`;
+export const NONE_LABEL = `None`;

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -2,6 +2,7 @@ import {
     type ApiError,
     type ApiJobStartedResults,
     type CreateProject,
+    type CreateWarehouseCredentials,
     type MostPopularAndRecentlyUpdated,
     type Project,
     type UpdateProject,
@@ -107,6 +108,42 @@ export const useCreateMutation = () => {
             onError: ({ error }) => {
                 showToastApiError({
                     title: `Failed to create project`,
+                    apiError: error,
+                });
+            },
+        },
+    );
+};
+
+const updateWarehouseCredentials = async (
+    uuid: string,
+    warehouseCredentials: CreateWarehouseCredentials,
+) =>
+    lightdashApi<undefined>({
+        url: `/projects/${uuid}/warehouse-credentials`,
+        method: 'PUT',
+        body: JSON.stringify({
+            warehouseConnection: warehouseCredentials,
+        }),
+    });
+
+export const useUpdateWarehouseCredentialsMutation = (uuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<undefined, ApiError, CreateWarehouseCredentials>(
+        (warehouseCredentials) =>
+            updateWarehouseCredentials(uuid, warehouseCredentials),
+        {
+            mutationKey: ['project_warehouse_credentials_update', uuid],
+            onSuccess: async () => {
+                showToastSuccess({
+                    title: 'Warehouse credentials updated',
+                });
+                await queryClient.invalidateQueries(['project', uuid]);
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to update warehouse credentials',
                     apiError: error,
                 });
             },

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -107,6 +107,7 @@ export default function mockHealthResponse(
         isServiceAccountEnabled: false,
         isOrganizationWarehouseCredentialsEnabled: false,
         isAthenaWarehouseIamRoleAuthEnabled: false,
+        isSaveCredentialsFormEnabled: false,
         isCustomRolesEnabled: false,
         embedding: {
             enabled: false,

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -217,7 +217,6 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
 
     constructor(credentials: CreateSnowflakeCredentials) {
         super(credentials, new SnowflakeSqlBuilder(credentials.startOfWeek));
-
         if (typeof credentials.quotedIdentifiersIgnoreCase !== 'undefined') {
             this.quotedIdentifiersIgnoreCase =
                 credentials.quotedIdentifiersIgnoreCase;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2087/should-be-able-to-run-project-without-any-project-level-credentials

<img width="597" height="801" alt="Screenshot from 2026-02-12 09-49-34" src="https://github.com/user-attachments/assets/8fb66080-c146-4c16-b6fa-8aed1d1e4095" />

<img width="463" height="423" alt="Screenshot from 2026-02-12 10-15-59" src="https://github.com/user-attachments/assets/8b9e9c84-5ec7-46d0-af5b-fc16217849bb" />

### Description:
Added a new feature to allow saving warehouse credentials separately from the full project configuration. This enables users to update credentials without triggering a full project refresh.

Key changes:
- Added a new configuration flag `saveCredentialsForm.enabled` controlled by the `SAVE_CREDENTIALS_FORM_ENABLED` environment variable
- Created a new API endpoint `/warehouse-credentials` to update credentials without triggering jobs
- Added a "Save credentials" button in the project connection form when the feature is enabled
- Added a new "None" authentication option for Snowflake to support user-provided credentials

This feature helps users manage their warehouse credentials more efficiently, especially in environments where credential updates should not trigger project rebuilds.