### PR TITLE
chore: fix share modal styles

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceUserList.tsx
@@ -270,14 +270,16 @@ const UserAccessList: FC<UserAccessListProps> = ({
                                     styles={{
                                         input: {
                                             fontWeight: 500,
-                                            textAlign: 'right',
+                                            textAlign: disabled
+                                                ? undefined
+                                                : 'right',
                                         },
                                         rightSection: {
                                             pointerEvents: 'none',
                                         },
                                     }}
                                     size="xs"
-                                    variant="unstyled"
+                                    variant={disabled ? 'default' : 'unstyled'}
                                     withinPortal
                                     data={userAccessTypes.map((u) => ({
                                         label: u.title,
@@ -404,14 +406,14 @@ const GroupsAccessList: FC<GroupAccessListProps> = ({
                             styles={{
                                 input: {
                                     fontWeight: 500,
-                                    textAlign: 'right',
+                                    textAlign: disabled ? undefined : 'right',
                                 },
                                 rightSection: {
                                     pointerEvents: 'none',
                                 },
                             }}
                             size="xs"
-                            variant="unstyled"
+                            variant={disabled ? 'default' : 'unstyled'}
                             withinPortal
                             data={userAccessTypes.map((u) => ({
                                 label: u.title,


### PR DESCRIPTION
### Description:

Fix some awkward styles in share space modal

**Before**
<img width="785" height="482" alt="Screenshot 2026-02-12 at 11 27 47" src="https://github.com/user-attachments/assets/97980860-61d8-4d9c-a533-9d64379da314" />

**After**
<img width="786" height="471" alt="Screenshot 2026-02-12 at 11 28 12" src="https://github.com/user-attachments/assets/9d7dc40a-b923-4524-935a-aa7e0d519f68" />

