### PR TITLE
fix: ability check for resource action menu missing projectUuid and organizationUuid

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -107,7 +107,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                 user.data?.ability?.cannot(
                     'manage',
                     subject('SqlRunner', {
-                        organizationUuid: user.data?.organizationUuid,
+                        organizationUuid,
                         projectUuid,
                         access: userAccess ? [userAccess] : [],
                     }),
@@ -121,6 +121,8 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                     'manage',
                     subject('SavedChart', {
                         ...item.data,
+                        projectUuid,
+                        organizationUuid,
                         access: userAccess ? [userAccess] : [],
                     }),
                 )
@@ -138,6 +140,8 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                     'manage',
                     subject('Dashboard', {
                         ...item.data,
+                        projectUuid,
+                        organizationUuid,
                         access: userAccess ? [userAccess] : [],
                     }),
                 )
@@ -155,6 +159,8 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                     'manage',
                     subject('Space', {
                         ...item.data,
+                        projectUuid,
+                        organizationUuid,
                         access: userAccess ? [userAccess] : [],
                     }),
                 )


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixed permission checks in ResourceActionMenu by ensuring all subject types have the correct `projectUuid` and `organizationUuid` properties. Previously, some subject types were missing these properties and there weren't provided from the `pinned-lists` api call. Since we already had them on the FE we just reused

**Before**

![CleanShot 2026-02-12 at 10.34.07.png](https://app.graphite.com/user-attachments/assets/89002f02-70c7-49d6-ae72-e7075da595e9.png)

**After**

![CleanShot 2026-02-12 at 10.33.45.png](https://app.graphite.com/user-attachments/assets/2c314a1d-dcf5-4044-ba5d-058423a15273.png)

