### PR TITLE
feat: filter out deleted resources in joins

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -334,8 +334,13 @@ export class AnalyticsModel {
                 .from(AnalyticsDashboardViewsTableName)
                 .leftJoin(
                     DashboardsTableName,
-                    `${DashboardsTableName}.dashboard_uuid`,
-                    `${AnalyticsDashboardViewsTableName}.dashboard_uuid`,
+                    function nonDeletedDashboardJoin() {
+                        this.on(
+                            `${DashboardsTableName}.dashboard_uuid`,
+                            '=',
+                            `${AnalyticsDashboardViewsTableName}.dashboard_uuid`,
+                        ).andOnNull(`${DashboardsTableName}.deleted_at`);
+                    },
                 )
                 .leftJoin(
                     UserTableName,

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -37,7 +37,7 @@ select
   100 * COUNT(DISTINCT(user_uuid)) / ${userUuids.length} AS count
 from analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 WHERE user_uuid in ('${userUuids.join(`','`)}')
   AND projects.project_uuid = '${projectUuid}'
@@ -56,7 +56,7 @@ select
 from analytics_chart_views
   LEFT JOIN users ON users.user_uuid = analytics_chart_views.user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}')
   AND projects.project_uuid = '${projectUuid}'
@@ -80,7 +80,7 @@ select
 from saved_queries_versions
   LEFT JOIN users ON users.user_uuid = saved_queries_versions.updated_by_user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_id = saved_queries_versions.saved_query_id AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}')
   AND projects.project_uuid = '${projectUuid}'
@@ -102,7 +102,7 @@ select
 from users
   LEFT JOIN analytics_chart_views ON users.user_uuid = analytics_chart_views.user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}') AND users.first_name <> ''
   AND
@@ -146,7 +146,7 @@ query_executed AS (
     COUNT(DISTINCT(chart_uuid)) AS num_queries_executed
   FROM analytics_chart_views acv  -- this is a table with one row per query executed
     left join ${SavedChartsTableName} sq on sq.saved_query_uuid = acv.chart_uuid AND sq.deleted_at IS NULL
-    left join ${SpaceTableName} s on s.space_id  = sq.space_id
+    left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
     left join projects on projects.project_id = s.project_id
   WHERE  projects.project_uuid = '${projectUuid}'
   GROUP BY 1, 2
@@ -206,7 +206,7 @@ SELECT
   sq.name
 FROM public.analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid  = chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 where projects.project_uuid = '${projectUuid}'
 group by chart_uuid, sq.name
@@ -221,7 +221,7 @@ SELECT
   d.name
 FROM public.analytics_dashboard_views dv
   left join ${DashboardsTableName} d  on d.dashboard_uuid  = dv.dashboard_uuid AND d.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = d.space_id
+  left join ${SpaceTableName} s on s.space_id  = d.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 where projects.project_uuid = '${projectUuid}'
 group by dv.dashboard_uuid, d.name
@@ -241,7 +241,7 @@ WITH RankedResults AS (
   FROM public.analytics_dashboard_views dv
   LEFT JOIN users u ON u.user_uuid = dv.user_uuid
   LEFT JOIN ${DashboardsTableName} d ON dv.dashboard_uuid = d.dashboard_uuid AND d.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = d.space_id
+  left join ${SpaceTableName} s on s.space_id  = d.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
   WHERE projects.project_uuid = '${projectUuid}'
     AND u.user_uuid IS NOT NULL
@@ -287,7 +287,7 @@ SELECT
   ) as last_viewed_by_user_name
 FROM ${SavedChartsTableName} sq
 LEFT JOIN users cu ON cu.user_uuid = sq.last_version_updated_by_user_uuid
-LEFT JOIN ${SpaceTableName} s ON s.space_id = sq.space_id
+LEFT JOIN ${SpaceTableName} s ON s.space_id = sq.space_id AND s.deleted_at IS NULL
 LEFT JOIN projects p ON p.project_id = s.project_id
 LEFT JOIN analytics_chart_views cv ON cv.chart_uuid = sq.saved_query_uuid
 WHERE p.project_uuid = ?
@@ -343,7 +343,7 @@ LEFT JOIN (
   ORDER BY dashboard_id, created_at ASC
 ) first_version ON first_version.dashboard_id = d.dashboard_id
 LEFT JOIN users cu ON cu.user_uuid = first_version.updated_by_user_uuid
-LEFT JOIN ${SpaceTableName} s ON s.space_id = d.space_id
+LEFT JOIN ${SpaceTableName} s ON s.space_id = d.space_id AND s.deleted_at IS NULL
 LEFT JOIN projects p ON p.project_id = s.project_id
 LEFT JOIN analytics_dashboard_views adv ON adv.dashboard_uuid = d.dashboard_uuid
 WHERE p.project_uuid = ? AND d.deleted_at IS NULL

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1538,6 +1538,7 @@ export class DashboardModel {
                 `${DashboardVersionsTableName}.dashboard_id`,
             )
             .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
             .orderBy(`${DashboardVersionsTableName}.created_at`, 'desc')
             .limit(1);
     }
@@ -1579,6 +1580,7 @@ export class DashboardModel {
                 `${UserTableName}.last_name`,
             )
             .where(`${DashboardsTableName}.dashboard_uuid`, dashboardUuid)
+            .whereNull(`${DashboardsTableName}.deleted_at`)
             .andWhere(function whereRecentVersionsOrCurrentVersion() {
                 void this.whereRaw(
                     `${DashboardVersionsTableName}.created_at >= DATE(current_timestamp - interval '?? days')`,
@@ -1853,15 +1855,22 @@ export class DashboardModel {
                     `${DashboardTilesTableName}.dashboard_version_id`,
                 );
             })
-            .leftJoin(
-                SavedSqlTableName,
-                `${DashboardTileSqlChartTableName}.saved_sql_uuid`,
-                `${SavedSqlTableName}.saved_sql_uuid`,
-            )
+            .leftJoin(SavedSqlTableName, function nonDeletedSavedSqlJoin() {
+                this.on(
+                    `${DashboardTileSqlChartTableName}.saved_sql_uuid`,
+                    '=',
+                    `${SavedSqlTableName}.saved_sql_uuid`,
+                ).andOnNull(`${SavedSqlTableName}.deleted_at`);
+            })
             .leftJoin(
                 SavedChartsTableName,
-                `${DashboardTileChartTableName}.saved_chart_id`,
-                `${SavedChartsTableName}.saved_query_id`,
+                function nonDeletedSavedChartsJoin() {
+                    this.on(
+                        `${DashboardTileChartTableName}.saved_chart_id`,
+                        '=',
+                        `${SavedChartsTableName}.saved_query_id`,
+                    ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+                },
             )
             .where(
                 `${DashboardTilesTableName}.dashboard_version_id`,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1652,10 +1652,12 @@ export class ProjectModel {
                 .select('project_id');
             const projectId = project.project_id;
 
-            const dbSpaces = await trx(SpaceTableName).whereIn(
-                'space_uuid',
-                spaces.map((s) => s.uuid),
-            );
+            const dbSpaces = await trx(SpaceTableName)
+                .whereIn(
+                    'space_uuid',
+                    spaces.map((s) => s.uuid),
+                )
+                .whereNull('deleted_at');
 
             Logger.info(
                 `Copying ${spaces.length} spaces on ${previewProjectUuid}`,

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -257,11 +257,13 @@ const getAllSpaces = async (
             `${PinnedListTableName}.pinned_list_uuid`,
             `${PinnedSpaceTableName}.pinned_list_uuid`,
         )
-        .innerJoin(
-            SpaceTableName,
-            `${PinnedSpaceTableName}.space_uuid`,
-            `${SpaceTableName}.space_uuid`,
-        )
+        .innerJoin(SpaceTableName, function nonDeletedSpaceJoin() {
+            this.on(
+                `${PinnedSpaceTableName}.space_uuid`,
+                '=',
+                `${SpaceTableName}.space_uuid`,
+            ).andOnNull(`${SpaceTableName}.deleted_at`);
+        })
         .leftJoin(
             SpaceUserAccessTableName,
             `${SpaceTableName}.space_uuid`,
@@ -296,6 +298,7 @@ const getAllSpaces = async (
                          JOIN ${SpaceTableName} root_space ON sua2.space_uuid = root_space.space_uuid
                          WHERE root_space.path @> ${SpaceTableName}.path
                          AND nlevel(root_space.path) = 1
+                         AND root_space.deleted_at IS NULL
                          LIMIT 1)
                     ELSE
                         COUNT(DISTINCT ${SpaceUserAccessTableName}.user_uuid)

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -553,6 +553,7 @@ export class SavedChartModel {
             )
             .select('saved_queries_version_uuid')
             .where(`${SavedChartsTableName}.saved_query_uuid`, chartUuid)
+            .whereNull(`${SavedChartsTableName}.deleted_at`)
             .limit(1)
             .orderBy(`${SavedChartVersionsTableName}.created_at`, 'desc');
     }
@@ -857,19 +858,26 @@ export class SavedChartModel {
                     .from<DbSavedChartDetails>(SavedChartsTableName)
                     .leftJoin(
                         DashboardsTableName,
-                        `${DashboardsTableName}.dashboard_uuid`,
-                        `${SavedChartsTableName}.dashboard_uuid`,
+                        function nonDeletedDashboardJoin() {
+                            this.on(
+                                `${DashboardsTableName}.dashboard_uuid`,
+                                '=',
+                                `${SavedChartsTableName}.dashboard_uuid`,
+                            ).andOnNull(`${DashboardsTableName}.deleted_at`);
+                        },
                     )
                     .innerJoin(SpaceTableName, function spaceJoin() {
                         this.on(
                             `${SpaceTableName}.space_id`,
                             '=',
                             `${DashboardsTableName}.space_id`,
-                        ).orOn(
-                            `${SpaceTableName}.space_id`,
-                            '=',
-                            `${SavedChartsTableName}.space_id`,
-                        );
+                        )
+                            .orOn(
+                                `${SpaceTableName}.space_id`,
+                                '=',
+                                `${SavedChartsTableName}.space_id`,
+                            )
+                            .andOnNull(`${SpaceTableName}.deleted_at`);
                     })
                     .innerJoin(
                         ProjectTableName,
@@ -1622,11 +1630,13 @@ export class SavedChartModel {
                 slug: `${SavedChartsTableName}.slug`,
                 viewsCount: `${SavedChartsTableName}.views_count`,
             })
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .joinRaw(
                 `INNER JOIN ${SpaceTableName} ON ${SpaceTableName}.space_id = COALESCE(${SavedChartsTableName}.space_id, ${DashboardsTableName}.space_id) AND ${SpaceTableName}.deleted_at IS NULL`,
             )
@@ -1673,21 +1683,25 @@ export class SavedChartModel {
                 projectUuid: 'projects.project_uuid',
                 organizationUuid: 'organizations.organization_uuid',
             })
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .innerJoin(SpaceTableName, function spaceJoin() {
                 this.on(
                     `${SpaceTableName}.space_id`,
                     '=',
                     `${DashboardsTableName}.space_id`,
-                ).orOn(
-                    `${SpaceTableName}.space_id`,
-                    '=',
-                    `${SavedChartsTableName}.space_id`,
-                );
+                )
+                    .orOn(
+                        `${SpaceTableName}.space_id`,
+                        '=',
+                        `${SavedChartsTableName}.space_id`,
+                    )
+                    .andOnNull(`${SpaceTableName}.deleted_at`);
             })
             .innerJoin(
                 SavedChartVersionsTableName,
@@ -1744,21 +1758,25 @@ export class SavedChartModel {
                 `${SavedChartsTableName}.saved_query_id`,
                 'saved_queries_versions.saved_query_id',
             )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .innerJoin(SpaceTableName, function spaceJoin() {
                 this.on(
                     `${SpaceTableName}.space_id`,
                     '=',
                     `${DashboardsTableName}.space_id`,
-                ).orOn(
-                    `${SpaceTableName}.space_id`,
-                    '=',
-                    `${SavedChartsTableName}.space_id`,
-                );
+                )
+                    .orOn(
+                        `${SpaceTableName}.space_id`,
+                        '=',
+                        `${SavedChartsTableName}.space_id`,
+                    )
+                    .andOnNull(`${SpaceTableName}.deleted_at`);
             })
             .leftJoin(
                 'projects',
@@ -1888,21 +1906,25 @@ export class SavedChartModel {
         userUuid?: string,
     ): Promise<KnexPaginatedData<DeletedChartContentSummary[]>> {
         const query = this.database(SavedChartsTableName)
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .innerJoin(SpaceTableName, function spaceJoin() {
                 this.on(
                     `${SpaceTableName}.space_id`,
                     '=',
                     `${DashboardsTableName}.space_id`,
-                ).orOn(
-                    `${SpaceTableName}.space_id`,
-                    '=',
-                    `${SavedChartsTableName}.space_id`,
-                );
+                )
+                    .orOn(
+                        `${SpaceTableName}.space_id`,
+                        '=',
+                        `${SavedChartsTableName}.space_id`,
+                    )
+                    .andOnNull(`${SpaceTableName}.deleted_at`);
             })
             .innerJoin(
                 ProjectTableName,

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -760,6 +760,7 @@ export class SearchModel {
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .whereRaw(searchFilterSql)
             .orderBy('search_rank', 'desc');
 
@@ -921,6 +922,7 @@ export class SearchModel {
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .whereRaw(savedChartsSearchFilterSql);
 
         const savedSqlSearchRankRawSql = getFullTextSearchRankCalcSql({
@@ -1012,6 +1014,16 @@ export class SearchModel {
                 this.database.raw('? as chart_source', ['sql']),
             )
             .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .where(function excludeDeletedSpaces() {
+                void this.whereNull('direct_space.deleted_at').orWhereNull(
+                    'direct_space.space_uuid',
+                );
+            })
+            .where(function excludeDeletedDashboardSpaces() {
+                void this.whereNull('dashboard_space.deleted_at').orWhereNull(
+                    'dashboard_space.space_uuid',
+                );
+            })
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereRaw(savedSqlSearchFilterSql);
 

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -149,6 +149,7 @@ export class SpacePermissionModel {
                             `${ProjectMembershipsTableName}.user_id`,
                         )
                         .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                        .whereNull(`${SpaceTableName}.deleted_at`)
                         .modify((qb) => {
                             if (filters?.userUuid) {
                                 void qb.where(
@@ -191,6 +192,7 @@ export class SpacePermissionModel {
                                     `${SpaceTableName}.space_uuid`,
                                     spaceUuids,
                                 )
+                                .whereNull(`${SpaceTableName}.deleted_at`)
                                 .modify((qb) => {
                                     if (filters?.userUuid) {
                                         void qb.where(
@@ -257,6 +259,7 @@ export class SpacePermissionModel {
                             `${OrganizationMembershipsTableName}.user_id`,
                         )
                         .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                        .whereNull(`${SpaceTableName}.deleted_at`)
                         .modify((qb) => {
                             if (filters?.userUuid) {
                                 void qb.where(
@@ -317,7 +320,8 @@ export class SpacePermissionModel {
                         `${OrganizationTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     )
-                    .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids);
+                    .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                    .whereNull(`${SpaceTableName}.deleted_at`);
 
                 return rows.reduce<
                     Record<

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -569,21 +569,25 @@ export class ValidationModel {
         const dashboardSpaceAlias = 'dashboard_space';
 
         const chartSubquery = this.database(ValidationTableName)
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${ValidationTableName}.saved_chart_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${ValidationTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(
                 SpaceTableName,
                 `${SpaceTableName}.space_id`,
                 `${SavedChartsTableName}.space_id`,
             )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .leftJoin(
                 `${SpaceTableName} as ${dashboardSpaceAlias}`,
                 `${dashboardSpaceAlias}.space_id`,
@@ -627,11 +631,13 @@ export class ValidationModel {
             ]);
 
         const dashboardSubquery = this.database(ValidationTableName)
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${ValidationTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${ValidationTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .leftJoin(
                 SpaceTableName,
                 `${DashboardsTableName}.space_id`,
@@ -775,21 +781,25 @@ export class ValidationModel {
         };
 
         const chartSubquery = this.database(ValidationTableName)
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${ValidationTableName}.saved_chart_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${ValidationTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
             .leftJoin(
                 SpaceTableName,
                 `${SpaceTableName}.space_id`,
                 `${SavedChartsTableName}.space_id`,
             )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .leftJoin(
                 `${SpaceTableName} as ${dashboardSpaceAlias}`,
                 `${dashboardSpaceAlias}.space_id`,
@@ -854,11 +864,13 @@ export class ValidationModel {
             ]);
 
         const dashboardSubquery = this.database(ValidationTableName)
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${ValidationTableName}.dashboard_uuid`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${ValidationTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .leftJoin(
                 SpaceTableName,
                 `${DashboardsTableName}.space_id`,


### PR DESCRIPTION
### Description:
This PR adds `deleted_at` checks to all relevant table joins to ensure that deleted resources (spaces, dashboards, charts) are properly excluded from queries. This prevents deleted items from appearing in analytics, search results, and other areas of the application.

The changes include:
- Adding `andOnNull('deleted_at')` conditions to table joins
- Updating SQL queries to include deleted_at checks
- Modifying join functions to use explicit join conditions for deleted resources
- Ensuring consistent handling of deleted resources across all models

This fix prevents deleted resources from appearing in the UI and ensures data integrity throughout the application.