### PR TITLE
docs: update soft delete documentation and add symlink

### DIFF
--- a/packages/backend/src/ee/models/CLAUDE.md
+++ b/packages/backend/src/ee/models/CLAUDE.md
@@ -1,0 +1,1 @@
+../../models/CLAUDE.md


### PR DESCRIPTION
### Description:
Expands and improves the soft delete documentation by:

- Creating a symlink to make the documentation accessible in the EE models directory
- Adding a comprehensive table of all entities that support soft delete
- Providing clearer examples for filtering soft-deleted records in different query types
- Adding guidance on when NOT to filter by deleted_at (slug generation, soft delete features)
- Including search commands to help developers find queries that need soft delete filters
- Improving the organization and clarity of the documentation