### PR TITLE
feat: respect deleted_at flag in database queries

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -334,8 +334,13 @@ export class AnalyticsModel {
                 .from(AnalyticsDashboardViewsTableName)
                 .leftJoin(
                     DashboardsTableName,
-                    `${DashboardsTableName}.dashboard_uuid`,
-                    `${AnalyticsDashboardViewsTableName}.dashboard_uuid`,
+                    function nonDeletedDashboardJoin() {
+                        this.on(
+                            `${DashboardsTableName}.dashboard_uuid`,
+                            '=',
+                            `${AnalyticsDashboardViewsTableName}.dashboard_uuid`,
+                        ).andOnNull(`${DashboardsTableName}.deleted_at`);
+                    },
                 )
                 .leftJoin(
                     UserTableName,

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -37,7 +37,7 @@ select
   100 * COUNT(DISTINCT(user_uuid)) / ${userUuids.length} AS count
 from analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 WHERE user_uuid in ('${userUuids.join(`','`)}')
   AND projects.project_uuid = '${projectUuid}'
@@ -56,7 +56,7 @@ select
 from analytics_chart_views
   LEFT JOIN users ON users.user_uuid = analytics_chart_views.user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}')
   AND projects.project_uuid = '${projectUuid}'
@@ -80,7 +80,7 @@ select
 from saved_queries_versions
   LEFT JOIN users ON users.user_uuid = saved_queries_versions.updated_by_user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_id = saved_queries_versions.saved_query_id AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}')
   AND projects.project_uuid = '${projectUuid}'
@@ -102,7 +102,7 @@ select
 from users
   LEFT JOIN analytics_chart_views ON users.user_uuid = analytics_chart_views.user_uuid
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid = analytics_chart_views.chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 WHERE users.user_uuid in ('${userUuids.join(`','`)}') AND users.first_name <> ''
   AND
@@ -146,7 +146,7 @@ query_executed AS (
     COUNT(DISTINCT(chart_uuid)) AS num_queries_executed
   FROM analytics_chart_views acv  -- this is a table with one row per query executed
     left join ${SavedChartsTableName} sq on sq.saved_query_uuid = acv.chart_uuid AND sq.deleted_at IS NULL
-    left join ${SpaceTableName} s on s.space_id  = sq.space_id
+    left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
     left join projects on projects.project_id = s.project_id
   WHERE  projects.project_uuid = '${projectUuid}'
   GROUP BY 1, 2
@@ -206,7 +206,7 @@ SELECT
   sq.name
 FROM public.analytics_chart_views
   left join ${SavedChartsTableName} sq on sq.saved_query_uuid  = chart_uuid AND sq.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = sq.space_id
+  left join ${SpaceTableName} s on s.space_id  = sq.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 where projects.project_uuid = '${projectUuid}'
 group by chart_uuid, sq.name
@@ -221,7 +221,7 @@ SELECT
   d.name
 FROM public.analytics_dashboard_views dv
   left join ${DashboardsTableName} d  on d.dashboard_uuid  = dv.dashboard_uuid AND d.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = d.space_id
+  left join ${SpaceTableName} s on s.space_id  = d.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
 where projects.project_uuid = '${projectUuid}'
 group by dv.dashboard_uuid, d.name
@@ -241,7 +241,7 @@ WITH RankedResults AS (
   FROM public.analytics_dashboard_views dv
   LEFT JOIN users u ON u.user_uuid = dv.user_uuid
   LEFT JOIN ${DashboardsTableName} d ON dv.dashboard_uuid = d.dashboard_uuid AND d.deleted_at IS NULL
-  left join ${SpaceTableName} s on s.space_id  = d.space_id
+  left join ${SpaceTableName} s on s.space_id  = d.space_id AND s.deleted_at IS NULL
   left join projects on projects.project_id = s.project_id
   WHERE projects.project_uuid = '${projectUuid}'
     AND u.user_uuid IS NOT NULL
@@ -287,7 +287,7 @@ SELECT
   ) as last_viewed_by_user_name
 FROM ${SavedChartsTableName} sq
 LEFT JOIN users cu ON cu.user_uuid = sq.last_version_updated_by_user_uuid
-LEFT JOIN ${SpaceTableName} s ON s.space_id = sq.space_id
+LEFT JOIN ${SpaceTableName} s ON s.space_id = sq.space_id AND s.deleted_at IS NULL
 LEFT JOIN projects p ON p.project_id = s.project_id
 LEFT JOIN analytics_chart_views cv ON cv.chart_uuid = sq.saved_query_uuid
 WHERE p.project_uuid = ?
@@ -343,7 +343,7 @@ LEFT JOIN (
   ORDER BY dashboard_id, created_at ASC
 ) first_version ON first_version.dashboard_id = d.dashboard_id
 LEFT JOIN users cu ON cu.user_uuid = first_version.updated_by_user_uuid
-LEFT JOIN ${SpaceTableName} s ON s.space_id = d.space_id
+LEFT JOIN ${SpaceTableName} s ON s.space_id = d.space_id AND s.deleted_at IS NULL
 LEFT JOIN projects p ON p.project_id = s.project_id
 LEFT JOIN analytics_dashboard_views adv ON adv.dashboard_uuid = d.dashboard_uuid
 WHERE p.project_uuid = ? AND d.deleted_at IS NULL

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1652,10 +1652,12 @@ export class ProjectModel {
                 .select('project_id');
             const projectId = project.project_id;
 
-            const dbSpaces = await trx(SpaceTableName).whereIn(
-                'space_uuid',
-                spaces.map((s) => s.uuid),
-            );
+            const dbSpaces = await trx(SpaceTableName)
+                .whereIn(
+                    'space_uuid',
+                    spaces.map((s) => s.uuid),
+                )
+                .whereNull('deleted_at');
 
             Logger.info(
                 `Copying ${spaces.length} spaces on ${previewProjectUuid}`,
@@ -1706,6 +1708,8 @@ export class ProjectModel {
                 WHERE
                     child.project_id = ?
                     AND parent.project_id = ?
+                    AND child.deleted_at IS NULL
+                    AND parent.deleted_at IS NULL
                     AND subpath(child.path, 0, nlevel(child.path) - 1) = parent.path
                     AND nlevel(child.path) > 1;`,
                 [previewProject.project_id, previewProject.project_id],
@@ -2400,7 +2404,8 @@ export class ProjectModel {
                         .update({
                             dashboard_uuid: newDashboardUuid,
                         })
-                        .where('saved_query_id', chart.saved_query_id);
+                        .where('saved_query_id', chart.saved_query_id)
+                        .whereNull('deleted_at');
                 },
             );
             await Promise.all(updateChartInDashboards);

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -301,7 +301,8 @@ export class SavedSqlModel {
                 last_version_updated_at: new Date(),
                 last_version_updated_by_user_uuid: data.userUuid,
             })
-            .where('saved_sql_uuid', data.savedSqlUuid);
+            .where('saved_sql_uuid', data.savedSqlUuid)
+            .whereNull('deleted_at');
         return savedSqlVersionUuid;
     }
 
@@ -358,7 +359,8 @@ export class SavedSqlModel {
                         description: data.sqlChart.unversionedData.description,
                         space_uuid: data.sqlChart.unversionedData.spaceUuid,
                     })
-                    .where('saved_sql_uuid', data.savedSqlUuid);
+                    .where('saved_sql_uuid', data.savedSqlUuid)
+                    .whereNull('deleted_at');
             }
 
             let savedSqlVersionUuid: string | null = null;
@@ -433,7 +435,8 @@ export class SavedSqlModel {
         const updateCount = await tx(SavedSqlTableName)
             .update({ space_uuid: targetSpaceUuid })
             .where('saved_sql_uuid', savedSqlUuid)
-            .where('project_uuid', projectUuid);
+            .where('project_uuid', projectUuid)
+            .whereNull('deleted_at');
 
         if (updateCount !== 1) {
             throw new Error('Failed to move saved sql to space');

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -692,7 +692,8 @@ export class SchedulerModel {
                 enabled,
                 updated_at: new Date(),
             })
-            .where('scheduler_uuid', schedulerUuid);
+            .where('scheduler_uuid', schedulerUuid)
+            .whereNull('deleted_at');
 
         return this.getSchedulerAndTargets(schedulerUuid);
     }
@@ -707,7 +708,8 @@ export class SchedulerModel {
                     created_by: newOwnerUserUuid,
                     updated_at: new Date(),
                 })
-                .whereIn('scheduler_uuid', schedulerUuids);
+                .whereIn('scheduler_uuid', schedulerUuids)
+                .whereNull('deleted_at');
         });
     }
 
@@ -748,7 +750,8 @@ export class SchedulerModel {
                             : null,
                     include_links: scheduler.includeLinks !== false,
                 })
-                .where('scheduler_uuid', scheduler.schedulerUuid);
+                .where('scheduler_uuid', scheduler.schedulerUuid)
+                .whereNull('deleted_at');
 
             const slackTargetsToUpdate = scheduler.targets.reduce<string[]>(
                 (acc, target) =>
@@ -1365,7 +1368,8 @@ export class SchedulerModel {
                 async ({ schedulerUuid, cron }) => {
                     await trx(SchedulerTableName)
                         .update({ cron })
-                        .where('scheduler_uuid', schedulerUuid);
+                        .where('scheduler_uuid', schedulerUuid)
+                        .whereNull('deleted_at');
                 },
             );
 

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -760,6 +760,7 @@ export class SearchModel {
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .whereRaw(searchFilterSql)
             .orderBy('search_rank', 'desc');
 
@@ -921,6 +922,7 @@ export class SearchModel {
             )
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereNull(`${SavedChartsTableName}.deleted_at`)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .whereRaw(savedChartsSearchFilterSql);
 
         const savedSqlSearchRankRawSql = getFullTextSearchRankCalcSql({
@@ -1012,6 +1014,16 @@ export class SearchModel {
                 this.database.raw('? as chart_source', ['sql']),
             )
             .whereNull(`${SavedSqlTableName}.deleted_at`)
+            .where(function excludeDeletedSpaces() {
+                void this.whereNull('direct_space.deleted_at').orWhereNull(
+                    'direct_space.space_uuid',
+                );
+            })
+            .where(function excludeDeletedDashboardSpaces() {
+                void this.whereNull('dashboard_space.deleted_at').orWhereNull(
+                    'dashboard_space.space_uuid',
+                );
+            })
             .where(`${ProjectTableName}.project_uuid`, projectUuid)
             .whereRaw(savedSqlSearchFilterSql);
 

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -149,6 +149,7 @@ export class SpacePermissionModel {
                             `${ProjectMembershipsTableName}.user_id`,
                         )
                         .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                        .whereNull(`${SpaceTableName}.deleted_at`)
                         .modify((qb) => {
                             if (filters?.userUuid) {
                                 void qb.where(
@@ -191,6 +192,7 @@ export class SpacePermissionModel {
                                     `${SpaceTableName}.space_uuid`,
                                     spaceUuids,
                                 )
+                                .whereNull(`${SpaceTableName}.deleted_at`)
                                 .modify((qb) => {
                                     if (filters?.userUuid) {
                                         void qb.where(
@@ -257,6 +259,7 @@ export class SpacePermissionModel {
                             `${OrganizationMembershipsTableName}.user_id`,
                         )
                         .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                        .whereNull(`${SpaceTableName}.deleted_at`)
                         .modify((qb) => {
                             if (filters?.userUuid) {
                                 void qb.where(
@@ -317,7 +320,8 @@ export class SpacePermissionModel {
                         `${OrganizationTableName}.organization_id`,
                         `${ProjectTableName}.organization_id`,
                     )
-                    .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids);
+                    .whereIn(`${SpaceTableName}.space_uuid`, spaceUuids)
+                    .whereNull(`${SpaceTableName}.deleted_at`);
 
                 return rows.reduce<
                     Record<

--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -249,11 +249,13 @@ export class ValidationModel {
                 ).andOnNull(`${SavedChartsTableName}.deleted_at`);
             })
             // Join to chart's direct space (for charts saved directly in a space)
-            .leftJoin(
-                SpaceTableName,
-                `${SpaceTableName}.space_id`,
-                `${SavedChartsTableName}.space_id`,
-            )
+            .leftJoin(SpaceTableName, function nonDeletedSpaceJoin() {
+                this.on(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${SavedChartsTableName}.space_id`,
+                ).andOnNull(`${SpaceTableName}.deleted_at`);
+            })
             // Join to dashboard's space for charts saved in dashboards (space_id is NULL)
             // Uses saved_charts.dashboard_uuid which directly references the dashboard
             .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
@@ -265,8 +267,13 @@ export class ValidationModel {
             })
             .leftJoin(
                 `${SpaceTableName} as ${dashboardSpaceAlias}`,
-                `${dashboardSpaceAlias}.space_id`,
-                `${DashboardsTableName}.space_id`,
+                function nonDeletedDashboardSpaceJoin() {
+                    this.on(
+                        `${dashboardSpaceAlias}.space_id`,
+                        '=',
+                        `${DashboardsTableName}.space_id`,
+                    ).andOnNull(`${dashboardSpaceAlias}.deleted_at`);
+                },
             )
             .leftJoin(
                 UserTableName,
@@ -366,11 +373,13 @@ export class ValidationModel {
                     `${ValidationTableName}.dashboard_uuid`,
                 ).andOnNull(`${DashboardsTableName}.deleted_at`);
             })
-            .leftJoin(
-                SpaceTableName,
-                `${DashboardsTableName}.space_id`,
-                `${SpaceTableName}.space_id`,
-            )
+            .leftJoin(SpaceTableName, function nonDeletedSpaceJoin() {
+                this.on(
+                    `${DashboardsTableName}.space_id`,
+                    '=',
+                    `${SpaceTableName}.space_id`,
+                ).andOnNull(`${SpaceTableName}.deleted_at`);
+            })
             .leftJoin(
                 `${DashboardVersionsTableName}`,
                 `${DashboardsTableName}.dashboard_id`,
@@ -569,25 +578,36 @@ export class ValidationModel {
         const dashboardSpaceAlias = 'dashboard_space';
 
         const chartSubquery = this.database(ValidationTableName)
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${ValidationTableName}.saved_chart_uuid`,
-            )
-            .leftJoin(
-                SpaceTableName,
-                `${SpaceTableName}.space_id`,
-                `${SavedChartsTableName}.space_id`,
-            )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${ValidationTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
+            .leftJoin(SpaceTableName, function nonDeletedSpaceJoin() {
+                this.on(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${SavedChartsTableName}.space_id`,
+                ).andOnNull(`${SpaceTableName}.deleted_at`);
+            })
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .leftJoin(
                 `${SpaceTableName} as ${dashboardSpaceAlias}`,
-                `${dashboardSpaceAlias}.space_id`,
-                `${DashboardsTableName}.space_id`,
+                function nonDeletedDashboardSpaceJoin() {
+                    this.on(
+                        `${dashboardSpaceAlias}.space_id`,
+                        '=',
+                        `${DashboardsTableName}.space_id`,
+                    ).andOnNull(`${dashboardSpaceAlias}.deleted_at`);
+                },
             )
             .leftJoin(
                 UserTableName,
@@ -627,16 +647,20 @@ export class ValidationModel {
             ]);
 
         const dashboardSubquery = this.database(ValidationTableName)
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${ValidationTableName}.dashboard_uuid`,
-            )
-            .leftJoin(
-                SpaceTableName,
-                `${DashboardsTableName}.space_id`,
-                `${SpaceTableName}.space_id`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${ValidationTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
+            .leftJoin(SpaceTableName, function nonDeletedSpaceJoin() {
+                this.on(
+                    `${DashboardsTableName}.space_id`,
+                    '=',
+                    `${SpaceTableName}.space_id`,
+                ).andOnNull(`${SpaceTableName}.deleted_at`);
+            })
             .leftJoin(
                 DashboardVersionsTableName,
                 `${DashboardsTableName}.dashboard_id`,
@@ -775,25 +799,36 @@ export class ValidationModel {
         };
 
         const chartSubquery = this.database(ValidationTableName)
-            .leftJoin(
-                SavedChartsTableName,
-                `${SavedChartsTableName}.saved_query_uuid`,
-                `${ValidationTableName}.saved_chart_uuid`,
-            )
-            .leftJoin(
-                SpaceTableName,
-                `${SpaceTableName}.space_id`,
-                `${SavedChartsTableName}.space_id`,
-            )
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${SavedChartsTableName}.dashboard_uuid`,
-            )
+            .leftJoin(SavedChartsTableName, function nonDeletedChartJoin() {
+                this.on(
+                    `${SavedChartsTableName}.saved_query_uuid`,
+                    '=',
+                    `${ValidationTableName}.saved_chart_uuid`,
+                ).andOnNull(`${SavedChartsTableName}.deleted_at`);
+            })
+            .leftJoin(SpaceTableName, function nonDeletedSpaceJoin() {
+                this.on(
+                    `${SpaceTableName}.space_id`,
+                    '=',
+                    `${SavedChartsTableName}.space_id`,
+                ).andOnNull(`${SpaceTableName}.deleted_at`);
+            })
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${SavedChartsTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
             .leftJoin(
                 `${SpaceTableName} as ${dashboardSpaceAlias}`,
-                `${dashboardSpaceAlias}.space_id`,
-                `${DashboardsTableName}.space_id`,
+                function nonDeletedDashboardSpaceJoin() {
+                    this.on(
+                        `${dashboardSpaceAlias}.space_id`,
+                        '=',
+                        `${DashboardsTableName}.space_id`,
+                    ).andOnNull(`${dashboardSpaceAlias}.deleted_at`);
+                },
             )
             .leftJoin(
                 UserTableName,
@@ -854,16 +889,20 @@ export class ValidationModel {
             ]);
 
         const dashboardSubquery = this.database(ValidationTableName)
-            .leftJoin(
-                DashboardsTableName,
-                `${DashboardsTableName}.dashboard_uuid`,
-                `${ValidationTableName}.dashboard_uuid`,
-            )
-            .leftJoin(
-                SpaceTableName,
-                `${DashboardsTableName}.space_id`,
-                `${SpaceTableName}.space_id`,
-            )
+            .leftJoin(DashboardsTableName, function nonDeletedDashboardJoin() {
+                this.on(
+                    `${DashboardsTableName}.dashboard_uuid`,
+                    '=',
+                    `${ValidationTableName}.dashboard_uuid`,
+                ).andOnNull(`${DashboardsTableName}.deleted_at`);
+            })
+            .leftJoin(SpaceTableName, function nonDeletedSpaceJoin() {
+                this.on(
+                    `${DashboardsTableName}.space_id`,
+                    '=',
+                    `${SpaceTableName}.space_id`,
+                ).andOnNull(`${SpaceTableName}.deleted_at`);
+            })
             .leftJoin(
                 DashboardVersionsTableName,
                 `${DashboardsTableName}.dashboard_id`,


### PR DESCRIPTION
### Description:
This PR adds `deleted_at` checks to database queries to properly filter out soft-deleted records. The changes ensure that when joining tables like spaces, dashboards, and saved charts, we only include non-deleted records in the results.

The main improvements include:
- Adding `whereNull('deleted_at')` clauses to direct queries
- Using named join functions like `nonDeletedSpaceJoin` to include deletion checks in join conditions
- Fixing queries in analytics, validation, and search models to respect soft deletion
- Ensuring proper filtering in space hierarchy queries

These changes prevent deleted content from appearing in search results, analytics, and other areas of the application.