### PR TITLE
fix: space deletion/restoration toast CTA and query invalidation

### DIFF
--- a/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
@@ -94,11 +94,26 @@ export function useRestoreDeletedContent(projectUuid: string) {
                                         `/projects/${projectUuid}/dashboards/${item.uuid}`,
                                     ),
                             }
-                          : undefined,
+                          : item.contentType === ContentType.SPACE
+                            ? {
+                                  children: 'Go to space',
+                                  icon: IconArrowRight,
+                                  onClick: () =>
+                                      navigate(
+                                          `/projects/${projectUuid}/spaces/${item.uuid}`,
+                                      ),
+                              }
+                            : undefined,
             });
             void queryClient.invalidateQueries({
                 queryKey: ['deletedContent'],
             });
+
+            if (item.contentType === ContentType.SPACE) {
+                void queryClient.invalidateQueries({
+                    queryKey: ['content'],
+                });
+            }
         },
         onError: ({ error }) => {
             showToastApiError({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Enhances the recently deleted feature by adding support for spaces. This PR adds:

1. A "Go to space" button after restoring a deleted space
2. Invalidation of content queries when a space is restored
3. A "Go to recently deleted" button after deleting a space when soft delete is enabled
