### PR TITLE
fix: populate SQL for custom metrics in MCP service

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -827,12 +827,14 @@ export class McpService extends BaseService {
                             ),
                     };
 
+                    const populatedAdditionalMetrics = populateCustomMetricsSQL(
+                        queryTool.customMetrics,
+                        explore,
+                    );
+
                     const results = await runAsyncQuery(
                         query,
-                        populateCustomMetricsSQL(
-                            queryTool.customMetrics,
-                            explore,
-                        ),
+                        populatedAdditionalMetrics,
                     );
 
                     if (results.rows.length === 0) {
@@ -906,7 +908,7 @@ export class McpService extends BaseService {
                             sorts: queryTool.queryConfig.sorts,
                             limit: query.limit,
                             filters: queryTool.filters ?? {},
-                            additionalMetrics: query.additionalMetrics,
+                            additionalMetrics: populatedAdditionalMetrics,
                             tableCalculations: query.tableCalculations,
                         },
                         tableConfig: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2992: MCP compilation error: 'sql' is required for additional metrics](https://linear.app/lightdash/issue/PROD-2992/mcp-compilation-error-sql-is-required-for-additional-metrics)

### Description:

Fixed MCP compilation error where 'sql' is required for additional metrics. The issue was that we were not passing the populated custom metrics SQL to the tableConfig. Now we populate the custom metrics SQL once and reuse it in both the query execution and the tableConfig.
