### PR TITLE
fix: exclude dashboard_version_uuid when copying content to preview projects

### DIFF
--- a/packages/backend/src/database/entities/dashboards.ts
+++ b/packages/backend/src/database/entities/dashboards.ts
@@ -94,11 +94,9 @@ export type DashboardVersionTable = Knex.CompositeTableType<
     DbDashboardVersion,
     Pick<
         DbDashboardVersion,
-        | 'dashboard_id'
-        | 'dashboard_version_uuid'
-        | 'updated_by_user_uuid'
-        | 'config'
-    >
+        'dashboard_id' | 'updated_by_user_uuid' | 'config'
+    > &
+        Partial<Pick<DbDashboardVersion, 'dashboard_version_uuid'>>
 >;
 
 export type DashboardViewTable = Knex.CompositeTableType<

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2298,11 +2298,13 @@ export class ProjectModel {
                                   const createDashboardVersion = {
                                       ...d,
                                       dashboard_version_id: undefined,
+                                      dashboard_version_uuid: undefined,
                                       dashboard_id: dashboardMapping.find(
                                           (m) => m.id === d.dashboard_id,
                                       )?.newId!,
                                   };
                                   delete createDashboardVersion.dashboard_version_id;
+                                  delete createDashboardVersion.dashboard_version_uuid;
                                   return createDashboardVersion;
                               }),
                           )


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2997: Preview project content copy fails silently due to dashboard_version_uuid unique constraint violation](https://linear.app/lightdash/issue/PROD-2997/preview-project-content-copy-fails-silently-due-to-dashboard-version)

### Description:

Fixed dashboard version creation during project export/import by making `dashboard_version_uuid` optional in the `DashboardVersionTable` type and explicitly removing it from the object before insertion. This ensures that new UUIDs are generated for dashboard versions when importing projects.
