### PR TITLE
refactor: remove root-space access SQL from SpaceModel and backfill direct access via SpacePermissionService

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -5,10 +5,7 @@ import { OrganizationTableName } from '../../../database/entities/organizations'
 import { PinnedSpaceTableName } from '../../../database/entities/pinnedList';
 import { ProjectTableName } from '../../../database/entities/projects';
 import { SavedChartsTableName } from '../../../database/entities/savedCharts';
-import {
-    SpaceTableName,
-    SpaceUserAccessTableName,
-} from '../../../database/entities/spaces';
+import { SpaceTableName } from '../../../database/entities/spaces';
 import { UserTableName } from '../../../database/entities/users';
 import { SpaceModel } from '../../SpaceModel';
 import {
@@ -68,16 +65,6 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                     `${SpaceTableName}.created_by_user_id`,
                 )
                 .leftJoin(
-                    `${SpaceUserAccessTableName}`,
-                    `${SpaceUserAccessTableName}.space_uuid`,
-                    `${SpaceTableName}.space_uuid`,
-                )
-                .leftJoin(
-                    `${UserTableName} as shared_with`,
-                    `${SpaceUserAccessTableName}.user_uuid`,
-                    'shared_with.user_uuid',
-                )
-                .leftJoin(
                     `${UserTableName} as deleted_by_user`,
                     `${SpaceTableName}.deleted_by_user_uuid`,
                     'deleted_by_user.user_uuid',
@@ -132,9 +119,7 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                                     ),
                                     'parentSpaceUuid', ${SpaceTableName}.parent_space_uuid,
                                     'path', ${SpaceTableName}.path,
-                                    'access', (${SpaceModel.getRootSpaceAccessQuery(
-                                        'shared_with',
-                                    )}),
+                                    'access', '[]'::json,
                                     'isPrivate', (${SpaceModel.getRootSpaceIsPrivateQuery()}),
                                     'inheritParentPermissions', ${SpaceTableName}.inherit_parent_permissions,
                                     'pinnedListOrder', ${PinnedSpaceTableName}.order

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -4,7 +4,7 @@ import {
     OrganizationSpaceAccess,
     ProjectSpaceAccess,
     ProjectSpaceAccessOrigin,
-    SpaceAccessUserMetadata,
+    type SpaceAccessUserMetadata,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { EmailTableName } from '../database/entities/emails';
@@ -357,7 +357,11 @@ export class SpacePermissionModel {
             )
             .where(`${EmailTableName}.is_primary`, true)
             .whereIn(`${UserTableName}.user_uuid`, userUuids)
-            .select<(SpaceAccessUserMetadata & { userUuid: string })[]>({
+            .select<
+                ({
+                    userUuid: string;
+                } & SpaceAccessUserMetadata)[]
+            >({
                 userUuid: `${UserTableName}.user_uuid`,
                 firstName: `${UserTableName}.first_name`,
                 lastName: `${UserTableName}.last_name`,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2332,7 +2332,7 @@ export class AsyncQueryService extends ProjectService {
         account: Account,
         projectUuid: string,
         savedChartUuid: string,
-        space: Omit<SpaceSummary, 'userAccess'>,
+        space: Omit<SpaceSummary, 'userAccess' | 'access'>,
     ) {
         if (isJwtUser(account)) {
             await this.permissionsService.checkEmbedPermissions(

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -496,7 +496,7 @@ export class CoderService extends BaseService {
         user: SessionUser,
         project: Project,
         content: T[],
-        spaces: Omit<SpaceSummary, 'userAccess'>[],
+        spaces: Omit<SpaceSummary, 'userAccess' | 'access'>[],
     ): Promise<T[]> {
         if (
             user.ability.can(
@@ -1184,7 +1184,10 @@ export class CoderService extends BaseService {
         user: SessionUser,
         skipSpaceCreate?: boolean,
         publicSpaceCreate?: boolean,
-    ): Promise<{ space: Omit<SpaceSummary, 'userAccess'>; created: boolean }> {
+    ): Promise<{
+        space: Omit<SpaceSummary, 'userAccess' | 'access'>;
+        created: boolean;
+    }> {
         const [existingSpace] = await this.spaceModel.find({
             path: getLtreePathFromContentAsCodePath(spaceSlug),
             projectUuid,
@@ -1305,7 +1308,6 @@ export class CoderService extends BaseService {
                 ...newSpaces[newSpaces.length - 1],
                 chartCount: 0,
                 dashboardCount: 0,
-                access: [],
             },
             created: true,
         };

--- a/packages/backend/src/services/PromoteService/PromoteService.mock.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.mock.ts
@@ -52,14 +52,13 @@ const organizationUuid = 'organization-uuid';
 const promotedProjectUuid = 'promoted-project-uuid';
 const upstreamProjectUuid = 'upstream-project-uuid';
 
-export const promotedSpace: PromotedChart['space'] = {
+export const promotedSpace: NonNullable<PromotedChart['space']> = {
     organizationUuid,
     projectUuid: promotedProjectUuid,
     uuid: 'promoted-space-uuid',
     name: 'Jaffle shop',
     isPrivate: false,
     inheritParentPermissions: true,
-    access: [],
     pinnedListUuid: null,
     pinnedListOrder: null,
     chartCount: 0,
@@ -69,14 +68,13 @@ export const promotedSpace: PromotedChart['space'] = {
     path: 'jaffle_shop',
 };
 
-export const upstreamSpace: UpstreamChart['space'] = {
+export const upstreamSpace: NonNullable<UpstreamChart['space']> = {
     organizationUuid,
     projectUuid: upstreamProjectUuid,
     uuid: 'upstream-space-uuid',
     name: 'Jaffle shop',
     isPrivate: false,
     inheritParentPermissions: true,
-    access: [],
     pinnedListUuid: null,
     pinnedListOrder: null,
     chartCount: 0,

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -1019,7 +1019,6 @@ export class PromoteService extends BaseService {
         const newSpaceChanges = Array.from(newSpaces.values()).map((space) => {
             const promotedSpace: PromotedSpace = {
                 ...space,
-                access: [],
                 chartCount: 0,
                 dashboardCount: 0,
             };

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -805,7 +805,7 @@ export class SavedChartService
 
     private async checkPermissions(
         account: Account,
-        space: Omit<SpaceSummary, 'userAccess'>,
+        space: Omit<SpaceSummary, 'userAccess' | 'access'>,
         savedChart: SavedChartDAO,
     ): Promise<SpaceAccess[]> {
         let access;

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -226,11 +226,27 @@ export class SavedSqlService
                 organizationId: savedChart.organization.organizationUuid,
             },
         });
+
+        const userMetadataByUuid =
+            await this.spacePermissionService.getUserMetadataByUuids([
+                user.userUuid,
+            ]);
+        const firstAccess = spaceCtx.access[0];
+        const firstAccessUserMetadata = firstAccess
+            ? userMetadataByUuid[firstAccess.userUuid]
+            : undefined;
+
         return {
             ...savedChart,
             space: {
                 ...savedChart.space,
-                userAccess: spaceCtx.access[0],
+                userAccess:
+                    firstAccess && firstAccessUserMetadata
+                        ? {
+                              ...firstAccess,
+                              ...firstAccessUserMetadata,
+                          }
+                        : undefined,
             },
         };
     }

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -265,6 +265,10 @@ export class SpaceService extends BaseService implements BulkActionable<Knex> {
         }
 
         const space = await this.spaceModel.getSpaceSummary(spaceUuid);
+        const accessContext =
+            await this.spacePermissionService.getAllSpaceAccessContext(
+                spaceUuid,
+            );
 
         // TODO: legacy nested space check. How do we migrate this?
         const isNested = !(await this.spaceModel.isRootSpace(spaceUuid));
@@ -294,7 +298,7 @@ export class SpaceService extends BaseService implements BulkActionable<Knex> {
                 spaceId: spaceUuid,
                 projectId: space.projectUuid,
                 isPrivate: space.isPrivate,
-                userAccessCount: space.access.length,
+                userAccessCount: accessContext.access.length,
                 isNested,
             },
         });

--- a/packages/common/src/types/promotion.ts
+++ b/packages/common/src/types/promotion.ts
@@ -9,7 +9,7 @@ export enum PromotionAction {
     DELETE = 'delete',
 }
 
-export type PromotedSpace = Omit<SpaceSummary, 'userAccess'>;
+export type PromotedSpace = Omit<SpaceSummary, 'userAccess' | 'access'>;
 
 export type PromotedDashboard = DashboardDAO & {
     spaceSlug: string;

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -57,7 +57,7 @@ export type Space = {
     pinnedListOrder: number | null;
     slug: string;
     // Nested Spaces MVP - disables nested spaces' access changes
-    childSpaces: Omit<SpaceSummary, 'userAccess'>[];
+    childSpaces: Omit<SpaceSummary, 'userAccess' | 'access'>[];
     parentSpaceUuid: string | null;
     inheritParentPermissions: boolean;
     // ltree path serialized as string


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
This PR optimizes space access queries by removing unnecessary joins and refactoring how space access information is retrieved. Instead of fetching access data in the initial queries, we now fetch it separately when needed, which improves performance.

Key changes:
- Removed unnecessary joins to `SpaceUserAccessTableName` and related user tables in multiple queries
- Added a new method `getDirectSpaceUserUuids` to fetch space access information separately
- Updated the `ContentService` to fetch access information after retrieving content
- Modified the `PinningService` to add access information to pinned spaces
- Updated type definitions to reflect changes in how access data is handled

This approach reduces the complexity of the initial queries and allows for more efficient data retrieval patterns.