### PR TITLE
chore: improve dashboard tab switching performance

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/tabs.module.css
+++ b/packages/frontend/src/features/dashboardTabs/tabs.module.css
@@ -93,6 +93,10 @@
     }
 }
 
+.tabGridContainer {
+    position: relative;
+}
+
 .gridInteracting {
     user-select: none;
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Tab navigation from/to tabs that contain a lot of content can become very very slow. To resolve this, this PR applies a few fixes:

1. Per-tab grids - Instead of one ResponsiveGridLayout with key={activeTab} that unmounts/remounts everything on tab switch, we now render one grid per tab. Inactive tabs are
  hidden with visibility: hidden + position: absolute (not display: none, which would break WidthProvider width measurement).
2. Instant DOM switching - handleChangeTab directly manipulates the DOM to toggle tab panel visibility and Mantine's data-active tab indicator, bypassing React's re-render cycle.
  React reconciles on its next render (producing the same state — so it's a no-op).
3. Properly memoized layouts - layoutsByTab is a useMemo that only recomputes when tiles or edit mode change (not on every render).

### Testing:
Note that the lag isn't as extreme locally, since there is obviously less latency and more compute power, but the difference is still very visible.

#### Before:


https://github.com/user-attachments/assets/178d4eee-d0c8-4733-b799-a36eec8d041e



#### After:



https://github.com/user-attachments/assets/40b9ccfb-baf6-4532-a21e-a13404324407


