### PR TITLE
feat: add deduped order amount metrics and optimize metric reference handling

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/payments.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.yml
@@ -48,6 +48,19 @@ models:
         config:
           meta:
             metrics:
+              total_order_amount_deduped:
+                type: number
+                sql: "SUM(DISTINCT (('x' || SUBSTR(MD5(CAST(${orders.order_id} AS VARCHAR)), 1, 15))::BIT(60)::BIGINT) + (${orders.amount})) - SUM(DISTINCT (('x' || SUBSTR(MD5(CAST(${orders.order_id} AS VARCHAR)), 1, 15))::BIT(60)::BIGINT))"
+                description: "Total order amount without double-counting from multiple payments per order. Each order's amount is counted once regardless of how many payment rows exist."
+                format: usd
+                round: 2
+              total_order_amount_inflated:
+                type: sum
+                sql: ${orders.amount}
+                description: "Regular SUM of order amount — inflated by join fan-out when orders have multiple payments. Compare with total_order_amount_deduped to see the difference."
+                format: usd
+                round: 2
+
               total_revenue:
                 spotlight:
                   owner: demo2@lightdash.com

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1376,35 +1376,26 @@ export class MetricQueryBuilder {
                         metricObject.table,
                     );
                     metricReferences.forEach((metricReference) => {
+                        const refId = getItemId({
+                            table: metricReference.refTable,
+                            name: metricReference.refName,
+                        });
+                        // Skip dimension references — only process metric references
+                        if (!this.availableMetrics[refId]) {
+                            return;
+                        }
                         const isInMetricsObjects = metricsObjects.some(
-                            (metric) =>
-                                getItemId(metric) ===
-                                getItemId({
-                                    table: metricReference.refTable,
-                                    name: metricReference.refName,
-                                }),
+                            (metric) => getItemId(metric) === refId,
                         );
                         const isInReferencedMetricObjects = acc.some(
-                            (metric) =>
-                                getItemId(metric) ===
-                                getItemId({
-                                    table: metricReference.refTable,
-                                    name: metricReference.refName,
-                                }),
+                            (metric) => getItemId(metric) === refId,
                         );
                         // Only add if doesn't exist in metricsObjects or referencedMetricObjects
                         if (
                             !isInMetricsObjects &&
                             !isInReferencedMetricObjects
                         ) {
-                            acc.push(
-                                this.getMetricFromId(
-                                    getItemId({
-                                        table: metricReference.refTable,
-                                        name: metricReference.refName,
-                                    }),
-                                ),
-                            );
+                            acc.push(this.getMetricFromId(refId));
                         }
                     });
                 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
Added two new metrics to the payments model in the full-jaffle-shop-demo:
- `total_order_amount_deduped`: A metric that prevents double-counting when multiple payments exist for a single order
- `total_order_amount_inflated`: A standard sum metric that shows the inflated amount when orders have multiple payments

Also refactored the metric reference handling in MetricQueryBuilder to improve code readability and efficiency by:
- Extracting the reference ID calculation to a variable
- Adding a check to skip dimension references
- Simplifying the comparison logic