### PR TITLE
fix: content invalidation across deletion operations

### DIFF
--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlCharts.tsx
@@ -16,6 +16,7 @@ import {
 import { useNavigate } from 'react-router';
 import { lightdashApi } from '../../../api';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { invalidateContent } from '../../../hooks/useContent';
 import useApp from '../../../providers/App/useApp';
 
 export type GetSavedSqlChartParams = {
@@ -165,14 +166,8 @@ export const useDeleteSqlChartMutation = (
         {
             mutationKey: ['sqlRunner', 'deleteSqlChart', savedSqlUuid],
             onSuccess: async () => {
+                await invalidateContent(queryClient, projectUuid);
                 await queryClient.invalidateQueries(['sqlRunner']);
-                await queryClient.invalidateQueries(['spaces']);
-                await queryClient.invalidateQueries(['space']);
-                await queryClient.invalidateQueries(['pinned_items']);
-                await queryClient.invalidateQueries([
-                    'most-popular-and-recently-updated',
-                ]);
-                await queryClient.invalidateQueries(['content']);
                 await queryClient.invalidateQueries(['deletedContent']);
 
                 showToastSuccess({

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -25,6 +25,7 @@ import { lightdashApi } from '../../api';
 import { pollJobStatus } from '../../features/scheduler/hooks/useScheduler';
 import useApp from '../../providers/App/useApp';
 import useToaster from '../toaster/useToaster';
+import { invalidateContent } from '../useContent';
 import useQueryError from '../useQueryError';
 import useDashboardStorage from './useDashboardStorage';
 
@@ -582,17 +583,10 @@ export const useDashboardDeleteMutation = () => {
     const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(deleteDashboard, {
         onSuccess: async () => {
-            await queryClient.invalidateQueries(['dashboards']);
-            await queryClient.invalidateQueries(['space']);
-
+            await invalidateContent(queryClient, projectUuid!);
             await queryClient.invalidateQueries([
                 'dashboards-containing-chart',
             ]);
-            await queryClient.invalidateQueries(['pinned_items']);
-            await queryClient.invalidateQueries([
-                'most-popular-and-recently-updated',
-            ]);
-            await queryClient.invalidateQueries(['content']);
             await queryClient.invalidateQueries(['deletedContent']);
             showToastSuccess({
                 title: `Deleted! Dashboard was deleted.`,

--- a/packages/frontend/src/hooks/useContent.ts
+++ b/packages/frontend/src/hooks/useContent.ts
@@ -112,7 +112,7 @@ const postContentBulkAction = async ({
     });
 };
 
-const invalidateContent = async (
+export const invalidateContent = async (
     queryClient: QueryClient,
     projectUuid: string,
 ) => {
@@ -125,6 +125,7 @@ const invalidateContent = async (
         queryClient.invalidateQueries(['space', projectUuid]),
         queryClient.invalidateQueries(['space']),
         queryClient.invalidateQueries(['spaces']),
+        queryClient.invalidateQueries([projectUuid, 'search']),
     ]);
 };
 

--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -20,6 +20,7 @@ import { lightdashApi } from '../api';
 import useApp from '../providers/App/useApp';
 import { convertDateFilters } from '../utils/dateFilter';
 import useToaster from './toaster/useToaster';
+import { invalidateContent } from './useContent';
 import useSearchParams from './useSearchParams';
 
 const createSavedQuery = async (
@@ -208,13 +209,7 @@ export const useSavedQueryDeleteMutation = () => {
         {
             mutationKey: ['saved_query_create'],
             onSuccess: async () => {
-                await queryClient.invalidateQueries(['spaces']);
-                await queryClient.invalidateQueries(['space']);
-                await queryClient.invalidateQueries(['pinned_items']);
-                await queryClient.invalidateQueries([
-                    'most-popular-and-recently-updated',
-                ]);
-                await queryClient.invalidateQueries(['content']);
+                await invalidateContent(queryClient, projectUuid!);
                 await queryClient.invalidateQueries(['deletedContent']);
 
                 showToastSuccess({

--- a/packages/frontend/src/hooks/useSpaces.ts
+++ b/packages/frontend/src/hooks/useSpaces.ts
@@ -16,6 +16,7 @@ import { useNavigate } from 'react-router';
 import { lightdashApi } from '../api';
 import useApp from '../providers/App/useApp';
 import useToaster from './toaster/useToaster';
+import { invalidateContent } from './useContent';
 import { useAccount } from './user/useAccount';
 
 const getSpaceSummaries = async (projectUuid: string) => {
@@ -96,13 +97,7 @@ export const useSpaceDeleteMutation = (projectUuid: string) => {
         {
             mutationKey: ['space_delete', projectUuid],
             onSuccess: async () => {
-                await queryClient.invalidateQueries([
-                    'projects',
-                    projectUuid,
-                    'spaces',
-                ]);
-                await queryClient.invalidateQueries(['pinned_items']);
-                await queryClient.refetchQueries(['content']);
+                await invalidateContent(queryClient, projectUuid);
                 await queryClient.invalidateQueries(['deletedContent']);
                 showToastSuccess({
                     title: `Success! Space was deleted.`,


### PR DESCRIPTION
### Description:
Refactored content invalidation logic by extracting it into a reusable `invalidateContent` function. This function is now exported from `useContent.ts` and used consistently across multiple components when content is modified, including:

- Recently deleted content restoration and permanent deletion
- SQL chart deletion
- Dashboard deletion
- Saved query deletion
- Space deletion

The function ensures that all relevant queries are invalidated in a consistent way, including the search query which was previously missing.