### PR TITLE
fix: optimize find fields tool to avoid calling `findExploresFromCache` multiple times

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -134,6 +134,7 @@ import {
     FindContentFn,
     FindExploresFn,
     FindFieldFn,
+    GetExploreFn,
     GetPromptFn,
     ListExploresFn,
     RunAsyncQueryFn,
@@ -2497,6 +2498,16 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 );
             });
 
+        const getExplore: GetExploreFn = async ({ table }) => {
+            const agentSettings = await this.getAgentSettings(user, prompt);
+            return this.getExplore(
+                user,
+                projectUuid,
+                agentSettings.tags,
+                table,
+            );
+        };
+
         const findExplores: FindExploresFn = (args) =>
             wrapSentryTransaction('AiAgent.findExplores', args, async () => {
                 const agentSettings = await this.getAgentSettings(user, prompt);
@@ -2588,15 +2599,6 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                         },
                     );
 
-                const agentSettings = await this.getAgentSettings(user, prompt);
-
-                const explore = await this.getExplore(
-                    user,
-                    projectUuid,
-                    agentSettings.tags,
-                    args.table,
-                );
-
                 const { data: catalogItems, pagination } =
                     await this.catalogService.searchCatalog({
                         projectUuid,
@@ -2611,7 +2613,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                         },
                         userAttributes,
                         fullTextSearchOperator: 'OR',
-                        filteredExplores: [explore],
+                        filteredExplores: [args.explore],
                     });
 
                 // TODO: we should not filter here, search should be returning a proper type
@@ -2619,7 +2621,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     (item) => item.type === CatalogType.Field,
                 );
 
-                return { fields: catalogFields, pagination, explore };
+                return { fields: catalogFields, pagination };
             });
 
         const updateProgress: UpdateProgressFn = (progress) =>
@@ -2858,6 +2860,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 
         return {
             listExplores,
+            getExplore,
             findContent,
             findFields,
             findExplores,
@@ -2932,6 +2935,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 
         const {
             listExplores,
+            getExplore,
             findContent,
             findFields,
             findExplores,
@@ -2984,6 +2988,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 
         const dependencies: AiAgentDependencies = {
             listExplores,
+            getExplore,
             findContent,
             findFields,
             findExplores,

--- a/packages/backend/src/ee/services/ai/agents/agentV2.ts
+++ b/packages/backend/src/ee/services/ai/agents/agentV2.ts
@@ -81,6 +81,7 @@ const getAgentTools = (
     });
 
     const findFields = getFindFields({
+        getExplore: dependencies.getExplore,
         findFields: dependencies.findFields,
         updateProgress: dependencies.updateProgress,
         pageSize: args.findFieldsPageSize,

--- a/packages/backend/src/ee/services/ai/tools/findFields.tsx
+++ b/packages/backend/src/ee/services/ai/tools/findFields.tsx
@@ -11,6 +11,7 @@ import {
 import { tool } from 'ai';
 import type {
     FindFieldFn,
+    GetExploreFn,
     UpdateProgressFn,
 } from '../types/aiAgentDependencies';
 import { toModelOutput } from '../utils/toModelOutput';
@@ -18,6 +19,7 @@ import { toolErrorHandler } from '../utils/toolErrorHandler';
 import { xmlBuilder } from '../xmlBuilder';
 
 type Dependencies = {
+    getExplore: GetExploreFn;
     findFields: FindFieldFn;
     updateProgress: UpdateProgressFn;
     pageSize: number;
@@ -97,6 +99,7 @@ const getFieldsText = (
 );
 
 export const getFindFields = ({
+    getExplore,
     findFields,
     updateProgress,
     pageSize,
@@ -116,6 +119,8 @@ export const getFindFields = ({
                     }...`,
                 );
 
+                const explore = await getExplore({ table: args.table });
+
                 const fieldSearchQueryResults = await Promise.all(
                     args.fieldSearchQueries.map(async (fieldSearchQuery) => {
                         const result = await findFields({
@@ -123,6 +128,7 @@ export const getFindFields = ({
                             fieldSearchQuery,
                             page: args.page ?? 1,
                             pageSize,
+                            explore,
                         });
                         return {
                             searchQuery: fieldSearchQuery.label,
@@ -130,9 +136,6 @@ export const getFindFields = ({
                         };
                     }),
                 );
-
-                // Use explore from the first result (all should have the same explore for the same table)
-                const explore = fieldSearchQueryResults[0]?.explore;
 
                 const fieldsText = fieldSearchQueryResults
                     .map((fieldSearchQueryResult) =>

--- a/packages/backend/src/ee/services/ai/types/aiAgent.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgent.ts
@@ -8,6 +8,7 @@ import {
     FindExploresFn,
     FindFieldFn,
     GetExploreCompilerFn,
+    GetExploreFn,
     GetPromptFn,
     ListExploresFn,
     RunAsyncQueryFn,
@@ -60,6 +61,7 @@ export type AiAgentDependencies = {
     findContent: FindContentFn;
     findExplores: FindExploresFn;
     findFields: FindFieldFn;
+    getExplore: GetExploreFn;
     getExploreCompiler: GetExploreCompilerFn;
     runAsyncQuery: RunAsyncQueryFn;
     getPrompt: GetPromptFn;

--- a/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
+++ b/packages/backend/src/ee/services/ai/types/aiAgentDependencies.ts
@@ -61,12 +61,14 @@ export type FindFieldFn = (
     args: KnexPaginateArgs & {
         table: ToolFindFieldsArgs['table'];
         fieldSearchQuery: ToolFindFieldsArgs['fieldSearchQueries'][number];
+        explore: Explore;
     },
 ) => Promise<{
     fields: CatalogField[];
     pagination: Pagination | undefined;
-    explore?: Explore;
 }>;
+
+export type GetExploreFn = (args: { table: string }) => Promise<Explore>;
 
 export type FindContentFn = (args: {
     searchQuery: ToolFindContentArgs['searchQueries'][number];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-3010: Ubie sql-cloud-proxy OOM issue](https://linear.app/lightdash/issue/PROD-3010/ubie-sql-cloud-proxy-oom-issue)

### Description:

Refactored the field search functionality to improve the architecture by:

1. Extracting the `getExplore` function as a separate dependency in the AI agent system
2. Passing the explore object directly to the `findFields` function instead of retrieving it inside
3. Updated the `getFindFields` tool to use the new `getExplore` dependency
4. Modified the McpService to align with these changes by returning both `findFields` and `getExplore` functions
