### PR TITLE
perf: optimize agent explore lookup by filtering at database level

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -412,12 +412,14 @@ export class AiAgentService {
         user: SessionUser,
         projectUuid: string,
         availableTags: string[] | null,
+        exploreNames?: string[],
     ) {
         return wrapSentryTransaction(
             'AiAgent.getAvailableExplores',
             {
                 projectUuid,
                 availableTags,
+                exploreNames,
             },
             async () => {
                 const { organizationUuid } = user;
@@ -434,6 +436,7 @@ export class AiAgentService {
                     await this.projectModel.findExploresFromCache(
                         projectUuid,
                         'name',
+                        exploreNames,
                     ),
                 );
 
@@ -467,14 +470,12 @@ export class AiAgentService {
         availableTags: string[] | null,
         exploreName: string,
     ) {
-        const explores = await this.getAvailableExplores(
+        const [explore] = await this.getAvailableExplores(
             user,
             projectUuid,
             availableTags,
+            [exploreName],
         );
-
-        const explore = explores.find((e) => e.name === exploreName);
-
         if (!explore) {
             throw new NotFoundError('Explore not found');
         }

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1140,12 +1140,14 @@ export class McpService extends BaseService {
         projectUuid: string,
         availableTags: string[] | null,
         userAttributeOverrides?: UserAttributeValueMap,
+        exploreNames?: string[],
     ) {
         return wrapSentryTransaction(
             'AiAgent.getAvailableExplores',
             {
                 projectUuid,
                 availableTags,
+                exploreNames,
             },
             async () => {
                 const { organizationUuid } = user;
@@ -1167,6 +1169,7 @@ export class McpService extends BaseService {
                     await this.projectModel.findExploresFromCache(
                         projectUuid,
                         'name',
+                        exploreNames,
                     ),
                 );
 
@@ -1201,15 +1204,13 @@ export class McpService extends BaseService {
         exploreName: string,
         userAttributeOverrides?: UserAttributeValueMap,
     ) {
-        const explores = await this.getAvailableExplores(
+        const [explore] = await this.getAvailableExplores(
             user,
             projectUuid,
             availableTags,
             userAttributeOverrides,
+            [exploreName],
         );
-
-        const explore = explores.find((e) => e.name === exploreName);
-
         if (!explore) {
             throw new NotFoundError('Explore not found');
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

This PR optimizes the explore retrieval process in both `AiAgentService` and `McpService` by adding an optional `exploreNames` parameter to filter explores by name. This allows for more efficient retrieval when looking for specific explores rather than fetching all explores and then filtering them.

The implementation:

1. Adds an optional `exploreNames` parameter to `getAvailableExplores` method in both services
2. Passes this parameter to the `findExploresFromCache` method
3. Refactors `getExplore` to use the new parameter, eliminating the need to fetch all explores and then filter them
