### PR TITLE
feat: add descendant counts to deleted content

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../database/entities/pinnedList';
 import { ProjectTableName } from '../../../database/entities/projects';
 import { SavedChartsTableName } from '../../../database/entities/savedCharts';
+import { SchedulerTableName } from '../../../database/entities/scheduler';
 import { SpaceTableName } from '../../../database/entities/spaces';
 import { UserTableName } from '../../../database/entities/users';
 import {
@@ -135,6 +136,14 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                     'chart_kind', ${SavedChartsTableName}.last_version_chart_kind,
                     'dashboard_uuid', ${DashboardsTableName}.dashboard_uuid,
                     'dashboard_name', ${DashboardsTableName}.name
+                    ${
+                        filters.includeDescendantCounts
+                            ? `, 'schedulerCount', (
+                                SELECT count(*) FROM ${SchedulerTableName} sch
+                                WHERE sch.saved_chart_uuid = ${SavedChartsTableName}.saved_query_uuid
+                            )`
+                            : ''
+                    }
                  ) as metadata`),
                 ])
                 .where((builder) => {

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -28,6 +28,7 @@ export type ContentFilters = {
     };
     deleted?: boolean;
     deletedByUserUuids?: string[];
+    includeDescendantCounts?: boolean;
 };
 
 export type ContentArgs = {

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -14,8 +14,8 @@ import {
     CustomDimensionType,
     CustomSqlDimension,
     DBFieldTypes,
-    DeletedChartContentSummary,
     DeletedContentFilters,
+    DeletedDbtChartContentSummary,
     DimensionOverrides,
     ECHARTS_DEFAULT_COLORS,
     Filters,
@@ -1885,7 +1885,7 @@ export class SavedChartModel {
         filters: DeletedContentFilters,
         paginateArgs?: KnexPaginateArgs,
         userUuid?: string,
-    ): Promise<KnexPaginatedData<DeletedChartContentSummary[]>> {
+    ): Promise<KnexPaginatedData<DeletedDbtChartContentSummary[]>> {
         const query = this.database(SavedChartsTableName)
             .leftJoin(
                 DashboardsTableName,

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -8,7 +8,7 @@ import {
     ContentType,
     DeletedContentFilters,
     DeletedContentItem,
-    DeletedContentSummary,
+    DeletedContentWithDescendants,
     ForbiddenError,
     KnexPaginateArgs,
     KnexPaginatedData,
@@ -309,7 +309,7 @@ export class ContentService extends BaseService {
         user: SessionUser,
         filters: DeletedContentFilters,
         paginateArgs?: KnexPaginateArgs,
-    ): Promise<KnexPaginatedData<DeletedContentSummary[]>> {
+    ): Promise<KnexPaginatedData<DeletedContentWithDescendants[]>> {
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -11,8 +11,8 @@ import {
     CreateSavedChart,
     CreateSavedChartVersion,
     CreateSchedulerAndTargetsWithoutIds,
-    DeletedChartContentSummary,
     DeletedContentFilters,
+    DeletedDbtChartContentSummary,
     ExploreType,
     ForbiddenError,
     GoogleSheetsTransientError,
@@ -1547,7 +1547,7 @@ export class SavedChartService
         projectUuid: string,
         filters: DeletedContentFilters,
         paginateArgs?: KnexPaginateArgs,
-    ): Promise<KnexPaginatedData<DeletedChartContentSummary[]>> {
+    ): Promise<KnexPaginatedData<DeletedDbtChartContentSummary[]>> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 

--- a/packages/frontend/src/features/recentlyDeleted/api/deletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/api/deletedContent.ts
@@ -1,7 +1,7 @@
 import {
     type ContentType,
     type DeletedContentItem,
-    type DeletedContentSummary,
+    type DeletedContentWithDescendants,
     type KnexPaginatedData,
 } from '@lightdash/common';
 import { lightdashApi } from '../../../api';
@@ -15,7 +15,9 @@ export type DeletedContentApiParams = {
     deletedByUserUuids?: string[];
 };
 
-type DeletedContentApiResponse = KnexPaginatedData<DeletedContentSummary[]>;
+type DeletedContentApiResponse = KnexPaginatedData<
+    DeletedContentWithDescendants[]
+>;
 
 export async function getDeletedContent(
     params: DeletedContentApiParams,

--- a/packages/frontend/src/features/recentlyDeleted/components/DeletedContentActionMenu.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/DeletedContentActionMenu.tsx
@@ -1,4 +1,4 @@
-import { type DeletedContentSummary } from '@lightdash/common';
+import { type DeletedContentWithDescendants } from '@lightdash/common';
 import { ActionIcon, Menu } from '@mantine-8/core';
 import { IconDotsVertical, IconRestore, IconTrash } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
@@ -6,7 +6,7 @@ import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 
 interface Props {
-    item: DeletedContentSummary;
+    item: DeletedContentWithDescendants;
     onRestore: () => void;
     onPermanentlyDelete: () => void;
     isLoading?: boolean;

--- a/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
@@ -2,7 +2,7 @@ import {
     ContentType,
     type ApiError,
     type DeletedContentItem,
-    type DeletedContentSummary,
+    type DeletedContentWithDescendants,
     type KnexPaginatedData,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
@@ -34,7 +34,7 @@ export function useInfiniteDeletedContent(
     params: UseInfiniteDeletedContentParams,
 ) {
     return useInfiniteQuery<
-        KnexPaginatedData<DeletedContentSummary[]>,
+        KnexPaginatedData<DeletedContentWithDescendants[]>,
         ApiError
     >({
         queryKey: [


### PR DESCRIPTION
### Description:
This PR enhances the Recently Deleted page by adding descendant counts to deleted content items. Now when viewing deleted spaces, dashboards, and charts, users can see how many nested items they contain (like charts within dashboards, scheduled deliveries, etc.).

The changes include:
- Adding descendant count queries to content configurations for spaces, dashboards, and charts
- Creating new types to properly represent content with descendant counts
- Updating the UI to display these counts in a more informative way
- Improving the visual presentation of deleted items to better show their hierarchical relationships

This makes it easier for users to understand the impact of restoring or permanently deleting content, as they can now see exactly what child items are contained within.