### PR TITLE
chore: move root space queries to SpacePermissionModel

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -12,7 +12,10 @@ import {
     SpaceUserAccessTableName,
 } from '../../../database/entities/spaces';
 import { UserTableName } from '../../../database/entities/users';
-import { SpaceModel } from '../../SpaceModel';
+import {
+    getRootSpaceAccessQuery,
+    getRootSpaceIsPrivateQuery,
+} from '../../SpacePermissionModel';
 import {
     ContentConfiguration,
     ContentFilters,
@@ -155,10 +158,8 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                         }),
                         'parentSpaceUuid', ${SpaceTableName}.parent_space_uuid,
                         'path', ${SpaceTableName}.path,
-                        'access', (${SpaceModel.getRootSpaceAccessQuery(
-                            'shared_with',
-                        )}),
-                        'isPrivate', (${SpaceModel.getRootSpaceIsPrivateQuery()}),
+                        'access', (${getRootSpaceAccessQuery('shared_with')}),
+                        'isPrivate', (${getRootSpaceIsPrivateQuery()}),
                         'inheritParentPermissions', ${SpaceTableName}.inherit_parent_permissions,
                         'pinnedListOrder', ${PinnedSpaceTableName}.order
                         ${

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -19,7 +19,10 @@ import {
     SpaceUserAccessTableName,
 } from '../database/entities/spaces';
 import { UserTableName } from '../database/entities/users';
-import { SpaceModel } from './SpaceModel';
+import {
+    getRootSpaceAccessQuery,
+    getRootSpaceIsPrivateQuery,
+} from './SpacePermissionModel';
 
 type ResourceViewItemModelArguments = {
     database: Knex;
@@ -284,8 +287,8 @@ const getAllSpaces = async (
             space_uuid: `${PinnedSpaceTableName}.space_uuid`,
             order: `${PinnedSpaceTableName}.order`,
             name: knex.raw(`max(${SpaceTableName}.name)`),
-            is_private: knex.raw(SpaceModel.getRootSpaceIsPrivateQuery()),
-            access: knex.raw(SpaceModel.getRootSpaceAccessQuery(UserTableName)),
+            is_private: knex.raw(getRootSpaceIsPrivateQuery()),
+            access: knex.raw(getRootSpaceAccessQuery(UserTableName)),
             parent_space_uuid: `${SpaceTableName}.parent_space_uuid`,
             path: `${SpaceTableName}.path`,
             access_list_length: knex.raw(`


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Refactored space permission queries by moving `getRootSpaceAccessQuery` and `getRootSpaceIsPrivateQuery` from `SpaceModel` to `SpacePermissionModel`. This improves code organization by centralizing permission-related logic in a dedicated file.

The functions are now imported where needed in `SpaceContentConfiguration`, `ResourceViewItemModel`, and `SpaceModel`, reducing code duplication and making future permission-related changes easier to maintain.