### PR TITLE
feat: include SQL chart changes in dashboard promotion diffs and confirm modal

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -16162,11 +16162,46 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PromotedSqlChart: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                spacePath: { dataType: 'string', required: true },
+                spaceSlug: { dataType: 'string', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                slug: { dataType: 'string', required: true },
+                oldUuid: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PromotionChanges: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                sqlCharts: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            data: { ref: 'PromotedSqlChart', required: true },
+                            action: { ref: 'PromotionAction', required: true },
+                        },
+                    },
+                },
                 charts: {
                     dataType: 'array',
                     array: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16798,8 +16798,63 @@
                     }
                 ]
             },
+            "PromotedSqlChart": {
+                "properties": {
+                    "spacePath": {
+                        "type": "string"
+                    },
+                    "spaceSlug": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "oldUuid": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "spacePath",
+                    "spaceSlug",
+                    "description",
+                    "name",
+                    "projectUuid",
+                    "slug",
+                    "oldUuid",
+                    "uuid"
+                ],
+                "type": "object"
+            },
             "PromotionChanges": {
                 "properties": {
+                    "sqlCharts": {
+                        "items": {
+                            "properties": {
+                                "data": {
+                                    "$ref": "#/components/schemas/PromotedSqlChart"
+                                },
+                                "action": {
+                                    "$ref": "#/components/schemas/PromotionAction"
+                                }
+                            },
+                            "required": ["data", "action"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
                     "charts": {
                         "items": {
                             "properties": {

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -12,6 +12,7 @@ import {
     NotFoundError,
     ParameterError,
     PromotedChart as PromotedChangeChart,
+    PromotedSqlChart as PromotedChangeSqlChart,
     PromotedSpace,
     PromotionAction,
     PromotionChanges,
@@ -1088,7 +1089,7 @@ export class PromoteService extends BaseService {
             );
 
         // We're going to be updating this structure with new UUIDs if we need to create the items (eg: spaces)
-        const [promotionChanges, promotedCharts] =
+        const [promotionChanges, , , sqlCharts] =
             await this.getPromotionDashboardChanges(
                 user,
                 promotedDashboard,
@@ -1097,6 +1098,10 @@ export class PromoteService extends BaseService {
 
         return {
             ...promotionChanges,
+            sqlCharts: sqlCharts.map((sqlChartChange) => ({
+                action: sqlChartChange.action,
+                data: PromoteService.toPromotedSqlChartChange(sqlChartChange),
+            })),
             spaces: PromoteService.sortSpaceChanges(promotionChanges.spaces),
         };
     }
@@ -1509,6 +1514,21 @@ export class PromoteService extends BaseService {
                 },
                 versionedData,
             },
+        };
+    }
+
+    static toPromotedSqlChartChange(
+        sqlChartChange: PromotedSqlChartChange,
+    ): PromotedChangeSqlChart {
+        return {
+            uuid: sqlChartChange.data.uuid,
+            oldUuid: sqlChartChange.data.oldUuid,
+            slug: sqlChartChange.data.slug,
+            projectUuid: sqlChartChange.data.projectUuid,
+            name: sqlChartChange.data.unversionedData.name,
+            description: sqlChartChange.data.unversionedData.description,
+            spaceSlug: sqlChartChange.data.spaceSlug,
+            spacePath: sqlChartChange.data.spacePath,
         };
     }
 

--- a/packages/common/src/types/promotion.ts
+++ b/packages/common/src/types/promotion.ts
@@ -21,6 +21,17 @@ export type PromotedChart = SavedChartDAO & {
     oldUuid: string;
 };
 
+export type PromotedSqlChart = {
+    uuid: string;
+    oldUuid: string;
+    slug: string;
+    projectUuid: string;
+    name: string;
+    description: string | null;
+    spaceSlug: string;
+    spacePath: string;
+};
+
 export type PromotionChanges = {
     spaces: {
         action: PromotionAction;
@@ -33,6 +44,10 @@ export type PromotionChanges = {
     charts: {
         action: PromotionAction;
         data: PromotedChart;
+    }[];
+    sqlCharts?: {
+        action: PromotionAction;
+        data: PromotedSqlChart;
     }[];
 };
 

--- a/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
+++ b/packages/frontend/src/features/promotion/components/PromotionConfirmDialog.tsx
@@ -8,6 +8,7 @@ import { useMemo, type FC } from 'react';
 
 import {
     IconChartAreaLine,
+    IconDatabase,
     IconFolder,
     IconLayoutDashboard,
     IconRocket,
@@ -32,7 +33,7 @@ type PromotionChange = {
 };
 
 const PromotionChangesAccordion: FC<{
-    type: 'spaces' | 'charts' | 'dashboards';
+    type: 'spaces' | 'charts' | 'dashboards' | 'sqlCharts';
     items: {
         created: PromotionChange[];
         updated: PromotionChange[];
@@ -141,6 +142,20 @@ export const PromotionConfirmDialog: FC<Props> = ({
                     (item) => item.action === PromotionAction.DELETE,
                 ),
             },
+            sqlCharts: {
+                total: (promotionChanges.sqlCharts ?? []).filter(
+                    (item) => item.action !== PromotionAction.NO_CHANGES,
+                ).length,
+                created: (promotionChanges.sqlCharts ?? []).filter(
+                    (item) => item.action === PromotionAction.CREATE,
+                ),
+                updated: (promotionChanges.sqlCharts ?? []).filter(
+                    (item) => item.action === PromotionAction.UPDATE,
+                ),
+                deleted: (promotionChanges.sqlCharts ?? []).filter(
+                    (item) => item.action === PromotionAction.DELETE,
+                ),
+            },
             dashboards: {
                 total: promotionChanges.dashboards.filter(
                     (item) => item.action !== PromotionAction.NO_CHANGES,
@@ -160,6 +175,7 @@ export const PromotionConfirmDialog: FC<Props> = ({
         const totalChangesNum =
             changes.spaces.total +
             changes.charts.total +
+            changes.sqlCharts.total +
             changes.dashboards.total;
         const withoutChangesNum =
             promotionChanges.spaces.filter(
@@ -169,6 +185,9 @@ export const PromotionConfirmDialog: FC<Props> = ({
                 (item) => item.action === PromotionAction.NO_CHANGES,
             ).length +
             promotionChanges.charts.filter(
+                (item) => item.action === PromotionAction.NO_CHANGES,
+            ).length +
+            (promotionChanges.sqlCharts ?? []).filter(
                 (item) => item.action === PromotionAction.NO_CHANGES,
             ).length;
 
@@ -264,6 +283,26 @@ export const PromotionConfirmDialog: FC<Props> = ({
                                 <PromotionChangesAccordion
                                     type="charts"
                                     items={groupedChanges.charts}
+                                />
+                            </>
+                        )}
+                        {groupedChanges.sqlCharts.total > 0 && (
+                            <>
+                                <Text fz="sm">
+                                    These changes will be applied:
+                                </Text>
+                                <Flex>
+                                    <MantineIcon
+                                        icon={IconDatabase}
+                                        color="cyan.7"
+                                    />{' '}
+                                    <Text ml={10} fw={600}>
+                                        SQL charts:{' '}
+                                    </Text>{' '}
+                                </Flex>
+                                <PromotionChangesAccordion
+                                    type="sqlCharts"
+                                    items={groupedChanges.sqlCharts}
                                 />
                             </>
                         )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added support for SQL charts in the promotion flow. This enhancement allows SQL runner tiles to be included in the dashboard promotion process, displaying them in the promotion confirmation dialog alongside spaces, charts, and dashboards.

The implementation includes:

- New `PromotedSqlChart` type definition
- Updated `PromotionChanges` interface to include SQL charts
- Added SQL charts to the promotion confirmation dialog UI with database icon
- Added test coverage for SQL chart promotion functionality
