### PR TITLE
fix: deduplicate repeated chart and SQL chart tiles during dashboard promotion

### DIFF
--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -1817,30 +1817,35 @@ export class PromoteService extends BaseService {
     > {
         const upstreamProjectUuid = upstreamDashboard.projectUuid;
 
-        const chartUuids = promotedDashboard.dashboard.tiles.reduce<string[]>(
-            (acc, tile) => {
-                if (
-                    isDashboardChartTileType(tile) &&
-                    tile.properties.savedChartUuid
-                ) {
-                    return [...acc, tile.properties.savedChartUuid];
-                }
-                return acc;
-            },
-            [],
+        const chartUuids = Array.from(
+            promotedDashboard.dashboard.tiles.reduce<Set<string>>(
+                (acc, tile) => {
+                    if (
+                        isDashboardChartTileType(tile) &&
+                        tile.properties.savedChartUuid
+                    ) {
+                        acc.add(tile.properties.savedChartUuid);
+                    }
+                    return acc;
+                },
+                new Set<string>(),
+            ),
         );
 
-        const savedSqlUuids = promotedDashboard.dashboard.tiles.reduce<
-            string[]
-        >((acc, tile) => {
-            if (
-                tile.type === DashboardTileTypes.SQL_CHART &&
-                tile.properties.savedSqlUuid
-            ) {
-                return [...acc, tile.properties.savedSqlUuid];
-            }
-            return acc;
-        }, []);
+        const savedSqlUuids = Array.from(
+            promotedDashboard.dashboard.tiles.reduce<Set<string>>(
+                (acc, tile) => {
+                    if (
+                        tile.type === DashboardTileTypes.SQL_CHART &&
+                        tile.properties.savedSqlUuid
+                    ) {
+                        acc.add(tile.properties.savedSqlUuid);
+                    }
+                    return acc;
+                },
+                new Set<string>(),
+            ),
+        );
 
         const chartPromises = chartUuids.map((chartUuid) =>
             this.getPromoteCharts(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-2989: Promoting dashboards with SQL runner charts does not promote the SQL charts](https://linear.app/lightdash/issue/PROD-2989/promoting-dashboards-with-sql-runner-charts-does-not-promote-the-sql)

### Description:

Deduplicate chart tiles when promoting dashboards. This PR modifies the `getPromotionDashboardChanges` method to use Sets instead of arrays to ensure that duplicate saved chart tiles and SQL chart tiles are only processed once during dashboard promotion. This prevents redundant processing of the same chart multiple times when a dashboard contains duplicate tiles referencing the same chart.
