### PR TITLE
refactor: redesign validator table for Mantine v8

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.module.css
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.module.css
@@ -1,0 +1,5 @@
+/* Mark component override for ErrorMessage */
+.customMark {
+    text-transform: none;
+    border-radius: 2px;
+}

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ErrorMessage.tsx
@@ -9,8 +9,7 @@ import {
 } from '@lightdash/common';
 import { Mark, Stack, Text } from '@mantine-8/core';
 import { type FC } from 'react';
-// eslint-disable-next-line css-modules/no-unused-class
-import classes from './ValidatorTable.module.css';
+import classes from './ErrorMessage.module.css';
 
 const CustomMark: FC<React.PropsWithChildren<{}>> = ({ children }) => (
     <Mark color="ldGray" px={2} fw={500} fz="xs" className={classes.customMark}>

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTable.module.css
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/ValidatorTable.module.css
@@ -59,9 +59,3 @@
     color: unset;
     text-decoration: none;
 }
-
-/* Mark component override for ErrorMessage */
-.customMark {
-    text-transform: none;
-    border-radius: 2px;
-}

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -32,7 +32,6 @@ import MantineIcon from '../../common/MantineIcon';
 import { ChartIcon, IconBox } from '../../common/ResourceIcon';
 import { getLinkToResource } from '../utils/utils';
 import { ErrorMessage } from './ErrorMessage';
-// eslint-disable-next-line css-modules/no-unused-class
 import classes from './ValidatorTable.module.css';
 
 const isDeleted = (validationError: ValidationResponse) =>
@@ -303,8 +302,8 @@ export const ValidatorTable: FC<{
                 )}
                 <Table.Tbody>
                     {paddingTop > 0 && (
-                        <tr>
-                            <td
+                        <Table.Tr>
+                            <Table.Td
                                 colSpan={3}
                                 style={{
                                     height: paddingTop,
@@ -312,7 +311,7 @@ export const ValidatorTable: FC<{
                                     border: 'none',
                                 }}
                             />
-                        </tr>
+                        </Table.Tr>
                     )}
                     {virtualRows.map((virtualRow) => {
                         const validationError = data[virtualRow.index];
@@ -331,8 +330,8 @@ export const ValidatorTable: FC<{
                         );
                     })}
                     {paddingBottom > 0 && (
-                        <tr>
-                            <td
+                        <Table.Tr>
+                            <Table.Td
                                 colSpan={3}
                                 style={{
                                     height: paddingBottom,
@@ -340,7 +339,7 @@ export const ValidatorTable: FC<{
                                     border: 'none',
                                 }}
                             />
-                        </tr>
+                        </Table.Tr>
                     )}
                 </Table.Tbody>
             </Table>


### PR DESCRIPTION
## Summary
- **Replace Mantine v6 `Table` + `useTableStyles` with native Mantine v8 `<Table>` sub-components** and CSS modules — the old approach used raw `<tr>`/`<td>` elements with a shared `useTableStyles` hook
- **Fix inconsistent font sizes** — use theme tokens (`sm` for item names, `xs` for metadata/errors) instead of hardcoded `fz={11}` pixel values
- **Always show Fix + dismiss buttons** on every row instead of hover-reveal (which caused choppy highlights)
- **Stable column widths** with `table-layout: fixed` so the Error column doesn't shift as title lengths vary
- **CSS keyframe animation** for pinned row flash instead of imperative Web Animations API
- **Full Mantine v6 → v8 migration**: `sx` → CSS modules, `color` → `c`, `spacing` → `gap`, raw `<tr>`/`<td>` → `Table.Tr`/`Table.Td`

## Test plan
- [ ] Navigate to Settings → Validator, verify table renders with consistent font sizes
- [ ] Verify Fix button and dismiss X are visible on all rows without hovering
- [ ] Verify columns stay stable when scrolling through items with varying title lengths
- [ ] Click a validation error link — should open in new tab
- [ ] Click Fix on a chart error — should open the fix modal
- [ ] Click dismiss X — should remove the error
- [ ] Navigate to validator with `?validationId=N` — pinned row should flash yellow
- [ ] Scroll down to trigger infinite loading of more errors
- [ ] Search/filter controls should still work with the table

🤖 Generated with [Claude Code](https://claude.com/claude-code)