### PR TITLE
feat: prevent service accounts from using personal warehouse credentials

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -336,6 +336,7 @@ export class AsyncQueryService extends ProjectService {
                 projectUuid: queryHistory.projectUuid,
                 userId: account.user.id,
                 isRegisteredUser: account.isRegisteredUser(),
+                isServiceAccount: account.isServiceAccount(),
             }),
         );
 
@@ -1369,6 +1370,7 @@ export class AsyncQueryService extends ProjectService {
     public async runAsyncWarehouseQuery({
         userId,
         isRegisteredUser,
+        isServiceAccount,
         projectUuid,
         query,
         fieldsMap,
@@ -1407,6 +1409,7 @@ export class AsyncQueryService extends ProjectService {
                 projectUuid,
                 userId,
                 isRegisteredUser,
+                isServiceAccount,
             });
 
             warehouseCredentialsType = warehouseCredentials.type;
@@ -1777,6 +1780,7 @@ export class AsyncQueryService extends ProjectService {
                             projectUuid,
                             userId: account.user.id,
                             isRegisteredUser: account.isRegisteredUser(),
+                            isServiceAccount: account.isServiceAccount(),
                         });
 
                     const warehouseCredentialsType = warehouseCredentials.type;
@@ -1960,6 +1964,7 @@ export class AsyncQueryService extends ProjectService {
                     void this.runAsyncWarehouseQuery({
                         userId: account.user.id,
                         isRegisteredUser: account.isRegisteredUser(),
+                        isServiceAccount: account.isServiceAccount(),
                         projectUuid,
                         query,
                         fieldsMap,
@@ -2065,6 +2070,7 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             userId: account.user.id,
             isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
         });
 
         const warehouseSqlBuilder = warehouseSqlBuilderFromType(
@@ -2251,6 +2257,7 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             userId: account.user.id,
             isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
         });
 
         const warehouseSqlBuilder = warehouseSqlBuilderFromType(
@@ -2503,6 +2510,7 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             userId: account.user.id,
             isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
         });
 
         const warehouseSqlBuilder = warehouseSqlBuilderFromType(
@@ -2617,6 +2625,7 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             userId: account.user.id,
             isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
         });
 
         const warehouseSqlBuilder = warehouseSqlBuilderFromType(
@@ -2968,6 +2977,7 @@ export class AsyncQueryService extends ProjectService {
                 projectUuid,
                 userId: account.user.id,
                 isRegisteredUser: account.isRegisteredUser(),
+                isServiceAccount: account.isServiceAccount(),
             }),
         );
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -148,6 +148,7 @@ export type RunAsyncWarehouseQueryArgs = {
     userId: string;
     // Is the user in the database?
     isRegisteredUser: boolean;
+    isServiceAccount?: boolean;
     projectUuid: string;
     queryTags: RunQueryTags;
     query: string;

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -90,6 +90,10 @@ export const buildAccount = ({
         isRegisteredUser: () => userType === 'registered',
         isJwtUser: () => accountType === 'jwt',
         isAnonymousUser: () => userType === 'anonymous',
+        isServiceAccount: () => accountType === 'service-account',
+        isPatUser: () => accountType === 'pat',
+        isOauthUser: () => accountType === 'oauth',
+        isAuthenticated: () => true,
     }) as unknown as Account;
 
 export const validExplore: Explore = {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1121,10 +1121,12 @@ export class ProjectService extends BaseService {
         projectUuid,
         userId,
         isRegisteredUser,
+        isServiceAccount = false,
     }: {
         projectUuid: string;
         userId: string;
         isRegisteredUser: boolean;
+        isServiceAccount?: boolean;
     }) {
         // First, check if project uses organization-level credentials
         const project = await this.projectModel.get(projectUuid);
@@ -1147,6 +1149,13 @@ export class ProjectService extends BaseService {
             credentials = await this.refreshCredentials(
                 credentials, // This credentials are already loaded from organization
                 userId,
+            );
+        }
+
+        // Service accounts cannot use personal warehouse credentials
+        if (isServiceAccount && credentials.requireUserCredentials) {
+            throw new ForbiddenError(
+                'Service accounts cannot run queries when user credentials are required.',
             );
         }
 
@@ -3417,6 +3426,7 @@ export class ProjectService extends BaseService {
                             projectUuid,
                             userId: account.user.id,
                             isRegisteredUser: account.isRegisteredUser(),
+                            isServiceAccount: account.isServiceAccount(),
                         });
                     const { warehouseClient, sshTunnel } =
                         await this._getWarehouseClient(
@@ -5881,6 +5891,7 @@ export class ProjectService extends BaseService {
                 projectUuid,
                 userId: account.user.id,
                 isRegisteredUser: account.isRegisteredUser(),
+                isServiceAccount: account.isServiceAccount(),
             }),
             {
                 snowflakeVirtualWarehouse: explore.warehouse,
@@ -5940,6 +5951,7 @@ export class ProjectService extends BaseService {
             projectUuid,
             userId: account.user.id,
             isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
         });
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
             projectUuid,
@@ -6584,6 +6596,7 @@ export class ProjectService extends BaseService {
                 projectUuid,
                 userId: account.user.id,
                 isRegisteredUser: account.isRegisteredUser(),
+                isServiceAccount: account.isServiceAccount(),
             }),
         );
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2933/stop-service-accounts-from-using-their-admins-credentials

<img width="809" height="81" alt="image" src="https://github.com/user-attachments/assets/6528cfec-c1da-4688-b094-c77b6113bcd0" />

### Description:
Prevents service accounts from using personal warehouse credentials by adding a check in the ProjectService. This PR passes the `isServiceAccount` flag through the AsyncQueryService to ensure proper credential validation when queries are executed.

The change adds a specific error message when service accounts attempt to run queries that require user credentials, directing users to use project or organization warehouse credentials instead.

test-backend