### PR TITLE
chore: move space permission methods to SpacePermissionModel

### DIFF
--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -6,6 +6,7 @@ import {
     type SessionUser,
     type SpaceAccess,
     type SpaceAccessUserMetadata,
+    type SpaceGroup,
 } from '@lightdash/common';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SpacePermissionModel } from '../../models/SpacePermissionModel';
@@ -208,6 +209,16 @@ export class SpacePermissionService extends BaseService {
                 rootSpaceAccessContext[rootSpaceUuid],
             ]),
         );
+    }
+
+    /**
+     * Gets group access for a space.
+     * Resolves to the root space for nested spaces.
+     */
+    async getGroupAccess(spaceUuid: string): Promise<SpaceGroup[]> {
+        const { spaceRoot: rootSpaceUuid } =
+            await this.spaceModel.getSpaceRootFromCacheOrDB(spaceUuid);
+        return this.spacePermissionModel.getGroupAccess(rootSpaceUuid);
     }
 
     async getUserMetadataByUuids(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Implements a caching mechanism for space root lookups to improve performance when working with nested spaces. This PR:

- Adds a NodeCache with a 30-second TTL for caching space root UUIDs
- Implements `getSpaceRootFromCacheOrDB` method using a cache-aside pattern
- Adds new methods to retrieve group access for spaces, resolving to the root space for nested spaces
- Adds `isRootSpace` helper method to check if a space has no parent
- Moves space root resolution from SpaceModel to SpacePermissionModel for better organization
- Uses PostgreSQL's ltree extension to efficiently find root spaces in hierarchies

See `SpaceModel` for original functions