### PR TITLE
chore: switch isRootSpace and getGroupAccess consumers to SpacePermissionService

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -704,26 +704,6 @@ export class SpaceModel {
         );
     }
 
-    async getGroupAccess(spaceUuid: string): Promise<SpaceGroup[]> {
-        const { spaceRoot: spaceOrRootUuid } =
-            await this.getSpaceRootFromCacheOrDB(spaceUuid);
-
-        const access = await this.database
-            .table(SpaceGroupAccessTableName)
-            .select({
-                groupUuid: `${SpaceGroupAccessTableName}.group_uuid`,
-                spaceRole: `${SpaceGroupAccessTableName}.space_role`,
-                groupName: `${GroupTableName}.name`,
-            })
-            .leftJoin(
-                `${GroupTableName}`,
-                `${GroupTableName}.group_uuid`,
-                `${SpaceGroupAccessTableName}.group_uuid`,
-            )
-            .where('space_uuid', spaceOrRootUuid);
-        return access;
-    }
-
     private async getSpaceCharts(
         chartsTable: {
             name: string;

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -1260,7 +1260,9 @@ export class CoderService extends BaseService {
                         this.spacePermissionService.getAllSpaceAccessContext(
                             parentSpaceUuid,
                         ),
-                        this.spaceModel.getGroupAccess(parentSpaceUuid),
+                        this.spacePermissionService.getGroupAccess(
+                            parentSpaceUuid,
+                        ),
                     ]);
 
                     const userAccessPromises = ctx.access

--- a/packages/backend/src/services/PromoteService/PromoteService.test.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.test.ts
@@ -58,7 +58,6 @@ const spaceModel = {
     getSpaceAncestors: jest.fn(async () => []),
     createSpace: jest.fn(async () => existingUpstreamChart.space),
     createSpaceWithAncestors: jest.fn(async () => existingUpstreamChart.space),
-    getGroupAccess: jest.fn(async () => upstreamFullSpace.groupsAccess),
     addSpaceAccess: jest.fn(async () => {}),
     addSpaceGroupAccess: jest.fn(async () => {}),
     update: jest.fn(async () => {}),
@@ -82,6 +81,7 @@ const spacePermissionService = {
         isPrivate: false,
         access: upstreamFullSpace.access,
     })),
+    getGroupAccess: jest.fn(async () => upstreamFullSpace.groupsAccess),
 };
 describe('PromoteService chart changes', () => {
     const service = new PromoteService({

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -1434,7 +1434,7 @@ export class PromoteService extends BaseService {
                         this.spacePermissionService.getAllSpaceAccessContext(
                             data.uuid,
                         ),
-                        this.spaceModel.getGroupAccess(data.uuid),
+                        this.spacePermissionService.getGroupAccess(data.uuid),
                     ]);
 
                     const userAccessPromises = ctx.access

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -122,7 +122,7 @@ export class SpaceService extends BaseService implements BulkActionable<Knex> {
         const space = await this.spaceModel.get(spaceUuid);
         const [ctx, groupsAccess, breadcrumbs] = await Promise.all([
             this.spacePermissionService.getAllSpaceAccessContext(spaceUuid),
-            this.spaceModel.getGroupAccess(spaceUuid),
+            this.spacePermissionService.getGroupAccess(spaceUuid),
             this.spaceModel.getSpaceBreadcrumbs(spaceUuid, space.projectUuid),
         ]);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Moved space permission-related methods from `SpaceModel` to `SpacePermissionService` to improve separation of concerns. Specifically:

- Moved `getGroupAccess()` method from `SpaceModel` to `SpacePermissionService`
- Moved `isRootSpace()` and related root space detection methods to `SpacePermissionService`
- Removed unused imports and the experimental cache for space roots
- Updated all service references to use the methods from their new location

This refactoring helps maintain cleaner boundaries between models and services while keeping permission-related functionality in the appropriate service.