### PR TITLE
feat: add confirmation modal for discarding tree changes

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/utils/treeDraftStorage.ts
+++ b/packages/frontend/src/features/metricsCatalog/utils/treeDraftStorage.ts
@@ -1,3 +1,6 @@
+import { useLocalStorage } from '@mantine-8/hooks';
+import { useCallback } from 'react';
+
 type TreeDraft = {
     nodes: Array<{
         catalogSearchUuid: string;
@@ -17,20 +20,24 @@ type TreeDraft = {
 
 const DRAFT_KEY_PREFIX = 'lightdash-tree-draft-';
 
-const getDraftKey = (treeUuid: string) => `${DRAFT_KEY_PREFIX}${treeUuid}`;
+export const useTreeDraft = (treeUuid: string | null) => {
+    const [, setDraft, removeDraft] = useLocalStorage<TreeDraft | null>({
+        key: `${DRAFT_KEY_PREFIX}${treeUuid ?? '__none__'}`,
+        defaultValue: null,
+    });
 
-export const saveDraft = (treeUuid: string, draft: TreeDraft): void => {
-    try {
-        localStorage.setItem(getDraftKey(treeUuid), JSON.stringify(draft));
-    } catch {
-        // localStorage may be full or unavailable — silently ignore
-    }
-};
+    const saveDraft = useCallback(
+        (draft: TreeDraft) => {
+            if (!treeUuid) return;
+            setDraft(draft);
+        },
+        [treeUuid, setDraft],
+    );
 
-export const clearDraft = (treeUuid: string): void => {
-    try {
-        localStorage.removeItem(getDraftKey(treeUuid));
-    } catch {
-        // silently ignore
-    }
+    const clearDraft = useCallback(() => {
+        if (!treeUuid) return;
+        removeDraft();
+    }, [treeUuid, removeDraft]);
+
+    return { saveDraft, clearDraft };
 };


### PR DESCRIPTION
Added confirmation modals for both when:
- leaving the page without saving
- discarding changes from draft


![CleanShot 2026-02-13 at 15.31.12@2x.png](https://app.graphite.com/user-attachments/assets/22811402-2111-411c-a983-7b23ac1eceab.png)

![CleanShot 2026-02-13 at 15.31.41@2x.png](https://app.graphite.com/user-attachments/assets/e2f74bd9-4d8f-4806-b7e9-6b7b36a82736.png)

