### PR TITLE
feat: add user attribute "any_attributes" access control

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/customers.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/customers.yml
@@ -94,7 +94,7 @@ models:
               type: string
               sql: "CONCAT(${first_name}, ' ', ${last_name})"
               any_attributes:
-                is_demo: true
+                is_demo: "true"
                 name: [demo, demo2]
       - name: age
         description: Customer's age

--- a/examples/full-jaffle-shop-demo/dbt/models/user_attribute_access_cases.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/user_attribute_access_cases.sql
@@ -1,0 +1,12 @@
+select
+    payment_id,
+    amount as ua_case_1_none,
+    amount as ua_case_2_any_only,
+    amount as ua_case_3_required_only,
+    amount as ua_case_4_required_and_any,
+    amount as ua_case_5_required_pass_any_fail,
+    amount as ua_case_6_any_pass_required_fail,
+    amount as ua_case_7_required_multi_and_array,
+    amount as ua_case_8_any_multi_and_array,
+    amount as ua_case_9_both_multi_and_array
+from {{ ref('payments') }}

--- a/examples/full-jaffle-shop-demo/dbt/models/user_attribute_access_cases.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/user_attribute_access_cases.yml
@@ -1,0 +1,102 @@
+version: 2
+models:
+  - name: user_attribute_access_cases
+    description: Model used for testing required_attributes and any_attributes access logic.
+    columns:
+      - name: payment_id
+        description: Payment ID
+        config:
+          meta:
+            dimension:
+              type: number
+
+      - name: ua_case_1_none
+        description: Case 1 - no required or any attributes (always allowed).
+        config:
+          meta:
+            dimension:
+              type: number
+
+      - name: ua_case_2_any_only
+        description: Case 2 - any only, should allow when ua_any matches.
+        config:
+          meta:
+            dimension:
+              type: number
+              any_attributes:
+                ua_any: "a"
+
+      - name: ua_case_3_required_only
+        description: Case 3 - required only, should allow when ua_required matches.
+        config:
+          meta:
+            dimension:
+              type: number
+              required_attributes:
+                ua_required: "yes"
+
+      - name: ua_case_4_required_and_any
+        description: Case 4 - both required and any must match.
+        config:
+          meta:
+            dimension:
+              type: number
+              required_attributes:
+                ua_required: "yes"
+              any_attributes:
+                ua_any: "a"
+
+      - name: ua_case_5_required_pass_any_fail
+        description: Case 5 - required passes but any fails.
+        config:
+          meta:
+            dimension:
+              type: number
+              required_attributes:
+                ua_required: "yes"
+              any_attributes:
+                ua_any: "b"
+
+      - name: ua_case_6_any_pass_required_fail
+        description: Case 6 - any passes but required fails.
+        config:
+          meta:
+            dimension:
+              type: number
+              required_attributes:
+                ua_required: "no"
+              any_attributes:
+                ua_any: "a"
+
+      - name: ua_case_7_required_multi_and_array
+        description: Required attributes with multiple keys and an array value.
+        config:
+          meta:
+            dimension:
+              type: number
+              required_attributes:
+                ua_required: ["yes", "yep"]
+                ua_required_2: "ok"
+
+      - name: ua_case_8_any_multi_and_array
+        description: Any attributes with multiple keys and an array value.
+        config:
+          meta:
+            dimension:
+              type: number
+              any_attributes:
+                ua_any: ["a", "alpha"]
+                ua_any_2: "b"
+
+      - name: ua_case_9_both_multi_and_array
+        description: Both required and any attributes with multiple keys and array values.
+        config:
+          meta:
+            dimension:
+              type: number
+              required_attributes:
+                ua_required: ["yes", "yep"]
+                ua_required_2: "ok"
+              any_attributes:
+                ua_any: ["a", "alpha"]
+                ua_any_2: "b"

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2512,6 +2512,7 @@ const models: TsoaRoute.Models = {
             requiredAttributes: {
                 ref: 'Record_string.string-or-string-Array_',
             },
+            anyAttributes: { ref: 'Record_string.string-or-string-Array_' },
             timeInterval: { ref: 'TimeFrames' },
             timeIntervalBaseDimensionName: { dataType: 'string' },
             isAdditionalDimension: { dataType: 'boolean' },
@@ -4882,6 +4883,7 @@ const models: TsoaRoute.Models = {
                 },
                 defaultTimeDimension: { ref: 'DefaultTimeDimension' },
                 groupDetails: { ref: 'Record_string.GroupType_' },
+                anyAttributes: { ref: 'Record_string.string-or-string-Array_' },
                 requiredAttributes: {
                     ref: 'Record_string.string-or-string-Array_',
                 },
@@ -4950,6 +4952,7 @@ const models: TsoaRoute.Models = {
             requiredAttributes: {
                 ref: 'Record_string.string-or-string-Array_',
             },
+            anyAttributes: { ref: 'Record_string.string-or-string-Array_' },
             timeInterval: { ref: 'TimeFrames' },
             timeIntervalBaseDimensionName: { dataType: 'string' },
             isAdditionalDimension: { dataType: 'boolean' },
@@ -5101,6 +5104,7 @@ const models: TsoaRoute.Models = {
             requiredAttributes: {
                 ref: 'Record_string.string-or-string-Array_',
             },
+            anyAttributes: { ref: 'Record_string.string-or-string-Array_' },
             defaultTimeDimension: { ref: 'DefaultTimeDimension' },
             spotlight: {
                 dataType: 'nestedObjectLiteral',
@@ -7369,11 +7373,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7461,7 +7465,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7484,7 +7488,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                chartUsage:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7513,17 +7517,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7719,7 +7723,7 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7742,7 +7746,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    chartUsage:
+                                                                                                    searchRank:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'union',
@@ -7771,17 +7775,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -7851,11 +7855,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7870,11 +7874,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7889,11 +7893,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7908,11 +7912,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7927,11 +7931,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -18105,7 +18109,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -18115,7 +18119,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -18125,7 +18129,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -18138,7 +18142,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21413,12 +21417,19 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Dimension.requiredAttributes_': {
+    'Pick_Dimension.requiredAttributes-or-anyAttributes_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 requiredAttributes: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'Record_string.string-or-string-Array_' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                anyAttributes: {
                     dataType: 'union',
                     subSchemas: [
                         { ref: 'Record_string.string-or-string-Array_' },
@@ -21507,7 +21518,7 @@ const models: TsoaRoute.Models = {
                 {
                     ref: 'Pick_Field.name-or-label-or-fieldType-or-tableLabel-or-description_',
                 },
-                { ref: 'Pick_Dimension.requiredAttributes_' },
+                { ref: 'Pick_Dimension.requiredAttributes-or-anyAttributes_' },
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
@@ -21600,7 +21611,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_TableBase.name-or-label-or-groupLabel-or-description-or-requiredAttributes_':
+    'Pick_TableBase.name-or-label-or-groupLabel-or-description-or-requiredAttributes-or-anyAttributes_':
         {
             dataType: 'refAlias',
             type: {
@@ -21629,6 +21640,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    anyAttributes: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'Record_string.string-or-string-Array_' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                 },
                 validators: {},
             },
@@ -21645,7 +21663,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_TableBase.name-or-label-or-groupLabel-or-description-or-requiredAttributes_',
+                    ref: 'Pick_TableBase.name-or-label-or-groupLabel-or-description-or-requiredAttributes-or-anyAttributes_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2751,6 +2751,9 @@
                     "requiredAttributes": {
                         "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
                     },
+                    "anyAttributes": {
+                        "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+                    },
                     "timeInterval": {
                         "$ref": "#/components/schemas/TimeFrames"
                     },
@@ -5350,6 +5353,9 @@
                     "groupDetails": {
                         "$ref": "#/components/schemas/Record_string.GroupType_"
                     },
+                    "anyAttributes": {
+                        "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+                    },
                     "requiredAttributes": {
                         "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
                     },
@@ -5488,6 +5494,9 @@
                         "deprecated": true
                     },
                     "requiredAttributes": {
+                        "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+                    },
+                    "anyAttributes": {
                         "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
                     },
                     "timeInterval": {
@@ -5732,6 +5741,9 @@
                         "type": "string"
                     },
                     "requiredAttributes": {
+                        "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+                    },
+                    "anyAttributes": {
                         "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
                     },
                     "defaultTimeDimension": {
@@ -8254,19 +8266,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -8282,12 +8281,12 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
+                                                                        "chartUsage": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
+                                                                        "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
@@ -8295,10 +8294,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8307,8 +8306,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8402,12 +8401,12 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "searchRank": {
+                                                                                    "chartUsage": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
+                                                                                    "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
@@ -8415,10 +8414,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8427,8 +8426,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -18893,22 +18892,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -22223,9 +22222,12 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Pick_Dimension.requiredAttributes_": {
+            "Pick_Dimension.requiredAttributes-or-anyAttributes_": {
                 "properties": {
                     "requiredAttributes": {
+                        "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+                    },
+                    "anyAttributes": {
                         "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
                     }
                 },
@@ -22308,7 +22310,7 @@
                         "$ref": "#/components/schemas/Pick_Field.name-or-label-or-fieldType-or-tableLabel-or-description_"
                     },
                     {
-                        "$ref": "#/components/schemas/Pick_Dimension.requiredAttributes_"
+                        "$ref": "#/components/schemas/Pick_Dimension.requiredAttributes-or-anyAttributes_"
                     },
                     {
                         "properties": {
@@ -22415,7 +22417,7 @@
                     }
                 ]
             },
-            "Pick_TableBase.name-or-label-or-groupLabel-or-description-or-requiredAttributes_": {
+            "Pick_TableBase.name-or-label-or-groupLabel-or-description-or-requiredAttributes-or-anyAttributes_": {
                 "properties": {
                     "description": {
                         "type": "string"
@@ -22431,6 +22433,9 @@
                     },
                     "requiredAttributes": {
                         "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
+                    },
+                    "anyAttributes": {
+                        "$ref": "#/components/schemas/Record_string.string-or-string-Array_"
                     }
                 },
                 "required": ["name", "label"],
@@ -22444,7 +22449,7 @@
             "CatalogTable": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_TableBase.name-or-label-or-groupLabel-or-description-or-requiredAttributes_"
+                        "$ref": "#/components/schemas/Pick_TableBase.name-or-label-or-groupLabel-or-description-or-requiredAttributes-or-anyAttributes_"
                     },
                     {
                         "properties": {
@@ -25715,7 +25720,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2469.0",
+        "version": "0.2470.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/e2e/cypress/e2e/api/catalog.cy.ts
+++ b/packages/e2e/cypress/e2e/api/catalog.cy.ts
@@ -1,4 +1,9 @@
-import { SEED_PROJECT, type CatalogField, type Space } from '@lightdash/common';
+import {
+    SEED_ORG_1_ADMIN,
+    SEED_PROJECT,
+    type CatalogField,
+    type Space,
+} from '@lightdash/common';
 import { chartMock } from '../../support/mocks';
 import { createSpace, deleteSpace } from '../../support/spaceUtils';
 import { createChartAndUpdateDashboard, createDashboard } from './dashboard.cy';
@@ -212,6 +217,269 @@ describe('Lightdash catalog search', () => {
         ).then((resp) => {
             expect(resp.status).to.eq(200);
             expect(resp.body.results).to.have.length(0);
+        });
+    });
+    describe('user attributes', () => {
+        const projectUuid = SEED_PROJECT.project_uuid;
+        const requiredAttributeName = 'ua_required';
+        const requiredAttributeName2 = 'ua_required_2';
+        const anyAttributeName = 'ua_any';
+        const anyAttributeName2 = 'ua_any_2';
+        const caseFields = [
+            'ua_case_1_none',
+            'ua_case_2_any_only',
+            'ua_case_3_required_only',
+            'ua_case_4_required_and_any',
+            'ua_case_5_required_pass_any_fail',
+            'ua_case_6_any_pass_required_fail',
+            'ua_case_7_required_multi_and_array',
+            'ua_case_8_any_multi_and_array',
+            'ua_case_9_both_multi_and_array',
+        ];
+
+        const getOrCreateAttribute = (name: string) =>
+            cy.request('GET', `${apiUrl}/org/attributes`).then((response) => {
+                const existing = response.body.results.find(
+                    (attr: { name: string; uuid: string }) =>
+                        attr.name === name,
+                );
+                if (existing) return existing.uuid;
+
+                return cy
+                    .request('POST', `${apiUrl}/org/attributes`, {
+                        name,
+                        users: [],
+                        groups: [],
+                        attributeDefault: null,
+                    })
+                    .then((createResponse) => createResponse.body.results.uuid);
+            });
+
+        const setAttributeValue = (
+            attributeUuid: string,
+            name: string,
+            value: string | null,
+        ) =>
+            cy.request('PUT', `${apiUrl}/org/attributes/${attributeUuid}`, {
+                name,
+                users:
+                    value === null
+                        ? []
+                        : [
+                              {
+                                  userUuid: SEED_ORG_1_ADMIN.user_uuid,
+                                  value,
+                              },
+                          ],
+                groups: [],
+                attributeDefault: null,
+            });
+
+        const searchCaseFields = () =>
+            cy
+                .request(
+                    `${apiUrl}/projects/${projectUuid}/dataCatalog?type=field&search=ua_case_`,
+                )
+                .then((response) => {
+                    expect(response.status).to.eq(200);
+                    return response.body.results
+                        .filter(
+                            (item: {
+                                type: string;
+                                tableName?: string;
+                                name: string;
+                            }) =>
+                                item.type === 'field' &&
+                                item.tableName ===
+                                    'user_attribute_access_cases',
+                        )
+                        .map((item: { name: string }) => item.name);
+                });
+
+        let requiredAttributeUuid: string;
+        let requiredAttributeUuid2: string;
+        let anyAttributeUuid: string;
+        let anyAttributeUuid2: string;
+
+        before(() => {
+            cy.login();
+            getOrCreateAttribute(requiredAttributeName).then((uuid) => {
+                requiredAttributeUuid = uuid;
+            });
+            getOrCreateAttribute(requiredAttributeName2).then((uuid) => {
+                requiredAttributeUuid2 = uuid;
+            });
+            getOrCreateAttribute(anyAttributeName).then((uuid) => {
+                anyAttributeUuid = uuid;
+            });
+            getOrCreateAttribute(anyAttributeName2).then((uuid) => {
+                anyAttributeUuid2 = uuid;
+            });
+        });
+
+        beforeEach(() => {
+            cy.login();
+        });
+
+        after(() => {
+            cy.login();
+            setAttributeValue(
+                requiredAttributeUuid,
+                requiredAttributeName,
+                null,
+            );
+            setAttributeValue(
+                requiredAttributeUuid2,
+                requiredAttributeName2,
+                null,
+            );
+            setAttributeValue(anyAttributeUuid, anyAttributeName, null);
+            setAttributeValue(anyAttributeUuid2, anyAttributeName2, null);
+        });
+
+        describe('required attributes', () => {
+            it('should enforce required-only and multi-required cases', () => {
+                setAttributeValue(
+                    requiredAttributeUuid,
+                    requiredAttributeName,
+                    'yes',
+                );
+                setAttributeValue(
+                    requiredAttributeUuid2,
+                    requiredAttributeName2,
+                    'ok',
+                );
+                setAttributeValue(anyAttributeUuid, anyAttributeName, null);
+                setAttributeValue(anyAttributeUuid2, anyAttributeName2, null);
+
+                searchCaseFields().then((visibleFieldNames) => {
+                    expect(visibleFieldNames).to.include(caseFields[0]); // case 1
+                    expect(visibleFieldNames).to.include(caseFields[2]); // case 3
+                    expect(visibleFieldNames).to.include(caseFields[6]); // case 7
+                    expect(visibleFieldNames).to.not.include(caseFields[1]); // case 2
+                    expect(visibleFieldNames).to.not.include(caseFields[3]); // case 4
+                    expect(visibleFieldNames).to.not.include(caseFields[8]); // case 9
+                });
+            });
+            it('should hide multi-required fields when one required key is missing', () => {
+                setAttributeValue(
+                    requiredAttributeUuid,
+                    requiredAttributeName,
+                    'yes',
+                );
+                setAttributeValue(
+                    requiredAttributeUuid2,
+                    requiredAttributeName2,
+                    null,
+                );
+                setAttributeValue(anyAttributeUuid, anyAttributeName, 'a');
+                setAttributeValue(anyAttributeUuid2, anyAttributeName2, 'b');
+
+                searchCaseFields().then((visibleFieldNames) => {
+                    expect(visibleFieldNames).to.not.include(caseFields[6]); // case 7
+                    expect(visibleFieldNames).to.not.include(caseFields[8]); // case 9
+                });
+            });
+        });
+
+        describe('any attributes', () => {
+            it('should enforce any-only and multi-any cases', () => {
+                setAttributeValue(
+                    requiredAttributeUuid,
+                    requiredAttributeName,
+                    null,
+                );
+                setAttributeValue(
+                    requiredAttributeUuid2,
+                    requiredAttributeName2,
+                    null,
+                );
+                setAttributeValue(anyAttributeUuid, anyAttributeName, 'a');
+                setAttributeValue(anyAttributeUuid2, anyAttributeName2, null);
+
+                searchCaseFields().then((visibleFieldNames) => {
+                    expect(visibleFieldNames).to.include(caseFields[0]); // case 1
+                    expect(visibleFieldNames).to.include(caseFields[1]); // case 2
+                    expect(visibleFieldNames).to.include(caseFields[7]); // case 8
+                    expect(visibleFieldNames).to.not.include(caseFields[2]); // case 3
+                    expect(visibleFieldNames).to.not.include(caseFields[3]); // case 4
+                });
+            });
+            it('should allow any via secondary key and array value matching', () => {
+                setAttributeValue(
+                    requiredAttributeUuid,
+                    requiredAttributeName,
+                    null,
+                );
+                setAttributeValue(
+                    requiredAttributeUuid2,
+                    requiredAttributeName2,
+                    null,
+                );
+                setAttributeValue(anyAttributeUuid, anyAttributeName, 'zzz');
+                setAttributeValue(anyAttributeUuid2, anyAttributeName2, 'b');
+
+                searchCaseFields().then((visibleFieldNames) => {
+                    expect(visibleFieldNames).to.include(caseFields[7]); // case 8
+                    expect(visibleFieldNames).to.not.include(caseFields[1]); // case 2
+                });
+            });
+        });
+
+        describe('both required and any attributes', () => {
+            it('should enforce all mixed logic cases when both required and any are set', () => {
+                setAttributeValue(
+                    requiredAttributeUuid,
+                    requiredAttributeName,
+                    'yes',
+                );
+                setAttributeValue(
+                    requiredAttributeUuid2,
+                    requiredAttributeName2,
+                    'ok',
+                );
+                setAttributeValue(anyAttributeUuid, anyAttributeName, 'a');
+                setAttributeValue(anyAttributeUuid2, anyAttributeName2, null);
+
+                searchCaseFields().then((visibleFieldNames) => {
+                    expect(visibleFieldNames).to.include(caseFields[0]); // case 1
+                    expect(visibleFieldNames).to.include(caseFields[1]); // case 2
+                    expect(visibleFieldNames).to.include(caseFields[2]); // case 3
+                    expect(visibleFieldNames).to.include(caseFields[3]); // case 4
+                    expect(visibleFieldNames).to.not.include(caseFields[4]); // case 5
+                    expect(visibleFieldNames).to.not.include(caseFields[5]); // case 6
+                    expect(visibleFieldNames).to.include(caseFields[6]); // case 7
+                    expect(visibleFieldNames).to.include(caseFields[7]); // case 8
+                    expect(visibleFieldNames).to.include(caseFields[8]); // case 9
+                });
+            });
+
+            it('should only show no-attribute field when user has no user-attribute values', () => {
+                setAttributeValue(
+                    requiredAttributeUuid,
+                    requiredAttributeName,
+                    null,
+                );
+                setAttributeValue(
+                    requiredAttributeUuid2,
+                    requiredAttributeName2,
+                    null,
+                );
+                setAttributeValue(anyAttributeUuid, anyAttributeName, null);
+                setAttributeValue(anyAttributeUuid2, anyAttributeName2, null);
+
+                searchCaseFields().then((visibleFieldNames) => {
+                    expect(visibleFieldNames).to.include(caseFields[0]); // case 1
+                    expect(visibleFieldNames).to.not.include(caseFields[1]); // case 2
+                    expect(visibleFieldNames).to.not.include(caseFields[2]); // case 3
+                    expect(visibleFieldNames).to.not.include(caseFields[3]); // case 4
+                    expect(visibleFieldNames).to.not.include(caseFields[4]); // case 5
+                    expect(visibleFieldNames).to.not.include(caseFields[5]); // case 6
+                    expect(visibleFieldNames).to.not.include(caseFields[6]); // case 7
+                    expect(visibleFieldNames).to.not.include(caseFields[7]); // case 8
+                    expect(visibleFieldNames).to.not.include(caseFields[8]); // case 9
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
### Description:

This PR adds support for `any_attributes` alongside the existing `required_attributes` in field and table access control. While `required_attributes` enforces that ALL specified attributes must match (AND logic), the new `any_attributes` allows access when ANY of the specified attributes match (OR logic).

The implementation includes:

- Backend support for `any_attributes` in the catalog model and API routes
- SQL query updates to handle both attribute types with proper AND/OR logic
- Support for array values and multiple attribute keys in both attribute types
- A comprehensive test model with 9 different access control test cases
- E2E tests to verify all access control scenarios work correctly

This enhancement provides more flexible access control options, allowing admins to create more nuanced permission schemes based on user attributes.



test-all