### PR TITLE
feat: improve permissions UX + some styles

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/SavedTrees/SavedTreeCanvas.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/SavedTrees/SavedTreeCanvas.tsx
@@ -68,6 +68,9 @@ const SavedTreeCanvas: FC<SavedTreeCanvasProps> = ({ mode, treeUuid }) => {
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
+    const canManageMetricsTree = useAppSelector(
+        (state) => state.metricsCatalog.abilities.canManageMetricsTree,
+    );
     const search = useAppSelector((state) => state.metricsCatalog.search);
     const categoryFilters = useAppSelector(
         (state) => state.metricsCatalog.categoryFilters,
@@ -346,6 +349,8 @@ const SavedTreeCanvas: FC<SavedTreeCanvasProps> = ({ mode, treeUuid }) => {
                 >
                     <Group gap="sm" wrap="nowrap" style={{ flex: 1 }}>
                         <TextInput
+                            required
+                            variant="subtle"
                             placeholder="Tree name"
                             value={treeName}
                             onChange={(e) => setTreeName(e.currentTarget.value)}
@@ -458,40 +463,45 @@ const SavedTreeCanvas: FC<SavedTreeCanvasProps> = ({ mode, treeUuid }) => {
                         <Button
                             variant="default"
                             size="compact-sm"
-                            color="gray"
                             onClick={handleBack}
                         >
                             Close
                         </Button>
-                        {lockByOther ? (
-                            <Tooltip label={`Being edited by ${lockerName}`}>
+                        {canManageMetricsTree &&
+                            (lockByOther ? (
+                                <Tooltip
+                                    label={`Being edited by ${lockerName}`}
+                                >
+                                    <Button
+                                        size="compact-sm"
+                                        variant="default"
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={IconPencil}
+                                                size={14}
+                                            />
+                                        }
+                                        disabled
+                                    >
+                                        Edit
+                                    </Button>
+                                </Tooltip>
+                            ) : (
                                 <Button
                                     size="compact-sm"
                                     variant="default"
+                                    onClick={handleEditClick}
+                                    loading={isAcquiringLock}
                                     leftSection={
                                         <MantineIcon
                                             icon={IconPencil}
                                             size={14}
                                         />
                                     }
-                                    disabled
                                 >
                                     Edit
                                 </Button>
-                            </Tooltip>
-                        ) : (
-                            <Button
-                                size="compact-sm"
-                                variant="default"
-                                onClick={handleEditClick}
-                                loading={isAcquiringLock}
-                                leftSection={
-                                    <MantineIcon icon={IconPencil} size={14} />
-                                }
-                            >
-                                Edit
-                            </Button>
-                        )}
+                            ))}
                     </Group>
                 </Group>
                 <Box className={classes.canvasContainer}>

--- a/packages/frontend/src/features/metricsCatalog/components/SavedTrees/TreeListSidebar.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/SavedTrees/TreeListSidebar.tsx
@@ -30,6 +30,9 @@ const TreeListSidebar: FC = () => {
     const activeTreeUuid = useAppSelector(
         (state) => state.metricsCatalog.activeTreeUuid,
     );
+    const canManageMetricsTree = useAppSelector(
+        (state) => state.metricsCatalog.abilities.canManageMetricsTree,
+    );
 
     const { data: treesData, isLoading } = useMetricsTrees(projectUuid);
     const trees = treesData?.data ?? [];
@@ -68,18 +71,23 @@ const TreeListSidebar: FC = () => {
                             wrap="nowrap"
                         >
                             <Text fz="sm" fw={600} c="ldGray.7">
-                                Trees
+                                Saved Trees
                             </Text>
-                            <Button
-                                variant="subtle"
-                                size="compact-xs"
-                                leftSection={
-                                    <MantineIcon icon={IconPlus} size={14} />
-                                }
-                                onClick={handleNewTree}
-                            >
-                                New
-                            </Button>
+                            {canManageMetricsTree && (
+                                <Button
+                                    variant="subtle"
+                                    size="compact-xs"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconPlus}
+                                            size={14}
+                                        />
+                                    }
+                                    onClick={handleNewTree}
+                                >
+                                    New
+                                </Button>
+                            )}
                         </Group>
 
                         <ScrollArea style={{ flex: 1 }} offsetScrollbars>
@@ -131,7 +139,7 @@ const TreeListSidebar: FC = () => {
                                                             <MantineIcon
                                                                 icon={IconLock}
                                                                 size={12}
-                                                                color="yellow.6"
+                                                                color="foreground"
                                                             />
                                                         </Tooltip>
                                                     )}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->



### Description:

Added permission checks for metrics tree management by implementing the `canManageMetricsTree` ability flag. Users without this permission will no longer see the "Edit" and "New" buttons for saved trees.

Additional UI improvements:

- Made the tree name input required and changed its variant to "subtle"
- Renamed sidebar header from "Trees" to "Saved Trees"
- Updated the lock icon color from yellow to foreground
- Removed explicit gray color from Close button to use default styling

These changes ensure that only authorized users can modify metrics trees while improving the overall UI consistency.