### PR TITLE
fix: validator table crash when scrolling (React error #185)

### DIFF
--- a/packages/backend/src/models/ValidationModel/ValidationModel.ts
+++ b/packages/backend/src/models/ValidationModel/ValidationModel.ts
@@ -1015,7 +1015,10 @@ export class ValidationModel {
                         });
                     }
                 })
-                .orderBy(sortColumn, sortDirection)
+                .orderBy([
+                    { column: sortColumn, order: sortDirection },
+                    { column: 'validation_id', order: 'asc' },
+                ])
                 .limit(paginateArgs.pageSize)
                 .offset((paginateArgs.page - 1) * paginateArgs.pageSize);
 

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/index.tsx
@@ -373,7 +373,6 @@ export const ValidatorTable: FC<{
                         return (
                             <TableValidationItem
                                 key={validationError.validationId}
-                                ref={rowVirtualizer.measureElement}
                                 data-index={virtualRow.index}
                                 projectUuid={projectUuid}
                                 validationError={validationError}


### PR DESCRIPTION
### Description:
A recent refactor of the validation page introduced a React error #185 when scrolling.

The fix is simple:

- Backend: Add validation_id tiebreaker to the paginated validation query's ORDER BY. Without it, rows with identical created_at timestamps (all errors from the same validation
  run) have non-deterministic ordering, causing the same row to appear on consecutive pages.
- Frontend: Remove rowVirtualizer.measureElement ref from table rows. The dynamic measurement triggered state updates on every ref assignment, creating an infinite re-render loop
  (measureElement → resize → setState → re-render → ref reassigned → measureElement → ...).

Why not keep measureElement with a stable ref?

Tried using useMergedRef (stable hook) instead of mergeRefs (unstable inline call) to prevent the ref from changing every render. This fixed the crash but introduced visible scroll jumpiness — when scrolling up, previously unmounted rows get remeasured and position recalculations shift the content. This is inherent to dynamic measurement in virtualized lists. Since all validation rows have the same structure and consistent height, the fixed estimateSize (65px) is sufficient and gives smooth scrolling.


### Before:

https://github.com/user-attachments/assets/d1d593b2-ed9b-4f34-b55d-faf69e600b80



### After:


https://github.com/user-attachments/assets/4c5a1ddc-d0e9-45b9-9fa0-8a7d178f4219

