### PR TITLE
feat: improve color palette display with light/dark mode indicators

### DIFF
--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteItem.tsx
@@ -15,6 +15,8 @@ import {
     IconDotsVertical,
     IconEdit,
     IconInfoCircle,
+    IconMoon,
+    IconSun,
     IconTrash,
 } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
@@ -28,7 +30,6 @@ type PaletteItemProps = {
     isActive: boolean;
     onSetActive?: ((uuid: string) => void) | undefined;
     readOnly?: boolean;
-    theme?: 'light' | 'dark';
 };
 
 export const PaletteItem: FC<PaletteItemProps> = ({
@@ -36,7 +37,6 @@ export const PaletteItem: FC<PaletteItemProps> = ({
     isActive,
     onSetActive,
     readOnly,
-    theme = 'light',
 }) => {
     const [isEditModalOpen, setIsEditModalOpen] = useState(false);
     const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
@@ -48,10 +48,8 @@ export const PaletteItem: FC<PaletteItemProps> = ({
         setIsDeleteModalOpen(false);
     };
 
-    const displayColors =
-        theme === 'dark' && palette.darkColors
-            ? palette.darkColors
-            : palette.colors;
+    const hasDarkColors =
+        palette.darkColors !== null && palette.darkColors !== undefined;
 
     return (
         <>
@@ -64,17 +62,58 @@ export const PaletteItem: FC<PaletteItemProps> = ({
                 onMouseLeave={() => setIsHovered(false)}
             >
                 <Flex justify="space-between" align="center">
-                    <Group spacing="xs">
+                    <Group spacing="sm">
                         <Group spacing="two">
-                            {displayColors.slice(0, 5).map((color, index) => (
-                                <ColorSwatch
-                                    key={color + index}
-                                    size={18}
-                                    color={color}
-                                />
-                            ))}
+                            <Tooltip label="Light mode" position="top">
+                                <Group spacing="two">
+                                    <MantineIcon
+                                        icon={IconSun}
+                                        size="sm"
+                                        color="foreground"
+                                    />
+                                    {palette.colors
+                                        .slice(0, 5)
+                                        .map((color, index) => (
+                                            <ColorSwatch
+                                                key={`light-${color}-${index}`}
+                                                size={18}
+                                                color={color}
+                                            />
+                                        ))}
+                                </Group>
+                            </Tooltip>
+                            {hasDarkColors && (
+                                <>
+                                    <Text c="ldGray.3" mx={4}>
+                                        /
+                                    </Text>
+                                    <Tooltip label="Dark mode" position="top">
+                                        <Group spacing="two">
+                                            <MantineIcon
+                                                icon={IconMoon}
+                                                size="sm"
+                                                color="foreground"
+                                            />
+                                            {palette
+                                                .darkColors!.slice(0, 5)
+                                                .map((color, index) => (
+                                                    <ColorSwatch
+                                                        key={`dark-${color}-${index}`}
+                                                        size={18}
+                                                        color={color}
+                                                    />
+                                                ))}
+                                        </Group>
+                                    </Tooltip>
+                                </>
+                            )}
                         </Group>
+                        <Text c="ldGray.3" mx={4}>
+                            |
+                        </Text>
+
                         <Text fw={500}>{palette.name}</Text>
+
                         {readOnly && (
                             <Tooltip
                                 label="This palette is read only. It has been configured as the override color palette for your organization. While this is set, you cannot update/edit, or delete this palette."
@@ -153,6 +192,7 @@ export const PaletteItem: FC<PaletteItemProps> = ({
             </Paper>
 
             <EditPaletteModal
+                key={`edit-palette-modal-${isEditModalOpen}`}
                 palette={palette}
                 opened={isEditModalOpen}
                 onClose={() => setIsEditModalOpen(false)}

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/PaletteModalBase.tsx
@@ -8,6 +8,7 @@ import {
     Stack,
     Tabs,
     TextInput,
+    useMantineColorScheme,
     type ModalProps,
 } from '@mantine-8/core';
 import { useForm } from '@mantine/form';
@@ -17,7 +18,7 @@ import {
     IconPalette,
     IconSun,
 } from '@tabler/icons-react';
-import { useState, type FC } from 'react';
+import { useEffect, useState, type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import MantineModal from '../../common/MantineModal';
 import { ChartPreviewComponent } from './ChartPreviewComponent';
@@ -49,7 +50,16 @@ export const PaletteModalBase: FC<PaletteModalBaseProps> = ({
     existingPaletteNames = [],
 }) => {
     const [showAllColors, setShowAllColors] = useState(false);
-    const [activeTab, setActiveTab] = useState<string | null>('light');
+    const { colorScheme } = useMantineColorScheme();
+    const [activeTab, setActiveTab] = useState<string | null>(
+        colorScheme === 'dark' ? 'dark' : 'light',
+    );
+
+    useEffect(() => {
+        if (opened) {
+            setActiveTab(colorScheme === 'dark' ? 'dark' : 'light');
+        }
+    }, [opened, colorScheme]);
 
     const form = useForm<PaletteFormValues>({
         initialValues: {

--- a/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/AppearanceSettingsPanel/index.tsx
@@ -7,7 +7,6 @@ import {
     Text,
     Title,
     Tooltip,
-    useMantineColorScheme,
 } from '@mantine/core';
 import { IconInfoCircle, IconPlus } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -28,7 +27,6 @@ const AppearanceColorSettings: FC = () => {
     const { data: palettes = [], isLoading: isPalettesLoading } =
         useColorPalettes();
 
-    const { colorScheme } = useMantineColorScheme();
     const setActivePalette = useSetActiveColorPalette();
 
     const [isCreatePaletteModalOpen, setIsCreatePaletteModalOpen] =
@@ -78,7 +76,6 @@ const AppearanceColorSettings: FC = () => {
                             health?.appearance.overrideColorPalette &&
                             organization?.organizationUuid && (
                                 <PaletteItem
-                                    theme={colorScheme}
                                     palette={{
                                         colorPaletteUuid: 'custom',
                                         createdAt: new Date(),
@@ -99,7 +96,6 @@ const AppearanceColorSettings: FC = () => {
                             )}
                         {palettes.map((palette) => (
                             <PaletteItem
-                                theme={colorScheme}
                                 key={palette.colorPaletteUuid}
                                 palette={palette}
                                 isActive={


### PR DESCRIPTION
Closes: #20298

### Description:
Improved color palette display in the Appearance Settings panel by showing both light and dark mode colors side by side. 

The PR also enhances the palette modal to automatically select the appropriate tab (light/dark) based on the user's current color scheme when opened, providing a more intuitive user experience.

This update helps guiding users to understand which palette was updated.

![CleanShot 2026-02-13 at 18.14.08@2x.png](https://app.graphite.com/user-attachments/assets/3eaec347-dd73-4713-8a1e-3d59c53dccd5.png)

