### PR TITLE
feat(athena): allow multiple Athena databases in a single project

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -214,6 +214,7 @@ export type CreateAthenaCredentials = {
     workGroup?: string;
     threads?: number;
     numRetries?: number;
+    accessibleSchemas?: string[];
     requireUserCredentials?: boolean;
     startOfWeek?: WeekDay | null;
     dataTimezone?: string;

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/AthenaForm.tsx
@@ -26,7 +26,7 @@ export const AthenaSchemaInput: FC<{
         <TextInput
             name="warehouse.schema"
             label="Schema"
-            description="This is the schema name (database in Athena)."
+            description="This is the default schema name (database in Athena)."
             required
             {...form.getInputProps('warehouse.schema')}
             disabled={disabled}
@@ -125,10 +125,47 @@ const AthenaForm: FC<{
                 <TextInput
                     name="warehouse.schema"
                     label="Database"
-                    description="This is the Athena database name (also known as schema)."
+                    description="This is the default Athena database name (also known as schema)."
                     required
                     {...form.getInputProps('warehouse.schema')}
                     disabled={disabled}
+                />
+                <TextInput
+                    name="warehouse.accessibleSchemas"
+                    label="Additional databases"
+                    description="Comma-separated list of additional Athena databases to explore. Supports wildcards: * (any characters), ? (single character). E.g. 'sales_*' or '*'."
+                    placeholder="db2, db3"
+                    disabled={disabled}
+                    value={
+                        Array.isArray(warehouse.accessibleSchemas)
+                            ? warehouse.accessibleSchemas.join(', ')
+                            : ''
+                    }
+                    onChange={(e) => {
+                        const val = e.currentTarget.value;
+                        const schemas = val
+                            .split(',')
+                            .map((s: string) => s.trim())
+                            .filter((s: string) => s !== '');
+                        form.setFieldValue(
+                            'warehouse.accessibleSchemas',
+                            schemas,
+                        );
+                        const invalid = schemas.filter(
+                            (s: string) =>
+                                s.length > 1000 ||
+                                !/^[a-zA-Z0-9_*?-]{1,1000}$/.test(s),
+                        );
+                        if (invalid.length > 0) {
+                            form.setFieldError(
+                                'warehouse.accessibleSchemas',
+                                `Invalid pattern: ${invalid.join(', ')}. Only alphanumeric characters, underscores, hyphens, *, and ? are allowed.`,
+                            );
+                        } else {
+                            form.clearFieldError('warehouse.accessibleSchemas');
+                        }
+                    }}
+                    error={form.errors['warehouse.accessibleSchemas']}
                 />
                 <TextInput
                     name="warehouse.s3StagingDir"

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
@@ -178,6 +178,7 @@ export const AthenaDefaultValues: CreateAthenaCredentials = {
     s3StagingDir: '',
     accessKeyId: '',
     secretAccessKey: '',
+    accessibleSchemas: [],
     threads: 1,
     numRetries: 5,
     startOfWeek: undefined,

--- a/packages/frontend/src/utils/fieldValidators.ts
+++ b/packages/frontend/src/utils/fieldValidators.ts
@@ -25,7 +25,7 @@ export const isUppercase: FieldValidator<string> = (fieldName) => (value) =>
 
 export const hasNoWhiteSpaces: FieldValidator<string> =
     (fieldName) => (value) =>
-        !value || value.indexOf(' ') <= 0
+        !value || value.indexOf(' ') < 0
             ? undefined
             : `${fieldName} should not have white spaces`;
 

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
@@ -374,4 +374,471 @@ describe('AthenaWarehouseClient', () => {
             });
         });
     });
+
+    describe('getAllTables with multi-schema', () => {
+        const mockSend = vi.fn();
+
+        beforeEach(() => {
+            mockAthenaClient.mockImplementation(() => ({
+                send: mockSend,
+            }));
+        });
+
+        test('should list tables from single schema', async () => {
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 'table1' }, { Name: 'table2' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_database',
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 'table1',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 'table2',
+                },
+            ]);
+        });
+
+        test('should list tables from schema and accessibleSchemas', async () => {
+            // Default schema tables
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 'table_a' }],
+                NextToken: undefined,
+            });
+            // Additional schema tables
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 'table_b' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'db1',
+                accessibleSchemas: ['db2'],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db1',
+                    table: 'table_a',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db2',
+                    table: 'table_b',
+                },
+            ]);
+        });
+
+        test('should deduplicate schemas when accessibleSchemas contains the default schema', async () => {
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 'table1' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'db1',
+                accessibleSchemas: ['db1'],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db1',
+                    table: 'table1',
+                },
+            ]);
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+
+        test('should list tables from only the default schema when accessibleSchemas is empty', async () => {
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 'tbl1' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_db',
+                accessibleSchemas: [],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_db',
+                    table: 'tbl1',
+                },
+            ]);
+        });
+
+        test('should expand * wildcard to all databases', async () => {
+            // ListDatabasesCommand response
+            mockSend.mockResolvedValueOnce({
+                DatabaseList: [
+                    { Name: 'db_alpha' },
+                    { Name: 'db_beta' },
+                    { Name: 'my_database' },
+                ],
+                NextToken: undefined,
+            });
+            // Tables for my_database (default schema)
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't1' }],
+                NextToken: undefined,
+            });
+            // Tables for db_alpha
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't2' }],
+                NextToken: undefined,
+            });
+            // Tables for db_beta
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't3' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_database',
+                accessibleSchemas: ['*'],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 't1',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db_alpha',
+                    table: 't2',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db_beta',
+                    table: 't3',
+                },
+            ]);
+        });
+
+        test('should expand prefix wildcard pattern', async () => {
+            // ListDatabasesCommand response
+            mockSend.mockResolvedValueOnce({
+                DatabaseList: [
+                    { Name: 'sales_us' },
+                    { Name: 'sales_eu' },
+                    { Name: 'marketing' },
+                ],
+                NextToken: undefined,
+            });
+            // Tables for default schema
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't0' }],
+                NextToken: undefined,
+            });
+            // Tables for sales_us
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't1' }],
+                NextToken: undefined,
+            });
+            // Tables for sales_eu
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't2' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_database',
+                accessibleSchemas: ['sales_*'],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 't0',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'sales_us',
+                    table: 't1',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'sales_eu',
+                    table: 't2',
+                },
+            ]);
+        });
+
+        test('should support ? single-character wildcard', async () => {
+            // ListDatabasesCommand response
+            mockSend.mockResolvedValueOnce({
+                DatabaseList: [
+                    { Name: 'db_a' },
+                    { Name: 'db_b' },
+                    { Name: 'db_ab' },
+                ],
+                NextToken: undefined,
+            });
+            // Tables for default schema
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't0' }],
+                NextToken: undefined,
+            });
+            // Tables for db_a
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't1' }],
+                NextToken: undefined,
+            });
+            // Tables for db_b
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't2' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_database',
+                accessibleSchemas: ['db_?'],
+            });
+            const tables = await client.getAllTables();
+
+            // db_ab should NOT match db_? (? matches exactly one character)
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 't0',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db_a',
+                    table: 't1',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db_b',
+                    table: 't2',
+                },
+            ]);
+        });
+
+        test('should mix explicit schemas and wildcard patterns', async () => {
+            // ListDatabasesCommand response (for wildcard resolution)
+            mockSend.mockResolvedValueOnce({
+                DatabaseList: [
+                    { Name: 'prod_us' },
+                    { Name: 'prod_eu' },
+                    { Name: 'staging' },
+                ],
+                NextToken: undefined,
+            });
+            // Tables for default schema
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't0' }],
+                NextToken: undefined,
+            });
+            // Tables for staging (explicit)
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't1' }],
+                NextToken: undefined,
+            });
+            // Tables for prod_us (matched by wildcard)
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't2' }],
+                NextToken: undefined,
+            });
+            // Tables for prod_eu (matched by wildcard)
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't3' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_database',
+                accessibleSchemas: ['staging', 'prod_*'],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 't0',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'staging',
+                    table: 't1',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'prod_us',
+                    table: 't2',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'prod_eu',
+                    table: 't3',
+                },
+            ]);
+        });
+
+        test('should ignore empty strings in accessibleSchemas', async () => {
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 'table1' }],
+                NextToken: undefined,
+            });
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 'table2' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'db1',
+                accessibleSchemas: ['', 'db2', '  '],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db1',
+                    table: 'table1',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db2',
+                    table: 'table2',
+                },
+            ]);
+        });
+
+        test('should return only default schema tables when wildcard matches nothing', async () => {
+            // ListDatabasesCommand response
+            mockSend.mockResolvedValueOnce({
+                DatabaseList: [{ Name: 'unrelated_db' }],
+                NextToken: undefined,
+            });
+            // Tables for default schema
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 'table1' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_database',
+                accessibleSchemas: ['nonexistent_*'],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 'table1',
+                },
+            ]);
+        });
+
+        test('should paginate through listAllDatabases', async () => {
+            // First page of ListDatabasesCommand
+            mockSend.mockResolvedValueOnce({
+                DatabaseList: [{ Name: 'db_page1' }],
+                NextToken: 'token123',
+            });
+            // Second page of ListDatabasesCommand
+            mockSend.mockResolvedValueOnce({
+                DatabaseList: [{ Name: 'db_page2' }],
+                NextToken: undefined,
+            });
+            // Tables for default schema
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't0' }],
+                NextToken: undefined,
+            });
+            // Tables for db_page1
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't1' }],
+                NextToken: undefined,
+            });
+            // Tables for db_page2
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [{ Name: 't2' }],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_database',
+                accessibleSchemas: ['db_*'],
+            });
+            const tables = await client.getAllTables();
+
+            expect(tables).toEqual([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 't0',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db_page1',
+                    table: 't1',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'db_page2',
+                    table: 't2',
+                },
+            ]);
+        });
+
+        test('should throw error when wildcard matches exceed limit', async () => {
+            // Generate 101 databases to exceed MAX_WILDCARD_MATCHES (100)
+            const databases = Array.from({ length: 101 }, (_, i) => ({
+                Name: `db_${i}`,
+            }));
+
+            mockSend.mockResolvedValueOnce({
+                DatabaseList: databases,
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient({
+                ...baseCredentials,
+                schema: 'my_database',
+                accessibleSchemas: ['*'],
+            });
+
+            await expect(client.getAllTables()).rejects.toThrow(
+                /Wildcard pattern matched 101 databases, exceeding the limit of 100/,
+            );
+        });
+    });
 });

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -3,6 +3,7 @@ import {
     GetQueryExecutionCommand,
     GetQueryResultsCommand,
     GetTableMetadataCommand,
+    ListDatabasesCommand,
     ListTableMetadataCommand,
     QueryExecutionState,
     StartQueryExecutionCommand,
@@ -255,6 +256,7 @@ export class AthenaSqlBuilder extends WarehouseBaseSqlBuilder {
 
 const POLL_INTERVAL_MS = 500;
 const MAX_POLL_ATTEMPTS = 1200; // 10 minutes max wait
+const MAX_WILDCARD_MATCHES = 100;
 
 export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCredentials> {
     client: AthenaClient;
@@ -314,6 +316,74 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
                 }. ${getErrorMessage(e)}`,
             );
         }
+    }
+
+    private static matchesGlob(name: string, pattern: string): boolean {
+        const regex = new RegExp(
+            `^${pattern
+                .replace(/[.+^${}()|[\]\\]/g, '\\$&')
+                .replace(/\*/g, '.*')
+                .replace(/\?/g, '.')}$`,
+        );
+        return regex.test(name);
+    }
+
+    private async listAllDatabases(): Promise<string[]> {
+        const databases: string[] = [];
+        let nextToken: string | undefined;
+
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            const response = await this.client.send(
+                new ListDatabasesCommand({
+                    CatalogName: this.credentials.database,
+                    NextToken: nextToken,
+                    MaxResults: 50,
+                }),
+            );
+
+            response.DatabaseList?.forEach((db) => {
+                if (db.Name) {
+                    databases.push(db.Name);
+                }
+            });
+
+            nextToken = response.NextToken;
+        } while (nextToken);
+
+        return databases;
+    }
+
+    private async getTargetSchemas(): Promise<string[]> {
+        const { schema, accessibleSchemas } = this.credentials;
+        const explicit: string[] = schema ? [schema] : [];
+        const patterns: string[] = [];
+
+        (accessibleSchemas ?? [])
+            .map((s) => s.trim())
+            .filter((s) => s !== '')
+            .forEach((trimmed) => {
+                if (trimmed.includes('*') || trimmed.includes('?')) {
+                    patterns.push(trimmed);
+                } else {
+                    explicit.push(trimmed);
+                }
+            });
+
+        if (patterns.length > 0) {
+            const allDatabases = await this.listAllDatabases();
+            const matched = allDatabases.filter((db) =>
+                patterns.some((p) => AthenaWarehouseClient.matchesGlob(db, p)),
+            );
+            if (matched.length > MAX_WILDCARD_MATCHES) {
+                throw new WarehouseConnectionError(
+                    `Wildcard pattern matched ${matched.length} databases, exceeding the limit of ${MAX_WILDCARD_MATCHES}. Use more specific patterns.`,
+                );
+            }
+            matched.forEach((db) => explicit.push(db));
+        }
+
+        return [...new Set(explicit)];
     }
 
     private async waitForQueryCompletion(
@@ -413,13 +483,19 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
             }
 
             // Start query execution
+            const queryExecutionContext = this.credentials.schema
+                ? {
+                      Catalog: this.credentials.database,
+                      Database: this.credentials.schema,
+                  }
+                : {
+                      Catalog: this.credentials.database,
+                  };
+
             const startResponse = await this.client.send(
                 new StartQueryExecutionCommand({
                     QueryString: alteredQuery,
-                    QueryExecutionContext: {
-                        Database: this.credentials.schema,
-                        Catalog: this.credentials.database,
-                    },
+                    QueryExecutionContext: queryExecutionContext,
                     ResultConfiguration: {
                         OutputLocation: this.credentials.s3StagingDir,
                     },
@@ -565,46 +641,63 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
         }, {});
     }
 
+    private async listTablesForSchema(
+        schemaName: string,
+    ): Promise<{ database: string; schema: string; table: string }[]> {
+        const tables: { database: string; schema: string; table: string }[] =
+            [];
+        let nextToken: string | undefined;
+
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            const response = await this.client.send(
+                new ListTableMetadataCommand({
+                    CatalogName: this.credentials.database,
+                    DatabaseName: schemaName,
+                    NextToken: nextToken,
+                    MaxResults: 50,
+                }),
+            );
+
+            response.TableMetadataList?.forEach((tableMeta) => {
+                if (tableMeta.Name) {
+                    tables.push({
+                        database: this.credentials.database,
+                        schema: schemaName,
+                        table: tableMeta.Name,
+                    });
+                }
+            });
+
+            nextToken = response.NextToken;
+        } while (nextToken);
+
+        return tables;
+    }
+
     async getAllTables(): Promise<
         { database: string; schema: string; table: string }[]
     > {
-        const tables: { database: string; schema: string; table: string }[] =
-            [];
-
+        let targetSchemas: string[] = [];
         try {
-            let nextToken: string | undefined;
+            targetSchemas = await this.getTargetSchemas();
 
-            do {
-                // eslint-disable-next-line no-await-in-loop
-                const response = await this.client.send(
-                    new ListTableMetadataCommand({
-                        CatalogName: this.credentials.database,
-                        DatabaseName: this.credentials.schema,
-                        NextToken: nextToken,
-                        MaxResults: 50,
-                    }),
-                );
+            const results = await processPromisesInBatches(
+                targetSchemas,
+                DEFAULT_BATCH_SIZE,
+                async (schemaName) => this.listTablesForSchema(schemaName),
+            );
 
-                response.TableMetadataList?.forEach((tableMeta) => {
-                    if (tableMeta.Name) {
-                        tables.push({
-                            database: this.credentials.database,
-                            schema: this.credentials.schema,
-                            table: tableMeta.Name,
-                        });
-                    }
-                });
-
-                nextToken = response.NextToken;
-            } while (nextToken);
+            return results.flat();
         } catch (e: unknown) {
+            if (e instanceof WarehouseConnectionError) {
+                throw e;
+            }
             throw translateAthenaError(e, {
-                contextPrefix: `Failed to list tables in '${this.credentials.database}.${this.credentials.schema}'.`,
+                contextPrefix: `Failed to list tables in catalog '${this.credentials.database}' for schemas [${targetSchemas.join(', ')}].`,
                 defaultErrorClass: 'connection',
             });
         }
-
-        return tables;
     }
 
     async getFields(
@@ -614,6 +707,12 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
     ): Promise<WarehouseCatalog> {
         const db = database || this.credentials.database;
         const sch = schema || this.credentials.schema;
+
+        if (!sch) {
+            throw new WarehouseConnectionError(
+                `Cannot get fields for table '${tableName}' without an explicit schema`,
+            );
+        }
 
         try {
             const response = await this.client.send(


### PR DESCRIPTION
### Description

This PR adds support for exploring tables across multiple Athena databases (schemas) within a single Lightdash project.

#### Problem

Currently, the Athena warehouse configuration only accepts a single database name in the schema field. Users who work with
 multiple databases need to switch between projects or manually query tables with fully-qualified names.

#### Solution

- Added a new **"Additional databases"** field (`accessibleSchemas`) to the Athena configuration, separate from the
existing default schema
- Supports **wildcard patterns**: `*` (any characters), `?` (single character) — e.g. `sales_*` or `*`
- Wildcard matches are capped at 100 databases to prevent excessive API calls
- Tables from all specified databases appear in the table explorer via batch-parallel fetching

