### PR TITLE
fix(athena): Athena warehouse in My Warehouse Connections

### DIFF
--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.test.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.test.ts
@@ -1,0 +1,67 @@
+import { WarehouseTypes } from '@lightdash/common';
+import { getCredentialsWithPlaceholders } from './EditCredentialsModal';
+
+describe('getCredentialsWithPlaceholders', () => {
+    test('should return placeholders for Athena credentials', () => {
+        const result = getCredentialsWithPlaceholders({
+            type: WarehouseTypes.ATHENA,
+        });
+        expect(result).toEqual({
+            type: WarehouseTypes.ATHENA,
+            accessKeyId: '',
+            secretAccessKey: '',
+        });
+    });
+
+    test('should return placeholders for Redshift credentials', () => {
+        const result = getCredentialsWithPlaceholders({
+            type: WarehouseTypes.REDSHIFT,
+            user: 'testuser',
+        });
+        expect(result).toEqual({
+            type: WarehouseTypes.REDSHIFT,
+            user: 'testuser',
+            password: '',
+        });
+    });
+
+    test('should return placeholders for Postgres credentials', () => {
+        const result = getCredentialsWithPlaceholders({
+            type: WarehouseTypes.POSTGRES,
+            user: 'testuser',
+        });
+        expect(result).toEqual({
+            type: WarehouseTypes.POSTGRES,
+            user: 'testuser',
+            password: '',
+        });
+    });
+
+    test('should return placeholders for BigQuery credentials', () => {
+        const result = getCredentialsWithPlaceholders({
+            type: WarehouseTypes.BIGQUERY,
+        });
+        expect(result).toEqual({
+            type: WarehouseTypes.BIGQUERY,
+            keyfileContents: {},
+        });
+    });
+
+    test('should return placeholders for Databricks credentials', () => {
+        const result = getCredentialsWithPlaceholders({
+            type: WarehouseTypes.DATABRICKS,
+        });
+        expect(result).toEqual({
+            type: WarehouseTypes.DATABRICKS,
+            personalAccessToken: '',
+        });
+    });
+
+    test('should throw for unsupported credential type', () => {
+        expect(() =>
+            getCredentialsWithPlaceholders({
+                type: 'unknown' as WarehouseTypes,
+            } as any),
+        ).toThrow('Credential type not supported');
+    });
+});

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -13,7 +13,7 @@ import MantineModal, {
 } from '../../common/MantineModal';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
 
-const getCredentialsWithPlaceholders = (
+export const getCredentialsWithPlaceholders = (
     credentials: UserWarehouseCredentials['credentials'],
 ): UpsertUserWarehouseCredentials['credentials'] => {
     switch (credentials.type) {
@@ -34,6 +34,12 @@ const getCredentialsWithPlaceholders = (
             return {
                 ...credentials,
                 personalAccessToken: '',
+            };
+        case WarehouseTypes.ATHENA:
+            return {
+                ...credentials,
+                accessKeyId: '',
+                secretAccessKey: '',
             };
         default:
             throw new Error(`Credential type not supported`);

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -1,5 +1,4 @@
 import {
-    WarehouseTypes,
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
 } from '@lightdash/common';
@@ -11,40 +10,8 @@ import { useUserWarehouseCredentialsUpdateMutation } from '../../../hooks/userWa
 import MantineModal, {
     type MantineModalProps,
 } from '../../common/MantineModal';
+import { getCredentialsWithPlaceholders } from './getCredentialsWithPlaceholders';
 import { WarehouseFormInputs } from './WarehouseFormInputs';
-
-export const getCredentialsWithPlaceholders = (
-    credentials: UserWarehouseCredentials['credentials'],
-): UpsertUserWarehouseCredentials['credentials'] => {
-    switch (credentials.type) {
-        case WarehouseTypes.REDSHIFT:
-        case WarehouseTypes.SNOWFLAKE:
-        case WarehouseTypes.POSTGRES:
-        case WarehouseTypes.TRINO:
-            return {
-                ...credentials,
-                password: '',
-            };
-        case WarehouseTypes.BIGQUERY:
-            return {
-                ...credentials,
-                keyfileContents: {},
-            };
-        case WarehouseTypes.DATABRICKS:
-            return {
-                ...credentials,
-                personalAccessToken: '',
-            };
-        case WarehouseTypes.ATHENA:
-            return {
-                ...credentials,
-                accessKeyId: '',
-                secretAccessKey: '',
-            };
-        default:
-            throw new Error(`Credential type not supported`);
-    }
-};
 
 const FORM_ID = 'edit-credentials-form';
 

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -123,6 +123,25 @@ export const WarehouseFormInputs: FC<{
                     credentialsName={databricksCredentialsName}
                 />
             );
+        case WarehouseTypes.ATHENA:
+            return (
+                <>
+                    <TextInput
+                        required
+                        size="xs"
+                        label="Access key ID"
+                        disabled={disabled}
+                        {...form.getInputProps('credentials.accessKeyId')}
+                    />
+                    <PasswordInput
+                        required
+                        size="xs"
+                        label="Secret access key"
+                        disabled={disabled}
+                        {...form.getInputProps('credentials.secretAccessKey')}
+                    />
+                </>
+            );
         default:
             return null;
     }

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/getCredentialsWithPlaceholders.test.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/getCredentialsWithPlaceholders.test.ts
@@ -1,5 +1,5 @@
 import { WarehouseTypes } from '@lightdash/common';
-import { getCredentialsWithPlaceholders } from './EditCredentialsModal';
+import { getCredentialsWithPlaceholders } from './getCredentialsWithPlaceholders';
 
 describe('getCredentialsWithPlaceholders', () => {
     test('should return placeholders for Athena credentials', () => {

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/getCredentialsWithPlaceholders.ts
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/getCredentialsWithPlaceholders.ts
@@ -1,0 +1,38 @@
+import {
+    WarehouseTypes,
+    type UpsertUserWarehouseCredentials,
+    type UserWarehouseCredentials,
+} from '@lightdash/common';
+
+export const getCredentialsWithPlaceholders = (
+    credentials: UserWarehouseCredentials['credentials'],
+): UpsertUserWarehouseCredentials['credentials'] => {
+    switch (credentials.type) {
+        case WarehouseTypes.REDSHIFT:
+        case WarehouseTypes.SNOWFLAKE:
+        case WarehouseTypes.POSTGRES:
+        case WarehouseTypes.TRINO:
+            return {
+                ...credentials,
+                password: '',
+            };
+        case WarehouseTypes.BIGQUERY:
+            return {
+                ...credentials,
+                keyfileContents: {},
+            };
+        case WarehouseTypes.DATABRICKS:
+            return {
+                ...credentials,
+                personalAccessToken: '',
+            };
+        case WarehouseTypes.ATHENA:
+            return {
+                ...credentials,
+                accessKeyId: '',
+                secretAccessKey: '',
+            };
+        default:
+            throw new Error(`Credential type not supported`);
+    }
+};


### PR DESCRIPTION
## Summary

Athena warehouse type was missing from the My Warehouse Connections edit modal — trying to edit Athena credentials would just throw an error. This adds the missing form inputs (access key ID and secret access key) and the credential placeholders so the modal works properly for Athena connections.
