### PR TITLE
fix: build relation_name fallback when dbt ls does not populate it

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1530,6 +1530,7 @@ describe('pre-aggregate virtual explore generation', () => {
             message:
                 'Pre-aggregate "broken_rollup" references unsupported metrics: "myTable_user_count" (count_distinct). Supported metric types: sum, count, min, max, average',
         });
+    });
 });
 
 describe('buildRelationName fallback when relation_name is missing', () => {

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1530,5 +1530,141 @@ describe('pre-aggregate virtual explore generation', () => {
             message:
                 'Pre-aggregate "broken_rollup" references unsupported metrics: "myTable_user_count" (count_distinct). Supported metric types: sum, count, min, max, average',
         });
+});
+
+describe('buildRelationName fallback when relation_name is missing', () => {
+    const baseModel: DbtModelNode = {
+        ...model,
+        relation_name: undefined as unknown as string,
+    };
+
+    it('should build relation_name from database, schema, and alias for Postgres', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            {
+                ...baseModel,
+                database: 'myDb',
+                schema: 'mySchema',
+                alias: 'myAlias',
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('"myDb"."mySchema"."myAlias"');
+    });
+
+    it('should build relation_name using backticks for BigQuery', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.BIGQUERY,
+            {
+                ...baseModel,
+                database: 'project',
+                schema: 'dataset',
+                alias: 'table',
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('`project`.`dataset`.`table`');
+    });
+
+    it('should build relation_name using backticks for Databricks', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.DATABRICKS,
+            { ...baseModel, database: 'catalog', schema: 'db', alias: 'tbl' },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('`catalog`.`db`.`tbl`');
+    });
+
+    it('should build relation_name using double quotes for Athena', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.ATHENA,
+            {
+                ...baseModel,
+                database: 'awscatalog',
+                schema: 'myschema',
+                alias: 'mytable',
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('"awscatalog"."myschema"."mytable"');
+    });
+
+    it('should build relation_name using double quotes for Snowflake', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.SNOWFLAKE,
+            { ...baseModel, database: 'DB', schema: 'SCH', alias: 'TBL' },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('"DB"."SCH"."TBL"');
+    });
+
+    it('should fall back to model name when alias is not set', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            {
+                ...baseModel,
+                database: 'myDb',
+                schema: 'mySchema',
+                alias: undefined as unknown as string,
+                name: 'my_model',
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('"myDb"."mySchema"."my_model"');
+    });
+
+    it('should omit database part when database is empty', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            {
+                ...baseModel,
+                database: '',
+                schema: 'mySchema',
+                alias: 'myAlias',
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('"mySchema"."myAlias"');
+    });
+
+    it('should prefer relation_name over buildRelationName when both are available', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            {
+                ...baseModel,
+                relation_name: 'explicit_relation',
+                database: 'myDb',
+                schema: 'mySchema',
+                alias: 'myAlias',
+            },
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('explicit_relation');
+    });
+
+    it('should prefer sql_from over both relation_name and buildRelationName', () => {
+        const modelWithSqlFrom: DbtModelNode = {
+            ...baseModel,
+            relation_name: 'explicit_relation',
+            database: 'myDb',
+            schema: 'mySchema',
+            alias: 'myAlias',
+            meta: { sql_from: 'custom_sql_table' },
+        };
+        const result = convertTable(
+            SupportedDbtAdapter.POSTGRES,
+            modelWithSqlFrom,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.sqlTable).toBe('custom_sql_table');
     });
 });

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -573,6 +573,7 @@ const getAdapterQuoteChar = (adapterType: SupportedDbtAdapter): string => {
         case SupportedDbtAdapter.TRINO:
         case SupportedDbtAdapter.ATHENA:
         case SupportedDbtAdapter.CLICKHOUSE:
+        case SupportedDbtAdapter.DUCKDB:
             return '"';
         default:
             return assertUnreachable(

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -562,6 +562,42 @@ function validateSets(
     });
 }
 
+const getAdapterQuoteChar = (adapterType: SupportedDbtAdapter): string => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+        case SupportedDbtAdapter.DATABRICKS:
+            return '`';
+        case SupportedDbtAdapter.SNOWFLAKE:
+        case SupportedDbtAdapter.REDSHIFT:
+        case SupportedDbtAdapter.POSTGRES:
+        case SupportedDbtAdapter.TRINO:
+        case SupportedDbtAdapter.ATHENA:
+        case SupportedDbtAdapter.CLICKHOUSE:
+            return '"';
+        default:
+            return assertUnreachable(
+                adapterType,
+                new ParseError(`Unknown adapter type ${adapterType}`),
+            );
+    }
+};
+
+const buildRelationName = (
+    adapterType: SupportedDbtAdapter,
+    model: DbtModelNode,
+): string | null => {
+    const identifier = model.alias || model.name;
+    if (!identifier) return null;
+    const q = getAdapterQuoteChar(adapterType);
+    const parts: string[] = [];
+    if (model.database) {
+        parts.push(`${q}${model.database}${q}`);
+    }
+    parts.push(`${q}${model.schema}${q}`);
+    parts.push(`${q}${identifier}${q}`);
+    return parts.join('.');
+};
+
 export const convertTable = (
     adapterType: SupportedDbtAdapter,
     model: DbtModelNode,
@@ -832,7 +868,10 @@ export const convertTable = (
         validateSets(dimensions, allMetrics, model, meta);
     }
 
-    const sqlTable = meta.sql_from || model.relation_name;
+    const sqlTable =
+        meta.sql_from ||
+        model.relation_name ||
+        buildRelationName(adapterType, model);
     if (sqlTable === null || sqlTable === undefined || sqlTable === '') {
         throw new Error(`Model "${model.name}" is missing a table reference.`);
     }


### PR DESCRIPTION
## Summary

Could you please review this when you get a chance?

When compiling a project using `dbt ls`, the `relation_name` field is not always populated even though the `database` and `schema` values resolved by `generate_schema_name` / `generate_database_name` macros are correctly set. This causes generated SQL queries to miss custom schema names, leading to incorrect table references on adapters like Athena.

This PR adds a `buildRelationName` helper to `convertTable()` that constructs a fully qualified table reference from the model's `database`, `schema`, and `alias` fields using the appropriate adapter quote character when `relation_name` is missing.

- Backwards-compatible: when `relation_name` is present, it is used as before
- Handles adapter-specific quoting (`` ` `` for BigQuery/Databricks, `"` for all others)

I've added tests as well — would appreciate it if you could take a look at those too. Thanks!
