### PR TITLE
feat: add support for anyAttributes in search results

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -1185,6 +1185,7 @@ export class SearchModel {
                                 explore: explore.name,
                                 exploreLabel: explore.label,
                                 requiredAttributes: table.requiredAttributes,
+                                anyAttributes: table.anyAttributes,
                                 regexMatchCount: tableRegexMatchCount,
                             });
                         }
@@ -1213,6 +1214,9 @@ export class SearchModel {
                                         exploreLabel: explore.label,
                                         requiredAttributes: isDimension(field)
                                             ? field.requiredAttributes
+                                            : undefined,
+                                        anyAttributes: isDimension(field)
+                                            ? field.anyAttributes
                                             : undefined,
                                         tablesRequiredAttributes:
                                             field.tablesRequiredAttributes,

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -76,9 +76,9 @@ import { wrapSentryTransaction } from '../../utils';
 import { BaseService } from '../BaseService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import {
+    checkUserAttributesAccess,
     doesExploreMatchRequiredAttributes,
     getFilteredExplore,
-    hasUserAttributes,
 } from '../UserAttributesService/UserAttributeUtils';
 
 export type CatalogArguments<T extends CatalogModel = CatalogModel> = {
@@ -782,7 +782,11 @@ export class CatalogService<
         const baseTable = explore.tables?.[explore.baseTable];
         const fields = parseFieldsFromCompiledTable(baseTable);
         const filteredFields = fields.filter((field) =>
-            hasUserAttributes(field.requiredAttributes, userAttributes),
+            checkUserAttributesAccess(
+                field.requiredAttributes,
+                field.anyAttributes,
+                userAttributes,
+            ),
         );
 
         const metadata: CatalogMetadata = {

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtil.test.ts
@@ -19,9 +19,7 @@ import {
     doesExploreMatchRequiredAttributes,
     exploreHasFilteredAttribute,
     getFilteredExplore,
-    hasAnyUserAttributes,
     hasUserAttribute,
-    hasUserAttributes,
 } from './UserAttributeUtils';
 
 describe('doesExploreMatchUserAttributes', () => {
@@ -160,60 +158,75 @@ describe('hasUserAttribute', () => {
 });
 describe('hasUserAttributes', () => {
     test('should be true if there are no required attributes', () => {
-        expect(hasUserAttributes(undefined, { test: ['1'] })).toStrictEqual(
-            true,
-        );
-        expect(hasUserAttributes({}, { test: ['1'] })).toStrictEqual(true);
+        expect(
+            checkUserAttributesAccess(undefined, undefined, { test: ['1'] }),
+        ).toStrictEqual(true);
+        expect(
+            checkUserAttributesAccess({}, undefined, { test: ['1'] }),
+        ).toStrictEqual(true);
     });
     test('should be false if required attributes are not present', () => {
         expect(
-            hasUserAttributes({ another: '1' }, { test: ['1'] }),
+            checkUserAttributesAccess({ another: '1' }, undefined, {
+                test: ['1'],
+            }),
         ).toStrictEqual(false);
     });
     test('should be false if required attribute values does not match', () => {
-        expect(hasUserAttributes({ test: '2' }, { test: ['1'] })).toStrictEqual(
-            false,
-        );
-        expect(hasUserAttributes({ test: '1' }, { test: [] })).toStrictEqual(
-            false,
-        );
         expect(
-            hasUserAttributes(
-                { test: '2', another: '1' },
-                { test: ['1'], another: ['1'] },
-            ),
+            checkUserAttributesAccess({ test: '2' }, undefined, {
+                test: ['1'],
+            }),
+        ).toStrictEqual(false);
+        expect(
+            checkUserAttributesAccess({ test: '1' }, undefined, { test: [] }),
+        ).toStrictEqual(false);
+        expect(
+            checkUserAttributesAccess({ test: '2', another: '1' }, undefined, {
+                test: ['1'],
+                another: ['1'],
+            }),
         ).toStrictEqual(false);
     });
     test('should be true if required attribute value match', () => {
-        expect(hasUserAttributes({ test: '1' }, { test: ['1'] })).toStrictEqual(
-            true,
-        );
+        expect(
+            checkUserAttributesAccess({ test: '1' }, undefined, {
+                test: ['1'],
+            }),
+        ).toStrictEqual(true);
     });
 });
 
 describe('hasAnyUserAttributes', () => {
     test('should be true if anyAttributes object is empty', () => {
-        expect(hasAnyUserAttributes({}, { test: ['1'] })).toStrictEqual(true);
-        expect(hasAnyUserAttributes({}, {})).toStrictEqual(true);
+        expect(
+            checkUserAttributesAccess(undefined, {}, { test: ['1'] }),
+        ).toStrictEqual(true);
+        expect(checkUserAttributesAccess(undefined, {}, {})).toStrictEqual(
+            true,
+        );
     });
     test('should be true if user has ANY matching attribute (OR logic)', () => {
         // User has 'sales' which matches one of the allowed values
         expect(
-            hasAnyUserAttributes(
+            checkUserAttributesAccess(
+                undefined,
                 { department: ['sales', 'finance'] },
                 { department: ['sales'] },
             ),
         ).toStrictEqual(true);
         // User has 'finance' which matches one of the allowed values
         expect(
-            hasAnyUserAttributes(
+            checkUserAttributesAccess(
+                undefined,
                 { department: ['sales', 'finance'] },
                 { department: ['finance'] },
             ),
         ).toStrictEqual(true);
         // User has both, still passes
         expect(
-            hasAnyUserAttributes(
+            checkUserAttributesAccess(
+                undefined,
                 { department: ['sales', 'finance'] },
                 { department: ['sales', 'finance'] },
             ),
@@ -222,14 +235,16 @@ describe('hasAnyUserAttributes', () => {
     test('should be true if user matches ANY of multiple attribute conditions', () => {
         // User has department=sales but not role=admin - should pass OR logic
         expect(
-            hasAnyUserAttributes(
+            checkUserAttributesAccess(
+                undefined,
                 { department: 'sales', role: 'admin' },
                 { department: ['sales'] },
             ),
         ).toStrictEqual(true);
         // User has role=admin but not department=sales - should pass OR logic
         expect(
-            hasAnyUserAttributes(
+            checkUserAttributesAccess(
+                undefined,
                 { department: 'sales', role: 'admin' },
                 { role: ['admin'] },
             ),
@@ -237,16 +252,22 @@ describe('hasAnyUserAttributes', () => {
     });
     test('should be false if user has NONE of the required attributes', () => {
         expect(
-            hasAnyUserAttributes(
+            checkUserAttributesAccess(
+                undefined,
                 { department: ['sales', 'finance'] },
                 { department: ['hr'] },
             ),
         ).toStrictEqual(false);
         expect(
-            hasAnyUserAttributes({ department: 'sales' }, { role: ['admin'] }),
+            checkUserAttributesAccess(
+                undefined,
+                { department: 'sales' },
+                { role: ['admin'] },
+            ),
         ).toStrictEqual(false);
         expect(
-            hasAnyUserAttributes(
+            checkUserAttributesAccess(
+                undefined,
                 { department: 'sales', role: 'admin' },
                 { department: ['hr'], role: ['analyst'] },
             ),
@@ -254,10 +275,18 @@ describe('hasAnyUserAttributes', () => {
     });
     test('should work with single string value in anyAttributes', () => {
         expect(
-            hasAnyUserAttributes({ role: 'admin' }, { role: ['admin'] }),
+            checkUserAttributesAccess(
+                undefined,
+                { role: 'admin' },
+                { role: ['admin'] },
+            ),
         ).toStrictEqual(true);
         expect(
-            hasAnyUserAttributes({ role: 'admin' }, { role: ['analyst'] }),
+            checkUserAttributesAccess(
+                undefined,
+                { role: 'admin' },
+                { role: ['analyst'] },
+            ),
         ).toStrictEqual(false);
     });
 });

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -95,7 +95,7 @@ export const hasUserAttribute = (
     !!userAttributes[attributeName] &&
     userAttributes[attributeName].includes(value);
 
-export const hasUserAttributes = (
+const hasUserAttributes = (
     requiredAttributes: Record<string, string | string[]> | undefined,
     userAttributes: UserAttributeValueMap,
 ): boolean => {
@@ -120,7 +120,7 @@ export const hasUserAttributes = (
  * @param userAttributes - User's actual attributes
  * @returns true if at least one attribute condition is satisfied
  */
-export const hasAnyUserAttributes = (
+const hasAnyUserAttributes = (
     anyAttributes: Record<string, string | string[]>,
     userAttributes: UserAttributeValueMap,
 ): boolean => {

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -118,7 +118,7 @@ export type AllChartsSearchResult = Pick<
 
 export type TableSearchResult = Pick<
     Table,
-    'name' | 'label' | 'description' | 'requiredAttributes'
+    'name' | 'label' | 'description' | 'requiredAttributes' | 'anyAttributes'
 > & {
     explore: string;
     exploreLabel: string;
@@ -145,6 +145,7 @@ export type FieldSearchResult = Pick<
     | 'tableLabel'
 > & {
     requiredAttributes?: Record<string, string | string[]>;
+    anyAttributes?: Record<string, string | string[]>;
     tablesRequiredAttributes?: Record<
         string,
         Record<string, string | string[]>


### PR DESCRIPTION
### Description:
Added support for `anyAttributes` in search results to enable OR-based access control for tables and fields. This enhancement allows users to access resources if they match any of the specified attributes, providing more flexible permission models alongside the existing required attributes which use AND-based logic.

The implementation passes `anyAttributes` through the search model and updates the access control logic to check both required and any attributes when filtering search results.