### PR TITLE
feat: support table-level any attributes for field access control

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5015,6 +5015,9 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 compilationError: { ref: 'FieldCompilationError' },
+                tablesAnyAttributes: {
+                    ref: 'Record_string.Record_string.string-or-string-Array__',
+                },
                 tablesRequiredAttributes: {
                     ref: 'Record_string.Record_string.string-or-string-Array__',
                 },
@@ -7373,11 +7376,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7855,11 +7858,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7874,11 +7877,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7893,11 +7896,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7912,11 +7915,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7931,11 +7934,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -5599,6 +5599,9 @@
                         "$ref": "#/components/schemas/FieldCompilationError",
                         "description": "When partial compilation mode is enabled, fields that fail to compile\nwill have this property set instead of causing the entire explore to fail."
                     },
+                    "tablesAnyAttributes": {
+                        "$ref": "#/components/schemas/Record_string.Record_string.string-or-string-Array__"
+                    },
                     "tablesRequiredAttributes": {
                         "$ref": "#/components/schemas/Record_string.Record_string.string-or-string-Array__"
                     },
@@ -8256,6 +8259,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -1220,6 +1220,8 @@ export class SearchModel {
                                             : undefined,
                                         tablesRequiredAttributes:
                                             field.tablesRequiredAttributes,
+                                        tablesAnyAttributes:
+                                            field.tablesAnyAttributes,
                                         regexMatchCount: fieldRegexMatchCount,
                                     });
                                 }

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -730,6 +730,18 @@ export class ExploreCompiler {
             },
             {},
         );
+        const tablesAnyAttributes = Array.from(
+            compiledMetric.tablesReferences,
+        ).reduce<Record<string, Record<string, string | string[]>>>(
+            (acc, tableReference) => {
+                const table = tables[tableReference] as Table | undefined;
+                if (table?.anyAttributes) {
+                    acc[tableReference] = table.anyAttributes;
+                }
+                return acc;
+            },
+            {},
+        );
 
         const compiledSql = compiledMetric.sql;
 
@@ -752,6 +764,9 @@ export class ExploreCompiler {
             tablesReferences: Array.from(compiledMetric.tablesReferences),
             ...(Object.keys(tablesRequiredAttributes).length
                 ? { tablesRequiredAttributes }
+                : {}),
+            ...(Object.keys(tablesAnyAttributes).length
+                ? { tablesAnyAttributes }
                 : {}),
             ...(parameterReferences.length > 0 ? { parameterReferences } : {}),
         };
@@ -981,6 +996,18 @@ export class ExploreCompiler {
             },
             {},
         );
+        const tablesAnyAttributes = Array.from(
+            compiledDimension.tablesReferences,
+        ).reduce<Record<string, Record<string, string | string[]>>>(
+            (acc, tableReference) => {
+                const table = tables[tableReference] as Table | undefined;
+                if (table?.anyAttributes) {
+                    acc[tableReference] = table.anyAttributes;
+                }
+                return acc;
+            },
+            {},
+        );
 
         const compiledSql = compiledDimension.sql;
 
@@ -1002,6 +1029,9 @@ export class ExploreCompiler {
             tablesReferences: Array.from(compiledDimension.tablesReferences),
             ...(Object.keys(tablesRequiredAttributes).length
                 ? { tablesRequiredAttributes }
+                : {}),
+            ...(Object.keys(tablesAnyAttributes).length
+                ? { tablesAnyAttributes }
                 : {}),
             ...(parameterReferences.length > 0 ? { parameterReferences } : {}),
         };

--- a/packages/common/src/types/changeset.ts
+++ b/packages/common/src/types/changeset.ts
@@ -48,6 +48,15 @@ export const ChangeBaseSchema = z
                                     ),
                                 )
                                 .optional(),
+                            tablesAnyAttributes: z
+                                .record(
+                                    z.string(),
+                                    z.record(
+                                        z.string(),
+                                        z.string().or(z.array(z.string())),
+                                    ),
+                                )
+                                .optional(),
                         }),
                     }),
                 ]),

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -67,14 +67,14 @@ export enum NumberSeparator {
 }
 type CompactConfig = {
     compact: Compact;
-    alias: Array<typeof CompactAlias[number]>;
+    alias: Array<(typeof CompactAlias)[number]>;
     orderOfMagnitude: number;
     convertFn: (value: number) => number;
     label: string;
     suffix: string;
 };
 
-export type CompactOrAlias = Compact | typeof CompactAlias[number];
+export type CompactOrAlias = Compact | (typeof CompactAlias)[number];
 
 export const CompactConfigMap: Record<Compact, CompactConfig> = {
     [Compact.THOUSANDS]: {
@@ -284,7 +284,7 @@ export interface CustomFormat {
     type: CustomFormatType;
     round?: number | undefined;
     separator?: NumberSeparator;
-    currency?: typeof currencies[number] | undefined;
+    currency?: (typeof currencies)[number] | undefined;
     compact?: CompactOrAlias | undefined;
     prefix?: string | undefined;
     suffix?: string | undefined;
@@ -595,6 +595,7 @@ type CompiledProperties = {
         string,
         Record<string, string | string[]>
     >;
+    tablesAnyAttributes?: Record<string, Record<string, string | string[]>>;
     /**
      * When partial compilation mode is enabled, fields that fail to compile
      * will have this property set instead of causing the entire explore to fail.

--- a/packages/common/src/types/search.ts
+++ b/packages/common/src/types/search.ts
@@ -150,6 +150,7 @@ export type FieldSearchResult = Pick<
         string,
         Record<string, string | string[]>
     >;
+    tablesAnyAttributes?: Record<string, Record<string, string | string[]>>;
     explore: string;
     exploreLabel: string;
     regexMatchCount: number;


### PR DESCRIPTION
### Description:
Added support for table-level "any attributes" in field access control. Previously, only table-level "required attributes" were being checked when determining field access. This PR adds the ability to specify "any attributes" at the table level, similar to how field-level access control works.

The changes include:
- Adding `tablesAnyAttributes` property to field types and schemas
- Updating the `ExploreCompiler` to collect and include table-level any attributes
- Modifying the `SearchService` to check both required and any attributes at the table level
- Fixing the order of success/error enums in the generated routes