### PR TITLE
fix: prevent search engines from indexing persistent download files

### DIFF
--- a/packages/backend/src/controllers/fileController.ts
+++ b/packages/backend/src/controllers/fileController.ts
@@ -41,5 +41,6 @@ export class FileController extends BaseController {
 
         this.setStatus(302);
         this.setHeader('Location', signedUrl);
+        this.setHeader('X-Robots-Tag', 'noindex, nofollow');
     }
 }

--- a/packages/frontend/public/robots.txt
+++ b/packages/frontend/public/robots.txt
@@ -1,3 +1,3 @@
 # https://www.robotstxt.org/robotstxt.html
 User-agent: *
-Disallow:
+Disallow: /api/v1/file/


### PR DESCRIPTION
## Summary
- Adds `Disallow: /api/v1/file/` to `robots.txt` so well-behaved crawlers won't attempt to fetch persistent download URLs
- Sets `X-Robots-Tag: noindex, nofollow` header on the file download endpoint's 302 redirect response, so engines that do reach it won't index the content

## Test plan
- [ ] Verify `robots.txt` at `/robots.txt` contains the new `Disallow` rule
- [ ] Verify GET `/api/v1/file/{nanoid}` response includes `X-Robots-Tag: noindex, nofollow` header

🤖 Generated with [Claude Code](https://claude.com/claude-code)