### PR TITLE
feat: add delete metrics tree endpoint

### DIFF
--- a/packages/backend/src/controllers/catalogController.ts
+++ b/packages/backend/src/controllers/catalogController.ts
@@ -231,6 +231,37 @@ export class CatalogController extends BaseController {
     }
 
     /**
+     * Delete a saved metrics tree and its associated nodes
+     * @summary Delete metrics tree
+     * @param projectUuid
+     * @param metricsTreeUuid
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Delete('/metrics/trees/{metricsTreeUuid}')
+    @OperationId('deleteMetricsTree')
+    async deleteMetricsTree(
+        @Path() projectUuid: string,
+        @Path() metricsTreeUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccessEmpty> {
+        this.setStatus(200);
+
+        await this.services
+            .getCatalogService()
+            .deleteMetricsTree(req.user!, projectUuid, metricsTreeUuid);
+
+        return {
+            status: 'ok',
+            results: undefined,
+        };
+    }
+
+    /**
      * Acquire an edit lock on a metrics tree
      * @summary Acquire tree lock
      * @param projectUuid

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7368,11 +7368,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7387,11 +7387,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7406,11 +7406,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7425,11 +7425,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7512,17 +7512,17 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                label: {
+                                                                                                    dataType:
+                                                                                                        'string',
+                                                                                                    required: true,
+                                                                                                },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                label: {
-                                                                                                    dataType:
-                                                                                                        'string',
-                                                                                                    required: true,
-                                                                                                },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7551,7 +7551,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7559,11 +7559,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7578,7 +7574,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7586,7 +7582,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7638,11 +7638,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7770,17 +7770,17 @@ const models: TsoaRoute.Models = {
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
+                                                                                                    label: {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
                                                                                                             required: true,
                                                                                                         },
-                                                                                                    label: {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -7812,11 +7812,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7831,11 +7831,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7850,11 +7850,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7869,11 +7869,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7888,11 +7888,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7907,11 +7907,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7926,11 +7926,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -24471,7 +24471,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DeletedChartContentSummary: {
+    DeletedChartBase: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -24513,7 +24513,6 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
-                source: { ref: 'ChartSourceType', required: true },
                 contentType: { ref: 'ContentType.CHART', required: true },
                 description: {
                     dataType: 'union',
@@ -24528,6 +24527,64 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartSourceType.DBT_EXPLORE': {
+        dataType: 'refEnum',
+        enums: ['dbt_explore'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WithDescendantCounts_DeletedDbtChartContentSummary.scheduler_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'DeletedChartBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        source: {
+                            ref: 'ChartSourceType.DBT_EXPLORE',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        schedulerCount: { dataType: 'double', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ChartSourceType.SQL': {
+        dataType: 'refEnum',
+        enums: ['sql'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DeletedSqlChartContentSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'DeletedChartBase' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        source: { ref: 'ChartSourceType.SQL', required: true },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WithDescendantCounts_DeletedSqlChartContentSummary.never_': {
+        dataType: 'refAlias',
+        type: { ref: 'DeletedSqlChartContentSummary', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DeletedDashboardContentSummary: {
@@ -24576,6 +24633,24 @@ const models: TsoaRoute.Models = {
                 name: { dataType: 'string', required: true },
                 uuid: { dataType: 'string', required: true },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WithDescendantCounts_DeletedDashboardContentSummary.chart-or-scheduler_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'DeletedDashboardContentSummary' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        schedulerCount: { dataType: 'double', required: true },
+                        chartCount: { dataType: 'double', required: true },
+                    },
+                },
+            ],
             validators: {},
         },
     },
@@ -24630,20 +24705,59 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DeletedContentSummary: {
+    'WithDescendantCounts_DeletedSpaceContentSummary.nestedSpace-or-dashboard-or-chart-or-scheduler_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'intersection',
+                subSchemas: [
+                    { ref: 'DeletedSpaceContentSummary' },
+                    {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            nestedSpaceCount: {
+                                dataType: 'double',
+                                required: true,
+                            },
+                            schedulerCount: {
+                                dataType: 'double',
+                                required: true,
+                            },
+                            dashboardCount: {
+                                dataType: 'double',
+                                required: true,
+                            },
+                            chartCount: { dataType: 'double', required: true },
+                        },
+                    },
+                ],
+                validators: {},
+            },
+        },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DeletedContentWithDescendants: {
         dataType: 'refAlias',
         type: {
             dataType: 'union',
             subSchemas: [
-                { ref: 'DeletedChartContentSummary' },
-                { ref: 'DeletedDashboardContentSummary' },
-                { ref: 'DeletedSpaceContentSummary' },
+                {
+                    ref: 'WithDescendantCounts_DeletedDbtChartContentSummary.scheduler_',
+                },
+                {
+                    ref: 'WithDescendantCounts_DeletedSqlChartContentSummary.never_',
+                },
+                {
+                    ref: 'WithDescendantCounts_DeletedDashboardContentSummary.chart-or-scheduler_',
+                },
+                {
+                    ref: 'WithDescendantCounts_DeletedSpaceContentSummary.nestedSpace-or-dashboard-or-chart-or-scheduler_',
+                },
             ],
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'KnexPaginatedData_DeletedContentSummary-Array_': {
+    'KnexPaginatedData_DeletedContentWithDescendants-Array_': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -24671,7 +24785,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'array',
                     array: {
                         dataType: 'refAlias',
-                        ref: 'DeletedContentSummary',
+                        ref: 'DeletedContentWithDescendants',
                     },
                     required: true,
                 },
@@ -24686,7 +24800,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 results: {
-                    ref: 'KnexPaginatedData_DeletedContentSummary-Array_',
+                    ref: 'KnexPaginatedData_DeletedContentWithDescendants-Array_',
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
@@ -45873,6 +45987,71 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateMetricsTree',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsCatalogController_deleteMetricsTree: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        metricsTreeUuid: {
+            in: 'path',
+            name: 'metricsTreeUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.delete(
+        '/api/v1/projects/:projectUuid/dataCatalog/metrics/trees/:metricsTreeUuid',
+        ...fetchMiddlewares<RequestHandler>(CatalogController),
+        ...fetchMiddlewares<RequestHandler>(
+            CatalogController.prototype.deleteMetricsTree,
+        ),
+
+        async function CatalogController_deleteMetricsTree(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsCatalogController_deleteMetricsTree,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<CatalogController>(CatalogController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteMetricsTree',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8251,8 +8251,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -8279,10 +8279,10 @@
                                                                         "fieldType": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "label": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -8291,8 +8291,8 @@
                                                                     },
                                                                     "required": [
                                                                         "fieldType",
-                                                                        "tableName",
                                                                         "label",
+                                                                        "tableName",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -8302,16 +8302,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
-                                                                            "nullable": true
-                                                                        },
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -8341,8 +8341,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -8399,10 +8399,10 @@
                                                                                     "fieldType": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "label": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -8411,8 +8411,8 @@
                                                                                 },
                                                                                 "required": [
                                                                                     "fieldType",
-                                                                                    "tableName",
                                                                                     "label",
+                                                                                    "tableName",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -8440,8 +8440,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -25255,7 +25255,7 @@
                 "required": ["action", "content"],
                 "type": "object"
             },
-            "DeletedChartContentSummary": {
+            "DeletedChartBase": {
                 "properties": {
                     "organizationUuid": {
                         "type": "string"
@@ -25297,9 +25297,6 @@
                         ],
                         "nullable": true
                     },
-                    "source": {
-                        "$ref": "#/components/schemas/ChartSourceType"
-                    },
                     "contentType": {
                         "$ref": "#/components/schemas/ContentType.CHART"
                     },
@@ -25322,13 +25319,65 @@
                     "deletedBy",
                     "deletedAt",
                     "chartKind",
-                    "source",
                     "contentType",
                     "description",
                     "name",
                     "uuid"
                 ],
                 "type": "object"
+            },
+            "ChartSourceType.DBT_EXPLORE": {
+                "enum": ["dbt_explore"],
+                "type": "string"
+            },
+            "WithDescendantCounts_DeletedDbtChartContentSummary.scheduler_": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/DeletedChartBase"
+                    },
+                    {
+                        "properties": {
+                            "source": {
+                                "$ref": "#/components/schemas/ChartSourceType.DBT_EXPLORE"
+                            }
+                        },
+                        "required": ["source"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "schedulerCount": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": ["schedulerCount"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ChartSourceType.SQL": {
+                "enum": ["sql"],
+                "type": "string"
+            },
+            "DeletedSqlChartContentSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/DeletedChartBase"
+                    },
+                    {
+                        "properties": {
+                            "source": {
+                                "$ref": "#/components/schemas/ChartSourceType.SQL"
+                            }
+                        },
+                        "required": ["source"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "WithDescendantCounts_DeletedSqlChartContentSummary.never_": {
+                "$ref": "#/components/schemas/DeletedSqlChartContentSummary"
             },
             "DeletedDashboardContentSummary": {
                 "properties": {
@@ -25392,6 +25441,27 @@
                 ],
                 "type": "object"
             },
+            "WithDescendantCounts_DeletedDashboardContentSummary.chart-or-scheduler_": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/DeletedDashboardContentSummary"
+                    },
+                    {
+                        "properties": {
+                            "schedulerCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "chartCount": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": ["schedulerCount", "chartCount"],
+                        "type": "object"
+                    }
+                ]
+            },
             "DeletedSpaceContentSummary": {
                 "properties": {
                     "organizationUuid": {
@@ -25454,20 +25524,57 @@
                 ],
                 "type": "object"
             },
-            "DeletedContentSummary": {
-                "anyOf": [
-                    {
-                        "$ref": "#/components/schemas/DeletedChartContentSummary"
-                    },
-                    {
-                        "$ref": "#/components/schemas/DeletedDashboardContentSummary"
-                    },
+            "WithDescendantCounts_DeletedSpaceContentSummary.nestedSpace-or-dashboard-or-chart-or-scheduler_": {
+                "allOf": [
                     {
                         "$ref": "#/components/schemas/DeletedSpaceContentSummary"
+                    },
+                    {
+                        "properties": {
+                            "nestedSpaceCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "schedulerCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "dashboardCount": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "chartCount": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": [
+                            "nestedSpaceCount",
+                            "schedulerCount",
+                            "dashboardCount",
+                            "chartCount"
+                        ],
+                        "type": "object"
                     }
                 ]
             },
-            "KnexPaginatedData_DeletedContentSummary-Array_": {
+            "DeletedContentWithDescendants": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/WithDescendantCounts_DeletedDbtChartContentSummary.scheduler_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/WithDescendantCounts_DeletedSqlChartContentSummary.never_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/WithDescendantCounts_DeletedDashboardContentSummary.chart-or-scheduler_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/WithDescendantCounts_DeletedSpaceContentSummary.nestedSpace-or-dashboard-or-chart-or-scheduler_"
+                    }
+                ]
+            },
+            "KnexPaginatedData_DeletedContentWithDescendants-Array_": {
                 "properties": {
                     "pagination": {
                         "allOf": [
@@ -25492,7 +25599,7 @@
                     },
                     "data": {
                         "items": {
-                            "$ref": "#/components/schemas/DeletedContentSummary"
+                            "$ref": "#/components/schemas/DeletedContentWithDescendants"
                         },
                         "type": "array"
                     }
@@ -25503,7 +25610,7 @@
             "ApiDeletedContentResponse": {
                 "properties": {
                     "results": {
-                        "$ref": "#/components/schemas/KnexPaginatedData_DeletedContentSummary-Array_"
+                        "$ref": "#/components/schemas/KnexPaginatedData_DeletedContentWithDescendants-Array_"
                     },
                     "status": {
                         "type": "string",
@@ -25592,7 +25699,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2461.0",
+        "version": "0.2468.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -39072,6 +39179,53 @@
                         }
                     }
                 }
+            },
+            "delete": {
+                "operationId": "deleteMetricsTree",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Delete a saved metrics tree and its associated nodes",
+                "summary": "Delete metrics tree",
+                "tags": ["Catalog"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "metricsTreeUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/projects/{projectUuid}/dataCatalog/metrics/trees/{metricsTreeUuid}/lock": {

--- a/packages/backend/src/models/CatalogModel/CatalogModel.ts
+++ b/packages/backend/src/models/CatalogModel/CatalogModel.ts
@@ -2341,6 +2341,24 @@ export class CatalogModel {
         return this.getMetricsTreeByUuid(projectUuid, metricsTreeUuid);
     }
 
+    async deleteMetricsTree(
+        projectUuid: string,
+        metricsTreeUuid: string,
+    ): Promise<void> {
+        const deletedCount = await this.database(MetricsTreesTableName)
+            .where({
+                metrics_tree_uuid: metricsTreeUuid,
+                project_uuid: projectUuid,
+            })
+            .delete();
+
+        if (deletedCount === 0) {
+            throw new NotFoundError(
+                `Metrics tree ${metricsTreeUuid} not found in project ${projectUuid}`,
+            );
+        }
+    }
+
     async getDistinctOwners(projectUuid: string): Promise<
         {
             userUuid: string;


### PR DESCRIPTION
Part of: ZAP-252

### Description:
Added a new API endpoint to delete metrics trees and their associated nodes. The implementation includes:

- New `deleteMetricsTree` controller method in `CatalogController`
- Supporting service method in `CatalogService` with proper permission checks
- Model method in `CatalogModel` to handle the database deletion
- Validation to prevent deletion of trees that are currently being edited

This completes the CRUD operations for metrics trees by adding the missing delete functionality.