### PR TITLE
fix: validate Databricks OAuth refresh token and improve token refresh handling

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
@@ -71,6 +71,12 @@ export const databricksPassportStrategy = !(
                       },
                   };
 
+                  if (!refreshToken) {
+                      throw new Error(
+                          'Databricks OAuth refresh token was not returned. Ensure offline_access scope is granted.',
+                      );
+                  }
+
                   // Create user warehouse credentials with the refresh token
                   // so they can use it to query Databricks SQL warehouses
                   Logger.info(

--- a/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
+++ b/packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts
@@ -1,5 +1,7 @@
 import {
     assertUnreachable,
+    DatabricksAuthenticationType,
+    databricksOauthU2mUserCredentialsSchema,
     NotFoundError,
     SnowflakeAuthenticationType,
     snowflakeSsoUserCredentialsSchema,
@@ -207,6 +209,23 @@ export class UserWarehouseCredentialsModel {
                 if (!result.success) {
                     throw new SnowflakeTokenError(
                         `Please reauthenticate to access snowflake`,
+                    );
+                }
+            }
+
+            if (
+                credentialsWithSecrets.credentials.type ===
+                    WarehouseTypes.DATABRICKS &&
+                credentialsWithSecrets.credentials.authenticationType ===
+                    DatabricksAuthenticationType.OAUTH_U2M
+            ) {
+                const result =
+                    databricksOauthU2mUserCredentialsSchema.safeParse(
+                        credentialsWithSecrets.credentials,
+                    );
+                if (!result.success) {
+                    throw new UnexpectedServerError(
+                        `Please reauthenticate to access databricks`,
                     );
                 }
             }

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+    DatabricksAuthenticationType,
     SnowflakeAuthenticationType,
     WarehouseTypes,
     type CreateAthenaCredentials,
@@ -86,5 +87,19 @@ export const snowflakeSsoUserCredentialsSchema = z
         password: z.string().optional(),
         authenticationType: z.literal(SnowflakeAuthenticationType.SSO),
         refreshToken: z.string(),
+    })
+    .strict();
+
+// Zod schema for validating Databricks OAuth U2M user warehouse credentials
+// Requires refreshToken and allows optional compatibility fields
+export const databricksOauthU2mUserCredentialsSchema = z
+    .object({
+        type: z.literal(WarehouseTypes.DATABRICKS),
+        authenticationType: z.literal(DatabricksAuthenticationType.OAUTH_U2M),
+        refreshToken: z.string(),
+        personalAccessToken: z.string().optional(),
+        database: z.string().optional(),
+        serverHostName: z.string().optional(),
+        httpPath: z.string().optional(),
     })
     .strict();

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -619,6 +619,7 @@ export const refreshDatabricksOAuthToken = async (
     host: string,
     clientId: string,
     refreshToken: string,
+    clientSecret?: string,
 ): Promise<{
     accessToken: string;
     refreshToken: string;
@@ -626,16 +627,21 @@ export const refreshDatabricksOAuthToken = async (
 }> => {
     const tokenUrl = `https://${host}/oidc/v1/token`;
 
+    const params = new URLSearchParams({
+        grant_type: 'refresh_token',
+        refresh_token: refreshToken,
+        client_id: clientId,
+    });
+    if (clientSecret) {
+        params.set('client_secret', clientSecret);
+    }
+
     const response = await fetch(tokenUrl, {
         method: 'POST',
         headers: {
             'Content-Type': 'application/x-www-form-urlencoded',
         },
-        body: new URLSearchParams({
-            grant_type: 'refresh_token',
-            refresh_token: refreshToken,
-            client_id: clientId,
-        }).toString(),
+        body: params.toString(),
     });
 
     if (!response.ok) {


### PR DESCRIPTION
# Databricks OAuth U2M — All Flows

## Flow 1: OAuth Callback (popup completing)

**When:** User clicks "Connect to Databricks" button, authenticates in Databricks popup, popup redirects back.

**Bug fixes:**

- **Issue No.4** — Guard against missing `refreshToken` before storing credentials
    - `packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts` — added `if (!refreshToken)` check
- **Issue No.6** — Zod schema validation for Databricks U2M credentials
    - `packages/common/src/types/userWarehouseCredentials.ts` — added `databricksOauthU2mUserCredentialsSchema`
    - `packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts` — validate on read in `findForProjectWithSecrets`

```
GET /api/v1/oauth/redirect/databricks?code=...&state=...
  → passport-oauth2 exchanges authorization code for tokens (PKCE)
      → POST https://{host}/oidc/v1/token (with client_id + client_secret)
      → receives accessToken + refreshToken
  → databricksPassportStrategy verify callback
      🆕 if (!refreshToken) throw Error ← prevents storing unusable creds
      → UserService.createDatabricksWarehouseCredentials(user, refreshToken)
          → deletes old Databricks user_warehouse_credentials
          🆕 validated by databricksOauthU2mUserCredentialsSchema (zod)
          → encrypts + inserts into user_warehouse_credentials table
      → UserService.loginWithOpenId(openIdUser, user, undefined, refreshToken)
          → openIdIdentityModel.updateIdentityByOpenId({ refreshToken })
          → stores refreshToken in open_id_identities table
  → redirect back to app
```

Tokens are now stored in **two places**:

- `user_warehouse_credentials` — used by query path (Flow 3) and dbt sync fallback (Flow 4)
- `open_id_identities` — used by project create/update paths (Flows 2, 5)

---

## Flow 2: Project Creation

**When:** User fills out "Connect Project" form and submits. Tests warehouse connection before saving.

**Bug fixes:**

- **Issue No.1** — Passes `clientSecret` during token refresh
    - `packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts` — added `clientSecret?` param to `refreshDatabricksOAuthToken`
    - `packages/backend/src/services/ProjectService/ProjectService.ts` — resolves `clientSecret` from config in `refreshCredentials` U2M branch
- **Issue No.5 (partial)** — Added U2M to `_resolveWarehouseClientCredentials`
    - `packages/backend/src/services/ProjectService/ProjectService.ts` — combined M2M/U2M condition in `_resolveWarehouseClientCredentials`

```
POST /api/v1/org/projects/precompiled
  → ProjectService.scheduleCreate()
      → encrypts project data, creates job record
      → schedulerClient.createProjectWithCompile() ← queues worker job

--- worker picks up job ---

SchedulerTask.createProjectWithCompile()
  → decrypts project data
  → ProjectService._create(user, projectData, jobUuid, method)
      → _resolveWarehouseClientCredentials(data, userUuid, orgUuid)
          🆕 U2M now enters combined M2M/U2M branch
          → userModel.getRefreshToken(userUuid, DATABRICKS) ← from open_id_identities
          → refreshCredentials({ ...warehouseConnection, refreshToken })
              → enters U2M branch
              🆕 resolves clientSecret from config
              🆕 passes clientSecret to refreshDatabricksOAuthToken()
              → POST https://{host}/oidc/v1/token ← now includes client_secret
              → returns { ...args, token: accessToken, refreshToken: newRefreshToken }
          → returns warehouseConnection with token populated ✅
      → testProjectAdapter(createProject)
          → new DatabricksWarehouseClient(credentials)
              → credentials.token exists ✅
      → compileAllExplores()
      → projectModel.create() + save credentials
```

---

## Flow 3: Query Execution

**When:** User runs any query — explores, SQL runner, chart refreshes, dashboard tile loads. The main data path.

**Bug fixes:**

- **Issue No.1** — Passes `clientSecret` during token refresh
    - `packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts` — `refreshDatabricksOAuthToken` accepts optional `clientSecret`
    - `packages/backend/src/services/ProjectService/ProjectService.ts` — resolves and passes `clientSecret` in `refreshCredentials` U2M branch
- **Issue No.2** — Proper error logging
    - `packages/backend/src/services/ProjectService/ProjectService.ts` — `getErrorMessage(e)` instead of `JSON.stringify(e)` in both M2M and U2M catch blocks
- **Issue No.6** — Zod schema validation on credential load
    - `packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts` — validates in `findForProjectWithSecrets`

```
POST /api/v2/projects/:uuid/query/metric-query (or any query endpoint)
  → getWarehouseCredentials(projectUuid, userId)
      → loads project credentials from warehouse_credentials table
      → finds user credentials from user_warehouse_credentials table
          🆕 validates with databricksOauthU2mUserCredentialsSchema (zod)
      → merges: { ...projectCreds, ...userCreds } ← authenticationType becomes oauth_u2m
      → refreshCredentials(merged, userId)
          → enters U2M branch
          🆕 resolves clientSecret from lightdashConfig || args.oauthClientSecret
          🆕 passes clientSecret to refreshDatabricksOAuthToken()
          → POST https://{host}/oidc/v1/token (with client_id + client_secret + refresh_token)
          🆕 error logging: getErrorMessage(e) instead of JSON.stringify(e)
          → returns credentials with token
      → returns merged credentials with access token
  → _getWarehouseClient(credentials)
      → new DatabricksWarehouseClient(credentials)
          → credentials.token exists ✅
  → execute query
```

---

## Flow 4: dbt Sync / Compile

**When:** User clicks "Sync dbt" or a scheduled refresh compiles the dbt project to update explores/models.

**Bug fixes:**

- **Issue No.1 / No.7** — Passes `clientSecret` during token refresh
    - `packages/backend/src/services/ProjectService/ProjectService.ts` — resolves `clientSecret` from config in `buildAdapter` U2M block
- **Issue No.5** — Falls back to user warehouse credentials when project has no refresh token
    - `packages/backend/src/services/ProjectService/ProjectService.ts` — `buildAdapter` now queries `userWarehouseCredentialsModel.findForProjectWithSecrets()` as fallback

```
compileProject() / _compile()
  → buildAdapter(projectUuid, user)
      → projectModel.getWithSensitiveFields() ← project-level creds
      → if authenticationType === OAUTH_U2M:
          → check project.warehouseConnection.refreshToken
          🆕 if missing → fallback to userWarehouseCredentialsModel.findForProjectWithSecrets()
          → if refreshToken found from either source:
              🆕 resolves clientId from config → project → default
              🆕 resolves clientSecret from config → project
              → refreshDatabricksOAuthToken(host, clientId, refreshToken, clientSecret)
              → sets project.warehouseConnection.token = accessToken ✅
              → updates refreshToken in-memory
      → projectAdapterFromConfig(dbtConnection, warehouseConnection)
      → adapter.compileAllExplores()
```

---

## Flow 5: Project Update

**When:** User edits warehouse/dbt settings in project settings and saves.

**Bug fixes:**

- **Issue No.1** — Passes `clientSecret` during token refresh (same as Flow 2)
    - `packages/backend/src/services/ProjectService/ProjectService.ts` — `refreshCredentials` U2M branch
- **Issue No.5 (partial)** — U2M branch in `_resolveWarehouseClientCredentials` (same as Flow 2)
    - `packages/backend/src/services/ProjectService/ProjectService.ts` — combined M2M/U2M condition

```
PATCH /api/v1/projects/:projectUuid
  → ProjectService.updateAndScheduleAsyncWork()
      → _resolveWarehouseClientCredentials(data, userId, orgUuid)
          🆕 U2M enters combined M2M/U2M branch
          → userModel.getRefreshToken(userUuid, DATABRICKS) ← from open_id_identities
          → refreshCredentials({ ...warehouseConnection, refreshToken })
              🆕 resolves clientSecret, passes to refreshDatabricksOAuthToken()
              → returns credentials with access token ✅
      → mergeMissingProjectConfigSecrets()
      → projectModel.update() ← saves resolved creds (with token + refreshToken) to DB
      → schedulerClient.testAndCompileProject() ← queues worker job

--- worker picks up job ---

SchedulerTask.testAndCompileProject()
  → ProjectService.testAndCompileProject()
      → projectModel.getWithSensitiveFields() ← re-reads from DB (has token)
      → testProjectAdapter(updatedProject)
          → new DatabricksWarehouseClient(credentials)
              → credentials.token exists ✅ (saved by update above)
      → compileAllExplores() (if dbt connection configured)
```

---

## Files Modified

| File | Issues |
| --- | --- |
| `packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts` | No.1 — added `clientSecret?` param to `refreshDatabricksOAuthToken` |
| `packages/backend/src/services/ProjectService/ProjectService.ts` | No.1 — pass `clientSecret` in `refreshCredentials` + `buildAdapter`; No.2 — `getErrorMessage(e)` in catch blocks; No.5 — combined M2M/U2M in `_resolveWarehouseClientCredentials` + user cred fallback in `buildAdapter` |
| `packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts` | No.4 — guard `!refreshToken` before storing |
| `packages/common/src/types/userWarehouseCredentials.ts` | No.6 — `databricksOauthU2mUserCredentialsSchema` zod schema |
| `packages/backend/src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts` | No.6 — validate Databricks U2M in `findForProjectWithSecrets` |

---

## Summary of Issues Fixed Per Flow

| Issue | Description | Flow 1 | Flow 2 | Flow 3 | Flow 4 | Flow 5 |
| --- | --- | --- | --- | --- | --- | --- |
| No.1 | U2M refresh omits `client_secret` | — | ✅ | ✅ | ✅ | ✅ |
| No.2 | Error logging hides Databricks error | — | — | ✅ | — | — |
| No.4 | Missing `refreshToken` guard in callback | ✅ | — | — | — | — |
| No.5 | `buildAdapter` uses project creds only | — | ✅ | — | ✅ | ✅ |
| No.6 | No zod validation for Databricks U2M | ✅ | — | ✅ | — | — |
| No.7 | `buildAdapter` refresh omits `client_secret` | — | — | — | ✅ | — |

