### PR TITLE
feat: add reactive YAML edge injection in metrics tree editor

### DIFF
--- a/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/Canvas/SavedTreeCanvasFlow.tsx
@@ -34,6 +34,8 @@ type Props = {
     onCanvasStateChange?: (nodes: ExpandedNodeData[], edges: Edge[]) => void;
     /** Optional filter applied only to the sidebar list (not the canvas) */
     sidebarFilter?: (node: ExpandedNodeData) => boolean;
+    /** All YAML edges for the project — used to inject YAML edges reactively in edit mode */
+    allProjectYamlEdges?: CatalogMetricsTreeEdge[];
 };
 
 const SavedTreeCanvasFlow: FC<Props> = ({
@@ -42,6 +44,7 @@ const SavedTreeCanvasFlow: FC<Props> = ({
     viewOnly,
     onCanvasStateChange,
     sidebarFilter,
+    allProjectYamlEdges,
 }) => {
     const theme = useMantineTheme();
 
@@ -52,6 +55,7 @@ const SavedTreeCanvasFlow: FC<Props> = ({
         preventResetAfterInit: !viewOnly, // In edit mode, prevent background refetch resets
         onCanvasStateChange,
         sidebarFilter,
+        allProjectYamlEdges,
         // No onEdgeCreated/onEdgesDeleted -- edges stay local until explicit save
     });
 


### PR DESCRIPTION
Closes: ZAP-251

### Description:

This PR enhances the Metrics Catalog Canvas to reactively display YAML-defined edges when editing a saved tree. Now when users add nodes to the canvas that have YAML-defined relationships, those connections automatically appear.

[CleanShot 2026-02-16 at 12.50.58.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/90c440dd-45bf-40c7-9921-593df0708c7c.mp4" />](https://app.graphite.com/user-attachments/video/90c440dd-45bf-40c7-9921-593df0708c7c.mp4)

