### PR TITLE
feat: add day of week index adjustment for custom week start

### DIFF
--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -62,6 +62,195 @@ describe('TimeFrames', () => {
         });
     });
 
+    describe('getSqlForDatePart - DAY_OF_WEEK_INDEX with startOfWeek', () => {
+        const col = '${TABLE}.created';
+        const tf = TimeFrames.DAY_OF_WEEK_INDEX;
+        const dt = DimensionType.DATE;
+
+        test('should adjust day of week index for Monday start', () => {
+            // BigQuery: native DAYOFWEEK 1=Sun..7=Sat, offset for Monday = 2
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.BIGQUERY,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`MOD(EXTRACT(DAYOFWEEK FROM ${col}) - 2 + 7, 7) + 1`);
+
+            // PostgreSQL: native DOW 0=Sun..6=Sat, offset for Monday = 1
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.POSTGRES,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(
+                `MOD(CAST(DATE_PART('DOW', ${col}) AS INT) - 1 + 7, 7) + 1`,
+            );
+
+            // Redshift uses same config as PostgreSQL
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.REDSHIFT,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(
+                `MOD(CAST(DATE_PART('DOW', ${col}) AS INT) - 1 + 7, 7) + 1`,
+            );
+
+            // Databricks: native DOW 0=Sun..6=Sat, offset for Monday = 1
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.DATABRICKS,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(
+                `MOD(CAST(DATE_PART('DOW', ${col}) AS INT) - 1 + 7, 7) + 1`,
+            );
+
+            // Trino: native DOW (ISO) 1=Mon..7=Sun, offset for Monday = 1
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.TRINO,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`MOD(EXTRACT(DOW FROM ${col}) - 1 + 7, 7) + 1`);
+
+            // Athena uses Trino config
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.ATHENA,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`MOD(EXTRACT(DOW FROM ${col}) - 1 + 7, 7) + 1`);
+
+            // ClickHouse: native toDayOfWeek (ISO) 1=Mon..7=Sun, offset for Monday = 1
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`modulo(toDayOfWeek(${col}) - 1 + 7, 7) + 1`);
+        });
+
+        test('should adjust day of week index for Sunday start', () => {
+            // BigQuery: offset for Sunday = (6+1)%7+1 = 0+1 = 1
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.BIGQUERY,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.SUNDAY,
+                ),
+            ).toEqual(`MOD(EXTRACT(DAYOFWEEK FROM ${col}) - 1 + 7, 7) + 1`);
+
+            // PostgreSQL: offset for Sunday = (6+1)%7 = 0
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.POSTGRES,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.SUNDAY,
+                ),
+            ).toEqual(
+                `MOD(CAST(DATE_PART('DOW', ${col}) AS INT) - 0 + 7, 7) + 1`,
+            );
+
+            // Trino: offset for Sunday = 6+1 = 7
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.TRINO,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.SUNDAY,
+                ),
+            ).toEqual(`MOD(EXTRACT(DOW FROM ${col}) - 7 + 7, 7) + 1`);
+
+            // ClickHouse: offset for Sunday = 6+1 = 7
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.SUNDAY,
+                ),
+            ).toEqual(`modulo(toDayOfWeek(${col}) - 7 + 7, 7) + 1`);
+        });
+
+        test('should not adjust day of week index when startOfWeek is not set', () => {
+            // Without startOfWeek, native behavior is preserved
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.BIGQUERY,
+                    tf,
+                    col,
+                    dt,
+                ),
+            ).toEqual(`EXTRACT(DAYOFWEEK FROM ${col})`);
+
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.POSTGRES,
+                    tf,
+                    col,
+                    dt,
+                ),
+            ).toEqual(`DATE_PART('DOW', ${col})`);
+
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.TRINO,
+                    tf,
+                    col,
+                    dt,
+                ),
+            ).toEqual(`EXTRACT(DOW FROM ${col})`);
+
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    tf,
+                    col,
+                    dt,
+                ),
+            ).toEqual(`toDayOfWeek(${col})`);
+
+            // Snowflake: always uses session variable, never adjusts
+            expect(
+                timeFrameConfigs[tf].getSql(
+                    SupportedDbtAdapter.SNOWFLAKE,
+                    tf,
+                    col,
+                    dt,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(`DATE_PART('DOW', ${col})`);
+        });
+    });
+
     describe('getDateDimension', () => {
         test('should parse dates', async () => {
             // Invalid date granularities


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2994/day-of-week-index-ignores-start-of-week-setting

Also fixed consistent range between warehouses (1-7) 

```
                                             
   
  PostgreSQL's DOW returns 0-indexed values: 0=Sunday, 1=Monday, ..., 6=Saturday. Other warehouses had   
  different native ranges (BigQuery: 1-7, Trino/ClickHouse: 1-7 ISO). So the old behavior was
  inconsistent across warehouses too.

  The fix normalizes all warehouses to 1-7 (where 1 = start-of-week day). This is a change from the old
  PostgreSQL 0-indexed output, but it's the intended behavior per the issue spec and makes things
  consistent across all warehouses.
```

Before

<img width="1493" height="777" alt="Screenshot from 2026-02-16 13-28-55" src="https://github.com/user-attachments/assets/7cd1b55e-9fd3-4600-99b2-d77c6bda6c37" />

After (starting wednesday)

postgres 

<img width="1493" height="777" alt="Screenshot from 2026-02-16 13-31-13" src="https://github.com/user-attachments/assets/7a7af794-2d3c-4555-b9d3-5030352afa4d" />

bigquery

<img width="1501" height="834" alt="Screenshot from 2026-02-16 13-33-50" src="https://github.com/user-attachments/assets/f4ee0538-27a4-4ffd-be54-c95b2fe90fa1" />

### Description:
Adds support for custom week start days in DAY_OF_WEEK_INDEX calculations across all supported database adapters. This allows users to configure whether weeks should start on Monday, Sunday, or any other day when using day-of-week dimensions.

The implementation adjusts the SQL generation for BigQuery, PostgreSQL, Redshift, Databricks, Trino, Athena, and ClickHouse to normalize day-of-week indexes based on the configured start day. Each adapter handles the adjustment differently based on their native day-of-week indexing system.

test-frontend test-backend