### PR TITLE
fix: improve PDF export formatting for embedded dashboards

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportPdf.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardExportPdf.tsx
@@ -41,17 +41,46 @@ const EmbedDashboardExportPdf: FC<Props> = ({
                         'embed-scroll-container',
                     );
 
+                    const originalStyles = {
+                        height: '',
+                        overflowY: '',
+                        overflow: '',
+                    };
+
+                    // Dynamically set the print page width to match the
+                    // dashboard content. react-grid-layout computes tile
+                    // positions based on the viewport width, so we size the
+                    // page to match rather than scaling the content down.
+                    let pageStyle: HTMLStyleElement | null = null;
+
                     if (printContainer) {
+                        originalStyles.height = printContainer.style.height;
+                        originalStyles.overflowY =
+                            printContainer.style.overflowY;
+                        originalStyles.overflow = printContainer.style.overflow;
+
+                        // Expand container for multi-page printing
                         printContainer.style.height = 'auto';
                         printContainer.style.overflowY = 'visible';
+                        printContainer.style.overflow = 'visible';
+
+                        const contentWidth = printContainer.scrollWidth;
+                        // 10mm margin on each side ≈ 76px at 96 dpi
+                        const PAGE_MARGIN_PX = 76;
+                        pageStyle = document.createElement('style');
+                        pageStyle.textContent = `@media print { @page { size: ${contentWidth + PAGE_MARGIN_PX}px 11in; margin: 10mm; } }`;
+                        document.head.appendChild(pageStyle);
                     }
 
                     window.print();
 
                     if (printContainer) {
-                        printContainer.style.height = '100vh';
-                        printContainer.style.overflowY = 'auto';
+                        printContainer.style.height = originalStyles.height;
+                        printContainer.style.overflowY =
+                            originalStyles.overflowY;
+                        printContainer.style.overflow = originalStyles.overflow;
                     }
+                    pageStyle?.remove();
                 }}
                 size="lg"
                 radius="md"

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/styles/print.css
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/styles/print.css
@@ -1,10 +1,10 @@
 @media print {
-    @page {
-        margin-top: 0;
-        margin-bottom: 0;
-    }
     body {
         -webkit-print-color-adjust: exact;
         print-color-adjust: exact;
+    }
+    #embed-scroll-container {
+        height: auto !important;
+        overflow: visible !important;
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2956/printing-embedded-dashboards-sometimes-gets-cut-off-horizontally

Note: now pdf aspect ratio might change

Before

<img width="1532" height="980" alt="image" src="https://github.com/user-attachments/assets/367b82a7-4813-428e-882e-8a98e9094223" />

After
<img width="941" height="1060" alt="Screenshot from 2026-02-16 13-59-47" src="https://github.com/user-attachments/assets/fd79fdb2-af82-41bd-89ce-1d32d754f9d5" />

<img width="1674" height="1061" alt="Screenshot from 2026-02-16 13-59-35" src="https://github.com/user-attachments/assets/c904eb41-0ac4-48f9-8604-2ef66b053b54" />


### Description:
Improves PDF export for embedded dashboards by dynamically sizing the print page to match dashboard content width. This prevents content from being scaled down or cut off during printing.

The implementation:
- Preserves original container styles and restores them after printing
- Dynamically calculates the optimal page width based on content
- Adds proper page margins (10mm)
- Ensures dashboard content is fully visible in the printed output