### PR TITLE
chore: remove getRootSpaceIsPrivateQuery from SpaceModel.find and get

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -55,7 +55,6 @@ import {
     generateUniqueSpaceSlug,
 } from '../utils/SlugUtils';
 import type { GetDashboardDetailsQuery } from './DashboardModel/DashboardModel';
-import { getRootSpaceIsPrivateQuery } from './SpacePermissionModel';
 
 type SpaceModelArguments = {
     database: Knex;
@@ -229,9 +228,7 @@ export class SpaceModel {
                 `${DashboardsTableName}.dashboard_uuid`,
                 `${DashboardsTableName}.name as dashboard_name`,
                 `${SavedChartsTableName}.slug`,
-                this.database.raw(
-                    `${getRootSpaceIsPrivateQuery()} AS is_private`,
-                ),
+                `${SpaceTableName}.is_private`,
             ])
             .orderBy(`${SavedChartsTableName}.last_version_updated_at`, 'desc')
             .where(`${SavedChartsTableName}.space_id`, space.space_id)
@@ -330,7 +327,7 @@ export class SpaceModel {
                         projectUuid: `${ProjectTableName}.project_uuid`,
                         uuid: `${SpaceTableName}.space_uuid`,
                         name: `${SpaceTableName}.name`,
-                        isPrivate: trx.raw(getRootSpaceIsPrivateQuery()),
+                        isPrivate: `${SpaceTableName}.is_private`,
                         pinnedListUuid: `${PinnedListTableName}.pinned_list_uuid`,
                         pinnedListOrder: `${PinnedSpaceTableName}.order`,
                         chartCount: trx
@@ -472,9 +469,6 @@ export class SpaceModel {
                     Pick<DBPinnedSpace, 'order'>)[]
             >([
                 `${SpaceTableName}.*`,
-                this.database.raw(
-                    `${getRootSpaceIsPrivateQuery()} AS is_private`,
-                ),
                 `${ProjectTableName}.project_uuid`,
                 `${OrganizationTableName}.organization_uuid`,
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5714,6 +5714,7 @@ export class ProjectService extends BaseService {
                 const ctx = spacesCtx[spaceSummary.uuid];
                 return {
                     ...spaceSummary,
+                    isPrivate: ctx?.isPrivate ?? spaceSummary.isPrivate,
                     access: ctx
                         ? ctx.access
                               .filter((a) => a.hasDirectAccess)

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -146,6 +146,7 @@ export class SpaceService extends BaseService implements BulkActionable<Knex> {
 
         return {
             ...space,
+            isPrivate: ctx.isPrivate,
             queries,
             dashboards,
             childSpaces,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new

### Description:
This PR simplifies how we determine if a space is private by directly using the `is_private` field from the `SpaceTableName` instead of using the `getRootSpaceIsPrivateQuery()` function. The changes ensure that the `isPrivate` property is properly passed through in the space context in both `ProjectService` and `SpaceService`.

The main changes:
- Remove dependency on `getRootSpaceIsPrivateQuery()` function
- Use the direct `is_private` column from the space table
- Ensure `isPrivate` property is properly passed through in service responses