### PR TITLE
chore: remove getRootSpace SQL helpers from SpaceContentConfiguration

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7376,11 +7376,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7858,11 +7858,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7877,11 +7877,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7896,11 +7896,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7915,11 +7915,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7934,11 +7934,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -24241,11 +24241,6 @@ const models: TsoaRoute.Models = {
             },
             isPrivate: { dataType: 'boolean', required: true },
             inheritParentPermissions: { dataType: 'boolean', required: true },
-            access: {
-                dataType: 'array',
-                array: { dataType: 'string' },
-                required: true,
-            },
             dashboardCount: { dataType: 'double', required: true },
             chartCount: { dataType: 'double', required: true },
             parentSpaceUuid: {
@@ -24257,6 +24252,11 @@ const models: TsoaRoute.Models = {
                 required: true,
             },
             path: { dataType: 'string', required: true },
+            access: {
+                dataType: 'array',
+                array: { dataType: 'string' },
+                required: true,
+            },
         },
         additionalProperties: true,
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8269,6 +8269,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -24998,12 +25011,6 @@
                     "inheritParentPermissions": {
                         "type": "boolean"
                     },
-                    "access": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "dashboardCount": {
                         "type": "number",
                         "format": "double"
@@ -25018,6 +25025,12 @@
                     },
                     "path": {
                         "type": "string"
+                    },
+                    "access": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
                     }
                 },
                 "required": [
@@ -25038,11 +25051,11 @@
                     "firstViewedAt",
                     "isPrivate",
                     "inheritParentPermissions",
-                    "access",
                     "dashboardCount",
                     "chartCount",
                     "parentSpaceUuid",
-                    "path"
+                    "path",
+                    "access"
                 ],
                 "type": "object",
                 "additionalProperties": true
@@ -25640,7 +25653,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2471.2",
+        "version": "0.2475.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/ContentModel/ContentModel.ts
+++ b/packages/backend/src/models/ContentModel/ContentModel.ts
@@ -6,7 +6,7 @@ import {
     DeletedContentWithDescendants,
     KnexPaginateArgs,
     KnexPaginatedData,
-    SummaryContent,
+    SummaryContentBase,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import KnexPaginate from '../../database/pagination';
@@ -50,7 +50,7 @@ export class ContentModel {
         filters: ContentFilters,
         queryArgs: ContentArgs,
         paginateArgs?: KnexPaginateArgs,
-    ): Promise<KnexPaginatedData<SummaryContent[]>> {
+    ): Promise<KnexPaginatedData<SummaryContentBase[]>> {
         const matchingConfigurations = this.contentConfigurations.filter(
             (config) => config.shouldQueryBeIncluded(filters),
         );

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -2,7 +2,7 @@ import {
     ChartContent,
     ContentSortByColumns,
     ContentType,
-    SummaryContent,
+    SummaryContentBase,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 
@@ -75,5 +75,5 @@ export type ContentConfiguration<
     shouldQueryBeIncluded: (filters: ContentFilters) => boolean;
     getSummaryQuery: (knex: Knex, filters: ContentFilters) => Knex.QueryBuilder;
     shouldRowBeConverted: (value: SummaryContentRow) => value is T;
-    convertSummaryRow: (value: SummaryContentRow) => SummaryContent;
+    convertSummaryRow: (value: SummaryContentRow) => SummaryContentBase;
 };

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -12,7 +12,7 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SpacePermissionModel } from '../../models/SpacePermissionModel';
 import { BaseService } from '../BaseService';
 
-type SpaceAccessContextForCasl = {
+export type SpaceAccessContextForCasl = {
     organizationUuid: string;
     projectUuid: string;
     isPrivate: boolean;

--- a/packages/common/src/types/content.ts
+++ b/packages/common/src/types/content.ts
@@ -74,11 +74,10 @@ export interface DashboardContent extends Content {
     contentType: ContentType.DASHBOARD;
 }
 
-export interface SpaceContent extends Content {
+export interface SpaceContentBase extends Content {
     contentType: ContentType.SPACE;
     isPrivate: boolean;
     inheritParentPermissions: boolean;
-    access: string[];
     dashboardCount: number;
     chartCount: number;
     pinnedList: {
@@ -89,8 +88,19 @@ export interface SpaceContent extends Content {
     path: string;
 }
 
+export interface SpaceContent extends SpaceContentBase {
+    access: string[];
+}
+
 // Group types
 
+// What the model returns (spaces without access data)
+export type SummaryContentBase =
+    | ChartContent
+    | DashboardContent
+    | SpaceContentBase;
+
+// What the API returns (spaces enriched with access data)
 export type SummaryContent = ChartContent | DashboardContent | SpaceContent; // Note: more types will be added.
 
 // API types


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-168/migrate-all-spaces-permissions-checks-to-use-the-new

### Description:
Refactored space content access data handling to improve performance. Instead of fetching access data in the SQL query, we now enrich the base space content with access information in the service layer. This change:

1. Created a new `SpaceContentBase` type without access properties
2. Modified `ContentModel` to return `SpaceContentBase` instead of `SpaceContent`
3. Enhanced `ContentService` to enrich spaces with access data after fetching
4. Removed unnecessary group by clauses and joins in the space content query

This approach allows for more efficient space content queries while maintaining the same API response structure.