### PR TITLE
fix: role cy test leaking data into groups.cy.ts

### DIFF
--- a/packages/e2e/cypress/e2e/api/roles.cy.ts
+++ b/packages/e2e/cypress/e2e/api/roles.cy.ts
@@ -557,10 +557,15 @@ describe('Roles API Tests', () => {
 
     describe('Project Access Management', () => {
         afterEach(() => {
-            // Clean up project access for SEED_ORG_1_ADMIN to avoid polluting other tests
+            // Clean up project access to avoid polluting other tests
             cy.login();
             cy.request({
                 url: `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/user/${SEED_ORG_1_ADMIN.user_uuid}`,
+                method: 'DELETE',
+                failOnStatusCode: false,
+            });
+            cy.request({
+                url: `${projectRolesApiUrl}/${SEED_PROJECT.project_uuid}/roles/assignments/group/${SEED_GROUP.groupUuid}`,
                 method: 'DELETE',
                 failOnStatusCode: false,
             });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Enhanced the cleanup process in the Project Access Management test suite by adding a DELETE request to remove group assignments after each test. This prevents test pollution by ensuring both user and group project role assignments are properly cleaned up.