### PR TITLE
fix: prioritize CLI-provided OAuth credentials for Databricks authentication

### DIFF
--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -35,7 +35,7 @@ import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 /**
  * Pre-registered Databricks public OAuth client ID for U2M authentication.
  * This is a built-in client that doesn't require registering a custom OAuth app.
- * This client id only works on he CLI redirect URIs. For the UI we require a custom OAuth app
+ * This client id only works on the CLI redirect URIs. For the UI we require a custom OAuth app
  * with a valid whitelisted redirect URI.
  * https://docs.databricks.com/en/dev-tools/auth/oauth-u2m.html
  */


### PR DESCRIPTION
### Description:
Prioritizes CLI-provided OAuth credentials over server config for Databricks authentication. This change allows the CLI to use its own OAuth flow by:

1. Prioritizing `oauthClientId` and `oauthClientSecret` from request arguments over server config
2. Accepting refresh tokens directly from request body for CLI-obtained tokens

These changes improve the authentication flow for Databricks connections when using the CLI, while maintaining backward compatibility with browser SSO flows.