### PR TITLE
fix(skills): add date filter operators to metrics reference

### DIFF
--- a/skills/developing-in-lightdash/resources/metrics-reference.md
+++ b/skills/developing-in-lightdash/resources/metrics-reference.md
@@ -139,6 +139,24 @@ metrics:
 - Comparison: `"> 100"`, `"< 50"`, `">= 10"`, `"<= 100"`
 - Multiple values: `["value1", "value2"]`
 - Null checks: `"null"`, `"!null"`
+- Date intervals: `"inThePast N days"`, `"inTheNext N months"` (supports: `days`, `weeks`, `months`, `years`)
+
+**Date filter examples:**
+
+```yaml
+metrics:
+  recent_orders:
+    type: count
+    filters:
+      - created_at: "inThePast 30 days"
+
+  upcoming_renewals:
+    type: count
+    filters:
+      - renewal_date: "inTheNext 7 days"
+```
+
+**Important:** `inTheCurrent` is NOT a valid operator in metric definition filters. It is only available in chart and dashboard filters. If you need current-period logic in a metric, use custom SQL with date truncation instead.
 
 ### Show Underlying Values
 


### PR DESCRIPTION
## Summary
- Adds `inThePast` and `inTheNext` as documented date filter operators for metric definitions in the skills file
- Explicitly notes that `inTheCurrent` is NOT valid in metric definition filters (only in chart/dashboard filters)
- Adds YAML examples for date-based metric filters

Prompted by [Pylon #10820](https://app.usepylon.com/issues?issueNumber=10820) — a customer used the Claude agent skill to create a month-to-date metric, and the agent incorrectly used `inTheCurrent` in the metric YAML definition because the skills file didn't document which date operators are valid in metric filters vs chart filters.

## Test plan
- [x] Verify the metrics-reference.md renders correctly
- [x] Confirm `inThePast` / `inTheNext` syntax matches Lightdash docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)