### PR TITLE
perf(athena): use ListTableMetadataCommand instead of GetTableMetadataCommand

### DIFF
--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
@@ -121,4 +121,204 @@ describe('AthenaWarehouseClient', () => {
             });
         });
     });
+
+    describe('getCatalog', () => {
+        const mockSend = jest.fn();
+
+        beforeEach(() => {
+            mockAthenaClient.mockImplementation(() => ({
+                send: mockSend,
+            }));
+        });
+
+        test('should use ListTableMetadataCommand to fetch catalog', async () => {
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [
+                    {
+                        Name: 'orders',
+                        Columns: [
+                            { Name: 'id', Type: 'integer' },
+                            { Name: 'status', Type: 'varchar' },
+                        ],
+                    },
+                    {
+                        Name: 'users',
+                        Columns: [
+                            { Name: 'id', Type: 'integer' },
+                            { Name: 'name', Type: 'varchar' },
+                        ],
+                    },
+                ],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient(baseCredentials);
+            const catalog = await client.getCatalog([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 'orders',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 'users',
+                },
+            ]);
+
+            expect(catalog).toEqual({
+                AwsDataCatalog: {
+                    my_database: {
+                        orders: { id: 'number', status: 'string' },
+                        users: { id: 'number', name: 'string' },
+                    },
+                },
+            });
+            // Should be a single ListTableMetadataCommand call, not per-table
+            expect(mockSend).toHaveBeenCalledTimes(1);
+        });
+
+        test('should handle multiple schemas in requests', async () => {
+            // First schema response
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [
+                    {
+                        Name: 'orders',
+                        Columns: [{ Name: 'id', Type: 'integer' }],
+                    },
+                ],
+                NextToken: undefined,
+            });
+            // Second schema response
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [
+                    {
+                        Name: 'events',
+                        Columns: [{ Name: 'ts', Type: 'timestamp' }],
+                    },
+                ],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient(baseCredentials);
+            const catalog = await client.getCatalog([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'schema_a',
+                    table: 'orders',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'schema_b',
+                    table: 'events',
+                },
+            ]);
+
+            expect(catalog).toEqual({
+                AwsDataCatalog: {
+                    schema_a: { orders: { id: 'number' } },
+                    schema_b: { events: { ts: 'timestamp' } },
+                },
+            });
+            expect(mockSend).toHaveBeenCalledTimes(2);
+        });
+
+        test('should handle pagination in ListTableMetadataCommand', async () => {
+            // First page
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [
+                    {
+                        Name: 'table1',
+                        Columns: [{ Name: 'col1', Type: 'varchar' }],
+                    },
+                ],
+                NextToken: 'page2',
+            });
+            // Second page
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [
+                    {
+                        Name: 'table2',
+                        Columns: [{ Name: 'col2', Type: 'integer' }],
+                    },
+                ],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient(baseCredentials);
+            const catalog = await client.getCatalog([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 'table1',
+                },
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 'table2',
+                },
+            ]);
+
+            expect(catalog).toEqual({
+                AwsDataCatalog: {
+                    my_database: {
+                        table1: { col1: 'string' },
+                        table2: { col2: 'number' },
+                    },
+                },
+            });
+            expect(mockSend).toHaveBeenCalledTimes(2);
+        });
+
+        test('should filter out tables not in the request', async () => {
+            mockSend.mockResolvedValueOnce({
+                TableMetadataList: [
+                    {
+                        Name: 'orders',
+                        Columns: [{ Name: 'id', Type: 'integer' }],
+                    },
+                    {
+                        Name: 'extra_table',
+                        Columns: [{ Name: 'x', Type: 'varchar' }],
+                    },
+                ],
+                NextToken: undefined,
+            });
+
+            const client = new AthenaWarehouseClient(baseCredentials);
+            const catalog = await client.getCatalog([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'my_database',
+                    table: 'orders',
+                },
+            ]);
+
+            expect(catalog).toEqual({
+                AwsDataCatalog: {
+                    my_database: {
+                        orders: { id: 'number' },
+                    },
+                },
+            });
+        });
+
+        test('should return empty catalog when schema does not exist (MetadataException)', async () => {
+            const metadataError = new Error('Schema not found');
+            (metadataError as unknown as { name: string }).name =
+                'MetadataException';
+            mockSend.mockRejectedValueOnce(metadataError);
+
+            const client = new AthenaWarehouseClient(baseCredentials);
+            const catalog = await client.getCatalog([
+                {
+                    database: 'AwsDataCatalog',
+                    schema: 'nonexistent',
+                    table: 'some_table',
+                },
+            ]);
+
+            expect(catalog).toEqual({});
+        });
+    });
 });

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.test.ts
@@ -4,6 +4,7 @@ import {
     WarehouseTypes,
 } from '@lightdash/common';
 
+const mockSend = jest.fn();
 const mockAthenaClient = jest.fn();
 jest.mock('@aws-sdk/client-athena', () => ({
     ...jest.requireActual('@aws-sdk/client-athena'),
@@ -123,12 +124,9 @@ describe('AthenaWarehouseClient', () => {
     });
 
     describe('getCatalog', () => {
-        const mockSend = jest.fn();
-
         beforeEach(() => {
-            mockAthenaClient.mockImplementation(() => ({
-                send: mockSend,
-            }));
+            mockSend.mockReset();
+            mockAthenaClient.mockImplementation(() => ({ send: mockSend }));
         });
 
         test('should use ListTableMetadataCommand to fetch catalog', async () => {

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -24,10 +24,7 @@ import {
     WarehouseTypes,
 } from '@lightdash/common';
 import { WarehouseCatalog } from '../types';
-import {
-    DEFAULT_BATCH_SIZE,
-    processPromisesInBatches,
-} from '../utils/processPromisesInBatches';
+import { processPromisesInBatches } from '../utils/processPromisesInBatches';
 import { normalizeUnicode } from '../utils/sql';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
@@ -416,6 +413,7 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
             table: string;
             columns: { name: string; type: string }[];
         }[] = [];
+
         let nextToken: string | undefined;
 
         try {

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -24,7 +24,10 @@ import {
     WarehouseTypes,
 } from '@lightdash/common';
 import { WarehouseCatalog } from '../types';
-import { processPromisesInBatches } from '../utils/processPromisesInBatches';
+import {
+    DEFAULT_BATCH_SIZE,
+    processPromisesInBatches,
+} from '../utils/processPromisesInBatches';
 import { normalizeUnicode } from '../utils/sql';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';

--- a/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/AthenaWarehouseClient.ts
@@ -407,60 +407,108 @@ export class AthenaWarehouseClient extends WarehouseBaseClient<CreateAthenaCrede
         }
     }
 
+    private async listMetadataForSchema(
+        database: string,
+        schema: string,
+        tableFilter: Set<string> | null,
+    ): Promise<{ table: string; columns: { name: string; type: string }[] }[]> {
+        const results: {
+            table: string;
+            columns: { name: string; type: string }[];
+        }[] = [];
+        let nextToken: string | undefined;
+
+        try {
+            do {
+                // eslint-disable-next-line no-await-in-loop
+                const response = await this.client.send(
+                    new ListTableMetadataCommand({
+                        CatalogName: database,
+                        DatabaseName: schema,
+                        NextToken: nextToken,
+                        MaxResults: 50,
+                    }),
+                );
+
+                response.TableMetadataList?.forEach((tableMeta) => {
+                    if (!tableMeta.Name) return;
+                    if (tableFilter && !tableFilter.has(tableMeta.Name)) return;
+
+                    results.push({
+                        table: tableMeta.Name,
+                        columns:
+                            tableMeta.Columns?.map((col) => ({
+                                name: col.Name || '',
+                                type: col.Type || 'varchar',
+                            })) || [],
+                    });
+                });
+
+                nextToken = response.NextToken;
+            } while (nextToken);
+        } catch (e: unknown) {
+            const error = e as { name?: string };
+            if (error.name === 'MetadataException') {
+                return [];
+            }
+            throw new WarehouseConnectionError(
+                `Failed to list table metadata for '${database}.${schema}'. ${getErrorMessage(e)}`,
+            );
+        }
+
+        return results;
+    }
+
+    private static readonly SCHEMA_BATCH_SIZE = 5;
+
     async getCatalog(
         requests: { database: string; schema: string; table: string }[],
     ): Promise<WarehouseCatalog> {
-        const results = await processPromisesInBatches(
-            requests,
-            DEFAULT_BATCH_SIZE,
-            async ({ database, schema, table }) => {
-                try {
-                    const response = await this.client.send(
-                        new GetTableMetadataCommand({
-                            CatalogName: database,
-                            DatabaseName: schema,
-                            TableName: table,
-                        }),
-                    );
+        // Group requests by {database, schema}
+        const schemaGroups = new Map<
+            string,
+            { database: string; schema: string; tables: Set<string> }
+        >();
 
-                    const columns =
-                        response.TableMetadata?.Columns?.map((col) => ({
-                            name: col.Name || '',
-                            type: col.Type || 'varchar',
-                        })) || [];
+        requests.forEach(({ database, schema, table }) => {
+            const key = `${database}\0${schema}`;
+            const existing = schemaGroups.get(key);
+            if (existing) {
+                existing.tables.add(table);
+            } else {
+                schemaGroups.set(key, {
+                    database,
+                    schema,
+                    tables: new Set([table]),
+                });
+            }
+        });
 
-                    return { database, schema, table, columns };
-                } catch (e: unknown) {
-                    // Table not found - return undefined
-                    const error = e as { name?: string };
-                    if (error.name === 'MetadataException') {
-                        return undefined;
-                    }
-                    throw new WarehouseConnectionError(
-                        `Failed to fetch table metadata for '${database}.${schema}.${table}'. ${getErrorMessage(
-                            e,
-                        )}`,
-                    );
-                }
-            },
+        const groups = Array.from(schemaGroups.values());
+
+        const batchResults = await processPromisesInBatches(
+            groups,
+            AthenaWarehouseClient.SCHEMA_BATCH_SIZE,
+            async ({ database, schema, tables }) =>
+                (
+                    await this.listMetadataForSchema(database, schema, tables)
+                ).map((entry) => ({ database, schema, ...entry })),
         );
 
-        return results.reduce<WarehouseCatalog>((acc, result) => {
-            if (result) {
-                const { database, schema, table, columns } = result;
-                acc[database] = acc[database] || {};
-                acc[database][schema] = acc[database][schema] || {};
-                acc[database][schema][table] = columns.reduce<
-                    Record<string, DimensionType>
-                >(
-                    (colAcc, { name, type }) => ({
-                        ...colAcc,
-                        [normalizeColumnName(name)]:
-                            convertDataTypeToDimensionType(type),
-                    }),
-                    {},
-                );
-            }
+        return batchResults.flat().reduce<WarehouseCatalog>((acc, result) => {
+            const { database, schema, table, columns } = result;
+            acc[database] = acc[database] || {};
+            acc[database][schema] = acc[database][schema] || {};
+            acc[database][schema][table] = columns.reduce<
+                Record<string, DimensionType>
+            >(
+                (colAcc, { name, type }) => ({
+                    ...colAcc,
+                    [normalizeColumnName(name)]:
+                        convertDataTypeToDimensionType(type),
+                }),
+                {},
+            );
             return acc;
         }, {});
     }


### PR DESCRIPTION
### Description:

The Athena getCatalog() method currently calls GetTableMetadataCommand once per table, which means a project with hundreds of tables triggers hundreds of individual AWS Glue API calls. This leads to rate limiting and slow catalog loading.

Replace per-table GetTableMetadataCommand calls with per-schema ListTableMetadataCommand calls. Requests are grouped by {database, schema}, and a single ListTableMetadataCommand retrieves all table metadata for  each schema in one paginated call, filtering to only the requested tables. For a project with 200 tables  across 5 schemas, this reduces API calls from 200 to 5.