### PR TITLE
fix: lazy load dashboard tabs on first visit

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -11,14 +11,7 @@ import { Button, Group, Tabs, Tooltip } from '@mantine-8/core';
 import { IconPlus } from '@tabler/icons-react';
 import { produce } from 'immer';
 import cloneDeep from 'lodash/cloneDeep';
-import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type FC,
-} from 'react';
+import { useCallback, useMemo, useRef, useState, type FC } from 'react';
 import { Responsive, WidthProvider, type Layout } from 'react-grid-layout';
 import { useLocation, useNavigate } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
@@ -183,18 +176,13 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
 
     // Track which tabs have been visited so we can lazy-mount tab content.
     // Tabs are mounted on first visit and kept mounted for instant re-switching.
-    const [visitedTabs, setVisitedTabs] = useState<Set<string>>(
-        () => new Set(activeTab ? [activeTab.uuid] : []),
-    );
-
-    useEffect(() => {
-        if (activeTab) {
-            setVisitedTabs((prev) => {
-                if (prev.has(activeTab.uuid)) return prev;
-                return new Set(prev).add(activeTab.uuid);
-            });
-        }
-    }, [activeTab]);
+    // We use a ref to accumulate visited UUIDs without triggering extra renders,
+    // then read it synchronously during render.
+    const visitedTabsRef = useRef(new Set<string>());
+    if (activeTab) {
+        visitedTabsRef.current.add(activeTab.uuid);
+    }
+    const visitedTabs = visitedTabsRef.current;
 
     // Group tiles by their tab UUID for per-tab grid rendering.
     // Only used when tabs are enabled. Tiles with stale/missing tab


### PR DESCRIPTION
### Description:
A user reported an issue with the last [tab performance improvements](https://github.com/lightdash/lightdash/pull/20275).
The issue is that all content of all tabs is being loaded on the first page visit, which causes issues on dashboards with a huge amount of tabs and tiles. It's better to give up a bit of performance and lazy load the tab content on the first visit of the tab.

### Before:

https://github.com/user-attachments/assets/6b3eb380-1ce9-4ce9-b34e-d5d6bf1d5182



### After:

https://github.com/user-attachments/assets/34b9b882-9799-48db-927d-9a1996e24c64



