### PR TITLE
feat: add `Default user spaces` to project settings

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -321,6 +321,9 @@ export const lightdashConfigMock: LightdashConfig = {
     nestedSpacesPermissions: {
         enabled: false,
     },
+    defaultUserSpaces: {
+        enabled: false,
+    },
     adminChangeNotifications: {
         enabled: false,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1037,6 +1037,9 @@ export type LightdashConfig = {
     nestedSpacesPermissions: {
         enabled: boolean;
     };
+    defaultUserSpaces: {
+        enabled: boolean;
+    };
     softDelete: {
         enabled: boolean;
         retentionDays: number;
@@ -1891,6 +1894,10 @@ export const parseConfig = (): LightdashConfig => {
         },
         nestedSpacesPermissions: {
             enabled: process.env.NESTED_SPACES_PERMISSIONS_ENABLED === 'true',
+        },
+        defaultUserSpaces: {
+            enabled:
+                process.env.LIGHTDASH_DEFAULT_USER_SPACES_ENABLED === 'true',
         },
         softDelete: {
             enabled: process.env.SOFT_DELETE_ENABLED === 'true',

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -48,6 +48,8 @@ export class FeatureFlagModel {
                 this.getAdminChangeNotifications.bind(this),
             [FeatureFlags.SavedMetricsTree]:
                 this.getSavedMetricsTreeEnabled.bind(this),
+            [FeatureFlags.DefaultUserSpaces]:
+                this.getDefaultUserSpacesEnabled.bind(this),
         };
     }
 
@@ -270,6 +272,15 @@ export class FeatureFlagModel {
         return {
             id: featureFlagId,
             enabled,
+        };
+    }
+
+    private async getDefaultUserSpacesEnabled({
+        featureFlagId,
+    }: FeatureFlagLogicArgs) {
+        return {
+            id: featureFlagId,
+            enabled: this.lightdashConfig.defaultUserSpaces.enabled,
         };
     }
 }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.mock.ts
@@ -58,6 +58,7 @@ export const projectMock = {
     organization_uuid: 'organizationUuid',
     dbt_version: DefaultSupportedDbtVersion,
     scheduler_timezone: 'UTC',
+    has_default_user_spaces: false,
 };
 
 export const tableSelectionMock: Pick<
@@ -105,6 +106,7 @@ export const expectedProject: Project = {
     dbtVersion: DefaultSupportedDbtVersion,
     schedulerTimezone: 'UTC',
     createdByUserUuid: null,
+    hasDefaultUserSpaces: false,
 };
 
 const metricFilter: MetricFilterRule = {

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -634,6 +634,7 @@ export class ProjectModel {
                   scheduler_timezone: string;
                   created_by_user_uuid: string | null;
                   organization_warehouse_credentials_uuid: string | null;
+                  has_default_user_spaces: boolean;
               }
             | {
                   name: string;
@@ -648,6 +649,7 @@ export class ProjectModel {
                   scheduler_timezone: string;
                   created_by_user_uuid: string | null;
                   organization_warehouse_credentials_uuid: string | null;
+                  has_default_user_spaces: boolean;
               }
         )[];
         return wrapSentryTransaction(
@@ -705,6 +707,9 @@ export class ProjectModel {
                         this.database
                             .ref('organization_warehouse_credentials_uuid')
                             .withSchema(ProjectTableName),
+                        this.database
+                            .ref('has_default_user_spaces')
+                            .withSchema(ProjectTableName),
                     ])
                     .select<QueryResult>()
                     .where('projects.project_uuid', projectUuid);
@@ -744,6 +749,7 @@ export class ProjectModel {
                     organizationWarehouseCredentialsUuid:
                         project.organization_warehouse_credentials_uuid ??
                         undefined,
+                    hasDefaultUserSpaces: project.has_default_user_spaces,
                 };
 
                 // If project uses organization warehouse credentials, load them
@@ -943,6 +949,7 @@ export class ProjectModel {
             createdByUserUuid: project.createdByUserUuid ?? null,
             organizationWarehouseCredentialsUuid:
                 project.organizationWarehouseCredentialsUuid,
+            hasDefaultUserSpaces: project.hasDefaultUserSpaces,
         };
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -324,6 +324,7 @@ export const projectWithSensitiveFields: Project = {
     },
     schedulerTimezone: 'UTC',
     createdByUserUuid: sessionAccount.user.id,
+    hasDefaultUserSpaces: false,
 };
 
 export const projectSummary: ProjectSummary = {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5554,6 +5554,12 @@ export class ProjectService extends BaseService {
         projectUuid: string,
         data: UpdateDefaultUserSpaces,
     ): Promise<void> {
+        if (!this.lightdashConfig.defaultUserSpaces.enabled) {
+            throw new ForbiddenError(
+                'Default user spaces feature is not enabled',
+            );
+        }
+
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1595,6 +1595,7 @@ export class UserService extends BaseService {
     private async ensureDefaultUserSpaces(
         sessionUser: SessionUser,
     ): Promise<void> {
+        if (!this.lightdashConfig.defaultUserSpaces.enabled) return;
         if (!sessionUser.organizationUuid) return;
 
         const projects =

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -494,6 +494,7 @@ export type CreateProject = Omit<
     | 'organizationUuid'
     | 'schedulerTimezone'
     | 'createdByUserUuid'
+    | 'hasDefaultUserSpaces'
 > & {
     warehouseConnection: CreateWarehouseCredentials;
     copyWarehouseConnectionFromUpstreamProject?: boolean;
@@ -523,6 +524,7 @@ export type UpdateProject = Omit<
     | 'type'
     | 'schedulerTimezone'
     | 'createdByUserUuid'
+    | 'hasDefaultUserSpaces'
 > & {
     warehouseConnection: CreateWarehouseCredentials;
 };

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -83,6 +83,11 @@ export enum FeatureFlags {
      * Enable saved metrics tree in metrics catalog
      */
     SavedMetricsTree = 'saved-metrics-tree',
+
+    /**
+     * Enable default personal spaces for project members
+     */
+    DefaultUserSpaces = 'default-user-spaces',
 }
 
 export type FeatureFlag = {

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -557,6 +557,7 @@ export type Project = {
     schedulerTimezone: string;
     createdByUserUuid: string | null;
     organizationWarehouseCredentialsUuid?: string;
+    hasDefaultUserSpaces: boolean;
 };
 
 export type ProjectSummary = Pick<

--- a/packages/frontend/src/components/DefaultUserSpaces/index.tsx
+++ b/packages/frontend/src/components/DefaultUserSpaces/index.tsx
@@ -1,0 +1,43 @@
+import { Switch, Text, Title } from '@mantine-8/core';
+import { type FC } from 'react';
+import { useProject, useUpdateDefaultUserSpaces } from '../../hooks/useProject';
+import { SettingsGridCard } from '../common/Settings/SettingsCard';
+
+export const DefaultUserSpaces: FC<{ projectUuid: string }> = ({
+    projectUuid,
+}) => {
+    const { data: project } = useProject(projectUuid);
+    const { mutate, isLoading } = useUpdateDefaultUserSpaces(projectUuid);
+
+    return (
+        <>
+            <Text c="dimmed">
+                Manage default personal spaces for project members
+            </Text>
+
+            <SettingsGridCard>
+                <div>
+                    <Title order={4}>Default user spaces</Title>
+                    <Text c="ldGray.6" fz="xs">
+                        When enabled, each project member will automatically get
+                        a personal space where they can save their own charts
+                        and dashboards.
+                    </Text>
+                </div>
+                <div>
+                    <Switch
+                        label="Enable default user spaces"
+                        checked={project?.hasDefaultUserSpaces ?? false}
+                        disabled={isLoading}
+                        onChange={(event) => {
+                            mutate({
+                                hasDefaultUserSpaces:
+                                    event.currentTarget.checked,
+                            });
+                        }}
+                    />
+                </div>
+            </SettingsGridCard>
+        </>
+    );
+};

--- a/packages/frontend/src/hooks/useProject.ts
+++ b/packages/frontend/src/hooks/useProject.ts
@@ -5,6 +5,7 @@ import {
     type CreateWarehouseCredentials,
     type MostPopularAndRecentlyUpdated,
     type Project,
+    type UpdateDefaultUserSpaces,
     type UpdateProject,
     type UpdateSchedulerSettings,
 } from '@lightdash/common';
@@ -176,6 +177,39 @@ export const useProjectUpdateSchedulerSettings = (uuid: string) => {
             onSuccess: async () => {
                 await queryClient.invalidateQueries(['project', uuid]);
                 await queryClient.invalidateQueries(['schedulerLogs']);
+            },
+        },
+    );
+};
+
+const updateDefaultUserSpaces = async (
+    uuid: string,
+    data: UpdateDefaultUserSpaces,
+) =>
+    lightdashApi<undefined>({
+        url: `/projects/${uuid}/hasDefaultUserSpaces`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useUpdateDefaultUserSpaces = (uuid: string) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<undefined, ApiError, UpdateDefaultUserSpaces>(
+        (data) => updateDefaultUserSpaces(uuid, data),
+        {
+            mutationKey: ['project_default_user_spaces_update', uuid],
+            onSuccess: async () => {
+                await queryClient.invalidateQueries(['project', uuid]);
+                showToastSuccess({
+                    title: 'Default user spaces updated',
+                });
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to update default user spaces',
+                    apiError: error,
+                });
             },
         },
     );

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -10,6 +10,7 @@ import {
     IconDatabase,
     IconDatabaseCog,
     IconDatabaseExport,
+    IconFolders,
     IconHistory,
     IconIdBadge2,
     IconKey,
@@ -113,6 +114,10 @@ const Settings: FC = () => {
 
     const userGroupsFeatureFlagQuery = useServerFeatureFlag(
         FeatureFlags.UserGroupsEnabled,
+    );
+
+    const { data: defaultUserSpacesFlag } = useServerFeatureFlag(
+        FeatureFlags.DefaultUserSpaces,
     );
 
     const { track } = useTracking();
@@ -846,6 +851,18 @@ const Settings: FC = () => {
                                                 <MantineIcon icon={IconUsers} />
                                             }
                                         />
+                                        {defaultUserSpacesFlag?.enabled && (
+                                            <RouterNavLink
+                                                label="Default user spaces"
+                                                exact
+                                                to={`/generalSettings/projectManagement/${project.projectUuid}/defaultUserSpaces`}
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconFolders}
+                                                    />
+                                                }
+                                            />
+                                        )}
                                     </Can>
 
                                     {user.ability.can(


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-170/by-default-users-with-interactive-viewer-access-and-above-should-have

### Description:
This PR adds the ability to toggle the "Default user spaces" via the project settings.

### Feature Overview:
- Admins can enable the feature on a project basis
- Default spaces are created lazily, when we fetch user info (when cache is missed)
- Anyone who can "manage SavedChart" gets the default space, this includes interactive viewer, but excludes viewer.
- The user gets explicit admin permissions on their space.

### Testing space creation

#### Admin

https://github.com/user-attachments/assets/f8078f57-6dc4-4952-8982-15f968cee209


#### Editor

https://github.com/user-attachments/assets/dd37812f-589d-4031-8b94-82bc71a07f65


#### Interactive Viewer

https://github.com/user-attachments/assets/285700c3-8e6d-4e6f-bc73-36eefa24de7c



#### Viewer

https://github.com/user-attachments/assets/e8cbd625-76b7-441d-8539-cc5ccaa05698



