### PR TITLE
feat: add support for required filters defined in model configuration

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -87,7 +87,7 @@ const FilterRuleForm: FC<Props> = memo(
         );
         const isRequired = filterRule.required;
         const isRequiredLabel = isRequired
-            ? "This filter is a required filter.\n It can't be deleted, but the value can be changed."
+            ? 'This is a required filter defined in the model configuration and cannot be modified.'
             : '';
 
         if (!activeField) {
@@ -101,21 +101,31 @@ const FilterRuleForm: FC<Props> = memo(
                 spacing="xs"
                 data-testid="FilterRuleForm/filter-rule"
             >
-                <FieldSelect
-                    size="xs"
-                    disabled={!isEditMode}
-                    withinPortal={popoverProps?.withinPortal}
-                    onDropdownOpen={popoverProps?.onOpen}
-                    onDropdownClose={popoverProps?.onClose}
-                    hasGrouping
-                    item={activeField}
-                    items={fields}
-                    onChange={(field) => {
-                        if (!field) return;
-                        onFieldChange(getItemId(field));
-                    }}
-                    baseTable={baseTable}
-                />
+                <Tooltip
+                    label={isRequiredLabel}
+                    disabled={!isRequired}
+                    withinPortal
+                    variant="xs"
+                    multiline
+                >
+                    <Box>
+                        <FieldSelect
+                            size="xs"
+                            disabled={!isEditMode || isRequired}
+                            withinPortal={popoverProps?.withinPortal}
+                            onDropdownOpen={popoverProps?.onOpen}
+                            onDropdownClose={popoverProps?.onClose}
+                            hasGrouping
+                            item={activeField}
+                            items={fields}
+                            onChange={(field) => {
+                                if (!field) return;
+                                onFieldChange(getItemId(field));
+                            }}
+                            baseTable={baseTable}
+                        />
+                    </Box>
+                </Tooltip>
                 <Select
                     limit={FILTER_SELECT_LIMIT}
                     size="xs"
@@ -124,7 +134,7 @@ const FilterRuleForm: FC<Props> = memo(
                     withinPortal={popoverProps?.withinPortal}
                     onDropdownOpen={popoverProps?.onOpen}
                     onDropdownClose={popoverProps?.onClose}
-                    disabled={!isEditMode}
+                    disabled={!isEditMode || isRequired}
                     value={filterRule.operator}
                     data={filterOperatorOptions}
                     onChange={(value) => {
@@ -147,7 +157,7 @@ const FilterRuleForm: FC<Props> = memo(
                     field={activeField}
                     rule={filterRule}
                     onChange={onChange}
-                    disabled={!isEditMode}
+                    disabled={!isEditMode || isRequired}
                     popoverProps={popoverProps}
                 />
 
@@ -167,6 +177,19 @@ const FilterRuleForm: FC<Props> = memo(
                                     data-testid="delete-filter-rule-button"
                                 >
                                     <MantineIcon icon={IconX} size="sm" />
+                                </ActionIcon>
+                            </span>
+                        </Tooltip>
+                    ) : isRequired ? (
+                        <Tooltip
+                            label={isRequiredLabel}
+                            withinPortal
+                            variant="xs"
+                            multiline
+                        >
+                            <span>
+                                <ActionIcon variant="subtle" disabled>
+                                    <IconDots size="20" />
                                 </ActionIcon>
                             </span>
                         </Tooltip>
@@ -191,23 +214,9 @@ const FilterRuleForm: FC<Props> = memo(
                                 <Menu.Item onClick={onConvertToGroup}>
                                     Convert to group
                                 </Menu.Item>
-                                <Tooltip
-                                    label={isRequiredLabel}
-                                    disabled={!isRequired}
-                                    withinPortal
-                                    variant="xs"
-                                    multiline
-                                >
-                                    <span>
-                                        <Menu.Item
-                                            color="red"
-                                            disabled={isRequired}
-                                            onClick={onDelete}
-                                        >
-                                            Remove
-                                        </Menu.Item>
-                                    </span>
-                                </Tooltip>
+                                <Menu.Item color="red" onClick={onDelete}>
+                                    Remove
+                                </Menu.Item>
                             </Menu.Dropdown>
                         </Menu>
                     ))}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-2641/required-default-date-filter-remains-applied-in-sql-but-is-hidden-in

When a required filter is updated , the filter is still enforced in the backend. -> not expected
When a non required filter is updated, the old filter is replaced -> expected

So what we need to do is to disable these required filters on the UI, to prevent the user from updating

## After

<img width="1749" height="685" alt="image" src="https://github.com/user-attachments/assets/8c6bd033-fac5-4b12-9265-b3fda14bd0d3" />



### Description:
Adds support for required filters defined in model configuration. This PR:

1. Updates the `subscriptions.yml` model to include a sample required filter for `plan_name`
2. Improves the UI for required filters by:
   - Disabling field selection, operator selection, and value inputs for required filters
   - Updating the tooltip message to clarify that required filters cannot be modified
   - Adding a disabled menu icon with tooltip for required filters
   - Removing the conditional "Remove" menu item since required filters now have a separate UI treatment

This enhancement allows model owners to define filters that must be applied when querying the model, ensuring consistent and valid data access patterns.