### PR TITLE
fix: wrong space access being checked when saving chart to dashboard

### DIFF
--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -891,15 +891,16 @@ export class SavedChartService
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
-        // Resolve space UUID if neither spaceUuid nor dashboardUuid is provided
-        const resolvedSpaceUuid =
-            savedChart.spaceUuid ??
-            (!savedChart.dashboardUuid
-                ? await this.spacePermissionService.getFirstViewableSpaceUuid(
-                      user,
-                      projectUuid,
-                  )
-                : undefined);
+        // When saving to a dashboard, always check permissions against the
+        // dashboard's space — the chart's spaceUuid may refer to a different
+        // space where the user has no access.
+        const resolvedSpaceUuid = savedChart.dashboardUuid
+            ? undefined
+            : (savedChart.spaceUuid ??
+              (await this.spacePermissionService.getFirstViewableSpaceUuid(
+                  user,
+                  projectUuid,
+              )));
 
         let isPrivate = false;
         let access: SpaceAccess[] = [];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixed permission handling when saving charts to dashboards across spaces. When a chart is saved to a dashboard, permissions are now correctly checked against the dashboard's space rather than the chart's space UUID. This ensures users can save charts to dashboards even when they have different permission levels across spaces.

The PR includes:
- Updated permission resolution logic in SavedChartService to prioritize dashboard space permissions
- Added comprehensive E2E tests to verify cross-space dashboard permissions work correctly

**Before**
New test was failing

![CleanShot 2026-02-17 at 12.31.09.png](https://app.graphite.com/user-attachments/assets/09939534-170b-4091-8dcd-edd7819fbd79.png)

**After**

![CleanShot 2026-02-17 at 12.31.38.png](https://app.graphite.com/user-attachments/assets/880c8efd-ce26-4cf2-9b97-3bf003477286.png)

