### PR TITLE
chore: remove unused PeriodOverPeriod feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -64,11 +64,6 @@ export enum FeatureFlags {
     UnusedContentDashboard = 'unused-content-dashboard',
 
     /**
-     * Enable period-over-period comparisons option
-     */
-    PeriodOverPeriod = 'pop',
-
-    /**
      * Enable viewing and editing YAML source files in the Explore UI
      */
     EditYamlInUi = 'edit-yaml-in-ui',


### PR DESCRIPTION
The feature flag was defined but never actually used to gate the feature in the codebase.

Slack thread: https://lightdash.slack.com/archives/C02GQKJK84Q/p1771339090111549?thread_ts=1771338946.161839&cid=C02GQKJK84Q

https://claude.ai/code/session_01Mp7iEXPkFDvvaXgNKaLc9E

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
