### PR TITLE
feat: add user_favorites schema and types

### DIFF
--- a/packages/backend/src/database/entities/userFavorites.ts
+++ b/packages/backend/src/database/entities/userFavorites.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+export const UserFavoritesTableName = 'user_favorites';
+
+export type DbUserFavorite = {
+    user_favorite_uuid: string;
+    user_uuid: string;
+    project_uuid: string;
+    content_type: string;
+    content_uuid: string;
+    created_at: Date;
+};
+
+export type CreateDbUserFavorite = Pick<
+    DbUserFavorite,
+    'user_uuid' | 'project_uuid' | 'content_type' | 'content_uuid'
+>;
+
+export type UserFavoritesTable = Knex.CompositeTableType<
+    DbUserFavorite,
+    CreateDbUserFavorite
+>;

--- a/packages/backend/src/database/migrations/20260217150000_add_user_favorites_table.ts
+++ b/packages/backend/src/database/migrations/20260217150000_add_user_favorites_table.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+const UserFavoritesTableName = 'user_favorites';
+const UsersTableName = 'users';
+const ProjectsTableName = 'projects';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(UserFavoritesTableName, (table) => {
+        table
+            .uuid('user_favorite_uuid')
+            .primary()
+            .defaultTo(knex.raw('uuid_generate_v4()'));
+        table
+            .uuid('user_uuid')
+            .notNullable()
+            .references('user_uuid')
+            .inTable(UsersTableName)
+            .onDelete('CASCADE');
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable(ProjectsTableName)
+            .onDelete('CASCADE');
+        table.text('content_type').notNullable();
+        table.uuid('content_uuid').notNullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+
+        table.unique(['user_uuid', 'content_type', 'content_uuid']);
+        table.index(['user_uuid', 'project_uuid']);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(UserFavoritesTableName);
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -107,6 +107,7 @@ export * from './types/downloadFile';
 export * from './types/email';
 export * from './types/errors';
 export * from './types/explore';
+export * from './types/favorites';
 export * from './types/featureFlags';
 export * from './types/field';
 export * from './types/fieldMatch';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1,4 +1,5 @@
 import { type AnyType } from './any';
+import { type ApiFavoriteItems, type ApiToggleFavorite } from './favorites';
 import { type ApiTogglePinnedItem, type PinnedItems } from './pinning';
 import { type ProjectGroupAccess } from './projectGroupAccess';
 import { type MostPopularAndRecentlyUpdated } from './resourceViewItem';
@@ -863,7 +864,9 @@ type ApiResults =
     | ApiUpdateAiOrganizationSettingsResponse['results']
     | ApiProjectCompileLogsResponse['results']
     | ApiProjectCompileLogResponse['results']
-    | ApiSingleValidationResponse['results'];
+    | ApiSingleValidationResponse['results']
+    | ApiFavoriteItems['results']
+    | ApiToggleFavorite['results'];
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'
 

--- a/packages/common/src/types/favorites.ts
+++ b/packages/common/src/types/favorites.ts
@@ -1,0 +1,31 @@
+import type { ContentType } from './content';
+import type {
+    ResourceViewChartItem,
+    ResourceViewDashboardItem,
+    ResourceViewSpaceItem,
+} from './resourceViewItem';
+
+export type ToggleFavoriteRequest = {
+    contentType: ContentType;
+    contentUuid: string;
+};
+
+export type ToggleFavoriteResponse = {
+    isFavorite: boolean;
+    contentType: ContentType;
+    contentUuid: string;
+};
+
+export type FavoriteItems = Array<
+    ResourceViewChartItem | ResourceViewDashboardItem | ResourceViewSpaceItem
+>;
+
+export type ApiFavoriteItems = {
+    status: 'ok';
+    results: FavoriteItems;
+};
+
+export type ApiToggleFavorite = {
+    status: 'ok';
+    results: ToggleFavoriteResponse;
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
Added support for user favourites functionality by creating a new database table `user_favourites` to store user favourite items. This includes:

- Created database entity definition for user favourites
- Added migration script to create the user favourites table with appropriate constraints
- Defined common types for favourites including request/response interfaces
- Added API response types for favourite operations

This lays the groundwork for allowing users to mark content items (charts, dashboards, spaces) as favourites.