### PR TITLE
feat: treat default user spaces as root

### DIFF
--- a/packages/backend/src/database/entities/spaces.ts
+++ b/packages/backend/src/database/entities/spaces.ts
@@ -16,6 +16,7 @@ export type DbSpace = {
     inherit_parent_permissions: boolean;
     deleted_at: Date | null;
     deleted_by_user_uuid: string | null;
+    is_default_user_space: boolean;
 };
 
 export type CreateDbSpace = Pick<

--- a/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.mock.ts
@@ -136,6 +136,7 @@ export const spaceEntry: SpaceTable['base'] = {
     parent_space_uuid: null,
     path: 'space-name',
     inherit_parent_permissions: true,
+    is_default_user_space: false,
 
     deleted_at: null,
     deleted_by_user_uuid: null,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1420,7 +1420,12 @@ export class SpaceModel {
 
     private async getSpaceRoot(spaceUuid: string): Promise<string> {
         const space = await this.database(SpaceTableName)
-            .select(['path', 'project_id', 'parent_space_uuid'])
+            .select([
+                'path',
+                'project_id',
+                'parent_space_uuid',
+                'is_default_user_space',
+            ])
             .where('space_uuid', spaceUuid)
             .first();
 
@@ -1428,6 +1433,12 @@ export class SpaceModel {
             throw new NotFoundError(
                 `Space with uuid ${spaceUuid} does not exist`,
             );
+        }
+
+        if (space.is_default_user_space) {
+            // EXPLAINME: default user spaces are treated like a root space
+            // this is because they should manage their own permissions
+            return spaceUuid;
         }
 
         const root = await this.database(SpaceTableName)

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -36,7 +36,7 @@ import { wrapSentryTransaction } from '../utils';
  */
 export const getRootSpaceIsPrivateQuery = (): string => `
                 CASE
-                    WHEN ${SpaceTableName}.parent_space_uuid IS NOT NULL THEN
+                    WHEN ${SpaceTableName}.parent_space_uuid IS NOT NULL AND ${SpaceTableName}.is_default_user_space = false THEN
                         (SELECT ps.is_private
                          FROM ${SpaceTableName} ps
                          WHERE ps.path @> ${SpaceTableName}.path

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -57,6 +57,7 @@ export const space: SpaceTable['base'] = {
     parent_space_uuid: null,
     path: 'space-name',
     inherit_parent_permissions: false,
+    is_default_user_space: false,
     deleted_at: null,
     deleted_by_user_uuid: null,
 };


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-170/by-default-users-with-interactive-viewer-access-and-above-should-have

### Description:
As a temporary workaround, treating a default space as its own root allows for the direct permissions (admin) that we add to take effect. This is especially needed for interactive viewers.