### PR TITLE
fix: only override environment when it has a non-empty value

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -536,7 +536,9 @@ export const maybeOverrideDbtConnection = <T extends DbtProjectConfig>(
         ...(isGitProjectType(connection) && overrides.branch
             ? { branch: overrides.branch }
             : undefined),
-        ...(!isRemoteType(connection) && overrides.environment
+        ...(!isRemoteType(connection) &&
+        overrides.environment &&
+        overrides.environment.length > 0
             ? { environment: overrides.environment }
             : undefined),
     };

--- a/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
+++ b/packages/frontend/src/components/NavBar/CreatePreviewProjectModal.tsx
@@ -372,7 +372,7 @@ const CreatePreviewModal: FC<Props> = ({ isOpened, onClose }) => {
             name: previewName,
             dbtConnectionOverrides: {
                 branch: selectedBranch ?? undefined,
-                environment,
+                environment: environment.length > 0 ? environment : undefined,
                 manifest: finalManifest,
             },
             warehouseConnectionOverrides: { schema },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fix environment handling in preview projects by ensuring empty environment strings are not included in connection overrides. This prevents issues when creating preview projects with no environment specified.

The changes ensure that:
1. In `maybeOverrideDbtConnection`, environment overrides are only applied when the environment value exists and is not an empty string
2. In `CreatePreviewProjectModal`, empty environment strings are explicitly converted to undefined before being passed as overrides