### PR TITLE
feat: introduce big number conditional formatting

### DIFF
--- a/packages/common/src/types/conditionalFormatting.ts
+++ b/packages/common/src/types/conditionalFormatting.ts
@@ -37,6 +37,7 @@ export const isConditionalFormattingWithCompareTarget = (
 export type ConditionalFormattingConfigWithSingleColor = {
     target: FieldTarget | null;
     color: string;
+    darkColor?: string;
     rules: ConditionalFormattingWithFilterOperator[];
     applyTo?: ConditionalFormattingColorApplyTo;
 };

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -65,6 +65,7 @@ export type BigNumber = {
     comparisonFormat?: ComparisonFormatTypes;
     flipColors?: boolean;
     comparisonLabel?: string;
+    conditionalFormattings?: ConditionalFormattingConfig[];
 };
 
 export const PieChartValueLabels = {

--- a/packages/frontend/src/components/SimpleStatistic/SimpleStatistic.module.css
+++ b/packages/frontend/src/components/SimpleStatistic/SimpleStatistic.module.css
@@ -1,3 +1,7 @@
+.bigNumberText {
+    color: var(--big-number-color, var(--mantine-color-foreground-0));
+}
+
 .trendPill {
     display: inline-flex;
     align-items: center;

--- a/packages/frontend/src/components/SimpleStatistic/index.tsx
+++ b/packages/frontend/src/components/SimpleStatistic/index.tsx
@@ -85,7 +85,6 @@ const BigNumberText: FC<
     return (
         <Text
             ref={ref}
-            c="foreground"
             ta="center"
             fw={500}
             {...textProps}
@@ -246,6 +245,7 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
 
     const {
         bigNumber,
+        bigNumberTextColor,
         showBigNumberLabel,
         bigNumberLabel,
         defaultLabel,
@@ -290,6 +290,8 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                         fw={600}
                         isHeading
                         data-testid="big-number-value"
+                        style={{ '--big-number-color': bigNumberTextColor }}
+                        className={styles.bigNumberText}
                     >
                         {bigNumber}
                     </BigNumberText>
@@ -306,7 +308,9 @@ const SimpleStatistic: FC<SimpleStatisticsProps> = ({
                             data-testid="big-number-value"
                             style={{
                                 cursor: 'pointer',
+                                '--big-number-color': bigNumberTextColor,
                             }}
+                            className={styles.bigNumberText}
                         >
                             {bigNumber}
                         </BigNumberText>

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormatting.tsx
@@ -1,0 +1,121 @@
+import {
+    createConditionalFormattingConfigWithSingleColor,
+    isFilterableItem,
+    isNumericItem,
+    isStringDimension,
+    type ConditionalFormattingConfig,
+    type FilterableItem,
+} from '@lightdash/common';
+import { Accordion } from '@mantine-8/core';
+import { produce } from 'immer';
+import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
+import { v4 as uuidv4 } from 'uuid';
+import { isBigNumberVisualizationConfig } from '../../LightdashVisualization/types';
+import { useVisualizationContext } from '../../LightdashVisualization/useVisualizationContext';
+import { AddButton } from '../common/AddButton';
+import { Config } from '../common/Config';
+import { BigNumberConditionalFormattingItem } from './BigNumberConditionalFormattingItem';
+
+export const BigNumberConditionalFormatting: FC = () => {
+    const { itemsMap, visualizationConfig, colorPalette } =
+        useVisualizationContext();
+
+    const chartConfig = useMemo(() => {
+        if (!isBigNumberVisualizationConfig(visualizationConfig))
+            return undefined;
+        return visualizationConfig.chartConfig;
+    }, [visualizationConfig]);
+
+    const selectedField = useMemo(() => {
+        if (!chartConfig?.selectedField || !itemsMap) return undefined;
+        const field = itemsMap[chartConfig.selectedField];
+        if (
+            field &&
+            (isNumericItem(field) || isStringDimension(field)) &&
+            isFilterableItem(field)
+        ) {
+            return field as FilterableItem;
+        }
+        return undefined;
+    }, [chartConfig?.selectedField, itemsMap]);
+
+    const activeConfigs = useMemo(
+        () => chartConfig?.conditionalFormattings ?? [],
+        [chartConfig?.conditionalFormattings],
+    );
+
+    const configIdsRef = useRef<string[]>([]);
+    useEffect(() => {
+        while (configIdsRef.current.length < activeConfigs.length) {
+            configIdsRef.current.push(uuidv4());
+        }
+    }, [activeConfigs.length]);
+
+    const handleAdd = useCallback(() => {
+        if (!chartConfig) return;
+
+        chartConfig.onSetConditionalFormattings(
+            produce(activeConfigs, (draft) => {
+                draft.push(
+                    createConditionalFormattingConfigWithSingleColor(
+                        colorPalette[0],
+                    ),
+                );
+            }),
+        );
+    }, [chartConfig, activeConfigs, colorPalette]);
+
+    const handleRemove = useCallback(
+        (index: number) => {
+            if (!chartConfig) return;
+
+            configIdsRef.current.splice(index, 1);
+
+            chartConfig.onSetConditionalFormattings(
+                produce(activeConfigs, (draft) => {
+                    draft.splice(index, 1);
+                }),
+            );
+        },
+        [chartConfig, activeConfigs],
+    );
+
+    const handleChange = useCallback(
+        (index: number, newConfig: ConditionalFormattingConfig) => {
+            if (!chartConfig) return;
+
+            chartConfig.onSetConditionalFormattings(
+                produce(activeConfigs, (draft) => {
+                    draft[index] = newConfig;
+                }),
+            );
+        },
+        [chartConfig, activeConfigs],
+    );
+
+    return (
+        <Config>
+            <Config.Section>
+                <Config.Group>
+                    <Config.Heading>Rules and Conditions</Config.Heading>
+                    <AddButton onClick={handleAdd} />
+                </Config.Group>
+                <Accordion multiple variant="contained" radius="md">
+                    {activeConfigs.map((conditionalFormatting, index) => (
+                        <BigNumberConditionalFormattingItem
+                            key={configIdsRef.current[index] ?? index}
+                            colorPalette={colorPalette}
+                            index={index + 1}
+                            field={selectedField}
+                            value={conditionalFormatting}
+                            onChange={(newConfig) =>
+                                handleChange(index, newConfig)
+                            }
+                            onRemove={() => handleRemove(index)}
+                        />
+                    ))}
+                </Accordion>
+            </Config.Section>
+        </Config>
+    );
+};

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingItem.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingItem.tsx
@@ -1,0 +1,286 @@
+import {
+    createConditionalFormattingRuleWithValues,
+    isConditionalFormattingConfigWithSingleColor,
+    type ConditionalFormattingConfig,
+    type ConditionalFormattingWithFilterOperator,
+    type FilterOperator,
+    type FilterableItem,
+} from '@lightdash/common';
+import {
+    Accordion,
+    ActionIcon,
+    Box,
+    Button,
+    Divider,
+    Group,
+    Menu,
+    Stack,
+    Text,
+    useMantineColorScheme,
+} from '@mantine-8/core';
+import {
+    IconDots,
+    IconMoon,
+    IconPlus,
+    IconSun,
+    IconTrash,
+} from '@tabler/icons-react';
+import { produce } from 'immer';
+import { Fragment, useCallback, useState, type FC } from 'react';
+import FiltersProvider from '../../common/Filters/FiltersProvider';
+import MantineIcon from '../../common/MantineIcon';
+import ColorSelector from '../ColorSelector';
+import { Config } from '../common/Config';
+import BigNumberConditionalFormattingRule from './BigNumberConditionalFormattingRule';
+
+type Props = {
+    colorPalette: string[];
+    index: number;
+    field: FilterableItem | undefined;
+    value: ConditionalFormattingConfig;
+    onChange: (newConfig: ConditionalFormattingConfig) => void;
+    onRemove: () => void;
+};
+
+export const BigNumberConditionalFormattingItem: FC<Props> = ({
+    colorPalette,
+    index: configIndex,
+    field,
+    value,
+    onChange,
+    onRemove,
+}) => {
+    const { colorScheme } = useMantineColorScheme();
+    const [isAddingRule, setIsAddingRule] = useState(false);
+
+    const handleAddRule = useCallback(() => {
+        setIsAddingRule(true);
+
+        if (isConditionalFormattingConfigWithSingleColor(value)) {
+            onChange(
+                produce(value, (draft) => {
+                    draft.rules.push(
+                        createConditionalFormattingRuleWithValues(),
+                    );
+                }),
+            );
+        }
+    }, [onChange, value]);
+
+    const handleRemoveRule = useCallback(
+        (index: number) => {
+            if (isConditionalFormattingConfigWithSingleColor(value)) {
+                onChange(
+                    produce(value, (draft) => {
+                        draft.rules.splice(index, 1);
+                    }),
+                );
+            }
+        },
+        [onChange, value],
+    );
+
+    const handleChangeRuleOperator = useCallback(
+        (index: number, newOperator: FilterOperator) => {
+            if (isConditionalFormattingConfigWithSingleColor(value)) {
+                onChange(
+                    produce(value, (draft) => {
+                        draft.rules[index] = {
+                            ...draft.rules[index],
+                            operator: newOperator,
+                        };
+                    }),
+                );
+            }
+        },
+        [onChange, value],
+    );
+
+    const handleChangeRule = useCallback(
+        (index: number, newRule: ConditionalFormattingWithFilterOperator) => {
+            if (isConditionalFormattingConfigWithSingleColor(value)) {
+                onChange(
+                    produce(value, (draft) => {
+                        draft.rules[index] = newRule;
+                    }),
+                );
+            }
+        },
+        [value, onChange],
+    );
+
+    const handleChangeLightColor = useCallback(
+        (newColor: string) => {
+            if (isConditionalFormattingConfigWithSingleColor(value)) {
+                onChange(
+                    produce(value, (draft) => {
+                        draft.color = newColor;
+                    }),
+                );
+            }
+        },
+        [onChange, value],
+    );
+
+    const handleChangeDarkColor = useCallback(
+        (newColor: string) => {
+            if (isConditionalFormattingConfigWithSingleColor(value)) {
+                onChange(
+                    produce(value, (draft) => {
+                        draft.darkColor = newColor;
+                    }),
+                );
+            }
+        },
+        [onChange, value],
+    );
+
+    const controlLabel = `Rule ${configIndex}`;
+    const accordionValue = `${configIndex}`;
+
+    const lightColor = isConditionalFormattingConfigWithSingleColor(value)
+        ? value.color
+        : colorPalette[0];
+    const darkColor = isConditionalFormattingConfigWithSingleColor(value)
+        ? (value.darkColor ?? value.color)
+        : colorPalette[0];
+    const previewColor = colorScheme === 'dark' ? darkColor : lightColor;
+
+    return (
+        <Accordion.Item value={accordionValue}>
+            <Accordion.Control
+                icon={
+                    <ColorSelector
+                        color={previewColor}
+                        swatches={colorPalette}
+                    />
+                }
+            >
+                <Group justify="space-between" wrap="nowrap">
+                    <Text fw={500} size="xs" truncate>
+                        {controlLabel}
+                    </Text>
+                    <Menu withArrow offset={-2}>
+                        <Menu.Target>
+                            <ActionIcon
+                                variant="transparent"
+                                color="gray"
+                                onClick={(e) => e.stopPropagation()}
+                            >
+                                <MantineIcon icon={IconDots} />
+                            </ActionIcon>
+                        </Menu.Target>
+                        <Menu.Dropdown>
+                            <Menu.Item
+                                leftSection={<MantineIcon icon={IconTrash} />}
+                                color="red"
+                                onClick={onRemove}
+                            >
+                                <Text fz="xs" fw={500}>
+                                    Delete
+                                </Text>
+                            </Menu.Item>
+                        </Menu.Dropdown>
+                    </Menu>
+                </Group>
+            </Accordion.Control>
+            <Accordion.Panel>
+                <Stack gap="xs">
+                    <FiltersProvider>
+                        <Group>
+                            <Group gap="xs">
+                                <Config.Label icon={IconSun}>
+                                    Light
+                                </Config.Label>
+                                <ColorSelector
+                                    color={lightColor}
+                                    swatches={colorPalette}
+                                    onColorChange={handleChangeLightColor}
+                                />
+                            </Group>
+
+                            <Group gap="xs">
+                                <Config.Label icon={IconMoon}>
+                                    Dark
+                                </Config.Label>
+                                <ColorSelector
+                                    color={darkColor}
+                                    swatches={colorPalette}
+                                    onColorChange={handleChangeDarkColor}
+                                />
+                            </Group>
+                        </Group>
+
+                        {isConditionalFormattingConfigWithSingleColor(value) ? (
+                            <Box
+                                p="xs"
+                                style={(theme) => ({
+                                    backgroundColor: theme.colors.ldGray[1],
+                                    border: `1px solid ${theme.colors.ldGray[4]}`,
+                                    borderRadius: theme.radius.md,
+                                })}
+                            >
+                                {value.rules.map((rule, ruleIndex) => (
+                                    <Fragment key={ruleIndex}>
+                                        <BigNumberConditionalFormattingRule
+                                            isDefaultOpen={
+                                                value.rules.length === 1 ||
+                                                isAddingRule
+                                            }
+                                            hasRemove={value.rules.length > 1}
+                                            ruleIndex={ruleIndex}
+                                            rule={rule}
+                                            field={field}
+                                            onChangeRule={(newRule) =>
+                                                handleChangeRule(
+                                                    ruleIndex,
+                                                    newRule,
+                                                )
+                                            }
+                                            onChangeRuleOperator={(
+                                                newOperator,
+                                            ) =>
+                                                handleChangeRuleOperator(
+                                                    ruleIndex,
+                                                    newOperator,
+                                                )
+                                            }
+                                            onRemoveRule={() =>
+                                                handleRemoveRule(ruleIndex)
+                                            }
+                                        />
+
+                                        {ruleIndex !==
+                                            value.rules.length - 1 && (
+                                            <Divider
+                                                mt="xs"
+                                                label={
+                                                    <Config.Label>
+                                                        AND
+                                                    </Config.Label>
+                                                }
+                                                labelPosition="center"
+                                            />
+                                        )}
+                                    </Fragment>
+                                ))}
+                            </Box>
+                        ) : null}
+
+                        {isConditionalFormattingConfigWithSingleColor(value) ? (
+                            <Button
+                                style={{ alignSelf: 'start' }}
+                                variant="subtle"
+                                size="compact-sm"
+                                leftSection={<MantineIcon icon={IconPlus} />}
+                                onClick={handleAddRule}
+                            >
+                                Add new condition
+                            </Button>
+                        ) : null}
+                    </FiltersProvider>
+                </Stack>
+            </Accordion.Panel>
+        </Accordion.Item>
+    );
+};

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConditionalFormattingRule.tsx
@@ -1,0 +1,175 @@
+import {
+    FilterOperator,
+    FilterType,
+    isConditionalFormattingWithValues,
+    isNumericItem,
+    isStringDimension,
+    type ConditionalFormattingWithFilterOperator,
+    type FilterableItem,
+} from '@lightdash/common';
+import {
+    ActionIcon,
+    Collapse,
+    Group,
+    Select,
+    Stack,
+    Text,
+    TextInput,
+    Tooltip,
+} from '@mantine/core';
+import { useHover } from '@mantine/hooks';
+import { IconChevronDown, IconChevronUp, IconTrash } from '@tabler/icons-react';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import { useParams } from 'react-router';
+import FilterInputComponent from '../../common/Filters/FilterInputs';
+import {
+    getFilterOperatorOptions,
+    getFilterOptions,
+} from '../../common/Filters/FilterInputs/utils';
+import FiltersProvider from '../../common/Filters/FiltersProvider';
+import MantineIcon from '../../common/MantineIcon';
+
+interface Props {
+    isDefaultOpen?: boolean;
+    ruleIndex: number;
+    rule: ConditionalFormattingWithFilterOperator;
+    field: FilterableItem | undefined;
+    hasRemove?: boolean;
+    onChangeRule: (newRule: ConditionalFormattingWithFilterOperator) => void;
+    onChangeRuleOperator: (newOperator: FilterOperator) => void;
+    onRemoveRule: () => void;
+}
+
+const BigNumberConditionalFormattingRule: FC<Props> = ({
+    isDefaultOpen = true,
+    ruleIndex,
+    rule,
+    field,
+    onChangeRule,
+    onChangeRuleOperator,
+    onRemoveRule,
+    hasRemove,
+}) => {
+    const { projectUuid } = useParams<{ projectUuid: string }>();
+
+    const { ref, hovered } = useHover();
+    const [isOpen, setIsOpen] = useState(isDefaultOpen);
+
+    const filterType: FilterType.NUMBER | FilterType.STRING | undefined =
+        useMemo(() => {
+            if (isNumericItem(field)) return FilterType.NUMBER;
+            if (isStringDimension(field)) return FilterType.STRING;
+            return undefined;
+        }, [field]);
+
+    const filterOperatorOptions = useMemo(() => {
+        if (!filterType) return [];
+        if (filterType === FilterType.NUMBER) {
+            return getFilterOperatorOptions(filterType);
+        }
+        if (filterType === FilterType.STRING) {
+            return getFilterOptions([
+                FilterOperator.EQUALS,
+                FilterOperator.NOT_EQUALS,
+                FilterOperator.INCLUDE,
+            ]);
+        }
+        return [];
+    }, [filterType]);
+
+    const handleChangeRule = useCallback(
+        (newRule: ConditionalFormattingWithFilterOperator) => {
+            if (isConditionalFormattingWithValues(newRule)) {
+                onChangeRule({
+                    ...newRule,
+                    values: newRule.values.map((v) => {
+                        if (isStringDimension(field)) {
+                            return String(v);
+                        }
+                        return Number(v);
+                    }),
+                });
+            } else {
+                onChangeRule(newRule);
+            }
+        },
+        [onChangeRule, field],
+    );
+
+    return (
+        <Stack spacing="xs" ref={ref}>
+            <Group noWrap position="apart">
+                <Group spacing="xs">
+                    <Text fw={500} fz="xs">
+                        Condition {ruleIndex + 1}
+                    </Text>
+
+                    {hasRemove && hovered && (
+                        <Tooltip
+                            variant="xs"
+                            label="Remove condition"
+                            position="left"
+                            withinPortal
+                        >
+                            <ActionIcon onClick={onRemoveRule}>
+                                <MantineIcon icon={IconTrash} />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+                </Group>
+
+                <ActionIcon onClick={() => setIsOpen(!isOpen)} size="sm">
+                    <MantineIcon
+                        icon={isOpen ? IconChevronUp : IconChevronDown}
+                    />
+                </ActionIcon>
+            </Group>
+
+            <Collapse in={isOpen}>
+                <Stack spacing="xs">
+                    <Group noWrap spacing="xs">
+                        <Select
+                            value={rule.operator}
+                            data={filterOperatorOptions}
+                            onChange={(value) => {
+                                if (!value) return;
+                                onChangeRuleOperator(value as FilterOperator);
+                            }}
+                            placeholder="Condition"
+                            disabled={!field || !filterType}
+                        />
+
+                        <Select
+                            display={field && filterType ? 'none' : 'block'}
+                            placeholder="Value(s)"
+                            data={[]}
+                            disabled={!field || !filterType}
+                        />
+
+                        {projectUuid &&
+                            filterType &&
+                            isConditionalFormattingWithValues(rule) && (
+                                <FiltersProvider projectUuid={projectUuid}>
+                                    {field ? (
+                                        <FilterInputComponent
+                                            filterType={filterType}
+                                            field={field}
+                                            rule={rule}
+                                            onChange={handleChangeRule}
+                                        />
+                                    ) : (
+                                        <TextInput
+                                            disabled={true}
+                                            placeholder="Values"
+                                        />
+                                    )}
+                                </FiltersProvider>
+                            )}
+                    </Group>
+                </Stack>
+            </Collapse>
+        </Stack>
+    );
+};
+
+export default BigNumberConditionalFormattingRule;

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberConfigTabs.tsx
@@ -2,6 +2,7 @@ import { MantineProvider, Tabs, useMantineColorScheme } from '@mantine/core';
 import { type FC, memo, useMemo } from 'react';
 import { getVizConfigThemeOverride } from '../mantineTheme';
 import { Comparison } from './BigNumberComparison';
+import { BigNumberConditionalFormatting } from './BigNumberConditionalFormatting';
 import { Layout } from './BigNumberLayout';
 
 export const ConfigTabs: FC = memo(() => {
@@ -21,6 +22,9 @@ export const ConfigTabs: FC = memo(() => {
                     <Tabs.Tab px="sm" value="comparison">
                         Comparison
                     </Tabs.Tab>
+                    <Tabs.Tab px="sm" value="conditionalFormatting">
+                        Conditional formatting
+                    </Tabs.Tab>
                 </Tabs.List>
 
                 <Tabs.Panel value="layout">
@@ -28,6 +32,9 @@ export const ConfigTabs: FC = memo(() => {
                 </Tabs.Panel>
                 <Tabs.Panel value="comparison">
                     <Comparison />
+                </Tabs.Panel>
+                <Tabs.Panel value="conditionalFormatting">
+                    <BigNumberConditionalFormatting />
                 </Tabs.Panel>
             </Tabs>
         </MantineProvider>

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/ConditionalFormattingRule.tsx
@@ -222,7 +222,6 @@ const ConditionalFormattingRule: FC<ConditionalFormattingRuleProps> = ({
 
                     {hasRemove && hovered && (
                         <Tooltip
-                            variant="xs"
                             label="Remove condition"
                             position="left"
                             withinPortal

--- a/packages/frontend/src/components/VisualizationConfigs/common/Config.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/common/Config.tsx
@@ -6,14 +6,21 @@ import {
     type GroupProps,
     type TextProps,
 } from '@mantine/core';
+import { type Icon as TablerIconType } from '@tabler/icons-react';
 import { type FC, type PropsWithChildren } from 'react';
+import MantineIcon from '../../common/MantineIcon';
+
+type LabelProps = PropsWithChildren &
+    TextProps & {
+        icon?: TablerIconType;
+    };
 
 interface ConfigComponent extends FC<PropsWithChildren> {
     Section: FC<PropsWithChildren>;
     Heading: FC<PropsWithChildren>;
     Subheading: FC<PropsWithChildren>;
     Group: FC<PropsWithChildren & GroupProps>;
-    Label: FC<PropsWithChildren & TextProps>;
+    Label: FC<LabelProps>;
 }
 
 export const Config: ConfigComponent = ({ children }) => <Box>{children}</Box>;
@@ -34,11 +41,19 @@ const Subheading: FC<PropsWithChildren> = ({ children }) => (
     </Text>
 );
 
-const Label: FC<PropsWithChildren & TextProps> = ({ children, ...props }) => (
-    <Text fw={500} size="xs" color="ldGray.6" {...props}>
-        {children}
-    </Text>
-);
+const Label: FC<LabelProps> = ({ children, icon, ...props }) =>
+    icon ? (
+        <MantineGroup spacing={4} noWrap>
+            <MantineIcon icon={icon} size={14} color="ldGray.6" />
+            <Text fw={500} size="xs" color="ldGray.6" {...props}>
+                {children}
+            </Text>
+        </MantineGroup>
+    ) : (
+        <Text fw={500} size="xs" color="ldGray.6" {...props}>
+            {children}
+        </Text>
+    );
 
 const Group: FC<PropsWithChildren & GroupProps> = ({ children, ...props }) => (
     <MantineGroup position="apart" {...props}>


### PR DESCRIPTION
Closes: #20371

### Description:

Adds conditional formatting support for Big Number visualizations. This allows users to apply color rules to the big number value based on conditions + dark mode support.

![CleanShot 2026-02-17 at 17.16.23@2x.png](https://app.graphite.com/user-attachments/assets/e3e0e00b-155a-4192-9186-dd1b39a6f77d.png)

![CleanShot 2026-02-17 at 17.16.10@2x.png](https://app.graphite.com/user-attachments/assets/8a0a9b95-a939-4f56-b75d-4a5884d8235d.png)



![CleanShot 2026-02-17 at 17.16.34@2x.png](https://app.graphite.com/user-attachments/assets/6f88fa61-6e4f-4a96-9af5-d4fee3e8bc07.png)

![CleanShot 2026-02-17 at 17.16.37@2x.png](https://app.graphite.com/user-attachments/assets/2adae3a5-5e84-409c-a481-4d3607e2d28e.png)

---

No condition stays with foreground color

![CleanShot 2026-02-17 at 17.18.51@2x.png](https://app.graphite.com/user-attachments/assets/6981f228-8261-4fb7-a4a6-9f7fee287b65.png)

![CleanShot 2026-02-17 at 17.18.47@2x.png](https://app.graphite.com/user-attachments/assets/b69a9004-875f-4342-8410-f191a1418454.png)

