### PR TITLE
feat: improve empty state experience

### DIFF
--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -14,6 +14,7 @@ export enum ResourceItemCategory {
     MOST_POPULAR = 'mostPopular',
     RECENTLY_UPDATED = 'recentlyUpdated',
     PINNED = 'pinned',
+    FAVORITES = 'favorites',
 }
 
 export type ResourceViewChartItem = {

--- a/packages/frontend/src/components/FavoritesPanel/index.tsx
+++ b/packages/frontend/src/components/FavoritesPanel/index.tsx
@@ -1,7 +1,9 @@
 import { ResourceViewItemType, type FavoriteItems } from '@lightdash/common';
+import { IconStar } from '@tabler/icons-react';
 import { type FC } from 'react';
 import PinnedItemsContext from '../../providers/PinnedItems/context';
 import { type PinnedItemsContextType } from '../../providers/PinnedItems/types';
+import MantineIcon from '../common/MantineIcon';
 import ResourceView from '../common/ResourceView';
 import { ResourceViewType } from '../common/ResourceView/types';
 
@@ -15,10 +17,14 @@ const noopPinnedContext: PinnedItemsContextType = {
 
 interface Props {
     favoriteItems: FavoriteItems;
+    showEmptyState?: boolean;
 }
 
-const FavoritesPanel: FC<Props> = ({ favoriteItems }) => {
-    if (!favoriteItems || favoriteItems.length === 0) {
+const FavoritesPanel: FC<Props> = ({
+    favoriteItems,
+    showEmptyState = false,
+}) => {
+    if (!showEmptyState && (!favoriteItems || favoriteItems.length === 0)) {
         return null;
     }
 
@@ -40,6 +46,12 @@ const FavoritesPanel: FC<Props> = ({ favoriteItems }) => {
                     title: 'My favorites',
                     description:
                         'Your personally favorited spaces, dashboards, and charts.',
+                }}
+                emptyStateProps={{
+                    icon: <MantineIcon icon={IconStar} size={24} />,
+                    title: 'No favorites yet',
+                    description:
+                        'Star items to add them to your personal favorites.',
                 }}
             />
         </PinnedItemsContext.Provider>

--- a/packages/frontend/src/components/PinnedAndFavoritesSection/index.tsx
+++ b/packages/frontend/src/components/PinnedAndFavoritesSection/index.tsx
@@ -1,0 +1,107 @@
+import {
+    ResourceItemCategory,
+    ResourceViewItemType,
+    type FavoriteItems,
+    type PinnedItems,
+} from '@lightdash/common';
+import { IconPin, IconStar } from '@tabler/icons-react';
+import { useMemo, type FC } from 'react';
+import usePinnedItemsContext from '../../providers/PinnedItems/usePinnedItemsContext';
+import MantineIcon from '../common/MantineIcon';
+import ResourceView from '../common/ResourceView';
+import { ResourceViewType } from '../common/ResourceView/types';
+import FavoritesPanel from '../FavoritesPanel';
+import PinnedItemsPanel from '../PinnedItemsPanel';
+
+const GRID_GROUPS = [
+    [ResourceViewItemType.SPACE],
+    [ResourceViewItemType.DASHBOARD, ResourceViewItemType.CHART],
+];
+
+interface Props {
+    pinnedItems: PinnedItems;
+    favoriteItems: FavoriteItems;
+    pinnedIsEnabled: boolean;
+}
+
+const PinnedAndFavoritesSection: FC<Props> = ({
+    pinnedItems,
+    favoriteItems,
+    pinnedIsEnabled,
+}) => {
+    const { userCanManage } = usePinnedItemsContext();
+
+    const hasPinned = pinnedItems.length > 0;
+    const hasFavorites = favoriteItems.length > 0;
+
+    const mergedItems = useMemo(() => {
+        const pinned = pinnedItems.map((item) => ({
+            ...item,
+            category: ResourceItemCategory.PINNED,
+        }));
+        const favorites = favoriteItems.map((item) => ({
+            ...item,
+            category: ResourceItemCategory.FAVORITES,
+        }));
+        return [...pinned, ...favorites];
+    }, [pinnedItems, favoriteItems]);
+
+    // At least one has items: show tabbed ResourceView with empty state inside tabs
+    if (hasPinned || hasFavorites) {
+        return (
+            <ResourceView
+                items={mergedItems}
+                view={ResourceViewType.GRID}
+                hasReorder={userCanManage}
+                defaultActiveTab={hasFavorites ? 'favorites' : 'pinned'}
+                tabs={[
+                    {
+                        id: 'favorites',
+                        name: 'My favorites',
+                        icon: <MantineIcon icon={IconStar} size="sm" />,
+                        infoTooltipText:
+                            'Your personally favorited spaces, dashboards, and charts.',
+                        filter: (item) =>
+                            'category' in item &&
+                            item.category === ResourceItemCategory.FAVORITES,
+                    },
+                    {
+                        id: 'pinned',
+                        name: userCanManage ? 'Pinned items' : 'Pinned for you',
+                        icon: <MantineIcon icon={IconPin} size="sm" />,
+                        infoTooltipText: userCanManage
+                            ? 'Pin Spaces, Dashboards and Charts to the top of the homepage to guide your business users to the right content.'
+                            : 'Your data team have pinned these items to help guide you towards the most relevant content!',
+                        filter: (item) =>
+                            'category' in item &&
+                            item.category === ResourceItemCategory.PINNED,
+                    },
+                ]}
+                gridProps={{ groups: GRID_GROUPS }}
+                emptyStateProps={{
+                    icon: <MantineIcon icon={IconStar} size={24} />,
+                    title: 'No favorites yet',
+                    description:
+                        'Star items to add them to your personal favorites.',
+                }}
+            />
+        );
+    }
+
+    // Neither has items:
+    // - Admins see pinned empty state + favorites empty state
+    // - Non-admins see only favorites empty state
+    return (
+        <>
+            {userCanManage && pinnedIsEnabled && (
+                <PinnedItemsPanel
+                    pinnedItems={pinnedItems}
+                    isEnabled={pinnedIsEnabled}
+                />
+            )}
+            <FavoritesPanel favoriteItems={favoriteItems} showEmptyState />
+        </>
+    );
+};
+
+export default PinnedAndFavoritesSection;

--- a/packages/frontend/src/pages/Home.tsx
+++ b/packages/frontend/src/pages/Home.tsx
@@ -1,13 +1,12 @@
 import { type FC } from 'react';
 import { useParams } from 'react-router';
 import { useUnmount } from 'react-use';
-import FavoritesPanel from '../components/FavoritesPanel';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import LandingPanel from '../components/Home/LandingPanel';
 import { MostPopularAndRecentlyUpdatedPanel } from '../components/Home/MostPopularAndRecentlyUpdatedPanel';
 import OnboardingPanel from '../components/Home/OnboardingPanel/index';
 import PageSpinner from '../components/PageSpinner';
-import PinnedItemsPanel from '../components/PinnedItemsPanel';
+import PinnedAndFavoritesSection from '../components/PinnedAndFavoritesSection';
 import ErrorState from '../components/common/ErrorState';
 import Page from '../components/common/Page/Page';
 import AiSearchBox from '../ee/components/Home/AiSearchBox';
@@ -100,9 +99,10 @@ const Home: FC = () => {
                             }
                             allowDelete={false}
                         >
-                            <PinnedItemsPanel
+                            <PinnedAndFavoritesSection
                                 pinnedItems={pinnedItems.data ?? []}
-                                isEnabled={Boolean(
+                                favoriteItems={favorites.data ?? []}
+                                pinnedIsEnabled={Boolean(
                                     mostPopularAndRecentlyUpdated
                                         ?.mostPopular.length ||
                                         mostPopularAndRecentlyUpdated
@@ -110,9 +110,6 @@ const Home: FC = () => {
                                 )}
                             />
                         </PinnedItemsProvider>
-                        <FavoritesPanel
-                            favoriteItems={favorites.data ?? []}
-                        />
                         <MostPopularAndRecentlyUpdatedPanel
                             data={mostPopularAndRecentlyUpdated}
                             projectUuid={project.data.projectUuid}

--- a/packages/frontend/src/pages/SavedDashboards.tsx
+++ b/packages/frontend/src/pages/SavedDashboards.tsx
@@ -11,6 +11,7 @@ import DashboardCreateModal from '../components/common/modal/DashboardCreateModa
 import { useDashboards } from '../hooks/dashboard/useDashboards';
 import useCreateInAnySpaceAccess from '../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../providers/App/useApp';
+import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 
 const SavedDashboards = () => {
     const navigate = useNavigate();
@@ -41,55 +42,57 @@ const SavedDashboards = () => {
     };
 
     return (
-        <Page
-            title="Dashboards"
-            withCenteredRoot
-            withCenteredContent
-            withXLargePaddedContent
-            withLargeContent
-        >
-            <Stack spacing="xxl" w="100%">
-                <Group position="apart">
-                    <PageBreadcrumbs
-                        items={[
-                            { title: 'Home', to: '/home' },
-                            { title: 'All dashboards', active: true },
-                        ]}
+        <FavoritesProvider projectUuid={projectUuid}>
+            <Page
+                title="Dashboards"
+                withCenteredRoot
+                withCenteredContent
+                withXLargePaddedContent
+                withLargeContent
+            >
+                <Stack spacing="xxl" w="100%">
+                    <Group position="apart">
+                        <PageBreadcrumbs
+                            items={[
+                                { title: 'Home', to: '/home' },
+                                { title: 'All dashboards', active: true },
+                            ]}
+                        />
+
+                        {dashboards.length > 0 &&
+                            userCanCreateDashboards &&
+                            !isDemo && (
+                                <Button
+                                    leftIcon={<IconPlus size={18} />}
+                                    onClick={handleCreateDashboard}
+                                >
+                                    Create dashboard
+                                </Button>
+                            )}
+                    </Group>
+
+                    <InfiniteResourceTable
+                        filters={{
+                            projectUuid,
+                            contentTypes: [ContentType.DASHBOARD],
+                        }}
                     />
+                </Stack>
 
-                    {dashboards.length > 0 &&
-                        userCanCreateDashboards &&
-                        !isDemo && (
-                            <Button
-                                leftIcon={<IconPlus size={18} />}
-                                onClick={handleCreateDashboard}
-                            >
-                                Create dashboard
-                            </Button>
-                        )}
-                </Group>
+                <DashboardCreateModal
+                    projectUuid={projectUuid}
+                    opened={isCreateDashboardOpen}
+                    onClose={() => setIsCreateDashboardOpen(false)}
+                    onConfirm={(dashboard) => {
+                        void navigate(
+                            `/projects/${projectUuid}/dashboards/${dashboard.uuid}/edit`,
+                        );
 
-                <InfiniteResourceTable
-                    filters={{
-                        projectUuid,
-                        contentTypes: [ContentType.DASHBOARD],
+                        setIsCreateDashboardOpen(false);
                     }}
                 />
-            </Stack>
-
-            <DashboardCreateModal
-                projectUuid={projectUuid}
-                opened={isCreateDashboardOpen}
-                onClose={() => setIsCreateDashboardOpen(false)}
-                onConfirm={(dashboard) => {
-                    void navigate(
-                        `/projects/${projectUuid}/dashboards/${dashboard.uuid}/edit`,
-                    );
-
-                    setIsCreateDashboardOpen(false);
-                }}
-            />
-        </Page>
+            </Page>
+        </FavoritesProvider>
     );
 };
 

--- a/packages/frontend/src/pages/SavedQueries.tsx
+++ b/packages/frontend/src/pages/SavedQueries.tsx
@@ -8,6 +8,7 @@ import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
 import InfiniteResourceTable from '../components/common/ResourceView/InfiniteResourceTable';
 import useCreateInAnySpaceAccess from '../hooks/user/useCreateInAnySpaceAccess';
 import useApp from '../providers/App/useApp';
+import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 
 const SavedQueries: FC = () => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -25,41 +26,43 @@ const SavedQueries: FC = () => {
     };
 
     return (
-        <Page
-            title="Saved charts"
-            withCenteredRoot
-            withCenteredContent
-            withXLargePaddedContent
-            withLargeContent
-        >
-            <Stack spacing="xxl" w="100%">
-                <Group position="apart">
-                    <PageBreadcrumbs
-                        items={[
-                            { title: 'Home', to: '/home' },
-                            { title: 'All saved charts', active: true },
-                        ]}
-                    />
-                    {!isDemo && userCanCreateCharts ? (
-                        <Button
-                            leftIcon={<IconPlus size={18} />}
-                            onClick={handleCreateChart}
-                        >
-                            Create chart
-                        </Button>
-                    ) : undefined}
-                </Group>
+        <FavoritesProvider projectUuid={projectUuid}>
+            <Page
+                title="Saved charts"
+                withCenteredRoot
+                withCenteredContent
+                withXLargePaddedContent
+                withLargeContent
+            >
+                <Stack spacing="xxl" w="100%">
+                    <Group position="apart">
+                        <PageBreadcrumbs
+                            items={[
+                                { title: 'Home', to: '/home' },
+                                { title: 'All saved charts', active: true },
+                            ]}
+                        />
+                        {!isDemo && userCanCreateCharts ? (
+                            <Button
+                                leftIcon={<IconPlus size={18} />}
+                                onClick={handleCreateChart}
+                            >
+                                Create chart
+                            </Button>
+                        ) : undefined}
+                    </Group>
 
-                {projectUuid ? (
-                    <InfiniteResourceTable
-                        filters={{
-                            projectUuid,
-                            contentTypes: [ContentType.CHART],
-                        }}
-                    />
-                ) : null}
-            </Stack>
-        </Page>
+                    {projectUuid ? (
+                        <InfiniteResourceTable
+                            filters={{
+                                projectUuid,
+                                contentTypes: [ContentType.CHART],
+                            }}
+                        />
+                    ) : null}
+                </Stack>
+            </Page>
+        </FavoritesProvider>
     );
 };
 

--- a/packages/frontend/src/pages/Spaces.tsx
+++ b/packages/frontend/src/pages/Spaces.tsx
@@ -15,6 +15,7 @@ import SpaceActionModal from '../components/common/SpaceActionModal';
 import { ActionType } from '../components/common/SpaceActionModal/types';
 
 import useApp from '../providers/App/useApp';
+import { FavoritesProvider } from '../providers/Favorites/FavoritesProvider';
 
 const Spaces: FC = () => {
     const { projectUuid } = useParams() as {
@@ -60,67 +61,69 @@ const Spaces: FC = () => {
     }
 
     return (
-        <Page
-            title="Spaces"
-            withCenteredRoot
-            withCenteredContent
-            withXLargePaddedContent
-            withLargeContent
-        >
-            <Stack spacing="xxl" w="100%">
-                <Group position="apart">
-                    <PageBreadcrumbs
-                        items={[
-                            { to: '/home', title: 'Home' },
-                            { title: 'Spaces', active: true },
-                        ]}
-                    />
+        <FavoritesProvider projectUuid={projectUuid}>
+            <Page
+                title="Spaces"
+                withCenteredRoot
+                withCenteredContent
+                withXLargePaddedContent
+                withLargeContent
+            >
+                <Stack spacing="xxl" w="100%">
+                    <Group position="apart">
+                        <PageBreadcrumbs
+                            items={[
+                                { to: '/home', title: 'Home' },
+                                { title: 'Spaces', active: true },
+                            ]}
+                        />
 
-                    <Group spacing="xs">
-                        {!isDemo && userCanManageSpace && (
-                            <Button
-                                leftIcon={<IconPlus size={18} />}
-                                onClick={handleCreateSpace}
-                            >
-                                Add
-                            </Button>
-                        )}
+                        <Group spacing="xs">
+                            {!isDemo && userCanManageSpace && (
+                                <Button
+                                    leftIcon={<IconPlus size={18} />}
+                                    onClick={handleCreateSpace}
+                                >
+                                    Add
+                                </Button>
+                            )}
+                        </Group>
                     </Group>
-                </Group>
-                <InfiniteResourceTable
-                    filters={{
-                        projectUuid,
-                        spaceUuids: [],
-                        contentTypes: [ContentType.SPACE],
-                    }}
-                    contentTypeFilter={{
-                        defaultValue: ContentType.SPACE,
-                        options: [],
-                    }}
-                    columnVisibility={{
-                        [ColumnVisibility.SPACE]: false,
-                        [ColumnVisibility.UPDATED_AT]: false,
-                        [ColumnVisibility.ACCESS]: true,
-                        [ColumnVisibility.CONTENT]: true,
-                    }}
-                    adminContentView={userCanManageProject}
-                    enableBottomToolbar={false}
-                    enableRowSelection={userCanManageSpace}
-                />
-
-                {isCreateModalOpen && (
-                    <SpaceActionModal
-                        projectUuid={projectUuid}
-                        parentSpaceUuid={null}
-                        actionType={ActionType.CREATE}
-                        title="Create new space"
-                        confirmButtonLabel="Create"
-                        icon={IconFolderPlus}
-                        onClose={() => setIsCreateModalOpen(false)}
+                    <InfiniteResourceTable
+                        filters={{
+                            projectUuid,
+                            spaceUuids: [],
+                            contentTypes: [ContentType.SPACE],
+                        }}
+                        contentTypeFilter={{
+                            defaultValue: ContentType.SPACE,
+                            options: [],
+                        }}
+                        columnVisibility={{
+                            [ColumnVisibility.SPACE]: false,
+                            [ColumnVisibility.UPDATED_AT]: false,
+                            [ColumnVisibility.ACCESS]: true,
+                            [ColumnVisibility.CONTENT]: true,
+                        }}
+                        adminContentView={userCanManageProject}
+                        enableBottomToolbar={false}
+                        enableRowSelection={userCanManageSpace}
                     />
-                )}
-            </Stack>
-        </Page>
+
+                    {isCreateModalOpen && (
+                        <SpaceActionModal
+                            projectUuid={projectUuid}
+                            parentSpaceUuid={null}
+                            actionType={ActionType.CREATE}
+                            title="Create new space"
+                            confirmButtonLabel="Create"
+                            icon={IconFolderPlus}
+                            onClose={() => setIsCreateModalOpen(false)}
+                        />
+                    )}
+                </Stack>
+            </Page>
+        </FavoritesProvider>
     );
 };
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #5874


### Description:
This PR introduces a new "Favorites" feature to the UI, allowing users to view their favorited items in a dedicated section. The implementation includes:

- Added a new `FAVORITES` category to `ResourceItemCategory` enum
- Created a combined `PinnedAndFavoritesSection` component that displays both pinned and favorite items in a tabbed interface
- Enhanced the `FavoritesPanel` component to support empty states
- Updated the Home page to use the new combined section instead of separate panels
- Added `FavoritesProvider` to Spaces, SavedQueries, and SavedDashboards pages

The new UI shows a tabbed interface when either pinned items or favorites exist, and appropriate empty states when they don't. For admins, both pinned and favorites empty states are shown, while non-admins only see the favorites empty state.