### PR TITLE
feat: add analytics events to favoriting

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -948,6 +948,17 @@ type PinnedListUpdated = BaseTrack & {
     };
 };
 
+type FavoriteToggled = BaseTrack & {
+    event: 'favorite.toggled';
+    userId: string;
+    properties: {
+        projectId: string;
+        organizationId: string;
+        contentType: string;
+        isFavorite: boolean;
+    };
+};
+
 export type SchedulerUpsertEvent = BaseTrack & {
     event: 'scheduler.created' | 'scheduler.updated';
     userId: string;
@@ -1566,6 +1577,7 @@ type TypedEvent =
     | SchedulerJobEvent
     | SchedulerNotificationJobEvent
     | PinnedListUpdated
+    | FavoriteToggled
     | DownloadCsv
     | SchedulerDashboardView
     | Validation

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1011,6 +1011,7 @@ export class ServiceRepository
             'favoritesService',
             () =>
                 new FavoritesService({
+                    analytics: this.context.lightdashAnalytics,
                     userFavoritesModel:
                         this.models.getUserFavoritesModel(),
                     projectModel: this.models.getProjectModel(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Added analytics tracking for favorite toggling functionality. Created a new `FavoriteToggled` event type in `LightdashAnalytics.ts` and integrated it into the `FavoritesService` to track when users favorite or unfavorite content. The analytics event captures the project ID, organization ID, content type, and whether the item is being favorited or unfavorited.