### PR TITLE
fix: retry query on network errors

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -24,6 +24,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         useSqlPivotResults: false,
         showExecutionTime: false,
         enableTableColumnCustomization: undefined,
+        retryQueryOnTransientErrors: false,
     },
 };
 
@@ -61,6 +62,7 @@ export const lightdashConfigWithBasicSMTP: Pick<
         useSqlPivotResults: false,
         showExecutionTime: false,
         enableTableColumnCustomization: undefined,
+        retryQueryOnTransientErrors: false,
     },
 };
 
@@ -86,6 +88,7 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         useSqlPivotResults: false,
         showExecutionTime: false,
         enableTableColumnCustomization: undefined,
+        retryQueryOnTransientErrors: false,
     },
 };
 
@@ -107,6 +110,7 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         useSqlPivotResults: false,
         showExecutionTime: false,
         enableTableColumnCustomization: undefined,
+        retryQueryOnTransientErrors: false,
     },
 };
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -212,6 +212,7 @@ export const lightdashConfigMock: LightdashConfig = {
         useSqlPivotResults: false,
         showExecutionTime: false,
         enableTableColumnCustomization: undefined,
+        retryQueryOnTransientErrors: true,
     },
     ai: {
         copilot: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -882,6 +882,7 @@ export type LightdashConfig = {
         useSqlPivotResults: boolean | undefined;
         showExecutionTime: boolean | undefined;
         enableTableColumnCustomization: boolean | undefined;
+        retryQueryOnTransientErrors: boolean;
     };
     pivotTable: {
         maxColumnLimit: number;
@@ -1682,6 +1683,11 @@ export const parseConfig = (): LightdashConfig => {
                 .ENABLE_TABLE_COLUMN_CUSTOMIZATION
                 ? process.env.ENABLE_TABLE_COLUMN_CUSTOMIZATION === 'true'
                 : undefined,
+            retryQueryOnTransientErrors: process.env
+                .LIGHTDASH_QUERY_RETRY_ON_TRANSIENT_ERRORS
+                ? process.env.LIGHTDASH_QUERY_RETRY_ON_TRANSIENT_ERRORS ===
+                  'true'
+                : false,
         },
         chart: {
             versionHistory: {

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -81,6 +81,7 @@ export const BaseResponse: HealthState = {
         maxLimit: 5000,
         maxPageSize: 2500,
         defaultLimit: 500,
+        retryQueryOnTransientErrors: true,
     },
     dashboard: {
         maxTilesPerTab: 50,

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -121,6 +121,8 @@ export class HealthService extends BaseService {
                 maxLimit: this.lightdashConfig.query.maxLimit,
                 maxPageSize: this.lightdashConfig.query.maxPageSize,
                 defaultLimit: this.lightdashConfig.query.defaultLimit,
+                retryQueryOnTransientErrors:
+                    this.lightdashConfig.query.retryQueryOnTransientErrors,
             },
             dashboard: this.lightdashConfig.dashboard,
             pivotTable: this.lightdashConfig.pivotTable,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -475,6 +475,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         useSqlPivotResults: false,
         showExecutionTime: false,
         enableTableColumnCustomization: undefined,
+        retryQueryOnTransientErrors: false,
     },
 };
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -419,6 +419,7 @@ export type HealthState = {
         defaultLimit: number;
         csvCellsLimit: number;
         maxPageSize: number;
+        retryQueryOnTransientErrors: boolean;
     };
     dashboard: {
         maxTilesPerTab: number;

--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -17,6 +17,7 @@ import { useQuery } from '@tanstack/react-query';
 import { useCallback } from 'react';
 import getChartDataModel from '../../../components/DataViz/transformers/getChartDataModel';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
+import { useQueryRetryConfig } from '../../../hooks/useQueryRetry';
 import {
     getDashboardSqlChartPivotChartData,
     getSqlChartPivotChartData,
@@ -62,6 +63,7 @@ type UseSavedSqlChartResults = {
 export const useSavedSqlChartResults = (
     args: UseSavedSqlChartResultsArguments,
 ) => {
+    const retryConfig = useQueryRetryConfig();
     // Needed for organization colors
     const { data: organization } = useOrganization();
 
@@ -78,6 +80,7 @@ export const useSavedSqlChartResults = (
             }),
         {
             enabled: (!!savedSqlUuid || !!slug) && !!projectUuid,
+            ...retryConfig,
         },
     );
 
@@ -171,6 +174,7 @@ export const useSavedSqlChartResults = (
                 !!chartQuery.data &&
                 !!projectUuid &&
                 (!!savedSqlUuid || !!slug),
+            ...retryConfig,
         },
     );
 

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -17,6 +17,7 @@ import { lightdashApi } from '../../api';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import { convertDateDashboardFilters } from '../../utils/dateFilter';
 import { useExplore } from '../useExplore';
+import { useQueryRetryConfig } from '../useQueryRetry';
 import { useSavedQuery } from '../useSavedQuery';
 import useSearchParams from '../useSearchParams';
 import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
@@ -65,6 +66,7 @@ export const useDashboardChartReadyQuery = (
     chartUuid: string | null,
     contextOverride?: QueryExecutionContext,
 ) => {
+    const retryConfig = useQueryRetryConfig();
     const dashboardUuid = useDashboardContext((c) => c.dashboard?.uuid);
     const invalidateCache = useDashboardContext((c) => c.invalidateCache);
     const dashboardFilters = useDashboardFiltersForTile(tileUuid);
@@ -260,7 +262,7 @@ export const useDashboardChartReadyQuery = (
         enabled: Boolean(
             chartUuid && dashboardUuid && chartQuery.data && explore,
         ),
-        retry: false,
+        ...retryConfig,
         refetchOnMount: false,
     });
 

--- a/packages/frontend/src/hooks/useQueryRetry.ts
+++ b/packages/frontend/src/hooks/useQueryRetry.ts
@@ -1,0 +1,61 @@
+import type { ApiError } from '@lightdash/common';
+import { useMemo } from 'react';
+import useApp from '../providers/App/useApp';
+
+/**
+ * Determines if an API error is retryable (transient database/server issues)
+ * @param error The API error from the query
+ * @returns true if the error should be retried
+ */
+const isRetryableError = (error: ApiError | Partial<ApiError>): boolean => {
+    const statusCode = error.error?.statusCode;
+    const errorName = error.error?.name;
+
+    // Retry on network errors (database connection issues, timeouts)
+    if (errorName === 'NetworkError') {
+        return true;
+    }
+
+    // Retry on 5xx server errors (backend/database overwhelmed)
+    if (statusCode && statusCode >= 500 && statusCode < 600) {
+        return true;
+    }
+
+    // Don't retry on 4xx client errors (bad request, not found, unauthorized, etc.)
+    return false;
+};
+
+/**
+ * Calculate exponential backoff delay for retries
+ * @param attemptIndex Zero-based retry attempt (0, 1, 2)
+ * @returns Delay in milliseconds
+ */
+const getRetryDelay = (attemptIndex: number): number =>
+    // Exponential backoff: 1s, 2s, 4s
+    Math.min(1000 * 2 ** attemptIndex, 4000);
+
+/**
+ * Retry configuration for React Query hooks
+ * - Max 3 retry attempts
+ * - Exponential backoff (1s, 2s, 4s)
+ * - Only retry on transient errors (5xx, NetworkError)
+ */
+const getRetryConfig = (retryEnabled: boolean) => ({
+    retry: retryEnabled
+        ? (failureCount: number, error: ApiError | Partial<ApiError>) => {
+              if (failureCount >= 3) {
+                  return false;
+              }
+              return isRetryableError(error);
+          }
+        : false,
+    retryDelay: getRetryDelay,
+});
+
+export const useQueryRetryConfig = () => {
+    const { health } = useApp();
+    const retryEnabled =
+        health.data?.query.retryQueryOnTransientErrors ?? false;
+
+    return useMemo(() => getRetryConfig(retryEnabled), [retryEnabled]);
+};

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -46,6 +46,7 @@ export default function mockHealthResponse(
             maxLimit: 1000000,
             defaultLimit: 500,
             csvCellsLimit: 100,
+            retryQueryOnTransientErrors: true,
         },
         dashboard: {
             maxTilesPerTab: 50,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
In our self-hosted deployment when the trino cluster is not scaled to a desired size during the peak hours we kept getting 5xx errors from the queries requests, to mitigate this problem, this PR adds retries to react-query. I tested it a bit and seems to work well. Current implementation retries 3 times with increasing delays between retries.

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
