### PR TITLE
fix: allow operator changes for required filters while preventing removal

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -87,7 +87,7 @@ const FilterRuleForm: FC<Props> = memo(
         );
         const isRequired = filterRule.required;
         const isRequiredLabel = isRequired
-            ? 'This is a required filter defined in the model configuration and cannot be modified.'
+            ? 'This is a required filter defined in the model configuration and cannot be removed.'
             : '';
 
         if (!activeField) {
@@ -134,7 +134,7 @@ const FilterRuleForm: FC<Props> = memo(
                     withinPortal={popoverProps?.withinPortal}
                     onDropdownOpen={popoverProps?.onOpen}
                     onDropdownClose={popoverProps?.onClose}
-                    disabled={!isEditMode || isRequired}
+                    disabled={!isEditMode}
                     value={filterRule.operator}
                     data={filterOperatorOptions}
                     onChange={(value) => {
@@ -157,7 +157,7 @@ const FilterRuleForm: FC<Props> = memo(
                     field={activeField}
                     rule={filterRule}
                     onChange={onChange}
-                    disabled={!isEditMode || isRequired}
+                    disabled={!isEditMode}
                     popoverProps={popoverProps}
                 />
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: 

### Description:
This PR updates the FilterRuleForm component to allow users to modify required filters while still preventing their removal. The tooltip text for required filters has been updated to clarify that they cannot be removed (rather than "cannot be modified"). Additionally, the disabled state has been removed from the operator dropdown and filter value components for required filters, enabling users to change these values while still maintaining the filter's required status.