### PR TITLE
chore: use inherit instead of isPrivate in space checks

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -231,7 +231,7 @@ export class AsyncQueryService extends ProjectService {
                 subject('SavedChart', {
                     organizationUuid: savedChart.organization.organizationUuid,
                     projectUuid: savedChart.project.projectUuid,
-                    isPrivate: ctx.isPrivate,
+                    inheritParentPermissions: ctx.inheritParentPermissions,
                     access: ctx.access,
                 }),
             )
@@ -2175,7 +2175,7 @@ export class AsyncQueryService extends ProjectService {
         }
 
         let access;
-        let spaceIsPrivate;
+        let spaceInheritsParentPermissions;
         if (isJwtUser(account)) {
             if (!ProjectService.isChartEmbed(account)) {
                 throw new ForbiddenError();
@@ -2193,14 +2193,14 @@ export class AsyncQueryService extends ProjectService {
             access = [{ chartUuid: savedChart.uuid }];
             const space =
                 await this.spaceModel.getSpaceSummary(savedChartSpaceUuid);
-            spaceIsPrivate = space.isPrivate;
+            spaceInheritsParentPermissions = !space.isPrivate;
         } else {
             const ctx = await this.spacePermissionService.getSpaceAccessContext(
                 account.user.id,
                 savedChartSpaceUuid,
             );
             access = ctx.access;
-            spaceIsPrivate = ctx.isPrivate;
+            spaceInheritsParentPermissions = ctx.inheritParentPermissions;
         }
 
         if (
@@ -2209,7 +2209,7 @@ export class AsyncQueryService extends ProjectService {
                 subject('SavedChart', {
                     organizationUuid: savedChartOrganizationUuid,
                     projectUuid,
-                    isPrivate: spaceIsPrivate,
+                    inheritParentPermissions: spaceInheritsParentPermissions,
                     access,
                 }),
             ) ||
@@ -2365,7 +2365,7 @@ export class AsyncQueryService extends ProjectService {
                     subject('SavedChart', {
                         organizationUuid: space.organizationUuid,
                         projectUuid,
-                        isPrivate: ctx.isPrivate,
+                        inheritParentPermissions: ctx.inheritParentPermissions,
                         access: ctx.access,
                     }),
                 )

--- a/packages/backend/src/services/DashboardService/DashboardService.mock.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.mock.ts
@@ -83,6 +83,7 @@ export const privateSpace: Space = {
     ...publicSpace,
     uuid: 'private-space-uuid',
     isPrivate: true,
+    inheritParentPermissions: false,
 };
 
 export const dashboard: Dashboard = {

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -75,19 +75,19 @@ const spaceContexts = {
     [space.space_uuid]: {
         organizationUuid: space.organization_uuid,
         projectUuid: publicSpace.projectUuid,
-        isPrivate: space.is_private,
+        inheritParentPermissions: !space.is_private,
         access: [],
     },
     [privateSpace.uuid]: {
         organizationUuid: privateSpace.organizationUuid,
         projectUuid: privateSpace.projectUuid,
-        isPrivate: privateSpace.isPrivate,
+        inheritParentPermissions: privateSpace.inheritParentPermissions,
         access: [],
     },
     [publicSpace.uuid]: {
         organizationUuid: publicSpace.organizationUuid,
         projectUuid: publicSpace.projectUuid,
-        isPrivate: publicSpace.isPrivate,
+        inheritParentPermissions: publicSpace.inheritParentPermissions,
         access: publicSpace.access,
     },
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3006,7 +3006,7 @@ export class ProjectService extends BaseService {
         return {
             chart: {
                 ...savedChart,
-                isPrivate: spaceCtx.isPrivate,
+                isPrivate: !spaceCtx.inheritParentPermissions,
                 access: spaceCtx.access,
             },
             explore,

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -220,7 +220,7 @@ export class SchedulerService extends BaseService {
             const { organizationUuid, spaceUuid, projectUuid } =
                 await this.savedChartModel.getSummary(scheduler.savedChartUuid);
 
-            const { isPrivate, access } =
+            const { inheritParentPermissions, access } =
                 await this.spacePermissionService.getSpaceAccessContext(
                     user.userUuid,
                     spaceUuid,
@@ -231,7 +231,7 @@ export class SchedulerService extends BaseService {
                     subject('SavedChart', {
                         organizationUuid,
                         projectUuid,
-                        isPrivate,
+                        inheritParentPermissions,
                         access,
                     }),
                 )
@@ -242,7 +242,7 @@ export class SchedulerService extends BaseService {
                 await this.dashboardModel.getByIdOrSlug(
                     scheduler.dashboardUuid,
                 );
-            const { isPrivate, access } =
+            const { inheritParentPermissions, access } =
                 await this.spacePermissionService.getSpaceAccessContext(
                     user.userUuid,
                     spaceUuid,
@@ -254,7 +254,7 @@ export class SchedulerService extends BaseService {
                     subject('Dashboard', {
                         organizationUuid,
                         projectUuid,
-                        isPrivate,
+                        inheritParentPermissions,
                         access,
                     }),
                 )

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.test.ts
@@ -105,7 +105,7 @@ describe('SpacePermissionService', () => {
 
             const result = await service.getAllSpaceAccessContext(spaceUuid);
 
-            expect(result.isPrivate).toBe(false);
+            expect(result.inheritParentPermissions).toBe(true);
             expect(result.projectUuid).toBe(projectUuid);
             // Project access was fetched for the root space
             expect(
@@ -162,7 +162,7 @@ describe('SpacePermissionService', () => {
 
             const result = await service.getAllSpaceAccessContext(spaceUuid);
 
-            expect(result.isPrivate).toBe(true);
+            expect(result.inheritParentPermissions).toBe(false);
             // Project/org access should NOT have been fetched
             expect(
                 mockPermissionModel.getProjectSpaceAccess,
@@ -308,7 +308,7 @@ describe('SpacePermissionService', () => {
 
             const result = await service.getAllSpaceAccessContext(spaceUuid);
 
-            expect(result.isPrivate).toBe(false);
+            expect(result.inheritParentPermissions).toBe(true);
             // Project access fetched for the root space (last in chain)
             expect(
                 mockPermissionModel.getProjectSpaceAccess,
@@ -361,7 +361,7 @@ describe('SpacePermissionService', () => {
 
             const result = await service.getAllSpaceAccessContext(spaceUuid);
 
-            expect(result.isPrivate).toBe(true);
+            expect(result.inheritParentPermissions).toBe(false);
             expect(
                 mockPermissionModel.getProjectSpaceAccess,
             ).not.toHaveBeenCalled();

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -17,7 +17,7 @@ import { BaseService } from '../BaseService';
 export type SpaceAccessContextForCasl = {
     organizationUuid: string;
     projectUuid: string;
-    isPrivate: boolean;
+    inheritParentPermissions: boolean;
     access: SpaceAccess[];
 };
 
@@ -241,7 +241,7 @@ export class SpacePermissionService extends BaseService {
             result[spaceUuid] = {
                 organizationUuid: space.organizationUuid,
                 projectUuid: space.projectUuid,
-                isPrivate,
+                inheritParentPermissions: inheritsFromOrgOrProject,
                 access,
             };
         }

--- a/packages/backend/src/services/SpaceService/SpaceService.mock.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.mock.ts
@@ -29,7 +29,9 @@ type TestAccessParams = {
     spaceRole?: SpaceMemberRole | null;
     groupSpaceRole?: SpaceMemberRole | null;
     groupSpaceRoles?: SpaceMemberRole[];
+    /** @deprecated Use inheritParentPermissions instead (inverted: isPrivate=true → inheritParentPermissions=false) */
     isPrivate?: boolean;
+    inheritParentPermissions?: boolean;
     spaceUuid?: string;
     userUuid?: string;
     organizationRole?: OrganizationMemberRole;
@@ -89,7 +91,8 @@ export const createSpaceAccessContext = ({
     userUuid = 'test-user-uuid',
     organizationUuid = 'test-org-uuid',
     projectUuid = 'test-project-uuid',
-    isPrivate = true,
+    isPrivate,
+    inheritParentPermissions = isPrivate !== undefined ? !isPrivate : false,
     organizationRole = OrganizationMemberRole.MEMBER,
     projectRole,
     spaceRole = null,
@@ -102,7 +105,7 @@ export const createSpaceAccessContext = ({
 }): {
     organizationUuid: string;
     projectUuid: string;
-    isPrivate: boolean;
+    inheritParentPermissions: boolean;
     access: SpaceAccess[];
 } => {
     // Compute effective space role (mirrors resolveSpaceAccess logic)
@@ -136,7 +139,7 @@ export const createSpaceAccessContext = ({
             );
             effectiveRole = getHighestSpaceRole(groupRoles);
         }
-    } else if (!isPrivate && projectRole) {
+    } else if (inheritParentPermissions && projectRole) {
         effectiveRole = convertProjectRoleToSpaceRole(projectRole);
     }
 
@@ -153,5 +156,5 @@ export const createSpaceAccessContext = ({
           ]
         : [];
 
-    return { organizationUuid, projectUuid, isPrivate, access };
+    return { organizationUuid, projectUuid, inheritParentPermissions, access };
 };

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -464,7 +464,7 @@ export class UnfurlService extends BaseService {
     ): Promise<string> {
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
-        const { isPrivate, access } =
+        const { inheritParentPermissions, access } =
             await this.spacePermissionService.getSpaceAccessContext(
                 user.userUuid,
                 dashboard.spaceUuid,
@@ -520,7 +520,7 @@ export class UnfurlService extends BaseService {
                 subject('Dashboard', {
                     organizationUuid,
                     projectUuid,
-                    isPrivate,
+                    inheritParentPermissions,
                     access,
                 }),
             )

--- a/packages/common/src/authorization/index.mock.ts
+++ b/packages/common/src/authorization/index.mock.ts
@@ -45,5 +45,5 @@ export const adminProjectProfile = {
 export const conditions = {
     organizationUuid: orgProfile.organizationUuid,
     projectUuid: projectProfile.projectUuid,
-    isPrivate: false,
+    inheritParentPermissions: true,
 };

--- a/packages/common/src/authorization/index.test.ts
+++ b/packages/common/src/authorization/index.test.ts
@@ -50,7 +50,7 @@ describe('Lightdash member permissions', () => {
             conditions = {
                 projectUuid: 'another-project',
                 organizationUuid: 'another-org',
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
             expect(
                 ability.can('view', subject('SavedChart', { ...conditions })),
@@ -115,7 +115,7 @@ describe('Lightdash member permissions', () => {
             conditions = {
                 organizationUuid: adminOrgProfile.organizationUuid,
                 projectUuid: projectProfile.projectUuid,
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
         });
 
@@ -135,7 +135,7 @@ describe('Lightdash member permissions', () => {
             conditions = {
                 organizationUuid: 'another-org',
                 projectUuid: 'another-project',
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
             expect(
                 ability.can('view', subject('SavedChart', { ...conditions })),
@@ -166,7 +166,7 @@ describe('Lightdash member permissions', () => {
             conditions = {
                 organizationUuid: orgProfile.organizationUuid,
                 projectUuid: adminProjectProfile.projectUuid,
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
         });
 
@@ -186,7 +186,7 @@ describe('Lightdash member permissions', () => {
             conditions = {
                 organizationUuid: 'another-org',
                 projectUuid: 'another-project',
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
             expect(
                 ability.can('view', subject('SavedChart', { ...conditions })),
@@ -233,7 +233,7 @@ describe('Lightdash member permissions', () => {
             // Project specific
             const projectConditions = {
                 projectUuid: conditions.projectUuid,
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
             expect(
                 ability.can(
@@ -265,14 +265,14 @@ describe('Lightdash member permissions', () => {
             conditions = {
                 organizationUuid: orgProfile.organizationUuid,
                 projectUuid: projectProfile.projectUuid,
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
         });
 
         it('can view org and project', async () => {
             const conditionsProjectView = {
                 projectUuid: projectProfile.projectUuid,
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
 
             expect(
@@ -296,7 +296,7 @@ describe('Lightdash member permissions', () => {
 
             const conditionsProjectAdmin = {
                 projectUuid: adminProjectProfile.projectUuid,
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
             expect(
                 ability.can(
@@ -321,7 +321,7 @@ describe('Lightdash member permissions', () => {
         it('cannot view another project', async () => {
             const projectConditions = {
                 projectUuid: 'another-project',
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
             expect(
                 ability.can(
@@ -346,7 +346,7 @@ describe('Lightdash member permissions', () => {
         it('can manage admin project but cannot manage view project', async () => {
             const conditionsProjectView = {
                 projectUuid: projectProfile.projectUuid,
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
 
             expect(
@@ -370,7 +370,7 @@ describe('Lightdash member permissions', () => {
 
             const conditionsProjectAdmin = {
                 projectUuid: adminProjectProfile.projectUuid,
-                isPrivate: false,
+                inheritParentPermissions: true,
             };
             expect(
                 ability.can(

--- a/packages/common/src/authorization/jwtAbility.test.ts
+++ b/packages/common/src/authorization/jwtAbility.test.ts
@@ -99,7 +99,7 @@ describe('Embedded dashboard abilities', () => {
                     'view',
                     subject('SavedChart', {
                         projectUuid,
-                        isPrivate: true,
+                        inheritParentPermissions: false,
                     }),
                 ),
             ).toBe(false);
@@ -114,7 +114,7 @@ describe('Embedded dashboard abilities', () => {
                     'view',
                     subject('SavedChart', {
                         projectUuid: 'different-project-uuid',
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     }),
                 ),
             ).toBe(false);

--- a/packages/common/src/authorization/organizationMemberAbility.test.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.test.ts
@@ -107,7 +107,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -117,7 +117,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -127,7 +127,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -138,7 +138,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -149,7 +149,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -165,7 +165,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -181,7 +181,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -197,7 +197,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -216,7 +216,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -226,7 +226,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -236,7 +236,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -247,7 +247,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -258,7 +258,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -274,7 +274,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -290,7 +290,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -306,7 +306,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -325,7 +325,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -335,7 +335,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -345,7 +345,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -356,7 +356,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -367,7 +367,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -383,7 +383,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -399,7 +399,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -415,7 +415,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_ADMIN.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_ADMIN.userUuid,
@@ -600,7 +600,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -610,7 +610,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -620,7 +620,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -631,7 +631,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -642,7 +642,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -658,7 +658,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -674,7 +674,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -690,7 +690,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -709,7 +709,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -719,7 +719,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -729,7 +729,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -740,7 +740,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -751,7 +751,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -767,7 +767,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -783,7 +783,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -799,7 +799,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -830,7 +830,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -840,7 +840,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -850,7 +850,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -861,7 +861,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -872,7 +872,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -888,7 +888,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -904,7 +904,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -920,7 +920,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -936,7 +936,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_EDITOR.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_EDITOR.userUuid,
@@ -954,7 +954,7 @@ describe('Organization member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             organizationUuid: '456',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                             access: [],
                         }),
                     ),
@@ -967,7 +967,7 @@ describe('Organization member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             organizationUuid: '789',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                             access: [],
                         }),
                     ),
@@ -1315,7 +1315,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -1325,7 +1325,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1335,7 +1335,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1346,7 +1346,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1357,7 +1357,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1373,7 +1373,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1389,7 +1389,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1405,7 +1405,7 @@ describe('Organization member permissions', () => {
                         subject('Dashboard', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1424,7 +1424,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -1434,7 +1434,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1444,7 +1444,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1455,7 +1455,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1466,7 +1466,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1482,7 +1482,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1498,7 +1498,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1514,7 +1514,7 @@ describe('Organization member permissions', () => {
                         subject('SavedChart', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1533,7 +1533,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -1543,7 +1543,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1553,7 +1553,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1564,7 +1564,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1575,7 +1575,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1591,7 +1591,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1607,7 +1607,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1623,7 +1623,7 @@ describe('Organization member permissions', () => {
                         subject('Space', {
                             organizationUuid:
                                 ORGANIZATION_VIEWER.organizationUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: ORGANIZATION_VIEWER.userUuid,
@@ -1837,7 +1837,10 @@ describe('Organization member permissions', () => {
             });
 
             it('can view dashboards from their own organization', () => {
-                const org = { organizationUuid: '456', isPrivate: false };
+                const org = {
+                    organizationUuid: '456',
+                    inheritParentPermissions: true,
+                };
                 expect(ability.can('view', subject('Dashboard', org))).toEqual(
                     true,
                 );
@@ -1858,7 +1861,7 @@ describe('Organization member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             organizationUuid: '456',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -1870,7 +1873,7 @@ describe('Organization member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             organizationUuid: '789',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -2252,7 +2255,10 @@ describe('Organization member permissions', () => {
             });
 
             it('can view dashboards from their own organization', () => {
-                const org = { organizationUuid: '456', isPrivate: false };
+                const org = {
+                    organizationUuid: '456',
+                    inheritParentPermissions: true,
+                };
                 expect(ability.can('view', subject('Dashboard', org))).toEqual(
                     true,
                 );
@@ -2264,7 +2270,7 @@ describe('Organization member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             organizationUuid: '789',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -2276,7 +2282,7 @@ describe('Organization member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             organizationUuid: '456',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -2288,7 +2294,7 @@ describe('Organization member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             organizationUuid: '789',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -42,11 +42,11 @@ const applyOrganizationMemberStaticAbilities: Record<
         applyOrganizationMemberStaticAbilities.member(member, { can });
         can('view', 'Dashboard', {
             organizationUuid: member.organizationUuid,
-            isPrivate: false,
+            inheritParentPermissions: true,
         });
         can('view', 'SavedChart', {
             organizationUuid: member.organizationUuid,
-            isPrivate: false,
+            inheritParentPermissions: true,
         });
         can('view', 'Dashboard', {
             organizationUuid: member.organizationUuid,
@@ -62,7 +62,7 @@ const applyOrganizationMemberStaticAbilities: Record<
         });
         can('view', 'Space', {
             organizationUuid: member.organizationUuid,
-            isPrivate: false,
+            inheritParentPermissions: true,
         });
         can('view', 'Space', {
             organizationUuid: member.organizationUuid,
@@ -196,7 +196,7 @@ const applyOrganizationMemberStaticAbilities: Record<
         });
         can('manage', 'Space', {
             organizationUuid: member.organizationUuid,
-            isPrivate: false,
+            inheritParentPermissions: true,
         });
         can('create', 'Space', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/projectMemberAbility.test.ts
+++ b/packages/common/src/authorization/projectMemberAbility.test.ts
@@ -40,7 +40,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -49,7 +49,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -58,7 +58,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -68,7 +68,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -78,7 +78,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -93,7 +93,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -108,7 +108,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -123,7 +123,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -140,7 +140,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -149,7 +149,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -158,7 +158,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -168,7 +168,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -178,7 +178,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -193,7 +193,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -208,7 +208,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -223,7 +223,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -240,7 +240,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -249,7 +249,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -258,7 +258,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -268,7 +268,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -278,7 +278,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -293,7 +293,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -308,7 +308,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -323,7 +323,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_ADMIN.userUuid,
@@ -350,7 +350,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -359,7 +359,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -368,7 +368,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -548,7 +548,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -557,7 +557,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -566,7 +566,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -576,7 +576,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -586,7 +586,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -601,7 +601,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -616,7 +616,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -631,7 +631,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -648,7 +648,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -657,7 +657,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -666,7 +666,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -676,7 +676,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -686,7 +686,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -701,7 +701,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -716,7 +716,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -731,7 +731,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -758,7 +758,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -767,7 +767,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -776,7 +776,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -786,7 +786,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -796,7 +796,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -811,7 +811,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -826,7 +826,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -841,7 +841,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -856,7 +856,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_EDITOR.userUuid,
@@ -1265,7 +1265,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -1274,7 +1274,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1283,7 +1283,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1293,7 +1293,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1303,7 +1303,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1318,7 +1318,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1333,7 +1333,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1348,7 +1348,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Dashboard', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1365,7 +1365,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -1374,7 +1374,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1383,7 +1383,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1393,7 +1393,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1403,7 +1403,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1418,7 +1418,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1433,7 +1433,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1448,7 +1448,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1465,7 +1465,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
@@ -1474,7 +1474,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1483,7 +1483,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1493,7 +1493,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [],
                         }),
                     ),
@@ -1503,7 +1503,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1518,7 +1518,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1533,7 +1533,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1548,7 +1548,7 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('Space', {
                             projectUuid,
-                            isPrivate: true,
+                            inheritParentPermissions: false,
                             access: [
                                 {
                                     userUuid: PROJECT_VIEWER.userUuid,
@@ -1571,7 +1571,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1580,7 +1580,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1589,7 +1589,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1793,20 +1793,26 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(true);
                 expect(
                     ability.can(
                         'view',
-                        subject('Dashboard', { projectUuid, isPrivate: false }),
+                        subject('Dashboard', {
+                            projectUuid,
+                            inheritParentPermissions: true,
+                        }),
                     ),
                 ).toEqual(true);
                 expect(
                     ability.can(
                         'view',
-                        subject('Space', { projectUuid, isPrivate: false }),
+                        subject('Space', {
+                            projectUuid,
+                            inheritParentPermissions: true,
+                        }),
                     ),
                 ).toEqual(true);
                 expect(
@@ -1823,19 +1829,28 @@ describe('Project member permissions', () => {
                 expect(
                     ability.can(
                         'view',
-                        subject('SavedChart', { projectUuid, isPrivate: true }),
+                        subject('SavedChart', {
+                            projectUuid,
+                            inheritParentPermissions: false,
+                        }),
                     ),
                 ).toEqual(false);
                 expect(
                     ability.can(
                         'view',
-                        subject('Dashboard', { projectUuid, isPrivate: true }),
+                        subject('Dashboard', {
+                            projectUuid,
+                            inheritParentPermissions: false,
+                        }),
                     ),
                 ).toEqual(false);
                 expect(
                     ability.can(
                         'view',
-                        subject('Space', { projectUuid, isPrivate: true }),
+                        subject('Space', {
+                            projectUuid,
+                            inheritParentPermissions: false,
+                        }),
                     ),
                 ).toEqual(false);
             });
@@ -1845,7 +1860,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('SavedChart', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1854,7 +1869,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Dashboard', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1863,7 +1878,7 @@ describe('Project member permissions', () => {
                         'view',
                         subject('Space', {
                             projectUuid: '5678',
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
@@ -1880,38 +1895,53 @@ describe('Project member permissions', () => {
                         'manage',
                         subject('SavedChart', {
                             projectUuid,
-                            isPrivate: false,
+                            inheritParentPermissions: true,
                         }),
                     ),
                 ).toEqual(false);
                 expect(
                     ability.can(
                         'manage',
-                        subject('Dashboard', { projectUuid, isPrivate: false }),
+                        subject('Dashboard', {
+                            projectUuid,
+                            inheritParentPermissions: true,
+                        }),
                     ),
                 ).toEqual(false);
                 expect(
                     ability.can(
                         'manage',
-                        subject('Space', { projectUuid, isPrivate: false }),
+                        subject('Space', {
+                            projectUuid,
+                            inheritParentPermissions: true,
+                        }),
                     ),
                 ).toEqual(false);
                 expect(
                     ability.can(
                         'manage',
-                        subject('SavedChart', { projectUuid, isPrivate: true }),
+                        subject('SavedChart', {
+                            projectUuid,
+                            inheritParentPermissions: false,
+                        }),
                     ),
                 ).toEqual(false);
                 expect(
                     ability.can(
                         'manage',
-                        subject('Dashboard', { projectUuid, isPrivate: true }),
+                        subject('Dashboard', {
+                            projectUuid,
+                            inheritParentPermissions: false,
+                        }),
                     ),
                 ).toEqual(false);
                 expect(
                     ability.can(
                         'manage',
-                        subject('Space', { projectUuid, isPrivate: true }),
+                        subject('Space', {
+                            projectUuid,
+                            inheritParentPermissions: false,
+                        }),
                     ),
                 ).toEqual(false);
                 expect(

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -16,14 +16,14 @@ export const projectMemberAbilities: Record<
     viewer(member, { can }) {
         can('view', 'Dashboard', {
             projectUuid: member.projectUuid,
-            isPrivate: false,
+            inheritParentPermissions: true,
         });
         can('view', 'JobStatus', {
             createdByUserUuid: member.userUuid,
         });
         can('view', 'SavedChart', {
             projectUuid: member.projectUuid,
-            isPrivate: false,
+            inheritParentPermissions: true,
         });
         can('view', 'Dashboard', {
             projectUuid: member.projectUuid,
@@ -39,7 +39,7 @@ export const projectMemberAbilities: Record<
         });
         can('view', 'Space', {
             projectUuid: member.projectUuid,
-            isPrivate: false,
+            inheritParentPermissions: true,
         });
         can('view', 'Space', {
             projectUuid: member.projectUuid,
@@ -161,7 +161,7 @@ export const projectMemberAbilities: Record<
         });
         can('manage', 'Space', {
             projectUuid: member.projectUuid,
-            isPrivate: false,
+            inheritParentPermissions: true,
         });
         can('manage', 'Job');
         can('manage', 'PinnedItems', {

--- a/packages/common/src/authorization/roleToScopeMapping.test.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.test.ts
@@ -184,7 +184,7 @@ describe('roleToScopeMapping', () => {
                     resource: {
                         organizationUuid: 'org-uuid-test',
                         projectUuid: PROJECT_EDITOR.projectUuid,
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     },
                 },
                 {
@@ -193,7 +193,7 @@ describe('roleToScopeMapping', () => {
                     resource: {
                         organizationUuid: 'org-uuid-test',
                         projectUuid: PROJECT_EDITOR.projectUuid,
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     },
                 },
                 {
@@ -202,7 +202,7 @@ describe('roleToScopeMapping', () => {
                     resource: {
                         organizationUuid: 'org-uuid-test',
                         projectUuid: PROJECT_EDITOR.projectUuid,
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     },
                 },
 
@@ -223,7 +223,7 @@ describe('roleToScopeMapping', () => {
                     resource: {
                         organizationUuid: 'org-uuid-test',
                         projectUuid: PROJECT_EDITOR.projectUuid,
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     },
                 },
                 {
@@ -374,7 +374,7 @@ describe('roleToScopeMapping', () => {
                 resource: {
                     organizationUuid: 'org-uuid-test',
                     projectUuid: 'test-project-uuid',
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                 },
             },
             {
@@ -391,7 +391,7 @@ describe('roleToScopeMapping', () => {
                 resource: {
                     organizationUuid: 'org-uuid-test',
                     projectUuid: 'test-project-uuid',
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                 },
             },
             {
@@ -493,7 +493,7 @@ describe('roleToScopeMapping', () => {
                 resource: {
                     organizationUuid: 'org-uuid-test',
                     projectUuid: 'project-uuid-test',
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                 },
             },
             {
@@ -510,7 +510,7 @@ describe('roleToScopeMapping', () => {
                 resource: {
                     organizationUuid: 'org-uuid-test',
                     projectUuid: 'project-uuid-test',
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                 },
             },
             {

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -69,7 +69,7 @@ describe('scopeAbilityBuilder', () => {
                 subject('Dashboard', {
                     organizationUuid: 'org-123',
                     projectUuid: 'project-123',
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                 }),
             ),
         ).toBe(true);
@@ -81,7 +81,7 @@ describe('scopeAbilityBuilder', () => {
                 subject('Dashboard', {
                     organizationUuid: 'org-123',
                     projectUuid: 'project-123',
-                    isPrivate: true,
+                    inheritParentPermissions: false,
                 }),
             ),
         ).toBe(false);
@@ -422,7 +422,7 @@ describe('scopeAbilityBuilder', () => {
                 subject('Dashboard', {
                     organizationUuid: 'org-123',
                     projectUuid: 'project-789',
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                 }),
             ),
         ).toBe(true);
@@ -549,7 +549,7 @@ describe('scopeAbilityBuilder', () => {
                     subject('Space', {
                         organizationUuid: 'org-123',
                         projectUuid: 'project-123',
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     }),
                 ),
             ).toBe(true);
@@ -797,7 +797,7 @@ describe('scopeAbilityBuilder', () => {
                     subject('Dashboard', {
                         organizationUuid: 'org-123',
                         projectUuid: 'project-123',
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     }),
                 ),
             ).toBe(true);
@@ -808,7 +808,7 @@ describe('scopeAbilityBuilder', () => {
                     subject('Dashboard', {
                         organizationUuid: 'org-123',
                         projectUuid: 'project-123',
-                        isPrivate: true,
+                        inheritParentPermissions: false,
                     }),
                 ),
             ).toBe(false);
@@ -858,7 +858,7 @@ describe('scopeAbilityBuilder', () => {
                     'view',
                     subject('Dashboard', {
                         organizationUuid: 'different-org',
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     }),
                 ),
             ).toBe(false);
@@ -879,7 +879,7 @@ describe('scopeAbilityBuilder', () => {
                     'view',
                     subject('Space', {
                         organizationUuid: 'different-org',
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     }),
                 ),
             ).toBe(false);
@@ -903,7 +903,7 @@ describe('scopeAbilityBuilder', () => {
                     subject('SavedChart', {
                         organizationUuid: 'org-123',
                         projectUuid: 'different-project',
-                        isPrivate: false,
+                        inheritParentPermissions: true,
                     }),
                 ),
             ).toBe(false);
@@ -933,7 +933,7 @@ describe('scopeAbilityBuilder', () => {
                     'view',
                     subject('Dashboard', {
                         organizationUuid: 'org-123',
-                        isPrivate: true,
+                        inheritParentPermissions: false,
                         access: [
                             {
                                 userUuid: 'user-456',
@@ -950,7 +950,7 @@ describe('scopeAbilityBuilder', () => {
                     'view',
                     subject('Dashboard', {
                         organizationUuid: 'org-123',
-                        isPrivate: true,
+                        inheritParentPermissions: false,
                         access: [],
                     }),
                 ),
@@ -962,7 +962,7 @@ describe('scopeAbilityBuilder', () => {
                     'view',
                     subject('Dashboard', {
                         organizationUuid: 'org-123',
-                        isPrivate: true,
+                        inheritParentPermissions: false,
                         access: [
                             {
                                 userUuid: 'other-user',
@@ -1088,7 +1088,7 @@ describe('scopeAbilityBuilder', () => {
                     'manage',
                     subject('Space', {
                         organizationUuid: 'org-123',
-                        isPrivate: true,
+                        inheritParentPermissions: false,
                         access: [
                             {
                                 userUuid: 'user-456',
@@ -1105,7 +1105,7 @@ describe('scopeAbilityBuilder', () => {
                     'manage',
                     subject('Space', {
                         organizationUuid: 'org-123',
-                        isPrivate: true,
+                        inheritParentPermissions: false,
                         access: [
                             {
                                 userUuid: 'user-456',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -11,7 +11,9 @@ import { SpaceMemberRole } from '../types/space';
 /** Context can have either/or organizationUuid or projectUuid. Applies the one we have. */
 const addUuidCondition = (
     context: ScopeContext,
-    modifiers?: { isPrivate: false } | { userUuid: string | boolean },
+    modifiers?:
+        | { inheritParentPermissions: true }
+        | { userUuid: string | boolean },
 ) => {
     const projectOrOrg = context.organizationUuid
         ? { organizationUuid: context.organizationUuid }
@@ -44,7 +46,7 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
-            addUuidCondition(context, { isPrivate: false }),
+            addUuidCondition(context, { inheritParentPermissions: true }),
             addAccessCondition(context),
         ],
     },
@@ -72,7 +74,7 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
-            addUuidCondition(context, { isPrivate: false }),
+            addUuidCondition(context, { inheritParentPermissions: true }),
             addAccessCondition(context),
         ],
     },
@@ -100,7 +102,7 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
-            addUuidCondition(context, { isPrivate: false }),
+            addUuidCondition(context, { inheritParentPermissions: true }),
             addAccessCondition(context),
         ],
     },
@@ -124,7 +126,7 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
-            addUuidCondition(context, { isPrivate: false }),
+            addUuidCondition(context, { inheritParentPermissions: true }),
         ],
     },
     {

--- a/packages/common/src/authorization/space/spaceAccessResolver.test.ts
+++ b/packages/common/src/authorization/space/spaceAccessResolver.test.ts
@@ -18,7 +18,7 @@ const makeInput = (
     overrides: Partial<SpaceAccessInput> = {},
 ): SpaceAccessInput => ({
     spaceUuid: 'space-1',
-    isPrivate: false,
+    inheritParentPermissions: true,
     directAccess: [],
     projectAccess: [],
     organizationAccess: [],
@@ -100,7 +100,7 @@ describe('resolveSpaceAccess', () => {
         it('admin can access private space even without direct access', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: true,
+                    inheritParentPermissions: false,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -202,7 +202,7 @@ describe('resolveSpaceAccess', () => {
         it('viewer gets viewer space role', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -221,7 +221,7 @@ describe('resolveSpaceAccess', () => {
         it('editor gets editor space role', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -238,7 +238,7 @@ describe('resolveSpaceAccess', () => {
         it('developer gets editor space role', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -255,7 +255,7 @@ describe('resolveSpaceAccess', () => {
         it('interactive_viewer gets viewer space role', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -274,7 +274,7 @@ describe('resolveSpaceAccess', () => {
         it('non-admin without direct access excluded from private space', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: true,
+                    inheritParentPermissions: false,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -290,7 +290,7 @@ describe('resolveSpaceAccess', () => {
         it('private space with direct access works', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: true,
+                    inheritParentPermissions: false,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -317,7 +317,7 @@ describe('resolveSpaceAccess', () => {
         it('org MEMBER with no other access is excluded', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -334,7 +334,7 @@ describe('resolveSpaceAccess', () => {
         it('org MEMBER with project access is included', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -361,7 +361,7 @@ describe('resolveSpaceAccess', () => {
         it('highest group role wins', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritParentPermissions: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',

--- a/packages/common/src/authorization/space/spaceAccessResolver.ts
+++ b/packages/common/src/authorization/space/spaceAccessResolver.ts
@@ -95,7 +95,7 @@ const getUserDirectGroupAccess = (
 const getSpaceRole = (
     highestRole: ProjectMemberRole,
     userDirectAccess: DirectSpaceAccess[],
-    isPrivate: boolean,
+    inheritParentPermissions: boolean,
 ): SpaceMemberRole | undefined => {
     const userAccessEntries = userDirectAccess.filter(
         (a) => a.from === DirectSpaceAccessOrigin.USER_ACCESS,
@@ -120,7 +120,7 @@ const getSpaceRole = (
             getHighestSpaceRole(groupAccessEntries.map((e) => e.role))
         );
     }
-    if (!isPrivate) {
+    if (inheritParentPermissions) {
         return convertProjectRoleToSpaceRole(highestRole);
     }
 
@@ -131,8 +131,12 @@ const resolveUserSpaceAccess = (
     userUuid: string,
     input: SpaceAccessInput,
 ): SpaceAccess | undefined => {
-    const { isPrivate, directAccess, projectAccess, organizationAccess } =
-        input;
+    const {
+        inheritParentPermissions,
+        directAccess,
+        projectAccess,
+        organizationAccess,
+    } = input;
     const organizationRole = getUserOrganizationRole(
         organizationAccess,
         userUuid,
@@ -161,7 +165,7 @@ const resolveUserSpaceAccess = (
     const spaceRole = getSpaceRole(
         highestRole.role,
         userDirectAccess,
-        isPrivate,
+        inheritParentPermissions,
     );
     if (!spaceRole) return undefined;
 

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -37,7 +37,7 @@ export type ProjectSpaceAccess = {
 
 export type SpaceAccessInput = {
     spaceUuid: string;
-    isPrivate: boolean;
+    inheritParentPermissions: boolean;
     directAccess: DirectSpaceAccess[];
     projectAccess: ProjectSpaceAccess[];
     organizationAccess: OrganizationSpaceAccess[];


### PR DESCRIPTION
### Description:

Rename isPrivate to `inheritParentPermissions`
