### PR TITLE
chore: remove chart-as-code schema drift check from CI

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -40,7 +40,6 @@ jobs:
         run: pnpm install --frozen-lockfile --prefer-offline
       - name: Run quality checks and build in parallel
         run: |
-          pnpm check:chart-as-code-schema &
           pnpm lint &
           pnpm format &
           pnpm -F frontend unused-exports &

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,8 +23,6 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
       - name: Install packages
         run: pnpm install --frozen-lockfile --prefer-offline
-      - name: Check chart-as-code schema drift
-        run: pnpm check:chart-as-code-schema
       - name: Build all packages
         run: pnpm build
 


### PR DESCRIPTION
## Summary
- Removes the `pnpm check:chart-as-code-schema` step from the PR and release GitHub Actions workflows

## Test plan
- [ ] Verify PR workflow still runs lint, format, typecheck, unused-exports, and build in parallel
- [ ] Verify release workflow still builds successfully without the schema check step

🤖 Generated with [Claude Code](https://claude.com/claude-code)