### PR TITLE
fix: render cells for leaf placeholder nodes in tables

### DIFF
--- a/packages/frontend/src/components/common/PivotTable/index.tsx
+++ b/packages/frontend/src/components/common/PivotTable/index.tsx
@@ -903,9 +903,13 @@ const PivotTable: FC<PivotTableProps> = ({
                                         : undefined;
                                 })();
 
+                                const isLeafPlaceholder =
+                                    cell.getIsPlaceholder() &&
+                                    !row.getCanExpand();
                                 const suppressContextMenu =
                                     (value === undefined ||
-                                        cell.getIsPlaceholder()) &&
+                                        (cell.getIsPlaceholder() &&
+                                            !isLeafPlaceholder)) &&
                                     !cell.getIsAggregated() &&
                                     !cell.getIsGrouped();
                                 const allowInteractions = suppressContextMenu
@@ -1017,7 +1021,14 @@ const PivotTable: FC<PivotTableProps> = ({
                                                     cell.column.columnDef.cell,
                                                 cell.getContext(),
                                             )
-                                        ) : cell.getIsPlaceholder() ? null : (
+                                        ) : cell.getIsPlaceholder() ? (
+                                            isLeafPlaceholder ? (
+                                                flexRender(
+                                                    cell.column.columnDef.cell,
+                                                    cell.getContext(),
+                                                )
+                                            ) : null
+                                        ) : (
                                             flexRender(
                                                 cell.column.columnDef.cell,
                                                 cell.getContext(),

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -163,8 +163,11 @@ const TableRow: FC<TableRowProps> = ({
                           );
                 }
 
+                const isLeafPlaceholder =
+                    cell.getIsPlaceholder() && !row.getCanExpand();
                 const suppressContextMenu =
-                    cell.getIsPlaceholder() || cell.getIsAggregated();
+                    (cell.getIsPlaceholder() && !isLeafPlaceholder) ||
+                    cell.getIsAggregated();
 
                 return (
                     <BodyCell
@@ -237,7 +240,14 @@ const TableRow: FC<TableRowProps> = ({
                                     cell.column.columnDef.cell,
                                 cell.getContext(),
                             )
-                        ) : cell.getIsPlaceholder() ? null : (
+                        ) : cell.getIsPlaceholder() ? (
+                            isLeafPlaceholder ? (
+                                flexRender(
+                                    cell.column.columnDef.cell,
+                                    cell.getContext(),
+                                )
+                            ) : null
+                        ) : (
                             flexRender(
                                 cell.column.columnDef.cell,
                                 cell.getContext(),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2655/table-view-shows-empty-dimension-values-when-rows-are-expanded-despite

### Description:
Fixed a bug in PivotTable and ScrollableTable where placeholder cells in leaf rows (rows that cannot expand) were not rendering their content. Now, placeholder cells in leaf rows will correctly display their content, improving the user experience by showing all relevant data.