### PR TITLE
fix: disable chalk colors in CLI tests for consistent local/CI behavior

### DIFF
--- a/packages/cli/jest.config.js
+++ b/packages/cli/jest.config.js
@@ -1,3 +1,7 @@
+// Disable chalk colors so test assertions on styled output work consistently
+// across local (TTY) and CI (non-TTY) environments.
+process.env.FORCE_COLOR = '0';
+
 module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',


### PR DESCRIPTION
### Description:
Fixes local CLI tests introduced here: https://github.com/lightdash/lightdash/pull/19781

The problem: The test checks console output for strings like `PARTIAL_SUCCESS> explore_with_warnings`. But the production code wraps those strings in chalk color codes (e.g. yellow for warnings), so the actual output is something like `\u001b[33mPARTIAL_SUCCESS\u001b[39m> explore_with_warnings`. 

- In CI there's no TTY so chalk auto-disables and outputs plain text -> test passes. 
- Locally the terminal supports colors so chalk is active -> test fails.
