### PR TITLE
feat: add dynamic Databricks OAuth support for project-specific credentials

### DIFF
--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -8,6 +8,12 @@ declare module 'express-session' {
             codeVerifier?: string | undefined;
             state?: string | undefined;
             isPopup?: boolean | undefined;
+            databricks?: {
+                projectUuid?: string | undefined;
+                projectName?: string | undefined;
+                serverHostName?: string | undefined;
+                credentialsName?: string | undefined;
+            };
         };
         slack: {
             teamId?: string | undefined;

--- a/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
@@ -5,11 +5,179 @@ import {
     ForbiddenError,
     OpenIdIdentityIssuerType,
     OpenIdUser,
+    ParameterError,
 } from '@lightdash/common';
+import { createHash } from 'crypto';
 import { Strategy as OAuth2Strategy, VerifyCallback } from 'passport-oauth2';
 import { URL } from 'url';
 import { lightdashConfig } from '../../../config/lightdashConfig';
 import Logger from '../../../logging/logger';
+
+type DatabricksStrategyConfig = {
+    authorizationURL: string;
+    tokenURL: string;
+    issuer: string;
+    clientId: string;
+    clientSecret?: string;
+};
+
+const normalizeDatabricksHost = (serverHostName: string): string => {
+    const trimmed = serverHostName.trim();
+    const parsed = new URL(
+        trimmed.startsWith('http://') || trimmed.startsWith('https://')
+            ? trimmed
+            : `https://${trimmed}`,
+    );
+    if (!parsed.host) {
+        throw new ParameterError('Invalid Databricks serverHostName');
+    }
+    if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+        throw new ParameterError(
+            'Databricks serverHostName must not include a path, query string, or hash',
+        );
+    }
+    return parsed.host;
+};
+
+export const getDatabricksOidcEndpointsFromHost = (serverHostName: string) => {
+    const host = normalizeDatabricksHost(serverHostName);
+    const issuer = `https://${host}`;
+    return {
+        host,
+        issuer,
+        authorizationURL: `${issuer}/oidc/v1/authorize`,
+        tokenURL: `${issuer}/oidc/v1/token`,
+    };
+};
+
+export const getDatabricksStrategyName = ({
+    host,
+    clientId,
+}: {
+    host: string;
+    clientId: string;
+}) =>
+    `databricks-${createHash('sha256')
+        .update(`${host}:${clientId}`)
+        .digest('hex')
+        .slice(0, 16)}`;
+
+export const createDatabricksStrategy = ({
+    authorizationURL,
+    tokenURL,
+    issuer,
+    clientId,
+    clientSecret,
+}: DatabricksStrategyConfig) =>
+    new OAuth2Strategy(
+        {
+            authorizationURL,
+            tokenURL,
+            clientID: clientId,
+            // U2M OAuth can use a public client without a secret, but passport-oauth2 requires this field
+            clientSecret: clientSecret || '',
+            callbackURL: new URL(
+                `/api/v1${lightdashConfig.auth.databricks.callbackPath}`,
+                lightdashConfig.siteUrl,
+            ).href,
+            scope: ['sql', 'offline_access'],
+            passReqToCallback: true,
+            // PKCE is required for Databricks U2M OAuth
+            pkce: true,
+            state: true,
+        },
+        async (
+            req: Express.Request,
+            accessToken: string,
+            refreshToken: string,
+            profile: AnyType,
+            done: VerifyCallback,
+        ) => {
+            try {
+                if (!lightdashConfig.license.licenseKey) {
+                    throw new ForbiddenError(
+                        `Enterprise license required for databricks authentication`,
+                    );
+                }
+
+                const loggedUser = req.user;
+                if (loggedUser === undefined) {
+                    throw new ForbiddenError('User not authenticated');
+                }
+
+                // Databricks OAuth doesn't return user profile in the token response
+                // We use the existing logged-in user's information
+                const openIdUser: OpenIdUser = {
+                    openId: {
+                        subject: loggedUser.userUuid,
+                        issuer,
+                        issuerType: OpenIdIdentityIssuerType.DATABRICKS,
+                        email: loggedUser.email!,
+                        firstName: loggedUser.firstName,
+                        lastName: loggedUser.lastName,
+                    },
+                };
+
+                if (!refreshToken) {
+                    throw new Error(
+                        'Databricks OAuth refresh token was not returned. Ensure offline_access scope is granted.',
+                    );
+                }
+
+                Logger.info(
+                    `Creating user warehouse credentials for Databricks`,
+                );
+                const userCredentials = await req.services
+                    .getUserService()
+                    .createDatabricksWarehouseCredentials(
+                        req.user!,
+                        refreshToken,
+                        {
+                            projectUuid:
+                                req.session.oauth?.databricks?.projectUuid,
+                            projectName:
+                                req.session.oauth?.databricks?.projectName,
+                            serverHostName:
+                                req.session.oauth?.databricks?.serverHostName,
+                            credentialsName:
+                                req.session.oauth?.databricks?.credentialsName,
+                        },
+                    );
+
+                if (
+                    userCredentials &&
+                    req.session.oauth?.databricks?.projectUuid
+                ) {
+                    try {
+                        await req.services
+                            .getProjectService()
+                            .upsertProjectCredentialsPreference(
+                                req.user!,
+                                req.session.oauth.databricks.projectUuid,
+                                userCredentials.uuid,
+                            );
+                    } catch (e) {
+                        Logger.warn(
+                            `Failed to set Databricks credentials preference for project ${req.session.oauth.databricks.projectUuid}`,
+                            e,
+                        );
+                    }
+                }
+
+                const user = await req.services
+                    .getUserService()
+                    .loginWithOpenId(
+                        openIdUser,
+                        req.user,
+                        undefined,
+                        refreshToken,
+                    );
+                done(null, user);
+            } catch (error) {
+                done(error);
+            }
+        },
+    );
 
 // Databricks U2M OAuth doesn't require a client secret (public client)
 // and requires PKCE (Proof Key for Code Exchange)
@@ -20,87 +188,11 @@ export const databricksPassportStrategy = !(
     lightdashConfig.auth.databricks.tokenEndpoint
 )
     ? undefined
-    : new OAuth2Strategy(
-          {
-              authorizationURL:
-                  lightdashConfig.auth.databricks.authorizationEndpoint,
-              tokenURL: lightdashConfig.auth.databricks.tokenEndpoint,
-              clientID: lightdashConfig.auth.databricks.clientId,
-              // U2M OAuth uses a public client without a secret, but passport-oauth2 requires this field
-              clientSecret: lightdashConfig.auth.databricks.clientSecret || '',
-              callbackURL: new URL(
-                  `/api/v1${lightdashConfig.auth.databricks.callbackPath}`,
-                  lightdashConfig.siteUrl,
-              ).href,
-              scope: ['sql', 'offline_access'],
-              passReqToCallback: true,
-              // PKCE is required for Databricks U2M OAuth
-              pkce: true,
-              state: true,
-          },
-          async (
-              req: Express.Request,
-              accessToken: string,
-              refreshToken: string,
-              profile: AnyType,
-              done: VerifyCallback,
-          ) => {
-              try {
-                  if (!lightdashConfig.license.licenseKey) {
-                      throw new ForbiddenError(
-                          `Enterprise license required for databricks authentication`,
-                      );
-                  }
-
-                  const loggedUser = req.user;
-                  if (loggedUser === undefined) {
-                      throw new ForbiddenError('User not authenticated');
-                  }
-
-                  // Databricks OAuth doesn't return user profile in the token response
-                  // We use the existing logged-in user's information
-                  const openIdUser: OpenIdUser = {
-                      openId: {
-                          subject: loggedUser.userUuid,
-                          issuer: lightdashConfig.auth.databricks
-                              .authorizationEndpoint!,
-                          issuerType: OpenIdIdentityIssuerType.DATABRICKS,
-                          email: loggedUser.email!,
-                          firstName: loggedUser.firstName,
-                          lastName: loggedUser.lastName,
-                      },
-                  };
-
-                  if (!refreshToken) {
-                      throw new Error(
-                          'Databricks OAuth refresh token was not returned. Ensure offline_access scope is granted.',
-                      );
-                  }
-
-                  // Create user warehouse credentials with the refresh token
-                  // so they can use it to query Databricks SQL warehouses
-                  Logger.info(
-                      `Creating user warehouse credentials for Databricks`,
-                  );
-                  await req.services
-                      .getUserService()
-                      .createDatabricksWarehouseCredentials(
-                          req.user!,
-                          refreshToken,
-                      );
-
-                  const user = await req.services
-                      .getUserService()
-                      .loginWithOpenId(
-                          openIdUser,
-                          req.user,
-                          undefined,
-                          refreshToken,
-                      );
-                  done(null, user);
-              } catch (error) {
-                  // Handle any errors that occur during processing
-                  done(error);
-              }
-          },
-      );
+    : createDatabricksStrategy({
+          authorizationURL:
+              lightdashConfig.auth.databricks.authorizationEndpoint,
+          tokenURL: lightdashConfig.auth.databricks.tokenEndpoint,
+          issuer: lightdashConfig.auth.databricks.authorizationEndpoint,
+          clientId: lightdashConfig.auth.databricks.clientId,
+          clientSecret: lightdashConfig.auth.databricks.clientSecret,
+      });

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -169,12 +169,10 @@ export class HealthService extends BaseService {
                         this.isEnterpriseEnabled(),
                 },
                 databricks: {
-                    // U2M OAuth only requires endpoints - client ID defaults to 'databricks-cli'
+                    // Databricks OAuth browser flow requires a configured client ID.
                     enabled:
                         !!this.lightdashConfig.auth.databricks.clientId &&
-                        !!this.lightdashConfig.auth.databricks
-                            .authorizationEndpoint &&
-                        !!this.lightdashConfig.auth.databricks.tokenEndpoint,
+                        this.isEnterpriseEnabled(),
                 },
             },
             hasEmailClient: !!this.lightdashConfig.smtp,

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -20,6 +20,8 @@ type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     description?: React.ReactNode;
     nameValue?: string;
     warehouseType?: WarehouseTypes;
+    projectUuid?: string;
+    projectName?: string;
     onSuccess?: (data: UserWarehouseCredentials) => void;
 };
 
@@ -76,6 +78,8 @@ export const CreateCredentialsModal: FC<Props> = ({
     description,
     nameValue,
     warehouseType,
+    projectUuid,
+    projectName,
     onSuccess,
 }) => {
     const health = useHealth();
@@ -165,6 +169,11 @@ export const CreateCredentialsModal: FC<Props> = ({
                         form={form}
                         disabled={isSaving}
                         onClose={onClose}
+                        projectUuid={projectUuid}
+                        projectName={projectName}
+                        databricksCredentialsName={
+                            nameValue || form.values.name
+                        }
                     />
                 </Stack>
             </form>

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -46,11 +46,19 @@ export const SnowflakeFormInput: FC<{ onClose: () => void }> = ({
     );
 };
 
-const DatabricksFormInput: FC<{ onClose: () => void }> = ({ onClose }) => {
+const DatabricksFormInput: FC<{
+    onClose: () => void;
+    projectUuid?: string;
+    projectName?: string;
+    credentialsName?: string;
+}> = ({ onClose, projectUuid, projectName, credentialsName }) => {
     const { mutate: openLoginPopup } = useDatabricksLoginPopup({
         onLogin: async () => {
             onClose();
         },
+        projectUuid,
+        projectName,
+        credentialsName,
     });
 
     // If this popup happens, it means we don't have warehouse credentials,
@@ -68,7 +76,17 @@ export const WarehouseFormInputs: FC<{
     disabled: boolean;
     form: UseFormReturnType<UpsertUserWarehouseCredentials>;
     onClose: () => void;
-}> = ({ form, disabled, onClose }) => {
+    projectUuid?: string;
+    projectName?: string;
+    databricksCredentialsName?: string;
+}> = ({
+    form,
+    disabled,
+    onClose,
+    projectUuid,
+    projectName,
+    databricksCredentialsName,
+}) => {
     switch (form.values.credentials.type) {
         case WarehouseTypes.SNOWFLAKE:
             return <SnowflakeFormInput onClose={onClose} />;
@@ -97,7 +115,14 @@ export const WarehouseFormInputs: FC<{
         case WarehouseTypes.BIGQUERY:
             return <BigQueryFormInput onClose={onClose} />;
         case WarehouseTypes.DATABRICKS:
-            return <DatabricksFormInput onClose={onClose} />;
+            return (
+                <DatabricksFormInput
+                    onClose={onClose}
+                    projectUuid={projectUuid}
+                    projectName={projectName}
+                    credentialsName={databricksCredentialsName}
+                />
+            );
         default:
             return null;
     }

--- a/packages/frontend/src/hooks/useDatabricks.ts
+++ b/packages/frontend/src/hooks/useDatabricks.ts
@@ -5,10 +5,30 @@ import { lightdashApi } from '../api';
 import useHealth from './health/useHealth';
 import useToaster from './toaster/useToaster';
 
-const triggerDatabricksLogin = async (siteUrl: string) => {
+const triggerDatabricksLogin = async (
+    siteUrl: string,
+    options?: {
+        projectUuid?: string;
+        projectName?: string;
+        serverHostName?: string;
+        credentialsName?: string;
+    },
+) => {
     return new Promise<void>((resolve, reject) => {
         const channel = new BroadcastChannel('lightdash-oauth-popup');
-        const loginUrl = `${siteUrl}/api/v1/login/databricks?isPopup=true`;
+        const params = new URLSearchParams({ isPopup: 'true' });
+        if (options?.projectUuid) {
+            params.set('projectUuid', options.projectUuid);
+        } else if (options?.serverHostName) {
+            params.set('serverHostName', options.serverHostName);
+        }
+        if (options?.projectName) {
+            params.set('projectName', options.projectName);
+        }
+        if (options?.credentialsName) {
+            params.set('credentialsName', options.credentialsName);
+        }
+        const loginUrl = `${siteUrl}/api/v1/login/databricks?${params.toString()}`;
         console.info(`Opening popup with url: ${loginUrl}`);
 
         const popupWindow = window.open(
@@ -42,14 +62,28 @@ const triggerDatabricksLogin = async (siteUrl: string) => {
 
 export function useDatabricksLoginPopup({
     onLogin: _onLogin,
+    projectUuid,
+    projectName,
+    serverHostName,
+    credentialsName,
 }: {
     onLogin: () => Promise<void>;
+    projectUuid?: string;
+    projectName?: string;
+    serverHostName?: string;
+    credentialsName?: string;
 }) {
     const { showToastError } = useToaster();
     const health = useHealth();
     const queryClient = useQueryClient();
     const ssoMutation = useMutation({
-        mutationFn: () => triggerDatabricksLogin(health.data?.siteUrl || ''),
+        mutationFn: () =>
+            triggerDatabricksLogin(health.data?.siteUrl || '', {
+                projectUuid,
+                projectName,
+                serverHostName,
+                credentialsName,
+            }),
         onSuccess: async () => {
             // Invalidate user warehouse credentials since the backend creates
             // credentials during the OAuth flow
@@ -72,16 +106,37 @@ export function useDatabricksLoginPopup({
     }, [ssoMutation, health.data?.auth.databricks.enabled]);
 }
 
-const getIsAuthenticated = async () =>
+const getIsAuthenticatedForProject = async (
+    projectUuid?: string,
+    serverHostName?: string,
+) =>
     lightdashApi<ApiSuccessEmpty['results']>({
-        url: `/databricks/sso/is-authenticated`,
+        url: `/databricks/sso/is-authenticated${
+            projectUuid
+                ? `?projectUuid=${encodeURIComponent(projectUuid)}`
+                : serverHostName
+                  ? `?serverHostName=${encodeURIComponent(serverHostName)}`
+                  : ''
+        }`,
         method: 'GET',
         body: undefined,
     });
 
-export const useIsDatabricksAuthenticated = () => {
+export const useIsDatabricksAuthenticated = ({
+    projectUuid,
+    serverHostName,
+}: {
+    projectUuid?: string;
+    serverHostName?: string;
+}) => {
     return useQuery<ApiSuccessEmpty['results'], ApiError>({
-        queryKey: ['databricks-sso-is-authenticated'],
-        queryFn: getIsAuthenticated,
+        queryKey: [
+            'databricks-sso-is-authenticated',
+            projectUuid,
+            serverHostName,
+        ],
+        queryFn: () =>
+            getIsAuthenticatedForProject(projectUuid, serverHostName),
+        enabled: !!projectUuid || !!serverHostName,
     });
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Adds dynamic Databricks OAuth support for project-specific credentials. This enhancement allows users to authenticate with different Databricks workspaces and store credentials scoped to specific projects.

Key improvements:

- Support for multiple Databricks workspaces with different OAuth configurations
- Project-scoped Databricks credentials that can be automatically selected
- Improved credential management with custom naming and host-based matching
- Dynamic OAuth strategy creation based on server hostname and project settings
- Session storage for Databricks connection context during authentication flow

This enables users to connect to different Databricks workspaces with appropriate credentials for each project, improving the multi-workspace experience.
