### PR TITLE
feat: add partitionBy support to ai agents

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -277,8 +277,8 @@ ${EXPLORE_SELECTION_AMBIGUITY_CHECKER}
       - Moving averages: "7-day moving average of sales", "3-month rolling average"
     - **Choose the right table calculation type** - Use this decision tree:
       - **First, check if a simple type fits** (faster and clearer):
-        - percent_change_from_previous: Period-over-period % change (MoM, YoY) with automatic ordering
-        - percent_of_previous_value: Each row as % of prior row with automatic ordering
+        - percent_change_from_previous: Period-over-period % change (MoM, YoY) with automatic ordering (supports partitionBy for per-group comparisons, e.g. MoM change per category)
+        - percent_of_previous_value: Each row as % of prior row with automatic ordering (supports partitionBy for per-group comparisons)
         - percent_of_column_total: Each value as % of column total - USE THIS for "% of total" questions (supports partitionBy for within-group percentages)
         - rank_in_column: Simple ranking by field value - no partitioning or custom ordering
         - running_total: Cumulative sum of a field - simple unbounded running total
@@ -289,6 +289,7 @@ ${EXPLORE_SELECTION_AMBIGUITY_CHECKER}
         - Aggregating metrics: avg/sum/count/min/max with no orderBy and no frame to aggregate across all result rows
       - **Decision examples**:
         - "% of total orders by status" → Use percent_of_column_total (simple, no partitioning needed)
+        - "MoM % change of revenue per category" → Use percent_change_from_previous with partitionBy: [category] - compares each category to its own previous month
         - "Top 5 customers per region" → Use window_function:row_number with partitionBy: [region] + filter row_number ≤ 5
         - "7-day moving average" → Use window_function:avg with frame clause
         - "Average of monthly averages" → Use window_function:avg with no orderBy, no frame
@@ -299,6 +300,7 @@ ${EXPLORE_SELECTION_AMBIGUITY_CHECKER}
         - "Top 5 customers per region" → partitionBy: [region] - ranking resets for each region
         - "% of total revenue by product within each month" → partitionBy: [month] - percentages sum to 100% per month
         - "Running total of orders by status" → partitionBy: [status] - separate running totals per status
+        - "MoM % change per category" → percent_change_from_previous with partitionBy: [category] - each category compares to its own previous month, not a different category's row
       - **Don't use partitionBy when**: Calculations should be across all rows
         - "Top 5 customers overall" → No partitionBy - single ranking across all customers
         - "% of total revenue by product" → No partitionBy (or empty array []) - percentages sum to 100% across all products

--- a/packages/backend/src/ee/services/ai/utils/validateAxisFields.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateAxisFields.test.ts
@@ -271,6 +271,7 @@ describe('validateAxisFields', () => {
                     displayName: 'Percent Change',
                     fieldId: 'orders_total_revenue',
                     orderBy: [],
+                    partitionBy: null,
                 },
             ];
 

--- a/packages/backend/src/ee/services/ai/utils/validateSelectedFieldsExistence.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateSelectedFieldsExistence.test.ts
@@ -127,6 +127,7 @@ describe('validateSelectedFieldsExistence', () => {
                     displayName: 'Percent Change',
                     fieldId: 'users_total_users',
                     orderBy: [],
+                    partitionBy: null,
                 },
             ];
 

--- a/packages/backend/src/ee/services/ai/utils/validateTableCalculations.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/validateTableCalculations.test.ts
@@ -216,6 +216,7 @@ describe('validateTableCalculations', () => {
                     displayName: 'Percent Change',
                     fieldId: 'running_total',
                     orderBy: [],
+                    partitionBy: null,
                 },
             ];
 
@@ -246,6 +247,7 @@ describe('validateTableCalculations', () => {
                     displayName: 'Percent Change',
                     fieldId: 'orders_order_count',
                     orderBy: [{ fieldId: 'running_total', order: 'asc' }],
+                    partitionBy: null,
                 },
             ];
 
@@ -350,6 +352,7 @@ describe('validateTableCalculations', () => {
                     displayName: 'Percent Change',
                     fieldId: 'orders_total_revenue',
                     orderBy: [{ fieldId: 'non_existent_field', order: 'asc' }],
+                    partitionBy: null,
                 },
             ];
 
@@ -424,6 +427,7 @@ describe('validateTableCalculations', () => {
                     displayName: 'Percent Change',
                     fieldId: 'orders_total_revenue',
                     orderBy: [{ fieldId: 'orders_order_count', order: 'asc' }],
+                    partitionBy: null,
                 },
             ];
 
@@ -452,6 +456,7 @@ describe('validateTableCalculations', () => {
                     displayName: 'Percent Change',
                     fieldId: 'orders_max_date',
                     orderBy: [],
+                    partitionBy: null,
                 },
             ];
 

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentChangeFromPrevious.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentChangeFromPrevious.ts
@@ -4,6 +4,8 @@ import {
     baseTableCalcSchema,
     orderBySchema,
     orderBySchemaDescription,
+    partitionBySchema,
+    partitionBySchemaDescription,
 } from './tableCalcBaseSchemas';
 
 export const tableCalcPercentChangeFromPreviousSchema =
@@ -16,6 +18,10 @@ export const tableCalcPercentChangeFromPreviousSchema =
             .array(orderBySchema)
             .min(1)
             .describe(orderBySchemaDescription),
+        partitionBy: z
+            .array(partitionBySchema)
+            .nullable()
+            .describe(partitionBySchemaDescription),
     });
 
 export type TableCalcPercentChangeFromPreviousSchema = z.infer<

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentOfPreviousValue.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcPercentOfPreviousValue.ts
@@ -4,6 +4,8 @@ import {
     baseTableCalcSchema,
     orderBySchema,
     orderBySchemaDescription,
+    partitionBySchema,
+    partitionBySchemaDescription,
 } from './tableCalcBaseSchemas';
 
 export const tableCalcPercentOfPreviousValueSchema = baseTableCalcSchema.extend(
@@ -16,6 +18,10 @@ export const tableCalcPercentOfPreviousValueSchema = baseTableCalcSchema.extend(
             .array(orderBySchema)
             .min(1)
             .describe(orderBySchemaDescription),
+        partitionBy: z
+            .array(partitionBySchema)
+            .nullable()
+            .describe(partitionBySchemaDescription),
     },
 );
 

--- a/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tableCalcs/tableCalcs.ts
@@ -86,6 +86,7 @@ function convertTableCalcSchemaToTableCalc(
                     type: TableCalculationTemplateType.PERCENT_CHANGE_FROM_PREVIOUS,
                     fieldId: tableCalc.fieldId,
                     orderBy: tableCalc.orderBy ?? [],
+                    partitionBy: tableCalc.partitionBy ?? [],
                 },
                 format: {
                     type: CustomFormatType.PERCENT,
@@ -99,6 +100,7 @@ function convertTableCalcSchemaToTableCalc(
                     type: TableCalculationTemplateType.PERCENT_OF_PREVIOUS_VALUE,
                     fieldId: tableCalc.fieldId,
                     orderBy: tableCalc.orderBy ?? [],
+                    partitionBy: tableCalc.partitionBy ?? [],
                 },
                 format: {
                     type: CustomFormatType.PERCENT,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #20361<!-- reference the related issue e.g. #150 -->

### Description:

Updated ai agents to support `partitionBy` during table calcs

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

![CleanShot 2026-02-18 at 18.51.43@2x.png](https://app.graphite.com/user-attachments/assets/78dac9ea-3845-4a5c-8ce4-3d4df6538760.png)

generated sql

```
WITH metrics AS (
SELECT
  DATE_TRUNC('MONTH', "orders".order_date) AS "orders_order_date_month",
  "orders".order_source AS "orders_order_source",
  SUM("payments".amount) AS "payments_total_revenue"
FROM "postgres"."jaffle"."payments" AS "payments"
LEFT OUTER JOIN "postgres"."jaffle"."orders" AS "orders"
  ON ("orders".order_id) = ("payments".order_id)
GROUP BY 1,2
)
SELECT
  *,
  (CAST("payments_total_revenue" AS FLOAT) / CAST(NULLIF(LAG("payments_total_revenue") OVER(PARTITION BY "orders_order_source" ORDER BY "orders_order_date_month" ASC ), 0) AS FLOAT)) - 1 AS "mom_pct_change_revenue"
FROM metrics
ORDER BY "orders_order_date_month", "orders_order_source"
LIMIT 500
```