### PR TITLE
feat: show favourites in browse menu

### DIFF
--- a/.claude/skills/frontend-style-guide/SKILL.md
+++ b/.claude/skills/frontend-style-guide/SKILL.md
@@ -255,6 +255,48 @@ const MyComponent = () => {
 - Use `Callout` from `components/common/Callout`
 - Variants: `danger`, `warning`, `info`
 
+### Polymorphic Clickable Containers
+
+Use these when you need a layout container that is also clickable — avoids the native `<button>` background/border reset problem.
+
+- **`PolymorphicGroupButton`** from `components/common/PolymorphicGroupButton` — a `Group` (flex row) that is polymorphic and sets `cursor: pointer`. Use for horizontal groups of elements that act as a single button.
+- **`PolymorphicPaperButton`** from `components/common/PolymorphicPaperButton` — a `Paper` (card surface) that is polymorphic and sets `cursor: pointer`. Use for card-like clickable surfaces.
+
+Both accept all props of their base component (`GroupProps` / `PaperProps`) plus a `component` prop for the underlying element.
+
+```tsx
+// ✅ Clickable row without native button style bleed
+<PolymorphicGroupButton component="div" gap="sm" onClick={handleClick}>
+    <MantineIcon icon={IconFolder} />
+    <Text>Label</Text>
+</PolymorphicGroupButton>
+
+// ✅ Clickable card surface
+<PolymorphicPaperButton component="div" p="md" onClick={handleClick}>
+    Card content
+</PolymorphicPaperButton>
+
+// ❌ Avoid - native <button> brings unwanted background/border in menus and panels
+<UnstyledButton>
+    <Group>...</Group>
+</UnstyledButton>
+```
+
+### TruncatedText
+
+- Use `TruncatedText` from `components/common/TruncatedText` whenever text may overflow a constrained width
+- Pass `maxWidth` (number or string) to control the truncation boundary
+- Automatically shows a tooltip with the full text **only when the text is actually truncated** (no tooltip spam for short names)
+- Defaults to `fz="sm"`; override via standard `Text` props
+
+```tsx
+// ✅ Good - truncates long names, tooltip only appears when needed
+<TruncatedText maxWidth={200}>{item.name}</TruncatedText>
+
+// ✅ Accepts any Text prop
+<TruncatedText maxWidth="100%" fw={500}>{space.name}</TruncatedText>
+```
+
 ## Mantine Documentation
 
 List of all components and links to their documentation in LLM-friendly format: `https://mantine.dev/llms.txt`

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -2,32 +2,71 @@ import {
     Box,
     Button,
     Center,
+    Collapse,
     getDefaultZIndex,
     Loader,
     Menu,
     ScrollArea,
+    Text,
 } from '@mantine-8/core';
 import {
     IconCategory,
     IconChartAreaLine,
+    IconChevronDown,
+    IconChevronRight,
     IconFolder,
     IconFolders,
     IconLayoutDashboard,
 } from '@tabler/icons-react';
 import { type FC, useState } from 'react';
 import { Link } from 'react-router';
+import {
+    ResourceViewItemType,
+    assertUnreachable,
+    type ResourceViewItem,
+} from '@lightdash/common';
 import { useHasMetricsInCatalog } from '../../features/metricsCatalog/hooks/useMetricsCatalog';
+import { useFavorites } from '../../hooks/favorites/useFavorites';
 import { useSpaceSummaries } from '../../hooks/useSpaces';
 import MantineIcon from '../common/MantineIcon';
+import { PolymorphicGroupButton } from '../common/PolymorphicGroupButton';
+import TruncatedText from '../common/TruncatedText';
 import { MetricsLink } from './MetricsLink';
 
 interface Props {
     projectUuid: string;
 }
 
+const getFavoriteItemUrl = (projectUuid: string, item: ResourceViewItem) => {
+    switch (item.type) {
+        case ResourceViewItemType.DASHBOARD:
+            return `/projects/${projectUuid}/dashboards/${item.data.uuid}/view`;
+        case ResourceViewItemType.CHART:
+            return `/projects/${projectUuid}/saved/${item.data.uuid}`;
+        case ResourceViewItemType.SPACE:
+            return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
+        default:
+            return assertUnreachable(item, `Unknown favorite item type`);
+    }
+};
+
+const getFavoriteItemIcon = (item: ResourceViewItem) => {
+    switch (item.type) {
+        case ResourceViewItemType.DASHBOARD:
+            return IconLayoutDashboard;
+        case ResourceViewItemType.CHART:
+            return IconChartAreaLine;
+        case ResourceViewItemType.SPACE:
+            return IconFolder;
+        default:
+            return assertUnreachable(item, `Unknown favorite item type`);
+    }
+};
+
 const BrowseMenu: FC<Props> = ({ projectUuid }) => {
     // Track if menu has ever been opened to defer loading spaces
     const [hasBeenOpened, setHasBeenOpened] = useState(false);
+    const [spacesExpanded, setSpacesExpanded] = useState(false);
 
     const { data: spaces, isInitialLoading } = useSpaceSummaries(
         projectUuid,
@@ -40,6 +79,10 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
     const { data: hasMetrics } = useHasMetricsInCatalog({
         projectUuid,
     });
+    const { data: favorites } = useFavorites(projectUuid);
+
+    const hasFavorites = favorites && favorites.length > 0;
+    const hasSpaces = isInitialLoading || (spaces && spaces.length > 0);
 
     return (
         <Menu
@@ -98,42 +141,108 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                     <MetricsLink projectUuid={projectUuid} asMenu />
                 )}
 
-                {isInitialLoading || (spaces && spaces.length > 0) ? (
+                {hasFavorites ? (
                     <>
                         <Menu.Divider />
-                        <Menu.Label>Spaces</Menu.Label>
-
-                        {isInitialLoading ? (
-                            <Center my="sm">
-                                <Loader size="sm" color="gray" />
-                            </Center>
-                        ) : null}
+                        <Menu.Label>Favourites</Menu.Label>
+                        <ScrollArea
+                            variant="primary"
+                            className="only-vertical"
+                            scrollbarSize={6}
+                            type="hover"
+                        >
+                            <Box mah={200}>
+                                {favorites.map((item) => (
+                                    <Menu.Item
+                                        key={item.data.uuid}
+                                        component={Link}
+                                        to={getFavoriteItemUrl(
+                                            projectUuid,
+                                            item,
+                                        )}
+                                        leftSection={
+                                            <MantineIcon
+                                                icon={getFavoriteItemIcon(item)}
+                                            />
+                                        }
+                                    >
+                                        <TruncatedText maxWidth={200}>
+                                            {item.data.name}
+                                        </TruncatedText>
+                                    </Menu.Item>
+                                ))}
+                            </Box>
+                        </ScrollArea>
                     </>
                 ) : null}
 
-                <ScrollArea
-                    variant="primary"
-                    className="only-vertical"
-                    scrollbarSize={6}
-                    type="hover"
-                >
-                    <Box mah={300}>
-                        {spaces
-                            ?.sort((a, b) => a.name.localeCompare(b.name))
-                            .map((space) => (
-                                <Menu.Item
-                                    key={space.uuid}
-                                    component={Link}
-                                    to={`/projects/${projectUuid}/spaces/${space.uuid}`}
-                                    leftSection={
-                                        <MantineIcon icon={IconFolder} />
-                                    }
+                {hasSpaces ? (
+                    <>
+                        <Menu.Divider />
+                        <PolymorphicGroupButton
+                            component="div"
+                            w="100%"
+                            px="sm"
+                            py={6}
+                            gap="xs"
+                            justify="space-between"
+                            onClick={() =>
+                                setSpacesExpanded((prev) => !prev)
+                            }
+                        >
+                            <Text fz="xs" fw={500} c="dimmed">
+                                Spaces
+                            </Text>
+                            <MantineIcon
+                                color="ldGray.6"
+                                size={14}
+                                icon={
+                                    spacesExpanded
+                                        ? IconChevronDown
+                                        : IconChevronRight
+                                }
+                            />
+                        </PolymorphicGroupButton>
+
+                        <Collapse in={spacesExpanded}>
+                            {isInitialLoading ? (
+                                <Center my="sm">
+                                    <Loader size="sm" color="gray" />
+                                </Center>
+                            ) : (
+                                <ScrollArea
+                                    variant="primary"
+                                    className="only-vertical"
+                                    scrollbarSize={6}
+                                    type="hover"
                                 >
-                                    {space.name}
-                                </Menu.Item>
-                            ))}
-                    </Box>
-                </ScrollArea>
+                                    <Box mah={300}>
+                                        {spaces
+                                            ?.sort((a, b) =>
+                                                a.name.localeCompare(b.name),
+                                            )
+                                            .map((space) => (
+                                                <Menu.Item
+                                                    key={space.uuid}
+                                                    component={Link}
+                                                    to={`/projects/${projectUuid}/spaces/${space.uuid}`}
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconFolder}
+                                                        />
+                                                    }
+                                                >
+                                                    <TruncatedText maxWidth={200}>
+                                                        {space.name}
+                                                    </TruncatedText>
+                                                </Menu.Item>
+                                            ))}
+                                    </Box>
+                                </ScrollArea>
+                            )}
+                        </Collapse>
+                    </>
+                ) : null}
             </Menu.Dropdown>
         </Menu>
     );

--- a/packages/frontend/src/components/common/TruncatedText/index.tsx
+++ b/packages/frontend/src/components/common/TruncatedText/index.tsx
@@ -1,0 +1,41 @@
+import { getDefaultZIndex, Text, Tooltip, type TextProps } from '@mantine-8/core';
+import { type FC } from 'react';
+import { useIsTruncated } from '../../../hooks/useIsTruncated';
+
+interface TruncatedTextProps extends Omit<TextProps, 'truncate'> {
+    children: string;
+    maxWidth: number | string;
+}
+
+/**
+ * Renders text truncated with an ellipsis at the given maxWidth.
+ * When the text is actually truncated, hovering shows the full text in a tooltip.
+ */
+const TruncatedText: FC<TruncatedTextProps> = ({
+    children,
+    maxWidth,
+    ...textProps
+}) => {
+    const { ref, isTruncated } = useIsTruncated<HTMLParagraphElement>();
+
+    return (
+        <Tooltip
+            label={children}
+            disabled={!isTruncated}
+            withinPortal
+            zIndex={getDefaultZIndex('max')}
+        >
+            <Text
+                ref={ref}
+                fz="sm"
+                truncate="end"
+                maw={maxWidth}
+                {...textProps}
+            >
+                {children}
+            </Text>
+        </Tooltip>
+    );
+};
+
+export default TruncatedText;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #N/A

### Description:
Enhances the Browse menu with new UI components and features:

1. Added Favorites section to the Browse menu, displaying favorited dashboards, charts, and spaces
2. Made Spaces section collapsible with expand/collapse controls
3. Implemented text truncation with tooltips for long names in the menu
4. Added new reusable components to the style guide:
   - `TruncatedText` - Automatically truncates text with ellipsis and shows tooltip only when needed
   - `PolymorphicGroupButton` and `PolymorphicPaperButton` - Clickable containers that avoid native button styling issues

These changes improve navigation and discoverability while maintaining a clean UI even with long item names.