### PR TITLE
feat: UI support partitionBy in quick templates

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -51,12 +51,14 @@ import QuickCalculationMenuOptions from './QuickCalculations';
 interface ContextMenuProps extends HeaderProps {
     onToggleCalculationEditModal: (value: boolean) => void;
     onToggleCalculationDeleteModal: (value: boolean) => void;
+    onQuickCalculationCreated: (tableCalculation: TableCalculation) => void;
 }
 
 const ContextMenu: FC<ContextMenuProps> = ({
     header,
     onToggleCalculationEditModal,
     onToggleCalculationDeleteModal,
+    onQuickCalculationCreated,
 }) => {
     const { addFilter } = useFilters();
     const { track } = useTracking();
@@ -176,7 +178,10 @@ const ContextMenu: FC<ContextMenuProps> = ({
                                 </>
                             )}
 
-                        <QuickCalculationMenuOptions item={item} />
+                        <QuickCalculationMenuOptions
+                            item={item}
+                            onCalculationCreated={onQuickCalculationCreated}
+                        />
                         <Menu.Divider />
                     </>
                 )}
@@ -335,6 +340,8 @@ const ContextMenu: FC<ContextMenuProps> = ({
 const ColumnHeaderContextMenu: FC<HeaderProps> = ({ header }) => {
     const [showUpdate, setShowUpdate] = useState(false);
     const [showDelete, setShowDelete] = useState(false);
+    const [quickCalcToEdit, setQuickCalcToEdit] =
+        useState<TableCalculation | null>(null);
 
     const meta = header.column.columnDef.meta as TableColumn['meta'];
     const item = meta?.item;
@@ -363,6 +370,7 @@ const ColumnHeaderContextMenu: FC<HeaderProps> = ({ header }) => {
                                 header={header}
                                 onToggleCalculationEditModal={setShowUpdate}
                                 onToggleCalculationDeleteModal={setShowDelete}
+                                onQuickCalculationCreated={setQuickCalcToEdit}
                             />
                         </Menu.Dropdown>
                     </Menu>
@@ -380,6 +388,14 @@ const ColumnHeaderContextMenu: FC<HeaderProps> = ({ header }) => {
                     <DeleteTableCalculationModal
                         tableCalculation={item as TableCalculation}
                         onClose={() => setShowDelete(false)}
+                    />
+                )}
+
+                {quickCalcToEdit && (
+                    <UpdateTableCalculationModal
+                        opened
+                        tableCalculation={quickCalcToEdit}
+                        onClose={() => setQuickCalcToEdit(null)}
                     />
                 )}
             </div>

--- a/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/QuickCalculations.tsx
@@ -24,6 +24,7 @@ import { generateTableCalculationTemplate } from './tableCalculationTemplateGene
 
 type Props = {
     item: Metric;
+    onCalculationCreated?: (tableCalculation: TableCalculation) => void;
 };
 
 // Use shared template labels from utilities
@@ -90,7 +91,10 @@ const isCalculationAvailable = (
     }
 };
 
-const QuickCalculationMenuOptions: FC<Props> = ({ item }) => {
+const QuickCalculationMenuOptions: FC<Props> = ({
+    item,
+    onCalculationCreated,
+}) => {
     const dispatch = useExplorerDispatch();
     const { track } = useTracking();
 
@@ -130,12 +134,15 @@ const QuickCalculationMenuOptions: FC<Props> = ({ item }) => {
             orderWithoutTableCalculations,
         );
 
-        handleAddTableCalculation({
+        const tableCalculation: TableCalculation = {
             name: uniqueName,
             displayName: name,
             template,
             format: getFormatForQuickCalculation(templateType),
-        });
+        };
+
+        handleAddTableCalculation(tableCalculation);
+        onCalculationCreated?.(tableCalculation);
     };
 
     return (

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -8,6 +8,7 @@ import {
     TableCalculationType,
     type CustomFormat,
     type TableCalculation,
+    type TableCalculationTemplate,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -154,6 +155,19 @@ const TableCalculationModal: FC<Props> = ({
         [tableCalculation, existingItemIds],
     );
 
+    // Memoize template for TemplateViewer
+    const template = useMemo(
+        () =>
+            tableCalculation && isTemplateTableCalculation(tableCalculation)
+                ? tableCalculation.template
+                : undefined,
+        [tableCalculation],
+    );
+
+    const [editedTemplate, setEditedTemplate] = useState<
+        TableCalculationTemplate | undefined
+    >(template);
+
     const form = useForm<TableCalculationFormInputs>({
         initialValues,
         validate: {
@@ -207,7 +221,7 @@ const TableCalculationModal: FC<Props> = ({
                     displayName: name,
                     format: data.format,
                     type: data.type,
-                    template: tableCalculation.template,
+                    template: editedTemplate ?? tableCalculation.template,
                 });
             } else {
                 onSave({
@@ -248,13 +262,11 @@ const TableCalculationModal: FC<Props> = ({
         }
     }, []);
 
-    // Memoize template for TemplateViewer
-    const template = useMemo(
-        () =>
-            tableCalculation && isTemplateTableCalculation(tableCalculation)
-                ? tableCalculation.template
-                : undefined,
-        [tableCalculation],
+    const handleTemplateChange = useCallback(
+        (updated: TableCalculationTemplate) => {
+            setEditedTemplate(updated);
+        },
+        [],
     );
 
     // Memoize table calculation type options
@@ -407,8 +419,13 @@ const TableCalculationModal: FC<Props> = ({
 
                                     <Tabs.Panel value="template" p="sm">
                                         <TemplateViewer
-                                            template={template}
-                                            readOnly={true}
+                                            template={
+                                                editedTemplate ?? template
+                                            }
+                                            readOnly={false}
+                                            onTemplateChange={
+                                                handleTemplateChange
+                                            }
                                         />
                                     </Tabs.Panel>
 


### PR DESCRIPTION
Related: #9778

### Description:

Introduced `partitionBy` UI when creating quick calculations if multiple dimensions are selected
https://github.com/user-attachments/assets/e434c0b9-cc98-4458-bd2d-f2ba6a5cabc6