### PR TITLE
fix: change "Favourites" to "Favorites" in Browse menu

### DIFF
--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -144,7 +144,7 @@ const BrowseMenu: FC<Props> = ({ projectUuid }) => {
                 {hasFavorites ? (
                     <>
                         <Menu.Divider />
-                        <Menu.Label>Favourites</Menu.Label>
+                        <Menu.Label>Favorites</Menu.Label>
                         <ScrollArea
                             variant="primary"
                             className="only-vertical"


### PR DESCRIPTION
Updated the Menu.Label text in BrowseMenu.tsx to use American spelling ("Favorites") for consistency with the rest of the application.

https://claude.ai/code/session_015PSYRvmn6o4ncFvdqCjj87

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
