### PR TITLE
fix: implement case-insensitive column matching in dbt schema editor

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -112,9 +112,11 @@ export default class DbtSchemaEditor {
             // node is not an array
             return undefined;
         }
+        const lowerColumnName = columnName.toLowerCase();
         return columns.items.find(
             (item): item is YAMLMap<unknown, unknown> =>
-                isMap(item) && item.get('name') === columnName,
+                isMap(item) &&
+                (item.get('name') as string)?.toLowerCase() === lowerColumnName,
         );
     }
 
@@ -201,9 +203,12 @@ export default class DbtSchemaEditor {
             throw new Error(`Model ${modelName} has invalid columns array`);
         }
         columnNames.forEach((columnName) => {
+            const lowerColumnName = columnName.toLowerCase();
             const index = columns.items.findIndex(
                 (item): item is YAMLMap<unknown, unknown> =>
-                    isMap(item) && item.get('name') === columnName,
+                    isMap(item) &&
+                    (item.get('name') as string)?.toLowerCase() ===
+                        lowerColumnName,
             );
             if (index !== -1) {
                 model.deleteIn(['columns', index]);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-3083/cli-lightdash-generate-preserve-column-case-overwrites-existing-yaml


 - --preserve-column-case controls the case of new column names written to YAML. When a column
  doesn't exist in YAML yet, it gets added with the warehouse's original case (e.g., appClassId)
  instead of lowercased (appclassid).
  - Our fix makes the comparison between existing YAML columns and warehouse columns
  case-insensitive, so they're recognized as the same column regardless of case differences.

  The flow is:
  1. Existing column Event_Id in YAML → matched case-insensitively to event_id from warehouse →
  updated in-place, YAML name stays Event_Id
  2. Brand new column not in YAML yet → added with warehouse case (e.g., appClassId with the flag,
   or appclassid without)

  Without the flag, new columns are always lowercased. With the flag, they keep the original
  warehouse case. That behavior is unchanged.

---


The issue was affecting columsn with different casing. 

<img width="573" height="170" alt="Screenshot from 2026-02-19 10-40-11" src="https://github.com/user-attachments/assets/04eef04b-541d-4d64-a1cb-0473b278da55" />


Before 

<img width="942" height="213" alt="Screenshot from 2026-02-19 10-40-05" src="https://github.com/user-attachments/assets/1830e584-4d6b-4c18-8f20-28720c25d2f4" />

<img width="573" height="170" alt="image" src="https://github.com/user-attachments/assets/6d1ca2c6-7094-481e-86a8-40ab7c1c64bc" />

After 

<img width="573" height="170" alt="Screenshot from 2026-02-19 10-40-11" src="https://github.com/user-attachments/assets/e38770ed-c13a-43ca-ad42-009642904780" />


### Description:
This PR adds case-insensitive column matching for dbt model files to improve compatibility with different warehouse systems. The changes include:

1. Modified `findAndUpdateModelYaml` to use case-insensitive comparisons when matching columns
2. Added a case-insensitive lookup for warehouse table columns
3. Updated column filtering logic to use lowercase comparisons
4. Added comprehensive tests for case-insensitive column matching in `DbtSchemaEditor.test.ts`
5. Modified `DbtSchemaEditor` methods to find, update, add, and remove columns using case-insensitive matching

This ensures that columns with different casing between the warehouse and dbt models are properly matched, preventing duplicate columns and maintaining the original casing in the YAML files.