### PR TITLE
fix: return the full direct user access list instead of list filtered to the user

### DIFF
--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -31,10 +31,7 @@ import { BaseService } from '../BaseService';
 import { DashboardService } from '../DashboardService/DashboardService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import { SavedSqlService } from '../SavedSqlService/SavedSqlService';
-import type {
-    SpaceAccessContextForCasl,
-    SpacePermissionService,
-} from '../SpaceService/SpacePermissionService';
+import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { SpaceService } from '../SpaceService/SpaceService';
 
 type ContentServiceArguments = {
@@ -150,11 +147,10 @@ export class ContentService extends BaseService {
                 item.contentType === ContentType.SPACE,
         );
 
-        let spacesCtx: Record<string, SpaceAccessContextForCasl> = {};
+        let directAccessMap: Record<string, string[]> = {};
         if (spaceItems.length > 0) {
-            spacesCtx =
-                await this.spacePermissionService.getSpacesAccessContext(
-                    user.userUuid,
+            directAccessMap =
+                await this.spacePermissionService.getDirectAccessUserUuids(
                     spaceItems.map((s) => s.uuid),
                 );
         }
@@ -165,14 +161,9 @@ export class ContentService extends BaseService {
                 if (item.contentType !== ContentType.SPACE) {
                     return item;
                 }
-                const ctx = spacesCtx[item.uuid];
                 return {
                     ...item,
-                    access: ctx
-                        ? ctx.access
-                              .filter((a) => a.hasDirectAccess)
-                              .map((a) => a.userUuid)
-                        : [],
+                    access: directAccessMap[item.uuid] ?? [],
                 };
             }),
         };

--- a/packages/backend/src/services/FavoritesService/FavoritesService.ts
+++ b/packages/backend/src/services/FavoritesService/FavoritesService.ts
@@ -204,18 +204,12 @@ export class FavoritesService extends BaseService {
 
         // Enrich favorite spaces with access data from SpacePermissionService
         const favSpaceUuids = favSpaceBases.map((s) => s.data.uuid);
-        const spacesCtx =
-            await this.spacePermissionService.getSpacesAccessContext(
-                user.userUuid,
+        const directAccessMap =
+            await this.spacePermissionService.getDirectAccessUserUuids(
                 favSpaceUuids,
             );
         const favSpaces: ResourceViewSpaceItem[] = favSpaceBases.map((item) => {
-            const ctx = spacesCtx[item.data.uuid];
-            const directAccessUuids = ctx
-                ? ctx.access
-                      .filter((a) => a.hasDirectAccess)
-                      .map((a) => a.userUuid)
-                : [];
+            const directAccessUuids = directAccessMap[item.data.uuid] ?? [];
             return {
                 type: ResourceViewItemType.SPACE,
                 data: {

--- a/packages/backend/src/services/PinningService/PinningService.ts
+++ b/packages/backend/src/services/PinningService/PinningService.ts
@@ -100,19 +100,13 @@ export class PinningService extends BaseService {
         const pinnedSpaceUuids = allowedPinnedSpaceBases.map(
             (s) => s.data.uuid,
         );
-        const spacesCtx =
-            await this.spacePermissionService.getSpacesAccessContext(
-                user.userUuid,
+        const directAccessMap =
+            await this.spacePermissionService.getDirectAccessUserUuids(
                 pinnedSpaceUuids,
             );
         const allowedPinnedSpaces: ResourceViewSpaceItem[] =
             allowedPinnedSpaceBases.map((item) => {
-                const ctx = spacesCtx[item.data.uuid];
-                const directAccessUuids = ctx
-                    ? ctx.access
-                          .filter((a) => a.hasDirectAccess)
-                          .map((a) => a.userUuid)
-                    : [];
+                const directAccessUuids = directAccessMap[item.data.uuid] ?? [];
                 return {
                     type: ResourceViewItemType.SPACE,
                     data: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/GLITCH-173/fix-access-lists-in-space-summaries

### Description:
Added a new `getDirectAccessUserUuids` method to the `SpacePermissionService` that efficiently retrieves user UUIDs with direct access to spaces.

This fixes an issue where the `access` list in `SpaceSummaries` was being populated only with the user uuid if the user had direct access to the space - this happened because we were using the full context filtered just to the user. 

This array should contain the full direct access list (all user uuids with direct access) so that we can show the correct tooltip on the frontend.

**Space**

![CleanShot 2026-02-19 at 10.15.37.png](https://app.graphite.com/user-attachments/assets/189acb20-f83a-440f-b074-5f2e110290a9.png)

**Before**
![CleanShot 2026-02-19 at 10.15.27.png](https://app.graphite.com/user-attachments/assets/15d6d9c7-0d88-4916-b5cf-61194664a037.png)

**After**
![CleanShot 2026-02-19 at 10.17.11.png](https://app.graphite.com/user-attachments/assets/9625020d-9b59-432d-a965-3c509b2662f3.png)

