### PR TITLE
feat: add warning when all content is skipped during upload

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -693,6 +693,21 @@ const logUploadChanges = (changes: Record<string, number>) => {
     Object.entries(changes).forEach(([key, value]) => {
         console.info(`Total ${key}: ${value} `);
     });
+
+    const totalSkipped = Object.entries(changes)
+        .filter(([key]) => key.includes('skipped'))
+        .reduce((sum, [, value]) => sum + value, 0);
+    const totalUpserted = Object.entries(changes)
+        .filter(([key]) => !key.includes('skipped'))
+        .reduce((sum, [, value]) => sum + value, 0);
+
+    if (totalSkipped > 0 && totalUpserted === 0) {
+        console.warn(
+            styles.warning(
+                `\nAll content was skipped (no local changes detected). Use --force to upload all content, e.g. when uploading to a new project.`,
+            ),
+        );
+    }
 };
 
 // SQL charts have 'sql' field instead of 'tableName'/'metricQuery'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-3077/lightdash-upload-skips-all-content-when-uploading-to-a-different

<img width="1001" height="344" alt="image" src="https://github.com/user-attachments/assets/61c3491a-8058-4eec-9ba1-9925b85cb209" />


### Description:
Added a warning message when all content is skipped during upload (no local changes detected). The warning suggests using the `--force` flag to upload all content, which is especially useful when uploading to a new project.