### PR TITLE
fix: refresh manifest when target is explicitly set in generate command

### DIFF
--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -120,7 +120,7 @@ const getJoinedModelsRecursively = (
     );
 };
 
-async function dbtList(options: DbtCompileOptions): Promise<string[]> {
+export async function dbtList(options: DbtCompileOptions): Promise<string[]> {
     try {
         const args = [
             ...optionsToArgs(options),

--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -21,6 +21,7 @@ import GlobalState from '../globalState';
 import * as styles from '../styles';
 import { CompileHandlerOptions } from './compile';
 import { checkLightdashVersion } from './dbt/apiClient';
+import { dbtList } from './dbt/compile';
 import { getDbtVersion } from './dbt/getDbtVersion';
 import getWarehouseClient from './dbt/getWarehouseClient';
 
@@ -82,6 +83,12 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
         target: options.target,
         startOfWeek: options.startOfWeek,
     });
+    // When --target is explicitly set, run dbt ls to refresh the manifest
+    // so model schema/database/catalog reflect the correct target
+    if (options.target) {
+        await dbtList(options);
+    }
+
     const manifest = await loadManifest({ targetDir: context.targetDir });
     const models = getModelsFromManifest(manifest);
     const compiledModels = await getCompiledModels(models, {


### PR DESCRIPTION
# Refresh dbt manifest when target is explicitly set in generate command

### Description:

When the `--target` flag is explicitly set in the generate command, this PR adds a call to `dbtList` to refresh the manifest before loading it. This ensures that model schema, database, and catalog information correctly reflect the specified target.

The PR exports the `dbtList` function from the compile module so it can be used in the generate handler.