### PR TITLE
chore: fix admin access check in inheritance chain

### DIFF
--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -326,14 +326,13 @@ export class SpacePermissionService extends BaseService {
                 directAccess: directAccessMap[item.spaceUuid] ?? [],
             }));
 
-            // Project/org access only if chain reaches project level
+            // Always pass project/org access — the resolver needs it for
+            // highestRole computation (admin detection) even on non-inheriting
+            // spaces. The isPrivate flag controls the fallback path inside
+            // getSpaceRoleFromChain, not whether this data is available.
             const rootSpaceUuid = chain[chain.length - 1].spaceUuid;
-            const projectAccess = inheritsFromOrgOrProject
-                ? (projectAccessMap[rootSpaceUuid] ?? [])
-                : [];
-            const orgAccess = inheritsFromOrgOrProject
-                ? (orgAccessMap[rootSpaceUuid] ?? [])
-                : [];
+            const projectAccess = projectAccessMap[rootSpaceUuid] ?? [];
+            const orgAccess = orgAccessMap[rootSpaceUuid] ?? [];
 
             const isPrivate = !inheritsFromOrgOrProject;
 


### PR DESCRIPTION
### Description:

In getSpacesCaslContextWithInheritance, when a space's chain has inheritsFromOrgOrProject: false, project and org access arrays were passed as empty to the resolver. This meant the resolver couldn't compute highestRole for users without direct space access — so org/project admins would be silently locked out of non-inheriting spaces. The isPrivate flag already handles the fallback logic inside the resolver; the data just needs to always be there.

Removed the conditional that only passed project/org access when `inheritsFromOrgOrProject was true. Now project/org access is always passed to the resolver, regardless of inheritance setting. 
The isPrivate flag (derived from !inheritsFromOrgOrProject) still controls the fallback path inside the resolver — non-admin users without direct access are excluded from private spaces. But the data is always available for highestRole computation, so admin detection works correctly. 
