### PR TITLE
chore: update claude.md's with description of  boolean

### DIFF
--- a/packages/backend/src/services/SpaceService/CLAUDE.md
+++ b/packages/backend/src/services/SpaceService/CLAUDE.md
@@ -52,6 +52,10 @@ const accessible = await spacePermissionService.getAccessibleSpaceUuids(
 - **Not yet wired up**: This service is registered in `ServiceRepository` but not consumed by
   any controller or other service yet. It's the intended replacement for inline permission
   checks that use `SpaceModel._getSpaceAccess`.
+- **`isPrivate` is derived from the inheritance chain**: The `isPrivate` boolean passed to
+  `resolveSpaceAccess` will be replaced by `inheritsFromOrgOrProject` (inverted), computed by
+  `SpacePermissionModel.getInheritanceChain()`. See
+  @packages/common/src/authorization/space/CLAUDE.md for the full mental model and mapping.
 
 **Why the old approach (`SpaceModel`) was bad:**
 

--- a/packages/common/src/authorization/space/CLAUDE.md
+++ b/packages/common/src/authorization/space/CLAUDE.md
@@ -5,6 +5,7 @@ Given three layers of access data (organization, project, direct space), it comp
 each user's final `SpaceMemberRole` (viewer | editor | admin), whether they have direct
 access, and what role they inherited from. This is the single source of truth for
 "who can access this space and with what permissions."
+
 </summary>
 
 <howToUse>
@@ -46,29 +47,55 @@ const access = resolveSpaceAccess({
 
 <importantToKnow>
 
--   **Admins always get in:** Any user with admin at org/project level becomes a space admin,
-    even on private spaces.
--   **Private spaces exclude non-direct users:** Non-admin users need explicit direct access
-    (user or group) to access private spaces. Public spaces grant access to anyone with an
-    org/project role.
--   **Org MEMBER role = no implicit access:** The `MEMBER` org role converts to `undefined`
-    project role, so these users need project-level or direct space access.
--   **Direct user access beats group access:** When a user has both `USER_ACCESS` and
-    `GROUP_ACCESS` on a space, the user-level role wins regardless of which is higher.
--   **`projectRole` vs `inheritedRole`:** `projectRole` only considers org + direct project
-    membership. `inheritedRole` includes all sources (groups, space groups). These serve
-    different purposes downstream.
--   **Role conversions lose granularity:** `INTERACTIVE_VIEWER` → `VIEWER` and
-    `DEVELOPER` → `EDITOR` when converting to space roles. See
-    @packages/common/src/utils/projectMemberRole.ts for full mappings.
+- **Admins always get in:** Any user with admin at org/project level becomes a space admin,
+  even on private spaces.
+- **Private spaces exclude non-direct users:** Non-admin users need explicit direct access
+  (user or group) to access private spaces. Public spaces grant access to anyone with an
+  org/project role.
+- **Org MEMBER role = no implicit access:** The `MEMBER` org role converts to `undefined`
+  project role, so these users need project-level or direct space access.
+- **Direct user access beats group access:** When a user has both `USER_ACCESS` and
+  `GROUP_ACCESS` on a space, the user-level role wins regardless of which is higher.
+- **`projectRole` vs `inheritedRole`:** `projectRole` only considers org + direct project
+  membership. `inheritedRole` includes all sources (groups, space groups). These serve
+  different purposes downstream.
+- **Role conversions lose granularity:** `INTERACTIVE_VIEWER` → `VIEWER` and
+  `DEVELOPER` → `EDITOR` when converting to space roles. See
+  @packages/common/src/utils/projectMemberRole.ts for full mappings.
+- **`isPrivate` maps to `inheritsFromOrgOrProject` (inverted):** The `isPrivate` boolean
+  in `SpaceAccessInput` is the legacy way to express whether org/project roles flow into
+  a space. With the inheritance chain model, think of each space as a door in a
+  corridor. `inherit_parent_permissions` controls whether the door is open or closed:
+
+    ```text
+    Organization role
+      └─► Project role
+            └─🚪 Root space (open/closed)
+                  └─🚪 Child space (open/closed)
+                        └─🚪 Grandchild space
+    ```
+
+    If every door is open (`inherit_parent_permissions: true` all the way up including
+    root), org/project roles walk straight through → `inheritsFromOrgOrProject: true`
+    (= old `isPrivate: false`, "public"). If any door is closed, roles can't pass →
+    `inheritsFromOrgOrProject: false` (= old `isPrivate: true`, "private") — only
+    users with a key (direct access) get past the closed door.
+
+    | Old (CASL)         | New (inheritance chain)           | Meaning                         |
+    | ------------------ | --------------------------------- | ------------------------------- |
+    | `isPrivate: false` | `inheritsFromOrgOrProject: true`  | Org/project roles flow down     |
+    | `isPrivate: true`  | `inheritsFromOrgOrProject: false` | Only direct access grants entry |
+
+    The resolver's behavior is the same either way — only the source of the boolean changes.
+    See `SpacePermissionModel.getInheritanceChain()` for how the chain is evaluated.
 
 </importantToKnow>
 
 <links>
 
--   Types: @packages/common/src/types/space.ts (`SpaceAccessInput`, `DirectSpaceAccess`, etc.)
--   Role utilities: @packages/common/src/utils/projectMemberRole.ts
--   Tests: @packages/common/src/authorization/space/spaceAccessResolver.test.ts
--   Consumer: @packages/backend/src/services/SpaceService/SpacePermissionService.ts
+- Types: @packages/common/src/types/space.ts (`SpaceAccessInput`, `DirectSpaceAccess`, etc.)
+- Role utilities: @packages/common/src/utils/projectMemberRole.ts
+- Tests: @packages/common/src/authorization/space/spaceAccessResolver.test.ts
+- Consumer: @packages/backend/src/services/SpaceService/SpacePermissionService.ts
 
 </links>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Clarifies the relationship between the legacy `isPrivate` boolean and the new inheritance chain model in space permissions documentation. Adds detailed explanation of how `inheritsFromOrgOrProject` maps to the old `isPrivate` flag. The documentation now provides a clear mental model for understanding how permissions flow through the space hierarchy.