### PR TITLE
chore: replace isPrivate in access resolver

### DIFF
--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -219,7 +219,7 @@ export class SpacePermissionService extends BaseService {
 
             const access = resolveSpaceAccess({
                 spaceUuid: rootSpaceUuid,
-                isPrivate,
+                inheritsFromOrgOrProject: !isPrivate,
                 directAccess: directAccessMap[rootSpaceUuid] ?? [],
                 projectAccess: projectAccessMap[rootSpaceUuid] ?? [],
                 organizationAccess: orgAccessMap[rootSpaceUuid] ?? [],
@@ -328,17 +328,15 @@ export class SpacePermissionService extends BaseService {
 
             // Always pass project/org access — the resolver needs it for
             // highestRole computation (admin detection) even on non-inheriting
-            // spaces. The isPrivate flag controls the fallback path inside
-            // getSpaceRoleFromChain, not whether this data is available.
+            // spaces. The inheritsFromOrgOrProject flag controls the fallback
+            // path inside the resolver, not whether this data is available.
             const rootSpaceUuid = chain[chain.length - 1].spaceUuid;
             const projectAccess = projectAccessMap[rootSpaceUuid] ?? [];
             const orgAccess = orgAccessMap[rootSpaceUuid] ?? [];
 
-            const isPrivate = !inheritsFromOrgOrProject;
-
             const access = resolveSpaceAccessWithInheritance({
                 spaceUuid,
-                isPrivate,
+                inheritsFromOrgOrProject,
                 chainDirectAccess,
                 projectAccess,
                 organizationAccess: orgAccess,
@@ -347,7 +345,7 @@ export class SpacePermissionService extends BaseService {
             result[spaceUuid] = {
                 organizationUuid: space.organizationUuid,
                 projectUuid: space.projectUuid,
-                isPrivate,
+                isPrivate: !inheritsFromOrgOrProject,
                 access,
             };
         }

--- a/packages/common/src/authorization/space/spaceAccessResolver.test.ts
+++ b/packages/common/src/authorization/space/spaceAccessResolver.test.ts
@@ -18,7 +18,7 @@ const makeInput = (
     overrides: Partial<SpaceAccessInput> = {},
 ): SpaceAccessInput => ({
     spaceUuid: 'space-1',
-    isPrivate: false,
+    inheritsFromOrgOrProject: true,
     directAccess: [],
     projectAccess: [],
     organizationAccess: [],
@@ -100,7 +100,7 @@ describe('resolveSpaceAccess', () => {
         it('admin can access private space even without direct access', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: true,
+                    inheritsFromOrgOrProject: false,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -202,7 +202,7 @@ describe('resolveSpaceAccess', () => {
         it('viewer gets viewer space role', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritsFromOrgOrProject: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -221,7 +221,7 @@ describe('resolveSpaceAccess', () => {
         it('editor gets editor space role', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritsFromOrgOrProject: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -238,7 +238,7 @@ describe('resolveSpaceAccess', () => {
         it('developer gets editor space role', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritsFromOrgOrProject: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -255,7 +255,7 @@ describe('resolveSpaceAccess', () => {
         it('interactive_viewer gets viewer space role', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritsFromOrgOrProject: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -274,7 +274,7 @@ describe('resolveSpaceAccess', () => {
         it('non-admin without direct access excluded from private space', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: true,
+                    inheritsFromOrgOrProject: false,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -290,7 +290,7 @@ describe('resolveSpaceAccess', () => {
         it('private space with direct access works', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: true,
+                    inheritsFromOrgOrProject: false,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -317,7 +317,7 @@ describe('resolveSpaceAccess', () => {
         it('org MEMBER with no other access is excluded', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritsFromOrgOrProject: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -334,7 +334,7 @@ describe('resolveSpaceAccess', () => {
         it('org MEMBER with project access is included', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritsFromOrgOrProject: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -361,7 +361,7 @@ describe('resolveSpaceAccess', () => {
         it('highest group role wins', () => {
             const result = resolveSpaceAccess(
                 makeInput({
-                    isPrivate: false,
+                    inheritsFromOrgOrProject: true,
                     organizationAccess: [
                         {
                             userUuid: 'user-1',
@@ -578,7 +578,7 @@ describe('resolveSpaceAccessWithInheritance', () => {
         > = {},
     ) => ({
         spaceUuid: 'child-space',
-        isPrivate: false,
+        inheritsFromOrgOrProject: true,
         chainDirectAccess: [],
         projectAccess: [] as ProjectSpaceAccess[],
         organizationAccess: [] as OrganizationSpaceAccess[],
@@ -924,7 +924,7 @@ describe('resolveSpaceAccessWithInheritance', () => {
         it('no access without direct access on private chain', () => {
             const result = resolveSpaceAccessWithInheritance(
                 makeChainInput({
-                    isPrivate: true,
+                    inheritsFromOrgOrProject: false,
                     chainDirectAccess: [
                         { spaceUuid: 'child-space', directAccess: [] },
                     ],
@@ -951,7 +951,7 @@ describe('resolveSpaceAccessWithInheritance', () => {
         it('admin always gets access on private chain', () => {
             const result = resolveSpaceAccessWithInheritance(
                 makeChainInput({
-                    isPrivate: true,
+                    inheritsFromOrgOrProject: false,
                     chainDirectAccess: [
                         { spaceUuid: 'child-space', directAccess: [] },
                     ],
@@ -971,7 +971,7 @@ describe('resolveSpaceAccessWithInheritance', () => {
         it('direct access on parent grants access on private child', () => {
             const result = resolveSpaceAccessWithInheritance(
                 makeChainInput({
-                    isPrivate: true,
+                    inheritsFromOrgOrProject: false,
                     chainDirectAccess: [
                         { spaceUuid: 'child-space', directAccess: [] },
                         {

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -37,7 +37,7 @@ export type ProjectSpaceAccess = {
 
 export type SpaceAccessInput = {
     spaceUuid: string;
-    isPrivate: boolean;
+    inheritsFromOrgOrProject: boolean;
     directAccess: DirectSpaceAccess[];
     projectAccess: ProjectSpaceAccess[];
     organizationAccess: OrganizationSpaceAccess[];
@@ -50,7 +50,7 @@ export type ChainSpaceDirectAccess = {
 
 export type SpaceAccessWithInheritanceInput = {
     spaceUuid: string;
-    isPrivate: boolean;
+    inheritsFromOrgOrProject: boolean;
     chainDirectAccess: ChainSpaceDirectAccess[];
     projectAccess: ProjectSpaceAccess[];
     organizationAccess: OrganizationSpaceAccess[];


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-171/replace-isprivate-with-inheritsfromorgorproject

### Description:
 Replace isPrivate with inheritsFromOrgOrProject in resolver types and logic                                                  
                                                                                                                             
  The resolver now uses inheritsFromOrgOrProject (a chain-level concept) instead of isPrivate. This is a pure inversion —inheritsFromOrgOrProject: true means the chain reaches org/project permissions (was isPrivate: false).                       
                                                                                                                               
  Deliberately keeps isPrivate on SpaceAccessContextForCasl as a compatibility layer for CASL rules (isPrivate:                
  !inheritsFromOrgOrProject). That rename is deferred to cleanup phase.  
