### PR TITLE
feat: add dashboard_tile_headings to copyDashboardTileContent

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -2686,6 +2686,7 @@ export class ProjectModel {
             await copyDashboardTileContent('dashboard_tile_looms');
             await copyDashboardTileContent('dashboard_tile_markdowns');
             await copyDashboardTileContent('dashboard_tile_sql_charts');
+            await copyDashboardTileContent('dashboard_tile_headings');
 
             // Get AI Agents from the source project
             // Note: AI agents are an Enterprise Edition feature. The table may not exist


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #20453

### Description:
Added support for copying dashboard tile headings when duplicating a project. This ensures that heading tiles are properly transferred along with other dashboard tile content types like looms, markdowns, and SQL charts.