### PR TITLE
fix: horizontal bar chart icon

### DIFF
--- a/packages/frontend/src/components/common/MantineIcon/index.tsx
+++ b/packages/frontend/src/components/common/MantineIcon/index.tsx
@@ -75,6 +75,7 @@ const MantineIcon = forwardRef<SVGSVGElement, MantineIconProps>(
             color,
             fill,
             display = 'block',
+            style,
             ...rest
         },
         ref,
@@ -99,6 +100,7 @@ const MantineIcon = forwardRef<SVGSVGElement, MantineIconProps>(
                     ...(typeof stroke === 'number' && {
                         strokeWidth: stroke,
                     }),
+                    ...style,
                 }}
             />
         );

--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -39,13 +39,7 @@ export const IconBox: FC<IconBoxProps> = ({
     bg = 'ldGray.0',
     ...mantineIconProps
 }) => (
-    <Paper
-        w={32}
-        h={32}
-        radius="md"
-        bg={bg}
-        className={classes.iconBox}
-    >
+    <Paper w={32} h={32} radius="md" bg={bg} className={classes.iconBox}>
         <MantineIcon
             icon={icon}
             color={color}
@@ -65,8 +59,10 @@ export const ChartIcon: FC<{
     <IconBox
         icon={getChartIcon(chartKind)}
         color={color ?? 'blue.6'}
-        transform={
-            chartKind === ChartKind.HORIZONTAL_BAR ? 'rotate(90)' : undefined
+        style={
+            chartKind === ChartKind.HORIZONTAL_BAR
+                ? { rotate: '90deg' }
+                : undefined
         }
     />
 );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [PROD-3081: Horizontal bar chart icon displays same as vertical bar chart icon​](https://linear.app/lightdash/issue/PROD-3081/horizontal-bar-chart-icon-displays-same-as-vertical-bar-chart-icon)

### Description:

Added support for custom styles in MantineIcon component by passing the `style` prop to the SVG element. Also updated the ChartIcon component to use the `style` prop with a proper CSS transform instead of the deprecated `transform` attribute for rotating horizontal bar charts.