### PR TITLE
chore: Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -35,10 +35,10 @@ jobs:
                     - 5432:5432
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
             - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
               with:
                   node-version: '20'
                   cache: 'pnpm'
@@ -57,7 +57,7 @@ jobs:
               run: pnpm backend-build
 
             - name: Setup Python and dbt
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4
               with:
                   python-version: '3.10.x'
 
@@ -141,10 +141,10 @@ jobs:
                     - 5432:5432
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
 
             - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
               with:
                   node-version: '20'
                   cache: 'pnpm'
@@ -166,7 +166,7 @@ jobs:
                   fail-on-cache-miss: true
 
             - name: Setup Python and dbt
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4
               with:
                   python-version: '3.10.x'
 
@@ -240,7 +240,7 @@ jobs:
                   AI_DEFAULT_EMBEDDING_PROVIDER: 'openai'
 
             - name: Upload test results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
               if: always()
               with:
                   name: ai-agent-test-results-${{ matrix.ai_provider }}-${{ matrix.model_name }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build and Push Images
     runs-on: depot-ubuntu-24.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false
@@ -128,7 +128,7 @@ jobs:
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
@@ -175,13 +175,13 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           ref: ${{ github.event.release.tag_name }}
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -189,7 +189,7 @@ jobs:
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: |
             node_modules
@@ -202,7 +202,7 @@ jobs:
 
       - name: Cache common build
         id: cache-common
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: packages/common/dist
           key: ${{ runner.os }}-common-build-${{ hashFiles('packages/common/src/**', 'packages/common/tsconfig*.json') }}
@@ -213,7 +213,7 @@ jobs:
 
       - name: Cache warehouses build
         id: cache-warehouses
-        uses: actions/cache@v4
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 #v4
         with:
           path: packages/warehouses/dist
           key: ${{ runner.os }}-warehouses-build-${{ hashFiles('packages/warehouses/src/**', 'packages/warehouses/tsconfig*.json', 'packages/common/src/**') }}
@@ -307,7 +307,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           repository: lightdash/homebrew-lightdash
           token: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,9 +29,9 @@ jobs:
       TURBO_API: https://cache.depot.dev
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: "20"
           cache: "pnpm"
@@ -62,7 +62,7 @@ jobs:
       timezone: ${{ steps.changes.outputs.timezone == 'true' || contains(github.event.pull_request.body, 'test-timezone') || contains(github.event.pull_request.body, 'test-all') }}
       cli: ${{ steps.changes.outputs.cli == 'true' || contains(github.event.pull_request.body, 'test-cli') || contains(github.event.pull_request.body, 'test-all') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Check for files changes
         uses: dorny/paths-filter@v3
         id: changes
@@ -76,7 +76,7 @@ jobs:
     needs: files-changed
     steps:
       - name: Post comment with test selection info
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 #v6
         with:
           script: |
             const marker = '<!-- test-selection-comment -->';
@@ -209,7 +209,7 @@ jobs:
           environment-url: https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev
 
       - name: Comment PR with preview info
-        uses: actions/github-script@v6
+        uses: actions/github-script@d7906e4ad0b1822421a7e6a35d5ca353c962f410 #v6
         with:
           script: |
             const marker = '<!-- preview-environment-comment -->';
@@ -259,7 +259,7 @@ jobs:
     name: Build E2E Image
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
       - name: GitHub Registry Login
@@ -268,7 +268,7 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 #v5
         with:
           file: ./packages/e2e/dockerfile
           context: .
@@ -294,7 +294,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
       - name: Build packages/common module
@@ -347,7 +347,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
       - name: Build packages/common module
@@ -383,7 +383,7 @@ jobs:
           CYPRESS_TRINO_PASSWORD: ${{ secrets.TRINO_PASSWORD }}
           TZ: "UTC"
           CYPRESS_TZ: "UTC"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         if: failure()
         with:
           name: cypress-screenshots-and-videos-${{ strategy.job-index }}
@@ -409,7 +409,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
       - name: Build packages/common module
@@ -432,7 +432,7 @@ jobs:
         env:
           TZ: ${{ matrix.timezone }}
           CYPRESS_TZ: ${{ matrix.timezone }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 #v4
         if: failure()
         with:
           name: cypress-screenshots-and-videos-timezone-${{ strategy.job-index }}
@@ -452,7 +452,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
       - name: Build packages/common module
@@ -485,10 +485,10 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4
         with:
           python-version: "3.10.x"
       - run: pip install dbt-core~=1.9.0 dbt-postgres~=1.9.0
@@ -552,10 +552,10 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@7f4fc3e22c37d6ff65e88745f38bd3157c663f7c #v4
         with:
           python-version: "3.10.x"
       - run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,9 +14,9 @@ jobs:
       TURBO_API: https://cache.depot.dev
       NODE_OPTIONS: '--max-old-space-size=8192'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
       - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: '20'
           cache: 'pnpm'
@@ -34,14 +34,14 @@ jobs:
       contents: read
       id-token: write  # Required for OIDC authentication with npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false
 
       - uses: pnpm/action-setup@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 #v4
         with:
           node-version: '20'
           cache: 'pnpm'

--- a/.github/workflows/test-easy-install.yml
+++ b/.github/workflows/test-easy-install.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 #v4
     - name: Run easy install
       env: 
         RUDDERSTACK_WRITE_KEY: '1vikeGadtB0Y0oRDFNL2Prdhkbp' # dev key

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Validate PR Title
-      uses: amannn/action-semantic-pull-request@v5
+      uses: amannn/action-semantic-pull-request@e32d7e603df1aa1ba07e981f2a23455dee596825 #v5
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
---

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Pinning GitHub Actions to specific commit SHAs ensures your workflow uses the exact same version every time, preventing unexpected changes when an action publisher releases a new version. This improves security and reliability. Learn more: https://docs.github.com/en/actions/security-guides/security-hardening-for-github-actions#using-third-party-actions

## Changes

- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/post-release.yml`
- Pinned `actions/cache` from `v4` to `0057852` in `.github/workflows/post-release.yml`
- Pinned `actions/setup-python` from `v4` to `7f4fc3e` in `.github/workflows/ai-agent-integration-tests.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/pr.yml`
- Pinned `actions/github-script` from `v6` to `d7906e4` in `.github/workflows/pr.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/ai-agent-integration-tests.yml`
- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/ai-agent-integration-tests.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/test-easy-install.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/release.yml`
- Pinned `actions/upload-artifact` from `v4` to `ea165f8` in `.github/workflows/pr.yml`
- Pinned `docker/build-push-action` from `v5` to `ca052bb` in `.github/workflows/pr.yml`
- Pinned `actions/setup-node` from `v4` to `49933ea` in `.github/workflows/pr.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/ai-agent-integration-tests.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/test-easy-install.yml`
- Pinned `actions/setup-python` from `v4` to `7f4fc3e` in `.github/workflows/pr.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/post-release.yml`
- Pinned `actions/checkout` from `v4` to `34e1148` in `.github/workflows/release.yml`
- Pinned `amannn/action-semantic-pull-request` from `v5` to `e32d7e6` in `.github/workflows/validate-pr-title.yml`

--- 

The changes will be tested in the CI pipeline of the pull request.