### PR TITLE
fix: remove dashboard tab requirement being a uuid

### DIFF
--- a/packages/backend/src/database/migrations/20260219120000_relax_dashboard_tab_uuid_type.ts
+++ b/packages/backend/src/database/migrations/20260219120000_relax_dashboard_tab_uuid_type.ts
@@ -1,0 +1,78 @@
+import { Knex } from 'knex';
+
+const DashboardTabsTableName = 'dashboard_tabs';
+const DashboardTilesTableName = 'dashboard_tiles';
+
+export async function up(knex: Knex): Promise<void> {
+    // Drop the composite foreign key on dashboard_tiles(tab_uuid, dashboard_version_id)
+    await knex.schema.alterTable(DashboardTilesTableName, (table) => {
+        table.dropForeign(['tab_uuid', 'dashboard_version_id']);
+    });
+
+    // Drop the composite primary key on dashboard_tabs(uuid, dashboard_version_id)
+    await knex.schema.alterTable(DashboardTabsTableName, (table) => {
+        table.dropPrimary();
+    });
+
+    // Change dashboard_tabs.uuid from uuid to text
+    await knex.raw(
+        `ALTER TABLE ${DashboardTabsTableName} ALTER COLUMN uuid TYPE text`,
+    );
+
+    // Change dashboard_tiles.tab_uuid from uuid to text
+    await knex.raw(
+        `ALTER TABLE ${DashboardTilesTableName} ALTER COLUMN tab_uuid TYPE text`,
+    );
+
+    // Re-add the composite primary key on dashboard_tabs
+    await knex.schema.alterTable(DashboardTabsTableName, (table) => {
+        table.primary(['uuid', 'dashboard_version_id']);
+    });
+
+    // Re-add the composite foreign key on dashboard_tiles
+    await knex.schema.alterTable(DashboardTilesTableName, (table) => {
+        table
+            .foreign(['tab_uuid', 'dashboard_version_id'])
+            .references(['uuid', 'dashboard_version_id'])
+            .inTable(DashboardTabsTableName)
+            .onDelete('CASCADE');
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    // Drop the composite foreign key on dashboard_tiles
+    await knex.schema.alterTable(DashboardTilesTableName, (table) => {
+        table.dropForeign(['tab_uuid', 'dashboard_version_id']);
+    });
+
+    // Drop the composite primary key on dashboard_tabs
+    await knex.schema.alterTable(DashboardTabsTableName, (table) => {
+        table.dropPrimary();
+    });
+
+    // Change dashboard_tiles.tab_uuid back to uuid
+    // NOTE: This will fail if any non-UUID values exist in the column
+    await knex.raw(
+        `ALTER TABLE ${DashboardTilesTableName} ALTER COLUMN tab_uuid TYPE uuid USING tab_uuid::uuid`,
+    );
+
+    // Change dashboard_tabs.uuid back to uuid
+    // NOTE: This will fail if any non-UUID values exist in the column
+    await knex.raw(
+        `ALTER TABLE ${DashboardTabsTableName} ALTER COLUMN uuid TYPE uuid USING uuid::uuid`,
+    );
+
+    // Re-add the composite primary key
+    await knex.schema.alterTable(DashboardTabsTableName, (table) => {
+        table.primary(['uuid', 'dashboard_version_id']);
+    });
+
+    // Re-add the composite foreign key
+    await knex.schema.alterTable(DashboardTilesTableName, (table) => {
+        table
+            .foreign(['tab_uuid', 'dashboard_version_id'])
+            .references(['uuid', 'dashboard_version_id'])
+            .inTable(DashboardTabsTableName)
+            .onDelete('CASCADE');
+    });
+}

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -241,11 +241,11 @@
             "items": {
                 "type": "object",
                 "additionalProperties": false,
-                "required": ["uuid", "name", "order"],
+                "required": ["name", "order"],
                 "properties": {
                     "uuid": {
                         "type": "string",
-                        "description": "Unique identifier for the tab"
+                        "description": "Identifier for the tab. Can be any string (e.g. 'overview', 'details'). Auto-generated if omitted."
                     },
                     "name": {
                         "type": "string",

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -8,6 +8,7 @@ import type {
     DashboardHeadingTileProperties,
     DashboardLoomTileProperties,
     DashboardMarkdownTileProperties,
+    DashboardTab,
     DashboardTile,
     FilterRule,
     MetricQuery,
@@ -141,10 +142,15 @@ export type DashboardTileWithSlug = DashboardTile & {
     tileSlug: string | undefined;
 };
 
+export type DashboardTabInput = Omit<DashboardTab, 'uuid'> & {
+    uuid?: string;
+};
+
 export type DashboardAsCode = Pick<
     Dashboard,
-    'name' | 'description' | 'tabs' | 'slug'
+    'name' | 'description' | 'slug'
 > & {
+    tabs: DashboardTabInput[];
     /** Not modifiable by user, but useful to know if it has been updated. Defaults to now if omitted. */
     updatedAt?: Date;
     tiles: DashboardTileAsCode[];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #XXXX

### Description:
This PR relaxes the dashboard tab UUID type from UUID to text, allowing more flexible tab identifiers. The changes include:

1. Added a new database migration that converts the `uuid` column in `dashboard_tabs` and the `tab_uuid` column in `dashboard_tiles` from UUID type to text type.

2. Enhanced the `CoderService` with a `normalizeTabIds` function that assigns UUIDs to any tabs missing them and updates tile references accordingly.

3. Updated the dashboard-as-code JSON schema to make the `uuid` field optional for tabs and clarified that it can be any string (e.g., 'overview', 'details').

4. Modified the TypeScript types to support optional UUIDs in tab inputs.

This change allows dashboard tabs to use more human-readable identifiers while maintaining backward compatibility with existing UUIDs.