### PR TITLE
feat: skip content type check on lightdash upload --force

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -1067,6 +1067,7 @@ export class ProjectController extends BaseController {
         chart: Omit<ChartAsCode, 'chartConfig' | 'description'> & {
             skipSpaceCreate?: boolean;
             publicSpaceCreate?: boolean;
+            force?: boolean;
             chartConfig: AnyType;
             description?: string | null; // Allow both undefined and null
         },
@@ -1085,6 +1086,7 @@ export class ProjectController extends BaseController {
                 },
                 chart.skipSpaceCreate,
                 chart.publicSpaceCreate,
+                chart.force,
             ),
         };
     }
@@ -1127,6 +1129,7 @@ export class ProjectController extends BaseController {
         sqlChart: Omit<SqlChartAsCode, 'config' | 'description'> & {
             skipSpaceCreate?: boolean;
             publicSpaceCreate?: boolean;
+            force?: boolean;
             config: AnyType;
             description?: string | null;
         },
@@ -1145,6 +1148,7 @@ export class ProjectController extends BaseController {
                 },
                 sqlChart.skipSpaceCreate,
                 sqlChart.publicSpaceCreate,
+                sqlChart.force,
             ),
         };
     }
@@ -1164,6 +1168,7 @@ export class ProjectController extends BaseController {
         dashboard: Omit<DashboardAsCode, 'tiles' | 'description'> & {
             skipSpaceCreate?: boolean;
             publicSpaceCreate?: boolean;
+            force?: boolean;
             tiles: AnyType;
             description?: string | null; // Allow both undefined and null
         }, // Simplify filter type for tsoa
@@ -1182,6 +1187,7 @@ export class ProjectController extends BaseController {
                 },
                 dashboard.skipSpaceCreate,
                 dashboard.publicSpaceCreate,
+                dashboard.force,
             ),
         };
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7396,11 +7396,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7878,11 +7878,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7897,11 +7897,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7916,11 +7916,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7935,11 +7935,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7954,11 +7954,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -40838,6 +40838,7 @@ export function RegisterRoutes(app: Router) {
                             ],
                         },
                         chartConfig: { ref: 'AnyType', required: true },
+                        force: { dataType: 'boolean' },
                         publicSpaceCreate: { dataType: 'boolean' },
                         skipSpaceCreate: { dataType: 'boolean' },
                     },
@@ -40988,6 +40989,7 @@ export function RegisterRoutes(app: Router) {
                             ],
                         },
                         config: { ref: 'AnyType', required: true },
+                        force: { dataType: 'boolean' },
                         publicSpaceCreate: { dataType: 'boolean' },
                         skipSpaceCreate: { dataType: 'boolean' },
                     },
@@ -41072,6 +41074,7 @@ export function RegisterRoutes(app: Router) {
                             ],
                         },
                         tiles: { ref: 'AnyType', required: true },
+                        force: { dataType: 'boolean' },
                         publicSpaceCreate: { dataType: 'boolean' },
                         skipSpaceCreate: { dataType: 'boolean' },
                     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8677,19 +8677,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -26383,7 +26370,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2495.0",
+        "version": "0.2496.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -35585,6 +35572,9 @@
                                             "chartConfig": {
                                                 "$ref": "#/components/schemas/AnyType"
                                             },
+                                            "force": {
+                                                "type": "boolean"
+                                            },
                                             "publicSpaceCreate": {
                                                 "type": "boolean"
                                             },
@@ -35728,6 +35718,9 @@
                                             "config": {
                                                 "$ref": "#/components/schemas/AnyType"
                                             },
+                                            "force": {
+                                                "type": "boolean"
+                                            },
                                             "publicSpaceCreate": {
                                                 "type": "boolean"
                                             },
@@ -35809,6 +35802,9 @@
                                             },
                                             "tiles": {
                                                 "$ref": "#/components/schemas/AnyType"
+                                            },
+                                            "force": {
+                                                "type": "boolean"
                                             },
                                             "publicSpaceCreate": {
                                                 "type": "boolean"

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -923,6 +923,7 @@ export class CoderService extends BaseService {
         chartAsCode: ChartAsCode,
         skipSpaceCreate?: boolean,
         publicSpaceCreate?: boolean,
+        force?: boolean,
     ) {
         const project = await this.projectModel.get(projectUuid);
 
@@ -1092,6 +1093,16 @@ export class CoderService extends BaseService {
                 updatedChart,
                 upstreamChart,
             );
+        if (force) {
+            promotionChanges = {
+                ...promotionChanges,
+                charts: promotionChanges.charts.map((c) =>
+                    c.action === PromotionAction.NO_CHANGES
+                        ? { ...c, action: PromotionAction.UPDATE }
+                        : c,
+                ),
+            };
+        }
         promotionChanges = await this.promoteService.upsertCharts(
             user,
             promotionChanges,
@@ -1111,6 +1122,7 @@ export class CoderService extends BaseService {
         sqlChartAsCode: SqlChartAsCode,
         skipSpaceCreate?: boolean,
         publicSpaceCreate?: boolean,
+        force?: boolean,
     ): Promise<PromotionChanges> {
         const project = await this.projectModel.get(projectUuid);
 
@@ -1379,6 +1391,7 @@ export class CoderService extends BaseService {
         dashboardAsCode: DashboardAsCode,
         skipSpaceCreate?: boolean,
         publicSpaceCreate?: boolean,
+        force?: boolean,
     ): Promise<PromotionChanges> {
         const project = await this.projectModel.get(projectUuid);
 
@@ -1520,6 +1533,17 @@ export class CoderService extends BaseService {
 
         // TODO: Right now dashboards on promote service always update dashboards
         // See isDashboardUpdated for more details
+
+        if (force) {
+            promotionChanges = {
+                ...promotionChanges,
+                charts: promotionChanges.charts.map((c) =>
+                    c.action === PromotionAction.NO_CHANGES
+                        ? { ...c, action: PromotionAction.UPDATE }
+                        : c,
+                ),
+            };
+        }
 
         promotionChanges = await this.promoteService.getOrCreateDashboard(
             user,

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -789,6 +789,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                     ...item,
                     skipSpaceCreate,
                     publicSpaceCreate,
+                    force,
                 }),
             });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: n/A

### Description:
Added a `force` parameter to chart, SQL chart, and dashboard creation endpoints to allow forcing updates even when no changes are detected. This enables users to override the default behavior where resources with no changes are skipped during promotion.

The implementation:
1. Added the `force` parameter to the controller methods
2. Passed the parameter through to the CoderService methods
3. Modified the promotion logic to convert NO_CHANGES actions to UPDATE actions when force is enabled
4. Updated the CLI to pass the force flag to the API

```

  1. Regular charts (upsertChart): promoteService.getChartChanges() could return NO_CHANGES based on timestamp/name/description comparison → now overridden to UPDATE when force=true
  2. Charts inside dashboards (upsertDashboard): promoteService.getPromotionDashboardChanges() could return NO_CHANGES for individual chart tiles → now also overridden to UPDATE when
  force=true
  3. Dashboards themselves: Already always UPDATE (no change needed — there's even a TODO comment about this at line 1534)
  4. SQL charts (upsertSqlChart): Already always CREATE or UPDATE directly — never goes through promoteService, so NO_CHANGES was never possible

  So with --force, every content type will always be written to the database — no server-side "nothing changed" skipping.
```