### PR TITLE
fix: prevent dashboard crash when SQL runner table has missing column config

### DIFF
--- a/packages/frontend/src/components/DataViz/hooks/useTableDataModel.ts
+++ b/packages/frontend/src/components/DataViz/hooks/useTableDataModel.ts
@@ -55,7 +55,7 @@ export const useTableDataModel = ({
             // we found the fix here -> https://github.com/TanStack/table/issues/1671
             // do not remove the line below
             accessorFn: TableDataModel.getColumnsAccessorFn(column),
-            header: config?.columns[column].label || column,
+            header: config?.columns?.[column]?.label || column,
             cell: getValueCell,
         }));
     }, [columns, config?.columns]);


### PR DESCRIPTION
## Summary

- Adds optional chaining to prevent a crash in `useTableDataModel` when a SQL runner table chart has a column config entry missing for a given column

## How we discovered this

While building new charts-as-code for the CLI Launch dashboard in our analytics project, we accidentally uploaded a SQL runner table chart with a `fieldConfig` (x/y axis config used by bar/line charts) instead of the correct `config.columns` format that table charts expect. This caused the entire dashboard page to crash with:

```
Cannot read properties of undefined (reading 'week')
```

The crash originated at `useTableDataModel.ts:58`:
```typescript
header: config?.columns[column].label || column,
```

`config?.columns` only guards against `config` being undefined. When `columns` exists but doesn't contain the specific column key, `config.columns[column]` returns `undefined`, and accessing `.label` on it throws.

## Reproduction steps

1. Create a SQL runner chart YAML file with `chartKind: table` but using the bar/line chart config shape (`fieldConfig` with `x`/`y` axes) instead of the correct table config shape (`config.columns`):

```yaml
# Bad config (bar/line chart shape — crashes table renderer)
config:
  type: table
  display: {}
  metadata:
    version: 1
  fieldConfig:
    x:
      type: category
      reference: week
    "y":
      - reference: error_rate
        aggregation: max
    groupBy: []
    sortBy: []
chartKind: table
```

```yaml
# Good config (table shape — works correctly)
config:
  type: table
  columns:
    week:
      label: Week
      frozen: false
      visible: true
      reference: week
    error_rate:
      label: Error rate (%)
      frozen: false
      visible: true
      reference: error_rate
  display: {}
  metadata:
    version: 1
chartKind: table
```

2. Upload the chart to a dashboard using `lightdash upload`
3. Open the dashboard — the entire page crashes with `Cannot read properties of undefined (reading 'week')`

## Fix

```diff
- header: config?.columns[column].label || column,
+ header: config?.columns?.[column]?.label || column,
```

With this fix, the table gracefully falls back to displaying the raw column name from the SQL query instead of crashing.

## Test plan

- [ ] Upload a SQL runner table chart with the bad config shape shown above
- [ ] Verify the dashboard renders the table with raw column names as headers instead of crashing
- [ ] Verify a correctly configured table chart still shows custom labels as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)