### PR TITLE
fix: skip manifest refresh for dbt Cloud CLI in generate command

### DIFF
--- a/packages/cli/src/handlers/generate.ts
+++ b/packages/cli/src/handlers/generate.ts
@@ -86,7 +86,7 @@ export const generateHandler = async (options: GenerateHandlerOptions) => {
     });
     // When --target is explicitly set, run dbt ls to refresh the manifest
     // so model schema/database/catalog reflect the correct target
-    if (options.target) {
+    if (options.target && !dbtVersion.isDbtCloudCLI) {
         await dbtList(options);
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Skip running `dbt ls` to refresh the manifest when using dbt Cloud CLI, even when the `--target` option is explicitly set. This prevents unnecessary manifest refresh operations in dbt Cloud CLI environments where they may not be needed or supported.
