### PR TITLE
feat: add CLI chart runner command

### DIFF
--- a/packages/cli/src/handlers/asyncQuery.ts
+++ b/packages/cli/src/handlers/asyncQuery.ts
@@ -1,0 +1,62 @@
+import {
+    ApiGetAsyncQueryResults,
+    QueryHistoryStatus,
+    ResultRow,
+} from '@lightdash/common';
+import GlobalState from '../globalState';
+import { lightdashApi } from './dbt/apiClient';
+
+const INITIAL_BACKOFF_MS = 250;
+const MAX_BACKOFF_MS = 1000;
+
+function sleep(ms: number): Promise<void> {
+    return new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+}
+
+export async function pollForResults(
+    projectUuid: string,
+    queryUuid: string,
+    options: { pageSize?: number; backoffMs?: number } = {},
+): Promise<ApiGetAsyncQueryResults> {
+    const { pageSize, backoffMs = INITIAL_BACKOFF_MS } = options;
+    const pageSizeParam = pageSize ? `?pageSize=${pageSize}` : '';
+    const result = await lightdashApi<ApiGetAsyncQueryResults>({
+        method: 'GET',
+        url: `/api/v2/projects/${projectUuid}/query/${queryUuid}${pageSizeParam}`,
+        body: undefined,
+    });
+
+    GlobalState.debug(`> Query status: ${result.status}`);
+
+    if (result.status === QueryHistoryStatus.PENDING) {
+        await sleep(backoffMs);
+        return pollForResults(projectUuid, queryUuid, {
+            pageSize,
+            backoffMs: Math.min(backoffMs * 2, MAX_BACKOFF_MS),
+        });
+    }
+
+    return result;
+}
+
+export function resultsToCsv(columns: string[], rows: ResultRow[]): string {
+    const escapeValue = (value: unknown): string => {
+        if (value === null || value === undefined) {
+            return '';
+        }
+        const str = String(value);
+        if (str.includes(',') || str.includes('"') || str.includes('\n')) {
+            return `"${str.replace(/"/g, '""')}"`;
+        }
+        return str;
+    };
+
+    const header = columns.map(escapeValue).join(',');
+    const dataRows = rows.map((row) =>
+        columns.map((col) => escapeValue(row[col]?.value?.raw)).join(','),
+    );
+
+    return [header, ...dataRows].join('\n');
+}

--- a/packages/cli/src/handlers/runChart.ts
+++ b/packages/cli/src/handlers/runChart.ts
@@ -1,0 +1,143 @@
+import {
+    ApiExecuteAsyncMetricQueryResults,
+    ChartAsCode,
+    QueryHistoryStatus,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import * as yaml from 'js-yaml';
+import { getConfig } from '../config';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { pollForResults, resultsToCsv } from './asyncQuery';
+import { lightdashApi } from './dbt/apiClient';
+
+type RunChartOptions = {
+    path: string;
+    output?: string;
+    limit?: number;
+    pageSize?: number;
+    verbose?: boolean;
+};
+
+const DEFAULT_PAGE_SIZE = 500;
+
+export const runChartHandler = async (
+    options: RunChartOptions,
+): Promise<void> => {
+    GlobalState.setVerbose(options.verbose ?? false);
+
+    // Read and parse YAML
+    let fileContent: string;
+    try {
+        fileContent = await fs.readFile(options.path, 'utf-8');
+    } catch (err) {
+        throw new Error(`Cannot read file: ${options.path}`);
+    }
+
+    let chart: unknown;
+    try {
+        chart = yaml.load(fileContent);
+    } catch (err) {
+        throw new Error(`Invalid YAML in ${options.path}`);
+    }
+
+    // Validate it's a metric query chart (not SQL)
+    const typedChart = chart as Record<string, unknown>;
+    if ('sql' in typedChart && !('tableName' in typedChart)) {
+        throw new Error(
+            'SQL charts are not supported. Only metric query charts (with tableName + metricQuery) can be run.',
+        );
+    }
+
+    if (!typedChart.tableName || !typedChart.metricQuery) {
+        throw new Error(
+            `File is not a valid metric query chart. Expected 'tableName' and 'metricQuery' fields.`,
+        );
+    }
+
+    const chartAsCode = chart as ChartAsCode;
+
+    // Get project UUID
+    const config = await getConfig();
+    const projectUuid = config.context?.project;
+    if (!projectUuid) {
+        throw new Error(
+            `No project selected. Run 'lightdash config set-project' first.`,
+        );
+    }
+
+    const chartName = chartAsCode.name ?? chartAsCode.slug ?? options.path;
+    GlobalState.debug(`> Running chart: ${chartName}`);
+    GlobalState.debug(`> Table: ${chartAsCode.tableName}`);
+    GlobalState.debug(`> Project: ${projectUuid}`);
+
+    const spinner = GlobalState.startSpinner(
+        `Executing query for '${chartName}'...`,
+    );
+
+    const { metricQuery } = chartAsCode;
+
+    // Build request body: convert MetricQuery to MetricQueryRequest shape
+    const queryBody = {
+        exploreName: chartAsCode.tableName,
+        dimensions: metricQuery.dimensions,
+        metrics: metricQuery.metrics,
+        filters: metricQuery.filters,
+        sorts: metricQuery.sorts,
+        limit: options.limit ?? metricQuery.limit,
+        tableCalculations: metricQuery.tableCalculations,
+        additionalMetrics: metricQuery.additionalMetrics,
+        customDimensions: metricQuery.customDimensions,
+    };
+
+    // Submit metric query
+    const submitResult = await lightdashApi<ApiExecuteAsyncMetricQueryResults>({
+        method: 'POST',
+        url: `/api/v2/projects/${projectUuid}/query/metric-query`,
+        body: JSON.stringify({
+            query: queryBody,
+            context: 'cli',
+        }),
+    });
+
+    GlobalState.debug(`> Query UUID: ${submitResult.queryUuid}`);
+    spinner.text = 'Waiting for query results...';
+
+    // Poll for completion
+    const result = await pollForResults(projectUuid, submitResult.queryUuid, {
+        pageSize: options.output
+            ? (options.pageSize ?? DEFAULT_PAGE_SIZE)
+            : undefined,
+    });
+
+    if (result.status === QueryHistoryStatus.ERROR) {
+        spinner.fail(`Query failed for '${chartName}'`);
+        throw new Error(result.error ?? 'Query execution failed');
+    }
+
+    if (result.status === QueryHistoryStatus.CANCELLED) {
+        spinner.fail(`Query cancelled for '${chartName}'`);
+        throw new Error('Query was cancelled');
+    }
+
+    if (result.status !== QueryHistoryStatus.READY) {
+        spinner.fail('Unexpected query status');
+        throw new Error(`Unexpected query status: ${result.status}`);
+    }
+
+    const durationMs = result.initialQueryExecutionMs;
+    const durationStr = durationMs ? ` (${durationMs}ms)` : '';
+
+    if (options.output) {
+        const columns = Object.keys(result.columns);
+        const csv = resultsToCsv(columns, result.rows);
+        await fs.writeFile(options.output, csv, 'utf8');
+        spinner.succeed(
+            `${styles.success('Success!')} Wrote ${result.rows.length} rows to ${options.output}${durationStr}`,
+        );
+    } else {
+        spinner.succeed(
+            `${styles.success('Success!')} '${chartName}' query succeeded${durationStr}`,
+        );
+    }
+};

--- a/packages/cli/src/handlers/sql.ts
+++ b/packages/cli/src/handlers/sql.ts
@@ -1,13 +1,12 @@
 import {
     ApiExecuteAsyncSqlQueryResults,
-    ApiGetAsyncQueryResults,
     QueryHistoryStatus,
-    ResultRow,
 } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import { getConfig } from '../config';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
+import { pollForResults, resultsToCsv } from './asyncQuery';
 import { lightdashApi } from './dbt/apiClient';
 
 type SqlHandlerOptions = {
@@ -18,92 +17,6 @@ type SqlHandlerOptions = {
 };
 
 const DEFAULT_PAGE_SIZE = 500;
-const POLL_INTERVAL_MS = 500;
-
-/**
- * Convert ResultRow array to CSV string
- */
-function resultsToCsv(columns: string[], rows: ResultRow[]): string {
-    // Escape CSV value: wrap in quotes if contains comma, quote, or newline
-    const escapeValue = (value: unknown): string => {
-        if (value === null || value === undefined) {
-            return '';
-        }
-        const str = String(value);
-        if (str.includes(',') || str.includes('"') || str.includes('\n')) {
-            return `"${str.replace(/"/g, '""')}"`;
-        }
-        return str;
-    };
-
-    const header = columns.map(escapeValue).join(',');
-    const dataRows = rows.map((row) =>
-        columns.map((col) => escapeValue(row[col]?.value?.raw)).join(','),
-    );
-
-    return [header, ...dataRows].join('\n');
-}
-
-/**
- * Fetch query results once
- */
-async function fetchQueryResults(
-    projectUuid: string,
-    queryUuid: string,
-    pageSize: number,
-): Promise<ApiGetAsyncQueryResults> {
-    const url = `/api/v2/projects/${projectUuid}/query/${queryUuid}?pageSize=${pageSize}`;
-    return lightdashApi<ApiGetAsyncQueryResults>({
-        method: 'GET',
-        url,
-        body: undefined,
-    });
-}
-
-/**
- * Sleep for a given duration
- */
-function sleep(ms: number): Promise<void> {
-    return new Promise((resolve) => {
-        setTimeout(resolve, ms);
-    });
-}
-
-/**
- * Poll for query results until status is READY or ERROR
- */
-async function pollQueryResults(
-    projectUuid: string,
-    queryUuid: string,
-    pageSize: number,
-): Promise<ApiGetAsyncQueryResults> {
-    const poll = async (): Promise<ApiGetAsyncQueryResults> => {
-        const result = await fetchQueryResults(
-            projectUuid,
-            queryUuid,
-            pageSize,
-        );
-        GlobalState.debug(`> Query status: ${result.status}`);
-
-        if (result.status === QueryHistoryStatus.READY) {
-            return result;
-        }
-
-        if (result.status === QueryHistoryStatus.ERROR) {
-            return result;
-        }
-
-        if (result.status === QueryHistoryStatus.CANCELLED) {
-            throw new Error('Query was cancelled');
-        }
-
-        // Still pending, wait and poll again
-        await sleep(POLL_INTERVAL_MS);
-        return poll();
-    };
-
-    return poll();
-}
 
 export const sqlHandler = async (
     sql: string,
@@ -142,11 +55,9 @@ export const sqlHandler = async (
     spinner.text = 'Waiting for query results...';
 
     // Poll for results
-    const result = await pollQueryResults(
-        projectUuid,
-        submitResult.queryUuid,
+    const result = await pollForResults(projectUuid, submitResult.queryUuid, {
         pageSize,
-    );
+    });
 
     if (result.status === QueryHistoryStatus.ERROR) {
         spinner.fail('Query failed');

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -35,6 +35,7 @@ import {
     stopPreviewHandler,
 } from './handlers/preview';
 import { renameHandler } from './handlers/renameHandler';
+import { runChartHandler } from './handlers/runChart';
 import { setProjectHandler } from './handlers/setProject';
 import { sqlHandler } from './handlers/sql';
 import { validateHandler } from './handlers/validate';
@@ -1152,6 +1153,24 @@ program
     )
     .option('--verbose', 'Show detailed output', false)
     .action(sqlHandler);
+
+const runProgram = program
+    .command('run')
+    .description('Run Lightdash resources');
+
+runProgram
+    .command('chart')
+    .description('Execute a chart YAML to verify the query runs')
+    .requiredOption('-p, --path <path>', 'Path to chart YAML file')
+    .option('-o, --output <file>', 'Output file path for CSV results')
+    .option('-l, --limit <number>', 'Row limit for query', parseIntArgument)
+    .option(
+        '--page-size <number>',
+        'Number of rows per page (default: 500)',
+        parseIntArgument,
+    )
+    .option('--verbose', undefined, false)
+    .action(runChartHandler);
 
 program
     .command('install-skills')


### PR DESCRIPTION
### Description:

This PR adds a new `lightdash run chart` command to the CLI that allows users to execute chart YAML files and verify their queries run successfully.

**Key features:**

- Executes metric query charts defined in YAML format
- Supports outputting results to CSV files with configurable page size and row limits
- Includes proper error handling for SQL charts (not supported) and invalid YAML files
- Provides real-time feedback with spinners and debug logging
- Validates that charts contain required `tableName` and `metricQuery` fields

**Implementation details:**

- Created a reusable `pollForResults` function with exponential backoff for async query polling
- Refactored the existing SQL handler to use the shared polling logic
- Added comprehensive error handling for different query states (ERROR, CANCELLED, etc.)
- Converts chart YAML definitions to proper API request format for execution
