### PR TITLE
fix: hasDirectAccess in chain resolver should only reflect leaf space

### DIFF
--- a/packages/common/src/authorization/space/spaceAccessResolver.ts
+++ b/packages/common/src/authorization/space/spaceAccessResolver.ts
@@ -299,10 +299,11 @@ const resolveUserSpaceAccessWithInheritance = (
     );
     if (!spaceRoleResult) return undefined;
 
-    // Step 3: Determine hasDirectAccess (any chain level)
-    const hasDirectAccess = allDirectAccess.some(
-        (a) => a.userUuid === userUuid,
-    );
+    // Step 3: Determine hasDirectAccess (leaf space only)
+    const leafLevel = chainDirectAccess.find((c) => c.spaceUuid === spaceUuid);
+    const hasDirectAccess = leafLevel
+        ? leafLevel.directAccess.some((a) => a.userUuid === userUuid)
+        : false;
 
     // Step 4: Compute projectRole metadata (org + direct project only)
     const highestProjectRole = getHighestProjectRole([
@@ -310,9 +311,12 @@ const resolveUserSpaceAccessWithInheritance = (
         projectRole,
     ]);
 
-    // Step 5: Determine inheritedFrom
+    // Step 5: Determine inheritedFrom — use chain-wide check (not leaf-only)
+    const hasAccessInChain = allDirectAccess.some(
+        (a) => a.userUuid === userUuid,
+    );
     const inheritedFrom: SpaceAccess['inheritedFrom'] =
-        hasDirectAccess && !spaceRoleResult.fromLeaf
+        hasAccessInChain && !spaceRoleResult.fromLeaf
             ? 'parent_space'
             : highestRole.type;
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Fixed the `hasDirectAccess` flag in space access resolution to only return `true` when a user has direct access on the leaf space itself, rather than on any space in the inheritance chain. Previously, inherited access from parent spaces was incorrectly being reported as direct access.

The changes ensure that:
- `hasDirectAccess` is `false` when access is inherited from parent spaces (whether through user access or group access)
- `hasDirectAccess` is `true` only when the user has explicit access on the target space
- `inheritedFrom` logic continues to work correctly by checking the full inheritance chain

Added comprehensive test coverage for various scenarios including direct access on leaf spaces, inherited access from parents, and group access inheritance.