### PR TITLE
fix: use category axis for numeric dimensions in charts

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -138,6 +138,13 @@ const isPxValue = (value: string): boolean => {
 
 export const getAxisTypeFromField = (item?: ItemsMap[string]): string => {
     if (item && isCustomBinDimension(item)) return 'category';
+    // Numeric dimensions should use category axis (they represent discrete groups, not continuous values)
+    if (
+        item &&
+        (isDimension(item) || isCustomSqlDimension(item)) &&
+        getItemType(item) === DimensionType.NUMBER
+    )
+        return 'category';
     if (item && isTableCalculation(item) && !item.type) return 'value';
     if (
         item &&


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #19742

### Description:

Added logic to force numeric dimensions to use category axis type instead of value axis type in ECharts configuration. This ensures that numeric dimensions are treated as discrete groups rather than continuous values, which is the correct behavior for dimensional data even when the underlying data type is numeric.

#### After

![CleanShot 2026-02-20 at 14.54.10@2x.png](https://app.graphite.com/user-attachments/assets/faba5cbc-d594-4a4e-ac5c-3648e415177f.png)

#### Before

![CleanShot 2026-02-20 at 14.54.30@2x.png](https://app.graphite.com/user-attachments/assets/dce0c331-fc09-419a-ab12-1cc918ceddee.png)

- very narrow columns
- uneven spacing 

