### PR TITLE
feat: add v2 create space modals and change wording

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/v2/InheritanceToggleCards.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/v2/InheritanceToggleCards.tsx
@@ -1,0 +1,87 @@
+import { Group, Paper, Stack, Text } from '@mantine-8/core';
+import { IconLock, IconUsersGroup } from '@tabler/icons-react';
+import { type FC } from 'react';
+import MantineIcon from '../../MantineIcon';
+import { InheritanceType } from './ShareSpaceModalUtils';
+
+type InheritanceToggleCardsProps = {
+    value: InheritanceType;
+    onChange: (value: InheritanceType) => void;
+    disabled?: boolean;
+};
+
+const InheritanceToggleCards: FC<InheritanceToggleCardsProps> = ({
+    value,
+    onChange,
+    disabled,
+}) => {
+    return (
+        <Group grow align="stretch">
+            <Paper
+                withBorder
+                p="md"
+                radius="md"
+                style={{
+                    cursor: disabled ? 'default' : 'pointer',
+                    borderColor:
+                        value === InheritanceType.INHERIT
+                            ? 'var(--mantine-color-blue-6)'
+                            : undefined,
+                    borderWidth:
+                        value === InheritanceType.INHERIT ? 2 : undefined,
+                }}
+                onClick={
+                    disabled
+                        ? undefined
+                        : () => onChange(InheritanceType.INHERIT)
+                }
+            >
+                <Stack align="center" gap="xs">
+                    <MantineIcon
+                        icon={IconUsersGroup}
+                        color="blue.6"
+                        size="xl"
+                    />
+                    <Text fz="sm" fw={600} ta="center">
+                        Shared
+                    </Text>
+                    <Text fz="xs" c="dimmed" ta="center">
+                        Project members can access this space
+                    </Text>
+                </Stack>
+            </Paper>
+
+            <Paper
+                withBorder
+                p="md"
+                radius="md"
+                style={{
+                    cursor: disabled ? 'default' : 'pointer',
+                    borderColor:
+                        value === InheritanceType.OWN_ONLY
+                            ? 'var(--mantine-color-blue-6)'
+                            : undefined,
+                    borderWidth:
+                        value === InheritanceType.OWN_ONLY ? 2 : undefined,
+                }}
+                onClick={
+                    disabled
+                        ? undefined
+                        : () => onChange(InheritanceType.OWN_ONLY)
+                }
+            >
+                <Stack align="center" gap="xs">
+                    <MantineIcon icon={IconLock} color="blue.6" size="xl" />
+                    <Text fz="sm" fw={600} ta="center">
+                        Private
+                    </Text>
+                    <Text fz="xs" c="dimmed" ta="center">
+                        Only invited members and admins can access this space
+                    </Text>
+                </Stack>
+            </Paper>
+        </Group>
+    );
+};
+
+export default InheritanceToggleCards;

--- a/packages/frontend/src/components/common/SpaceActionModal/v2/CreateSpaceModalContentV2.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/v2/CreateSpaceModalContentV2.tsx
@@ -1,0 +1,54 @@
+import { type Space } from '@lightdash/common';
+import { Stack, TextInput } from '@mantine-8/core';
+import { type UseFormReturnType } from '@mantine/form';
+import { type FC } from 'react';
+import { useSpace } from '../../../../hooks/useSpaces';
+import InheritanceToggleCards from '../../ShareSpaceModal/v2/InheritanceToggleCards';
+import { type InheritanceType } from '../../ShareSpaceModal/v2/ShareSpaceModalUtils';
+
+type CreateSpaceModalContentV2Props = {
+    form: UseFormReturnType<Space>;
+    projectUuid: string;
+    parentSpaceUuid: Space['parentSpaceUuid'];
+    inheritanceValue: InheritanceType;
+    onInheritanceChange: (value: InheritanceType) => void;
+};
+
+const CreateSpaceModalContentV2: FC<CreateSpaceModalContentV2Props> = ({
+    form,
+    projectUuid,
+    parentSpaceUuid,
+    inheritanceValue,
+    onInheritanceChange,
+}) => {
+    const isNestedSpace = !!parentSpaceUuid;
+    const { data: parentSpace } = useSpace(
+        projectUuid,
+        parentSpaceUuid ?? undefined,
+        { enabled: isNestedSpace },
+    );
+
+    return (
+        <Stack>
+            <TextInput
+                {...form.getInputProps('name')}
+                label="Enter a memorable name for your space"
+                placeholder="eg. KPIs"
+                description={
+                    isNestedSpace
+                        ? `This space will have the same access as "${parentSpace?.name ?? 'the parent space'}". You can change this later.`
+                        : undefined
+                }
+            />
+
+            {!isNestedSpace && (
+                <InheritanceToggleCards
+                    value={inheritanceValue}
+                    onChange={onInheritanceChange}
+                />
+            )}
+        </Stack>
+    );
+};
+
+export default CreateSpaceModalContentV2;

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceCreationForm.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceCreationForm.tsx
@@ -1,6 +1,10 @@
+import { FeatureFlags } from '@lightdash/common';
 import { Alert, Box, Button, Stack, Text, TextInput } from '@mantine/core';
 import { IconArrowLeft, IconInfoCircle } from '@tabler/icons-react';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import MantineIcon from '../MantineIcon';
+import { InheritanceType } from '../ShareSpaceModal/v2/ShareSpaceModalUtils';
+import SpaceCreationFormV2 from './SpaceCreationFormV2';
 
 type SpaceCreationFormProps = {
     spaceName: string;
@@ -8,6 +12,8 @@ type SpaceCreationFormProps = {
     onCancel: () => void;
     isLoading?: boolean;
     parentSpaceName?: string;
+    inheritanceValue?: InheritanceType;
+    onInheritanceChange?: (value: InheritanceType) => void;
 };
 
 const SpaceCreationForm = ({
@@ -16,7 +22,27 @@ const SpaceCreationForm = ({
     onCancel,
     isLoading,
     parentSpaceName,
+    inheritanceValue,
+    onInheritanceChange,
 }: SpaceCreationFormProps) => {
+    const { data: nestedSpacesPermissionsFlag } = useServerFeatureFlag(
+        FeatureFlags.NestedSpacesPermissions,
+    );
+
+    if (nestedSpacesPermissionsFlag?.enabled && onInheritanceChange) {
+        return (
+            <SpaceCreationFormV2
+                spaceName={spaceName}
+                onSpaceNameChange={onSpaceNameChange}
+                onCancel={onCancel}
+                isLoading={isLoading}
+                parentSpaceName={parentSpaceName}
+                inheritanceValue={inheritanceValue ?? InheritanceType.OWN_ONLY}
+                onInheritanceChange={onInheritanceChange}
+            />
+        );
+    }
+
     return (
         <Stack spacing="xs">
             <Box>

--- a/packages/frontend/src/components/common/SpaceSelector/SpaceCreationFormV2.tsx
+++ b/packages/frontend/src/components/common/SpaceSelector/SpaceCreationFormV2.tsx
@@ -1,0 +1,74 @@
+import { Box, Button, Stack, TextInput } from '@mantine-8/core';
+import { IconArrowLeft } from '@tabler/icons-react';
+import { useEffect, type FC } from 'react';
+import MantineIcon from '../MantineIcon';
+import InheritanceToggleCards from '../ShareSpaceModal/v2/InheritanceToggleCards';
+import { InheritanceType } from '../ShareSpaceModal/v2/ShareSpaceModalUtils';
+
+type SpaceCreationFormV2Props = {
+    spaceName: string;
+    onSpaceNameChange: (name: string) => void;
+    onCancel: () => void;
+    isLoading?: boolean;
+    parentSpaceName?: string;
+    inheritanceValue: InheritanceType;
+    onInheritanceChange: (value: InheritanceType) => void;
+};
+
+const SpaceCreationFormV2: FC<SpaceCreationFormV2Props> = ({
+    spaceName,
+    onSpaceNameChange,
+    onCancel,
+    isLoading,
+    parentSpaceName,
+    inheritanceValue,
+    onInheritanceChange,
+}) => {
+    const isNestedSpace = !!parentSpaceName;
+
+    useEffect(() => {
+        onInheritanceChange(
+            isNestedSpace ? InheritanceType.INHERIT : InheritanceType.OWN_ONLY,
+        );
+    }, [isNestedSpace, onInheritanceChange]);
+
+    return (
+        <Stack gap="xs">
+            <Box>
+                <Button
+                    variant="subtle"
+                    leftSection={<MantineIcon icon={IconArrowLeft} />}
+                    onClick={onCancel}
+                    disabled={isLoading}
+                    size="xs"
+                >
+                    Back to Space selection
+                </Button>
+            </Box>
+
+            <TextInput
+                label="Name"
+                placeholder="Space name"
+                required
+                disabled={isLoading}
+                value={spaceName}
+                onChange={(e) => onSpaceNameChange(e.target.value)}
+                description={
+                    isNestedSpace
+                        ? `New space in "${parentSpaceName}". This space will have the same access. You can change this later.`
+                        : undefined
+                }
+            />
+
+            {!isNestedSpace && (
+                <InheritanceToggleCards
+                    value={inheritanceValue}
+                    onChange={onInheritanceChange}
+                    disabled={isLoading}
+                />
+            )}
+        </Stack>
+    );
+};
+
+export default SpaceCreationFormV2;

--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -97,6 +97,8 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
         handleCreateNewSpace,
         openCreateSpaceForm,
         closeCreateSpaceForm,
+        inheritanceValue,
+        setInheritanceValue,
     } = useSpaceManagement({
         projectUuid,
         defaultSpaceUuid,
@@ -181,6 +183,8 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
                     onCancel={closeCreateSpaceForm}
                     isLoading={createSpaceMutation.isLoading}
                     parentSpaceName={selectedSpaceLabel}
+                    inheritanceValue={inheritanceValue ?? undefined}
+                    onInheritanceChange={setInheritanceValue}
                 />
             ) : (
                 <>

--- a/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceForm.tsx
+++ b/packages/frontend/src/components/common/modal/ChartCreateModal/SaveToSpaceForm.tsx
@@ -29,6 +29,8 @@ const SaveToSpaceForm = <T extends SaveToSpaceFormType>({
         selectedSpaceUuid,
         setSelectedSpaceUuid,
         closeCreateSpaceForm,
+        inheritanceValue,
+        setInheritanceValue,
     } = spaceManagement;
 
     if (isCreatingNewSpace) {
@@ -47,6 +49,8 @@ const SaveToSpaceForm = <T extends SaveToSpaceFormType>({
                 }}
                 isLoading={isLoading}
                 parentSpaceName={selectedSpaceName}
+                inheritanceValue={inheritanceValue ?? undefined}
+                onInheritanceChange={setInheritanceValue}
             />
         );
     }

--- a/packages/frontend/src/hooks/useSpaceManagement.ts
+++ b/packages/frontend/src/hooks/useSpaceManagement.ts
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState } from 'react';
+import { InheritanceType } from '../components/common/ShareSpaceModal/v2/ShareSpaceModalUtils';
 import { useCreateMutation } from './useSpaces';
 
 type UseSpaceManagementProps = {
@@ -19,6 +20,8 @@ export const useSpaceManagement = ({
     );
     const [isCreatingNewSpace, setIsCreatingNewSpace] = useState(false);
     const [newSpaceName, setNewSpaceName] = useState('');
+    const [inheritanceValue, setInheritanceValue] =
+        useState<InheritanceType | null>(null);
 
     const createSpaceMutation = useCreateMutation(projectUuid);
 
@@ -30,19 +33,33 @@ export const useSpaceManagement = ({
         async ({ isPrivate }: { isPrivate?: boolean } = {}) => {
             if (newSpaceName.length === 0) return;
 
+            const inheritParentPermissions =
+                inheritanceValue !== null
+                    ? inheritanceValue === InheritanceType.INHERIT
+                    : undefined;
+
             const result = await createSpaceMutation.mutateAsync({
                 name: newSpaceName,
                 parentSpaceUuid: selectedSpaceUuid || undefined,
                 ...(isPrivate && { isPrivate }),
+                ...(inheritParentPermissions !== undefined && {
+                    inheritParentPermissions,
+                }),
             });
 
             // Reset form state after successful creation
             setNewSpaceName('');
             setIsCreatingNewSpace(false);
+            setInheritanceValue(null);
 
             return result;
         },
-        [createSpaceMutation, newSpaceName, selectedSpaceUuid],
+        [
+            createSpaceMutation,
+            inheritanceValue,
+            newSpaceName,
+            selectedSpaceUuid,
+        ],
     );
 
     const openCreateSpaceForm = useCallback(() => {
@@ -52,6 +69,7 @@ export const useSpaceManagement = ({
     const closeCreateSpaceForm = useCallback(() => {
         setIsCreatingNewSpace(false);
         setNewSpaceName('');
+        setInheritanceValue(null);
     }, []);
 
     return {
@@ -65,5 +83,7 @@ export const useSpaceManagement = ({
         handleCreateNewSpace,
         openCreateSpaceForm,
         closeCreateSpaceForm,
+        inheritanceValue,
+        setInheritanceValue,
     };
 };


### PR DESCRIPTION
### Description:

This PR introduces a new version of the space creation modal that integrates permission inheritance controls directly into the creation flow when the `NestedSpacesPermissions` feature flag is enabled.

**Summary:**

  - Add v2 create space modals behind the NestedSpacesPermissions feature flag with Shared/Private toggle cards for root spaces and an inline description for nested spaces                                                                                          
  - Wire inheritance state through useSpaceManagement hook so save chart, save dashboard, and transfer modals all pass inheritParentPermissions when creating spaces
  - Add SpaceCreationFormV2 for inline space creation flows and CreateSpaceModalContentV2 for the standalone create space modal
  - Simplify SpaceActionModal footer buttons when v2 is active (single-step flow, no Back/Continue)

The changes maintain backward compatibility by falling back to the original components when the feature flag is disabled, while providing an enhanced user experience with clearer permission controls when enabled.


https://github.com/user-attachments/assets/acf4881c-fe20-4ea7-b4d4-ae8969268119



