### PR TITLE
fix: cache field conversion in PostgresClient query streaming

### DIFF
--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -296,8 +296,6 @@ export class PostgresClient<
                         string,
                         { type: DimensionType }
                     > | null = null;
-                    let cachedFieldsRef: QueryResult<AnyType>['fields'] | null =
-                        null;
 
                     const writable = new Writable({
                         objectMode: true,
@@ -310,15 +308,11 @@ export class PostgresClient<
                             callback,
                         ) {
                             try {
-                                if (
-                                    cachedFields === null ||
-                                    cachedFieldsRef !== chunk.fields
-                                ) {
+                                if (cachedFields === null) {
                                     cachedFields =
                                         PostgresClient.convertQueryResultFields(
                                             chunk.fields,
                                         );
-                                    cachedFieldsRef = chunk.fields;
                                 }
                                 await streamCallback({
                                     fields: cachedFields,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

Optimized PostgresWarehouseClient performance by implementing field conversion caching and refactoring the field conversion method. 

The `convertQueryResultFields` method now uses `Object.fromEntries` and `map` instead of `reduce` for cleaner code. More importantly, added caching logic in the query stream processing to avoid redundant field conversions - since `result.fields` maintains the same array reference across all rows in a query, the converted fields are now cached and reused rather than being recalculated for every row.

This reduces unnecessary computation during large query result processing by caching the field type conversions.