### PR TITLE
fix: change run chart command from subcommand to run-chart

### DIFF
--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -77,7 +77,7 @@ node ./packages/cli/dist/index.js preview --project-dir ./examples/full-jaffle-s
 - `validate` - Validate dbt project structure
 - `deploy` - Deploy project to Lightdash
 - `preview` - Preview changes before deployment
-- `run chart` - Execute a chart YAML's metric query against the warehouse
+- `run-chart` - Execute a chart YAML's metric query against the warehouse
 - `dbt [command]` - Proxy dbt commands
 
 **Handler Pattern:**

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1155,12 +1155,8 @@ program
     .option('--verbose', 'Show detailed output', false)
     .action(sqlHandler);
 
-const runProgram = program
-    .command('run')
-    .description('Run Lightdash resources');
-
-runProgram
-    .command('chart')
+program
+    .command('run-chart')
     .description('Execute a chart YAML to verify the query runs')
     .requiredOption('-p, --path <path>', 'Path to chart YAML file')
     .option('-o, --output <file>', 'Output file path for CSV results')

--- a/skills/developing-in-lightdash/resources/cli-reference.md
+++ b/skills/developing-in-lightdash/resources/cli-reference.md
@@ -179,19 +179,19 @@ Execute a chart YAML file's metric query against the warehouse. Only supports me
 
 ```bash
 # Verify a chart query runs successfully
-lightdash run chart -p ./lightdash/charts/monthly-revenue.yml
+lightdash run-chart -p ./lightdash/charts/monthly-revenue.yml
 
 # Run chart and save results to CSV
-lightdash run chart -p ./lightdash/charts/monthly-revenue.yml -o results.csv
+lightdash run-chart -p ./lightdash/charts/monthly-revenue.yml -o results.csv
 
 # Limit rows returned
-lightdash run chart -p ./lightdash/charts/monthly-revenue.yml -o results.csv -l 100
+lightdash run-chart -p ./lightdash/charts/monthly-revenue.yml -o results.csv -l 100
 
 # Adjust pagination for large results
-lightdash run chart -p ./lightdash/charts/monthly-revenue.yml -o results.csv --page-size 2000
+lightdash run-chart -p ./lightdash/charts/monthly-revenue.yml -o results.csv --page-size 2000
 
 # Verbose output for debugging
-lightdash run chart -p ./lightdash/charts/monthly-revenue.yml --verbose
+lightdash run-chart -p ./lightdash/charts/monthly-revenue.yml --verbose
 ```
 
 **Options:**
@@ -223,4 +223,4 @@ lightdash run chart -p ./lightdash/charts/monthly-revenue.yml --verbose
 | `lightdash lint`      | Validate YAML locally            |
 | `lightdash generate`  | Generate YAML from dbt models    |
 | `lightdash sql`       | Run SQL queries                  |
-| `lightdash run chart` | Execute chart YAML query         |
+| `lightdash run-chart` | Execute chart YAML query         |

--- a/skills/developing-in-lightdash/resources/workflows-reference.md
+++ b/skills/developing-in-lightdash/resources/workflows-reference.md
@@ -403,10 +403,10 @@ Verify chart queries execute successfully against the warehouse before deploying
 
 ```bash
 # Validate a single chart runs
-lightdash run chart -p ./lightdash/charts/monthly-revenue.yml
+lightdash run-chart -p ./lightdash/charts/monthly-revenue.yml
 
 # Validate and inspect results
-lightdash run chart -p ./lightdash/charts/monthly-revenue.yml -o /tmp/results.csv
+lightdash run-chart -p ./lightdash/charts/monthly-revenue.yml -o /tmp/results.csv
 ```
 
 **When to use:**


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Refactored the CLI command structure by changing `run chart` to `run-chart` to simplify the command hierarchy. This removes the nested subcommand pattern and makes the chart execution command a top-level command.

The change affects:

- CLI command registration in the main index file
- Documentation examples showing the new command syntax
- Reference tables listing available commands
