### PR TITLE
feat: add indicator for in-accessible breadcrumbs

### DIFF
--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -77,6 +77,7 @@ export type Space = {
     breadcrumbs?: {
         name: string;
         uuid: string;
+        hasAccess: boolean;
     }[];
 };
 

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -13,6 +13,7 @@ import {
     IconFolderCog,
     IconFolderPlus,
     IconFolderX,
+    IconLock,
     IconPlus,
 } from '@tabler/icons-react';
 import { useCallback, useState, type FC } from 'react';
@@ -155,32 +156,68 @@ const Space: FC = () => {
                                     to: `/projects/${projectUuid}/spaces`,
                                 },
                                 ...(space.breadcrumbs?.map(
-                                    (breadcrumb, index) => ({
-                                        title: breadcrumb.name,
-                                        active:
+                                    (breadcrumb, index) => {
+                                        const isLastBreadcrumb =
                                             index ===
                                             (space.breadcrumbs?.length ?? 0) -
-                                                1,
-                                        to: `/projects/${projectUuid}/spaces/${breadcrumb.uuid}`,
-                                        onClick: () => {
-                                            if (
-                                                user.data?.userUuid &&
-                                                user.data?.organizationUuid
-                                            ) {
-                                                track({
-                                                    name: EventName.SPACE_BREADCRUMB_CLICKED,
-                                                    properties: {
-                                                        userId: user.data
-                                                            ?.userUuid,
-                                                        organizationId:
-                                                            user.data
-                                                                ?.organizationUuid,
-                                                        projectId: projectUuid,
-                                                    },
-                                                });
-                                            }
-                                        },
-                                    }),
+                                                1;
+                                        const isAccessible =
+                                            breadcrumb.hasAccess;
+
+                                        return {
+                                            title: isAccessible ? (
+                                                breadcrumb.name
+                                            ) : (
+                                                <span
+                                                    style={{
+                                                        display: 'inline-flex',
+                                                        alignItems: 'center',
+                                                        gap: 4,
+                                                    }}
+                                                >
+                                                    <MantineIcon
+                                                        icon={IconLock}
+                                                        size={14}
+                                                        color="ldGray.5"
+                                                    />
+                                                    {breadcrumb.name}
+                                                </span>
+                                            ),
+                                            active: isLastBreadcrumb,
+                                            ...(isAccessible
+                                                ? {
+                                                      to: `/projects/${projectUuid}/spaces/${breadcrumb.uuid}`,
+                                                      onClick: () => {
+                                                          if (
+                                                              user.data
+                                                                  ?.userUuid &&
+                                                              user.data
+                                                                  ?.organizationUuid
+                                                          ) {
+                                                              track({
+                                                                  name: EventName.SPACE_BREADCRUMB_CLICKED,
+                                                                  properties: {
+                                                                      userId: user
+                                                                          .data
+                                                                          ?.userUuid,
+                                                                      organizationId:
+                                                                          user
+                                                                              .data
+                                                                              ?.organizationUuid,
+                                                                      projectId:
+                                                                          projectUuid,
+                                                                  },
+                                                              });
+                                                          }
+                                                      },
+                                                  }
+                                                : {
+                                                      tooltipProps: {
+                                                          label: 'You do not have access to this space',
+                                                      },
+                                                  }),
+                                        };
+                                    },
                                 ) ?? []),
                             ]}
                         />


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-158/handle-breadcrumbs-for-hidden-parent-spaces

### Description:
Adding a visual indicator when a space in the breadcrumbs is in-accessible. This can become the case in the new inheritance permission model, where a parent breaks the chain. In this case, a user might have direct access to a space, but not necessarily a parent space.

This flips the pre-existing breadcrumbs api tests to green (requires `addSpaceUserAccess` to allow the change of nested permissions):
> Breadcrumb Access Information
      ✓ should include breadcrumbs with hasAccess for each ancestor (100ms)
      ✓ should show hasAccess=false for inaccessible ancestors (90ms)

### Before

![Before.png](https://app.graphite.com/user-attachments/assets/11cbd242-4d6a-4933-aeeb-79e134955198.png)

### After

![After.png](https://app.graphite.com/user-attachments/assets/bc34b4e2-5520-4531-b4e2-493df3d3435f.png)

