### PR TITLE
fix(cli): add default 50k row limit to sql command

### DIFF
--- a/packages/cli/src/handlers/sql.ts
+++ b/packages/cli/src/handlers/sql.ts
@@ -17,6 +17,7 @@ type SqlHandlerOptions = {
 };
 
 const DEFAULT_PAGE_SIZE = 500;
+const DEFAULT_LIMIT = 50000;
 
 export const sqlHandler = async (
     sql: string,
@@ -41,12 +42,15 @@ export const sqlHandler = async (
     // Submit the query
     const spinner = GlobalState.startSpinner('Submitting SQL query...');
 
+    // Default to 50k limit to prevent runaway queries
+    const limit = options.limit ?? DEFAULT_LIMIT;
+
     const submitResult = await lightdashApi<ApiExecuteAsyncSqlQueryResults>({
         method: 'POST',
         url: `/api/v2/projects/${projectUuid}/query/sql`,
         body: JSON.stringify({
             sql,
-            limit: options.limit,
+            limit,
             context: 'cli',
         }),
     });


### PR DESCRIPTION
## Summary
- Adds a default limit of 50,000 rows when running `lightdash sql` without the `--limit` flag
- Prevents runaway queries from creating massive result files (e.g., a `SELECT *` without limit previously created a 20GB file)

## Test plan
- [ ] Run `lightdash sql "SELECT * FROM large_table" -o output.csv` without `--limit` flag
- [ ] Verify the query is limited to 50k rows
- [ ] Run with `--limit 100` and verify it uses the provided limit