### PR TITLE
feat: pre-aggregate virtual explores

### DIFF
--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -1249,21 +1249,36 @@ export class SearchModel {
             .limit(1);
 
         if (explores.length > 0 && explores[0].explores) {
+            const includePreAggregateDebugExplores =
+                process.env.ENABLE_PRE_AGGREGATE_DEBUG_VIEW === 'true' ||
+                process.env.ENABLE_PRE_AGGREGATE_INTERNAL_VISIBILITY === 'true';
             return explores[0].explores.filter(
                 (explore: Explore | ExploreError) => {
+                    if (
+                        !includePreAggregateDebugExplores &&
+                        explore.type === ExploreType.PRE_AGGREGATE
+                    ) {
+                        return false;
+                    }
                     if (tableSelection.type === TableSelectionType.WITH_TAGS) {
                         return (
                             hasIntersection(
                                 explore.tags || [],
                                 tableSelection.value || [],
-                            ) || explore.type === ExploreType.VIRTUAL
+                            ) ||
+                            explore.type === ExploreType.VIRTUAL ||
+                            (includePreAggregateDebugExplores &&
+                                explore.type === ExploreType.PRE_AGGREGATE)
                         );
                     }
                     if (tableSelection.type === TableSelectionType.WITH_NAMES) {
                         return (
                             (tableSelection.value || []).includes(
                                 explore.name,
-                            ) || explore.type === ExploreType.VIRTUAL
+                            ) ||
+                            explore.type === ExploreType.VIRTUAL ||
+                            (includePreAggregateDebugExplores &&
+                                explore.type === ExploreType.PRE_AGGREGATE)
                         );
                     }
                     return true;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2114,10 +2114,10 @@ export class AsyncQueryService extends ProjectService {
 
         let preAggregateMetadata: Pick<CacheMetadata, 'preAggregate'> | null =
             null;
-        if (
-            process.env.ENABLE_PRE_AGGREGATE_DRY_RUN === 'true' &&
-            (explore.preAggregates || []).length > 0
-        ) {
+        const preAggregatesEnabled =
+            process.env.ENABLE_PRE_AGGREGATES === 'true' ||
+            process.env.ENABLE_PRE_AGGREGATE_DRY_RUN === 'true';
+        if (preAggregatesEnabled && (explore.preAggregates || []).length > 0) {
             const matchResult = findMatch(metricQuery, explore);
 
             preAggregateMetadata = {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -193,6 +193,14 @@ export const virtualExplore: Explore = {
     tags: [],
 };
 
+export const preAggregateExplore: Explore = {
+    ...validExplore,
+    name: '__preagg__valid_explore__rollup',
+    label: 'Pre-agg Explore',
+    type: ExploreType.PRE_AGGREGATE,
+    tags: [],
+};
+
 export const exploreWithRequiredAttributes: Explore = {
     ...validExplore,
     name: 'explore_with_required_attributes',

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1,5 +1,6 @@
 import merge from 'lodash/merge';
 import { parseDbtPreAggregates } from '../preAggregates/definition';
+import { generatePreAggregateExplores } from '../preAggregates/generatePreAggregateExplores';
 import {
     buildModelGraph,
     convertColumnMetric,
@@ -1122,7 +1123,7 @@ export const convertExplores = async (
         // Multiple explores can be created from a single model. The base explore + additional explores
         // Properties created from `model` are the same across all explores. e.g. all explores will have the same base table & warehouse
         // Properties created from `exploreToCreate` are specific to each explore. e.g. each explore can have a different name, label & joins
-        const newExplores = exploresToCreate.map((exploreToCreate) => {
+        const compiledExplores = exploresToCreate.map((exploreToCreate) => {
             try {
                 return exploreCompiler.compileExplore({
                     name: exploreToCreate.name,
@@ -1195,7 +1196,14 @@ export const convertExplores = async (
             }
         });
 
-        return [...acc, ...newExplores];
+        const exploresWithGeneratedPreAggregates = generatePreAggregateExplores(
+            {
+                compiledExplores,
+                parsedPreAggregates,
+            },
+        );
+
+        return [...acc, ...exploresWithGeneratedPreAggregates];
     }, []);
 
     return [...explores, ...exploreErrors];

--- a/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts
@@ -1,0 +1,257 @@
+import { SupportedDbtAdapter } from '../types/dbt';
+import { ExploreType, type Explore } from '../types/explore';
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type CompiledDimension,
+    type CompiledMetric,
+} from '../types/field';
+import { TimeFrames } from '../types/timeFrames';
+import { buildPreAggregateExplore } from './buildPreAggregateExplore';
+
+const makeDimension = ({
+    name,
+    table,
+    type = DimensionType.STRING,
+    timeInterval,
+    timeIntervalBaseDimensionName,
+}: {
+    name: string;
+    table: string;
+    type?: DimensionType;
+    timeInterval?: TimeFrames;
+    timeIntervalBaseDimensionName?: string;
+}): CompiledDimension => ({
+    index: 0,
+    fieldType: FieldType.DIMENSION,
+    type,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql: `${table}.${name}`,
+    hidden: false,
+    compiledSql: `${table}.${name}`,
+    tablesReferences: [table],
+    ...(timeInterval ? { timeInterval } : {}),
+    ...(timeIntervalBaseDimensionName ? { timeIntervalBaseDimensionName } : {}),
+});
+
+const makeMetric = ({
+    name,
+    table,
+    type,
+}: {
+    name: string;
+    table: string;
+    type: MetricType;
+}): CompiledMetric => ({
+    index: 0,
+    fieldType: FieldType.METRIC,
+    type,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql: `${table}.${name}`,
+    hidden: false,
+    compiledSql: `${table}.${name}`,
+    tablesReferences: [table],
+});
+
+const sourceExplore = (): Explore => ({
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [
+        {
+            table: 'customers',
+            sqlOn: '${orders.customer_id} = ${customers.customer_id}',
+            compiledSqlOn: 'orders.customer_id = customers.customer_id',
+        },
+    ],
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'orders',
+            dimensions: {
+                status: makeDimension({ name: 'status', table: 'orders' }),
+                order_date: makeDimension({
+                    name: 'order_date',
+                    table: 'orders',
+                    type: DimensionType.DATE,
+                }),
+                order_date_hour: makeDimension({
+                    name: 'order_date_hour',
+                    table: 'orders',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.HOUR,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
+                order_date_day: makeDimension({
+                    name: 'order_date_day',
+                    table: 'orders',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.DAY,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
+                order_date_month: makeDimension({
+                    name: 'order_date_month',
+                    table: 'orders',
+                    type: DimensionType.DATE,
+                    timeInterval: TimeFrames.MONTH,
+                    timeIntervalBaseDimensionName: 'order_date',
+                }),
+            },
+            metrics: {
+                total_order_amount: makeMetric({
+                    name: 'total_order_amount',
+                    table: 'orders',
+                    type: MetricType.SUM,
+                }),
+                order_count: makeMetric({
+                    name: 'order_count',
+                    table: 'orders',
+                    type: MetricType.COUNT,
+                }),
+                avg_order_amount: makeMetric({
+                    name: 'avg_order_amount',
+                    table: 'orders',
+                    type: MetricType.AVERAGE,
+                }),
+                custom_sql: makeMetric({
+                    name: 'custom_sql',
+                    table: 'orders',
+                    type: MetricType.NUMBER,
+                }),
+            },
+            lineageGraph: {},
+        },
+        customers: {
+            name: 'customers',
+            label: 'Customers',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'customers',
+            dimensions: {
+                first_name: makeDimension({
+                    name: 'first_name',
+                    table: 'customers',
+                }),
+            },
+            metrics: {
+                max_customer_age: makeMetric({
+                    name: 'max_customer_age',
+                    table: 'customers',
+                    type: MetricType.MAX,
+                }),
+            },
+            lineageGraph: {},
+        },
+    },
+    preAggregates: [
+        {
+            name: 'orders_rollup',
+            dimensions: ['status', 'customers.first_name', 'order_date'],
+            metrics: [
+                'total_order_amount',
+                'order_count',
+                'avg_order_amount',
+                'custom_sql',
+                'customers.max_customer_age',
+            ],
+            timeDimension: 'order_date',
+            granularity: TimeFrames.DAY,
+        },
+    ],
+});
+
+describe('buildPreAggregateExplore', () => {
+    it('builds a deterministic internal pre-aggregate explore', () => {
+        const result = buildPreAggregateExplore(
+            sourceExplore(),
+            sourceExplore().preAggregates![0],
+        );
+
+        expect(result.name).toBe('__preagg__orders__orders_rollup');
+        expect(result.type).toBe(ExploreType.PRE_AGGREGATE);
+        expect(result.baseTable).toBe('orders');
+        expect(result.joinedTables).toEqual([]);
+        expect(result.preAggregates).toEqual([]);
+        expect(result.tables.orders.sqlTable).toBe(
+            sourceExplore().tables.orders.sqlTable,
+        );
+    });
+
+    it('rewrites metrics and excludes unsupported metric types', () => {
+        const result = buildPreAggregateExplore(
+            sourceExplore(),
+            sourceExplore().preAggregates![0],
+        );
+
+        expect(
+            result.tables.orders.metrics.total_order_amount.compiledSql,
+        ).toBe('SUM(orders.orders_total_order_amount)');
+        expect(result.tables.orders.metrics.order_count.compiledSql).toBe(
+            'SUM(orders.orders_order_count)',
+        );
+        expect(
+            result.tables.customers.metrics.max_customer_age.compiledSql,
+        ).toBe('MAX(orders.customers_max_customer_age)');
+
+        expect(result.tables.orders.metrics.avg_order_amount).toBeUndefined();
+        expect(result.tables.orders.metrics.custom_sql).toBeUndefined();
+    });
+
+    it('maps joined dimensions to flattened ldj columns', () => {
+        const result = buildPreAggregateExplore(
+            sourceExplore(),
+            sourceExplore().preAggregates![0],
+        );
+
+        expect(result.tables.customers.dimensions.first_name.compiledSql).toBe(
+            'orders.ldj__customers__first_name',
+        );
+    });
+
+    it('keeps compatible time intervals and drops finer intervals than rollup granularity', () => {
+        const result = buildPreAggregateExplore(
+            sourceExplore(),
+            sourceExplore().preAggregates![0],
+        );
+
+        expect(result.tables.orders.dimensions.order_date_day.compiledSql).toBe(
+            'orders.order_date_day',
+        );
+        expect(
+            result.tables.orders.dimensions.order_date_month.compiledSql,
+        ).toContain('orders.order_date_day');
+        expect(result.tables.orders.dimensions.order_date_hour).toBeUndefined();
+    });
+
+    it('throws when pre-aggregate references unknown fields', () => {
+        expect(() =>
+            buildPreAggregateExplore(sourceExplore(), {
+                name: 'invalid_rollup',
+                dimensions: ['unknown_dimension'],
+                metrics: ['order_count'],
+            }),
+        ).toThrow('references unknown dimensions');
+    });
+
+    it('supports legacy metric fieldIds in pre-aggregate definitions', () => {
+        const result = buildPreAggregateExplore(sourceExplore(), {
+            name: 'legacy_field_id_rollup',
+            dimensions: ['status'],
+            metrics: ['orders_order_count'],
+        });
+
+        expect(result.tables.orders.metrics.order_count).toBeDefined();
+    });
+});

--- a/packages/common/src/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/common/src/preAggregates/buildPreAggregateExplore.ts
@@ -1,0 +1,346 @@
+import {
+    ExploreType,
+    type CompiledTable,
+    type Explore,
+} from '../types/explore';
+import {
+    MetricType,
+    PostCalculationMetricTypes,
+    type CompiledDimension,
+    type CompiledMetric,
+    type DimensionType,
+    type FieldId,
+} from '../types/field';
+import { type PreAggregateDef } from '../types/preAggregate';
+import { type TimeFrames } from '../types/timeFrames';
+import { getItemId } from '../utils/item';
+import { getSqlForTruncatedDate, timeFrameOrder } from '../utils/timeFrames';
+import {
+    getJoinedDimensionColumnName,
+    getMetricColumnName,
+    getPreAggregateExploreName,
+    getTimeDimensionColumnName,
+} from './naming';
+import {
+    getDimensionBaseName,
+    getDimensionReferences,
+    getMetricReferences,
+} from './references';
+
+const isFinerGranularity = (
+    candidateGranularity: TimeFrames,
+    targetGranularity: TimeFrames,
+): boolean => {
+    const candidateIndex = timeFrameOrder.indexOf(candidateGranularity);
+    const targetIndex = timeFrameOrder.indexOf(targetGranularity);
+    if (candidateIndex === -1 || targetIndex === -1) {
+        return false;
+    }
+    return candidateIndex < targetIndex;
+};
+
+const getDimensionsByReference = (sourceExplore: Explore) =>
+    Object.values(sourceExplore.tables).reduce<
+        Map<string, CompiledDimension[]>
+    >((acc, table) => {
+        Object.values(table.dimensions).forEach((dimension) => {
+            getDimensionReferences({
+                dimension,
+                baseTable: sourceExplore.baseTable,
+            }).forEach((reference) => {
+                const existingDimensions = acc.get(reference) || [];
+                acc.set(reference, [...existingDimensions, dimension]);
+            });
+        });
+        return acc;
+    }, new Map<string, CompiledDimension[]>());
+
+const getMetricsByReference = (sourceExplore: Explore) =>
+    Object.values(sourceExplore.tables).reduce<
+        Map<string, { fieldId: FieldId; metric: CompiledMetric }>
+    >((acc, table) => {
+        Object.values(table.metrics).forEach((metric) => {
+            const fieldId = getItemId(metric);
+            new Set([
+                fieldId,
+                ...getMetricReferences({
+                    metric,
+                    baseTable: sourceExplore.baseTable,
+                }),
+            ]).forEach((reference) => {
+                acc.set(reference, { fieldId, metric });
+            });
+        });
+        return acc;
+    }, new Map<string, { fieldId: FieldId; metric: CompiledMetric }>());
+
+const isSupportedMetricType = (metricType: MetricType): boolean =>
+    [MetricType.SUM, MetricType.COUNT, MetricType.MIN, MetricType.MAX].includes(
+        metricType,
+    );
+
+const getMetricAggregateSql = (
+    metricType: MetricType,
+    columnReference: string,
+): string => {
+    switch (metricType) {
+        case MetricType.SUM:
+        case MetricType.COUNT:
+            return `SUM(${columnReference})`;
+        case MetricType.MIN:
+            return `MIN(${columnReference})`;
+        case MetricType.MAX:
+            return `MAX(${columnReference})`;
+        default:
+            throw new Error(`Unsupported metric type "${metricType}"`);
+    }
+};
+
+const getPhysicalDimensionColumnName = ({
+    dimension,
+    preAggregateDef,
+    baseTable,
+}: {
+    dimension: CompiledDimension;
+    preAggregateDef: PreAggregateDef;
+    baseTable: string;
+}): string => {
+    const dimensionBaseName = getDimensionBaseName(dimension);
+
+    if (
+        preAggregateDef.timeDimension &&
+        preAggregateDef.granularity &&
+        dimensionBaseName === preAggregateDef.timeDimension
+    ) {
+        return getTimeDimensionColumnName(
+            dimensionBaseName,
+            preAggregateDef.granularity,
+        );
+    }
+
+    if (dimension.table === baseTable) {
+        return dimensionBaseName;
+    }
+
+    return getJoinedDimensionColumnName(dimension.table, dimensionBaseName);
+};
+
+const getBaseDimensionType = (
+    sourceExplore: Explore,
+    dimension: CompiledDimension,
+): DimensionType => {
+    const dimensionBaseName = getDimensionBaseName(dimension);
+    const baseDimension =
+        sourceExplore.tables[dimension.table]?.dimensions[dimensionBaseName];
+    return baseDimension?.type || dimension.type;
+};
+
+const buildDimensionSql = ({
+    sourceExplore,
+    dimension,
+    preAggregateDef,
+}: {
+    sourceExplore: Explore;
+    dimension: CompiledDimension;
+    preAggregateDef: PreAggregateDef;
+}): string => {
+    const dimensionBaseName = getDimensionBaseName(dimension);
+    const physicalBaseColumnName = getPhysicalDimensionColumnName({
+        dimension,
+        preAggregateDef,
+        baseTable: sourceExplore.baseTable,
+    });
+    const physicalBaseColumnReference = `${sourceExplore.baseTable}.${physicalBaseColumnName}`;
+
+    if (!dimension.timeInterval) {
+        return physicalBaseColumnReference;
+    }
+
+    if (
+        preAggregateDef.timeDimension &&
+        preAggregateDef.granularity &&
+        dimensionBaseName === preAggregateDef.timeDimension &&
+        dimension.timeInterval === preAggregateDef.granularity
+    ) {
+        return physicalBaseColumnReference;
+    }
+
+    return getSqlForTruncatedDate(
+        sourceExplore.targetDatabase,
+        dimension.timeInterval,
+        physicalBaseColumnReference,
+        getBaseDimensionType(sourceExplore, dimension),
+    );
+};
+
+const getIncludedDimensions = (
+    sourceExplore: Explore,
+    preAggregateDef: PreAggregateDef,
+): CompiledDimension[] => {
+    const dimensionsByReference = getDimensionsByReference(sourceExplore);
+
+    const missingReferences = preAggregateDef.dimensions.filter(
+        (reference) =>
+            (dimensionsByReference.get(reference) || []).length === 0,
+    );
+    if (missingReferences.length > 0) {
+        throw new Error(
+            `Pre-aggregate "${preAggregateDef.name}" references unknown dimensions: ${missingReferences.join(
+                ', ',
+            )}`,
+        );
+    }
+
+    const defDimensions = new Set(preAggregateDef.dimensions);
+    const includedDimensions = Object.values(sourceExplore.tables).flatMap(
+        (table) =>
+            Object.values(table.dimensions).filter((dimension) =>
+                getDimensionReferences({
+                    dimension,
+                    baseTable: sourceExplore.baseTable,
+                }).some((reference) => defDimensions.has(reference)),
+            ),
+    );
+
+    const uniqueDimensions = Array.from(
+        includedDimensions
+            .reduce<Map<FieldId, CompiledDimension>>((acc, dimension) => {
+                acc.set(getItemId(dimension), dimension);
+                return acc;
+            }, new Map<FieldId, CompiledDimension>())
+            .values(),
+    );
+
+    return uniqueDimensions.filter((dimension) => {
+        const dimensionBaseName = getDimensionBaseName(dimension);
+        if (
+            !preAggregateDef.timeDimension ||
+            !preAggregateDef.granularity ||
+            dimensionBaseName !== preAggregateDef.timeDimension ||
+            !dimension.timeInterval
+        ) {
+            return true;
+        }
+
+        return !isFinerGranularity(
+            dimension.timeInterval,
+            preAggregateDef.granularity,
+        );
+    });
+};
+
+const getIncludedMetrics = (
+    sourceExplore: Explore,
+    preAggregateDef: PreAggregateDef,
+): Array<{ fieldId: FieldId; metric: CompiledMetric }> => {
+    const metricsByReference = getMetricsByReference(sourceExplore);
+
+    return preAggregateDef.metrics.reduce<
+        Array<{ fieldId: FieldId; metric: CompiledMetric }>
+    >((acc, metricReference) => {
+        const metricLookup = metricsByReference.get(metricReference);
+        if (!metricLookup) {
+            throw new Error(
+                `Pre-aggregate "${preAggregateDef.name}" references unknown metric "${metricReference}"`,
+            );
+        }
+
+        const { fieldId, metric } = metricLookup;
+
+        // TODO: Support AVERAGE by materializing SUM + COUNT and deriving AVG at query time.
+        if (
+            metric.type === MetricType.AVERAGE ||
+            PostCalculationMetricTypes.includes(metric.type) ||
+            !isSupportedMetricType(metric.type)
+        ) {
+            return acc;
+        }
+
+        return [...acc, { fieldId, metric }];
+    }, []);
+};
+
+const getEmptyTable = (
+    sourceTable: CompiledTable,
+    sqlTable: string,
+): CompiledTable => ({
+    ...sourceTable,
+    sqlTable,
+    dimensions: {},
+    metrics: {},
+});
+
+export const buildPreAggregateExplore = (
+    sourceExplore: Explore,
+    preAggregateDef: PreAggregateDef,
+): Explore => {
+    const baseTableSqlTable =
+        sourceExplore.tables[sourceExplore.baseTable].sqlTable;
+    const includedDimensions = getIncludedDimensions(
+        sourceExplore,
+        preAggregateDef,
+    );
+    const includedMetrics = getIncludedMetrics(sourceExplore, preAggregateDef);
+
+    const includedTableNames = new Set<string>([
+        sourceExplore.baseTable,
+        ...includedDimensions.map((dimension) => dimension.table),
+        ...includedMetrics.map(({ metric }) => metric.table),
+    ]);
+
+    const tables = Array.from(includedTableNames).reduce<
+        Record<string, CompiledTable>
+    >((acc, tableName) => {
+        const sourceTable = sourceExplore.tables[tableName];
+        if (!sourceTable) {
+            throw new Error(
+                `Pre-aggregate "${preAggregateDef.name}" references unknown table "${tableName}"`,
+            );
+        }
+        acc[tableName] = getEmptyTable(sourceTable, baseTableSqlTable);
+        return acc;
+    }, {});
+
+    includedDimensions.forEach((dimension) => {
+        const compiledSql = buildDimensionSql({
+            sourceExplore,
+            dimension,
+            preAggregateDef,
+        });
+
+        tables[dimension.table].dimensions[dimension.name] = {
+            ...dimension,
+            sql: compiledSql,
+            compiledSql,
+            tablesReferences: [sourceExplore.baseTable],
+        };
+    });
+
+    includedMetrics.forEach(({ fieldId, metric }) => {
+        const metricColumnName = getMetricColumnName(fieldId);
+        const metricColumnReference = `${sourceExplore.baseTable}.${metricColumnName}`;
+        const compiledSql = getMetricAggregateSql(
+            metric.type,
+            metricColumnReference,
+        );
+
+        tables[metric.table].metrics[metric.name] = {
+            ...metric,
+            sql: metricColumnReference,
+            compiledSql,
+            tablesReferences: [sourceExplore.baseTable],
+        };
+    });
+
+    return {
+        ...sourceExplore,
+        name: getPreAggregateExploreName(
+            sourceExplore.name,
+            preAggregateDef.name,
+        ),
+        type: ExploreType.PRE_AGGREGATE,
+        joinedTables: [],
+        tables,
+        preAggregates: [],
+    };
+};

--- a/packages/common/src/preAggregates/generatePreAggregateExplores.ts
+++ b/packages/common/src/preAggregates/generatePreAggregateExplores.ts
@@ -1,0 +1,68 @@
+import {
+    InlineErrorType,
+    isExploreError,
+    type Explore,
+    type ExploreError,
+} from '../types/explore';
+import { type PreAggregateDef } from '../types/preAggregate';
+import { buildPreAggregateExplore } from './buildPreAggregateExplore';
+
+const isPreAggregateVirtualExploreGenerationEnabled = (): boolean =>
+    process.env.ENABLE_PRE_AGGREGATES === 'true' ||
+    process.env.ENABLE_PRE_AGGREGATE_VIRTUAL_EXPLORES === 'true';
+
+export const generatePreAggregateExplores = ({
+    compiledExplores,
+    parsedPreAggregates,
+}: {
+    compiledExplores: Array<Explore | ExploreError>;
+    parsedPreAggregates: PreAggregateDef[];
+}): Array<Explore | ExploreError> => {
+    if (
+        !isPreAggregateVirtualExploreGenerationEnabled() ||
+        parsedPreAggregates.length === 0
+    ) {
+        return compiledExplores;
+    }
+
+    return compiledExplores.flatMap<Explore | ExploreError>((compiled) => {
+        if (isExploreError(compiled)) {
+            return [compiled];
+        }
+
+        const generatedPreAggregateExplores: Explore[] = [];
+        const generationErrors: string[] = [];
+
+        parsedPreAggregates.forEach((preAggregateDef) => {
+            try {
+                generatedPreAggregateExplores.push(
+                    buildPreAggregateExplore(compiled, preAggregateDef),
+                );
+            } catch (error) {
+                generationErrors.push(
+                    error instanceof Error
+                        ? error.message
+                        : `Failed to generate pre-aggregate "${preAggregateDef.name}" for explore "${compiled.name}"`,
+                );
+            }
+        });
+
+        if (generationErrors.length === 0) {
+            return [compiled, ...generatedPreAggregateExplores];
+        }
+
+        return [
+            {
+                ...compiled,
+                warnings: [
+                    ...(compiled.warnings || []),
+                    ...generationErrors.map((message) => ({
+                        type: InlineErrorType.FIELD_ERROR,
+                        message,
+                    })),
+                ],
+            },
+            ...generatedPreAggregateExplores,
+        ];
+    });
+};

--- a/packages/common/src/preAggregates/index.ts
+++ b/packages/common/src/preAggregates/index.ts
@@ -1,3 +1,7 @@
 export * from './additivity';
+export * from './buildPreAggregateExplore';
 export * from './definition';
+export * from './generatePreAggregateExplores';
 export * from './matcher';
+export * from './naming';
+export * from './references';

--- a/packages/common/src/preAggregates/naming.ts
+++ b/packages/common/src/preAggregates/naming.ts
@@ -1,0 +1,21 @@
+import { type TimeFrames } from '../types/timeFrames';
+
+export const PRE_AGGREGATE_EXPLORE_PREFIX = '__preagg__';
+
+export const getPreAggregateExploreName = (
+    exploreName: string,
+    preAggregateName: string,
+): string =>
+    `${PRE_AGGREGATE_EXPLORE_PREFIX}${exploreName}__${preAggregateName}`;
+
+export const getJoinedDimensionColumnName = (
+    tableName: string,
+    dimensionName: string,
+): string => `ldj__${tableName}__${dimensionName}`;
+
+export const getMetricColumnName = (fieldId: string): string => fieldId;
+
+export const getTimeDimensionColumnName = (
+    dimensionName: string,
+    granularity: TimeFrames,
+): string => `${dimensionName}_${granularity.toLowerCase()}`;

--- a/packages/common/src/preAggregates/references.ts
+++ b/packages/common/src/preAggregates/references.ts
@@ -1,0 +1,44 @@
+import { type CompiledDimension, type CompiledMetric } from '../types/field';
+
+export const getDimensionBaseName = (
+    dimension: Pick<
+        CompiledDimension,
+        'name' | 'timeIntervalBaseDimensionName'
+    >,
+): string => dimension.timeIntervalBaseDimensionName ?? dimension.name;
+
+export const getDimensionReferences = ({
+    dimension,
+    baseTable,
+}: {
+    dimension: Pick<
+        CompiledDimension,
+        'table' | 'name' | 'timeIntervalBaseDimensionName'
+    >;
+    baseTable: string;
+}): string[] => {
+    const baseName = getDimensionBaseName(dimension);
+    const tableQualifiedReference = `${dimension.table}.${baseName}`;
+
+    if (dimension.table === baseTable) {
+        return [baseName, tableQualifiedReference];
+    }
+
+    return [tableQualifiedReference];
+};
+
+export const getMetricReferences = ({
+    metric,
+    baseTable,
+}: {
+    metric: Pick<CompiledMetric, 'table' | 'name'>;
+    baseTable: string;
+}): string[] => {
+    const references = [`${metric.table}.${metric.name}`];
+
+    if (metric.table === baseTable) {
+        references.push(metric.name);
+    }
+
+    return references;
+};

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -58,6 +58,7 @@ export type CompiledTable = TableBase & {
 export enum ExploreType {
     VIRTUAL = 'virtual',
     DEFAULT = 'default',
+    PRE_AGGREGATE = 'pre_aggregate',
 }
 
 export enum InlineErrorType {


### PR DESCRIPTION
### Description:

This PR introduces pre-aggregate virtual explore generation and visibility controls for pre-aggregate explores.

**Key Changes:**

- **Pre-aggregate Virtual Explore Generation**: Added functionality to automatically generate internal pre-aggregate explores when `ENABLE_PRE_AGGREGATE_VIRTUAL_EXPLORES` is enabled. These explores are built from pre-aggregate definitions and include only supported metric types (SUM, COUNT, MIN, MAX).

- **Visibility Controls**: Implemented environment variable-based visibility controls for pre-aggregate explores:

  - `ENABLE_PRE_AGGREGATE_DEBUG_VIEW` - Shows pre-aggregate explores in the UI for debugging
  - `ENABLE_PRE_AGGREGATE_INTERNAL_VISIBILITY` - Internal visibility flag for pre-aggregate explores
  - Pre-aggregate explores are filtered out by default unless these flags are enabled

- **Pre-aggregate Query Processing**: Extended async query service to process pre-aggregates when `ENABLE_PRE_AGGREGATES` or `ENABLE_PRE_AGGREGATE_DRY_RUN` is enabled.

- **Explore Filtering**: Updated explore filtering logic in both SearchModel and ProjectService to respect pre-aggregate visibility settings while ensuring they're included when debug flags are enabled.

- **Metric Rewriting**: Pre-aggregate explores automatically rewrite metrics to use appropriate aggregate functions (e.g., SUM for pre-aggregated values) and exclude unsupported metric types like AVERAGE and custom SQL metrics.

- **Time Dimension Handling**: Added logic to handle time dimensions in pre-aggregate explores, filtering out time intervals finer than the rollup granularity and mapping to appropriate column names.
