### PR TITLE
chore: change labels from shared/private to explicit access and custom

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceAccessInfo.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceAccessInfo.tsx
@@ -39,14 +39,17 @@ const getV2AccessType = (
     return ResourceAccess.Private;
 };
 
-const getV2Status = (accessType: ResourceAccess): string => {
+const getV2Status = (
+    accessType: ResourceAccess,
+    isNestedSpace: boolean,
+): string => {
     switch (accessType) {
         case ResourceAccess.Public:
-            return 'Shared';
+            return isNestedSpace ? 'Parent Access' : 'Project Access';
         case ResourceAccess.Private:
             return 'Private';
         case ResourceAccess.Shared:
-            return 'Shared';
+            return 'Custom Access';
     }
 };
 
@@ -58,10 +61,10 @@ const getV2Label = (
     switch (accessType) {
         case ResourceAccess.Public:
             return isNestedSpace
-                ? 'Access matches the parent space'
-                : 'Shared with all users in this project';
+                ? 'Inherits access from the parent space'
+                : 'All project members can access';
         case ResourceAccess.Private:
-            return 'Only invited members and admins have access';
+            return 'Only you and admins can access';
         case ResourceAccess.Shared:
             return `Shared with ${item.data.accessListLength} member${
                 item.data.accessListLength > 1 ? 's' : ''
@@ -92,7 +95,7 @@ const ResourceAccessInfo: React.FC<ResourceAccessInfoProps> = ({
     const isNestedSpace = !!item.data.parentSpaceUuid;
     const { Icon } = ResourceAccessInfoData[accessType];
     const status = isV2
-        ? getV2Status(accessType)
+        ? getV2Status(accessType, isNestedSpace)
         : ResourceAccessInfoData[accessType].status;
     const tooltipLabel = isV2
         ? getV2Label(item, accessType, isNestedSpace)

--- a/packages/frontend/src/components/common/ShareSpaceModal/v2/InheritanceToggleCards.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/v2/InheritanceToggleCards.tsx
@@ -2,19 +2,36 @@ import { Group, Paper, Stack, Text } from '@mantine-8/core';
 import { IconLock, IconUsersGroup } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../MantineIcon';
-import { InheritanceType } from './ShareSpaceModalUtils';
+import {
+    InheritanceType,
+    NestedInheritanceOptions,
+    RootInheritanceOptions,
+} from './ShareSpaceModalUtils';
 
 type InheritanceToggleCardsProps = {
     value: InheritanceType;
     onChange: (value: InheritanceType) => void;
     disabled?: boolean;
+    isNestedSpace?: boolean;
 };
 
 const InheritanceToggleCards: FC<InheritanceToggleCardsProps> = ({
     value,
     onChange,
     disabled,
+    isNestedSpace = false,
 }) => {
+    const options = isNestedSpace
+        ? NestedInheritanceOptions
+        : RootInheritanceOptions;
+
+    const inheritOption = options.find(
+        (o) => o.value === InheritanceType.INHERIT,
+    );
+    const ownOnlyOption = options.find(
+        (o) => o.value === InheritanceType.OWN_ONLY,
+    );
+
     return (
         <Group grow align="stretch">
             <Paper
@@ -43,10 +60,10 @@ const InheritanceToggleCards: FC<InheritanceToggleCardsProps> = ({
                         size="xl"
                     />
                     <Text fz="sm" fw={600} ta="center">
-                        Shared
+                        {inheritOption?.title}
                     </Text>
                     <Text fz="xs" c="dimmed" ta="center">
-                        Project members can access this space
+                        {inheritOption?.description}
                     </Text>
                 </Stack>
             </Paper>
@@ -73,10 +90,10 @@ const InheritanceToggleCards: FC<InheritanceToggleCardsProps> = ({
                 <Stack align="center" gap="xs">
                     <MantineIcon icon={IconLock} color="blue.6" size="xl" />
                     <Text fz="sm" fw={600} ta="center">
-                        Private
+                        {ownOnlyOption?.title}
                     </Text>
                     <Text fz="xs" c="dimmed" ta="center">
-                        Only invited members and admins can access this space
+                        {ownOnlyOption?.description}
                     </Text>
                 </Stack>
             </Paper>

--- a/packages/frontend/src/components/common/ShareSpaceModal/v2/ShareSpaceModalShared.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/v2/ShareSpaceModalShared.tsx
@@ -376,9 +376,6 @@ export const AccessModelToggle: FC<AccessModelToggleProps> = ({
     const currentOption =
         options.find((o) => o.value === currentValue) ?? options[0];
 
-    const label =
-        currentValue === InheritanceType.INHERIT ? 'Shared' : 'Private';
-
     return (
         <Paper
             withBorder
@@ -406,7 +403,7 @@ export const AccessModelToggle: FC<AccessModelToggleProps> = ({
                     </Avatar>
                     <Stack gap={2}>
                         <Text fw={600} fz="sm">
-                            {label}
+                            {currentOption.title}
                         </Text>
                         <Text c="ldGray.6" fz="xs">
                             {currentOption.description}

--- a/packages/frontend/src/components/common/ShareSpaceModal/v2/ShareSpaceModalUtils.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/v2/ShareSpaceModalUtils.ts
@@ -13,7 +13,7 @@ export const enum InheritanceType {
 
 export const RootInheritanceOptions: AccessOption[] = [
     {
-        title: 'Shared',
+        title: 'Project Access',
         description:
             'All project members can access with their project permissions',
         selectDescription:
@@ -21,7 +21,7 @@ export const RootInheritanceOptions: AccessOption[] = [
         value: InheritanceType.INHERIT,
     },
     {
-        title: 'Private',
+        title: 'Custom Access',
         description: 'Only directly invited members and admins can access',
         selectDescription:
             'Only directly invited members and admins can access this space',
@@ -31,7 +31,7 @@ export const RootInheritanceOptions: AccessOption[] = [
 
 export const NestedInheritanceOptions: AccessOption[] = [
     {
-        title: 'Shared',
+        title: 'Parent Access',
         description:
             'Users with access to the parent space also have access here',
         selectDescription:
@@ -39,7 +39,7 @@ export const NestedInheritanceOptions: AccessOption[] = [
         value: InheritanceType.INHERIT,
     },
     {
-        title: 'Private',
+        title: 'Custom Access',
         description: 'Only directly invited members and admins can access',
         selectDescription:
             'This space ignores parent space permissions and uses only its own access list',


### PR DESCRIPTION
### Description:

Updated the terminology and labels throughout the space sharing interface to provide clearer context about access types:

**Resource Access Info:**
- Changed "Shared" status to "Project Access" for root spaces and "Parent Access" for nested spaces
- Updated "Shared" status for custom access to "Custom Access"
- Refined tooltip descriptions: "Access matches the parent space" → "Inherits access from the parent space" and "Shared with all users in this project" → "All project members can access"
- Changed private access description from "Only invited members and admins have access" to "Only you and admins can access"

**Share Space Modal:**
- Updated inheritance toggle cards to use dynamic titles and descriptions based on whether the space is nested or root-level
- Changed hardcoded "Shared"/"Private" labels to use the appropriate option titles ("Project Access"/"Parent Access" and "Custom Access")
- Modified access option titles in the configuration:
  - Root spaces: "Shared" → "Project Access", "Private" → "Custom Access"  
  - Nested spaces: "Shared" → "Parent Access", "Private" → "Custom Access"

These changes make the access control terminology more descriptive and contextually appropriate for different space types.

![CleanShot 2026-02-23 at 16.32.04.png](https://app.graphite.com/user-attachments/assets/dd2ca4a1-8760-4574-abd0-317683f6ca43.png)

![CleanShot 2026-02-23 at 16.32.14.png](https://app.graphite.com/user-attachments/assets/88acbf98-d8a9-4e2b-b146-78fbc744300d.png)

![CleanShot 2026-02-23 at 16.32.25.gif](https://app.graphite.com/user-attachments/assets/b3571429-8423-4a00-b08a-d187e3a5b12e.gif)

