### PR TITLE
fix: default wrapColumnTitles to false when not set

### DIFF
--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -81,7 +81,7 @@ const useTableConfig = (
     );
 
     const [wrapColumnTitles, setWrapColumnTitles] = useState<boolean>(
-        tableChartConfig?.wrapColumnTitles ?? true,
+        tableChartConfig?.wrapColumnTitles ?? false,
     );
 
     const [metricsAsRows, setMetricsAsRows] = useState<boolean>(

--- a/packages/frontend/src/providers/Explorer/utils.ts
+++ b/packages/frontend/src/providers/Explorer/utils.ts
@@ -6,7 +6,10 @@ import { type ConfigCacheMap } from './types';
 const DEFAULTS = {
     [ChartType.CARTESIAN]: () => ({ ...EMPTY_CARTESIAN_CHART_CONFIG }), // factory to avoid shared refs
     [ChartType.BIG_NUMBER]: () => ({ showTableNamesInLabel: false }),
-    [ChartType.TABLE]: () => ({ showTableNames: false, wrapColumnTitles: true }),
+    [ChartType.TABLE]: () => ({
+        showTableNames: false,
+        wrapColumnTitles: false,
+    }),
     [ChartType.PIE]: () => ({ showLegend: false, valueLabel: 'outside' }),
     [ChartType.FUNNEL]: () => ({}),
     [ChartType.TREEMAP]: () => ({}),


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/20546 

## Summary

The recent column title wrapping feature (#20532) defaulted `wrapColumnTitles` to `true`, which changed the appearance of existing tables. Users with narrow columns displaying boolean or small number values — but with long column title names — were particularly impacted, as the wrapped headers significantly increased header height and disrupted their table layouts.

This changes the default to `false` so that tables behave the same way they did when column resizing was released. Users who prefer wrapped titles can still enable it via the toggle in the table config panel.

### Changes
- `useTableConfig.ts`: fallback for legacy charts without `wrapColumnTitles` set → `false`
- `Explorer/utils.ts`: default config for new table charts → `false`

## Test plan
- [ ] Open a legacy table chart (created before the wrap feature) — column titles should **not** wrap by default
- [ ] Create a new table chart in the Explorer — column titles should **not** wrap by default
- [ ] Toggle "Wrap column titles" on in the config panel — titles should wrap
- [ ] Save and reload — the explicit `true` setting should persist

Closes: [PROD-3556](https://linear.app/lightdash/issue/PROD-3556/column-headers-are-squished-and-table-data-is-inaccessible-in-wide
)
🤖 Generated with [Claude Code](https://claude.com/claude-code)