### PR TITLE
feat: display pre-aggregate logs table

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -450,6 +450,7 @@ declare module 'knex/types/tables' {
         [OrganizationWarehouseCredentialsTableName]: OrganizationWarehouseCredentialsTable;
         [QueryHistoryTableName]: QueryHistoryTable;
         [PreAggregateDefinitionsTableName]: PreAggregateDefinitionsTable;
+        [PreAggregateDailyStatsTableName]: PreAggregateDailyStatsTable;
         [PreAggregateMaterializationsTableName]: PreAggregateMaterializationsTable;
         [ProjectParametersTableName]: ProjectParametersTable;
         [RolesTableName]: RoleTable;

--- a/packages/backend/src/controllers/v2/PreAggregateStatsController.ts
+++ b/packages/backend/src/controllers/v2/PreAggregateStatsController.ts
@@ -1,0 +1,64 @@
+import {
+    ApiErrorPayload,
+    type ApiGetPreAggregateStatsResponse,
+} from '@lightdash/common';
+import {
+    Get,
+    Middlewares,
+    OperationId,
+    Path,
+    Query,
+    Request,
+    Response,
+    Route,
+    SuccessResponse,
+    Tags,
+} from '@tsoa/runtime';
+import express from 'express';
+import { allowApiKeyAuthentication, isAuthenticated } from '../authentication';
+import { BaseController } from '../baseController';
+
+@Route('/api/v2/projects/{projectUuid}/pre-aggregate-stats')
+@Response<ApiErrorPayload>('default', 'Error')
+@Tags('v2', 'Pre-Aggregates')
+export class PreAggregateStatsController extends BaseController {
+    /**
+     * Retrieves aggregated pre-aggregate hit/miss statistics for a project
+     * @summary Get pre-aggregate stats
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/')
+    @OperationId('getPreAggregateStats')
+    async getPreAggregateStats(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() days?: number,
+        @Query() page?: number,
+        @Query() pageSize?: number,
+        @Query() exploreName?: string,
+        @Query() queryType?: 'chart' | 'dashboard' | 'explorer',
+    ): Promise<ApiGetPreAggregateStatsResponse> {
+        this.setStatus(200);
+
+        const paginateArgs = page && pageSize ? { page, pageSize } : undefined;
+
+        const filters =
+            exploreName || queryType ? { exploreName, queryType } : undefined;
+
+        const results = await this.services
+            .getAsyncQueryService()
+            .getPreAggregateStats(
+                req.account!,
+                projectUuid,
+                days ?? 3,
+                paginateArgs,
+                filters,
+            );
+
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+}

--- a/packages/backend/src/database/entities/preAggregateDailyStats.ts
+++ b/packages/backend/src/database/entities/preAggregateDailyStats.ts
@@ -1,0 +1,28 @@
+import { Knex } from 'knex';
+
+export const PreAggregateDailyStatsTableName = 'pre_aggregate_daily_stats';
+
+export type DbPreAggregateDailyStat = {
+    project_uuid: string;
+    explore_name: string;
+    date: Date;
+    chart_uuid: string | null;
+    dashboard_uuid: string | null;
+    query_context: string;
+    hit_count: number;
+    miss_count: number;
+    miss_reason: string | null;
+    pre_aggregate_name: string | null;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbPreAggregateDailyStatIn = Omit<
+    DbPreAggregateDailyStat,
+    'created_at' | 'updated_at'
+>;
+
+export type PreAggregateDailyStatsTable = Knex.CompositeTableType<
+    DbPreAggregateDailyStat,
+    DbPreAggregateDailyStatIn
+>;

--- a/packages/backend/src/database/migrations/20260227120000_create_pre_aggregate_daily_stats.ts
+++ b/packages/backend/src/database/migrations/20260227120000_create_pre_aggregate_daily_stats.ts
@@ -1,0 +1,67 @@
+import { Knex } from 'knex';
+
+const PreAggregateDailyStatsTableName = 'pre_aggregate_daily_stats';
+const ProjectsTableName = 'projects';
+const SavedQueriesTableName = 'saved_queries';
+const DashboardsTableName = 'dashboards';
+
+export async function up(knex: Knex): Promise<void> {
+    // Create pre_aggregate_daily_stats table
+    await knex.schema.createTable(PreAggregateDailyStatsTableName, (table) => {
+        table
+            .uuid('project_uuid')
+            .notNullable()
+            .references('project_uuid')
+            .inTable(ProjectsTableName)
+            .onDelete('CASCADE');
+        table.text('explore_name').notNullable();
+        table.date('date').notNullable();
+        table
+            .uuid('chart_uuid')
+            .nullable()
+            .references('saved_query_uuid')
+            .inTable(SavedQueriesTableName)
+            .onDelete('CASCADE');
+        table
+            .uuid('dashboard_uuid')
+            .nullable()
+            .references('dashboard_uuid')
+            .inTable(DashboardsTableName)
+            .onDelete('CASCADE');
+        table.text('query_context').notNullable();
+        table.integer('hit_count').notNullable().defaultTo(0);
+        table.integer('miss_count').notNullable().defaultTo(0);
+        table.text('miss_reason').nullable();
+        table.text('pre_aggregate_name').nullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+
+    // Use a unique index with COALESCE expressions to handle nullable columns
+    // PostgreSQL doesn't allow expressions in PRIMARY KEY definitions,
+    // but UNIQUE INDEX on expressions works and can be used with ON CONFLICT
+    await knex.raw(`
+        CREATE UNIQUE INDEX pre_aggregate_daily_stats_ukey
+        ON ${PreAggregateDailyStatsTableName} (
+            project_uuid, explore_name, date, query_context,
+            COALESCE(chart_uuid, '00000000-0000-0000-0000-000000000000'),
+            COALESCE(dashboard_uuid, '00000000-0000-0000-0000-000000000000')
+        )
+    `);
+
+    // Create index for project+date lookups
+    await knex.raw(`
+        CREATE INDEX idx_pre_agg_stats_project_date
+        ON ${PreAggregateDailyStatsTableName} (project_uuid, date)
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(PreAggregateDailyStatsTableName);
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -292,6 +292,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     encryptionUtil: utils.getEncryptionUtil(),
                     userModel: models.getUserModel(),
                     queryHistoryModel: models.getQueryHistoryModel(),
+                    preAggregateDailyStatsModel:
+                        models.getPreAggregateDailyStatsModel(),
                     downloadAuditModel: models.getDownloadAuditModel(),
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -97,6 +97,8 @@ import { FeatureFlagController } from './../controllers/v2/FeatureFlagController
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ParametersController } from './../controllers/v2/ParametersController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+import { PreAggregateStatsController } from './../controllers/v2/PreAggregateStatsController';
+// WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { QueryController } from './../controllers/v2/QueryController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { SavedChartControllerV2 } from './../controllers/v2/SavedChartController';
@@ -2532,6 +2534,7 @@ const models: TsoaRoute.Models = {
                 ],
             },
             formatOptions: { ref: 'CustomFormat' },
+            caseSensitive: { dataType: 'boolean' },
             image: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
@@ -4991,6 +4994,7 @@ const models: TsoaRoute.Models = {
                 ],
             },
             formatOptions: { ref: 'CustomFormat' },
+            caseSensitive: { dataType: 'boolean' },
             image: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
@@ -5460,6 +5464,7 @@ const models: TsoaRoute.Models = {
                         },
                     },
                 },
+                caseSensitive: { dataType: 'boolean' },
                 type: { ref: 'ExploreType' },
                 sqlPath: { dataType: 'string' },
                 ymlPath: { dataType: 'string' },
@@ -19386,6 +19391,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                caseSensitive: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 spotlight: {
                     dataType: 'union',
                     subSchemas: [
@@ -22153,6 +22165,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                caseSensitive: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 aiHint: {
                     dataType: 'union',
                     subSchemas: [
@@ -24883,6 +24902,133 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             ref: 'Pick_DownloadAsyncQueryResultsRequestParams.Exclude_keyofDownloadAsyncQueryResultsRequestParams.queryUuid__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PreAggregateDailyStatResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                updatedAt: { dataType: 'string', required: true },
+                preAggregateName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                missReason: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                missCount: { dataType: 'double', required: true },
+                hitCount: { dataType: 'double', required: true },
+                queryContext: { dataType: 'string', required: true },
+                dashboardName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                dashboardUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                chartName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                chartUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                date: { dataType: 'string', required: true },
+                exploreName: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPreAggregateStatsResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                stats: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'PreAggregateDailyStatResult',
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    KnexPaginatedData_ApiPreAggregateStatsResults_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pagination: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'KnexPaginateArgs' },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                totalResults: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                totalPageCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+                data: { ref: 'ApiPreAggregateStatsResults', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetPreAggregateStatsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'KnexPaginatedData_ApiPreAggregateStatsResults_',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
             validators: {},
         },
     },
@@ -52017,6 +52163,81 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'scheduleDownloadResults',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsPreAggregateStatsController_getPreAggregateStats: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        days: { in: 'query', name: 'days', dataType: 'double' },
+        page: { in: 'query', name: 'page', dataType: 'double' },
+        pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+        exploreName: { in: 'query', name: 'exploreName', dataType: 'string' },
+        queryType: {
+            in: 'query',
+            name: 'queryType',
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['chart'] },
+                { dataType: 'enum', enums: ['dashboard'] },
+                { dataType: 'enum', enums: ['explorer'] },
+            ],
+        },
+    };
+    app.get(
+        '/api/v2/projects/:projectUuid/pre-aggregate-stats',
+        ...fetchMiddlewares<RequestHandler>(PreAggregateStatsController),
+        ...fetchMiddlewares<RequestHandler>(
+            PreAggregateStatsController.prototype.getPreAggregateStats,
+        ),
+
+        async function PreAggregateStatsController_getPreAggregateStats(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsPreAggregateStatsController_getPreAggregateStats,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<PreAggregateStatsController>(
+                        PreAggregateStatsController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getPreAggregateStats',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2801,6 +2801,9 @@
                     "formatOptions": {
                         "$ref": "#/components/schemas/CustomFormat"
                     },
+                    "caseSensitive": {
+                        "type": "boolean"
+                    },
                     "image": {
                         "properties": {
                             "fit": {
@@ -5941,6 +5944,9 @@
                     "formatOptions": {
                         "$ref": "#/components/schemas/CustomFormat"
                     },
+                    "caseSensitive": {
+                        "type": "boolean"
+                    },
                     "image": {
                         "properties": {
                             "fit": {
@@ -6533,6 +6539,9 @@
                         },
                         "required": ["visibility"],
                         "type": "object"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean"
                     },
                     "type": {
                         "$ref": "#/components/schemas/ExploreType"
@@ -20508,6 +20517,9 @@
                     "type": {
                         "$ref": "#/components/schemas/ExploreType"
                     },
+                    "caseSensitive": {
+                        "type": "boolean"
+                    },
                     "spotlight": {
                         "properties": {
                             "owner": {
@@ -23304,6 +23316,9 @@
                     "sqlPath": {
                         "type": "string"
                     },
+                    "caseSensitive": {
+                        "type": "boolean"
+                    },
                     "aiHint": {
                         "anyOf": [
                             {
@@ -25965,6 +25980,125 @@
                 "$ref": "#/components/schemas/Pick_DownloadAsyncQueryResultsRequestParams.Exclude_keyofDownloadAsyncQueryResultsRequestParams.queryUuid__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
+            "PreAggregateDailyStatResult": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string"
+                    },
+                    "preAggregateName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "missReason": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "missCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "hitCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "queryContext": {
+                        "type": "string"
+                    },
+                    "dashboardName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "dashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "chartName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "chartUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "date": {
+                        "type": "string"
+                    },
+                    "exploreName": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "preAggregateName",
+                    "missReason",
+                    "missCount",
+                    "hitCount",
+                    "queryContext",
+                    "dashboardName",
+                    "dashboardUuid",
+                    "chartName",
+                    "chartUuid",
+                    "date",
+                    "exploreName"
+                ],
+                "type": "object"
+            },
+            "ApiPreAggregateStatsResults": {
+                "properties": {
+                    "stats": {
+                        "items": {
+                            "$ref": "#/components/schemas/PreAggregateDailyStatResult"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["stats"],
+                "type": "object"
+            },
+            "KnexPaginatedData_ApiPreAggregateStatsResults_": {
+                "properties": {
+                    "pagination": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/KnexPaginateArgs"
+                            },
+                            {
+                                "properties": {
+                                    "totalResults": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "totalPageCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    }
+                                },
+                                "required": ["totalResults", "totalPageCount"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/ApiPreAggregateStatsResults"
+                    }
+                },
+                "required": ["data"],
+                "type": "object"
+            },
+            "ApiGetPreAggregateStatsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/KnexPaginatedData_ApiPreAggregateStatsResults_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "ProjectParameterSummary": {
                 "properties": {
                     "modelName": {
@@ -27263,7 +27397,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2536.2",
+        "version": "0.2543.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -44593,6 +44727,91 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v2/projects/{projectUuid}/pre-aggregate-stats": {
+            "get": {
+                "operationId": "getPreAggregateStats",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGetPreAggregateStatsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Retrieves aggregated pre-aggregate hit/miss statistics for a project",
+                "summary": "Get pre-aggregate stats",
+                "tags": ["v2", "Pre-Aggregates"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "days",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "exploreName",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "queryType",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["chart", "dashboard", "explorer"]
+                        }
+                    }
+                ]
             }
         },
         "/api/v2/projects/{projectUuid}/parameters/list": {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -31,6 +31,7 @@ import { OrganizationWarehouseCredentialsModel } from './OrganizationWarehouseCr
 import { PasswordResetLinkModel } from './PasswordResetLinkModel';
 import { PersistentDownloadFileModel } from './PersistentDownloadFileModel';
 import { PinnedListModel } from './PinnedListModel';
+import { PreAggregateDailyStatsModel } from './PreAggregateDailyStatsModel';
 import { PreAggregateModel } from './PreAggregateModel';
 import { ProjectCompileLogModel } from './ProjectCompileLogModel';
 import { ProjectModel } from './ProjectModel/ProjectModel';
@@ -117,6 +118,7 @@ export type ModelManifest = {
     spotlightTableConfigModel: SpotlightTableConfigModel;
     queryHistoryModel: QueryHistoryModel;
     preAggregateModel: PreAggregateModel;
+    preAggregateDailyStatsModel: PreAggregateDailyStatsModel;
     projectParametersModel: ProjectParametersModel;
     changesetModel: ChangesetModel;
     /** An implementation signature for these models are not available at this stage */
@@ -684,6 +686,16 @@ export class ModelRepository
         return this.getModel(
             'queryHistoryModel',
             () => new QueryHistoryModel({ database: this.database }),
+        );
+    }
+
+    public getPreAggregateDailyStatsModel(): PreAggregateDailyStatsModel {
+        return this.getModel(
+            'preAggregateDailyStatsModel',
+            () =>
+                new PreAggregateDailyStatsModel({
+                    database: this.database,
+                }),
         );
     }
 

--- a/packages/backend/src/models/PreAggregateDailyStatsModel.ts
+++ b/packages/backend/src/models/PreAggregateDailyStatsModel.ts
@@ -1,0 +1,213 @@
+import {
+    assertUnreachable,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+} from '@lightdash/common';
+import { Knex } from 'knex';
+import { PreAggregateDailyStatsTableName } from '../database/entities/preAggregateDailyStats';
+import KnexPaginate from '../database/pagination';
+
+export type PreAggregateDailyStatsUpsertParams = {
+    projectUuid: string;
+    exploreName: string;
+    chartUuid: string | null;
+    dashboardUuid: string | null;
+    queryContext: string;
+    hit: boolean;
+    missReason: string | null;
+    preAggregateName: string | null;
+};
+
+export type PreAggregateDailyStatRow = {
+    projectUuid: string;
+    exploreName: string;
+    date: Date;
+    chartUuid: string | null;
+    chartName: string | null;
+    dashboardUuid: string | null;
+    dashboardName: string | null;
+    queryContext: string;
+    hitCount: number;
+    missCount: number;
+    missReason: string | null;
+    preAggregateName: string | null;
+    updatedAt: Date;
+};
+
+type DbJoinedRow = {
+    project_uuid: string;
+    explore_name: string;
+    date: Date;
+    chart_uuid: string | null;
+    chart_name: string | null;
+    dashboard_uuid: string | null;
+    dashboard_name: string | null;
+    query_context: string;
+    hit_count: number;
+    miss_count: number;
+    miss_reason: string | null;
+    pre_aggregate_name: string | null;
+    updated_at: Date;
+};
+
+function convertDbRow(row: DbJoinedRow): PreAggregateDailyStatRow {
+    return {
+        projectUuid: row.project_uuid,
+        exploreName: row.explore_name,
+        date: row.date,
+        chartUuid: row.chart_uuid,
+        chartName: row.chart_name,
+        dashboardUuid: row.dashboard_uuid,
+        dashboardName: row.dashboard_name,
+        queryContext: row.query_context,
+        hitCount: row.hit_count,
+        missCount: row.miss_count,
+        missReason: row.miss_reason,
+        preAggregateName: row.pre_aggregate_name,
+        updatedAt: row.updated_at,
+    };
+}
+
+export class PreAggregateDailyStatsModel {
+    readonly database: Knex;
+
+    constructor({ database }: { database: Knex }) {
+        this.database = database;
+    }
+
+    async upsert(params: PreAggregateDailyStatsUpsertParams): Promise<void> {
+        const hitCount = params.hit ? 1 : 0;
+        const missCount = params.hit ? 0 : 1;
+        const missReason = !params.hit ? params.missReason : null;
+
+        await this.database.raw(
+            `
+            INSERT INTO ${PreAggregateDailyStatsTableName}
+                (project_uuid, explore_name, date, chart_uuid,
+                 dashboard_uuid, query_context,
+                 hit_count, miss_count, miss_reason, pre_aggregate_name)
+            VALUES (?, ?, CURRENT_DATE, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT (
+                project_uuid, explore_name, date, query_context,
+                COALESCE(chart_uuid, '00000000-0000-0000-0000-000000000000'),
+                COALESCE(dashboard_uuid, '00000000-0000-0000-0000-000000000000')
+            )
+            DO UPDATE SET
+                hit_count = ${PreAggregateDailyStatsTableName}.hit_count + EXCLUDED.hit_count,
+                miss_count = ${PreAggregateDailyStatsTableName}.miss_count + EXCLUDED.miss_count,
+                miss_reason = COALESCE(EXCLUDED.miss_reason, ${PreAggregateDailyStatsTableName}.miss_reason),
+                pre_aggregate_name = COALESCE(EXCLUDED.pre_aggregate_name, ${PreAggregateDailyStatsTableName}.pre_aggregate_name),
+                updated_at = NOW()
+            `,
+            [
+                params.projectUuid,
+                params.exploreName,
+                params.chartUuid,
+                params.dashboardUuid,
+                params.queryContext,
+                hitCount,
+                missCount,
+                missReason,
+                params.preAggregateName,
+            ],
+        );
+    }
+
+    async getByProject(
+        projectUuid: string,
+        days: number = 3,
+        paginateArgs?: KnexPaginateArgs,
+        filters?: {
+            exploreName?: string;
+            queryType?: 'chart' | 'dashboard' | 'explorer';
+        },
+    ): Promise<KnexPaginatedData<PreAggregateDailyStatRow[]>> {
+        const stats = PreAggregateDailyStatsTableName;
+        const query = this.database(stats)
+            .select(
+                `${stats}.project_uuid`,
+                `${stats}.explore_name`,
+                `${stats}.date`,
+                `${stats}.chart_uuid`,
+                this.database.raw('sq.name as chart_name'),
+                `${stats}.dashboard_uuid`,
+                this.database.raw('d.name as dashboard_name'),
+                `${stats}.query_context`,
+                `${stats}.hit_count`,
+                `${stats}.miss_count`,
+                `${stats}.miss_reason`,
+                `${stats}.pre_aggregate_name`,
+                `${stats}.updated_at`,
+            )
+            .leftJoin('saved_queries as sq', function getChartJoin() {
+                this.on(
+                    'sq.saved_query_uuid',
+                    '=',
+                    `${stats}.chart_uuid`,
+                ).andOnNull('sq.deleted_at');
+            })
+            .leftJoin('dashboards as d', function getDashboardJoin() {
+                this.on(
+                    'd.dashboard_uuid',
+                    '=',
+                    `${stats}.dashboard_uuid`,
+                ).andOnNull('d.deleted_at');
+            })
+            .where(`${stats}.project_uuid`, projectUuid)
+            .where(
+                `${stats}.date`,
+                '>=',
+                this.database.raw(`CURRENT_DATE - ? * INTERVAL '1 day'`, [
+                    days,
+                ]),
+            )
+            .orderBy(`${stats}.updated_at`, 'desc');
+
+        if (filters?.exploreName) {
+            void query.where(`${stats}.explore_name`, filters.exploreName);
+        }
+
+        if (filters?.queryType) {
+            switch (filters.queryType) {
+                case 'chart':
+                    void query
+                        .whereNotNull(`${stats}.chart_uuid`)
+                        .whereNull(`${stats}.dashboard_uuid`);
+                    break;
+                case 'dashboard':
+                    void query.whereNotNull(`${stats}.dashboard_uuid`);
+                    break;
+                case 'explorer':
+                    void query
+                        .whereNull(`${stats}.chart_uuid`)
+                        .whereNull(`${stats}.dashboard_uuid`);
+                    break;
+                default:
+                    return assertUnreachable(
+                        filters.queryType,
+                        'Invalid query type',
+                    );
+            }
+        }
+
+        const result = await KnexPaginate.paginate(query, paginateArgs);
+        return {
+            data: (result.data as unknown as DbJoinedRow[]).map(convertDbRow),
+            pagination: result.pagination,
+        };
+    }
+
+    async cleanup(retentionDays: number = 3): Promise<number> {
+        const deleted = await this.database(PreAggregateDailyStatsTableName)
+            .where(
+                'date',
+                '<',
+                this.database.raw(`CURRENT_DATE - ? * INTERVAL '1 day'`, [
+                    retentionDays,
+                ]),
+            )
+            .delete();
+
+        return deleted;
+    }
+}

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -942,6 +942,23 @@ export class SchedulerWorker extends SchedulerTask {
                     Logger.error('Error during query history cleanup:', error);
                     throw error;
                 }
+
+                // Also clean up pre-aggregate daily stats (3-day retention)
+                try {
+                    const preAggDeleted =
+                        await this.asyncQueryService.cleanupPreAggregateDailyStats(
+                            3,
+                        );
+                    Logger.info(
+                        `Pre-aggregate daily stats cleanup completed. Records deleted: ${preAggDeleted}`,
+                    );
+                } catch (error) {
+                    Logger.error(
+                        'Error during pre-aggregate daily stats cleanup:',
+                        error,
+                    );
+                    // Don't throw - this is secondary cleanup, don't fail the job
+                }
             },
             [SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS]: async () => {
                 Logger.info('Starting deploy sessions cleanup job');

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -222,6 +222,9 @@ const getMockedAsyncQueryService = (
         projectCompileLogModel: {} as ProjectCompileLogModel,
         adminNotificationService: {} as AdminNotificationService,
         spacePermissionService: {} as SpacePermissionService,
+        preAggregateDailyStatsModel: {
+            upsert: jest.fn(),
+        } as unknown as import('../../models/PreAggregateDailyStatsModel').PreAggregateDailyStatsModel,
         ...overrides,
     });
 

--- a/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -7,8 +7,8 @@ import {
     type PreAggregateMaterializationTrigger,
 } from '@lightdash/common';
 import { PreAggregateModel } from '../../models/PreAggregateModel';
-import type PrometheusMetrics from '../../prometheus';
 import { type QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
+import type PrometheusMetrics from '../../prometheus';
 import { type AsyncQueryService } from '../AsyncQueryService/AsyncQueryService';
 
 const QUERY_POLL_INTERVAL_MS = 1000;

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -679,6 +679,8 @@ export class ServiceRepository
                     encryptionUtil: this.utils.getEncryptionUtil(),
                     userModel: this.models.getUserModel(),
                     queryHistoryModel: this.models.getQueryHistoryModel(),
+                    preAggregateDailyStatsModel:
+                        this.models.getPreAggregateDailyStatsModel(),
                     downloadAuditModel: this.models.getDownloadAuditModel(),
                     savedSqlModel: this.models.getSavedSqlModel(),
                     resultsStorageClient:

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -132,7 +132,10 @@ import {
 } from './personalAccessToken';
 import { type ApiTogglePinnedItem, type PinnedItems } from './pinning';
 import { type PivotConfiguration } from './pivot';
-import type { PreAggregateMatchMiss } from './preAggregate';
+import type {
+    ApiGetPreAggregateStatsResponse,
+    PreAggregateMatchMiss,
+} from './preAggregate';
 import {
     type ApiProjectCompileLogResponse,
     type ApiProjectCompileLogsResponse,
@@ -940,7 +943,8 @@ type ApiResults =
     | ApiChartValidationResponse['results']
     | ApiDashboardValidationResponse['results']
     | ApiToggleFavorite['results']
-    | ApiSpaceDeleteImpactResponse['results'];
+    | ApiSpaceDeleteImpactResponse['results']
+    | ApiGetPreAggregateStatsResponse['results'];
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'
 

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -1,4 +1,5 @@
 import { type FieldId } from './field';
+import { type KnexPaginatedData } from './knex-paginate';
 import { type MetricQuery } from './metricQuery';
 import { type ResultColumns } from './results';
 import { type PreAggregateMaterializationTrigger } from './scheduler';
@@ -157,4 +158,28 @@ export type PreAggregateSchedulerDetails = {
     preAggregateDefinitionUuid: string;
     preAggExploreName: string;
     refreshCron: string;
+};
+
+export type PreAggregateDailyStatResult = {
+    exploreName: string;
+    date: string;
+    chartUuid: string | null;
+    chartName: string | null;
+    dashboardUuid: string | null;
+    dashboardName: string | null;
+    queryContext: string;
+    hitCount: number;
+    missCount: number;
+    missReason: string | null;
+    preAggregateName: string | null;
+    updatedAt: string;
+};
+
+export type ApiPreAggregateStatsResults = {
+    stats: PreAggregateDailyStatResult[];
+};
+
+export type ApiGetPreAggregateStatsResponse = {
+    status: 'ok';
+    results: KnexPaginatedData<ApiPreAggregateStatsResults>;
 };

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateFilters.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateFilters.tsx
@@ -1,0 +1,332 @@
+import {
+    Badge,
+    Button,
+    Popover,
+    Radio,
+    ScrollArea,
+    Stack,
+    Text,
+    Tooltip,
+} from '@mantine-8/core';
+import type { FC } from 'react';
+import {
+    ALL_QUERY_TYPES,
+    formatMissReason,
+    QUERY_TYPE_LABELS,
+    type QueryType,
+} from './preAggregateHelpers';
+import classes from './PreAggregateStatsTable.module.css';
+
+// --- Query Type Filter ---
+
+type QueryTypeFilterProps = {
+    selected: QueryType | null;
+    onChange: (value: QueryType | null) => void;
+};
+
+export const QueryTypeFilter: FC<QueryTypeFilterProps> = ({
+    selected,
+    onChange,
+}) => {
+    const hasSelection = selected !== null;
+
+    return (
+        <Popover width={250} position="bottom-start">
+            <Popover.Target>
+                <Tooltip withinPortal variant="xs" label="Filter by query type">
+                    <Button
+                        h={32}
+                        c="foreground"
+                        fw={500}
+                        fz="sm"
+                        variant="default"
+                        radius="md"
+                        px="sm"
+                        className={
+                            hasSelection
+                                ? classes.filterButtonSelected
+                                : classes.filterButton
+                        }
+                        rightSection={
+                            hasSelection ? (
+                                <Badge
+                                    size="xs"
+                                    variant="filled"
+                                    color="indigo.6"
+                                    circle
+                                >
+                                    1
+                                </Badge>
+                            ) : null
+                        }
+                    >
+                        Type
+                    </Button>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown p="sm">
+                <Stack gap={4}>
+                    <Text fz="xs" c="ldDark.3" fw={600}>
+                        Filter by type:
+                    </Text>
+                    <ScrollArea.Autosize mah={200} type="always" scrollbars="y">
+                        <Radio.Group
+                            value={selected ?? ''}
+                            onChange={(v) => onChange(v as QueryType)}
+                        >
+                            <Stack gap="xs">
+                                {ALL_QUERY_TYPES.map((type) => (
+                                    <Radio
+                                        key={type}
+                                        value={type}
+                                        label={QUERY_TYPE_LABELS[type]}
+                                        size="xs"
+                                    />
+                                ))}
+                            </Stack>
+                        </Radio.Group>
+                    </ScrollArea.Autosize>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+// --- Explore Filter ---
+
+type ExploreFilterProps = {
+    explores: string[];
+    selected: string | null;
+    onChange: (value: string | null) => void;
+};
+
+export const ExploreFilter: FC<ExploreFilterProps> = ({
+    explores,
+    selected,
+    onChange,
+}) => {
+    const hasSelection = selected !== null;
+
+    return (
+        <Popover width={250} position="bottom-start">
+            <Popover.Target>
+                <Tooltip withinPortal variant="xs" label="Filter by explore">
+                    <Button
+                        h={32}
+                        c="foreground"
+                        fw={500}
+                        fz="sm"
+                        variant="default"
+                        radius="md"
+                        px="sm"
+                        className={
+                            hasSelection
+                                ? classes.filterButtonSelected
+                                : classes.filterButton
+                        }
+                        rightSection={
+                            hasSelection ? (
+                                <Badge
+                                    size="xs"
+                                    variant="filled"
+                                    color="indigo.6"
+                                    circle
+                                >
+                                    1
+                                </Badge>
+                            ) : null
+                        }
+                    >
+                        Explore
+                    </Button>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown p="sm">
+                <Stack gap={4}>
+                    <Text fz="xs" c="ldDark.3" fw={600}>
+                        Filter by explore:
+                    </Text>
+                    <ScrollArea.Autosize mah={200} type="always" scrollbars="y">
+                        <Radio.Group
+                            value={selected ?? ''}
+                            onChange={(v) => onChange(v || null)}
+                        >
+                            <Stack gap="xs">
+                                {explores.map((explore) => (
+                                    <Radio
+                                        key={explore}
+                                        value={explore}
+                                        label={explore}
+                                        size="xs"
+                                    />
+                                ))}
+                            </Stack>
+                        </Radio.Group>
+                    </ScrollArea.Autosize>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+// --- Pre-aggregate Filter ---
+
+type PreAggregateFilterProps = {
+    names: string[];
+    selected: string | null;
+    onChange: (value: string | null) => void;
+};
+
+export const PreAggregateFilter: FC<PreAggregateFilterProps> = ({
+    names,
+    selected,
+    onChange,
+}) => {
+    const hasSelection = selected !== null;
+
+    return (
+        <Popover width={250} position="bottom-start">
+            <Popover.Target>
+                <Tooltip
+                    withinPortal
+                    variant="xs"
+                    label="Filter by pre-aggregate"
+                >
+                    <Button
+                        h={32}
+                        c="foreground"
+                        fw={500}
+                        fz="sm"
+                        variant="default"
+                        radius="md"
+                        px="sm"
+                        className={
+                            hasSelection
+                                ? classes.filterButtonSelected
+                                : classes.filterButton
+                        }
+                        rightSection={
+                            hasSelection ? (
+                                <Badge
+                                    size="xs"
+                                    variant="filled"
+                                    color="indigo.6"
+                                    circle
+                                >
+                                    1
+                                </Badge>
+                            ) : null
+                        }
+                    >
+                        Pre-aggregate
+                    </Button>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown p="sm">
+                <Stack gap={4}>
+                    <Text fz="xs" c="ldDark.3" fw={600}>
+                        Filter by pre-aggregate:
+                    </Text>
+                    <ScrollArea.Autosize mah={200} type="always" scrollbars="y">
+                        <Radio.Group
+                            value={selected ?? ''}
+                            onChange={(v) => onChange(v || null)}
+                        >
+                            <Stack gap="xs">
+                                {names.map((name) => (
+                                    <Radio
+                                        key={name}
+                                        value={name}
+                                        label={name}
+                                        size="xs"
+                                    />
+                                ))}
+                            </Stack>
+                        </Radio.Group>
+                    </ScrollArea.Autosize>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};
+
+// --- Miss Reason Filter ---
+
+type MissReasonFilterProps = {
+    reasons: string[];
+    selected: string | null;
+    onChange: (value: string | null) => void;
+};
+
+export const MissReasonFilter: FC<MissReasonFilterProps> = ({
+    reasons,
+    selected,
+    onChange,
+}) => {
+    const hasSelection = selected !== null;
+
+    return (
+        <Popover width={280} position="bottom-start">
+            <Popover.Target>
+                <Tooltip
+                    withinPortal
+                    variant="xs"
+                    label="Filter by miss reason"
+                >
+                    <Button
+                        h={32}
+                        c="foreground"
+                        fw={500}
+                        fz="sm"
+                        variant="default"
+                        radius="md"
+                        px="sm"
+                        className={
+                            hasSelection
+                                ? classes.filterButtonSelected
+                                : classes.filterButton
+                        }
+                        rightSection={
+                            hasSelection ? (
+                                <Badge
+                                    size="xs"
+                                    variant="filled"
+                                    color="indigo.6"
+                                    circle
+                                >
+                                    1
+                                </Badge>
+                            ) : null
+                        }
+                    >
+                        Reason
+                    </Button>
+                </Tooltip>
+            </Popover.Target>
+            <Popover.Dropdown p="sm">
+                <Stack gap={4}>
+                    <Text fz="xs" c="ldDark.3" fw={600}>
+                        Filter by miss reason:
+                    </Text>
+                    <ScrollArea.Autosize mah={200} type="always" scrollbars="y">
+                        <Radio.Group
+                            value={selected ?? ''}
+                            onChange={(v) => onChange(v || null)}
+                        >
+                            <Stack gap="xs">
+                                {reasons.map((reason) => (
+                                    <Radio
+                                        key={reason}
+                                        value={reason}
+                                        label={formatMissReason(reason)}
+                                        size="xs"
+                                    />
+                                ))}
+                            </Stack>
+                        </Radio.Group>
+                    </ScrollArea.Autosize>
+                </Stack>
+            </Popover.Dropdown>
+        </Popover>
+    );
+};

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.module.css
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.module.css
@@ -1,0 +1,30 @@
+.filterButton {
+    border: 1px dashed var(--mantine-color-ldGray-3);
+    background: var(--mantine-color-background-0);
+    box-shadow: var(--mantine-shadow-subtle);
+}
+
+.filterButton:hover {
+    border: 1px dashed var(--mantine-color-ldGray-4);
+    background: var(--mantine-color-ldGray-0);
+}
+
+.filterButtonSelected {
+    border: 1px solid var(--mantine-color-indigo-2);
+    background: var(--mantine-color-indigo-0);
+    box-shadow: var(--mantine-shadow-subtle);
+
+    @mixin dark {
+        background: var(--mantine-color-indigo-8);
+        border-color: var(--mantine-color-indigo-4);
+    }
+}
+
+.filterButtonSelected:hover {
+    border: 1px solid var(--mantine-color-indigo-3);
+    background: var(--mantine-color-indigo-1);
+
+    @mixin dark {
+        background: var(--mantine-color-indigo-9);
+    }
+}

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
@@ -1,0 +1,421 @@
+import { type PreAggregateDailyStatResult } from '@lightdash/common';
+import { Anchor, Group, Text, useMantineTheme } from '@mantine-8/core';
+import {
+    IconAlertTriangle,
+    IconArrowDown,
+    IconArrowsSort,
+    IconArrowUp,
+    IconChartBar,
+    IconClock,
+    IconCube,
+    IconLayoutDashboard,
+    IconTable,
+    IconTarget,
+} from '@tabler/icons-react';
+import {
+    MantineReactTable,
+    useMantineReactTable,
+    type MRT_ColumnDef,
+    type MRT_SortingState,
+} from 'mantine-react-table';
+import { useCallback, useMemo, useState, type FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+import {
+    aggregateStats,
+    formatMissReason,
+    type AggregatedRow,
+    type QueryType,
+} from './preAggregateHelpers';
+import PreAggregateTopToolbar from './PreAggregateTopToolbar';
+
+type Props = {
+    stats: PreAggregateDailyStatResult[];
+    isLoading: boolean;
+    isError: boolean;
+    projectUuid: string;
+};
+
+const PreAggregateStatsTable: FC<Props> = ({
+    stats,
+    isLoading,
+    isError,
+    projectUuid,
+}) => {
+    const theme = useMantineTheme();
+
+    const [sorting, setSorting] = useState<MRT_SortingState>([
+        { id: 'queries', desc: true },
+    ]);
+    const [selectedQueryType, setSelectedQueryType] =
+        useState<QueryType | null>(null);
+    const [selectedExplore, setSelectedExplore] = useState<string | null>(null);
+    const [selectedMissReason, setSelectedMissReason] = useState<string | null>(
+        null,
+    );
+    const [selectedPreAggregate, setSelectedPreAggregate] = useState<
+        string | null
+    >(null);
+
+    const hasActiveFilters =
+        selectedQueryType !== null ||
+        selectedExplore !== null ||
+        selectedMissReason !== null ||
+        selectedPreAggregate !== null;
+    const resetFilters = useCallback(() => {
+        setSelectedQueryType(null);
+        setSelectedExplore(null);
+        setSelectedMissReason(null);
+        setSelectedPreAggregate(null);
+    }, []);
+
+    const allRows = useMemo(() => aggregateStats(stats), [stats]);
+
+    const explores = useMemo(
+        () => [...new Set(allRows.map((r) => r.exploreName))].sort(),
+        [allRows],
+    );
+
+    const missReasons = useMemo(
+        () =>
+            [
+                ...new Set(
+                    allRows
+                        .map((r) => r.topMissReason)
+                        .filter((r): r is string => r !== null),
+                ),
+            ].sort(),
+        [allRows],
+    );
+
+    const preAggregateNames = useMemo(
+        () =>
+            [
+                ...new Set(
+                    allRows
+                        .map((r) => r.preAggregateName)
+                        .filter((r): r is string => r !== null),
+                ),
+            ].sort(),
+        [allRows],
+    );
+
+    const filteredRows = useMemo(() => {
+        let rows = allRows;
+        if (selectedExplore) {
+            rows = rows.filter((r) => r.exploreName === selectedExplore);
+        }
+        if (selectedPreAggregate) {
+            rows = rows.filter(
+                (r) => r.preAggregateName === selectedPreAggregate,
+            );
+        }
+        if (selectedQueryType) {
+            rows = rows.filter((r) => r.queryType === selectedQueryType);
+        }
+        if (selectedMissReason) {
+            rows = rows.filter((r) => r.topMissReason === selectedMissReason);
+        }
+        return rows;
+    }, [
+        allRows,
+        selectedExplore,
+        selectedPreAggregate,
+        selectedQueryType,
+        selectedMissReason,
+    ]);
+
+    const columns = useMemo<MRT_ColumnDef<AggregatedRow>[]>(
+        () => [
+            {
+                accessorKey: 'exploreName',
+                header: 'Explore',
+                enableSorting: false,
+                size: 160,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconTable} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Text size="xs" fw={500} ff="monospace">
+                        {row.original.exploreName}
+                    </Text>
+                ),
+            },
+            {
+                accessorKey: 'preAggregateName',
+                header: 'Pre-aggregate',
+                enableSorting: false,
+                size: 160,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconCube} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) =>
+                    row.original.preAggregateName ? (
+                        <Text size="xs" fw={500} ff="monospace">
+                            {row.original.preAggregateName}
+                        </Text>
+                    ) : (
+                        <Text size="xs" c="dimmed">
+                            {'\u2014'}
+                        </Text>
+                    ),
+            },
+            {
+                accessorKey: 'chartName',
+                header: 'Chart',
+                enableSorting: false,
+                size: 200,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconChartBar} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) =>
+                    row.original.chartUuid ? (
+                        <Anchor
+                            href={`/projects/${projectUuid}/saved/${row.original.chartUuid}`}
+                            target="_blank"
+                            size="xs"
+                        >
+                            {row.original.chartName}
+                        </Anchor>
+                    ) : (
+                        <Text size="xs" c="dimmed" fs="italic">
+                            Ad-hoc query
+                        </Text>
+                    ),
+            },
+            {
+                accessorKey: 'dashboardName',
+                header: 'Dashboard',
+                enableSorting: false,
+                size: 180,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon
+                            icon={IconLayoutDashboard}
+                            color="ldGray.6"
+                        />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) =>
+                    row.original.dashboardUuid ? (
+                        <Anchor
+                            href={`/projects/${projectUuid}/dashboards/${row.original.dashboardUuid}`}
+                            target="_blank"
+                            size="xs"
+                        >
+                            {row.original.dashboardName}
+                        </Anchor>
+                    ) : (
+                        <Text size="xs" c="dimmed">
+                            {'\u2014'}
+                        </Text>
+                    ),
+            },
+            {
+                id: 'queries',
+                header: 'Queries',
+                enableSorting: true,
+                size: 160,
+                accessorFn: (row) => row.hitCount + row.missCount,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconTarget} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const { hitCount, missCount } = row.original;
+                    return (
+                        <Group gap={8} wrap="nowrap">
+                            <Text size="xs" c="ldGray.6" ff="monospace">
+                                {hitCount} hit{hitCount !== 1 ? 's' : ''}
+                            </Text>
+                            <Text size="xs" c="ldGray.4" ff="monospace">
+                                /
+                            </Text>
+                            <Text
+                                size="xs"
+                                ff="monospace"
+                                c={missCount > 0 ? 'ldGray.8' : 'ldGray.4'}
+                                fw={missCount > 0 ? 500 : 400}
+                            >
+                                {missCount} miss{missCount !== 1 ? 'es' : ''}
+                            </Text>
+                        </Group>
+                    );
+                },
+                sortingFn: 'basic',
+            },
+            {
+                accessorKey: 'topMissReason',
+                header: 'Miss Reason',
+                enableSorting: false,
+                size: 200,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon
+                            icon={IconAlertTriangle}
+                            color="ldGray.6"
+                        />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => {
+                    const reason = row.original.topMissReason;
+                    return (
+                        <Text size="xs" c={reason ? 'ldGray.6' : 'ldGray.3'}>
+                            {formatMissReason(reason)}
+                        </Text>
+                    );
+                },
+            },
+            {
+                accessorKey: 'updatedAt',
+                header: 'Last Seen',
+                enableSorting: true,
+                size: 150,
+                Header: ({ column }) => (
+                    <Group gap="two" align="flex-start">
+                        <MantineIcon icon={IconClock} color="ldGray.6" />
+                        {column.columnDef.header}
+                    </Group>
+                ),
+                Cell: ({ row }) => (
+                    <Text size="xs" c="ldGray.6">
+                        {new Date(row.original.updatedAt).toLocaleString()}
+                    </Text>
+                ),
+                sortingFn: 'datetime',
+            },
+        ],
+        [projectUuid],
+    );
+
+    const table = useMantineReactTable({
+        columns,
+        data: filteredRows,
+        enableColumnResizing: false,
+        enableRowNumbers: false,
+        enablePagination: true,
+        paginationDisplayMode: 'pages',
+        initialState: {
+            pagination: { pageIndex: 0, pageSize: 20 },
+        },
+        enableFilters: false,
+        enableFullScreenToggle: false,
+        enableDensityToggle: false,
+        enableColumnActions: false,
+        enableColumnFilters: false,
+        enableHiding: false,
+        enableStickyHeader: true,
+        enableGlobalFilterModes: false,
+        enableSorting: true,
+        enableMultiSort: false,
+        enableTopToolbar: true,
+        enableBottomToolbar: true,
+        enableRowActions: false,
+        renderTopToolbar: () => (
+            <PreAggregateTopToolbar
+                explores={explores}
+                preAggregateNames={preAggregateNames}
+                missReasons={missReasons}
+                selectedExplore={selectedExplore}
+                setSelectedExplore={setSelectedExplore}
+                selectedPreAggregate={selectedPreAggregate}
+                setSelectedPreAggregate={setSelectedPreAggregate}
+                selectedQueryType={selectedQueryType}
+                setSelectedQueryType={setSelectedQueryType}
+                selectedMissReason={selectedMissReason}
+                setSelectedMissReason={setSelectedMissReason}
+                hasActiveFilters={hasActiveFilters}
+                resetFilters={resetFilters}
+            />
+        ),
+        mantinePaperProps: {
+            shadow: undefined,
+            style: {
+                border: `1px solid ${theme.colors.ldGray[2]}`,
+                borderRadius: theme.spacing.sm,
+                boxShadow: theme.shadows.subtle,
+                display: 'flex',
+                flexDirection: 'column',
+            },
+        },
+        mantineTableHeadRowProps: {
+            sx: {
+                boxShadow: 'none',
+            },
+        },
+        mantineTableContainerProps: {
+            style: { maxHeight: 'calc(100dvh - 450px)' },
+        },
+        mantineTableProps: {
+            highlightOnHover: true,
+            withColumnBorders: false,
+        },
+        mantineTableHeadCellProps: {
+            h: '3xl',
+            pos: 'relative',
+            style: {
+                padding: `${theme.spacing.xs} ${theme.spacing.md}`,
+                backgroundColor: theme.colors.ldGray[0],
+                fontWeight: 600,
+                fontSize: theme.fontSizes.xs,
+                justifyContent: 'center',
+            },
+            sx: {
+                '&:last-of-type': {
+                    borderLeft: 'none!important',
+                },
+            },
+        },
+        mantineTableBodyCellProps: {
+            sx: {
+                '&:last-of-type': {
+                    borderLeft: 'none!important',
+                },
+            },
+            style: {
+                padding: `${theme.spacing.xs} ${theme.spacing.md}`,
+                fontSize: theme.fontSizes.xs,
+                color: theme.colors.ldGray[7],
+            },
+        },
+        icons: {
+            IconArrowsSort: () => (
+                <MantineIcon icon={IconArrowsSort} size="md" color="ldGray.5" />
+            ),
+            IconSortAscending: () => (
+                <MantineIcon icon={IconArrowUp} size="md" color="blue.6" />
+            ),
+            IconSortDescending: () => (
+                <MantineIcon icon={IconArrowDown} size="md" color="blue.6" />
+            ),
+        },
+        state: {
+            isLoading,
+            showAlertBanner: isError,
+            density: 'md',
+            sorting,
+        },
+        mantinePaginationProps: {
+            showRowsPerPage: false,
+            color: 'dark',
+            size: 'sm',
+        },
+        onSortingChange: setSorting,
+    });
+
+    return <MantineReactTable table={table} />;
+};
+
+export default PreAggregateStatsTable;

--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateTopToolbar.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateTopToolbar.tsx
@@ -1,0 +1,93 @@
+import { ActionIcon, Group, Tooltip } from '@mantine-8/core';
+import { IconFilter, IconFilterOff } from '@tabler/icons-react';
+import type { FC } from 'react';
+import MantineIcon from '../common/MantineIcon';
+import {
+    ExploreFilter,
+    MissReasonFilter,
+    PreAggregateFilter,
+    QueryTypeFilter,
+} from './PreAggregateFilters';
+import type { QueryType } from './preAggregateHelpers';
+
+type Props = {
+    explores: string[];
+    preAggregateNames: string[];
+    missReasons: string[];
+    selectedExplore: string | null;
+    setSelectedExplore: (value: string | null) => void;
+    selectedPreAggregate: string | null;
+    setSelectedPreAggregate: (value: string | null) => void;
+    selectedQueryType: QueryType | null;
+    setSelectedQueryType: (value: QueryType | null) => void;
+    selectedMissReason: string | null;
+    setSelectedMissReason: (value: string | null) => void;
+    hasActiveFilters: boolean;
+    resetFilters: () => void;
+};
+
+const PreAggregateTopToolbar: FC<Props> = ({
+    explores,
+    preAggregateNames,
+    missReasons,
+    selectedExplore,
+    setSelectedExplore,
+    selectedPreAggregate,
+    setSelectedPreAggregate,
+    selectedQueryType,
+    setSelectedQueryType,
+    selectedMissReason,
+    setSelectedMissReason,
+    hasActiveFilters,
+    resetFilters,
+}) => {
+    return (
+        <Group
+            justify="space-between"
+            px="sm"
+            py="md"
+            wrap="nowrap"
+            style={(theme) => ({
+                borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
+            })}
+        >
+            <Group gap="xs" wrap="nowrap">
+                <MantineIcon icon={IconFilter} color="ldGray" />
+                <ExploreFilter
+                    explores={explores}
+                    selected={selectedExplore}
+                    onChange={setSelectedExplore}
+                />
+                <PreAggregateFilter
+                    names={preAggregateNames}
+                    selected={selectedPreAggregate}
+                    onChange={setSelectedPreAggregate}
+                />
+                <QueryTypeFilter
+                    selected={selectedQueryType}
+                    onChange={setSelectedQueryType}
+                />
+                <MissReasonFilter
+                    reasons={missReasons}
+                    selected={selectedMissReason}
+                    onChange={setSelectedMissReason}
+                />
+            </Group>
+            {hasActiveFilters && (
+                <Tooltip label="Reset filters">
+                    <ActionIcon
+                        variant="subtle"
+                        size="sm"
+                        color="gray"
+                        onClick={resetFilters}
+                        style={{ flexShrink: 0 }}
+                    >
+                        <MantineIcon icon={IconFilterOff} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
+        </Group>
+    );
+};
+
+export default PreAggregateTopToolbar;

--- a/packages/frontend/src/components/PreAggregateAudit/index.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/index.tsx
@@ -1,0 +1,142 @@
+import {
+    Button,
+    Card,
+    Group,
+    LoadingOverlay,
+    SimpleGrid,
+    Stack,
+    Text,
+    Title,
+} from '@mantine-8/core';
+import { IconRefresh } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
+import { useEffect, useMemo, type FC } from 'react';
+import useToaster from '../../hooks/toaster/useToaster';
+import { usePreAggregateStats } from '../../hooks/usePreAggregateStats';
+import { useProject } from '../../hooks/useProject';
+import MantineIcon from '../common/MantineIcon';
+import PreAggregateStatsTable from './PreAggregateStatsTable';
+
+type PreAggregateAuditProps = {
+    projectUuid: string;
+};
+
+const PreAggregateAudit: FC<PreAggregateAuditProps> = ({ projectUuid }) => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess } = useToaster();
+    const { isLoading: isLoadingProject } = useProject(projectUuid);
+    const {
+        data,
+        isLoading,
+        isError,
+        fetchNextPage,
+        hasNextPage,
+        isFetchingNextPage,
+    } = usePreAggregateStats(projectUuid, 3);
+
+    // Eagerly load all pages
+    useEffect(() => {
+        if (hasNextPage && !isFetchingNextPage) {
+            void fetchNextPage();
+        }
+    }, [hasNextPage, isFetchingNextPage, fetchNextPage]);
+
+    const stats = useMemo(
+        () => data?.pages.flatMap((page) => page.data.stats) ?? [],
+        [data],
+    );
+
+    const summary = useMemo(() => {
+        let totalHits = 0;
+        let totalMisses = 0;
+        const explores = new Set<string>();
+
+        for (const stat of stats) {
+            totalHits += stat.hitCount;
+            totalMisses += stat.missCount;
+            explores.add(stat.exploreName);
+        }
+
+        const totalQueries = totalHits + totalMisses;
+        const hitRate =
+            totalQueries > 0 ? Math.round((totalHits / totalQueries) * 100) : 0;
+
+        return {
+            hitRate,
+            totalQueries,
+            exploreCount: explores.size,
+        };
+    }, [stats]);
+
+    const handleRefresh = async () => {
+        await queryClient.invalidateQueries(['preAggregateStats', projectUuid]);
+        showToastSuccess({
+            title: 'Pre-aggregate stats refreshed',
+        });
+    };
+
+    return (
+        <>
+            <LoadingOverlay visible={isLoadingProject} />
+
+            <Stack gap="md">
+                <Group justify="space-between">
+                    <Stack gap={2}>
+                        <Title order={5}>Pre-Aggregate Audit</Title>
+                        <Text c="dimmed" size="xs">
+                            Track how often your pre-aggregates are being used.
+                            Data is retained for 3 days.
+                        </Text>
+                    </Stack>
+
+                    <Button
+                        onClick={handleRefresh}
+                        variant="default"
+                        size="xs"
+                        leftSection={<MantineIcon icon={IconRefresh} />}
+                    >
+                        Refresh stats
+                    </Button>
+                </Group>
+
+                <SimpleGrid cols={3}>
+                    <Card withBorder p="md">
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                            Hit Rate (3 days)
+                        </Text>
+                        <Text size="xl" fw={700}>
+                            {summary.totalQueries > 0
+                                ? `${summary.hitRate}%`
+                                : 'No data'}
+                        </Text>
+                    </Card>
+                    <Card withBorder p="md">
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                            Total Queries
+                        </Text>
+                        <Text size="xl" fw={700}>
+                            {summary.totalQueries}
+                        </Text>
+                    </Card>
+                    <Card withBorder p="md">
+                        <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
+                            Explores with Pre-Aggregates
+                        </Text>
+                        <Text size="xl" fw={700}>
+                            {summary.exploreCount}
+                        </Text>
+                    </Card>
+                </SimpleGrid>
+
+                <PreAggregateStatsTable
+                    stats={stats}
+                    isLoading={isLoading}
+                    isError={isError}
+                    projectUuid={projectUuid}
+                />
+            </Stack>
+        </>
+    );
+};
+
+export default PreAggregateAudit;

--- a/packages/frontend/src/components/PreAggregateAudit/preAggregateHelpers.ts
+++ b/packages/frontend/src/components/PreAggregateAudit/preAggregateHelpers.ts
@@ -1,0 +1,80 @@
+import {
+    preAggregateMissReasonLabels,
+    type PreAggregateDailyStatResult,
+    type PreAggregateMissReason,
+} from '@lightdash/common';
+
+export type QueryType = 'explorer' | 'chart' | 'dashboard';
+
+export const QUERY_TYPE_LABELS: Record<QueryType, string> = {
+    explorer: 'Ad-hoc Explorer',
+    chart: 'Saved Chart',
+    dashboard: 'Dashboard Chart',
+};
+
+export const ALL_QUERY_TYPES: QueryType[] = ['explorer', 'chart', 'dashboard'];
+
+export type AggregatedRow = {
+    chartName: string | null;
+    chartUuid: string | null;
+    dashboardName: string | null;
+    dashboardUuid: string | null;
+    exploreName: string;
+    queryContext: string;
+    queryType: QueryType;
+    hitCount: number;
+    missCount: number;
+    topMissReason: string | null;
+    preAggregateName: string | null;
+    updatedAt: string;
+};
+
+function getQueryType(row: PreAggregateDailyStatResult): QueryType {
+    if (row.dashboardUuid) return 'dashboard';
+    if (row.chartUuid) return 'chart';
+    return 'explorer';
+}
+
+export function aggregateStats(
+    stats: PreAggregateDailyStatResult[],
+): AggregatedRow[] {
+    const grouped = new Map<string, AggregatedRow>();
+
+    for (const stat of stats) {
+        const key = `${stat.exploreName}|${stat.chartUuid ?? 'adhoc'}|${stat.dashboardUuid ?? 'none'}|${stat.queryContext}`;
+
+        const existing = grouped.get(key);
+        if (existing) {
+            existing.hitCount += stat.hitCount;
+            existing.missCount += stat.missCount;
+            existing.topMissReason ??= stat.missReason;
+            if (stat.updatedAt > existing.updatedAt) {
+                existing.updatedAt = stat.updatedAt;
+            }
+        } else {
+            grouped.set(key, {
+                chartName: stat.chartName,
+                chartUuid: stat.chartUuid,
+                dashboardName: stat.dashboardName,
+                dashboardUuid: stat.dashboardUuid,
+                exploreName: stat.exploreName,
+                queryContext: stat.queryContext,
+                queryType: getQueryType(stat),
+                hitCount: stat.hitCount,
+                missCount: stat.missCount,
+                topMissReason: stat.missReason,
+                preAggregateName: stat.preAggregateName,
+                updatedAt: stat.updatedAt,
+            });
+        }
+    }
+
+    return Array.from(grouped.values());
+}
+
+export function formatMissReason(reason: string | null): string {
+    if (!reason) return '\u2014';
+    return (
+        preAggregateMissReasonLabels[reason as PreAggregateMissReason] ?? reason
+    );
+}

--- a/packages/frontend/src/hooks/usePreAggregateStats.ts
+++ b/packages/frontend/src/hooks/usePreAggregateStats.ts
@@ -1,0 +1,51 @@
+import {
+    type ApiError,
+    type ApiGetPreAggregateStatsResponse,
+    type KnexPaginateArgs,
+} from '@lightdash/common';
+import { useInfiniteQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+
+const getPreAggregateStats = async (
+    projectUuid: string,
+    days: number,
+    paginateArgs?: KnexPaginateArgs,
+) =>
+    lightdashApi<ApiGetPreAggregateStatsResponse['results']>({
+        version: 'v2',
+        url: `/projects/${projectUuid}/pre-aggregate-stats?days=${days}${
+            paginateArgs
+                ? `&page=${paginateArgs.page}&pageSize=${paginateArgs.pageSize}`
+                : ''
+        }`,
+        method: 'GET',
+        body: undefined,
+    });
+
+export const usePreAggregateStats = (
+    projectUuid: string,
+    days: number = 3,
+    pageSize: number = 100,
+) => {
+    return useInfiniteQuery<
+        ApiGetPreAggregateStatsResponse['results'],
+        ApiError
+    >({
+        queryKey: ['preAggregateStats', projectUuid, days, pageSize],
+        queryFn: ({ pageParam }) =>
+            getPreAggregateStats(projectUuid, days, {
+                page: (pageParam as number) ?? 1,
+                pageSize,
+            }),
+        getNextPageParam: (lastPage) => {
+            if (lastPage.pagination) {
+                return lastPage.pagination.page <
+                    lastPage.pagination.totalPageCount
+                    ? lastPage.pagination.page + 1
+                    : undefined;
+            }
+            return undefined;
+        },
+        enabled: !!projectUuid,
+    });
+};

--- a/packages/frontend/src/pages/ProjectSettings.tsx
+++ b/packages/frontend/src/pages/ProjectSettings.tsx
@@ -9,6 +9,7 @@ import SuboptimalState from '../components/common/SuboptimalState/SuboptimalStat
 import CompilationHistory from '../components/CompilationHistory';
 import { DataOps } from '../components/DataOps';
 import { DefaultUserSpaces } from '../components/DefaultUserSpaces';
+import PreAggregateAudit from '../components/PreAggregateAudit';
 import ProjectUserAccess from '../components/ProjectAccess';
 import { UpdateProjectConnection } from '../components/ProjectConnection';
 import ProjectParameters from '../components/ProjectParameters';
@@ -103,6 +104,10 @@ const ProjectSettings: FC = () => {
             {
                 path: `/compilationHistory`,
                 element: <CompilationHistory projectUuid={projectUuid} />,
+            },
+            {
+                path: `/preAggregateAudit`,
+                element: <PreAggregateAudit projectUuid={projectUuid} />,
             },
             {
                 path: '*',

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -476,6 +476,12 @@ const Settings: FC = () => {
                     path: '/generalSettings/customRoles/:roleId',
                 },
                 location.pathname,
+            ) &&
+            !matchPath(
+                {
+                    path: '/generalSettings/projectManagement/:projectUuid/preAggregateAudit',
+                },
+                location.pathname,
             )
         );
     }, [location.pathname]);
@@ -825,6 +831,19 @@ const Settings: FC = () => {
                                             <MantineIcon icon={IconRefresh} />
                                         }
                                     />
+
+                                    {health.preAggregates.enabled && (
+                                        <RouterNavLink
+                                            label="Pre-aggregate audit"
+                                            exact
+                                            to={`/generalSettings/projectManagement/${project.projectUuid}/preAggregateAudit`}
+                                            leftSection={
+                                                <MantineIcon
+                                                    icon={IconReportAnalytics}
+                                                />
+                                            }
+                                        />
+                                    )}
 
                                     <RouterNavLink
                                         label="Parameters"


### PR DESCRIPTION
Closes: [ZAP-259: Add audit log/trail for DashCache](https://linear.app/lightdash/issue/ZAP-259/add-audit-logtrail-for-dashcache)

# Add pre-aggregate statistics tracking and audit interface

### Description:

This PR introduces comprehensive pre-aggregate statistics tracking and an audit interface to monitor pre-aggregate usage and performance.

**Backend Changes:**
- Added `PreAggregateDailyStatsModel` and database table to track daily hit/miss statistics for pre-aggregates
- Created `PreAggregateStatsController` with API endpoint to retrieve aggregated statistics
- Integrated statistics collection into the query execution flow in `AsyncQueryService`
- Added database migration for the new `pre_aggregate_daily_stats` table with proper indexing
- Implemented automatic cleanup of old statistics data (3-day retention)

**Frontend Changes:**
- Added `PreAggregateAudit` component with filterable statistics table
- Created `PreAggregateStatsTable` with advanced filtering by query type, explore, and miss reason
- Added summary cards showing hit rate, total queries, and explore count
- Integrated audit interface into project settings navigation
- Added `usePreAggregateStats` hook for data fetching

**Key Features:**
- Real-time tracking of pre-aggregate hits and misses with detailed miss reasons
- Aggregated daily statistics with context about charts, dashboards, and ad-hoc queries
- Filterable audit interface with sorting and pagination
- Automatic data retention management
- Performance metrics and usage insights

The system provides visibility into pre-aggregate effectiveness, helping users optimize their pre-aggregate configurations and understand query patterns.