### PR TITLE
refactor(backend): replace project adapter inheritance with composition

### DIFF
--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -38,7 +38,7 @@ import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { ProjectParametersModel } from '../../../models/ProjectParametersModel';
 import { TagsModel } from '../../../models/TagsModel';
 import { UserAttributesModel } from '../../../models/UserAttributesModel';
-import { projectAdapterFromConfig } from '../../../projectAdapters/projectAdapter';
+import { projectAdapterFromConfigV2 as projectAdapterFromConfig } from '../../../projectAdapters/projectAdapter';
 import { EncryptionUtil } from '../../../utils/EncryptionUtil/EncryptionUtil';
 import { DbEmailIn } from '../../entities/emails';
 import { OnboardingTableName } from '../../entities/onboarding';

--- a/packages/backend/src/projectAdapters/ExploreCompiler.ts
+++ b/packages/backend/src/projectAdapters/ExploreCompiler.ts
@@ -1,0 +1,422 @@
+import {
+    AnyType,
+    attachTypesToModels,
+    convertExplores,
+    DbtManifestVersion,
+    DbtMetric,
+    DbtModelNode,
+    DbtPackages,
+    DbtRawModelNode,
+    DEFAULT_SPOTLIGHT_CONFIG,
+    Explore,
+    ExploreError,
+    friendlyName,
+    getCompiledModels,
+    getDbtManifestVersion,
+    getModelsFromManifest,
+    getSchemaStructureFromDbtModels,
+    InlineError,
+    InlineErrorType,
+    isSupportedDbtAdapter,
+    LightdashProjectConfig,
+    loadLightdashProjectConfig,
+    ManifestValidator,
+    MissingCatalogEntryError,
+    normaliseModelDatabase,
+    NotFoundError,
+    ParseError,
+    SupportedDbtAdapter,
+    SupportedDbtVersions,
+} from '@lightdash/common';
+import { WarehouseClient } from '@lightdash/warehouses';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
+import Logger from '../logging/logger';
+import { CachedWarehouse, ProjectAdapter, type TrackingParams } from '../types';
+import { ManifestProvider, ProfileGenerator, SourceAccessor } from './types';
+
+export type ExploreCompilerArgs = {
+    /** Provides the dbt manifest */
+    manifestProvider: ManifestProvider;
+    /** Provides access to project source files (optional for cloud/manifest modes) */
+    sourceAccessor?: SourceAccessor;
+    /** Generates dbt profiles (optional for cloud/manifest modes) */
+    profileGenerator?: ProfileGenerator;
+    /** Warehouse client for catalog and query operations */
+    warehouseClient: WarehouseClient;
+    /** Cached warehouse catalog for lazy type attachment */
+    cachedWarehouse: CachedWarehouse;
+    /** dbt version being used */
+    dbtVersion: SupportedDbtVersions;
+    /** Analytics instance for tracking */
+    analytics?: LightdashAnalytics;
+};
+
+/**
+ * ExploreCompiler is a composed ProjectAdapter that uses separate components
+ * for manifest retrieval, source access, and profile generation.
+ *
+ * This is the new architecture replacing the inheritance-based adapter chain.
+ */
+export class ExploreCompiler implements ProjectAdapter {
+    private readonly manifestProvider: ManifestProvider;
+
+    private readonly sourceAccessor: SourceAccessor | undefined;
+
+    private readonly profileGenerator: ProfileGenerator | undefined;
+
+    private readonly warehouseClient: WarehouseClient;
+
+    private readonly cachedWarehouse: CachedWarehouse;
+
+    private readonly dbtVersion: SupportedDbtVersions;
+
+    private readonly analytics: LightdashAnalytics | undefined;
+
+    constructor({
+        manifestProvider,
+        sourceAccessor,
+        profileGenerator,
+        warehouseClient,
+        cachedWarehouse,
+        dbtVersion,
+        analytics,
+    }: ExploreCompilerArgs) {
+        this.manifestProvider = manifestProvider;
+        this.sourceAccessor = sourceAccessor;
+        this.profileGenerator = profileGenerator;
+        this.warehouseClient = warehouseClient;
+        this.cachedWarehouse = cachedWarehouse;
+        this.dbtVersion = dbtVersion;
+        this.analytics = analytics;
+    }
+
+    async destroy(): Promise<void> {
+        Logger.debug('Destroy ExploreCompiler');
+        await this.manifestProvider.destroy();
+        await this.sourceAccessor?.destroy();
+        await this.profileGenerator?.destroy();
+    }
+
+    async test(): Promise<void> {
+        Logger.debug('Test ExploreCompiler');
+
+        // Refresh source if we have a source accessor
+        if (this.sourceAccessor) {
+            await this.sourceAccessor.test();
+        }
+
+        // Test manifest provider
+        await this.manifestProvider.test();
+
+        // Test warehouse client
+        await this.warehouseClient.test();
+    }
+
+    async getDbtPackages(): Promise<DbtPackages | undefined> {
+        Logger.debug('Get dbt packages');
+        if (this.manifestProvider.getDbtPackages) {
+            return this.manifestProvider.getDbtPackages();
+        }
+        return undefined;
+    }
+
+    async getLightdashProjectConfig(
+        trackingParams?: TrackingParams,
+    ): Promise<LightdashProjectConfig> {
+        const projectDir = this.sourceAccessor?.getProjectDirectory();
+
+        if (!projectDir) {
+            return {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            };
+        }
+
+        const configPath = path.join(projectDir, 'lightdash.config.yml');
+
+        try {
+            const fileContents = await fs.readFile(configPath, 'utf8');
+            const config = await loadLightdashProjectConfig(
+                fileContents,
+                async (lightdashConfig) => {
+                    if (trackingParams) {
+                        void this.analytics?.track({
+                            event: 'lightdashconfig.loaded',
+                            userId: trackingParams.userUuid,
+                            properties: {
+                                projectId: trackingParams.projectUuid,
+                                userId: trackingParams.userUuid,
+                                organizationId: trackingParams.organizationUuid,
+                                categories_count: Number(
+                                    Object.keys(
+                                        lightdashConfig.spotlight.categories ??
+                                            {},
+                                    ).length,
+                                ),
+                                default_visibility:
+                                    lightdashConfig.spotlight
+                                        .default_visibility,
+                            },
+                        });
+                    }
+                },
+            );
+            return config;
+        } catch (e) {
+            Logger.debug(`No lightdash.config.yml found in ${configPath}`);
+
+            if (e instanceof Error && 'code' in e && e.code === 'ENOENT') {
+                return {
+                    spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+                };
+            }
+            throw e;
+        }
+    }
+
+    async compileAllExplores(
+        trackingParams?: TrackingParams,
+        loadSources: boolean = false,
+        allowPartialCompilation: boolean = false,
+    ): Promise<(Explore | ExploreError)[]> {
+        // Refresh source files if we have a source accessor
+        if (this.sourceAccessor) {
+            Logger.debug('Refresh source files');
+            await this.sourceAccessor.refresh();
+        }
+
+        // Install dependencies if manifest provider supports it
+        if (this.manifestProvider.installDeps) {
+            Logger.debug('Install dependencies');
+            await this.manifestProvider.installDeps();
+        }
+
+        // Get the manifest
+        Logger.debug('Get dbt manifest');
+        const { manifest } = await this.manifestProvider.getManifest();
+
+        // Validate adapter type
+        if (!isSupportedDbtAdapter(manifest.metadata)) {
+            throw new ParseError(
+                `Dbt project not supported. Lightdash does not support adapter ${manifest.metadata.adapter_type}`,
+                {},
+            );
+        }
+
+        // Get models from manifest
+        let models: DbtRawModelNode[] = [];
+        const selector = this.manifestProvider.getSelector();
+
+        if (selector) {
+            Logger.info(`Manifest generated with selector "${selector}"`);
+            const manifestModels = getModelsFromManifest(manifest);
+            Logger.info(`Manifest models ${manifestModels.length}`);
+            const compiledModels = getCompiledModels(manifestModels, undefined);
+            Logger.info(`Compiled models ${compiledModels.length}`);
+            models = compiledModels.filter(
+                (node: AnyType) => node.resource_type === 'model' && node.meta,
+            ) as DbtRawModelNode[];
+            Logger.info(`Filtered models ${models.length}`);
+        } else {
+            const nodes = Object.values(manifest.nodes);
+            Logger.info(`Manifest models ${nodes.length}`);
+            models = nodes.filter(
+                (node: AnyType) => node.resource_type === 'model' && node.meta,
+            ) as DbtRawModelNode[];
+            Logger.info(`Filtered models ${models.length}`);
+        }
+
+        const adapterType = manifest.metadata.adapter_type;
+        const manifestVersion = getDbtManifestVersion(manifest);
+
+        Logger.info(
+            `Validate ${models.length} models in manifest with version ${manifestVersion}`,
+        );
+
+        if (models.length === 0) {
+            throw new NotFoundError('No models found');
+        }
+
+        // Validate models
+        const [validModels, failedExplores] = ExploreCompiler.validateDbtModel(
+            adapterType,
+            models,
+            manifestVersion,
+        );
+
+        // Validate metrics
+        const metrics = ExploreCompiler.validateDbtMetrics(
+            manifestVersion,
+            [
+                DbtManifestVersion.V10,
+                DbtManifestVersion.V11,
+                DbtManifestVersion.V12,
+            ].includes(manifestVersion)
+                ? []
+                : Object.values(manifest.metrics),
+        );
+
+        // Load lightdash project config
+        const lightdashProjectConfig =
+            await this.getLightdashProjectConfig(trackingParams);
+
+        // Try to attach types lazily first
+        try {
+            if (this.cachedWarehouse?.warehouseCatalog === undefined) {
+                throw new MissingCatalogEntryError(
+                    'Warehouse catalog is undefined',
+                    {},
+                );
+            }
+
+            Logger.info(`Attach types to ${validModels.length} models`);
+            const lazyTypedModels = attachTypesToModels(
+                validModels,
+                this.cachedWarehouse.warehouseCatalog,
+                true,
+                adapterType !== 'snowflake',
+            );
+
+            Logger.info('Convert explores');
+            const disableTimestampConversion =
+                this.warehouseClient.credentials.type === 'snowflake' &&
+                this.warehouseClient.credentials.disableTimestampConversion ===
+                    true;
+
+            const lazyExplores = await convertExplores(
+                lazyTypedModels,
+                loadSources,
+                adapterType,
+                metrics,
+                this.warehouseClient,
+                lightdashProjectConfig,
+                disableTimestampConversion,
+                allowPartialCompilation,
+            );
+
+            Logger.info('Finished compiling explores');
+            return [...lazyExplores, ...failedExplores];
+        } catch (e) {
+            if (e instanceof MissingCatalogEntryError) {
+                Logger.info(
+                    'Get warehouse catalog after missing catalog error',
+                );
+                const modelCatalog =
+                    getSchemaStructureFromDbtModels(validModels);
+                Logger.info(
+                    `Fetching table metadata for ${modelCatalog.length} tables`,
+                );
+
+                const warehouseCatalog =
+                    await this.warehouseClient.getCatalog(modelCatalog);
+                await this.cachedWarehouse?.onWarehouseCatalogChange(
+                    warehouseCatalog,
+                );
+
+                Logger.info(
+                    'Attach types to models after missing catalog error',
+                );
+                const typedModels = attachTypesToModels(
+                    validModels,
+                    warehouseCatalog,
+                    false,
+                    adapterType !== 'snowflake',
+                );
+
+                Logger.info('Convert explores after missing catalog error');
+                const disableTimestampConversion =
+                    this.warehouseClient.credentials.type === 'snowflake' &&
+                    this.warehouseClient.credentials
+                        .disableTimestampConversion === true;
+
+                const explores = await convertExplores(
+                    typedModels,
+                    loadSources,
+                    adapterType,
+                    metrics,
+                    this.warehouseClient,
+                    lightdashProjectConfig,
+                    disableTimestampConversion,
+                    allowPartialCompilation,
+                );
+
+                Logger.info(
+                    'Finished compiling explores after missing catalog error',
+                );
+                return [...explores, ...failedExplores];
+            }
+            throw e;
+        }
+    }
+
+    static validateDbtMetrics(
+        version: DbtManifestVersion,
+        metrics: DbtMetric[],
+    ): DbtMetric[] {
+        const validator = new ManifestValidator(version);
+        metrics.forEach((metric) => {
+            const [isValid, errorMessage] = validator.isDbtMetricValid(metric);
+            if (!isValid) {
+                throw new ParseError(
+                    `Could not parse dbt metric with id ${metric.unique_id}: ${errorMessage}`,
+                    {},
+                );
+            }
+        });
+        return metrics;
+    }
+
+    static validateDbtModel(
+        adapterType: SupportedDbtAdapter,
+        models: DbtRawModelNode[],
+        manifestVersion: DbtManifestVersion,
+    ): [DbtModelNode[], ExploreError[]] {
+        const validator = new ManifestValidator(manifestVersion);
+        return models.reduce(
+            ([validModels, invalidModels], model) => {
+                let error: InlineError | undefined;
+                const [isValid, errorMessage] = validator.isModelValid(model);
+
+                if (!isValid) {
+                    error = {
+                        type: InlineErrorType.METADATA_PARSE_ERROR,
+                        message: errorMessage,
+                    };
+                } else if (
+                    isValid &&
+                    Object.values(model.columns).length <= 0
+                ) {
+                    error = {
+                        type: InlineErrorType.NO_DIMENSIONS_FOUND,
+                        message: 'No dimensions available',
+                    };
+                }
+
+                if (error) {
+                    const exploreError: ExploreError = {
+                        name: model.name,
+                        label: model.meta.label || friendlyName(model.name),
+                        groupLabel: model.meta.group_label,
+                        errors: [
+                            error.type === InlineErrorType.METADATA_PARSE_ERROR
+                                ? {
+                                      ...error,
+                                      message: `${model.name ? `${model.name}: ` : ''}${error.message}`,
+                                  }
+                                : error,
+                        ],
+                    };
+                    return [validModels, [...invalidModels, exploreError]];
+                }
+
+                const validatedModel = normaliseModelDatabase(
+                    model,
+                    adapterType,
+                );
+                return [[...validModels, validatedModel], invalidModels];
+            },
+            [[] as DbtModelNode[], [] as ExploreError[]],
+        );
+    }
+}

--- a/packages/backend/src/projectAdapters/ProfileGenerator.ts
+++ b/packages/backend/src/projectAdapters/ProfileGenerator.ts
@@ -1,0 +1,120 @@
+import {
+    CreateWarehouseCredentials,
+    DbtProjectEnvironmentVariable,
+} from '@lightdash/common';
+import * as fs from 'fs';
+import * as fspromises from 'fs/promises';
+import * as path from 'path';
+import {
+    LIGHTDASH_PROFILE_NAME,
+    LIGHTDASH_TARGET_NAME,
+    profileFromCredentials,
+} from '../dbt/profiles';
+import Logger from '../logging/logger';
+import { ProfileGenerator, ProfileGeneratorResult } from './types';
+
+export type WarehouseProfileGeneratorArgs = {
+    /** Warehouse credentials to generate profile from */
+    warehouseCredentials: CreateWarehouseCredentials;
+    /** Optional custom target name (defaults to 'prod') */
+    targetName?: string;
+    /** Optional additional environment variables from project config */
+    environment?: DbtProjectEnvironmentVariable[];
+};
+
+/**
+ * ProfileGenerator implementation that generates dbt profiles from warehouse credentials.
+ * Creates a temporary directory containing profiles.yml and any additional required files.
+ */
+export class WarehouseProfileGenerator implements ProfileGenerator {
+    private readonly profilesDir: string;
+
+    private readonly targetName: string;
+
+    private readonly environment: Record<string, string>;
+
+    private generated: boolean = false;
+
+    constructor({
+        warehouseCredentials,
+        targetName,
+        environment,
+    }: WarehouseProfileGeneratorArgs) {
+        // Create temp directory for profiles
+        this.profilesDir = fs.mkdtempSync('/tmp/profiles_');
+        this.targetName = targetName || LIGHTDASH_TARGET_NAME;
+
+        // Generate profile from credentials
+        const {
+            profile,
+            environment: injectedEnvironment,
+            files,
+        } = profileFromCredentials(
+            warehouseCredentials,
+            this.profilesDir,
+            this.targetName,
+        );
+
+        // Write additional files (certificates, keys, etc.)
+        if (files) {
+            Object.entries(files).forEach(([filePath, content]) => {
+                fs.writeFileSync(filePath, content);
+            });
+        }
+
+        // Write profiles.yml
+        const profilesFilename = path.join(this.profilesDir, 'profiles.yml');
+        fs.writeFileSync(profilesFilename, profile);
+
+        // Merge user-provided environment with injected (credential) environment
+        const userEnvironment = (environment || []).reduce<
+            Record<string, string>
+        >(
+            (acc, { key, value }) => ({
+                ...acc,
+                ...(key.length > 0 ? { [key]: value } : {}), // ignore empty strings
+            }),
+            {},
+        );
+
+        this.environment = {
+            ...userEnvironment,
+            ...injectedEnvironment, // Credential env vars take precedence
+        };
+
+        this.generated = true;
+    }
+
+    generate(): ProfileGeneratorResult {
+        if (!this.generated) {
+            throw new Error(
+                'ProfileGenerator has been destroyed and cannot be used',
+            );
+        }
+
+        return {
+            profilesDir: this.profilesDir,
+            profileName: LIGHTDASH_PROFILE_NAME,
+            targetName: this.targetName,
+            environment: this.environment,
+        };
+    }
+
+    async destroy(): Promise<void> {
+        Logger.debug(`Destroy WarehouseProfileGenerator: ${this.profilesDir}`);
+        if (this.generated) {
+            await fspromises.rm(this.profilesDir, {
+                recursive: true,
+                force: true,
+            });
+            this.generated = false;
+        }
+    }
+}
+
+/**
+ * Factory function to create WarehouseProfileGenerator
+ */
+export const createProfileGenerator = (
+    args: WarehouseProfileGeneratorArgs,
+): ProfileGenerator => new WarehouseProfileGenerator(args);

--- a/packages/backend/src/projectAdapters/gitUrlBuilders.ts
+++ b/packages/backend/src/projectAdapters/gitUrlBuilders.ts
@@ -1,0 +1,118 @@
+import { validateGithubToken } from '@lightdash/common';
+import { GitUrlBuilder, GitUrlParams } from './types';
+
+const DEFAULT_GITHUB_HOST = 'github.com';
+const DEFAULT_GITLAB_HOST = 'gitlab.com';
+const DEFAULT_BITBUCKET_HOST = 'bitbucket.org';
+const AZURE_DEVOPS_HOST = 'dev.azure.com';
+
+/**
+ * Build a git URL for GitHub repositories.
+ * Supports custom host domains for GitHub Enterprise.
+ *
+ * @example
+ * githubUrlBuilder({ token: 'ghp_xxx', repository: 'org/repo' })
+ * // => 'https://lightdash:ghp_xxx@github.com/org/repo.git'
+ *
+ * githubUrlBuilder({ token: 'ghp_xxx', repository: 'org/repo', host: 'github.mycompany.com' })
+ * // => 'https://lightdash:ghp_xxx@github.mycompany.com/org/repo.git'
+ */
+export const githubUrlBuilder: GitUrlBuilder = ({
+    token,
+    repository,
+    host = DEFAULT_GITHUB_HOST,
+}: GitUrlParams): string => {
+    const [isValid, error] = validateGithubToken(token);
+    if (!isValid) {
+        throw new Error(error);
+    }
+    return `https://lightdash:${token}@${host}/${repository}.git`;
+};
+
+/**
+ * Build a git URL for GitLab repositories.
+ * Supports custom host domains for self-hosted GitLab.
+ *
+ * @example
+ * gitlabUrlBuilder({ token: 'glpat-xxx', repository: 'org/repo' })
+ * // => 'https://lightdash:glpat-xxx@gitlab.com/org/repo.git'
+ */
+export const gitlabUrlBuilder: GitUrlBuilder = ({
+    token,
+    repository,
+    host = DEFAULT_GITLAB_HOST,
+}: GitUrlParams): string =>
+    `https://lightdash:${token}@${host}/${repository}.git`;
+
+/**
+ * Build a git URL for Bitbucket repositories.
+ * Requires username in addition to token.
+ * Supports custom host domains for Bitbucket Server.
+ *
+ * @example
+ * bitbucketUrlBuilder({ token: 'xxx', repository: 'org/repo', username: 'user' })
+ * // => 'https://user:xxx@bitbucket.org/org/repo.git'
+ */
+export const bitbucketUrlBuilder: GitUrlBuilder = ({
+    token,
+    repository,
+    host = DEFAULT_BITBUCKET_HOST,
+    username,
+}: GitUrlParams): string => {
+    if (!username) {
+        throw new Error('Bitbucket requires a username');
+    }
+    return `https://${username}:${token}@${host}/${repository}.git`;
+};
+
+/**
+ * Build a git URL for Azure DevOps repositories.
+ * Requires organization and project in addition to repository name.
+ * Always uses dev.azure.com as the host.
+ *
+ * @example
+ * azureDevOpsUrlBuilder({
+ *   token: 'xxx',
+ *   repository: 'my-repo',
+ *   organization: 'my-org',
+ *   project: 'my-project'
+ * })
+ * // => 'https://xxx@dev.azure.com/my-org/my-project/_git/my-repo'
+ */
+export const azureDevOpsUrlBuilder: GitUrlBuilder = ({
+    token,
+    repository,
+    organization,
+    project,
+}: GitUrlParams): string => {
+    if (!organization) {
+        throw new Error('Azure DevOps requires an organization');
+    }
+    if (!project) {
+        throw new Error('Azure DevOps requires a project');
+    }
+    return `https://${token}@${AZURE_DEVOPS_HOST}/${organization}/${project}/_git/${repository}`;
+};
+
+/**
+ * Git provider types that match DbtProjectType values
+ */
+export type GitProvider = 'github' | 'gitlab' | 'bitbucket' | 'azure_devops';
+
+/**
+ * Get the appropriate URL builder for a git provider
+ */
+export const getGitUrlBuilder = (provider: GitProvider): GitUrlBuilder => {
+    switch (provider) {
+        case 'github':
+            return githubUrlBuilder;
+        case 'gitlab':
+            return gitlabUrlBuilder;
+        case 'bitbucket':
+            return bitbucketUrlBuilder;
+        case 'azure_devops':
+            return azureDevOpsUrlBuilder;
+        default:
+            throw new Error(`Unknown git provider: ${provider}`);
+    }
+};

--- a/packages/backend/src/projectAdapters/manifestProviders/DbtCliManifestProvider.ts
+++ b/packages/backend/src/projectAdapters/manifestProviders/DbtCliManifestProvider.ts
@@ -1,0 +1,74 @@
+import {
+    DbtPackages,
+    DbtRpcGetManifestResults,
+    SupportedDbtVersions,
+} from '@lightdash/common';
+import { DbtCliClient } from '../../dbt/dbtCliClient';
+import Logger from '../../logging/logger';
+import { DbtCliManifestProviderArgs, ManifestProvider } from '../types';
+
+/**
+ * ManifestProvider implementation that uses the dbt CLI to compile and get manifest.
+ * Wraps DbtCliClient to provide manifest access through the composition interface.
+ */
+export class DbtCliManifestProvider implements ManifestProvider {
+    private readonly dbtClient: DbtCliClient;
+
+    private readonly selector: string | undefined;
+
+    constructor({
+        projectDir,
+        profilesDir,
+        profileName,
+        target,
+        environment,
+        dbtVersion,
+        useDbtLs,
+        selector,
+    }: DbtCliManifestProviderArgs) {
+        this.dbtClient = new DbtCliClient({
+            dbtProjectDirectory: projectDir,
+            dbtProfilesDirectory: profilesDir,
+            environment,
+            profileName,
+            target,
+            dbtVersion,
+            useDbtLs,
+            selector,
+        });
+        this.selector = selector;
+    }
+
+    async getManifest(): Promise<DbtRpcGetManifestResults> {
+        return this.dbtClient.getDbtManifest();
+    }
+
+    async getDbtPackages(): Promise<DbtPackages | undefined> {
+        return this.dbtClient.getDbtPackages();
+    }
+
+    async installDeps(): Promise<void> {
+        return this.dbtClient.installDeps();
+    }
+
+    getSelector(): string | undefined {
+        return this.selector;
+    }
+
+    async test(): Promise<void> {
+        return this.dbtClient.test();
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async destroy(): Promise<void> {
+        Logger.debug('Destroy DbtCliManifestProvider');
+        // DbtCliClient doesn't have any resources to clean up
+    }
+}
+
+/**
+ * Factory function to create DbtCliManifestProvider
+ */
+export const createDbtCliManifestProvider = (
+    args: DbtCliManifestProviderArgs,
+): ManifestProvider => new DbtCliManifestProvider(args);

--- a/packages/backend/src/projectAdapters/manifestProviders/DbtCloudManifestProvider.ts
+++ b/packages/backend/src/projectAdapters/manifestProviders/DbtCloudManifestProvider.ts
@@ -1,0 +1,60 @@
+import { DbtPackages, DbtRpcGetManifestResults } from '@lightdash/common';
+import { DbtMetadataApiClient } from '../../dbt/DbtMetadataApiClient';
+import Logger from '../../logging/logger';
+import { DbtCloudManifestProviderArgs, ManifestProvider } from '../types';
+
+/**
+ * ManifestProvider implementation that fetches manifest from dbt Cloud Metadata API.
+ * Wraps DbtMetadataApiClient to provide manifest access through the composition interface.
+ */
+export class DbtCloudManifestProvider implements ManifestProvider {
+    private readonly dbtClient: DbtMetadataApiClient;
+
+    constructor({
+        environmentId,
+        bearerToken,
+        discoveryApiEndpoint,
+        tags,
+    }: DbtCloudManifestProviderArgs) {
+        this.dbtClient = new DbtMetadataApiClient({
+            environmentId,
+            bearerToken,
+            discoveryApiEndpoint,
+            tags,
+        });
+    }
+
+    async getManifest(): Promise<DbtRpcGetManifestResults> {
+        return this.dbtClient.getDbtManifest();
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async getDbtPackages(): Promise<DbtPackages | undefined> {
+        // dbt Cloud API doesn't provide packages.yml info
+        return undefined;
+    }
+
+    // dbt Cloud doesn't need to install deps - it's already done in the cloud
+    // No installDeps method needed
+
+    getSelector(): string | undefined {
+        return this.dbtClient.getSelector();
+    }
+
+    async test(): Promise<void> {
+        return this.dbtClient.test();
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async destroy(): Promise<void> {
+        Logger.debug('Destroy DbtCloudManifestProvider');
+        // DbtMetadataApiClient doesn't have any resources to clean up
+    }
+}
+
+/**
+ * Factory function to create DbtCloudManifestProvider
+ */
+export const createDbtCloudManifestProvider = (
+    args: DbtCloudManifestProviderArgs,
+): ManifestProvider => new DbtCloudManifestProvider(args);

--- a/packages/backend/src/projectAdapters/manifestProviders/StaticManifestProvider.ts
+++ b/packages/backend/src/projectAdapters/manifestProviders/StaticManifestProvider.ts
@@ -1,0 +1,85 @@
+import {
+    DbtError,
+    DbtPackages,
+    DbtRpcGetManifestResults,
+    isDbtRpcManifestResults,
+    UnexpectedServerError,
+} from '@lightdash/common';
+import Logger from '../../logging/logger';
+import { ManifestProvider } from '../types';
+
+export type StaticManifestProviderArgs = {
+    /** Raw JSON string of the manifest */
+    manifest: string;
+};
+
+/**
+ * ManifestProvider implementation that uses a pre-provided manifest JSON string.
+ * Useful for scenarios where the manifest is already available (e.g., from CLI deployment).
+ */
+export class StaticManifestProvider implements ManifestProvider {
+    private readonly manifest: string;
+
+    constructor({ manifest }: StaticManifestProviderArgs) {
+        this.manifest = manifest;
+    }
+
+    async getManifest(): Promise<DbtRpcGetManifestResults> {
+        if (!this.manifest) {
+            throw new UnexpectedServerError(
+                'Missing manifest in StaticManifestProvider',
+            );
+        }
+
+        let parsedManifest: unknown;
+        try {
+            parsedManifest = JSON.parse(this.manifest);
+        } catch (e) {
+            throw new DbtError(
+                'Cannot parse manifest JSON in StaticManifestProvider',
+            );
+        }
+
+        const rawManifest = {
+            manifest: parsedManifest,
+        };
+
+        if (isDbtRpcManifestResults(rawManifest)) {
+            return rawManifest;
+        }
+        throw new DbtError(
+            'Cannot read response from dbt, manifest.json not valid',
+        );
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async getDbtPackages(): Promise<DbtPackages | undefined> {
+        // Static manifest doesn't include packages.yml info
+        return undefined;
+    }
+
+    // No installDeps needed - manifest is already provided
+
+    // eslint-disable-next-line class-methods-use-this
+    getSelector(): string | undefined {
+        return undefined;
+    }
+
+    async test(): Promise<void> {
+        // Validate that manifest can be parsed
+        await this.getManifest();
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async destroy(): Promise<void> {
+        Logger.debug('Destroy StaticManifestProvider');
+        // Nothing to clean up
+    }
+}
+
+/**
+ * Factory function to create StaticManifestProvider
+ */
+export const createStaticManifestProvider = (
+    args: StaticManifestProviderArgs,
+): ManifestProvider => new StaticManifestProvider(args);

--- a/packages/backend/src/projectAdapters/manifestProviders/index.ts
+++ b/packages/backend/src/projectAdapters/manifestProviders/index.ts
@@ -1,0 +1,13 @@
+export {
+    DbtCliManifestProvider,
+    createDbtCliManifestProvider,
+} from './DbtCliManifestProvider';
+export {
+    DbtCloudManifestProvider,
+    createDbtCloudManifestProvider,
+} from './DbtCloudManifestProvider';
+export {
+    StaticManifestProvider,
+    createStaticManifestProvider,
+    type StaticManifestProviderArgs,
+} from './StaticManifestProvider';

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     CreateWarehouseCredentials,
     DbtProjectConfig,
     DbtProjectType,
@@ -21,6 +22,20 @@ import { DbtGitlabProjectAdapter } from './dbtGitlabProjectAdapter';
 import { DbtLocalCredentialsProjectAdapter } from './dbtLocalCredentialsProjectAdapter';
 import { DbtManifestProjectAdapter } from './dbtManifestProjectAdapter';
 import { DbtNoneCredentialsProjectAdapter } from './dbtNoneCredentialsProjectAdapter';
+import { ExploreCompiler } from './ExploreCompiler';
+import {
+    azureDevOpsUrlBuilder,
+    bitbucketUrlBuilder,
+    githubUrlBuilder,
+    gitlabUrlBuilder,
+} from './gitUrlBuilders';
+import {
+    DbtCliManifestProvider,
+    DbtCloudManifestProvider,
+    StaticManifestProvider,
+} from './manifestProviders';
+import { WarehouseProfileGenerator } from './ProfileGenerator';
+import { GitSourceAccessor, LocalSourceAccessor } from './sourceAccessors';
 
 export const projectAdapterFromConfig = async (
     config: DbtProjectConfig,
@@ -173,5 +188,329 @@ export const projectAdapterFromConfig = async (
         default:
             const never: never = config;
             throw new Error(`Adapter not implemented for type: ${configType}`);
+    }
+};
+
+/**
+ * V2 factory function using composition-based architecture.
+ * Creates a ProjectAdapter using the new ExploreCompiler with
+ * ManifestProvider, SourceAccessor, and ProfileGenerator components.
+ *
+ * This replaces the inheritance-based adapter chain with a more flexible
+ * composition approach that makes it easier to add new providers and features.
+ */
+export const projectAdapterFromConfigV2 = async (
+    config: DbtProjectConfig,
+    warehouseCredentials: CreateWarehouseCredentials,
+    cachedWarehouse: CachedWarehouse,
+    dbtVersionOption: DbtVersionOption,
+    useDbtLs: boolean = true,
+    analytics?: LightdashAnalytics,
+): Promise<ProjectAdapter> => {
+    Logger.debug(
+        `Initialize warehouse client of type ${warehouseCredentials.type} (V2)`,
+    );
+    const warehouseClient =
+        warehouseClientFromCredentials(warehouseCredentials);
+    const configType = config.type;
+    Logger.debug(`Initialize project adaptor of type ${configType} (V2)`);
+
+    const dbtVersion: SupportedDbtVersions =
+        dbtVersionOption === DbtVersionOptionLatest.LATEST
+            ? getLatestSupportDbtVersion()
+            : dbtVersionOption;
+
+    switch (config.type) {
+        case DbtProjectType.DBT: {
+            // Local dbt project with credentials
+            const sourceAccessor = new LocalSourceAccessor({
+                projectDir: config.project_dir || '/usr/app/dbt',
+            });
+
+            const profileGenerator = new WarehouseProfileGenerator({
+                warehouseCredentials,
+                targetName: config.target,
+                environment: config.environment,
+            });
+
+            const profileResult = profileGenerator.generate();
+
+            const manifestProvider = new DbtCliManifestProvider({
+                projectDir: sourceAccessor.getProjectDirectory(),
+                profilesDir: profileResult.profilesDir,
+                profileName: profileResult.profileName,
+                target: profileResult.targetName,
+                environment: profileResult.environment,
+                dbtVersion,
+                useDbtLs,
+                selector: config.selector,
+            });
+
+            return new ExploreCompiler({
+                manifestProvider,
+                sourceAccessor,
+                profileGenerator,
+                warehouseClient,
+                cachedWarehouse,
+                dbtVersion,
+                analytics,
+            });
+        }
+
+        case DbtProjectType.NONE:
+            // No dbt connection - just warehouse client
+            // Use the existing simple adapter since it doesn't need composition
+            return new DbtNoneCredentialsProjectAdapter({
+                warehouseClient,
+            });
+
+        case DbtProjectType.MANIFEST: {
+            // Pre-provided manifest JSON
+            const manifestProvider = new StaticManifestProvider({
+                manifest: config.manifest,
+            });
+
+            return new ExploreCompiler({
+                manifestProvider,
+                // No source accessor needed - manifest is provided
+                // No profile generator needed - no dbt CLI calls
+                warehouseClient,
+                cachedWarehouse,
+                dbtVersion,
+                analytics,
+            });
+        }
+
+        case DbtProjectType.DBT_CLOUD_IDE: {
+            // dbt Cloud IDE - fetch manifest from Metadata API
+            const manifestProvider = new DbtCloudManifestProvider({
+                environmentId: config.environment_id,
+                bearerToken: config.api_key,
+                discoveryApiEndpoint: config.discovery_api_endpoint,
+                tags: config.tags,
+            });
+
+            return new ExploreCompiler({
+                manifestProvider,
+                // No source accessor needed - dbt Cloud handles source
+                // No profile generator needed - no dbt CLI calls
+                warehouseClient,
+                cachedWarehouse,
+                dbtVersion,
+                analytics,
+            });
+        }
+
+        case DbtProjectType.GITHUB: {
+            // GitHub repository
+            const githubToken =
+                config.installation_id &&
+                config.authorization_method === 'installation_id'
+                    ? await getInstallationToken(config.installation_id)
+                    : config.personal_access_token;
+
+            if (githubToken === undefined) {
+                throw new ParameterError(
+                    `Missing github token for authorization method: ${
+                        config.authorization_method || 'personal access token'
+                    }`,
+                );
+            }
+
+            if (!config.repository) {
+                throw new ParameterError(
+                    `Missing repository for GitHub project`,
+                );
+            }
+
+            const sourceAccessor = new GitSourceAccessor({
+                urlBuilder: githubUrlBuilder,
+                urlParams: {
+                    token: githubToken,
+                    repository: config.repository,
+                    host: config.host_domain,
+                },
+                branch: config.branch,
+                projectSubPath: config.project_sub_path,
+            });
+
+            // Refresh source to ensure we have the repo cloned
+            await sourceAccessor.refresh();
+
+            const profileGenerator = new WarehouseProfileGenerator({
+                warehouseCredentials,
+                targetName: config.target,
+                environment: config.environment,
+            });
+
+            const profileResult = profileGenerator.generate();
+
+            const manifestProvider = new DbtCliManifestProvider({
+                projectDir: sourceAccessor.getProjectDirectory(),
+                profilesDir: profileResult.profilesDir,
+                profileName: profileResult.profileName,
+                target: profileResult.targetName,
+                environment: profileResult.environment,
+                dbtVersion,
+                useDbtLs,
+                selector: config.selector,
+            });
+
+            return new ExploreCompiler({
+                manifestProvider,
+                sourceAccessor,
+                profileGenerator,
+                warehouseClient,
+                cachedWarehouse,
+                dbtVersion,
+                analytics,
+            });
+        }
+
+        case DbtProjectType.GITLAB: {
+            // GitLab repository
+            const sourceAccessor = new GitSourceAccessor({
+                urlBuilder: gitlabUrlBuilder,
+                urlParams: {
+                    token: config.personal_access_token,
+                    repository: config.repository,
+                    host: config.host_domain,
+                },
+                branch: config.branch,
+                projectSubPath: config.project_sub_path,
+            });
+
+            // Refresh source to ensure we have the repo cloned
+            await sourceAccessor.refresh();
+
+            const profileGenerator = new WarehouseProfileGenerator({
+                warehouseCredentials,
+                targetName: config.target,
+                environment: config.environment,
+            });
+
+            const profileResult = profileGenerator.generate();
+
+            const manifestProvider = new DbtCliManifestProvider({
+                projectDir: sourceAccessor.getProjectDirectory(),
+                profilesDir: profileResult.profilesDir,
+                profileName: profileResult.profileName,
+                target: profileResult.targetName,
+                environment: profileResult.environment,
+                dbtVersion,
+                useDbtLs,
+                selector: config.selector,
+            });
+
+            return new ExploreCompiler({
+                manifestProvider,
+                sourceAccessor,
+                profileGenerator,
+                warehouseClient,
+                cachedWarehouse,
+                dbtVersion,
+                analytics,
+            });
+        }
+
+        case DbtProjectType.BITBUCKET: {
+            // Bitbucket repository
+            const sourceAccessor = new GitSourceAccessor({
+                urlBuilder: bitbucketUrlBuilder,
+                urlParams: {
+                    token: config.personal_access_token,
+                    repository: config.repository,
+                    host: config.host_domain,
+                    username: config.username,
+                },
+                branch: config.branch,
+                projectSubPath: config.project_sub_path,
+            });
+
+            // Refresh source to ensure we have the repo cloned
+            await sourceAccessor.refresh();
+
+            const profileGenerator = new WarehouseProfileGenerator({
+                warehouseCredentials,
+                targetName: config.target,
+                environment: config.environment,
+            });
+
+            const profileResult = profileGenerator.generate();
+
+            const manifestProvider = new DbtCliManifestProvider({
+                projectDir: sourceAccessor.getProjectDirectory(),
+                profilesDir: profileResult.profilesDir,
+                profileName: profileResult.profileName,
+                target: profileResult.targetName,
+                environment: profileResult.environment,
+                dbtVersion,
+                useDbtLs,
+                selector: config.selector,
+            });
+
+            return new ExploreCompiler({
+                manifestProvider,
+                sourceAccessor,
+                profileGenerator,
+                warehouseClient,
+                cachedWarehouse,
+                dbtVersion,
+                analytics,
+            });
+        }
+
+        case DbtProjectType.AZURE_DEVOPS: {
+            // Azure DevOps repository
+            const sourceAccessor = new GitSourceAccessor({
+                urlBuilder: azureDevOpsUrlBuilder,
+                urlParams: {
+                    token: config.personal_access_token,
+                    repository: config.repository,
+                    organization: config.organization,
+                    project: config.project,
+                },
+                branch: config.branch,
+                projectSubPath: config.project_sub_path,
+            });
+
+            // Refresh source to ensure we have the repo cloned
+            await sourceAccessor.refresh();
+
+            const profileGenerator = new WarehouseProfileGenerator({
+                warehouseCredentials,
+                targetName: config.target,
+                environment: config.environment,
+            });
+
+            const profileResult = profileGenerator.generate();
+
+            const manifestProvider = new DbtCliManifestProvider({
+                projectDir: sourceAccessor.getProjectDirectory(),
+                profilesDir: profileResult.profilesDir,
+                profileName: profileResult.profileName,
+                target: profileResult.targetName,
+                environment: profileResult.environment,
+                dbtVersion,
+                useDbtLs,
+                selector: config.selector,
+            });
+
+            return new ExploreCompiler({
+                manifestProvider,
+                sourceAccessor,
+                profileGenerator,
+                warehouseClient,
+                cachedWarehouse,
+                dbtVersion,
+                analytics,
+            });
+        }
+
+        default:
+            return assertUnreachable(
+                config,
+                `Adapter not implemented for type: ${configType}`,
+            );
     }
 };

--- a/packages/backend/src/projectAdapters/sourceAccessors/GitSourceAccessor.ts
+++ b/packages/backend/src/projectAdapters/sourceAccessors/GitSourceAccessor.ts
@@ -1,0 +1,208 @@
+import {
+    AuthorizationError,
+    getErrorMessage,
+    NotFoundError,
+    UnexpectedGitError,
+    UnexpectedServerError,
+} from '@lightdash/common';
+import * as fs from 'fs';
+import * as fspromises from 'fs-extra';
+import * as path from 'path';
+import simpleGit, {
+    GitError,
+    SimpleGit,
+    SimpleGitProgressEvent,
+} from 'simple-git';
+import Logger from '../../logging/logger';
+import { GitUrlBuilder, GitUrlParams, SourceAccessor } from '../types';
+
+export type GitSourceAccessorArgs = {
+    /** Function to build the authenticated git URL */
+    urlBuilder: GitUrlBuilder;
+    /** Parameters for the URL builder */
+    urlParams: GitUrlParams;
+    /** Branch to clone/pull */
+    branch: string;
+    /** Relative path to dbt project within the repository */
+    projectSubPath: string;
+};
+
+/**
+ * Strip tokens from URLs in error messages to prevent credential leakage
+ */
+const stripTokensFromUrls = (raw: string): string => {
+    const pattern = /\/\/(.*)@/g;
+    return raw.replace(pattern, '//*****@');
+};
+
+/**
+ * Convert git errors to appropriate Lightdash error types
+ */
+const handleGitError = (e: unknown, repository: string): never => {
+    if (!(e instanceof Error)) {
+        throw new UnexpectedServerError(
+            `Unexpected git error: ${getErrorMessage(e)}`,
+        );
+    }
+    if (e.message.includes('Authentication failed')) {
+        throw new AuthorizationError(
+            'Git credentials not recognized for this repository',
+            { message: e.message },
+        );
+    }
+    if (e.message.includes('Repository not found')) {
+        throw new NotFoundError(
+            `Could not find git repository "${repository}". Check that your personal access token has access to the repository and that the repository name is correct.`,
+        );
+    }
+    if (e instanceof GitError) {
+        throw new UnexpectedGitError(
+            `Error while running "${e.task?.commands[0]}": ${stripTokensFromUrls(e.message)}`,
+        );
+    }
+    throw new UnexpectedGitError(
+        `Unexpected error while cloning git repository: ${e}`,
+    );
+};
+
+/**
+ * SourceAccessor implementation that clones/pulls from git repositories.
+ * Uses URL builders to construct authenticated URLs for different git providers.
+ */
+export class GitSourceAccessor implements SourceAccessor {
+    private readonly remoteUrl: string;
+
+    private readonly repository: string;
+
+    private readonly branch: string;
+
+    private readonly projectSubPath: string;
+
+    private readonly localRepositoryDir: string;
+
+    private readonly projectDir: string;
+
+    private readonly git: SimpleGit;
+
+    private hasCloned: boolean = false;
+
+    constructor({
+        urlBuilder,
+        urlParams,
+        branch,
+        projectSubPath,
+    }: GitSourceAccessorArgs) {
+        this.remoteUrl = urlBuilder(urlParams);
+        this.repository = urlParams.repository;
+        this.branch = branch;
+        this.projectSubPath = projectSubPath;
+        this.localRepositoryDir = fs.mkdtempSync('/tmp/git_');
+        this.projectDir = path.join(this.localRepositoryDir, projectSubPath);
+        this.git = simpleGit({
+            progress({ method, stage, progress }: SimpleGitProgressEvent) {
+                Logger.debug(
+                    `git.${method} ${stage} stage ${progress}% complete`,
+                );
+            },
+        });
+    }
+
+    getProjectDirectory(): string {
+        return this.projectDir;
+    }
+
+    async refresh(): Promise<void> {
+        if (!this.hasCloned) {
+            await this.clone();
+        } else {
+            await this.refreshRepo();
+        }
+    }
+
+    async test(): Promise<void> {
+        // Clone the repo to verify we can access it
+        await this.refresh();
+    }
+
+    async destroy(): Promise<void> {
+        Logger.debug(`Destroy GitSourceAccessor: ${this.localRepositoryDir}`);
+        try {
+            await fspromises.rm(this.localRepositoryDir, {
+                recursive: true,
+                force: true,
+            });
+        } catch (e) {
+            throw new UnexpectedServerError(
+                `Unexpected error while removing local git directory: ${e}`,
+            );
+        }
+    }
+
+    private async clone(): Promise<void> {
+        try {
+            const cloneOptions = {
+                '--single-branch': null,
+                '--depth': 1,
+                '--branch': this.branch,
+                '--no-tags': null,
+                '--progress': null,
+            };
+
+            Logger.debug(`Git clone to ${this.localRepositoryDir}`);
+            await this.git
+                .env('GIT_TERMINAL_PROMPT', '0')
+                .clone(this.remoteUrl, this.localRepositoryDir, cloneOptions);
+
+            this.hasCloned = true;
+        } catch (e) {
+            handleGitError(e, this.repository);
+        }
+    }
+
+    private async pull(): Promise<void> {
+        try {
+            Logger.debug(`Git pull to ${this.localRepositoryDir}`);
+            await fspromises.access(this.localRepositoryDir);
+            await this.git
+                .env('GIT_TERMINAL_PROMPT', '0')
+                .cwd(this.localRepositoryDir)
+                .pull(this.remoteUrl, this.branch, {
+                    '--ff-only': null,
+                    '--depth': 1,
+                    '--no-tags': null,
+                    '--progress': null,
+                });
+        } catch (e) {
+            handleGitError(e, this.repository);
+        }
+    }
+
+    private async cleanLocal(): Promise<void> {
+        try {
+            Logger.debug(`Clean ${this.localRepositoryDir}`);
+            await fspromises.emptyDir(this.localRepositoryDir);
+            this.hasCloned = false;
+        } catch (e) {
+            throw new UnexpectedServerError(
+                `Unexpected error while cleaning local git directory: ${e}`,
+            );
+        }
+    }
+
+    private async refreshRepo(): Promise<void> {
+        try {
+            await this.pull();
+        } catch (e) {
+            Logger.debug(`Failed git pull, falling back to clone: ${e}`);
+            await this.cleanLocal();
+            await this.clone();
+        }
+    }
+}
+
+/**
+ * Factory function to create GitSourceAccessor
+ */
+export const createGitSourceAccessor = (
+    args: GitSourceAccessorArgs,
+): SourceAccessor => new GitSourceAccessor(args);

--- a/packages/backend/src/projectAdapters/sourceAccessors/LocalSourceAccessor.ts
+++ b/packages/backend/src/projectAdapters/sourceAccessors/LocalSourceAccessor.ts
@@ -1,0 +1,61 @@
+import { DbtError } from '@lightdash/common';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import Logger from '../../logging/logger';
+import { SourceAccessor } from '../types';
+
+export type LocalSourceAccessorArgs = {
+    /** Path to the dbt project directory */
+    projectDir: string;
+};
+
+/**
+ * SourceAccessor implementation for local filesystem dbt projects.
+ * Simply validates that the project directory exists.
+ */
+export class LocalSourceAccessor implements SourceAccessor {
+    private readonly projectDir: string;
+
+    constructor({ projectDir }: LocalSourceAccessorArgs) {
+        this.projectDir = projectDir;
+    }
+
+    getProjectDirectory(): string {
+        return this.projectDir;
+    }
+
+    async refresh(): Promise<void> {
+        // Local filesystem doesn't need refreshing
+        // Just validate the directory still exists
+        await this.test();
+    }
+
+    async test(): Promise<void> {
+        try {
+            await fs.access(this.projectDir);
+            // Also check for dbt_project.yml to verify it's a valid dbt project
+            const dbtProjectPath = path.join(
+                this.projectDir,
+                'dbt_project.yml',
+            );
+            await fs.access(dbtProjectPath);
+        } catch (e) {
+            throw new DbtError(
+                `dbt project directory not found or invalid: ${path.basename(this.projectDir)}`,
+            );
+        }
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    async destroy(): Promise<void> {
+        Logger.debug('Destroy LocalSourceAccessor');
+        // Local filesystem accessor doesn't own the directory, so nothing to clean up
+    }
+}
+
+/**
+ * Factory function to create LocalSourceAccessor
+ */
+export const createLocalSourceAccessor = (
+    args: LocalSourceAccessorArgs,
+): SourceAccessor => new LocalSourceAccessor(args);

--- a/packages/backend/src/projectAdapters/sourceAccessors/index.ts
+++ b/packages/backend/src/projectAdapters/sourceAccessors/index.ts
@@ -1,0 +1,10 @@
+export {
+    GitSourceAccessor,
+    createGitSourceAccessor,
+    type GitSourceAccessorArgs,
+} from './GitSourceAccessor';
+export {
+    LocalSourceAccessor,
+    createLocalSourceAccessor,
+    type LocalSourceAccessorArgs,
+} from './LocalSourceAccessor';

--- a/packages/backend/src/projectAdapters/types.ts
+++ b/packages/backend/src/projectAdapters/types.ts
@@ -1,0 +1,138 @@
+import {
+    DbtPackages,
+    DbtRpcGetManifestResults,
+    SupportedDbtVersions,
+} from '@lightdash/common';
+
+/**
+ * Provides manifest from various sources (dbt CLI, dbt Cloud, static JSON).
+ * Responsible for obtaining the dbt manifest that contains model definitions.
+ */
+export interface ManifestProvider {
+    /**
+     * Get the dbt manifest containing model definitions
+     */
+    getManifest(): Promise<DbtRpcGetManifestResults>;
+
+    /**
+     * Get the dbt packages.yml content if available
+     */
+    getDbtPackages?(): Promise<DbtPackages | undefined>;
+
+    /**
+     * Install dbt dependencies (dbt deps)
+     */
+    installDeps?(): Promise<void>;
+
+    /**
+     * Get the selector used to filter models (if any)
+     */
+    getSelector(): string | undefined;
+
+    /**
+     * Test the connection to the manifest source
+     */
+    test(): Promise<void>;
+
+    /**
+     * Clean up any resources
+     */
+    destroy(): Promise<void>;
+}
+
+/**
+ * Provides access to project source files (local filesystem or git repository).
+ * Responsible for ensuring the project files are available locally.
+ */
+export interface SourceAccessor {
+    /**
+     * Get the path to the project directory containing dbt project files
+     */
+    getProjectDirectory(): string;
+
+    /**
+     * Refresh the source files (e.g., git pull)
+     */
+    refresh(): Promise<void>;
+
+    /**
+     * Test the connection to the source
+     */
+    test(): Promise<void>;
+
+    /**
+     * Clean up any resources (e.g., remove temp directories)
+     */
+    destroy(): Promise<void>;
+}
+
+/**
+ * Result of profile generation
+ */
+export type ProfileGeneratorResult = {
+    /** Path to the directory containing profiles.yml */
+    profilesDir: string;
+    /** The profile name to use */
+    profileName: string;
+    /** The target name to use */
+    targetName: string;
+    /** Environment variables to set for dbt (containing sensitive credentials) */
+    environment: Record<string, string>;
+};
+
+/**
+ * Generates dbt profiles for warehouse connections.
+ * Responsible for creating profiles.yml and managing credentials securely.
+ */
+export interface ProfileGenerator {
+    /**
+     * Generate the profile and return the result
+     */
+    generate(): ProfileGeneratorResult;
+
+    /**
+     * Clean up any resources (e.g., remove temp profile directory)
+     */
+    destroy(): Promise<void>;
+}
+
+/**
+ * Configuration for creating a DbtCliManifestProvider
+ */
+export type DbtCliManifestProviderArgs = {
+    projectDir: string;
+    profilesDir: string;
+    profileName: string;
+    target: string;
+    environment: Record<string, string>;
+    dbtVersion: SupportedDbtVersions;
+    useDbtLs: boolean;
+    selector?: string;
+};
+
+/**
+ * Configuration for creating a DbtCloudManifestProvider
+ */
+export type DbtCloudManifestProviderArgs = {
+    environmentId: string | number;
+    bearerToken: string;
+    discoveryApiEndpoint: string | undefined;
+    tags: string[] | undefined;
+};
+
+/**
+ * Git URL builder function signature
+ */
+export type GitUrlBuilder = (params: GitUrlParams) => string;
+
+/**
+ * Parameters for git URL builders
+ */
+export type GitUrlParams = {
+    token: string;
+    repository: string;
+    host?: string;
+    username?: string;
+    organization?: string;
+    project?: string;
+};

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -229,7 +229,7 @@ import { UserWarehouseCredentialsModel } from '../../models/UserWarehouseCredent
 import { WarehouseAvailableTablesModel } from '../../models/WarehouseAvailableTablesModel/WarehouseAvailableTablesModel';
 import { isFeatureFlagEnabled } from '../../postHog';
 import { DbtBaseProjectAdapter } from '../../projectAdapters/dbtBaseProjectAdapter';
-import { projectAdapterFromConfig } from '../../projectAdapters/projectAdapter';
+import { projectAdapterFromConfigV2 as projectAdapterFromConfig } from '../../projectAdapters/projectAdapter';
 import { compileMetricQuery } from '../../queryCompiler';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { ProjectAdapter } from '../../types';


### PR DESCRIPTION
## Summary

- Replace 6-level inheritance chain in project adapters with composition-based architecture
- Add three core interfaces: `ManifestProvider`, `SourceAccessor`, `ProfileGenerator`
- Create `ExploreCompiler` as the new composed `ProjectAdapter` implementation
- Add pure functions for git URL building (GitHub, GitLab, Bitbucket, Azure DevOps)
- Switch to V2 factory as default implementation

## Architecture

```
┌─────────────────────────────────────────┐
│        ExploreCompiler                  │
│   (implements ProjectAdapter)           │
└─────────────────────────────────────────┘
         ↓          ↓          ↓
    ┌────────┐  ┌────────┐  ┌──────────┐
    │Manifest│  │Source  │  │Profile   │
    │Provider│  │Accessor│  │Generator │
    └────────┘  └────────┘  └──────────┘
         ↓          ↓
    • DbtCli       • Local
    • DbtCloud     • Git (+ URL builders)
    • Static
```

## Benefits

- **~90% less code** for git providers (URL builders are pure functions)
- **Composable** - Mix manifest sources with source accessors freely
- **Testable** - Each component has a focused interface
- **Extensible** - Adding new providers requires minimal code

## Files Added

| File | Purpose |
|------|---------|
| `types.ts` | Core interfaces (ManifestProvider, SourceAccessor, ProfileGenerator) |
| `gitUrlBuilders.ts` | Pure functions for GitHub, GitLab, Bitbucket, Azure DevOps |
| `manifestProviders/` | DbtCli, DbtCloud, Static manifest providers |
| `sourceAccessors/` | Local filesystem and Git source accessors |
| `ProfileGenerator.ts` | Generates profiles.yml from warehouse credentials |
| `ExploreCompiler.ts` | Composed ProjectAdapter implementation |

## Test plan

- [x] Backend typecheck passes
- [x] Backend lint passes  
- [x] Backend unit tests pass (100/100)
- [ ] E2E tests for `DbtProjectType.DBT` (createProjects.cy.ts)
- [ ] E2E tests for `DbtProjectType.MANIFEST` (createPreviewWithManifest.cy.ts)

## Follow-up

Legacy adapter classes are kept for now and can be removed in a follow-up PR after e2e validation.