### PR TITLE
chore: add prometheus metrics on materialization of pre-aggregates

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -249,6 +249,7 @@ export default class App {
     async start() {
         this.prometheusMetrics.start();
         this.prometheusMetrics.monitorDatabase(this.database);
+        this.prometheusMetrics.monitorPreAggregates(this.database);
         // @ts-ignore
         // eslint-disable-next-line no-extend-native, func-names
         BigInt.prototype.toJSON = function () {

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -179,6 +179,7 @@ export default class SchedulerApp {
 
         this.prometheusMetrics.start();
         this.prometheusMetrics.monitorDatabase(this.database);
+        this.prometheusMetrics.monitorPreAggregates(this.database);
         // @ts-ignore
         // eslint-disable-next-line no-extend-native, func-names
         BigInt.prototype.toJSON = function () {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2266,6 +2266,13 @@ export class AsyncQueryService extends ProjectService {
             context,
         });
 
+        if (routingDecision.preAggregateMetadata) {
+            this.prometheusMetrics?.incrementPreAggregateMatch(
+                routingDecision.preAggregateMetadata.hit,
+                routingDecision.preAggregateMetadata.reason?.reason,
+            );
+        }
+
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
                 account,
@@ -2484,6 +2491,13 @@ export class AsyncQueryService extends ProjectService {
             explore,
             context,
         });
+
+        if (routingDecision.preAggregateMetadata) {
+            this.prometheusMetrics?.incrementPreAggregateMatch(
+                routingDecision.preAggregateMetadata.hit,
+                routingDecision.preAggregateMetadata.reason?.reason,
+            );
+        }
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
@@ -2759,6 +2773,13 @@ export class AsyncQueryService extends ProjectService {
             explore,
             context,
         });
+
+        if (routingDecision.preAggregateMetadata) {
+            this.prometheusMetrics?.incrementPreAggregateMatch(
+                routingDecision.preAggregateMetadata.hit,
+                routingDecision.preAggregateMetadata.reason?.reason,
+            );
+        }
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -549,6 +549,7 @@ export class ServiceRepository
                     preAggregateModel: this.models.getPreAggregateModel(),
                     queryHistoryModel: this.models.getQueryHistoryModel(),
                     asyncQueryService: this.getAsyncQueryService(),
+                    prometheusMetrics: this.prometheusMetrics,
                 }),
         );
     }


### PR DESCRIPTION
Closes: [ZAP-258: Add prometheus metrics](https://linear.app/lightdash/issue/ZAP-258/add-prometheus-metrics)

## Add Prometheus metrics for pre-aggregate monitoring

### Description:

This PR introduces comprehensive Prometheus metrics for monitoring pre-aggregate functionality across the application.

**New metrics added:**
- `pre_aggregate_match_total` - Counter tracking hit/miss results with miss reasons
- `pre_aggregate_materialization_total` - Counter for materialization outcomes by status and trigger
- `pre_aggregate_materialization_duration_ms` - Histogram measuring materialization duration with configurable buckets (1s to 30min)
- `pre_aggregate_active_materializations` - Gauge showing current count of active materializations

**Key changes:**
- Added `monitorPreAggregates()` method to PrometheusMetrics class with database monitoring for active materializations
- Integrated pre-aggregate match tracking in AsyncQueryService to record hits/misses with specific reasons
- Enhanced PreAggregateMaterializationService with comprehensive timing and outcome tracking for all materialization attempts
- Enabled pre-aggregate monitoring in both main App and SchedulerApp startup sequences

The metrics provide visibility into pre-aggregate performance, success rates, and system load to help with optimization and troubleshooting.

logs:

```
# HELP pre_aggregate_match_total Total number of pre-aggregate match attempts
# TYPE pre_aggregate_match_total counter
pre_aggregate_match_total{result="hit",miss_reason="none"} 2

# HELP pre_aggregate_materialization_total Total number of pre-aggregate materializations by outcome
# TYPE pre_aggregate_materialization_total counter
pre_aggregate_materialization_total{status="active",trigger="compile"} 2

# HELP pre_aggregate_materialization_duration_ms Histogram of pre-aggregate materialization duration in milliseconds
# TYPE pre_aggregate_materialization_duration_ms histogram
pre_aggregate_materialization_duration_ms_bucket{le="1000",status="active",trigger="compile"} 0
pre_aggregate_materialization_duration_ms_bucket{le="5000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="10000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="30000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="60000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="120000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="300000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="600000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="900000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="1800000",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_bucket{le="+Inf",status="active",trigger="compile"} 2
pre_aggregate_materialization_duration_ms_sum{status="active",trigger="compile"} 2132
pre_aggregate_materialization_duration_ms_count{status="active",trigger="compile"} 2

```

analysis:
`
There were 2 materializations (_count = 2), both triggered by compile, both succeeded (active).

  The buckets show both took between 1s and 5s — 0 observations fell in the ≤1000ms bucket, but 2 fell in the ≤5000ms
  bucket. The _sum of 2128ms across 2 observations gives an average of ~1064ms per materialization.
`