### PR TITLE
feat: add development seed for personal access tokens

### DIFF
--- a/packages/backend/src/database/seeds/development/13_personal_access_token.ts
+++ b/packages/backend/src/database/seeds/development/13_personal_access_token.ts
@@ -1,0 +1,26 @@
+import { SEED_ORG_1_ADMIN, SEED_PAT } from '@lightdash/common';
+import { Knex } from 'knex';
+import { hash } from '../../../utils/hash';
+import { PersonalAccessTokenTableName } from '../../entities/personalAccessTokens';
+
+export async function seed(knex: Knex): Promise<void> {
+    // Clean existing PATs for the admin user
+    const [user] = await knex('users')
+        .where('user_uuid', SEED_ORG_1_ADMIN.user_uuid)
+        .select('user_id');
+
+    if (!user) return;
+
+    await knex(PersonalAccessTokenTableName)
+        .where('created_by_user_id', user.user_id)
+        .del();
+
+    const tokenHash = await hash(SEED_PAT.token);
+
+    await knex(PersonalAccessTokenTableName).insert({
+        created_by_user_id: user.user_id,
+        description: SEED_PAT.description,
+        token_hash: tokenHash,
+        expires_at: null, // never expires
+    });
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -392,6 +392,13 @@ export const SEED_ORG_2_ADMIN_PASSWORD = {
 export const SEED_ORG_2_ADMIN_ROLE = OrganizationMemberRole.ADMIN;
 export const SEED_EMBED_SECRET = 'zU3h50saDOO20czNFNRok';
 
+// Deterministic PAT for dev environment
+// Use with: Authorization: ApiKey ldpat_deadbeefdeadbeefdeadbeefdeadbeef
+export const SEED_PAT = {
+    token: 'ldpat_deadbeefdeadbeefdeadbeefdeadbeef',
+    description: 'Dev seed PAT',
+};
+
 export const SEED_PROJECT = {
     project_uuid: '3675b69e-8324-4110-bdca-059031aa8da3',
     name: 'Jaffle shop',


### PR DESCRIPTION
### Description:

Adds a development seed for personal access tokens to enable API testing in the development environment. The seed creates a deterministic PAT (`ldpat_deadbeefdeadbeefdeadbeefdeadbeef`) for the admin user that never expires and can be used with the Authorization header `ApiKey ldpat_deadbeefdeadbeefdeadbeefdeadbeef`. The seed cleans any existing PATs for the admin user before creating the new one to ensure a consistent development state.
