### PR TITLE
feat: add DuckDB pre-aggregation query execution with warehouse fallback

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1316,11 +1316,13 @@ export const parseConfig = (): LightdashConfig => {
         copilotConfig = copilotConfigParse.data;
     }
 
+    const licenseKey = process.env.LIGHTDASH_LICENSE_KEY || null;
+
     return {
         mode,
         cookieSameSite: iframeEmbeddingEnabled ? 'none' : 'lax',
         license: {
-            licenseKey: process.env.LIGHTDASH_LICENSE_KEY || null,
+            licenseKey,
         },
         security: {
             contentSecurityPolicy: {
@@ -1915,8 +1917,12 @@ export const parseConfig = (): LightdashConfig => {
                 ) ?? 30,
         },
         preAggregates: {
-            enabled: process.env.PRE_AGGREGATES_ENABLED === 'true',
-            debug: process.env.DEBUG_PRE_AGGREGATES === 'true',
+            enabled:
+                licenseKey !== null &&
+                process.env.PRE_AGGREGATES_ENABLED === 'true',
+            debug:
+                licenseKey !== null &&
+                process.env.DEBUG_PRE_AGGREGATES === 'true',
         },
     };
 };

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -5,6 +5,7 @@ import { lightdashConfig } from '../config/lightdashConfig';
 import Logger from '../logging/logger';
 import { McpContextModel } from '../models/McpContextModel';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
+import { PreAggregationDuckDbClient } from '../services/AsyncQueryService/PreAggregationDuckDbClient';
 import { InstanceConfigurationService } from '../services/InstanceConfigurationService/InstanceConfigurationService';
 import { ProjectService } from '../services/ProjectService/ProjectService';
 import { RolesService } from '../services/RolesService/RolesService';
@@ -304,6 +305,11 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     permissionsService: repository.getPermissionsService(),
                     persistentDownloadFileService:
                         repository.getPersistentDownloadFileService(),
+                    preAggregationDuckDbClient: new PreAggregationDuckDbClient({
+                        lightdashConfig: context.lightdashConfig,
+                        preAggregateModel: models.getPreAggregateModel(),
+                        projectModel: models.getProjectModel(),
+                    }),
                     projectCompileLogModel: models.getProjectCompileLogModel(),
                     adminNotificationService:
                         repository.getAdminNotificationService(),

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5359,6 +5359,7 @@ const models: TsoaRoute.Models = {
             'snowflake',
             'redshift',
             'postgres',
+            'duckdb',
             'trino',
             'clickhouse',
             'athena',
@@ -7474,6 +7475,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['searchFieldValues'] },
                 { dataType: 'enum', enums: ['findDashboards'] },
                 { dataType: 'enum', enums: ['findCharts'] },
+                { dataType: 'enum', enums: ['getDashboardCharts'] },
                 { dataType: 'enum', enums: ['improveContext'] },
                 { dataType: 'enum', enums: ['runQuery'] },
             ],
@@ -7630,11 +7632,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7649,11 +7651,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7668,11 +7670,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7794,7 +7796,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7802,7 +7804,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7817,7 +7823,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -7825,11 +7831,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -7881,11 +7883,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8055,11 +8057,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8074,11 +8076,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6416,6 +6416,7 @@
                     "snowflake",
                     "redshift",
                     "postgres",
+                    "duckdb",
                     "trino",
                     "clickhouse",
                     "athena"
@@ -8787,6 +8788,7 @@
                     "searchFieldValues",
                     "findDashboards",
                     "findCharts",
+                    "getDashboardCharts",
                     "improveContext",
                     "runQuery"
                 ],
@@ -8928,19 +8930,6 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
@@ -9021,8 +9010,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -9120,8 +9109,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -24588,6 +24577,36 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "BigqueryProject": {
+                "properties": {
+                    "friendlyName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "projectId": {
+                        "type": "string"
+                    }
+                },
+                "required": ["friendlyName", "projectId"],
+                "type": "object"
+            },
+            "ApiBigqueryProjects": {
+                "properties": {
+                    "results": {
+                        "items": {
+                            "$ref": "#/components/schemas/BigqueryProject"
+                        },
+                        "type": "array"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "RoleAssignment": {
                 "properties": {
                     "updatedAt": {
@@ -27064,7 +27083,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2526.0",
+        "version": "0.2530.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -42719,9 +42738,41 @@
                 ]
             }
         },
+        "/api/v1/bigquery/sso/projects": {
+            "get": {
+                "operationId": "GetBigQueryProjects",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiBigqueryProjects"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get BigQuery projects accessible by the user",
+                "summary": "Get BigQuery projects",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": []
+            }
+        },
         "/api/v1/bigquery/sso/is-authenticated": {
             "get": {
-                "operationId": "getAccessToken",
+                "operationId": "checkBigqueryAuthentication",
                 "responses": {
                     "200": {
                         "description": "Success",

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -1,0 +1,219 @@
+import { DimensionType, type WarehouseClient } from '@lightdash/common';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { type PreAggregateModel } from '../../models/PreAggregateModel';
+import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { warehouseClientMock } from '../../utils/QueryBuilder/MetricQueryBuilder.mock';
+import { ProjectService } from '../ProjectService/ProjectService';
+import {
+    metricQueryMock,
+    preAggregateExplore,
+} from '../ProjectService/ProjectService.mock';
+import { PreAggregationDuckDbClient } from './PreAggregationDuckDbClient';
+
+describe('PreAggregationDuckDbClient', () => {
+    const getClient = ({
+        lightdashConfig,
+        activeMaterialization = {
+            materializationUuid: 'mat-1',
+            queryUuid: 'mat-query-1',
+            resultsFileName: 'abc123',
+            format: 'jsonl' as const,
+            columns: null,
+            materializedAt: new Date('2024-01-01T00:00:00.000Z'),
+        },
+    }: {
+        lightdashConfig?: typeof lightdashConfigMock;
+        activeMaterialization?: Awaited<
+            ReturnType<PreAggregateModel['getActiveMaterialization']>
+        >;
+    } = {}) => {
+        const resolvedLightdashConfig = {
+            ...lightdashConfigMock,
+            ...lightdashConfig,
+            preAggregates: {
+                ...lightdashConfigMock.preAggregates,
+                ...lightdashConfig?.preAggregates,
+                enabled: lightdashConfig?.preAggregates?.enabled ?? true,
+            },
+        };
+        const preAggregateModel = {
+            getActiveMaterialization: jest
+                .fn()
+                .mockResolvedValue(activeMaterialization),
+        };
+        const projectModel = {
+            getExploreFromCache: jest
+                .fn()
+                .mockResolvedValue(preAggregateExplore),
+        };
+        const createDuckdbWarehouseClient = jest
+            .fn()
+            .mockReturnValue(warehouseClientMock as unknown as WarehouseClient);
+
+        const client = new PreAggregationDuckDbClient({
+            lightdashConfig: resolvedLightdashConfig,
+            preAggregateModel:
+                preAggregateModel as unknown as PreAggregateModel,
+            projectModel: projectModel as unknown as ProjectModel,
+            createDuckdbWarehouseClient,
+        });
+
+        return {
+            client,
+            preAggregateModel,
+            projectModel,
+            createDuckdbWarehouseClient,
+        };
+    };
+
+    const baseResolveArgs = {
+        projectUuid: 'projectUuid',
+        metricQuery: {
+            ...metricQueryMock,
+            tableCalculations: [],
+        },
+        dateZoom: undefined,
+        parameters: { region: 'us-east' },
+        preAggregationRoute: {
+            sourceExploreName: 'valid_explore',
+            preAggregateName: 'rollup',
+        },
+        fieldsMap: {},
+        pivotConfiguration: undefined,
+        startOfWeek: undefined,
+        userAccessControls: {
+            userAttributes: {},
+            intrinsicUserAttributes: {},
+        },
+        availableParameterDefinitions: {},
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        jest.spyOn(ProjectService, '_compileQuery').mockResolvedValue({
+            query: 'SELECT * FROM test',
+        } as unknown as Awaited<
+            ReturnType<typeof ProjectService._compileQuery>
+        >);
+    });
+
+    afterEach(() => {
+        jest.restoreAllMocks();
+    });
+
+    test('returns unresolved when no active materialization exists', async () => {
+        const { client, preAggregateModel, projectModel } = getClient();
+        preAggregateModel.getActiveMaterialization.mockResolvedValue(undefined);
+
+        const result = await client.resolve(baseResolveArgs);
+
+        expect(result).toEqual({
+            resolved: false,
+            reason: 'no_active_materialization',
+        });
+        expect(preAggregateModel.getActiveMaterialization).toHaveBeenCalledWith(
+            'projectUuid',
+            '__preagg__valid_explore__rollup',
+        );
+        expect(projectModel.getExploreFromCache).not.toHaveBeenCalled();
+    });
+
+    test('returns unresolved when results S3 bucket config is missing', async () => {
+        const { client, preAggregateModel } = getClient({
+            lightdashConfig: {
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+                results: {
+                    ...lightdashConfigMock.results,
+                    s3: undefined,
+                },
+            },
+        });
+
+        const result = await client.resolve(baseResolveArgs);
+
+        expect(result).toEqual({
+            resolved: false,
+            reason: 'missing_results_s3_bucket',
+        });
+        expect(
+            preAggregateModel.getActiveMaterialization,
+        ).not.toHaveBeenCalled();
+    });
+
+    test('returns resolved DuckDB query/client and patches pre-aggregate sqlTable', async () => {
+        const { client, createDuckdbWarehouseClient } = getClient();
+
+        const result = await client.resolve(baseResolveArgs);
+
+        expect(result).toEqual({
+            resolved: true,
+            query: 'SELECT * FROM test',
+            warehouseClient: warehouseClientMock,
+        });
+        expect(ProjectService._compileQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                explore: expect.objectContaining({
+                    name: '__preagg__valid_explore__rollup',
+                    tables: expect.objectContaining({
+                        a: expect.objectContaining({
+                            sqlTable:
+                                "read_json_auto('s3://mock_bucket/abc123.jsonl')",
+                        }),
+                        b: expect.objectContaining({
+                            sqlTable:
+                                "read_json_auto('s3://mock_bucket/abc123.jsonl')",
+                        }),
+                    }),
+                }),
+            }),
+        );
+        expect(createDuckdbWarehouseClient).toHaveBeenCalledTimes(1);
+    });
+
+    test('uses active materialization columns as DuckDB JSON schema when available', async () => {
+        const { client } = getClient({
+            activeMaterialization: {
+                materializationUuid: 'mat-1',
+                queryUuid: 'mat-query-1',
+                resultsFileName: 'abc123',
+                format: 'jsonl',
+                columns: {
+                    a_dim1: {
+                        reference: 'a.dim1',
+                        type: DimensionType.STRING,
+                    },
+                    a_met_count: {
+                        reference: 'a.met_count',
+                        type: DimensionType.NUMBER,
+                    },
+                    a_created_at: {
+                        reference: 'a.created_at',
+                        type: DimensionType.TIMESTAMP,
+                    },
+                },
+                materializedAt: new Date('2024-01-01T00:00:00.000Z'),
+            },
+        });
+
+        await client.resolve(baseResolveArgs);
+
+        expect(ProjectService._compileQuery).toHaveBeenCalledWith(
+            expect.objectContaining({
+                explore: expect.objectContaining({
+                    tables: expect.objectContaining({
+                        a: expect.objectContaining({
+                            sqlTable: `read_json('s3://mock_bucket/abc123.jsonl', columns={"a_dim1": 'VARCHAR', "a_met_count": 'DOUBLE', "a_created_at": 'TIMESTAMP'}, format='newline_delimited')`,
+                        }),
+                        b: expect.objectContaining({
+                            sqlTable: `read_json('s3://mock_bucket/abc123.jsonl', columns={"a_dim1": 'VARCHAR', "a_met_count": 'DOUBLE', "a_created_at": 'TIMESTAMP'}, format='newline_delimited')`,
+                        }),
+                    }),
+                }),
+            }),
+        );
+    });
+});

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -1,0 +1,230 @@
+import {
+    getErrorMessage,
+    getPreAggregateExploreName,
+    isExploreError,
+    ItemsMap,
+    MetricQuery,
+    ParameterDefinitions,
+    ParametersValuesMap,
+    PivotConfiguration,
+    SupportedDbtAdapter,
+    UserAccessControls,
+    WarehouseClient,
+    type CreateWarehouseCredentials,
+    type DateZoom,
+} from '@lightdash/common';
+import {
+    DuckdbS3SessionConfig,
+    DuckdbWarehouseClient,
+    warehouseSqlBuilderFromType,
+} from '@lightdash/warehouses';
+import { type LightdashConfig } from '../../config/parseConfig';
+import Logger from '../../logging/logger';
+import { type PreAggregateModel } from '../../models/PreAggregateModel';
+import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { wrapSentryTransaction } from '../../utils';
+import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
+import {
+    getDuckdbPreAggregateSqlTable,
+    getPreAggregateDuckdbLocator,
+} from '../PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable';
+import { ProjectService } from '../ProjectService/ProjectService';
+import { getDuckdbRuntimeConfig } from './getDuckdbRuntimeConfig';
+import { type PreAggregationRoute } from './types';
+
+type PreAggregationDuckDbClientArgs = {
+    lightdashConfig: LightdashConfig;
+    preAggregateModel: Pick<PreAggregateModel, 'getActiveMaterialization'>;
+    projectModel: Pick<ProjectModel, 'getExploreFromCache'>;
+    createDuckdbWarehouseClient?: (args: {
+        s3Config: DuckdbS3SessionConfig;
+    }) => WarehouseClient;
+};
+
+export type ResolvePreAggregationDuckDbArgs = {
+    projectUuid: string;
+    metricQuery: MetricQuery;
+    dateZoom: DateZoom | undefined;
+    parameters: ParametersValuesMap | undefined;
+    preAggregationRoute: PreAggregationRoute;
+    fieldsMap: ItemsMap;
+    pivotConfiguration: PivotConfiguration | undefined;
+    startOfWeek: CreateWarehouseCredentials['startOfWeek'];
+    userAccessControls: UserAccessControls;
+    availableParameterDefinitions: ParameterDefinitions;
+};
+
+export type PreAggregationDuckDbResolution =
+    | { resolved: false; reason: string }
+    | { resolved: true; query: string; warehouseClient: WarehouseClient };
+
+export class PreAggregationDuckDbClient {
+    private readonly lightdashConfig: LightdashConfig;
+
+    private readonly preAggregateModel: Pick<
+        PreAggregateModel,
+        'getActiveMaterialization'
+    >;
+
+    private readonly projectModel: Pick<ProjectModel, 'getExploreFromCache'>;
+
+    private readonly createDuckdbWarehouseClient: (args: {
+        s3Config: DuckdbS3SessionConfig;
+    }) => WarehouseClient;
+
+    constructor(args: PreAggregationDuckDbClientArgs) {
+        this.lightdashConfig = args.lightdashConfig;
+        this.preAggregateModel = args.preAggregateModel;
+        this.projectModel = args.projectModel;
+        this.createDuckdbWarehouseClient =
+            args.createDuckdbWarehouseClient ??
+            ((warehouseArgs) => new DuckdbWarehouseClient(warehouseArgs));
+    }
+
+    async resolve(
+        args: ResolvePreAggregationDuckDbArgs,
+    ): Promise<PreAggregationDuckDbResolution> {
+        try {
+            const result = await wrapSentryTransaction(
+                'PreAggregationDuckDbClient.resolve',
+                {},
+                () => this._resolve(args),
+            );
+
+            if (!result.resolved) {
+                Logger.info(`DuckDB pre-agg skipped: ${result.reason}`);
+            }
+
+            return result;
+        } catch (error) {
+            Logger.warn(
+                `DuckDB pre-agg resolve failed: ${getErrorMessage(error)}. Returning unresolved`,
+            );
+            return { resolved: false, reason: 'resolve_error' };
+        }
+    }
+
+    private async _resolve(
+        args: ResolvePreAggregationDuckDbArgs,
+    ): Promise<PreAggregationDuckDbResolution> {
+        if (!this.lightdashConfig.preAggregates.enabled) {
+            return { resolved: false, reason: 'pre_aggregates_disabled' };
+        }
+
+        const resultsBucket = this.lightdashConfig.results.s3?.bucket;
+        if (!resultsBucket) {
+            return {
+                resolved: false,
+                reason: 'missing_results_s3_bucket',
+            };
+        }
+
+        const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
+            this.lightdashConfig,
+        );
+        if (!duckdbRuntimeConfig) {
+            return {
+                resolved: false,
+                reason: 'missing_duckdb_runtime_config',
+            };
+        }
+
+        const preAggExploreName = getPreAggregateExploreName(
+            args.preAggregationRoute.sourceExploreName,
+            args.preAggregationRoute.preAggregateName,
+        );
+
+        const activeMaterialization =
+            await this.preAggregateModel.getActiveMaterialization(
+                args.projectUuid,
+                preAggExploreName,
+            );
+
+        if (!activeMaterialization) {
+            return {
+                resolved: false,
+                reason: 'no_active_materialization',
+            };
+        }
+
+        const locator = getPreAggregateDuckdbLocator({
+            bucket: resultsBucket,
+            resultsFileName: activeMaterialization.resultsFileName,
+            format: 'jsonl',
+        });
+        const sqlTable = getDuckdbPreAggregateSqlTable(
+            locator,
+            activeMaterialization.columns,
+        );
+
+        const preAggExplore = await this.projectModel.getExploreFromCache(
+            args.projectUuid,
+            preAggExploreName,
+        );
+
+        if (isExploreError(preAggExplore)) {
+            throw new Error(
+                `Pre-aggregate explore ${preAggExploreName} is not queryable`,
+            );
+        }
+
+        const patchedPreAggExplore = {
+            ...preAggExplore,
+            tables: Object.fromEntries(
+                Object.entries(preAggExplore.tables).map(
+                    ([tableName, table]) => [
+                        tableName,
+                        {
+                            ...table,
+                            sqlTable,
+                        },
+                    ],
+                ),
+            ),
+        };
+
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            SupportedDbtAdapter.DUCKDB,
+            args.startOfWeek,
+        );
+
+        const fullQuery = await ProjectService._compileQuery({
+            metricQuery: args.metricQuery,
+            explore: patchedPreAggExplore,
+            warehouseSqlBuilder,
+            intrinsicUserAttributes:
+                args.userAccessControls.intrinsicUserAttributes,
+            userAttributes: args.userAccessControls.userAttributes,
+            timezone: this.lightdashConfig.query.timezone || 'UTC',
+            dateZoom: args.dateZoom,
+            parameters: args.parameters,
+            availableParameterDefinitions: args.availableParameterDefinitions,
+            pivotConfiguration: args.pivotConfiguration,
+        });
+
+        let { query } = fullQuery;
+        if (args.pivotConfiguration) {
+            const pivotQueryBuilder = new PivotQueryBuilder(
+                fullQuery.query,
+                args.pivotConfiguration,
+                warehouseSqlBuilder,
+                args.metricQuery.limit,
+                args.fieldsMap,
+            );
+
+            query = pivotQueryBuilder.toSql({
+                columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+            });
+        }
+
+        const warehouseClient = this.createDuckdbWarehouseClient({
+            s3Config: duckdbRuntimeConfig,
+        });
+
+        return {
+            resolved: true,
+            query,
+            warehouseClient,
+        };
+    }
+}

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -94,6 +94,11 @@ export type ExecuteAsyncQueryReturn = {
     cacheMetadata: CacheMetadata;
 };
 
+export type PreAggregationRoute = {
+    sourceExploreName: string;
+    preAggregateName: string;
+};
+
 export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {
     sql: string;
     limit?: number;

--- a/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.test.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.test.ts
@@ -1,0 +1,69 @@
+import { DimensionType, type ResultColumns } from '@lightdash/common';
+import {
+    getDuckdbPreAggregateSqlTable,
+    type PreAggregateDuckdbLocator,
+} from './getDuckdbPreAggregateSqlTable';
+
+const locator: PreAggregateDuckdbLocator = {
+    storage: 's3',
+    format: 'jsonl',
+    key: 'abc123.jsonl',
+    uri: 's3://bucket/abc123.jsonl',
+};
+
+describe('getDuckdbPreAggregateSqlTable', () => {
+    test('generates read_json with typed schema when columns are provided', () => {
+        const columns: ResultColumns = {
+            orders_total: {
+                reference: 'orders.total',
+                type: DimensionType.NUMBER,
+            },
+            orders_created_date: {
+                reference: 'orders.created_date',
+                type: DimensionType.DATE,
+            },
+            orders_created_at: {
+                reference: 'orders.created_at',
+                type: DimensionType.TIMESTAMP,
+            },
+            orders_is_paid: {
+                reference: 'orders.is_paid',
+                type: DimensionType.BOOLEAN,
+            },
+        };
+
+        expect(getDuckdbPreAggregateSqlTable(locator, columns)).toBe(
+            `read_json('s3://bucket/abc123.jsonl', columns={"orders_total": 'DOUBLE', "orders_created_date": 'DATE', "orders_created_at": 'TIMESTAMP', "orders_is_paid": 'BOOLEAN'}, format='newline_delimited')`,
+        );
+    });
+
+    test('falls back to read_json_auto when columns are empty or null', () => {
+        expect(getDuckdbPreAggregateSqlTable(locator, {})).toBe(
+            `read_json_auto('s3://bucket/abc123.jsonl')`,
+        );
+        expect(getDuckdbPreAggregateSqlTable(locator, null)).toBe(
+            `read_json_auto('s3://bucket/abc123.jsonl')`,
+        );
+    });
+
+    test('escapes uri and safely quotes/escapes column keys', () => {
+        const columns: ResultColumns = {
+            [`orders"status'value`]: {
+                reference: `orders.status`,
+                type: DimensionType.STRING,
+            },
+        };
+
+        expect(
+            getDuckdbPreAggregateSqlTable(
+                {
+                    ...locator,
+                    uri: `s3://bucket/o'hara.jsonl`,
+                },
+                columns,
+            ),
+        ).toBe(
+            `read_json('s3://bucket/o''hara.jsonl', columns={"orders""status'value": 'VARCHAR'}, format='newline_delimited')`,
+        );
+    });
+});

--- a/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.ts
@@ -1,0 +1,93 @@
+import {
+    assertUnreachable,
+    DimensionType,
+    type ResultColumns,
+} from '@lightdash/common';
+
+export type PreAggregateDuckdbLocator = {
+    storage: 's3';
+    format: 'jsonl';
+    key: string;
+    uri: string;
+};
+
+const escapeSqlString = (value: string): string => value.replace(/'/g, "''");
+
+const escapeDuckdbStructKey = (value: string): string =>
+    value.replace(/"/g, '""');
+
+const quoteDuckdbStructKey = (value: string): string =>
+    `"${escapeDuckdbStructKey(value)}"`;
+
+const resultFieldTypeToDuckdbType = (type: DimensionType): string => {
+    switch (type) {
+        case DimensionType.NUMBER:
+            return 'DOUBLE';
+        case DimensionType.BOOLEAN:
+            return 'BOOLEAN';
+        case DimensionType.DATE:
+            return 'DATE';
+        case DimensionType.TIMESTAMP:
+            return 'TIMESTAMP';
+        case DimensionType.STRING:
+            return 'VARCHAR';
+        default:
+            return assertUnreachable(type, `Unknown DimensionType: ${type}`);
+    }
+};
+
+export const getPreAggregateDuckdbLocator = ({
+    bucket,
+    resultsFileName,
+    format,
+}: {
+    bucket: string;
+    resultsFileName: string;
+    format: 'jsonl';
+}): PreAggregateDuckdbLocator => {
+    const trimmedBucket = bucket.trim();
+    const trimmedResultsFileName = resultsFileName.trim();
+
+    if (trimmedBucket.length === 0) {
+        throw new Error(
+            'Cannot build pre-aggregate DuckDB locator without S3 bucket',
+        );
+    }
+
+    if (trimmedResultsFileName.length === 0) {
+        throw new Error(
+            'Cannot build pre-aggregate DuckDB locator without results file name',
+        );
+    }
+
+    const key = `${trimmedResultsFileName}.${format}`;
+
+    return {
+        storage: 's3',
+        format,
+        key,
+        uri: `s3://${trimmedBucket}/${key}`,
+    };
+};
+
+export const getDuckdbPreAggregateSqlTable = (
+    locator: PreAggregateDuckdbLocator,
+    columns?: ResultColumns | null,
+): string => {
+    const escapedUri = escapeSqlString(locator.uri);
+
+    if (!columns || Object.keys(columns).length === 0) {
+        return `read_json_auto('${escapedUri}')`;
+    }
+
+    const columnDefs = Object.entries(columns)
+        .map(
+            ([fieldId, col]) =>
+                `${quoteDuckdbStructKey(fieldId)}: '${resultFieldTypeToDuckdbType(
+                    col.type,
+                )}'`,
+        )
+        .join(', ');
+
+    return `read_json('${escapedUri}', columns={${columnDefs}}, format='newline_delimited')`;
+};

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -8,6 +8,7 @@ import type { UtilRepository } from '../utils/UtilRepository';
 import { AdminNotificationService } from './AdminNotificationService/AdminNotificationService';
 import { AnalyticsService } from './AnalyticsService/AnalyticsService';
 import { AsyncQueryService } from './AsyncQueryService/AsyncQueryService';
+import { PreAggregationDuckDbClient } from './AsyncQueryService/PreAggregationDuckDbClient';
 import { BaseService } from './BaseService';
 import { CatalogService } from './CatalogService/CatalogService';
 import { ChangesetService } from './ChangesetService';
@@ -691,6 +692,11 @@ export class ServiceRepository
                     permissionsService: this.getPermissionsService(),
                     persistentDownloadFileService:
                         this.getPersistentDownloadFileService(),
+                    preAggregationDuckDbClient: new PreAggregationDuckDbClient({
+                        lightdashConfig: this.context.lightdashConfig,
+                        preAggregateModel: this.models.getPreAggregateModel(),
+                        projectModel: this.models.getProjectModel(),
+                    }),
                     projectCompileLogModel:
                         this.models.getProjectCompileLogModel(),
                     adminNotificationService:


### PR DESCRIPTION
### Description:

- Async routing + fallback orchestration in [AsyncQueryService.ts](/Users/giorgi/develop/lightdash/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts)
- New DuckDB pre-agg executor in [PreAggregationDuckDbClient.ts](/Users/giorgi/develop/lightdash/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts)
- Internal route payload type in [types.ts](/Users/giorgi/develop/lightdash/packages/backend/src/services/AsyncQueryService/types.ts)
- DuckDB pre-agg S3 table helper in [getDuckdbPreAggregateSqlTable.ts](/Users/giorgi/develop/lightdash/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.ts)
- Pre-agg explore SQL rewrite/casting updates in [buildPreAggregateExplore.ts](/Users/giorgi/develop/lightdash/packages/common/src/preAggregates/buildPreAggregateExplore.ts)
- Matching tests in:
  - [AsyncQueryService.test.ts](/Users/giorgi/develop/lightdash/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts)
  - [PreAggregationDuckDbClient.test.ts](/Users/giorgi/develop/lightdash/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts)
  - [getDuckdbPreAggregateSqlTable.test.ts](/Users/giorgi/develop/lightdash/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.test.ts)
  - [buildPreAggregateExplore.test.ts](/Users/giorgi/develop/lightdash/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts)
