### PR TITLE
refactor: standardize service method names and add SoftDeletableService interface

### DIFF
--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -112,7 +112,7 @@ export class SpaceController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await this.services.getSpaceService().deleteSpace(req.user!, spaceUuid);
+        await this.services.getSpaceService().delete(req.user!, spaceUuid);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/controllers/sqlRunnerController.ts
+++ b/packages/backend/src/controllers/sqlRunnerController.ts
@@ -400,9 +400,7 @@ export class SqlRunnerController extends BaseController {
         @Request() req: express.Request,
     ): Promise<ApiSuccessEmpty> {
         this.setStatus(200);
-        await this.services
-            .getSavedSqlService()
-            .deleteSqlChart(req.user!, projectUuid, uuid);
+        await this.services.getSavedSqlService().delete(req.user!, uuid);
         return {
             status: 'ok',
             results: undefined,

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -411,15 +411,9 @@ export class ContentService extends BaseService {
             case ContentType.CHART:
                 switch (item.source) {
                     case ChartSourceType.DBT_EXPLORE:
-                        return this.savedChartService.restoreChart(
-                            user,
-                            item.uuid,
-                        );
+                        return this.savedChartService.restore(user, item.uuid);
                     case ChartSourceType.SQL:
-                        return this.savedSqlService.restoreSqlChart(
-                            user,
-                            item.uuid,
-                        );
+                        return this.savedSqlService.restore(user, item.uuid);
                     default:
                         return assertUnreachable(
                             item.source,
@@ -427,9 +421,9 @@ export class ContentService extends BaseService {
                         );
                 }
             case ContentType.DASHBOARD:
-                return this.dashboardService.restoreDashboard(user, item.uuid);
+                return this.dashboardService.restore(user, item.uuid);
             case ContentType.SPACE:
-                return this.spaceService.restoreSpace(user, item.uuid);
+                return this.spaceService.restore(user, item.uuid);
             default:
                 return assertUnreachable(item, 'Unknown content type');
         }
@@ -462,12 +456,12 @@ export class ContentService extends BaseService {
             case ContentType.CHART:
                 switch (item.source) {
                     case ChartSourceType.DBT_EXPLORE:
-                        return this.savedChartService.permanentlyDeleteChart(
+                        return this.savedChartService.permanentDelete(
                             user,
                             item.uuid,
                         );
                     case ChartSourceType.SQL:
-                        return this.savedSqlService.permanentlyDeleteSqlChart(
+                        return this.savedSqlService.permanentDelete(
                             user,
                             item.uuid,
                         );
@@ -478,15 +472,9 @@ export class ContentService extends BaseService {
                         );
                 }
             case ContentType.DASHBOARD:
-                return this.dashboardService.permanentlyDeleteDashboard(
-                    user,
-                    item.uuid,
-                );
+                return this.dashboardService.permanentDelete(user, item.uuid);
             case ContentType.SPACE:
-                return this.spaceService.permanentlyDeleteSpace(
-                    user,
-                    item.uuid,
-                );
+                return this.spaceService.permanentDelete(user, item.uuid);
             default:
                 return assertUnreachable(item, 'Unknown content type');
         }

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -67,6 +67,7 @@ import { UserModel } from '../../models/UserModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { getAdjustedCronByOffset } from '../../utils/cronUtils';
 import { BaseService } from '../BaseService';
+import type { SoftDeleteOptions } from '../SoftDeletableService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
 
@@ -792,19 +793,22 @@ export class SchedulerService extends BaseService {
         user: SessionUser,
         chartUuid: string,
         context: { projectUuid: string; organizationUuid: string },
+        options?: SoftDeleteOptions,
     ): Promise<void> {
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('ScheduledDeliveries', {
-                    organizationUuid: context.organizationUuid,
-                    projectUuid: context.projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                `User ${user.userUuid} cannot manage scheduled deliveries for cascade soft-delete on chart ${chartUuid}`,
-            );
+        if (!options?.bypassPermissions) {
+            if (
+                user.ability.cannot(
+                    'manage',
+                    subject('ScheduledDeliveries', {
+                        organizationUuid: context.organizationUuid,
+                        projectUuid: context.projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    `User ${user.userUuid} cannot manage scheduled deliveries for cascade soft-delete on chart ${chartUuid}`,
+                );
+            }
         }
 
         const deletedSchedulers =
@@ -837,19 +841,22 @@ export class SchedulerService extends BaseService {
         user: SessionUser,
         dashboardUuid: string,
         context: { projectUuid: string; organizationUuid: string },
+        options?: SoftDeleteOptions,
     ): Promise<void> {
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('ScheduledDeliveries', {
-                    organizationUuid: context.organizationUuid,
-                    projectUuid: context.projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                `User ${user.userUuid} cannot manage scheduled deliveries for cascade soft-delete on dashboard ${dashboardUuid}`,
-            );
+        if (!options?.bypassPermissions) {
+            if (
+                user.ability.cannot(
+                    'manage',
+                    subject('ScheduledDeliveries', {
+                        organizationUuid: context.organizationUuid,
+                        projectUuid: context.projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    `User ${user.userUuid} cannot manage scheduled deliveries for cascade soft-delete on dashboard ${dashboardUuid}`,
+                );
+            }
         }
 
         const deletedSchedulers =
@@ -875,25 +882,28 @@ export class SchedulerService extends BaseService {
 
     /**
      * Cascade restore schedulers belonging to a chart.
-     * Called from SavedChartService.restoreChart().
+     * Called from SavedChartService.restore().
      */
     async restoreByChartUuid(
         user: SessionUser,
         chartUuid: string,
         context: { projectUuid: string; organizationUuid: string },
+        options?: SoftDeleteOptions,
     ): Promise<void> {
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('ScheduledDeliveries', {
-                    organizationUuid: context.organizationUuid,
-                    projectUuid: context.projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                `User ${user.userUuid} cannot manage scheduled deliveries for cascade restore on chart ${chartUuid}`,
-            );
+        if (!options?.bypassPermissions) {
+            if (
+                user.ability.cannot(
+                    'manage',
+                    subject('ScheduledDeliveries', {
+                        organizationUuid: context.organizationUuid,
+                        projectUuid: context.projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    `User ${user.userUuid} cannot manage scheduled deliveries for cascade restore on chart ${chartUuid}`,
+                );
+            }
         }
 
         const restoredSchedulers =
@@ -915,25 +925,28 @@ export class SchedulerService extends BaseService {
 
     /**
      * Cascade restore schedulers belonging to a dashboard.
-     * Called from DashboardService.restoreDashboard().
+     * Called from DashboardService.restore().
      */
     async restoreByDashboardUuid(
         user: SessionUser,
         dashboardUuid: string,
         context: { projectUuid: string; organizationUuid: string },
+        options?: SoftDeleteOptions,
     ): Promise<void> {
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('ScheduledDeliveries', {
-                    organizationUuid: context.organizationUuid,
-                    projectUuid: context.projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                `User ${user.userUuid} cannot manage scheduled deliveries for cascade restore on dashboard ${dashboardUuid}`,
-            );
+        if (!options?.bypassPermissions) {
+            if (
+                user.ability.cannot(
+                    'manage',
+                    subject('ScheduledDeliveries', {
+                        organizationUuid: context.organizationUuid,
+                        projectUuid: context.projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError(
+                    `User ${user.userUuid} cannot manage scheduled deliveries for cascade restore on dashboard ${dashboardUuid}`,
+                );
+            }
         }
 
         const restoredSchedulers =

--- a/packages/backend/src/services/SoftDeletableService.ts
+++ b/packages/backend/src/services/SoftDeletableService.ts
@@ -1,0 +1,47 @@
+import type { SessionUser } from '@lightdash/common';
+
+/**
+ * Options for soft-delete operations.
+ * Use `bypassPermissions: true` in cascade calls where the parent
+ * operation already verified the user has permission.
+ */
+export type SoftDeleteOptions = {
+    bypassPermissions?: boolean;
+};
+
+/**
+ * Standard interface for services that support soft-delete lifecycle:
+ *
+ * - `delete()`          — entry point; checks perms + feature flag, delegates to softDelete or hard-delete
+ * - `softDelete()`      — marks record as deleted, cascades to children
+ * - `restore()`         — restores from trash, cascades to children
+ * - `permanentDelete()` — permanently removes a trashed record
+ *
+ * SchedulerService does NOT implement this interface because it operates
+ * by parent UUID (chart/dashboard), not by its own entity UUID.
+ */
+export interface SoftDeletableService {
+    delete(
+        user: SessionUser,
+        uuid: string,
+        options?: SoftDeleteOptions,
+    ): Promise<void>;
+
+    softDelete(
+        user: SessionUser,
+        uuid: string,
+        options?: SoftDeleteOptions,
+    ): Promise<void>;
+
+    restore(
+        user: SessionUser,
+        uuid: string,
+        options?: SoftDeleteOptions,
+    ): Promise<void>;
+
+    permanentDelete(
+        user: SessionUser,
+        uuid: string,
+        options?: SoftDeleteOptions,
+    ): Promise<void>;
+}


### PR DESCRIPTION
Refactored soft-delete services to implement a standardized `SoftDeletableService` interface with consistent method naming and permission handling.

### What changed?

- Created a new `SoftDeletableService` interface defining standard methods: `delete()`, `softDelete()`, `restore()`, and `permanentDelete()`
- Renamed service methods to use consistent naming:
    - `deleteSpace()` → `delete()`
    - `deleteSqlChart()` → `delete()`
    - `restoreChart()` → `restore()`
    - `restoreSpace()` → `restore()`
    - `restoreSqlChart()` → `restore()`
    - `permanentlyDeleteChart()` → `permanentDelete()`
    - `permanentlyDeleteSpace()` → `permanentDelete()`
    - `permanentlyDeleteSqlChart()` → `permanentDelete()`
- Added `SoftDeleteOptions` type with `bypassPermissions` flag for cascade operations
- Updated all services (DashboardService, SavedChartService, SavedSqlService, SpaceService) to implement the interface
- Modified permission checks to be conditional based on `bypassPermissions` option
- Updated cascade operations to use `bypassPermissions: true` to avoid redundant permission checks
- Removed duplicate analytics tracking and error handling code
- Updated controller calls to use new method names