### PR TITLE
refactor: migrate some mantine components to mantine 8 part 2

### DIFF
--- a/packages/frontend/src/components/CronInput/MonthlyInputs.tsx
+++ b/packages/frontend/src/components/CronInput/MonthlyInputs.tsx
@@ -1,4 +1,4 @@
-import { Group, Input, NumberInput } from '@mantine/core';
+import { Group, Input, NumberInput } from '@mantine-8/core';
 import React, { type FC } from 'react';
 import {
     getMonthlyCronExpression,
@@ -13,8 +13,8 @@ const MonthlyInputs: FC<{
 }> = ({ disabled, cronExpression, onChange }) => {
     const { minutes, hours, day } = parseCronExpression(cronExpression);
 
-    const onDayChange = (newDay: number) => {
-        if (newDay >= 1 && newDay <= 31) {
+    const onDayChange = (newDay: string | number) => {
+        if (typeof newDay === 'number' && newDay >= 1 && newDay <= 31) {
             onChange(getMonthlyCronExpression(minutes, hours, newDay));
         }
     };
@@ -24,7 +24,7 @@ const MonthlyInputs: FC<{
     };
 
     return (
-        <Group spacing="sm">
+        <Group gap="sm">
             <Input.Label>on day</Input.Label>
             <NumberInput
                 value={day}

--- a/packages/frontend/src/components/DashboardTiles/TileForms/LoomTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/LoomTileForm.tsx
@@ -1,5 +1,5 @@
 import { type DashboardLoomTileProperties } from '@lightdash/common';
-import { ActionIcon, Flex, Stack, TextInput } from '@mantine/core';
+import { ActionIcon, Flex, Stack, TextInput } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
 import { IconEye, IconEyeOff } from '@tabler/icons-react';
 import MantineIcon from '../../common/MantineIcon';
@@ -10,7 +10,7 @@ interface LoomTileFormProps {
 }
 
 const LoomTileForm = ({ form, withHideTitle }: LoomTileFormProps) => (
-    <Stack spacing="md">
+    <Stack gap="md">
         <Flex
             align={form.getInputProps('title').error ? 'center' : 'flex-end'}
             gap="xs"
@@ -18,7 +18,7 @@ const LoomTileForm = ({ form, withHideTitle }: LoomTileFormProps) => (
             <TextInput
                 label="Title"
                 placeholder="Tile title"
-                style={{ flex: 1 }}
+                flex={1}
                 required
                 disabled={form.values.hideTitle}
                 {...form.getInputProps('title')}

--- a/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileForms/MarkdownTileForm.tsx
@@ -1,5 +1,5 @@
 import { type DashboardMarkdownTileProperties } from '@lightdash/common';
-import { Group, Stack, Switch, TextInput } from '@mantine/core';
+import { Group, Stack, Switch, TextInput } from '@mantine-8/core';
 import { type UseFormReturnType } from '@mantine/form';
 import MDEditor from '@uiw/react-md-editor';
 
@@ -9,7 +9,7 @@ interface MarkdownTileFormProps {
 
 const MarkdownTileForm = ({ form }: MarkdownTileFormProps) => {
     return (
-        <Stack spacing="md">
+        <Stack gap="md">
             <TextInput
                 label="Title"
                 placeholder="Tile title"
@@ -26,7 +26,7 @@ const MarkdownTileForm = ({ form }: MarkdownTileFormProps) => {
                 {...form.getInputProps('content')}
             />
             <Switch
-                label={<Group spacing="xs">Show tile frame</Group>}
+                label={<Group gap="xs">Show tile frame</Group>}
                 checked={!form.values.hideFrame}
                 onChange={(e) =>
                     form.setFieldValue('hideFrame', !e.currentTarget.checked)

--- a/packages/frontend/src/components/DataViz/config/CartesianChartConfiguration.tsx
+++ b/packages/frontend/src/components/DataViz/config/CartesianChartConfiguration.tsx
@@ -1,5 +1,5 @@
 import { ChartKind, type VizColumn } from '@lightdash/common';
-import { Stack, Tabs } from '@mantine/core';
+import { Stack, Tabs } from '@mantine-8/core';
 import { barChartConfigSlice } from '../store/barChartSlice';
 import { lineChartConfigSlice } from '../store/lineChartSlice';
 import { CartesianChartDisplayConfig } from './CartesianChartDisplayConfig';
@@ -25,7 +25,7 @@ export const CartesianChartConfig = ({
     }
 
     return (
-        <Stack spacing="xs" mb="lg">
+        <Stack gap="xs" mb="lg">
             <Tabs defaultValue="data" keepMounted>
                 <Tabs.List>
                     <Tabs.Tab value="data">Data</Tabs.Tab>

--- a/packages/frontend/src/components/Home/LandingPanel/index.tsx
+++ b/packages/frontend/src/components/Home/LandingPanel/index.tsx
@@ -1,5 +1,5 @@
 import { subject } from '@casl/ability';
-import { Group, Stack, Text, Title } from '@mantine/core';
+import { Group, Stack, Text, Title } from '@mantine-8/core';
 import { type FC } from 'react';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
@@ -14,13 +14,13 @@ interface Props {
 const LandingPanel: FC<Props> = ({ userName, projectUuid }) => {
     const { user } = useApp();
     return (
-        <Group position="apart" my="xl">
-            <Stack justify="flex-start" spacing="xs">
+        <Group justify="space-between" my="xl">
+            <Stack justify="flex-start" gap="xs">
                 <Title order={3}>
                     {`Welcome${userName ? ', ' + userName : ' to Lightdash'}!`}{' '}
                     ⚡️
                 </Title>
-                <Text color="ldGray.7">
+                <Text c="ldGray.7">
                     Run a query to ask a business question or browse your data
                     below:
                 </Text>

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtLocalForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtLocalForm.tsx
@@ -1,4 +1,4 @@
-import { Alert, Stack, Text } from '@mantine/core';
+import { Alert, Stack, Text } from '@mantine-8/core';
 import { IconExclamationCircle, IconInfoCircle } from '@tabler/icons-react';
 import { type FC } from 'react';
 import MantineIcon from '../../common/MantineIcon';
@@ -12,7 +12,7 @@ const DbtLocalForm: FC<{ disabled: boolean }> = ({ disabled }) => (
             color="orange"
             icon={<MantineIcon icon={IconExclamationCircle} size="lg" />}
         >
-            <Text color="orange">
+            <Text c="orange">
                 This connection type should only be used for local development.
             </Text>
         </Alert>
@@ -21,15 +21,15 @@ const DbtLocalForm: FC<{ disabled: boolean }> = ({ disabled }) => (
             color="blue"
             icon={<MantineIcon icon={IconInfoCircle} size="lg" />}
         >
-            <Stack spacing="xs">
-                <Text color="blue">
+            <Stack gap="xs">
+                <Text c="blue">
                     When using the install script, when you&apos;re asked{' '}
                     <b>How do you want to setup Lightdash ?</b>, select the
                     option <b>with local dbt</b> and then provide the absolute
                     path to your dbt project.
                 </Text>
 
-                <Text color="blue">
+                <Text c="blue">
                     When using the install script, set the env var{' '}
                     <b>DBT_PROJECT_DIR</b> with the absolute path to your dbt
                     project.

--- a/packages/frontend/src/components/ProjectConnection/Inputs/BooleanSwitch.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/BooleanSwitch.tsx
@@ -5,7 +5,7 @@ import {
     Switch,
     Text,
     type SwitchProps,
-} from '@mantine/core';
+} from '@mantine-8/core';
 import { type FC } from 'react';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
 import { type FormInputProps } from '../formContext';
@@ -25,9 +25,9 @@ const BooleanSwitch: FC<BooleanSwitchProps> = ({
     const requiredLabel = required ? '*' : '';
 
     return (
-        <Stack className={`input-wrapper ${className}`} spacing="two">
-            <Group spacing="xs" position="apart">
-                <Text fw={450}>
+        <Stack className={`input-wrapper ${className}`} gap="two">
+            <Group gap="xs" justify="space-between">
+                <Text fw={450} fz="sm">
                     {label} <span style={{ flex: 1 }}>{requiredLabel}</span>
                 </Text>
 

--- a/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep2.tsx
+++ b/packages/frontend/src/components/ProjectConnection/ProjectConnectFlow/ConnectManually/ConnectManuallyStep2.tsx
@@ -1,5 +1,5 @@
 import { type WarehouseTypes } from '@lightdash/common';
-import { Button, Stack } from '@mantine/core';
+import { Button, Stack } from '@mantine-8/core';
 import { IconChevronLeft } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { CreateProjectConnection } from '../..';
@@ -20,13 +20,12 @@ const ConnectManuallyStep2: FC<ConnectManuallyStep2Props> = ({
 }) => {
     return (
         <>
-            <Stack align="left">
+            <Stack align="flex-start">
                 <Button
                     variant="subtle"
                     size="sm"
-                    leftIcon={<MantineIcon icon={IconChevronLeft} />}
+                    leftSection={<MantineIcon icon={IconChevronLeft} />}
                     onClick={onBack}
-                    sx={{ alignSelf: 'flex-start' }}
                 >
                     Back
                 </Button>

--- a/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
+++ b/packages/frontend/src/components/SettingsUsageAnalytics/index.tsx
@@ -1,5 +1,5 @@
 import { FeatureFlags } from '@lightdash/common';
-import { Card, Group, Stack, Text } from '@mantine/core';
+import { Card, Group, Stack, Text } from '@mantine-8/core';
 import { IconArchive, IconLayoutDashboard } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { Link } from 'react-router';
@@ -19,12 +19,12 @@ const SettingsUsageAnalytics: FC<ProjectUserAccessProps> = ({
 
     return (
         <>
-            <Text color="dimmed">
+            <Text c="dimmed">
                 Lightdash curated dashboards that show usage and performance
                 information about your project.
             </Text>
 
-            <Stack spacing="md">
+            <Stack gap="md">
                 <Card
                     component={Link}
                     shadow="sm"

--- a/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/DeleteOrganizationPanel/index.tsx
@@ -1,4 +1,4 @@
-import { Button, Group } from '@mantine/core';
+import { Button, Group } from '@mantine-8/core';
 import { IconTrash } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
@@ -15,11 +15,11 @@ export const DeleteOrganizationPanel: FC = () => {
     if (isOrganizationLoading || organization === undefined) return null;
 
     return (
-        <Group position="right">
+        <Group justify="flex-end">
             <Button
                 variant="outline"
                 color="red"
-                leftIcon={<MantineIcon icon={IconTrash} />}
+                leftSection={<MantineIcon icon={IconTrash} />}
                 onClick={() => setShowDeleteOrganizationModal(true)}
             >
                 Delete '{organization.name}'

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Axes/AxisMinMax.tsx
@@ -1,4 +1,4 @@
-import { Group, Switch, TextInput } from '@mantine/core';
+import { Group, Switch, TextInput } from '@mantine-8/core';
 import { useCallback, type FC } from 'react';
 import { useToggle } from 'react-use';
 import useTracking from '../../../../providers/Tracking/useTracking';
@@ -26,7 +26,7 @@ export const AxisMinMax: FC<Props> = ({ label, min, max, setMin, setMax }) => {
     }, [isAuto, setMin, setMax]);
 
     return (
-        <Group noWrap spacing="xs">
+        <Group wrap="nowrap" gap="xs">
             <Switch
                 label={isAuto && label}
                 checked={isAuto}
@@ -43,7 +43,7 @@ export const AxisMinMax: FC<Props> = ({ label, min, max, setMin, setMax }) => {
                 }}
             />
             {!isAuto && (
-                <Group noWrap spacing="xs">
+                <Group wrap="nowrap" gap="xs">
                     <Config.Label>Min</Config.Label>
                     <TextInput
                         placeholder="Min"

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipSortConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/TooltipSortConfig.tsx
@@ -1,5 +1,5 @@
 import { TooltipSortByOptions, type TooltipSortBy } from '@lightdash/common';
-import { Group, Select } from '@mantine/core';
+import { Group, Select } from '@mantine-8/core';
 import { type FC } from 'react';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
@@ -31,13 +31,14 @@ export const TooltipSortConfig: FC = () => {
     };
 
     return (
-        <Group spacing="xs">
+        <Group gap="xs">
             <Config.Label>Sort by</Config.Label>
             <Select
                 data={TOOLTIP_SORT_OPTIONS}
                 value={tooltipSort ?? TooltipSortByOptions.DEFAULT}
                 onChange={handleChange}
                 w={160}
+                size="xs"
             />
         </Group>
     );

--- a/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/StepConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/FunnelChartConfig/StepConfig.tsx
@@ -1,7 +1,7 @@
 // TODO: This could be combined with the pie chart or cartesian
 // chart series configs if they have more similar options in the future.
 
-import { Box, Group, Stack } from '@mantine/core';
+import { Box, Group, Stack } from '@mantine-8/core';
 import { type FC } from 'react';
 import ColorSelector from '../ColorSelector';
 import { EditableText } from '../common/EditableText';
@@ -33,8 +33,8 @@ export const StepConfig: FC<StepConfigProps> = ({
 }) => {
     const stepId = id ?? defaultLabel;
     return (
-        <Stack spacing="xs" {...rest}>
-            <Group spacing="xs">
+        <Stack gap="xs" {...rest}>
+            <Group gap="xs">
                 <ColorSelector
                     color={color}
                     defaultColor={defaultColor}
@@ -43,7 +43,7 @@ export const StepConfig: FC<StepConfigProps> = ({
                         onColorChange(stepId, newColor)
                     }
                 />
-                <Box style={{ flexGrow: 1 }}>
+                <Box flex={1}>
                     <EditableText
                         placeholder={defaultLabel}
                         value={label}

--- a/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/ValueOptions.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/PieChartConfig/ValueOptions.tsx
@@ -4,7 +4,7 @@ import {
     PieChartValueLabels,
     type PieChartValueLabel,
 } from '@lightdash/common';
-import { Checkbox, Group, SegmentedControl } from '@mantine/core';
+import { Checkbox, Group, SegmentedControl } from '@mantine-8/core';
 import { type FC } from 'react';
 import { Config } from '../common/Config';
 
@@ -36,7 +36,7 @@ export const ValueOptions: FC<ValueOptionsProps> = ({
     onToggleShowPercentage,
 }) => (
     <>
-        <Group spacing="xs" noWrap>
+        <Group gap="xs" wrap="nowrap">
             <Config.Label>Value position</Config.Label>
             <SegmentedControl
                 value={isValueLabelOverriden ? 'mixed' : valueLabel}
@@ -48,14 +48,14 @@ export const ValueOptions: FC<ValueOptionsProps> = ({
                     label,
                     disabled: value === 'mixed',
                 }))}
-                onChange={(newValueLabel: PieChartValueLabel) => {
-                    onValueLabelChange(newValueLabel);
+                onChange={(value: string) => {
+                    onValueLabelChange(value as PieChartValueLabel);
                 }}
             />
         </Group>
 
         {valueLabel !== 'hidden' && (
-            <Group spacing="xs">
+            <Group gap="xs">
                 <Checkbox
                     indeterminate={isShowValueOverriden}
                     checked={showValue}

--- a/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapDisplayConfig.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TreemapConfig/TreemapDisplayConfig.tsx
@@ -1,4 +1,4 @@
-import { Group, NumberInput, Stack, Tooltip } from '@mantine/core';
+import { Group, NumberInput, Stack, Tooltip } from '@mantine-8/core';
 import { IconHelpCircle } from '@tabler/icons-react';
 import React from 'react';
 import MantineIcon from '../../common/MantineIcon';
@@ -17,8 +17,8 @@ export const Display: React.FC = () => {
     return (
         <Stack>
             <Config>
-                <Stack spacing="xs">
-                    <Group spacing="xs">
+                <Stack gap="xs">
+                    <Group gap="xs">
                         <Config.Heading>Minimum section size</Config.Heading>
                         <Tooltip
                             withinPortal={true}
@@ -36,18 +36,16 @@ export const Display: React.FC = () => {
                         </Tooltip>
                         <NumberInput
                             value={visibleMin}
-                            onChange={setVisibleMin}
+                            onChange={(value) => {
+                                if (typeof value === 'number')
+                                    setVisibleMin(value);
+                            }}
                             min={0}
                             step={500}
-                            formatter={(value) =>
-                                value ? `${value}px\u00B2` : ''
-                            }
-                            parser={(value) =>
-                                value.replace(/px\u00B2\s?$/, '')
-                            }
+                            suffix="px²"
                         />
                     </Group>
-                    <Group spacing="xs">
+                    <Group gap="xs">
                         <Config.Heading>Max leaf depth</Config.Heading>
                         <Tooltip
                             withinPortal={true}
@@ -65,7 +63,10 @@ export const Display: React.FC = () => {
                         </Tooltip>
                         <NumberInput
                             value={leafDepth}
-                            onChange={setLeafDepth}
+                            onChange={(value) => {
+                                if (typeof value === 'number')
+                                    setLeafDepth(value);
+                            }}
                             min={1}
                             placeholder="No limit"
                         />

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.module.css
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.module.css
@@ -1,0 +1,3 @@
+.noWrap {
+    white-space: nowrap;
+}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateRangePicker.tsx
@@ -1,8 +1,9 @@
-import { Flex, Text } from '@mantine/core';
+import { Flex, Text } from '@mantine-8/core';
 import { type DateInputProps, type DayOfWeek } from '@mantine/dates';
 import dayjs from 'dayjs';
 import { useState, type FC } from 'react';
 import FilterDatePicker from './FilterDatePicker';
+import styles from './FilterDateRangePicker.module.css';
 
 interface Props extends Omit<
     DateInputProps,
@@ -44,7 +45,7 @@ const FilterDateRangePicker: FC<Props> = ({
                 }}
             />
 
-            <Text color="dimmed" sx={{ whiteSpace: 'nowrap' }} size="xs">
+            <Text c="dimmed" className={styles.noWrap} fz="xs">
                 –
             </Text>
 

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.module.css
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.module.css
@@ -1,0 +1,3 @@
+.noWrap {
+    white-space: nowrap;
+}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimePicker.tsx
@@ -1,4 +1,4 @@
-import { Group, Text } from '@mantine/core';
+import { Group, Text } from '@mantine-8/core';
 import {
     DateTimePicker,
     type DateTimePickerProps,
@@ -7,6 +7,7 @@ import {
 import dayjs from 'dayjs';
 import timezone from 'dayjs/plugin/timezone';
 import { type FC } from 'react';
+import styles from './FilterDateTimePicker.module.css';
 
 dayjs.extend(timezone);
 
@@ -30,7 +31,7 @@ const FilterDateTimePicker: FC<Props> = ({
     const displayFormat = 'YYYY-MM-DD HH:mm:ss';
 
     return (
-        <Group noWrap spacing="xs" align="start" w="100%">
+        <Group wrap="nowrap" gap="xs" align="start" w="100%">
             {/* // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
             // @ts-ignore */}
             <DateTimePicker
@@ -55,10 +56,10 @@ const FilterDateTimePicker: FC<Props> = ({
             />
             {showTimezone && (
                 <Text
-                    size="xs"
-                    color="dimmed"
+                    fz="xs"
+                    c="dimmed"
                     mt={7}
-                    sx={{ whiteSpace: 'nowrap' }}
+                    className={styles.noWrap}
                 >
                     {dayjs.tz.guess()}
                 </Text>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.module.css
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.module.css
@@ -1,0 +1,3 @@
+.noWrap {
+    white-space: nowrap;
+}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterDateTimeRangePicker.tsx
@@ -1,8 +1,9 @@
-import { Group, Text } from '@mantine/core';
+import { Group, Text } from '@mantine-8/core';
 import { type DateTimePickerProps, type DayOfWeek } from '@mantine/dates';
 import dayjs from 'dayjs';
 import { useState, type FC } from 'react';
 import FilterDateTimePicker from './FilterDateTimePicker';
+import styles from './FilterDateTimeRangePicker.module.css';
 
 interface Props extends Omit<
     DateTimePickerProps,
@@ -24,7 +25,7 @@ const FilterDateTimeRangePicker: FC<Props> = ({
     const [date2, setDate2] = useState(value?.[1] ?? null);
 
     return (
-        <Group noWrap align="start" w="100%" spacing="xs">
+        <Group wrap="nowrap" align="start" w="100%" gap="xs">
             <FilterDateTimePicker
                 size="xs"
                 withSeconds
@@ -52,7 +53,7 @@ const FilterDateTimeRangePicker: FC<Props> = ({
                 }}
             />
 
-            <Text color="dimmed" mt={7} sx={{ whiteSpace: 'nowrap' }} size="xs">
+            <Text c="dimmed" mt={7} className={styles.noWrap} fz="xs">
                 –
             </Text>
 

--- a/packages/frontend/src/components/common/Filters/SimplifiedFilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/SimplifiedFilterGroupForm.tsx
@@ -1,5 +1,5 @@
 import { type FilterableField, type FilterRule } from '@lightdash/common';
-import { Stack, Text, Tooltip } from '@mantine/core';
+import { Stack, Text, Tooltip } from '@mantine-8/core';
 import { memo, useCallback, type FC } from 'react';
 import FilterRuleForm from './FilterRuleForm';
 
@@ -34,18 +34,18 @@ const SimplifiedFilterGroupForm: FC<Props> = memo(
         );
 
         return (
-            <Stack style={{ flexGrow: 1 }}>
+            <Stack flex={1}>
                 <Tooltip
                     label="You can only use the 'and' operator when combining metrics & dimensions"
                     disabled={filterRules.length > 1}
                     arrowPosition="center"
                 >
-                    <Text color="dimmed" size="xs">
+                    <Text c="dimmed" fz="xs">
                         All of the following conditions match:
                     </Text>
                 </Tooltip>
 
-                <Stack spacing="sm">
+                <Stack gap="sm">
                     {filterRules.map((item, index) => (
                         <FilterRuleForm
                             isEditMode={isEditMode}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.module.css
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.module.css
@@ -1,0 +1,3 @@
+.noSelect {
+    user-select: none;
+}

--- a/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricCatalogColumnHeaderCell.tsx
@@ -1,5 +1,6 @@
-import { Group, Text, Tooltip } from '@mantine/core';
+import { Group, Text, Tooltip } from '@mantine-8/core';
 import { type FC, type SVGProps } from 'react';
+import styles from './MetricCatalogColumnHeaderCell.module.css';
 
 export const MetricCatalogColumnHeaderCell = ({
     children,
@@ -19,15 +20,13 @@ export const MetricCatalogColumnHeaderCell = ({
             maw={250}
             fz="xs"
         >
-            <Group spacing={6} mr={6} h="100%" noWrap>
+            <Group gap={6} mr={6} h="100%" wrap="nowrap">
                 <Icon />
                 <Text
                     fz="xs"
                     fw={600}
-                    color="ldGray.7"
-                    sx={{
-                        userSelect: 'none',
-                    }}
+                    c="ldGray.7"
+                    className={styles.noSelect}
                 >
                     {children}
                 </Text>

--- a/packages/frontend/src/features/sqlRunner/components/Header/index.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/Header/index.tsx
@@ -1,4 +1,4 @@
-import { Paper, Skeleton, Stack } from '@mantine/core';
+import { Paper, Skeleton, Stack } from '@mantine-8/core';
 import { type FC } from 'react';
 import { useAppSelector } from '../../store/hooks';
 import { HeaderCreate } from './HeaderCreate';
@@ -27,7 +27,7 @@ export const Header: FC<{
 
     return (
         <Paper shadow="none" radius={0} px="md" py="xs" withBorder={false}>
-            <Stack spacing="xs">
+            <Stack gap="xs">
                 <Skeleton height={20} width={'15%'} radius="sm" />
                 <Skeleton height={10} width={'20%'} radius="sm" />
             </Stack>

--- a/packages/frontend/src/mantine8Theme.ts
+++ b/packages/frontend/src/mantine8Theme.ts
@@ -5,6 +5,7 @@ import {
     Loader,
     Modal,
     MultiSelect,
+    NumberInput,
     Paper,
     PasswordInput,
     Pill,
@@ -245,6 +246,12 @@ export const getMantine8ThemeOverride = (
                     if (props.variant === 'subtle')
                         return subtleInputStyles(theme);
                     return {};
+                },
+            }),
+
+            NumberInput: NumberInput.extend({
+                defaultProps: {
+                    radius: 'md',
                 },
             }),
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Migrates components from Mantine v7 to v8 by updating import paths from `@mantine/core` to `@mantine-8/core` and modernizing component props and styling patterns.

**Key changes:**
- Updated import statements to use `@mantine-8/core` package
- Replaced deprecated `spacing` prop with `gap` on Stack and Group components
- Updated Group component props: `position` → `justify`, `noWrap` → `wrap="nowrap"`
- Modernized Button component: `leftIcon` → `leftSection`
- Updated Text component: `color` → `c`, `size` → `fz`
- Replaced inline `style` props with `flex` prop where appropriate
- Updated NumberInput component to handle string/number union types with proper type checking
- Added CSS modules for styling that was previously handled with `sx` prop
- Enhanced NumberInput with `suffix` prop and improved onChange handlers
- Added default props and styling for NumberInput component in theme configuration