### PR TITLE
chore: fix import orders in SpaceService.test.ts

### DIFF
--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -2,8 +2,8 @@ import {
     AbilityAction,
     OrganizationMemberRole,
     ProjectMemberRole,
-    type SessionUser,
     SpaceMemberRole,
+    type SessionUser,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Reorder imports in SpaceService test file to follow alphabetical ordering convention. Move `SpaceMemberRole` import before `type SessionUser` import from `@lightdash/common`.