### PR TITLE
chore: add delete impact endpoint

### DIFF
--- a/packages/backend/src/controllers/spaceController.ts
+++ b/packages/backend/src/controllers/spaceController.ts
@@ -2,6 +2,7 @@ import {
     AddSpaceGroupAccess,
     AddSpaceUserAccess,
     ApiErrorPayload,
+    ApiSpaceDeleteImpactResponse,
     ApiSpaceResponse,
     ApiSuccessEmpty,
     CreateSpace,
@@ -57,6 +58,31 @@ export class SpaceController extends BaseController {
         return {
             status: 'ok',
             results,
+        };
+    }
+
+    /**
+     * Get the impact of deleting a space (affected child spaces, charts, dashboards)
+     * @summary Get delete impact
+     * @param projectUuid The uuid of the space's parent project
+     * @param spaceUuid The uuid of the space to check
+     * @param req
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('{spaceUuid}/delete-impact')
+    @OperationId('GetSpaceDeleteImpact')
+    async getDeleteImpact(
+        @Path() projectUuid: string,
+        @Path() spaceUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSpaceDeleteImpactResponse> {
+        this.setStatus(200);
+        return {
+            status: 'ok',
+            results: await this.services
+                .getSpaceService()
+                .getDeleteImpact(req.user!, spaceUuid),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -14802,6 +14802,46 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SpaceDeleteImpact: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                dashboardCount: { dataType: 'double', required: true },
+                chartCount: { dataType: 'double', required: true },
+                spaces: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            dashboardCount: {
+                                dataType: 'double',
+                                required: true,
+                            },
+                            chartCount: { dataType: 'double', required: true },
+                            name: { dataType: 'string', required: true },
+                            uuid: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSpaceDeleteImpactResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'SpaceDeleteImpact', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_SpaceShare.userUuid-or-role_': {
         dataType: 'refAlias',
         type: {
@@ -35631,6 +35671,71 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getSpace',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsSpaceController_getDeleteImpact: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        spaceUuid: {
+            in: 'path',
+            name: 'spaceUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v1/projects/:projectUuid/spaces/:spaceUuid/delete-impact',
+        ...fetchMiddlewares<RequestHandler>(SpaceController),
+        ...fetchMiddlewares<RequestHandler>(
+            SpaceController.prototype.getDeleteImpact,
+        ),
+
+        async function SpaceController_getDeleteImpact(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsSpaceController_getDeleteImpact,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<SpaceController>(SpaceController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getDeleteImpact',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -15736,6 +15736,62 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
+            "SpaceDeleteImpact": {
+                "properties": {
+                    "dashboardCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "chartCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "spaces": {
+                        "items": {
+                            "properties": {
+                                "dashboardCount": {
+                                    "type": "number",
+                                    "format": "double"
+                                },
+                                "chartCount": {
+                                    "type": "number",
+                                    "format": "double"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": [
+                                "dashboardCount",
+                                "chartCount",
+                                "name",
+                                "uuid"
+                            ],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["dashboardCount", "chartCount", "spaces"],
+                "type": "object"
+            },
+            "ApiSpaceDeleteImpactResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/SpaceDeleteImpact"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "Pick_SpaceShare.userUuid-or-role_": {
                 "properties": {
                     "userUuid": {
@@ -31351,6 +31407,57 @@
                         }
                     }
                 }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/spaces/{spaceUuid}/delete-impact": {
+            "get": {
+                "operationId": "GetSpaceDeleteImpact",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSpaceDeleteImpactResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get the impact of deleting a space (affected child spaces, charts, dashboards)",
+                "summary": "Get delete impact",
+                "tags": ["Spaces"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "The uuid of the space's parent project",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "The uuid of the space to check",
+                        "in": "path",
+                        "name": "spaceUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
             }
         },
         "/api/v1/projects/{projectUuid}/spaces": {

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -1134,6 +1134,16 @@ export class SpaceModel {
         }
     }
 
+    async getDescendantSpaceUuids(spaceUuid: string): Promise<string[]> {
+        const space = await this.get(spaceUuid);
+        const rows = await this.database(SpaceTableName)
+            .select('space_uuid')
+            .whereRaw('path <@ ?::ltree', [space.path])
+            .andWhereNot('space_uuid', spaceUuid)
+            .whereNull('deleted_at');
+        return rows.map((r: { space_uuid: string }) => r.space_uuid);
+    }
+
     async getChildSpaceUuids(
         spaceUuid: string,
         options?: { deleted?: boolean; deletedByUserUuid?: string },

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -187,6 +187,22 @@ export type ApiSpaceResponse = {
     results: Space;
 };
 
+export type SpaceDeleteImpact = {
+    spaces: {
+        uuid: string;
+        name: string;
+        chartCount: number;
+        dashboardCount: number;
+    }[];
+    chartCount: number;
+    dashboardCount: number;
+};
+
+export type ApiSpaceDeleteImpactResponse = {
+    status: 'ok';
+    results: SpaceDeleteImpact;
+};
+
 export type AddSpaceUserAccess = {
     userUuid: string;
     spaceRole: SpaceMemberRole;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [GLITCH-179](https://linear.app/lightdash/issue/GLITCH-179/implement-delete-impact)

### Description:

- Add GET /api/v1/projects/{projectUuid}/spaces/{spaceUuid}/delete-impact endpoint that returns the full impact of deleting a space — all descendant spaces, charts, and dashboards that would be affected                                             
- Uses ltree <@ operator for efficient single-query descendant lookup                                                        
- Requires delete permission on the space

 ```json
 # Leaf space with content
  curl -H "Authorization: ApiKey $LDPAT" \
    "$SITE_URL/api/v1/projects/$PROJECT_UUID/spaces/$SPACE_UUID/delete-impact"

  # Response:
  {
    "status": "ok",
    "results": {
      "spaces": [
        { "uuid": "...", "name": "Jaffle shop", "chartCount": 38, "dashboardCount": 5 }
      ],
      "chartCount": 38,
      "dashboardCount": 5
    }
  }

  # Parent space with nested hierarchy
  {
    "status": "ok",
    "results": {
      "spaces": [
        { "uuid": "...", "name": "Parent Space 1", "chartCount": 0, "dashboardCount": 0 },
        { "uuid": "...", "name": "Child Space 1.1", "chartCount": 0, "dashboardCount": 0 },
        { "uuid": "...", "name": "Grandchild Space 1.1.1", "chartCount": 0, "dashboardCount": 0 },
        ...
      ],
      "chartCount": 0,
      "dashboardCount": 0
    }
  }


```