### PR TITLE
chore: replace corepack with pnpm_9 and add canvas native dependencies

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -48,7 +48,7 @@
 
             buildInputs = with pkgs; [
               nodejs_20
-              corepack
+              pnpm_9
 
               # for dbt
               python312
@@ -64,6 +64,19 @@
               okteto
 
               graphite-cli
+
+              # for canvas native module
+              expat
+              zlib
+              util-linux # libuuid
+              xz # liblzma
+            ];
+
+            env.LD_LIBRARY_PATH = pkgs.lib.makeLibraryPath [
+              pkgs.expat
+              pkgs.zlib
+              pkgs.util-linux
+              pkgs.xz
             ];
 
             shellHook = ''


### PR DESCRIPTION
### Description:

This PR updates the Nix development environment to better support canvas native modules. The changes include:

- Replaced `corepack` with `pnpm_9` for package management
- Added native dependencies required for canvas: `expat`, `zlib`, `util-linux` (for libuuid), and `xz` (for liblzma)
- Configured `LD_LIBRARY_PATH` to include the library paths for these dependencies, ensuring they can be found at runtime

These changes resolve build and runtime issues when working with canvas-related functionality in the development environment.