### PR TITLE
feat: add automated cleanup scheduler for soft-deleted content

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -144,6 +144,9 @@ const schedulerWorkerFactory = (context: {
         preAggregateModel: context.models.getPreAggregateModel(),
         preAggregateMaterializationService:
             context.serviceRepository.getPreAggregateMaterializationService(),
+        spaceService: context.serviceRepository.getSpaceService(),
+        savedChartService: context.serviceRepository.getSavedChartService(),
+        savedSqlService: context.serviceRepository.getSavedSqlService(),
     });
 
 export type AppArguments = {

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -76,6 +76,9 @@ const schedulerWorkerFactory = (context: {
         preAggregateModel: context.models.getPreAggregateModel(),
         preAggregateMaterializationService:
             context.serviceRepository.getPreAggregateMaterializationService(),
+        spaceService: context.serviceRepository.getSpaceService(),
+        savedChartService: context.serviceRepository.getSavedChartService(),
+        savedSqlService: context.serviceRepository.getSavedSqlService(),
     });
 
 export default class SchedulerApp {

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -344,6 +344,11 @@ export const lightdashConfigMock: LightdashConfig = {
     softDelete: {
         enabled: false,
         retentionDays: 30,
+        cleanup: {
+            batchSize: 100,
+            delayMs: 100,
+            maxBatches: 100,
+        },
     },
     preAggregates: {
         enabled: false,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1246,6 +1246,11 @@ export type LightdashConfig = {
     softDelete: {
         enabled: boolean;
         retentionDays: number;
+        cleanup: {
+            batchSize: number;
+            delayMs: number;
+            maxBatches: number;
+        };
     };
     preAggregates: {
         enabled: boolean;
@@ -2245,6 +2250,20 @@ export const parseConfig = (): LightdashConfig => {
                 getIntegerFromEnvironmentVariable(
                     'SOFT_DELETE_RETENTION_DAYS',
                 ) ?? 30,
+            cleanup: {
+                batchSize:
+                    getIntegerFromEnvironmentVariable(
+                        'SOFT_DELETE_CLEANUP_BATCH_SIZE',
+                    ) ?? 100,
+                delayMs:
+                    getIntegerFromEnvironmentVariable(
+                        'SOFT_DELETE_CLEANUP_DELAY_MS',
+                    ) ?? 100,
+                maxBatches:
+                    getIntegerFromEnvironmentVariable(
+                        'SOFT_DELETE_CLEANUP_MAX_BATCHES',
+                    ) ?? 100,
+            },
         },
         preAggregates: {
             enabled: preAggregatesEnabled,

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -463,6 +463,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 preAggregateModel: context.models.getPreAggregateModel(),
                 preAggregateMaterializationService:
                     context.serviceRepository.getPreAggregateMaterializationService(),
+                spaceService: context.serviceRepository.getSpaceService(),
+                savedChartService:
+                    context.serviceRepository.getSavedChartService(),
+                savedSqlService: context.serviceRepository.getSavedSqlService(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1300,6 +1300,23 @@ export class DashboardModel {
         );
     }
 
+    async permanentlyDeleteExpiredBatch(
+        retentionDays: number,
+        limit: number,
+    ): Promise<number> {
+        const subquery = this.database(DashboardsTableName)
+            .select('dashboard_id')
+            .whereNotNull('deleted_at')
+            .andWhereRaw('deleted_at < NOW() - make_interval(days => ?)', [
+                retentionDays,
+            ])
+            .orderBy('deleted_at', 'asc')
+            .limit(limit);
+        return this.database(DashboardsTableName)
+            .whereIn('dashboard_id', subquery)
+            .delete();
+    }
+
     async permanentDelete(dashboardUuid: string): Promise<DashboardDAO> {
         const dashboard = await this.getByIdOrSlug(dashboardUuid, {
             deleted: 'any',

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -782,6 +782,23 @@ export class SavedChartModel {
         );
     }
 
+    async permanentlyDeleteExpiredBatch(
+        retentionDays: number,
+        limit: number,
+    ): Promise<number> {
+        const subquery = this.database(SavedChartsTableName)
+            .select('saved_query_id')
+            .whereNotNull('deleted_at')
+            .andWhereRaw('deleted_at < NOW() - make_interval(days => ?)', [
+                retentionDays,
+            ])
+            .orderBy('deleted_at', 'asc')
+            .limit(limit);
+        return this.database(SavedChartsTableName)
+            .whereIn('saved_query_id', subquery)
+            .delete();
+    }
+
     async permanentDelete(savedChartUuid: string): Promise<SavedChartDAO> {
         const savedChart = await this.get(savedChartUuid, undefined, {
             deleted: 'any',

--- a/packages/backend/src/models/SavedSqlModel.ts
+++ b/packages/backend/src/models/SavedSqlModel.ts
@@ -407,6 +407,23 @@ export class SavedSqlModel {
         }
     }
 
+    async permanentlyDeleteExpiredBatch(
+        retentionDays: number,
+        limit: number,
+    ): Promise<number> {
+        const subquery = this.database(SavedSqlTableName)
+            .select('saved_sql_uuid')
+            .whereNotNull('deleted_at')
+            .andWhereRaw('deleted_at < NOW() - make_interval(days => ?)', [
+                retentionDays,
+            ])
+            .orderBy('deleted_at', 'asc')
+            .limit(limit);
+        return this.database(SavedSqlTableName)
+            .whereIn('saved_sql_uuid', subquery)
+            .delete();
+    }
+
     async permanentDelete(savedSqlUuid: string): Promise<void> {
         await this.database(SavedSqlTableName)
             .where('saved_sql_uuid', savedSqlUuid)

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -1027,6 +1027,23 @@ export class SchedulerModel {
         return this.getSchedulerAndTargets(scheduler.schedulerUuid);
     }
 
+    async permanentlyDeleteExpiredBatch(
+        retentionDays: number,
+        limit: number,
+    ): Promise<number> {
+        const subquery = this.database(SchedulerTableName)
+            .select('scheduler_uuid')
+            .whereNotNull('deleted_at')
+            .andWhereRaw('deleted_at < NOW() - make_interval(days => ?)', [
+                retentionDays,
+            ])
+            .orderBy('deleted_at', 'asc')
+            .limit(limit);
+        return this.database(SchedulerTableName)
+            .whereIn('scheduler_uuid', subquery)
+            .delete();
+    }
+
     async deleteScheduler(schedulerUuid: string): Promise<void> {
         await this.database.transaction(async (trx) => {
             await trx(SchedulerTableName)

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -150,7 +150,10 @@ import { PersistentDownloadFileService } from '../services/PersistentDownloadFil
 import { getDashboardParametersValuesMap } from '../services/ProjectService/parameters';
 import { ProjectService } from '../services/ProjectService/ProjectService';
 import { RenameService } from '../services/RenameService/RenameService';
+import { SavedChartService } from '../services/SavedChartsService/SavedChartService';
+import { SavedSqlService } from '../services/SavedSqlService/SavedSqlService';
 import { SchedulerService } from '../services/SchedulerService/SchedulerService';
+import { SpaceService } from '../services/SpaceService/SpaceService';
 import {
     ScreenshotContext,
     UnfurlService,
@@ -187,6 +190,9 @@ export type SchedulerTaskArguments = {
     persistentDownloadFileService: PersistentDownloadFileService;
     preAggregateModel: PreAggregateModel;
     preAggregateMaterializationService: PreAggregateMaterializationService;
+    spaceService: SpaceService;
+    savedChartService: SavedChartService;
+    savedSqlService: SavedSqlService;
 };
 
 export default class SchedulerTask {
@@ -240,6 +246,12 @@ export default class SchedulerTask {
 
     protected readonly preAggregateModel: PreAggregateModel;
 
+    protected readonly spaceService: SpaceService;
+
+    protected readonly savedChartService: SavedChartService;
+
+    protected readonly savedSqlService: SavedSqlService;
+
     constructor(args: SchedulerTaskArguments) {
         this.lightdashConfig = args.lightdashConfig;
         this.analytics = args.analytics;
@@ -267,6 +279,9 @@ export default class SchedulerTask {
         this.preAggregateModel = args.preAggregateModel;
         this.preAggregateMaterializationService =
             args.preAggregateMaterializationService;
+        this.spaceService = args.spaceService;
+        this.savedChartService = args.savedChartService;
+        this.savedSqlService = args.savedSqlService;
     }
 
     private static getCsvOptions(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -182,6 +182,7 @@ const getTagsForTask: {
     [SCHEDULER_TASKS.GENERATE_SLACK_CHANNEL_SYNC_JOBS]: () => ({}),
     [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS]: () => ({}),
+    [SCHEDULER_TASKS.CLEAN_SOFT_DELETED_CONTENT]: () => ({}),
 } as const;
 
 // Generic accessor function

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -115,6 +115,18 @@ export class SchedulerWorker extends SchedulerTask {
                         maxAttempts: 3,
                     },
                 },
+                ...(this.lightdashConfig.softDelete.enabled
+                    ? [
+                          {
+                              task: SCHEDULER_TASKS.CLEAN_SOFT_DELETED_CONTENT,
+                              pattern: '0 3 * * *', // 3 AM UTC
+                              options: {
+                                  backfillPeriod: 24 * 3600 * 1000,
+                                  maxAttempts: 3,
+                              },
+                          },
+                      ]
+                    : []),
             ]),
             taskList: traceTasks(this.getTaskList()),
             events: schedulerWorkerEventEmitter,
@@ -1126,6 +1138,73 @@ export class SchedulerWorker extends SchedulerTask {
             },
             [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: async () => {
                 await this.schedulerService.checkForStuckJobs();
+            },
+            [SCHEDULER_TASKS.CLEAN_SOFT_DELETED_CONTENT]: async () => {
+                if (!this.lightdashConfig.softDelete.enabled) {
+                    Logger.info(
+                        'Soft delete cleanup job skipped: soft delete is disabled',
+                    );
+                    return;
+                }
+
+                Logger.info('Starting soft delete cleanup job');
+
+                const { retentionDays, cleanup: cleanupConfig } =
+                    this.lightdashConfig.softDelete;
+
+                Logger.info(
+                    `Cleaning soft-deleted content older than ${retentionDays} days`,
+                );
+
+                try {
+                    const results: Record<
+                        string,
+                        { totalDeleted: number; batchCount: number }
+                    > = {};
+
+                    results.spaces =
+                        await this.spaceService.permanentDeleteExpired(
+                            retentionDays,
+                            cleanupConfig,
+                        );
+                    results.dashboards =
+                        await this.dashboardService.permanentDeleteExpired(
+                            retentionDays,
+                            cleanupConfig,
+                        );
+                    results.charts =
+                        await this.savedChartService.permanentDeleteExpired(
+                            retentionDays,
+                            cleanupConfig,
+                        );
+                    results.sqlCharts =
+                        await this.savedSqlService.permanentDeleteExpired(
+                            retentionDays,
+                            cleanupConfig,
+                        );
+                    results.schedulers =
+                        await this.schedulerService.permanentDeleteExpired(
+                            retentionDays,
+                            cleanupConfig,
+                        );
+
+                    const totalDeleted = Object.values(results).reduce(
+                        (sum, r) => sum + r.totalDeleted,
+                        0,
+                    );
+
+                    Logger.info(
+                        `Soft delete cleanup completed. Total deleted: ${totalDeleted} ` +
+                            `(spaces: ${results.spaces.totalDeleted}, ` +
+                            `dashboards: ${results.dashboards.totalDeleted}, ` +
+                            `charts: ${results.charts.totalDeleted}, ` +
+                            `sqlCharts: ${results.sqlCharts.totalDeleted}, ` +
+                            `schedulers: ${results.schedulers.totalDeleted})`,
+                    );
+                } catch (error) {
+                    Logger.error('Error during soft delete cleanup:', error);
+                    throw error;
+                }
             },
         };
     }

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -78,9 +78,12 @@ import { BaseService } from '../BaseService';
 import { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
-import type {
-    SoftDeletableService,
-    SoftDeleteOptions,
+import {
+    batchDeleteExpired,
+    type CleanupConfig,
+    type CleanupResult,
+    type SoftDeletableService,
+    type SoftDeleteOptions,
 } from '../SoftDeletableService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { hasDirectAccessToSpace } from '../SpaceService/SpaceService';
@@ -1361,6 +1364,13 @@ export class DashboardService
         }
 
         await this.dashboardModel.permanentDelete(dashboardUuid);
+    }
+
+    async permanentDeleteExpired(
+        retentionDays: number,
+        config: CleanupConfig,
+    ): Promise<CleanupResult> {
+        return batchDeleteExpired(this.dashboardModel, retentionDays, config);
     }
 
     async getSchedulers(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -84,9 +84,12 @@ import { BaseService } from '../BaseService';
 import { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
-import type {
-    SoftDeletableService,
-    SoftDeleteOptions,
+import {
+    batchDeleteExpired,
+    type CleanupConfig,
+    type CleanupResult,
+    type SoftDeletableService,
+    type SoftDeleteOptions,
 } from '../SoftDeletableService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
@@ -1917,5 +1920,12 @@ export class SavedChartService
         }
 
         await this.savedChartModel.permanentDelete(chartUuid);
+    }
+
+    async permanentDeleteExpired(
+        retentionDays: number,
+        config: CleanupConfig,
+    ): Promise<CleanupResult> {
+        return batchDeleteExpired(this.savedChartModel, retentionDays, config);
     }
 }

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -36,9 +36,12 @@ import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
-import type {
-    SoftDeletableService,
-    SoftDeleteOptions,
+import {
+    batchDeleteExpired,
+    type CleanupConfig,
+    type CleanupResult,
+    type SoftDeletableService,
+    type SoftDeleteOptions,
 } from '../SoftDeletableService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 
@@ -514,6 +517,13 @@ export class SavedSqlService
         }
 
         await this.savedSqlModel.permanentDelete(savedSqlUuid);
+    }
+
+    async permanentDeleteExpired(
+        retentionDays: number,
+        config: CleanupConfig,
+    ): Promise<CleanupResult> {
+        return batchDeleteExpired(this.savedSqlModel, retentionDays, config);
     }
 
     async getResultJobFromSql(

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -67,7 +67,12 @@ import { UserModel } from '../../models/UserModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { getAdjustedCronByOffset } from '../../utils/cronUtils';
 import { BaseService } from '../BaseService';
-import type { SoftDeleteOptions } from '../SoftDeletableService';
+import {
+    batchDeleteExpired,
+    type CleanupConfig,
+    type CleanupResult,
+    type SoftDeleteOptions,
+} from '../SoftDeletableService';
 import type { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { UserService } from '../UserService';
 
@@ -1719,5 +1724,12 @@ export class SchedulerService extends BaseService {
         );
 
         return { runningCount: runningJobs.length, warningCount, errorCount };
+    }
+
+    async permanentDeleteExpired(
+        retentionDays: number,
+        config: CleanupConfig,
+    ): Promise<CleanupResult> {
+        return batchDeleteExpired(this.schedulerModel, retentionDays, config);
     }
 }

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -25,9 +25,12 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { BaseService } from '../BaseService';
 import type { DashboardService } from '../DashboardService/DashboardService';
 import type { SavedChartService } from '../SavedChartsService/SavedChartService';
-import type {
-    SoftDeletableService,
-    SoftDeleteOptions,
+import {
+    batchDeleteExpired,
+    type CleanupConfig,
+    type CleanupResult,
+    type SoftDeletableService,
+    type SoftDeleteOptions,
 } from '../SoftDeletableService';
 import { SpacePermissionService } from './SpacePermissionService';
 
@@ -699,6 +702,13 @@ export class SpaceService
         }
 
         await this.spaceModel.permanentDelete(spaceUuid);
+    }
+
+    async permanentDeleteExpired(
+        retentionDays: number,
+        config: CleanupConfig,
+    ): Promise<CleanupResult> {
+        return batchDeleteExpired(this.spaceModel, retentionDays, config);
     }
 
     async addSpaceUserAccess(

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -68,6 +68,7 @@ export const SCHEDULER_TASKS = {
     RENAME_RESOURCES: 'renameResources',
     MATERIALIZE_PRE_AGGREGATE: 'materializePreAggregate',
     CLEAN_QUERY_HISTORY: 'cleanQueryHistory',
+    CLEAN_SOFT_DELETED_CONTENT: 'cleanSoftDeletedContent',
     DOWNLOAD_ASYNC_QUERY_RESULTS: 'downloadAsyncQueryResults',
     SYNC_SLACK_CHANNELS: 'syncSlackChannels',
     GENERATE_SLACK_CHANNEL_SYNC_JOBS: 'generateSlackChannelSyncJobs',
@@ -108,6 +109,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.RENAME_RESOURCES]: RenameResourcesPayload;
     [SCHEDULER_TASKS.MATERIALIZE_PRE_AGGREGATE]: MaterializePreAggregatePayload;
     [SCHEDULER_TASKS.CLEAN_QUERY_HISTORY]: TraceTaskBase;
+    [SCHEDULER_TASKS.CLEAN_SOFT_DELETED_CONTENT]: TraceTaskBase;
     [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: DownloadAsyncQueryResultsPayload;
     [SCHEDULER_TASKS.SYNC_SLACK_CHANNELS]: SyncSlackChannelsPayload;
     [SCHEDULER_TASKS.GENERATE_SLACK_CHANNEL_SYNC_JOBS]: TraceTaskBase;


### PR DESCRIPTION
### Description:

Implements automated cleanup of soft-deleted content through a scheduled background job. Adds a new `CLEAN_SOFT_DELETED_CONTENT` scheduler task that runs daily at 3 AM UTC to permanently delete soft-deleted items that have exceeded the retention period.

**Key changes:**

- **New scheduler task**: `CLEAN_SOFT_DELETED_CONTENT` that processes expired soft-deleted content in batches
- **Batch deletion methods**: Added `permanentlyDeleteExpiredBatch()` methods to all relevant models (Dashboard, SavedChart, SavedSql, Scheduler, Space) for efficient cleanup
- **Configuration options**: Extended soft delete config with cleanup parameters:
  - `batchSize`: Number of items to process per batch (default: 100)
  - `delayMs`: Delay between batches to prevent database overload (default: 100ms)
  - `maxBatches`: Maximum batches per cleanup run (default: 100)
- **Service integration**: Added cleanup methods to all soft-deletable services with proper batch processing and logging
- **Dependency injection**: Wired up required services (SpaceService, SavedChartService, SavedSqlService) in scheduler workers

The cleanup job only runs when soft delete is enabled and processes items in order of deletion date, with spaces processed shallowest-first to leverage cascade deletion for parent-child relationships.