### PR TITLE
fix: show correct private/custom label on space

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceAccessInfo.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceAccessInfo.tsx
@@ -3,7 +3,6 @@ import { Group, Text, Tooltip } from '@mantine-8/core';
 import { IconLock, IconUser, IconUsers } from '@tabler/icons-react';
 import React, { useMemo } from 'react';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
-import useApp from '../../../providers/App/useApp';
 import MantineIcon from '../MantineIcon';
 import { ResourceAccess } from './types';
 import { getResourceAccessLabel, getResourceAccessType } from './utils';
@@ -23,17 +22,11 @@ const ResourceAccessInfoData = {
     },
 } as const;
 
-const getV2AccessType = (
-    item: ResourceViewSpaceItem,
-    currentUserUuid: string | undefined,
-): ResourceAccess => {
+const getV2AccessType = (item: ResourceViewSpaceItem): ResourceAccess => {
     if (item.data.inheritParentPermissions) {
         return ResourceAccess.Public;
     }
-    const othersWithAccess = item.data.access.filter(
-        (uuid) => uuid !== currentUserUuid,
-    );
-    if (othersWithAccess.length > 0) {
+    if (item.data.access.length > 1) {
         return ResourceAccess.Shared;
     }
     return ResourceAccess.Private;
@@ -83,14 +76,13 @@ const ResourceAccessInfo: React.FC<ResourceAccessInfoProps> = ({
     type = 'secondary',
     withTooltip = false,
 }) => {
-    const { user } = useApp();
     const { data: nestedSpacesPermissionsFlag } = useServerFeatureFlag(
         FeatureFlags.NestedSpacesPermissions,
     );
     const isV2 = !!nestedSpacesPermissionsFlag?.enabled;
 
     const accessType = isV2
-        ? getV2AccessType(item, user.data?.userUuid)
+        ? getV2AccessType(item)
         : getResourceAccessType(item);
     const isNestedSpace = !!item.data.parentSpaceUuid;
     const { Icon } = ResourceAccessInfoData[accessType];


### PR DESCRIPTION
### Description:
Previously, the `getV2AccessType` would filter out the current user from the access list to determine whether the space is shared with anyone or not.
That's very flawed though, since the current user could be any one. So if someone looks at their own space, it would show private correctly. But if a user looks at another persons space, the filter wouldn't work so it ends up showing "Custom", even though only the owner is in the access list.

### Before (left Admin, right Editor)
<img width="5298" height="3308" alt="image" src="https://github.com/user-attachments/assets/3b09afd5-02eb-45be-bec5-e644f3ca4686" />


### After (left Admin, right Editor)
<img width="5298" height="3308" alt="image" src="https://github.com/user-attachments/assets/7141651b-9e13-46fc-9504-fb56a2a0428d" />
