### PR TITLE
feat: add project-scoped Databricks OAuth with dynamic strategy registration

### DIFF
--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -8,6 +8,9 @@ declare module 'express-session' {
             codeVerifier?: string | undefined;
             state?: string | undefined;
             isPopup?: boolean | undefined;
+            databricks?: {
+                projectUuid?: string | undefined;
+            };
         };
         slack: {
             teamId?: string | undefined;

--- a/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
@@ -5,11 +5,217 @@ import {
     ForbiddenError,
     OpenIdIdentityIssuerType,
     OpenIdUser,
+    ParameterError,
 } from '@lightdash/common';
+import { createHash } from 'crypto';
 import { Strategy as OAuth2Strategy, VerifyCallback } from 'passport-oauth2';
 import { URL } from 'url';
 import { lightdashConfig } from '../../../config/lightdashConfig';
 import Logger from '../../../logging/logger';
+
+type DatabricksStrategyConfig = {
+    authorizationURL: string;
+    tokenURL: string;
+    issuer: string;
+    clientId: string;
+    clientSecret?: string;
+};
+
+export const normalizeDatabricksHost = (serverHostName: string): string => {
+    const trimmed = serverHostName.trim();
+    const parsed = new URL(
+        trimmed.startsWith('http://') || trimmed.startsWith('https://')
+            ? trimmed
+            : `https://${trimmed}`,
+    );
+    if (!parsed.host) {
+        throw new ParameterError('Invalid Databricks serverHostName');
+    }
+    if (parsed.pathname !== '/' || parsed.search || parsed.hash) {
+        throw new ParameterError(
+            'Databricks serverHostName must not include a path, query string, or hash',
+        );
+    }
+    return parsed.host;
+};
+
+export const normalizeDatabricksHostLenient = (
+    serverHostName?: string,
+): string => {
+    if (!serverHostName) {
+        return '';
+    }
+    const trimmed = serverHostName.trim();
+    if (!trimmed) {
+        return '';
+    }
+    try {
+        return normalizeDatabricksHost(trimmed).toLowerCase();
+    } catch {
+        return trimmed.toLowerCase();
+    }
+};
+
+export const getDatabricksOidcEndpointsFromHost = (serverHostName: string) => {
+    const host = normalizeDatabricksHost(serverHostName);
+    const issuer = `https://${host}`;
+    return {
+        host,
+        issuer,
+        authorizationURL: `${issuer}/oidc/v1/authorize`,
+        tokenURL: `${issuer}/oidc/v1/token`,
+    };
+};
+
+export const getDatabricksStrategyName = ({
+    host,
+    clientId,
+    clientSecret,
+}: {
+    host: string;
+    clientId: string;
+    clientSecret?: string;
+}) =>
+    `databricks-${createHash('sha256')
+        .update(`${host}:${clientId}:${clientSecret || ''}`)
+        .digest('hex')
+        .slice(0, 16)}`;
+
+export const createDatabricksStrategy = ({
+    authorizationURL,
+    tokenURL,
+    issuer,
+    clientId,
+    clientSecret,
+}: DatabricksStrategyConfig) =>
+    new OAuth2Strategy(
+        {
+            authorizationURL,
+            tokenURL,
+            clientID: clientId,
+            // U2M OAuth can use a public client without a secret, but passport-oauth2 requires this field
+            clientSecret: clientSecret || '',
+            callbackURL: new URL(
+                `/api/v1${lightdashConfig.auth.databricks.callbackPath}`,
+                lightdashConfig.siteUrl,
+            ).href,
+            scope: ['sql', 'offline_access'],
+            passReqToCallback: true,
+            // PKCE is required for Databricks U2M OAuth
+            pkce: true,
+            state: true,
+        },
+        async (
+            req: Express.Request,
+            accessToken: string,
+            refreshToken: string,
+            profile: AnyType,
+            done: VerifyCallback,
+        ) => {
+            try {
+                if (!lightdashConfig.license.licenseKey) {
+                    throw new ForbiddenError(
+                        `Enterprise license required for databricks authentication`,
+                    );
+                }
+
+                const loggedUser = req.user;
+                if (loggedUser === undefined) {
+                    throw new ForbiddenError('User not authenticated');
+                }
+
+                // Databricks OAuth doesn't return user profile in the token response
+                // We use the existing logged-in user's information
+                const openIdUser: OpenIdUser = {
+                    openId: {
+                        subject: loggedUser.userUuid,
+                        issuer,
+                        issuerType: OpenIdIdentityIssuerType.DATABRICKS,
+                        email: loggedUser.email!,
+                        firstName: loggedUser.firstName,
+                        lastName: loggedUser.lastName,
+                    },
+                };
+
+                if (!refreshToken) {
+                    throw new Error(
+                        'Databricks OAuth refresh token was not returned. Ensure offline_access scope is granted.',
+                    );
+                }
+
+                const projectUuid = req.session.oauth?.databricks?.projectUuid;
+
+                let serverHostName: string | undefined;
+                let projectName: string | undefined;
+                if (projectUuid) {
+                    if (!req.account) {
+                        throw new ForbiddenError('User session not found');
+                    }
+                    const databricksConfig = await req.services
+                        .getProjectService()
+                        .getDatabricksOAuthConfigForProject(
+                            projectUuid,
+                            req.account,
+                        );
+                    serverHostName = databricksConfig.serverHostName;
+                    projectName = databricksConfig.projectName;
+                } else {
+                    // Derive host from the issuer in the strategy's closure
+                    serverHostName = new URL(issuer).host;
+                }
+
+                const credentialsName = serverHostName
+                    ? `Databricks (${serverHostName})`
+                    : undefined;
+
+                Logger.info(
+                    `Creating user warehouse credentials for Databricks`,
+                );
+                const userCredentials = await req.services
+                    .getUserService()
+                    .createDatabricksWarehouseCredentials(
+                        req.user!,
+                        refreshToken,
+                        {
+                            projectUuid,
+                            projectName,
+                            serverHostName,
+                            credentialsName,
+                            oauthClientId: clientId,
+                        },
+                    );
+
+                if (userCredentials && projectUuid) {
+                    try {
+                        await req.services
+                            .getProjectService()
+                            .upsertProjectCredentialsPreference(
+                                req.user!,
+                                projectUuid,
+                                userCredentials.uuid,
+                            );
+                    } catch (e) {
+                        Logger.warn(
+                            `Failed to set Databricks credentials preference for project ${projectUuid}`,
+                            e,
+                        );
+                    }
+                }
+
+                const user = await req.services
+                    .getUserService()
+                    .loginWithOpenId(
+                        openIdUser,
+                        req.user,
+                        undefined,
+                        refreshToken,
+                    );
+                done(null, user);
+            } catch (error) {
+                done(error);
+            }
+        },
+    );
 
 // Databricks U2M OAuth doesn't require a client secret (public client)
 // and requires PKCE (Proof Key for Code Exchange)
@@ -20,87 +226,16 @@ export const databricksPassportStrategy = !(
     lightdashConfig.auth.databricks.tokenEndpoint
 )
     ? undefined
-    : new OAuth2Strategy(
-          {
-              authorizationURL:
+    : createDatabricksStrategy({
+          authorizationURL:
+              lightdashConfig.auth.databricks.authorizationEndpoint,
+          tokenURL: lightdashConfig.auth.databricks.tokenEndpoint,
+          issuer: (() => {
+              const authUrl = new URL(
                   lightdashConfig.auth.databricks.authorizationEndpoint,
-              tokenURL: lightdashConfig.auth.databricks.tokenEndpoint,
-              clientID: lightdashConfig.auth.databricks.clientId,
-              // U2M OAuth uses a public client without a secret, but passport-oauth2 requires this field
-              clientSecret: lightdashConfig.auth.databricks.clientSecret || '',
-              callbackURL: new URL(
-                  `/api/v1${lightdashConfig.auth.databricks.callbackPath}`,
-                  lightdashConfig.siteUrl,
-              ).href,
-              scope: ['sql', 'offline_access'],
-              passReqToCallback: true,
-              // PKCE is required for Databricks U2M OAuth
-              pkce: true,
-              state: true,
-          },
-          async (
-              req: Express.Request,
-              accessToken: string,
-              refreshToken: string,
-              profile: AnyType,
-              done: VerifyCallback,
-          ) => {
-              try {
-                  if (!lightdashConfig.license.licenseKey) {
-                      throw new ForbiddenError(
-                          `Enterprise license required for databricks authentication`,
-                      );
-                  }
-
-                  const loggedUser = req.user;
-                  if (loggedUser === undefined) {
-                      throw new ForbiddenError('User not authenticated');
-                  }
-
-                  // Databricks OAuth doesn't return user profile in the token response
-                  // We use the existing logged-in user's information
-                  const openIdUser: OpenIdUser = {
-                      openId: {
-                          subject: loggedUser.userUuid,
-                          issuer: lightdashConfig.auth.databricks
-                              .authorizationEndpoint!,
-                          issuerType: OpenIdIdentityIssuerType.DATABRICKS,
-                          email: loggedUser.email!,
-                          firstName: loggedUser.firstName,
-                          lastName: loggedUser.lastName,
-                      },
-                  };
-
-                  if (!refreshToken) {
-                      throw new Error(
-                          'Databricks OAuth refresh token was not returned. Ensure offline_access scope is granted.',
-                      );
-                  }
-
-                  // Create user warehouse credentials with the refresh token
-                  // so they can use it to query Databricks SQL warehouses
-                  Logger.info(
-                      `Creating user warehouse credentials for Databricks`,
-                  );
-                  await req.services
-                      .getUserService()
-                      .createDatabricksWarehouseCredentials(
-                          req.user!,
-                          refreshToken,
-                      );
-
-                  const user = await req.services
-                      .getUserService()
-                      .loginWithOpenId(
-                          openIdUser,
-                          req.user,
-                          undefined,
-                          refreshToken,
-                      );
-                  done(null, user);
-              } catch (error) {
-                  // Handle any errors that occur during processing
-                  done(error);
-              }
-          },
-      );
+              );
+              return `${authUrl.protocol}//${authUrl.host}`;
+          })(),
+          clientId: lightdashConfig.auth.databricks.clientId,
+          clientSecret: lightdashConfig.auth.databricks.clientSecret,
+      });

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7405,11 +7405,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7887,11 +7887,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7906,11 +7906,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7925,11 +7925,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7944,11 +7944,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7963,11 +7963,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -11880,12 +11880,19 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Partial_Pick_CreateDatabricksCredentials.database-or-serverHostName-or-httpPath__':
+    'Partial_Pick_CreateDatabricksCredentials.database-or-serverHostName-or-httpPath-or-oauthClientId__':
         {
             dataType: 'refAlias',
             type: {
                 dataType: 'nestedObjectLiteral',
                 nestedProperties: {
+                    oauthClientId: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     database: {
                         dataType: 'union',
                         subSchemas: [
@@ -11970,7 +11977,7 @@ const models: TsoaRoute.Models = {
                                     ref: 'Pick_CreateDatabricksCredentials.type-or-personalAccessToken-or-authenticationType-or-refreshToken_',
                                 },
                                 {
-                                    ref: 'Partial_Pick_CreateDatabricksCredentials.database-or-serverHostName-or-httpPath__',
+                                    ref: 'Partial_Pick_CreateDatabricksCredentials.database-or-serverHostName-or-httpPath-or-oauthClientId__',
                                 },
                             ],
                         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8695,19 +8695,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "error",
                                                             "success"
                                                         ]
@@ -12739,8 +12726,11 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Partial_Pick_CreateDatabricksCredentials.database-or-serverHostName-or-httpPath__": {
+            "Partial_Pick_CreateDatabricksCredentials.database-or-serverHostName-or-httpPath-or-oauthClientId__": {
                 "properties": {
+                    "oauthClientId": {
+                        "type": "string"
+                    },
                     "database": {
                         "type": "string"
                     },
@@ -12798,7 +12788,7 @@
                                         "$ref": "#/components/schemas/Pick_CreateDatabricksCredentials.type-or-personalAccessToken-or-authenticationType-or-refreshToken_"
                                     },
                                     {
-                                        "$ref": "#/components/schemas/Partial_Pick_CreateDatabricksCredentials.database-or-serverHostName-or-httpPath__"
+                                        "$ref": "#/components/schemas/Partial_Pick_CreateDatabricksCredentials.database-or-serverHostName-or-httpPath-or-oauthClientId__"
                                     }
                                 ]
                             },
@@ -26552,7 +26542,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2518.1",
+        "version": "0.2521.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -1,4 +1,8 @@
 import { AuthorizationError } from '@lightdash/common';
+import {
+    DATABRICKS_DEFAULT_OAUTH_CLIENT_ID,
+    isDatabricksCliOAuthClientId,
+} from '@lightdash/warehouses';
 import express, { type Router } from 'express';
 import passport from 'passport';
 import { lightdashConfig } from '../config/lightdashConfig';
@@ -6,10 +10,16 @@ import {
     getLoginHint,
     getOidcRedirectURL,
     initiateOktaOpenIdLogin,
+    isAuthenticated,
     storeOIDCRedirect,
     storeSlackContext,
 } from '../controllers/authentication';
-import { databricksPassportStrategy } from '../controllers/authentication/strategies/databricksStrategy';
+import {
+    createDatabricksStrategy,
+    databricksPassportStrategy,
+    getDatabricksOidcEndpointsFromHost,
+    getDatabricksStrategyName,
+} from '../controllers/authentication/strategies/databricksStrategy';
 import { AiAgentService } from '../ee/services/AiAgentService/AiAgentService';
 import Logger from '../logging/logger';
 import { UserModel } from '../models/UserModel';
@@ -26,6 +36,160 @@ import { savedChartRouter } from './savedChartRouter';
 import { userRouter } from './userRouter';
 
 export const apiV1Router: Router = express.Router();
+
+const resolveDynamicDatabricksOauthConfig = async (req: express.Request) => {
+    const projectUuid =
+        req.session.oauth?.databricks?.projectUuid ||
+        (typeof req.query.projectUuid === 'string'
+            ? req.query.projectUuid
+            : undefined);
+
+    let serverHostName =
+        typeof req.query.serverHostName === 'string'
+            ? req.query.serverHostName
+            : undefined;
+
+    // On the OAuth callback, Databricks sends an `iss` param with the OIDC
+    // issuer URL (e.g. https://dbc-xxx.cloud.databricks.com/oidc).
+    // Extract the host from it as a fallback when serverHostName isn't present.
+    if (!serverHostName && typeof req.query.iss === 'string') {
+        try {
+            serverHostName = new URL(req.query.iss).host;
+        } catch {
+            // ignore invalid iss
+        }
+    }
+    let projectClientId: string | undefined;
+    let projectClientSecret: string | undefined;
+
+    if (projectUuid) {
+        if (!req.account) {
+            throw new AuthorizationError('User session not found');
+        }
+        const databricksConfig = await req.services
+            .getProjectService()
+            .getDatabricksOAuthConfigForProject(projectUuid, req.account);
+        serverHostName = databricksConfig.serverHostName;
+        projectClientId = databricksConfig.oauthClientId;
+        projectClientSecret = databricksConfig.oauthClientSecret;
+    }
+
+    if (!serverHostName) {
+        return undefined;
+    }
+
+    // Resolve which OAuth client to use. CLI-default client IDs
+    // (databricks-cli, dbt-databricks) only work with CLI redirect URIs,
+    // so for browser flows prefer the server-configured client.
+    let clientId: string;
+    let clientSecret: string | undefined;
+    if (projectClientId && !isDatabricksCliOAuthClientId(projectClientId)) {
+        clientId = projectClientId;
+        clientSecret = projectClientSecret;
+    } else if (lightdashConfig.auth.databricks.clientId) {
+        clientId = lightdashConfig.auth.databricks.clientId;
+        clientSecret = lightdashConfig.auth.databricks.clientSecret;
+    } else {
+        throw new AuthorizationError(
+            'Databricks OAuth client is not configured',
+        );
+    }
+    const oidc = getDatabricksOidcEndpointsFromHost(serverHostName);
+    return {
+        projectUuid,
+        clientId,
+        clientSecret,
+        authorizationURL: oidc.authorizationURL,
+        tokenURL: oidc.tokenURL,
+        issuer: oidc.issuer,
+        strategyName: getDatabricksStrategyName({
+            host: oidc.host,
+            clientId,
+            clientSecret,
+        }),
+    };
+};
+
+// Cache dynamic Databricks strategies to avoid leaking memory by
+// registering a new passport strategy on every request.  The cache is
+// bounded: entries are evicted after 10 minutes of inactivity so that
+// stale config (e.g. rotated client secrets) is eventually picked up.
+const DATABRICKS_STRATEGY_TTL_MS = 10 * 60 * 1000;
+const databricksStrategyCache = new Map<
+    string,
+    { timer: ReturnType<typeof setTimeout> }
+>();
+
+const getOrCreateDatabricksStrategy = (
+    config: NonNullable<
+        Awaited<ReturnType<typeof resolveDynamicDatabricksOauthConfig>>
+    >,
+): string => {
+    const { strategyName } = config;
+    const existing = databricksStrategyCache.get(strategyName);
+    if (existing) {
+        // Refresh TTL on access
+        clearTimeout(existing.timer);
+        existing.timer = setTimeout(() => {
+            databricksStrategyCache.delete(strategyName);
+            passport.unuse(strategyName);
+        }, DATABRICKS_STRATEGY_TTL_MS);
+        return strategyName;
+    }
+
+    passport.use(strategyName, createDatabricksStrategy(config));
+    const timer = setTimeout(() => {
+        databricksStrategyCache.delete(strategyName);
+        passport.unuse(strategyName);
+    }, DATABRICKS_STRATEGY_TTL_MS);
+    databricksStrategyCache.set(strategyName, { timer });
+    return strategyName;
+};
+
+const authenticateDatabricks = (
+    getAuthenticateOptions?: (
+        req: express.Request,
+    ) => passport.AuthenticateOptions,
+) =>
+    async function databricksAuthHandler(
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction,
+    ) {
+        try {
+            const options = getAuthenticateOptions?.(req);
+            const dynamicConfig =
+                await resolveDynamicDatabricksOauthConfig(req);
+
+            let strategyName: string;
+            if (dynamicConfig) {
+                strategyName = getOrCreateDatabricksStrategy(dynamicConfig);
+                req.session.oauth = req.session.oauth || {};
+                req.session.oauth.databricks = {
+                    projectUuid: dynamicConfig.projectUuid,
+                };
+            } else {
+                req.session.oauth = req.session.oauth || {};
+                req.session.oauth.databricks = undefined;
+                if (!databricksPassportStrategy) {
+                    res.status(404).json({
+                        status: 'error',
+                        message: 'Databricks OAuth is not configured',
+                    });
+                    return;
+                }
+                strategyName = 'databricks';
+            }
+
+            if (options) {
+                passport.authenticate(strategyName, options)(req, res, next);
+            } else {
+                passport.authenticate(strategyName)(req, res, next);
+            }
+        } catch (error) {
+            next(error);
+        }
+    };
 
 apiV1Router.get('/livez', async (req, res, next) => {
     res.json({
@@ -277,35 +441,21 @@ apiV1Router.get(
     },
 );
 
-// Databricks OAuth routes - only register if strategy is configured
-// (requires DATABRICKS_OAUTH_CLIENT_ID, DATABRICKS_OAUTH_AUTHORIZATION_ENDPOINT, DATABRICKS_OAUTH_TOKEN_ENDPOINT)
-if (databricksPassportStrategy) {
-    apiV1Router.get(
-        lightdashConfig.auth.databricks.loginPath,
-        storeOIDCRedirect,
-        passport.authenticate('databricks'),
-    );
+apiV1Router.get(
+    lightdashConfig.auth.databricks.loginPath,
+    isAuthenticated,
+    storeOIDCRedirect,
+    authenticateDatabricks(),
+);
 
-    apiV1Router.get(
-        lightdashConfig.auth.databricks.callbackPath,
-        (req, res, next) => {
-            passport.authenticate('databricks', {
-                failureRedirect: getOidcRedirectURL(false)(req),
-                successRedirect: getOidcRedirectURL(true)(req),
-            })(req, res, next);
-        },
-    );
-} else {
-    apiV1Router.get(
-        lightdashConfig.auth.databricks.loginPath,
-        (req, res, next) => {
-            res.status(404).json({
-                status: 'error',
-                message: 'Databricks OAuth is not configured',
-            });
-        },
-    );
-}
+apiV1Router.get(
+    lightdashConfig.auth.databricks.callbackPath,
+    isAuthenticated,
+    authenticateDatabricks((req) => ({
+        failureRedirect: getOidcRedirectURL(false)(req),
+        successRedirect: getOidcRedirectURL(true)(req),
+    })),
+);
 
 apiV1Router.get('/logout', (req, res, next) => {
     req.logout((err) => {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -169,12 +169,10 @@ export class HealthService extends BaseService {
                         this.isEnterpriseEnabled(),
                 },
                 databricks: {
-                    // U2M OAuth only requires endpoints - client ID defaults to 'databricks-cli'
+                    // Databricks OAuth browser flow requires a configured client ID.
                     enabled:
                         !!this.lightdashConfig.auth.databricks.clientId &&
-                        !!this.lightdashConfig.auth.databricks
-                            .authorizationEndpoint &&
-                        !!this.lightdashConfig.auth.databricks.tokenEndpoint,
+                        this.isEnterpriseEnabled(),
                 },
             },
             hasEmailClient: !!this.lightdashConfig.smtp,

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1851,6 +1851,18 @@ export class UserService extends BaseService {
         );
     }
 
+    async hasDatabricksOAuthCredentialForHost(
+        user: SessionUser,
+        serverHostName: string,
+    ): Promise<boolean> {
+        const credential =
+            await this.userWarehouseCredentialsModel.findDatabricksOauthU2mForHostWithSecrets(
+                user.userUuid,
+                serverHostName,
+            );
+        return credential !== undefined;
+    }
+
     async createBigqueryWarehouseCredentials(
         user: SessionUser,
         refreshToken: string,
@@ -1897,34 +1909,105 @@ export class UserService extends BaseService {
     async createDatabricksWarehouseCredentials(
         user: SessionUser,
         refreshToken: string,
+        options?: {
+            projectUuid?: string;
+            projectName?: string;
+            serverHostName?: string;
+            credentialsName?: string;
+            oauthClientId?: string;
+        },
     ) {
-        // Remove old Databricks credentials to prevent duplicates on re-authentication
-        await this.userWarehouseCredentialsModel.deleteAllByUserAndWarehouseType(
-            user.userUuid,
-            WarehouseTypes.DATABRICKS,
-        );
-
-        // Only store authentication fields - connection details (database, serverHostName, httpPath)
-        // come from the project configuration and shouldn't be stored in user credentials
+        const credentialsNameFromOptions = options?.credentialsName?.trim();
+        const projectName = options?.projectName?.trim();
+        const serverHostName = options?.serverHostName?.trim();
+        let credentialsName = 'Default';
+        if (credentialsNameFromOptions) {
+            credentialsName = credentialsNameFromOptions;
+        } else if (serverHostName) {
+            credentialsName = `Databricks (${serverHostName})`;
+        }
         const databricksCredentials: UpsertUserWarehouseCredentials = {
-            name: 'Default',
+            name: credentialsName,
             credentials: {
                 type: WarehouseTypes.DATABRICKS,
                 authenticationType: DatabricksAuthenticationType.OAUTH_U2M,
                 refreshToken,
+                serverHostName,
+                oauthClientId: options?.oauthClientId,
             },
         };
-        await this.createWarehouseCredentials(user, databricksCredentials);
+
+        if (options?.projectUuid) {
+            if (serverHostName) {
+                const matchingCredential =
+                    await this.userWarehouseCredentialsModel.findDatabricksOauthU2mForHostWithSecrets(
+                        user.userUuid,
+                        serverHostName,
+                        {
+                            projectUuid: options.projectUuid,
+                        },
+                    );
+                if (matchingCredential) {
+                    return this.updateWarehouseCredentials(
+                        user,
+                        matchingCredential.uuid,
+                        databricksCredentials,
+                    );
+                }
+            }
+
+            const existingCredentials =
+                await this.userWarehouseCredentialsModel.findForProject(
+                    options.projectUuid,
+                    user.userUuid,
+                    WarehouseTypes.DATABRICKS,
+                );
+            if (existingCredentials) {
+                return this.updateWarehouseCredentials(
+                    user,
+                    existingCredentials.uuid,
+                    databricksCredentials,
+                );
+            }
+
+            return this.createWarehouseCredentials(
+                user,
+                databricksCredentials,
+                options.projectUuid,
+            );
+        }
+
+        if (serverHostName) {
+            const existingCredentials =
+                await this.userWarehouseCredentialsModel.findDatabricksOauthU2mForHostWithSecrets(
+                    user.userUuid,
+                    serverHostName,
+                    {
+                        includeProjectScoped: false,
+                    },
+                );
+            if (existingCredentials) {
+                return this.updateWarehouseCredentials(
+                    user,
+                    existingCredentials.uuid,
+                    databricksCredentials,
+                );
+            }
+        }
+
+        return this.createWarehouseCredentials(user, databricksCredentials);
     }
 
     async createWarehouseCredentials(
         user: SessionUser,
         data: UpsertUserWarehouseCredentials,
+        projectUuid?: string,
     ) {
         const userWarehouseCredentialsUuid =
             await this.userWarehouseCredentialsModel.create(
                 user.userUuid,
                 data,
+                projectUuid,
             );
         this.analytics.track({
             userId: user.userUuid,

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -617,6 +617,20 @@ export class SnowflakeTokenError extends LightdashError {
     }
 }
 
+/* This specific error will be used in the frontend
+to show a "reauthenticate" button in the UI
+*/
+export class DatabricksTokenError extends LightdashError {
+    constructor(message: string) {
+        super({
+            message,
+            name: 'DatabricksTokenError',
+            statusCode: 401,
+            data: {},
+        });
+    }
+}
+
 export class CustomSqlQueryForbiddenError extends LightdashError {
     constructor(
         message: string = 'User cannot run queries with custom SQL dimensions',

--- a/packages/common/src/types/userWarehouseCredentials.ts
+++ b/packages/common/src/types/userWarehouseCredentials.ts
@@ -72,7 +72,10 @@ export type UserWarehouseCredentialsWithSecrets = Pick<
               Partial<
                   Pick<
                       CreateDatabricksCredentials,
-                      'database' | 'serverHostName' | 'httpPath'
+                      | 'database'
+                      | 'serverHostName'
+                      | 'httpPath'
+                      | 'oauthClientId'
                   >
               >)
         | Pick<
@@ -105,6 +108,7 @@ export const databricksOauthU2mUserCredentialsSchema = z
         type: z.literal(WarehouseTypes.DATABRICKS),
         authenticationType: z.literal(DatabricksAuthenticationType.OAUTH_U2M),
         refreshToken: z.string(),
+        oauthClientId: z.string().optional(),
         personalAccessToken: z.string().optional(),
         database: z.string().optional(),
         serverHostName: z.string().optional(),

--- a/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/UserCredentialsSwitcher.tsx
@@ -77,7 +77,17 @@ const UserCredentialsSwitcher = () => {
                             ?.requireUserCredentials
                     ) {
                         console.info('Triggering reauth modal for Snowflake');
-                        // Trigger the reauth modal
+                        setShowCreateModalOnPageLoad(true);
+                        setIsCreatingCredentials(true);
+                    }
+                    if (
+                        error?.error?.name === 'DatabricksTokenError' &&
+                        activeProject?.warehouseConnection?.type ===
+                            'databricks' &&
+                        activeProject?.warehouseConnection
+                            ?.requireUserCredentials
+                    ) {
+                        console.info('Triggering reauth modal for Databricks');
                         setShowCreateModalOnPageLoad(true);
                         setIsCreatingCredentials(true);
                     }
@@ -204,6 +214,8 @@ const UserCredentialsSwitcher = () => {
                         showCreateModalOnPageLoad ? 'Default' : undefined
                     }
                     warehouseType={activeProject.warehouseConnection?.type}
+                    projectUuid={activeProjectUuid}
+                    projectName={activeProject.name}
                     onSuccess={(data) => {
                         mutate({
                             projectUuid: activeProjectUuid,

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -20,6 +20,8 @@ type Props = Pick<MantineModalProps, 'opened' | 'onClose'> & {
     description?: React.ReactNode;
     nameValue?: string;
     warehouseType?: WarehouseTypes;
+    projectUuid?: string;
+    projectName?: string;
     onSuccess?: (data: UserWarehouseCredentials) => void;
 };
 
@@ -76,6 +78,8 @@ export const CreateCredentialsModal: FC<Props> = ({
     description,
     nameValue,
     warehouseType,
+    projectUuid,
+    projectName,
     onSuccess,
 }) => {
     const health = useHealth();
@@ -165,6 +169,11 @@ export const CreateCredentialsModal: FC<Props> = ({
                         form={form}
                         disabled={isSaving}
                         onClose={onClose}
+                        projectUuid={projectUuid}
+                        projectName={projectName}
+                        databricksCredentialsName={
+                            nameValue || form.values.name
+                        }
                     />
                 </Stack>
             </form>

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx
@@ -46,11 +46,19 @@ export const SnowflakeFormInput: FC<{ onClose: () => void }> = ({
     );
 };
 
-const DatabricksFormInput: FC<{ onClose: () => void }> = ({ onClose }) => {
+const DatabricksFormInput: FC<{
+    onClose: () => void;
+    projectUuid?: string;
+    projectName?: string;
+    credentialsName?: string;
+}> = ({ onClose, projectUuid, projectName, credentialsName }) => {
     const { mutate: openLoginPopup } = useDatabricksLoginPopup({
         onLogin: async () => {
             onClose();
         },
+        projectUuid,
+        projectName,
+        credentialsName,
     });
 
     // If this popup happens, it means we don't have warehouse credentials,
@@ -68,7 +76,17 @@ export const WarehouseFormInputs: FC<{
     disabled: boolean;
     form: UseFormReturnType<UpsertUserWarehouseCredentials>;
     onClose: () => void;
-}> = ({ form, disabled, onClose }) => {
+    projectUuid?: string;
+    projectName?: string;
+    databricksCredentialsName?: string;
+}> = ({
+    form,
+    disabled,
+    onClose,
+    projectUuid,
+    projectName,
+    databricksCredentialsName,
+}) => {
     switch (form.values.credentials.type) {
         case WarehouseTypes.SNOWFLAKE:
             return <SnowflakeFormInput onClose={onClose} />;
@@ -97,7 +115,14 @@ export const WarehouseFormInputs: FC<{
         case WarehouseTypes.BIGQUERY:
             return <BigQueryFormInput onClose={onClose} />;
         case WarehouseTypes.DATABRICKS:
-            return <DatabricksFormInput onClose={onClose} />;
+            return (
+                <DatabricksFormInput
+                    onClose={onClose}
+                    projectUuid={projectUuid}
+                    projectName={projectName}
+                    credentialsName={databricksCredentialsName}
+                />
+            );
         default:
             return null;
     }

--- a/packages/frontend/src/hooks/useDatabricks.ts
+++ b/packages/frontend/src/hooks/useDatabricks.ts
@@ -5,10 +5,30 @@ import { lightdashApi } from '../api';
 import useHealth from './health/useHealth';
 import useToaster from './toaster/useToaster';
 
-const triggerDatabricksLogin = async (siteUrl: string) => {
+const triggerDatabricksLogin = async (
+    siteUrl: string,
+    options?: {
+        projectUuid?: string;
+        projectName?: string;
+        serverHostName?: string;
+        credentialsName?: string;
+    },
+) => {
     return new Promise<void>((resolve, reject) => {
         const channel = new BroadcastChannel('lightdash-oauth-popup');
-        const loginUrl = `${siteUrl}/api/v1/login/databricks?isPopup=true`;
+        const params = new URLSearchParams({ isPopup: 'true' });
+        if (options?.projectUuid) {
+            params.set('projectUuid', options.projectUuid);
+        } else if (options?.serverHostName) {
+            params.set('serverHostName', options.serverHostName);
+        }
+        if (options?.projectName) {
+            params.set('projectName', options.projectName);
+        }
+        if (options?.credentialsName) {
+            params.set('credentialsName', options.credentialsName);
+        }
+        const loginUrl = `${siteUrl}/api/v1/login/databricks?${params.toString()}`;
         console.info(`Opening popup with url: ${loginUrl}`);
 
         const popupWindow = window.open(
@@ -42,14 +62,28 @@ const triggerDatabricksLogin = async (siteUrl: string) => {
 
 export function useDatabricksLoginPopup({
     onLogin: _onLogin,
+    projectUuid,
+    projectName,
+    serverHostName,
+    credentialsName,
 }: {
     onLogin: () => Promise<void>;
+    projectUuid?: string;
+    projectName?: string;
+    serverHostName?: string;
+    credentialsName?: string;
 }) {
     const { showToastError } = useToaster();
     const health = useHealth();
     const queryClient = useQueryClient();
     const ssoMutation = useMutation({
-        mutationFn: () => triggerDatabricksLogin(health.data?.siteUrl || ''),
+        mutationFn: () =>
+            triggerDatabricksLogin(health.data?.siteUrl || '', {
+                projectUuid,
+                projectName,
+                serverHostName,
+                credentialsName,
+            }),
         onSuccess: async () => {
             // Invalidate user warehouse credentials since the backend creates
             // credentials during the OAuth flow
@@ -72,16 +106,37 @@ export function useDatabricksLoginPopup({
     }, [ssoMutation, health.data?.auth.databricks.enabled]);
 }
 
-const getIsAuthenticated = async () =>
+const getIsAuthenticatedForProject = async (
+    projectUuid?: string,
+    serverHostName?: string,
+) =>
     lightdashApi<ApiSuccessEmpty['results']>({
-        url: `/databricks/sso/is-authenticated`,
+        url: `/databricks/sso/is-authenticated${
+            projectUuid
+                ? `?projectUuid=${encodeURIComponent(projectUuid)}`
+                : serverHostName
+                  ? `?serverHostName=${encodeURIComponent(serverHostName)}`
+                  : ''
+        }`,
         method: 'GET',
         body: undefined,
     });
 
-export const useIsDatabricksAuthenticated = () => {
+export const useIsDatabricksAuthenticated = ({
+    projectUuid,
+    serverHostName,
+}: {
+    projectUuid?: string;
+    serverHostName?: string;
+}) => {
     return useQuery<ApiSuccessEmpty['results'], ApiError>({
-        queryKey: ['databricks-sso-is-authenticated'],
-        queryFn: getIsAuthenticated,
+        queryKey: [
+            'databricks-sso-is-authenticated',
+            projectUuid,
+            serverHostName,
+        ],
+        queryFn: () =>
+            getIsAuthenticatedForProject(projectUuid, serverHostName),
+        enabled: !!projectUuid || !!serverHostName,
     });
 };

--- a/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DatabricksWarehouseClient.ts
@@ -41,6 +41,16 @@ import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
  */
 export const DATABRICKS_DEFAULT_OAUTH_CLIENT_ID = 'databricks-cli';
 
+/** Client IDs that only work with CLI redirect URIs, not browser OAuth flows */
+const DATABRICKS_CLI_OAUTH_CLIENT_IDS = new Set([
+    'databricks-cli',
+    'dbt-databricks',
+]);
+
+export const isDatabricksCliOAuthClientId = (
+    clientId: string | undefined,
+): boolean => !!clientId && DATABRICKS_CLI_OAUTH_CLIENT_IDS.has(clientId);
+
 type SchemaResult = {
     TABLE_CAT: string;
     TABLE_SCHEM: string;


### PR DESCRIPTION
### TL;DR

Enhanced Databricks OAuth authentication to support project-scoped credentials and dynamic OAuth client configuration with improved host-based credential matching.

### What changed?

- Added project-scoped Databricks OAuth authentication that stores `projectUuid` in session state
- Implemented dynamic OAuth strategy creation with caching to support multiple Databricks workspaces
- Enhanced credential resolution to match by server hostname and prevent cross-workspace token misuse  
- Added host normalization utilities for consistent Databricks workspace URL handling
- Updated user warehouse credentials model to find OAuth credentials by hostname with project scoping options
- Modified authentication endpoints to accept `projectUuid` and `serverHostName` query parameters
- Added credential preference management for project-specific Databricks connections
- Enhanced error handling with `DatabricksTokenError` for better user experience
- Updated frontend components to pass project context during OAuth flows

### How to test?

1. Configure a Databricks project with OAuth credentials
2. Test OAuth login flow with project-specific parameters (`/api/v1/login/databricks?projectUuid=<uuid>`)
3. Verify credentials are scoped to the correct project and workspace
4. Test cross-workspace scenarios to ensure tokens don't leak between workspaces
5. Test the credential switcher UI shows appropriate re-authentication prompts
6. Verify dynamic strategy caching works for multiple concurrent OAuth flows

### Why make this change?

This change enables proper multi-tenant Databricks OAuth support where users can authenticate to different Databricks workspaces within the same Lightdash instance. Previously, credentials were global and could cause token mismatches across workspaces. The project-scoped approach ensures credentials are properly isolated and matched to their intended workspace, improving security and user experience.