### PR TITLE
feat: add payload size error handling and batched deploy options to preview commands

### DIFF
--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -37,6 +37,9 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     organizationCredentials?: string;
     assumeYes?: boolean;
     warehouseCredentials?: boolean;
+    useBatchedDeploy?: boolean;
+    batchSize?: string;
+    parallelBatches?: string;
 };
 
 type StopPreviewHandlerOptions = {

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -531,6 +531,21 @@ program
         '--organization-credentials <name>',
         'Use organization warehouse credentials with the specified name (Enterprise Edition feature)',
     )
+    .option(
+        '--use-batched-deploy',
+        'Use the new batched deploy feature to upload explores in batches',
+        false,
+    )
+    .option(
+        '--batch-size <number>',
+        'Number of explores to deploy in each batch (default: 50)',
+        '50',
+    )
+    .option(
+        '--parallel-batches <number>',
+        'Number of batches to send in parallel (default: 1, use higher values with caution)',
+        '1',
+    )
     .action(previewHandler);
 
 program
@@ -635,6 +650,21 @@ program
         'Create preview without warehouse credentials. Copies credentials from upstream project.',
     )
     .option('-y, --assume-yes', 'assume yes to prompts', false)
+    .option(
+        '--use-batched-deploy',
+        'Use the new batched deploy feature to upload explores in batches',
+        false,
+    )
+    .option(
+        '--batch-size <number>',
+        'Number of explores to deploy in each batch (default: 50)',
+        '50',
+    )
+    .option(
+        '--parallel-batches <number>',
+        'Number of batches to send in parallel (default: 1, use higher values with caution)',
+        '1',
+    )
     .action(startPreviewHandler);
 
 program
@@ -837,7 +867,7 @@ program
     )
     .option(
         '--parallel-batches <number>',
-        'Number of batches to send in parallel (default: 1)',
+        'Number of batches to send in parallel (default: 1, use higher values with caution)',
         '1',
     )
     .action(deployHandler);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR improves the deploy experience when dealing with large projects by adding better error handling and making batched deploy more accessible.

**Key changes:**

- **Enhanced error handling for payload size limits**: Added specific error detection for 413 "Payload Too Large" responses and related size errors. When detected, the CLI now provides clear guidance on using the batched deploy feature instead of generic error messages.

- **Reduced default parallel batches**: Changed the default `parallelBatches` from 5 to 1 to prevent overwhelming servers and reduce the risk of rate limiting or connection issues during deployment.

- **Added batched deploy options to preview commands**: Extended both `preview` and `start-preview` commands with `--use-batched-deploy`, `--batch-size`, and `--parallel-batches` options, making the batched deployment feature available across all deployment scenarios.

- **Improved CLI help text**: Updated the `--parallel-batches` option description to include a caution about using higher values, helping users make informed decisions about parallelism settings.

When a deployment fails due to payload size, users now see helpful output like:
```
❌ Deploy failed: Payload too large

Your project is too large to deploy in a single request.
Please use the batched deploy feature:

  lightdash deploy --use-batched-deploy
```