### PR TITLE
ci: daily GitHub Actions cache cleanup

### DIFF
--- a/.github/workflows/cache-cleanup.yml
+++ b/.github/workflows/cache-cleanup.yml
@@ -2,7 +2,7 @@ name: Cache Cleanup
 
 on:
   schedule:
-    - cron: '0 3 * * 0' # Weekly on Sunday at 3am UTC
+    - cron: '0 3 * * *' # Daily at 3am UTC
   workflow_dispatch: # Allow manual trigger
 
 jobs:


### PR DESCRIPTION
## Summary
- Adds a daily workflow (3am UTC) that checks if the GitHub Actions cache exceeds 9GB
- If over the threshold, deletes the oldest caches (by last accessed time) until it's back down to ~6GB
- Can also be triggered manually via `workflow_dispatch`
- This prevents the `failed to reserve cache` error that blocks the Build E2E Image job (the 10GB repo cache limit was being hit)

## Test plan
- [ ] Trigger manually from Actions tab to verify it runs correctly
- [ ] Check that it correctly reports cache size and skips cleanup when under 9GB

🤖 Generated with [Claude Code](https://claude.com/claude-code)