### PR TITLE
style: decrease anchor font size on validation indicator

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -69,6 +69,7 @@ const ResourceValidationErrorIndicator = ({
                                 search: `?validationId=${validationId}`,
                             }}
                             color="blue.4"
+                            fz="xs"
                         >
                             here
                         </Anchor>

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewList/index.tsx
@@ -165,6 +165,7 @@ const ResourceViewList: FC<ResourceViewListProps> = ({
                                                             search: `?validationId=${item.data.validationErrors[0].validationId}`,
                                                         }}
                                                         c="blue.4"
+                                                        fz="xs"
                                                     >
                                                         here
                                                     </Anchor>

--- a/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItemIcon.tsx
@@ -60,7 +60,8 @@ export const OmnibarItemIconWithIndicator: FC<
                                 pathname: `/generalSettings/projectManagement/${projectUuid}/validator`,
                                 search: `?validationId=${item.item.validationErrors[0].validationId}`,
                             }}
-                            color="blue.4"
+                            c="blue.4"
+                            fz="xs"
                         >
                             here
                         </Anchor>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Standardized validation error link styling by applying consistent font size and color properties to "here" anchor elements. Updated the `color` prop to `c` in the omnibar component and added `fz="xs"` to all validation error links for uniform appearance across the resource view table, resource view list, and omnibar components.