### PR TITLE
chore: update broken imports in embed.cy.ts

### DIFF
--- a/packages/e2e/cypress/e2e/app/embed.cy.ts
+++ b/packages/e2e/cypress/e2e/app/embed.cy.ts
@@ -3,11 +3,25 @@ import {
     FilterInteractivityValues,
     SEED_PROJECT,
 } from '@lightdash/common';
-import { updateEmbedConfigDashboards } from '../api/embedManagement.cy';
+
+const EMBED_API_PREFIX = `/api/v1/embed/${SEED_PROJECT.project_uuid}`;
+
+const updateEmbedConfigDashboards = (dashboardUuids: string[]) =>
+    cy.request({
+        url: `${EMBED_API_PREFIX}/config/dashboards`,
+        headers: { 'Content-type': 'application/json' },
+        method: 'PATCH',
+        body: {
+            dashboardUuids,
+            chartUuids: [],
+            allowAllDashboards: false,
+            allowAllCharts: false,
+        },
+    });
 
 const getEmbedUrl = (body: CreateEmbedJwt) =>
     cy.request({
-        url: `/api/v1/embed/${SEED_PROJECT.project_uuid}/get-embed-url`,
+        url: `${EMBED_API_PREFIX}/get-embed-url`,
         headers: { 'Content-type': 'application/json' },
         method: 'POST',
         body,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:

This PR refactors the embed end-to-end tests by moving the `updateEmbedConfigDashboards` function directly into the test file and introducing a shared `EMBED_API_PREFIX` constant. The function now uses the centralized API prefix for consistency with other embed API calls in the same file.

This import was no longer available as tests moved from cypress to vitest