### PR TITLE
chore: updated nested permission text

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceAccessInfo.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceAccessInfo.tsx
@@ -10,15 +10,15 @@ import { getResourceAccessLabel, getResourceAccessType } from './utils';
 const ResourceAccessInfoData = {
     [ResourceAccess.Private]: {
         Icon: IconLock,
-        status: 'Private',
+        status: 'Restricted access',
     },
     [ResourceAccess.Public]: {
         Icon: IconUsers,
-        status: 'Public',
+        status: 'Inherited access',
     },
     [ResourceAccess.Shared]: {
         Icon: IconUser,
-        status: 'Shared',
+        status: 'Restricted access',
     },
 } as const;
 
@@ -32,17 +32,14 @@ const getV2AccessType = (item: ResourceViewSpaceItem): ResourceAccess => {
     return ResourceAccess.Private;
 };
 
-const getV2Status = (
-    accessType: ResourceAccess,
-    isNestedSpace: boolean,
-): string => {
+const getV2Status = (accessType: ResourceAccess): string => {
     switch (accessType) {
         case ResourceAccess.Public:
-            return isNestedSpace ? 'Parent Access' : 'Project Access';
+            return 'Inherited access';
         case ResourceAccess.Private:
             return 'Private';
         case ResourceAccess.Shared:
-            return 'Custom Access';
+            return 'Restricted access';
     }
 };
 
@@ -87,7 +84,7 @@ const ResourceAccessInfo: React.FC<ResourceAccessInfoProps> = ({
     const isNestedSpace = !!item.data.parentSpaceUuid;
     const { Icon } = ResourceAccessInfoData[accessType];
     const status = isV2
-        ? getV2Status(accessType, isNestedSpace)
+        ? getV2Status(accessType)
         : ResourceAccessInfoData[accessType].status;
     const tooltipLabel = isV2
         ? getV2Label(item, accessType, isNestedSpace)

--- a/packages/frontend/src/components/common/ShareSpaceModal/v2/ShareSpaceModalShared.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/v2/ShareSpaceModalShared.tsx
@@ -470,7 +470,7 @@ export const AccessModelToggle: FC<AccessModelToggleProps> = ({
             <MantineModal
                 opened={confirmOpened}
                 onClose={closeConfirm}
-                title="Make space private?"
+                title="Restrict access?"
                 onConfirm={() => {
                     spaceMutation({
                         name: space.name,
@@ -478,19 +478,18 @@ export const AccessModelToggle: FC<AccessModelToggleProps> = ({
                     });
                     closeConfirm();
                 }}
-                confirmLabel="Make private"
+                confirmLabel="Restrict access"
                 confirmLoading={isMutating}
             >
                 <Stack gap="sm">
                     <Text fz="sm">
-                        Users with direct access will keep their access. Org and
-                        project members who haven't been explicitly invited will
-                        lose access to this space.
+                        Users with direct access will keep their access. Project
+                        members will lose access unless specifically invited.
                     </Text>
                     {showLockoutWarning && (
                         <Callout variant="warning">
                             You don't have direct access to this space. Once
-                            it's private, you won't be able to change this
+                            it's restricted, you won't be able to change this
                             setting again.
                         </Callout>
                     )}

--- a/packages/frontend/src/components/common/ShareSpaceModal/v2/ShareSpaceModalUtils.ts
+++ b/packages/frontend/src/components/common/ShareSpaceModal/v2/ShareSpaceModalUtils.ts
@@ -13,25 +13,22 @@ export const enum InheritanceType {
 
 export const RootInheritanceOptions: AccessOption[] = [
     {
-        title: 'Project Access',
-        description:
-            'All project members can access with their project permissions',
-        selectDescription:
-            'All project members can access with their project permissions',
+        title: 'Inherited access',
+        description: 'All members of this project can access this space',
+        selectDescription: 'All members of this project can access this space',
         value: InheritanceType.INHERIT,
     },
     {
-        title: 'Custom Access',
-        description: 'Only directly invited members and admins can access',
-        selectDescription:
-            'Only directly invited members and admins can access this space',
+        title: 'Restricted access',
+        description: 'Only invited users & groups can access this space',
+        selectDescription: 'Only invited users & groups can access this space',
         value: InheritanceType.OWN_ONLY,
     },
 ];
 
 export const NestedInheritanceOptions: AccessOption[] = [
     {
-        title: 'Parent Access',
+        title: 'Inherited access',
         description:
             'Users with access to the parent space also have access here',
         selectDescription:
@@ -39,8 +36,9 @@ export const NestedInheritanceOptions: AccessOption[] = [
         value: InheritanceType.INHERIT,
     },
     {
-        title: 'Custom Access',
-        description: 'Only directly invited members and admins can access',
+        title: 'Restricted access',
+        description:
+            'Only invited users & groups, as well as admins, can access this space',
         selectDescription:
             'This space ignores parent space permissions and uses only its own access list',
         value: InheritanceType.OWN_ONLY,


### PR DESCRIPTION
### Description:

Text and terminology update around nested space permissions. The goal is to make terminology clearer -- if this doesn't make sense we can iterate. With this there are two main permission categories
- Inherited access - the space inherits permissions from its parents and project
- Restricted access - the space defines it's own permissions, which it's children inherit

I chose 'inherited permissions' here since it makes it clear what to expect. We tried some others (Parent, Public, Project) which were all trying to convey something specific that needed to be explained, but wasn't accurate. 'Inherited' is clear about what to expect and works at multiple levels in the tree. 

'Restricted' is also more clear than some of the alternatives we tried (Custom, private). It makes it clear that access isn't open while leaving space for it to be private or a little less than private. 

There was some question about whether *top-level* spaces should have their own term, like 'Project access', but after trying it, I found it more confusing to try to explain the top-level space access differently. Partly because we don't have different visuals or iconography to show that you are at a top-level space. The distinction only feels meaningful to those of us who are familiar with the system. I think other users will understand 'Inherited access' better, even at the root. 