### PR TITLE
fix: admin can't see child spaces after being explicitly added to par…

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -317,7 +317,7 @@ const InfiniteResourceTable = ({
 
                 const space = spaces.find((s) => s.uuid === item.data.uuid);
                 if (!space) return false;
-                return !space.isPrivate || space.userAccess?.hasDirectAccess;
+                return !space.isPrivate || !!space.userAccess;
             });
     }, [data, userCanManageProject, spaces, selectedAdminContentType]);
 


### PR DESCRIPTION
### Description:
Fixed a bug where an admin would lose visibility of child spaces in the "shared" content view after being explicitly added to the parent space
The filter was checking `hasDirectAccess` on the child space, which is only `true` when the user has a `space_user_access` entry on that specific space — not when access is inherited from a parent space


### The bug in action:

https://github.com/user-attachments/assets/1fe7dfd5-c645-40ce-ae73-58bc0dac2677

