### PR TITLE
revert: stop filter autoFocus from stealing focus to last filter (#20564)

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -23,7 +23,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableFilterAutofocusFix: undefined,
     },
 };
 
@@ -60,7 +59,6 @@ export const lightdashConfigWithBasicSMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableFilterAutofocusFix: undefined,
     },
 };
 
@@ -85,7 +83,6 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableFilterAutofocusFix: undefined,
     },
 };
 
@@ -106,7 +103,6 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableFilterAutofocusFix: undefined,
     },
 };
 

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -209,7 +209,6 @@ export const lightdashConfigMock: LightdashConfig = {
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableFilterAutofocusFix: undefined,
     },
     ai: {
         copilot: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -827,7 +827,6 @@ export type LightdashConfig = {
         maxPageSize: number;
         useSqlPivotResults: boolean | undefined;
         showExecutionTime: boolean | undefined;
-        enableFilterAutofocusFix: boolean | undefined;
     };
     pivotTable: {
         maxColumnLimit: number;
@@ -1600,9 +1599,6 @@ export const parseConfig = (): LightdashConfig => {
                 : undefined,
             showExecutionTime: process.env.SHOW_EXECUTION_TIME
                 ? process.env.SHOW_EXECUTION_TIME === 'true'
-                : undefined,
-            enableFilterAutofocusFix: process.env.ENABLE_FILTER_AUTOFOCUS_FIX
-                ? process.env.ENABLE_FILTER_AUTOFOCUS_FIX === 'true'
                 : undefined,
         },
         chart: {

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -50,8 +50,6 @@ export class FeatureFlagModel {
                 this.getSavedMetricsTreeEnabled.bind(this),
             [FeatureFlags.DefaultUserSpaces]:
                 this.getDefaultUserSpacesEnabled.bind(this),
-            [FeatureFlags.EnableFilterAutofocusFix]:
-                this.getFilterAutofocusFixEnabled.bind(this),
         };
     }
 
@@ -286,29 +284,4 @@ export class FeatureFlagModel {
         };
     }
 
-    private async getFilterAutofocusFixEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.query.enableFilterAutofocusFix ??
-            (user !== undefined
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.EnableFilterAutofocusFix,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
-
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
 }

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -464,7 +464,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableFilterAutofocusFix: undefined,
     },
 };
 

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -89,10 +89,6 @@ export enum FeatureFlags {
      */
     DefaultUserSpaces = 'default-user-spaces',
 
-    /**
-     * Enable the filter autofocus fix for form inputs
-     */
-    EnableFilterAutofocusFix = 'enable-filter-autofocus-fix',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterGroupForm.tsx
@@ -42,8 +42,6 @@ type Props = {
     fields: FilterableField[];
     filterGroup: FilterGroup;
     isEditMode: boolean;
-    autoFocusRuleId?: string;
-    onAutoFocusRule?: (ruleId: string) => void;
     onChange: (value: FilterGroup) => void;
     onDelete: () => void;
 };
@@ -80,8 +78,6 @@ const FilterGroupForm: FC<Props> = memo(
         fields,
         filterGroup,
         isEditMode,
-        autoFocusRuleId,
-        onAutoFocusRule,
         onChange,
         onDelete,
     }) => {
@@ -164,25 +160,17 @@ const FilterGroupForm: FC<Props> = memo(
 
         const onAddFilterRule = useCallback(() => {
             if (availableFieldsForGroupRules.length > 0) {
-                const newRule = createFilterRuleFromField(
-                    availableFieldsForGroupRules[0],
-                );
-                onAutoFocusRule?.(newRule.id);
                 onChange({
                     ...filterGroup,
                     [getFilterGroupItemsPropertyName(filterGroup)]: [
                         ...items,
-                        newRule,
+                        createFilterRuleFromField(
+                            availableFieldsForGroupRules[0],
+                        ),
                     ],
                 });
             }
-        }, [
-            availableFieldsForGroupRules,
-            filterGroup,
-            items,
-            onChange,
-            onAutoFocusRule,
-        ]);
+        }, [availableFieldsForGroupRules, filterGroup, items, onChange]);
 
         const onChangeOperator = useCallback(
             (value: FilterGroupOperator) => {
@@ -255,7 +243,6 @@ const FilterGroupForm: FC<Props> = memo(
                                     filterRule={item}
                                     fields={availableFieldsForGroupRules}
                                     isEditMode={isEditMode}
-                                    autoFocus={autoFocusRuleId === item.id}
                                     onChange={(value) =>
                                         onChangeItem(index, value)
                                     }
@@ -286,8 +273,6 @@ const FilterGroupForm: FC<Props> = memo(
                                 <FilterGroupForm
                                     groupDepth={groupDepth + 1}
                                     isEditMode={isEditMode}
-                                    autoFocusRuleId={autoFocusRuleId}
-                                    onAutoFocusRule={onAutoFocusRule}
                                     filterGroup={item}
                                     fields={availableFieldsForGroupRules}
                                     onChange={(value) =>

--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -11,8 +11,7 @@ import DefaultFilterInputs from './DefaultFilterInputs';
 const BooleanFilterInputs = <T extends BaseFilterRule>(
     props: FilterInputsProps<T>,
 ) => {
-    const { rule, onChange, disabled, autoFocus, filterType, popoverProps } =
-        props;
+    const { rule, onChange, disabled, filterType, popoverProps } = props;
 
     const isFilterRuleDisabled = isFilterRule(rule) && rule.disabled;
 
@@ -35,7 +34,7 @@ const BooleanFilterInputs = <T extends BaseFilterRule>(
                     onDropdownOpen={popoverProps?.onOpen}
                     onDropdownClose={popoverProps?.onClose}
                     disabled={disabled}
-                    autoFocus={autoFocus}
+                    autoFocus={true}
                     initiallyOpened={currentValue === null && !disabled}
                     placeholder={placeholder}
                     data={[

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -31,15 +31,7 @@ import FilterYearPicker from './FilterYearPicker';
 const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
     props: FilterInputsProps<T>,
 ) => {
-    const {
-        field,
-        rule,
-        onChange,
-        popoverProps,
-        disabled,
-        autoFocus,
-        filterType,
-    } = props;
+    const { field, rule, onChange, popoverProps, disabled, filterType } = props;
     const { startOfWeek } = useFiltersContext();
 
     const isTimestamp =
@@ -80,7 +72,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 <FilterWeekPicker
                                     placeholder={placeholder}
                                     disabled={disabled}
-                                    autoFocus={autoFocus}
+                                    autoFocus={true}
                                     value={
                                         rule.values && rule.values[0]
                                             ? parseDate(
@@ -122,7 +114,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                                 // @ts-ignore
                                 placeholder={placeholder}
-                                autoFocus={autoFocus}
+                                autoFocus={true}
                                 popoverProps={popoverProps}
                                 value={
                                     rule.values && rule.values[0]
@@ -154,7 +146,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                             <FilterQuarterPicker
                                 disabled={disabled}
                                 placeholder={placeholder}
-                                autoFocus={autoFocus}
+                                autoFocus={true}
                                 popoverProps={popoverProps}
                                 value={parsedValue}
                                 onChange={(newDate: Date) => {
@@ -174,7 +166,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                                 // @ts-ignore
                                 placeholder={placeholder}
-                                autoFocus={autoFocus}
+                                autoFocus={true}
                                 popoverProps={popoverProps}
                                 value={
                                     rule.values && rule.values[0]
@@ -219,7 +211,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                         // @ts-ignore
                         placeholder={placeholder}
-                        autoFocus={autoFocus}
+                        autoFocus={true}
                         withSeconds
                         // FIXME: mantine v7
                         // mantine does not set the first day of the week based on the locale
@@ -247,7 +239,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     // so we need to do it manually and always pass it as a prop
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     popoverProps={popoverProps}
-                    autoFocus={autoFocus}
+                    autoFocus={true}
                     value={
                         rule.values
                             ? parseDate(
@@ -277,7 +269,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         sx={{ flexShrink: 1, flexGrow: 1 }}
                         placeholder={placeholder}
                         disabled={disabled}
-                        autoFocus={autoFocus}
+                        autoFocus={true}
                         value={isNaN(parsedValue) ? undefined : parsedValue}
                         min={0}
                         onChange={(value) => {
@@ -329,7 +321,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     }
                     showOptionsInPlural={false}
                     showCompletedOptions={false}
-                    autoFocus={autoFocus && !rule.settings?.unitOfTime}
+                    autoFocus={!rule.settings?.unitOfTime}
                     completed={false}
                     withinPortal={popoverProps?.withinPortal}
                     onDropdownOpen={popoverProps?.onOpen}
@@ -350,7 +342,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 return (
                     <FilterDateTimeRangePicker
                         disabled={disabled}
-                        autoFocus={autoFocus}
+                        autoFocus={true}
                         firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                         value={
                             rule.values && rule.values[0] && rule.values[1]
@@ -379,7 +371,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
             return (
                 <FilterDateRangePicker
                     disabled={disabled}
-                    autoFocus={autoFocus}
+                    autoFocus={true}
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     value={
                         rule.values && rule.values[0] && rule.values[1]

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -23,7 +23,6 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
     filterType,
     rule,
     disabled,
-    autoFocus,
     onChange,
     popoverProps,
 }: FilterInputsProps<T>) => {
@@ -62,7 +61,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             limit={FILTER_SELECT_LIMIT}
                             disabled={disabled}
                             placeholder={placeholder}
-                            autoFocus={autoFocus}
+                            autoFocus={true}
                             withinPortal={popoverProps?.withinPortal}
                             onDropdownOpen={popoverProps?.onOpen}
                             onDropdownClose={popoverProps?.onClose}
@@ -80,7 +79,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             filterId={rule.id}
                             disabled={disabled}
                             field={field}
-                            autoFocus={autoFocus}
+                            autoFocus={true}
                             placeholder={placeholder}
                             suggestions={suggestions || []}
                             withinPortal={popoverProps?.withinPortal}
@@ -108,7 +107,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                         return (
                             <FilterNumberInput
                                 disabled={disabled}
-                                autoFocus={autoFocus}
+                                autoFocus={true}
                                 placeholder={placeholder}
                                 value={rule.values?.[0]}
                                 onChange={(newValue) => {
@@ -123,7 +122,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                     } else {
                         return (
                             <FilterMultiNumberInput
-                                autoFocus={autoFocus}
+                                autoFocus={true}
                                 disabled={disabled}
                                 placeholder={placeholder}
                                 values={rule.values?.map(String) ?? []}
@@ -139,7 +138,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                         <TagInput
                             w="100%"
                             clearable
-                            autoFocus={autoFocus}
+                            autoFocus={true}
                             size="xs"
                             disabled={disabled}
                             placeholder={placeholder}
@@ -167,7 +166,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
             return (
                 <FilterNumberInput
                     disabled={disabled}
-                    autoFocus={autoFocus}
+                    autoFocus={true}
                     placeholder={placeholder}
                     value={rule.values?.[0]}
                     onChange={(newValue) => {
@@ -183,7 +182,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
             return (
                 <FilterNumberRangeInput
                     disabled={disabled}
-                    autoFocus={autoFocus}
+                    autoFocus={true}
                     placeholder={placeholder}
                     value={rule.values}
                     onChange={(value) => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberRangeInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberRangeInput.tsx
@@ -48,7 +48,7 @@ const FilterNumberRangeInput: FC<Props> = ({
                 <FilterNumberInput
                     error={!!errorMessage}
                     disabled={disabled}
-                    autoFocus={autoFocus}
+                    autoFocus={true}
                     placeholder="Min value"
                     {...rest}
                     value={value?.[0]}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/index.tsx
@@ -15,7 +15,6 @@ export type FilterInputsProps<T extends BaseFilterRule> = {
     rule: T;
     onChange: (value: T) => void;
     disabled?: boolean;
-    autoFocus?: boolean;
     popoverProps?: Omit<PopoverProps, 'children'>;
 };
 

--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -22,7 +22,6 @@ type Props = {
     fields: FilterableField[];
     filterRule: FilterRule;
     isEditMode: boolean;
-    autoFocus?: boolean;
     onChange: (value: FilterRule) => void;
     onDelete: () => void;
     onConvertToGroup?: () => void;
@@ -33,7 +32,6 @@ const FilterRuleForm: FC<Props> = memo(
         fields,
         filterRule,
         isEditMode,
-        autoFocus,
         onChange,
         onDelete,
         onConvertToGroup,
@@ -101,7 +99,6 @@ const FilterRuleForm: FC<Props> = memo(
                 align="start"
                 gap="xs"
                 data-testid="FilterRuleForm/filter-rule"
-                data-rule-id={filterRule.id}
             >
                 <Tooltip
                     label={isRequiredLabel}
@@ -159,7 +156,6 @@ const FilterRuleForm: FC<Props> = memo(
                     filterType={filterType}
                     field={activeField}
                     rule={filterRule}
-                    autoFocus={autoFocus}
                     onChange={onChange}
                     disabled={!isEditMode}
                     popoverProps={popoverProps}

--- a/packages/frontend/src/components/common/Filters/SimplifiedFilterGroupForm.tsx
+++ b/packages/frontend/src/components/common/Filters/SimplifiedFilterGroupForm.tsx
@@ -7,12 +7,11 @@ type Props = {
     fields: FilterableField[];
     filterRules: FilterRule[];
     isEditMode: boolean;
-    autoFocusRuleId?: string;
     onChange: (value: FilterRule[]) => void;
 };
 
 const SimplifiedFilterGroupForm: FC<Props> = memo(
-    ({ isEditMode, fields, filterRules, autoFocusRuleId, onChange }) => {
+    ({ isEditMode, fields, filterRules, onChange }) => {
         const onDeleteItem = useCallback(
             (index: number) => {
                 onChange([
@@ -53,7 +52,6 @@ const SimplifiedFilterGroupForm: FC<Props> = memo(
                             key={item.id}
                             filterRule={item}
                             fields={fields}
-                            autoFocus={autoFocusRuleId === item.id}
                             onChange={(value) => onChangeItem(index, value)}
                             onDelete={() => onDeleteItem(index)}
                         />

--- a/packages/frontend/src/hooks/useIsFilterAutofocusEnabled.ts
+++ b/packages/frontend/src/hooks/useIsFilterAutofocusEnabled.ts
@@ -1,9 +1,0 @@
-import { FeatureFlags } from '@lightdash/common';
-import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
-
-export function useIsFilterAutofocusEnabled(): boolean {
-    const { data } = useServerFeatureFlag(
-        FeatureFlags.EnableFilterAutofocusFix,
-    );
-    return data?.enabled ?? false;
-}


### PR DESCRIPTION
## Summary
- Reverts commit f394daaf0bd302d793afa3f96255509804c9cefb ("fix: stop filter autoFocus from stealing focus to last filter (#20564)")
- Restores original filter autofocus behavior

## Test plan
- [ ] Verify filters still work correctly with the original autoFocus behavior
- [ ] Confirm no regressions in filter input focus behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)