### PR TITLE
feat: add debug heap snapshot endpoint to API v1 router

### DIFF
--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -222,14 +222,14 @@ apiV1Router.get('/debug/heap-snapshot', async (req, res) => {
             return;
         }
 
-        const stats = fs.statSync(snapshotPath);
+        const stats = await fs.promises.stat(snapshotPath);
         const fileSizeMB = (stats.size / 1024 / 1024).toFixed(1);
         const mem = process.memoryUsage();
 
         res.json({
             status: 'ok',
             results: {
-                snapshotPath,
+                snapshotFile: path.basename(snapshotPath),
                 fileSizeMB: `${fileSizeMB}MB`,
                 memory: {
                     rss: `${(mem.rss / 1024 / 1024).toFixed(1)}MB`,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Adds a new `/debug/heap-snapshot` endpoint to the API v1 router for memory debugging purposes. The endpoint is protected by an environment variable `ENABLE_DEBUG_HEAP_SNAPSHOT` that must be set to 'true' to enable access.

When called, the endpoint:
- Forces garbage collection if available
- Generates a V8 heap snapshot using `v8.writeHeapSnapshot()`
- Returns the snapshot file path, file size, and current memory usage statistics including RSS, heap used/total, external memory, and array buffers
- Handles errors gracefully with appropriate HTTP status codes

This debugging tool will help with memory leak investigation and performance analysis in production environments when explicitly enabled.