### PR TITLE
fix: preserve CSS color keywords in MantineIcon color conversion

### DIFF
--- a/packages/frontend/src/components/common/MantineIcon/index.tsx
+++ b/packages/frontend/src/components/common/MantineIcon/index.tsx
@@ -40,6 +40,9 @@ const MANTINE_KEYWORD_COLORS = new Set([
     'anchor',
 ]);
 
+/** CSS color keywords that should pass through as-is, not be converted to Mantine vars. */
+const CSS_COLOR_KEYWORDS = new Set(['transparent', 'currentColor', 'inherit']);
+
 /** Mantine tokens are bare words ("red", "dimmed") or word.shade ("ldGray.6"). */
 const MANTINE_TOKEN_RE = /^[a-zA-Z]\w*(\.\d+)?$/;
 
@@ -50,6 +53,7 @@ const MANTINE_TOKEN_RE = /^[a-zA-Z]\w*(\.\d+)?$/;
 function toColorVar(color: MantineColor): string {
     const str = String(color);
     if (!MANTINE_TOKEN_RE.test(str)) return str;
+    if (CSS_COLOR_KEYWORDS.has(str)) return str;
     // "ldGray.6" → var(--mantine-color-ldGray-6)
     if (str.includes('.')) {
         return `var(--mantine-color-${str.replace('.', '-')})`;


### PR DESCRIPTION
### Description:

Added support for CSS color keywords (`transparent`, `currentColor`, `inherit`) in the MantineIcon component. These keywords now pass through as-is instead of being converted to Mantine CSS variables, preventing invalid color variable references.

Fixes `DefaultAgentButton` fill color:

![CleanShot 2026-02-25 at 18.49.47@2x.png](https://app.graphite.com/user-attachments/assets/1ef8c544-22ac-49a8-b045-eadd30c3e3cb.png)

_before_
![CleanShot 2026-02-25 at 18.50.34@2x.png](https://app.graphite.com/user-attachments/assets/9344e302-c9e7-405a-89ad-ddaa396eb7d5.png)

