### PR TITLE
chore: add DuckDB compatibility to jaffle shop demo

### DIFF
--- a/.claude/skills/add-warehouse-adapter/SKILL.md
+++ b/.claude/skills/add-warehouse-adapter/SKILL.md
@@ -1,0 +1,126 @@
+# Add a Warehouse Adapter
+
+Step-by-step checklist for adding a new warehouse connection to Lightdash. Follow the Athena adapter as the canonical example (PRs #19751/#19752). The MotherDuck/DuckDB adapter is the most recent implementation.
+
+## Layer 1: Common Types (`packages/common/`)
+
+- [ ] Add entry to `WarehouseTypes` enum in `src/types/projects.ts`
+- [ ] Define `CreateXxxCredentials` type with `type: WarehouseTypes.XXX` discriminant
+  - Sensitive fields (tokens, passwords, keys) should be optional (`token?: string`) — not required with empty-string sentinel
+- [ ] Define `XxxCredentials = Omit<CreateXxxCredentials, SensitiveCredentialsFieldNames>`
+- [ ] Add sensitive fields to `sensitiveCredentialsFieldNames` array if not already present (tokens, passwords, keys)
+- [ ] Add `CreateXxxCredentials` to `CreateWarehouseCredentials` union
+- [ ] Add `XxxCredentials` to `WarehouseCredentials` union
+- [ ] Update `UserWarehouseCredentials` union in `src/types/userWarehouseCredentials.ts`
+- [ ] Update `UserWarehouseCredentialsWithSecrets` union
+- [ ] Add case to `getFieldQuoteChar()` in `src/utils/warehouse.ts`
+- [ ] Verify `getAggregatedField()` in `src/utils/warehouse.ts` handles the new adapter (may fall into existing case)
+- [ ] Check `src/utils/timeFrames.ts` adapter config map has the new adapter
+- [ ] Check `src/compiler/translator.ts` `convertTimezone()` has the new adapter
+- [ ] Run: `pnpm -F common typecheck && pnpm -F common lint`
+
+## Layer 2: Backend (`packages/backend/`)
+
+### Database Migration
+- [ ] Create migration: `pnpm -F backend create-migration add_xxx_warehouse_type`
+- [ ] `up`: Insert `{ warehouse_type: 'xxx' }` into `warehouse_types`
+- [ ] `down`: Delete xxx credentials and type
+
+### Entity & Profile
+- [ ] Add `'xxx'` to `warehouseTypes` array in `src/database/entities/warehouseCredentials.ts`
+- [ ] Add case to `credentialsTarget()` in `src/dbt/profiles.ts` (before `default`)
+  - Pass secrets via `envVarReference()`/`envVar()` pattern (not raw env var names or inline values)
+  - Follow ClickHouse pattern: `password: envVarReference('password')` in target, `[envVar('password')]: credentials.password` in environment
+- [ ] Verify `quoteChars` in `src/dbt/DbtMetadataApiClient.ts` has the adapter
+
+### Service Updates (exhaustive switch statements)
+- [ ] `src/services/ProjectService/ProjectService.ts` - `clearSecretsFromCredentials()`
+  - Blank sensitive fields (`token: undefined`) instead of destructuring + unsafe `as` cast
+  - Follow the same pattern as other warehouses (`{ ...credentials, password: '' }`)
+- [ ] `src/services/ProjectService/ProjectService.ts` - warehouse client creation switch
+- [ ] `src/services/ProjectService/ProjectService.ts` - user credentials creation switch
+- [ ] `src/services/ProjectService/ProjectService.ts` - `getDatabaseFromWarehouseCredentials()`
+- [ ] `src/models/UserWarehouseCredentials/UserWarehouseCredentialsModel.ts`
+- [ ] Run: `pnpm -F backend typecheck && pnpm -F backend lint`
+
+## Layer 3: Warehouse Client (`packages/warehouses/`)
+
+- [ ] Create `src/warehouseClients/XxxWarehouseClient.ts`
+  - Extend `WarehouseBaseClient<CreateXxxCredentials>`
+  - Implement `XxxSqlBuilder extends WarehouseBaseSqlBuilder`
+  - Implement: `streamQuery()`, `getCatalog()`, `getAllTables()`, `getFields()` (inherited `test()`, `runQuery()`, `executeAsyncQuery()` work via base class — don't add no-op overrides)
+  - Pass credentials directly to client library (like ClickHouse/Databricks), never via `process.env`
+  - Use constructor `overrides` param for alternate construction (e.g. pre-aggregate) instead of `AnyType` casts on readonly fields
+- [ ] Add case in `src/warehouseClientFromCredentials.ts` factory
+- [ ] Add case in `src/ssh/sshTunnel.ts` (typically a no-op `break` for cloud warehouses)
+- [ ] Export from `src/index.ts`
+- [ ] Write tests in `src/warehouseClients/XxxWarehouseClient.test.ts`
+- [ ] Run: `pnpm -F @lightdash/warehouses typecheck && pnpm -F @lightdash/warehouses test`
+
+## Layer 4: Frontend (`packages/frontend/`)
+
+### Warehouse Form
+- [ ] Create `src/components/ProjectConnection/WarehouseForms/XxxForm.tsx`
+  - Follow `AthenaForm.tsx` pattern with Mantine v8 components
+  - Export `XxxSchemaInput` for `DbtSettingsForm`
+- [ ] Add SVG logo to `src/components/ProjectConnection/ProjectConnectFlow/Assets/`
+
+### Registration
+- [ ] Add defaults to `WarehouseForms/defaultValues.ts` (`XxxDefaultValues` + add to `warehouseDefaultValues`)
+- [ ] Add validators to `WarehouseForms/validators.ts`
+- [ ] Register in `WarehouseSettingsForm.tsx` (labels + forms maps)
+- [ ] Register in `DbtSettingsForm.tsx` (schema input switch)
+- [ ] Register in `ProjectConnectFlow/utils.tsx` (WarehouseTypeLabels array)
+- [ ] Register in `UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx` (defaultCredentials)
+- [ ] Register in `UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx` (getCredentialsWithPlaceholders)
+- [ ] Register in `UserSettings/MyWarehouseConnectionsPanel/WarehouseFormInputs.tsx`
+- [ ] Run: `pnpm -F frontend typecheck && pnpm -F frontend lint`
+
+## Layer 5: CLI (`packages/cli/`)
+
+- [ ] Create `src/dbt/targets/xxx.ts`
+  - Define `XxxTarget` type matching dbt profile structure
+  - Define `xxxSchema: JSONSchemaType<XxxTarget>` for ajv validation
+  - Export `convertXxxSchema()` function
+- [ ] Add `case 'xxx':` in `src/dbt/profile.ts` `warehouseCredentialsFromDbtTarget()`
+- [ ] Add mock credentials in `src/handlers/dbt/getWarehouseClient.ts` `getMockCredentials()`
+
+## Layer 6: Docker (`Dockerfile`)
+
+- [ ] Add the dbt adapter pip package (`dbt-xxx`) to dbt venvs **1.8+** in the `Dockerfile`
+  - The adapter package name is typically `dbt-xxx` (e.g., `dbt-duckdb`, `dbt-athena`)
+  - Use unversioned `"dbt-xxx"` if the adapter has its own version scheme, or `"dbt-xxx~=X.Y.0"` if it tracks dbt-core versions
+  - Check [PyPI](https://pypi.org) for the package name and version compatibility
+  - Only add to dbt versions that support the adapter (1.8+, not older 1.4-1.7)
+  - Reference: `dbt-athena` was added from 1.9+, `dbt-duckdb` from 1.8+
+
+## Layer 7: Demo Project Compatibility (`examples/full-jaffle-shop-demo/`)
+
+- [ ] Update `dbt/data/seeds.yml` column types for the new adapter (DuckDB doesn't support `jsonb`, `TIME`, etc.)
+- [ ] Update SQL macros in `dbt/macros/` that have warehouse-specific branches (e.g. `quarter_end_date.sql`, `casts.sql`)
+- [ ] Add a profile target in `profiles/profiles.yml` for testing
+- [ ] Test: `dbt seed --target xxx && dbt run --target xxx`
+
+## Post-Implementation
+
+- [ ] `pnpm generate-api` (regenerates routes.ts and swagger.json)
+- [ ] `pnpm generate:chart-as-code-schema`
+- [ ] `pnpm check:chart-as-code-schema`
+- [ ] Run full typecheck: `pnpm -F common typecheck && pnpm -F backend typecheck && pnpm -F frontend typecheck`
+
+## Reference Files
+
+| Layer | Key File | Purpose |
+|-------|----------|---------|
+| Common | `packages/common/src/types/projects.ts` | Types, sensitive fields, unions |
+| Backend | `packages/backend/src/dbt/profiles.ts` | dbt profile generation |
+| Backend | `packages/backend/src/database/entities/warehouseCredentials.ts` | DB entity |
+| Warehouse | `packages/warehouses/src/warehouseClientFromCredentials.ts` | Factory |
+| Frontend | `packages/frontend/src/components/ProjectConnection/WarehouseSettingsForm.tsx` | Form registration |
+| CLI | `packages/cli/src/dbt/profile.ts` | CLI target conversion |
+| Docker | `Dockerfile` | dbt adapter pip packages per version |
+
+## Canonical Examples
+
+- **Athena**: PRs #19751/#19752 (first adapter added with this pattern)
+- **MotherDuck/DuckDB**: Branch `02-23-feat_add_duckdb_warehouse_client_with_s3_support`

--- a/examples/full-jaffle-shop-demo/dbt/data/seeds.yml
+++ b/examples/full-jaffle-shop-demo/dbt/data/seeds.yml
@@ -4,9 +4,9 @@ seeds:
   - name: raw_events
     config:
       column_types:
-        timestamp_tz: "{{ 'timestamp_tz' if target.type == 'snowflake' else 'timestamp' }}"
-        timestamp_ltz: "{{ 'timestamp_ltz' if target.type == 'snowflake' else 'timestamp' }}"
-        timestamp_ntz: "{{ 'timestamp_ntz' if target.type == 'snowflake' else 'timestamp' }}"
+        timestamp_tz: "{{ 'timestamp_tz' if target.type == 'snowflake' else ('timestamptz' if target.type == 'duckdb' else 'timestamp') }}"
+        timestamp_ltz: "{{ 'timestamp_ltz' if target.type == 'snowflake' else ('timestamptz' if target.type == 'duckdb' else 'timestamp') }}"
+        timestamp_ntz: "{{ 'timestamp_ntz' if target.type == 'snowflake' else ('timestamptz' if target.type == 'duckdb' else 'timestamp') }}"
   - name: raw_generated
     config:
       column_types:
@@ -41,8 +41,11 @@ seeds:
         numberrange14: integer
         numberrange15: integer
         primary_key: integer
-        # Athena's Hive metastore doesn't support TIME type
-        time: "{{ 'varchar' if target.type == 'athena' else 'time' }}"
+        # Values arrive as strings like "$54.98"; keep the seed column textual
+        # and cast in downstream models so all warehouses can load the raw data.
+        currency: varchar
+        # Athena's Hive metastore doesn't support TIME type; DuckDB can't auto-parse "7:01 AM" format
+        time: "{{ 'varchar' if target.type in ['athena', 'duckdb'] else 'time' }}"
   - name: raw_subscriptions
     config:
       column_types:
@@ -58,11 +61,69 @@ seeds:
         event_id: integer
         user_id: integer
         event_timestamp: timestamp
-        event_properties: "{{ 'variant' if target.type == 'snowflake' else ('varchar' if target.type in ['athena', 'trino'] else 'jsonb') }}"
+        event_properties: "{{ 'variant' if target.type == 'snowflake' else ('varchar' if target.type in ['athena', 'trino', 'duckdb'] else 'jsonb') }}"
   - name: raw_plan
     config:
       column_types:
-        metadata: "{{ 'variant' if target.type == 'snowflake' else ('varchar' if target.type in ['athena', 'trino'] else 'jsonb') }}"
+        metadata: "{{ 'variant' if target.type == 'snowflake' else ('varchar' if target.type in ['athena', 'trino', 'duckdb'] else 'jsonb') }}"
+  - name: raw_buildings
+    config:
+      column_types:
+        # DuckDB sniffs integer columns as BIGINT; force bigint to avoid type mismatch
+        building_id: bigint
+        address_zip: varchar
+        construction_year: bigint
+        last_renovation_year: bigint
+        building_age_years: bigint
+        total_square_feet: bigint
+        rentable_square_feet: bigint
+        usable_square_feet: bigint
+        common_area_square_feet: bigint
+        number_of_floors: bigint
+        basement_levels: bigint
+        roof_age_years: bigint
+        parking_spaces: bigint
+        parking_revenue_monthly: bigint
+        total_units: bigint
+        occupied_units: bigint
+        vacant_units: bigint
+        number_of_tenants: bigint
+        largest_tenant_sqft: bigint
+        building_value: bigint
+        assessed_value: bigint
+        property_tax_annual: bigint
+        insurance_premium_annual: bigint
+        utility_cost_monthly: bigint
+        maintenance_cost_monthly: bigint
+        janitorial_cost_monthly: bigint
+        security_cost_monthly: bigint
+        landscaping_cost_monthly: bigint
+        total_operating_cost_monthly: bigint
+        revenue_monthly: bigint
+        net_operating_income_monthly: bigint
+        energy_star_score: bigint
+        walkability_score: bigint
+        transit_score: bigint
+        bike_score: bigint
+        hvac_system_age: bigint
+        hvac_capacity_tons: bigint
+        electrical_capacity_amps: bigint
+        generator_capacity_kw: bigint
+        elevator_count: bigint
+        cctv_camera_count: bigint
+        bandwidth_mbps: bigint
+        average_water_usage_gallons: bigint
+        average_electricity_kwh: bigint
+        average_gas_therms: bigint
+        solar_capacity_kw: bigint
+        ev_charging_stations: bigint
+        bike_storage_capacity: bigint
+        building_code_violations: bigint
+        code_violations_resolved: bigint
+        insurance_claims_5yr: bigint
+        total_work_orders_ytd: bigint
+        open_work_orders: bigint
+        sprinkler_coverage: varchar
   - name: raw_orders
     config:
       column_types:

--- a/examples/full-jaffle-shop-demo/dbt/macros/quarter_end_date.sql
+++ b/examples/full-jaffle-shop-demo/dbt/macros/quarter_end_date.sql
@@ -1,7 +1,7 @@
 {% macro quarter_end_date(quarter_start_column) %}
   {% if target.type == 'bigquery' %}
     DATE_ADD(DATE_ADD({{ quarter_start_column }}, INTERVAL 3 MONTH), INTERVAL -1 DAY)
-  {% elif target.type == 'postgres' or target.type == 'redshift' %}
+  {% elif target.type == 'postgres' or target.type == 'redshift' or target.type == 'duckdb' %}
     ({{ quarter_start_column }} + INTERVAL '3 months' - INTERVAL '1 day')::date
   {% elif target.type == 'snowflake' %}
     DATEADD(day, -1, DATEADD(month, 3, {{ quarter_start_column }}))

--- a/examples/full-jaffle-shop-demo/dbt/models/visit_analytics.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/visit_analytics.sql
@@ -55,9 +55,11 @@ visit_metrics as (
         extract(year from v.visit_date) as visit_year,
         extract(quarter from v.visit_date) as visit_quarter,
         extract(month from v.visit_date) as visit_month,
-        -- Athena/Trino: no to_char, use date_format instead
+        -- Athena/Trino: no to_char, use date_format; DuckDB: use strftime
         {% if target.type == 'trino' or target.type == 'athena' %}
         date_format(v.visit_date, '%W') as visit_day_of_week,
+        {% elif target.type == 'duckdb' %}
+        strftime(v.visit_date, '%A') as visit_day_of_week,
         {% else %}
         to_char(v.visit_date, 'Day') as visit_day_of_week,
         {% endif %}


### PR DESCRIPTION
## Changes

- Add comprehensive warehouse adapter implementation guide in `.claude/skills/add-warehouse-adapter/SKILL.md`
- Update jaffle shop demo project for DuckDB compatibility:
  - Fix `seeds.yml` column types (use `timestamptz` for timestamp fields, `varchar` for JSON/currency, force `bigint` for integer columns)
  - Add DuckDB branch to `quarter_end_date.sql` macro (reuses Postgres syntax)
  - Add DuckDB support to `visit_analytics.sql` model (use `strftime` for day-of-week formatting)

## Test plan
- [ ] `dbt seed --target duckdb` — verify all seeds pass with correct column types
- [ ] `dbt run --target duckdb` — verify all models materialize successfully
- [ ] Validate warehouse adapter implementation checklist covers all required layers