### PR TITLE
feat: add investigate-pylon skill for AE support workflow

### DIFF
--- a/.claude/skills/investigate-pylon/SKILL.md
+++ b/.claude/skills/investigate-pylon/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: investigate-pylon
 description: Investigate a Pylon support ticket. Use when asked to investigate, triage, or look into a Pylon issue. Classifies the ticket, searches for existing GitHub/Linear issues, searches docs, inspects code if needed, and drafts a customer reply.
-allowed-tools: Read, Grep, Glob, Bash, WebFetch
+allowed-tools: Read, Grep, Glob, Bash, WebFetch, Task
 ---
 
 # Investigate Pylon Ticket
@@ -13,12 +13,19 @@ Investigate Pylon issue `$ARGUMENTS`.
 1. Fetch the Pylon issue using `get_issue` with the issue number
 2. Fetch the full message history using `get_issue_messages`
 3. Fetch the customer account using `get_account`
+4. Fetch the customer contact using `get_contact`
 
-Summarize: who is the customer, what are they reporting, and any relevant account context.
+**The message thread is often more important than the issue body.** Pay close attention to:
+- Follow-up messages where the customer added crucial details
+- Prior replies from colleagues (don't contradict them)
+- What the customer is *currently* waiting on, which may differ from the original question
+- Whether the issue has already resolved itself
+
+Use the customer's first name in any draft replies. Note their account tier (Starter, Starter Plus, etc.) to calibrate expectations around feature availability.
 
 ## Step 2: Classify the ticket
 
-Based on the issue content, classify it as one of:
+Based on the issue content and messages, classify it as one of:
 - **Question** - the customer is asking how to do something
 - **Feature request** - the customer wants functionality that doesn't exist
 - **Bug** - something is broken or behaving unexpectedly
@@ -42,8 +49,9 @@ Before answering, consider whether you need to ask the customer to clarify their
    gh search issues --repo lightdash/lightdash "<relevant keywords>" --state open
    ```
 2. Also try broader search terms if the first search returns nothing
-3. If a matching issue exists: note it with a link and its current status
-4. If no match exists: draft a GitHub issue body (title + description). Do NOT create it yet.
+3. Search Linear for related issues using `list_issues` with a search query
+4. If a matching issue exists: note it with a link and its current status
+5. If no match exists: draft a GitHub issue body (title + description). Do NOT create it yet.
 
 ### If it's a bug
 
@@ -51,17 +59,23 @@ Before answering, consider whether you need to ask the customer to clarify their
    ```
    gh search issues --repo lightdash/lightdash "<relevant keywords>" --label bug
    ```
-2. Search the codebase for relevant code:
+2. Search Linear for related issues using `list_issues`
+3. Search the codebase for relevant code:
    ```
    gh search code --repo lightdash/lightdash "<relevant keywords>"
    ```
-3. Review what you find in the code. Determine:
+4. For complex bugs, use a Task subagent to do a deeper codebase investigation with Grep, Read, and Glob to find the specific logic causing the issue
+5. Review what you find. Determine:
    - Is this intended behavior?
    - Is this a genuine bug?
    - What part of the code is responsible?
-4. If no existing issue: draft a GitHub issue body. Do NOT create it yet.
+6. If no existing issue: draft a GitHub issue body. Do NOT create it yet.
 
 **Important**: If you need to create a GitHub issue, always create it on GitHub (not Linear). The GitHub-Linear sync will automatically create a linked Linear issue. Creating in Linear first causes duplicates.
+
+### For ALL types
+
+Always verify your understanding of product behavior against the docs using `SearchLightdash` before drafting any reply. This is the technical backstop that prevents inaccurate answers. Don't rely on assumptions about how the product works.
 
 ## Step 4: Draft a customer reply
 
@@ -70,6 +84,7 @@ Write a draft reply to send to the customer. Rules:
 - Keep it concise and natural. Write like a human, not an AI.
 - Never use em dashes.
 - Be friendly and direct.
+- Use the customer's first name.
 - If it's a question: include the answer with links to relevant docs.
 - If it's a bug or feature request: acknowledge what they reported and let them know we're looking into it.
 - If you need more info from the customer, ask a specific clarifying question instead of guessing.
@@ -94,7 +109,7 @@ Output your findings in this format:
 [Question / Feature Request / Bug]
 
 ## Customer
-[Account name and relevant context]
+[Name, account name, tier, and any relevant context]
 
 ## Summary
 [What the customer is asking about, 2-3 sentences max]
@@ -119,3 +134,5 @@ Output your findings in this format:
 ```
 
 **Do not auto-create GitHub issues, send Slack messages, or take any action beyond presenting drafts. Everything stays in this chat for the AE to review and act on.**
+
+The AE will likely refine the draft. Be ready for follow-up instructions to adjust the reply, dig deeper into the code, or change the approach.


### PR DESCRIPTION
## Summary
- Adds a new Claude Code skill `/investigate-pylon` that automates the AE support investigation workflow
- When invoked with a Pylon issue number, it fetches the ticket, classifies it (question/feature request/bug), searches for existing GitHub issues, searches docs, inspects code if needed, and drafts a customer reply
- All outputs are drafts presented in chat for AE review before taking any action

## How to use
In Claude Code from the lightdash repo:
```
/investigate-pylon 292929
```

## What it does
1. Fetches Pylon issue details, messages, and account context
2. Classifies as question, feature request, or bug
3. Searches GitHub issues and Lightdash docs (and codebase for bugs)
4. Drafts a customer reply (concise, human tone, no em dashes)
5. Drafts an internal engineering message if needed
6. Drafts a GitHub issue body if needed
7. Presents everything in a structured format for the AE to review

## Context
Discussed in [this Slack thread](https://lightdash.slack.com/archives/C03MCQ08UKS/p1771278832891209) - Hamzah suggested turning Tori's manual investigation workflow into a reusable skill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)