### PR TITLE
feat: introduce parameter labels

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7310,6 +7310,25 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    LightdashParameterOption: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                value: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'double' },
+                    ],
+                    required: true,
+                },
+                label: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     LightdashProjectParameter: {
         dataType: 'refAlias',
         type: {
@@ -7327,6 +7346,13 @@ const models: TsoaRoute.Models = {
                     subSchemas: [
                         { dataType: 'array', array: { dataType: 'string' } },
                         { dataType: 'array', array: { dataType: 'double' } },
+                        {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'LightdashParameterOption',
+                            },
+                        },
                     ],
                 },
                 allow_custom_values: { dataType: 'boolean' },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8513,6 +8513,26 @@
             "LineageGraph": {
                 "$ref": "#/components/schemas/Record_string.LineageNodeDependency-Array_"
             },
+            "LightdashParameterOption": {
+                "properties": {
+                    "value": {
+                        "anyOf": [
+                            {
+                                "type": "string"
+                            },
+                            {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        ]
+                    },
+                    "label": {
+                        "type": "string"
+                    }
+                },
+                "required": ["value", "label"],
+                "type": "object"
+            },
             "LightdashProjectParameter": {
                 "properties": {
                     "options_from_dimension": {
@@ -8539,6 +8559,12 @@
                                 "items": {
                                     "type": "number",
                                     "format": "double"
+                                },
+                                "type": "array"
+                            },
+                            {
+                                "items": {
+                                    "$ref": "#/components/schemas/LightdashParameterOption"
                                 },
                                 "type": "array"
                             }

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -76,11 +76,30 @@
                             "type": "boolean"
                         },
                         "options": {
-                            "description": "A list of possible values for the parameter",
+                            "description": "A list of possible values for the parameter, either as plain values or as label+value pairs",
                             "type": "array",
                             "minItems": 1,
                             "items": {
-                                "type": ["string", "number"]
+                                "oneOf": [
+                                    {
+                                        "type": ["string", "number"]
+                                    },
+                                    {
+                                        "type": "object",
+                                        "properties": {
+                                            "label": {
+                                                "description": "Display text shown in the UI",
+                                                "type": "string"
+                                            },
+                                            "value": {
+                                                "description": "Underlying value used in SQL substitution",
+                                                "type": ["string", "number"]
+                                            }
+                                        },
+                                        "required": ["label", "value"],
+                                        "additionalProperties": false
+                                    }
+                                ]
                             }
                         },
                         "default": {

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -16,6 +16,16 @@ type SpotlightConfig = {
     };
 };
 
+export type LightdashParameterOption = {
+    label: string;
+    value: string | number;
+};
+
+export const isLightdashParameterOption = (
+    opt: unknown,
+): opt is LightdashParameterOption =>
+    typeof opt === 'object' && opt !== null && 'label' in opt && 'value' in opt;
+
 export type LightdashProjectParameter = {
     label: string;
     description?: string;
@@ -23,7 +33,7 @@ export type LightdashProjectParameter = {
     default?: ParameterValue;
     multiple?: boolean; // the parameter input will be a multi select
     allow_custom_values?: boolean; // allows users to input custom values beyond predefined options
-    options?: string[] | number[]; // hardcoded options - kept separate as they're always homogeneous arrays
+    options?: string[] | number[] | LightdashParameterOption[]; // hardcoded options - string/number arrays or label+value pairs
     options_from_dimension?: {
         // options will be populated from dimension values
         model: string;

--- a/packages/common/src/utils/loadLightdashProjectConfig.mock.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.mock.ts
@@ -205,3 +205,16 @@ export const validConfigWithoutCustomGranularities = `
 spotlight:
   default_visibility: show
 `;
+
+export const validConfigWithLabeledOptions = `
+spotlight:
+  default_visibility: show
+parameters:
+  status:
+    label: Status
+    options:
+      - label: Active
+        value: "active_id_1"
+      - label: Inactive
+        value: "inactive_id_2"
+`;

--- a/packages/common/src/utils/loadLightdashProjectConfig.test.ts
+++ b/packages/common/src/utils/loadLightdashProjectConfig.test.ts
@@ -13,6 +13,7 @@ import {
     validConfigWithCustomGranularities,
     validConfigWithDateParameter,
     validConfigWithDateParameterFromDimension,
+    validConfigWithLabeledOptions,
     validConfigWithMixedArrayTypes,
     validConfigWithNumberArrayParameter,
     validConfigWithNumberParameter,
@@ -267,5 +268,25 @@ describe('loadLightdashProjectConfig', () => {
             validConfigWithoutCustomGranularities,
         );
         expect(config.custom_granularities).toBeUndefined();
+    });
+
+    it('should load a valid config with labeled options (label+value pairs)', async () => {
+        const config = await loadLightdashProjectConfig(
+            validConfigWithLabeledOptions,
+        );
+        expect(config).toEqual({
+            spotlight: {
+                default_visibility: 'show',
+            },
+            parameters: {
+                status: {
+                    label: 'Status',
+                    options: [
+                        { label: 'Active', value: 'active_id_1' },
+                        { label: 'Inactive', value: 'inactive_id_2' },
+                    ],
+                },
+            },
+        });
     });
 });

--- a/packages/frontend/src/features/parameters/components/ParameterInput.tsx
+++ b/packages/frontend/src/features/parameters/components/ParameterInput.tsx
@@ -3,6 +3,7 @@ import {
     FieldType,
     formatDate,
     getItemId,
+    isLightdashParameterOption,
     parseDate,
     TimeFrames,
     type FilterableItem,
@@ -19,7 +20,6 @@ import {
 } from '@mantine-8/core';
 import { DatePickerInput } from '@mantine/dates';
 import { IconPlus } from '@tabler/icons-react';
-import uniq from 'lodash/uniq';
 import React, {
     useCallback,
     useEffect,
@@ -184,12 +184,20 @@ export const ParameterInput: FC<ParameterInputProps> = ({
 
         // Add custom values if allowed
         if (parameter.allow_custom_values) {
-            // Needed because current values are not in the same group as parameter options
+            // Filter out current values already covered by fetched results or parameterOptions
+            // For labeled options, compare against the option's value field
             const filteredCurrentValues = currentValues.filter(
-                (option) => !fetchedResults.includes(String(option)),
+                (option, index, self) =>
+                    self.indexOf(option) === index && // deduplicate within currentValues
+                    !fetchedResults.includes(String(option)) &&
+                    !parameterOptions.some((opt) =>
+                        isLightdashParameterOption(opt)
+                            ? String(opt.value) === String(option)
+                            : String(opt) === String(option),
+                    ),
             );
 
-            return uniq([...parameterOptions, ...filteredCurrentValues]);
+            return [...parameterOptions, ...filteredCurrentValues];
         }
 
         // Always return a copy to avoid Redux immutability issues
@@ -263,16 +271,33 @@ export const ParameterInput: FC<ParameterInputProps> = ({
         const baseItems = shouldFetch
             ? optionsData.filter(
                   (option) =>
-                      option !== '__refresh__' && option !== '__create__',
+                      typeof option === 'object' ||
+                      (option !== '__refresh__' && option !== '__create__'),
               )
             : optionsData;
 
         const regularItems = [...baseItems] // Create a copy to avoid mutating Redux state
-            .sort((a, b) => String(a).localeCompare(String(b)))
-            .map((option) => ({
-                value: String(option),
-                label: formatDisplayValue(String(option)),
-            }));
+            .sort((a, b) => {
+                const aLabel = isLightdashParameterOption(a)
+                    ? a.label
+                    : formatDisplayValue(String(a));
+                const bLabel = isLightdashParameterOption(b)
+                    ? b.label
+                    : formatDisplayValue(String(b));
+                return aLabel.localeCompare(bLabel);
+            })
+            .map((option) => {
+                if (isLightdashParameterOption(option)) {
+                    return {
+                        value: String(option.value),
+                        label: option.label,
+                    };
+                }
+                return {
+                    value: String(option),
+                    label: formatDisplayValue(String(option)),
+                };
+            });
 
         const fetchedItems =
             fetchedResults.length > 0


### PR DESCRIPTION
Thanks for maintaining this project! I'd love to get a review on this feature addition that extends Lightdash parameters with label support.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #15959
 
### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->

This PR introduces **parameter labels** — the ability to show human-readable display text for parameter option values, separate from the underlying SQL-substituted value.

There are two ways to use this:

**1. `label_dimension` in `options_from_dimension`**

When fetching options from a dbt dimension, an optional `label_dimension` can now be specified to display a different field as the label while the `dimension` field is used as the actual value:

```yaml
parameters:
  employer:
    label: Employer
    options_from_dimension:
      model: employer_lookup
      dimension: employer_id          # value used in SQL substitution
      label_dimension: employer_name  # display label shown in the UI
```

When `label_dimension` is set, the API fetches both fields, searches/sorts by the label field, and returns `{ value, label }` pairs to the frontend.

**2. Labeled static `options`**

Static options can now be specified as `{ label, value }` objects instead of plain strings/numbers:

```yaml
parameters:
  status:
    label: Status
    options:
      - label: Active
        value: active_id_1
      - label: Inactive
        value: inactive_id_2
```

**Changes summary:**
- `common`: Added `LightdashParameterOption` type and `isLightdashParameterOption` type guard; extended `LightdashProjectParameter` to accept labeled options; updated JSON schema accordingly.
- `backend`: `_getFieldValuesMetricQuery` resolves an optional label dimension, queries both value and label fields, and returns `{ value, label }` pairs when a label field is present.
- `frontend`: `useFieldValues` accumulates a `labelMap` (value → label) from labeled API responses; `ParameterInput` uses this map to display labels in the dropdown while submitting the underlying value.
- Tests added for both new config shapes.
