### PR TITLE
fix: sum_distinct SQL when no other dims/metrics selected

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -2670,8 +2670,8 @@ export class MetricQueryBuilder {
         );
 
         if (sdMetricIds.length > 0) {
-            const fieldQuoteChar =
-                this.args.warehouseSqlBuilder.getFieldQuoteChar();
+            // Base query has dimensions or regular metrics — wrap it and join
+            const sdBaseCteName = 'sd_base';
 
             const hasNonSdSelects =
                 Object.keys(dimensionsSQL.selects).length > 0 ||
@@ -2688,13 +2688,11 @@ export class MetricQueryBuilder {
                 sqlFrom,
                 joinsSql: joins.joinSQL,
                 dimensionJoins: dimensionsSQL.joins,
-                baseCteName: 'sd_base',
+                baseCteName: sdBaseCteName,
             });
             ctes.push(...sdCtes);
 
             if (hasNonSdSelects) {
-                // Base query has dimensions or regular metrics — wrap it and join
-                const sdBaseCteName = 'sd_base';
                 ctes.push(
                     MetricQueryBuilder.wrapAsCte(
                         sdBaseCteName,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/20627

### Description:
When no dims or metrics are selected along with a sum distinct metric, the metricQueryBuilder was generating an invalid query. This query did not fail for Postgres warehouse but did not group the result correctly, resulting in a record for every row in the original table. The query did, however, fail in BigQuery as the SQL was invalid. 

Updated the metricQueryBuilder to only wrap the sum_distinct logic in the `sd_base` CTE if at least one other metric or dimension is included. If the sum_distinct metric is the only thing selected, then we select directly from the sum_distinct query without wrapping it in a CTE. 

### Before (Postgres)
<img width="1087" height="759" alt="Pages Scrol" src="https://github.com/user-attachments/assets/dbd46ae1-e22e-492c-94b8-d153bfe6300e" />

``` sql 
WITH sd_base AS (
SELECT

FROM "postgres"."jaffle"."customer_order_payments" AS "customer_order_payments"

),
sd_customer_order_payments_total_line_item_revenue_deduped AS (
SELECT
  SUM(CASE WHEN __sd_rn = 1 THEN __sd_val ELSE 0 END) AS "customer_order_payments_total_line_item_revenue_deduped"
FROM (
SELECT
  ("customer_order_payments".line_item_total) AS __sd_val,
  ROW_NUMBER() OVER (PARTITION BY ("customer_order_payments".line_item_id) ORDER BY ("customer_order_payments".line_item_total)) AS __sd_rn
FROM "postgres"."jaffle"."customer_order_payments" AS "customer_order_payments"

) __sd_sub

)
SELECT
  sd_base.*,
  sd_customer_order_payments_total_line_item_revenue_deduped."customer_order_payments_total_line_item_revenue_deduped" AS "customer_order_payments_total_line_item_revenue_deduped"
FROM sd_base
CROSS JOIN sd_customer_order_payments_total_line_item_revenue_deduped
ORDER BY "customer_order_payments_total_line_item_revenue_deduped" DESC
LIMIT 500
```

### After (Postgres)
<img width="1110" height="639" alt="Pasted Graphic" src="https://github.com/user-attachments/assets/94fee913-1dd1-4bd5-94ca-f373b70200ad" />

``` sql
WITH sd_customer_order_payments_total_line_item_revenue_deduped AS (
SELECT
  SUM(CASE WHEN __sd_rn = 1 THEN __sd_val ELSE 0 END) AS "customer_order_payments_total_line_item_revenue_deduped"
FROM (
SELECT
  ("customer_order_payments".line_item_total) AS __sd_val,
  ROW_NUMBER() OVER (PARTITION BY ("customer_order_payments".line_item_id) ORDER BY ("customer_order_payments".line_item_total)) AS __sd_rn
FROM "postgres"."jaffle"."customer_order_payments" AS "customer_order_payments"

) __sd_sub

)
SELECT
  sd_customer_order_payments_total_line_item_revenue_deduped."customer_order_payments_total_line_item_revenue_deduped" AS "customer_order_payments_total_line_item_revenue_deduped"
FROM sd_customer_order_payments_total_line_item_revenue_deduped
ORDER BY "customer_order_payments_total_line_item_revenue_deduped" DESC
LIMIT 500
```

Tests Performed: 
- [1 sum distinct metric selected](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customer_order_payments?create_saved_chart_version=%7B%22tableName%22%3A%22customer_order_payments%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22customer_order_payments%22%2C%22dimensions%22%3A%5B%5D%2C%22metrics%22%3A%5B%22customer_order_payments_total_line_item_revenue_deduped%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22customer_order_payments_total_line_item_revenue_deduped%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22yField%22%3A%5B%22customer_order_payments_total_payment_amount_deduped%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22customer_order_payments_total_payment_amount_deduped%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%7D&isExploreFromHere=true)
- [2 sum distinct metrics selected from the same table](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customer_order_payments?create_saved_chart_version=%7B%22tableName%22%3A%22customer_order_payments%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22customer_order_payments%22%2C%22dimensions%22%3A%5B%5D%2C%22metrics%22%3A%5B%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22customer_order_payments_total_payment_amount_deduped%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22customer_order_payments_total_payment_amount_deduped%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22yField%22%3A%5B%22customer_order_payments_total_payment_amount_deduped%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22customer_order_payments_total_payment_amount_deduped%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%7D&isExploreFromHere=true)
- [2 sum distinct metrics selected, from joined tables ](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customers?create_saved_chart_version=%7B%22tableName%22%3A%22customers%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22customers%22%2C%22dimensions%22%3A%5B%5D%2C%22metrics%22%3A%5B%22customers_total_order_amount_deduped%22%2C%22payments_total_order_amount_deduped%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22customers_total_order_amount_deduped%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22customers_total_order_amount_deduped%22%2C%22payments_total_order_amount_deduped%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22customers_total_order_amount_deduped%22%2C%22yField%22%3A%5B%22payments_total_order_amount_deduped%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22customers_total_order_amount_deduped%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22payments_total_order_amount_deduped%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%7D&isExploreFromHere=true)
- [sum_distinct metric selected with another metric](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customer_order_payments?create_saved_chart_version=%7B%22tableName%22%3A%22customer_order_payments%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22customer_order_payments%22%2C%22dimensions%22%3A%5B%5D%2C%22metrics%22%3A%5B%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22customer_order_payments_total_line_item_revenue_inflated%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22customer_order_payments_total_line_item_revenue_inflated%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22yField%22%3A%5B%22customer_order_payments_total_line_item_revenue_inflated%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22customer_order_payments_total_line_item_revenue_inflated%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%7D&isExploreFromHere=true)
- [sum_distinct metric selected with another dim](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customer_order_payments?create_saved_chart_version=%7B%22tableName%22%3A%22customer_order_payments%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22customer_order_payments%22%2C%22dimensions%22%3A%5B%22customer_order_payments_shipping_cost%22%5D%2C%22metrics%22%3A%5B%22customer_order_payments_total_line_item_revenue_deduped%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22customer_order_payments_shipping_cost%22%2C%22customer_order_payments_total_line_item_revenue_deduped%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22yField%22%3A%5B%22customer_order_payments_shipping_cost%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22customer_order_payments_shipping_cost%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%7D&isExploreFromHere=true)
- [sum_distinct metric selected with another metric and dim](http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/customer_order_payments?create_saved_chart_version=%7B%22tableName%22%3A%22customer_order_payments%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22customer_order_payments%22%2C%22dimensions%22%3A%5B%22customer_order_payments_payment_method%22%5D%2C%22metrics%22%3A%5B%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22customer_order_payments_unique_line_items%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22descending%22%3Atrue%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%5D%2C%22additionalMetrics%22%3A%5B%5D%2C%22metricOverrides%22%3A%7B%7D%2C%22customDimensions%22%3A%5B%5D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22customer_order_payments_payment_method%22%2C%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22customer_order_payments_unique_line_items%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%2C%22yField%22%3A%5B%22customer_order_payments_unique_line_items%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22customer_order_payments_total_line_item_revenue_deduped%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22customer_order_payments_unique_line_items%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%7D%7D%7D&isExploreFromHere=true)