### PR TITLE
fix: make inherit the default for spaces

### DIFF
--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -27,6 +27,7 @@ describe('Space', () => {
 
         cy.contains('New').click();
         cy.contains('Organize your saved charts and dashboards.').click();
+        cy.findByText('Restricted access').click();
         cy.findByPlaceholderText('eg. KPIs')
             .click()
             .clear()
@@ -91,7 +92,7 @@ describe('Space', () => {
         cy.contains(`Private chart ${timestamp}`);
     };
 
-    it('Another non-admin user cannot see private content', () => {
+    it.only('Another non-admin user cannot see private content', () => {
         createPrivateSpace();
 
         // We assume the previous test has been run and the private space has been created

--- a/packages/frontend/src/components/common/SpaceActionModal/index.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/index.tsx
@@ -109,7 +109,7 @@ const SpaceModal: FC<ActionModalProps> = ({
 
     const isNestedSpace = !!parentSpaceUuid;
     const [inheritanceValue, setInheritanceValue] = useState<InheritanceType>(
-        isNestedSpace ? InheritanceType.INHERIT : InheritanceType.OWN_ONLY,
+        InheritanceType.INHERIT,
     );
 
     const [modalStep, setModalStep] = useState(CreateModalStep.SET_NAME);


### PR DESCRIPTION
### Description:

Makes 'inherit' the default permission mode for spaces. 
