### PR TITLE
fix: format findContent results as markdown links instead of bare URLs

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -365,7 +365,7 @@ ${EXPLORE_SELECTION_AMBIGUITY_CHECKER}
 
   3.4. **Finding Existing Content (Dashboards & Charts):**
     - Use "findContent" tool when users ask about finding, searching for, or getting links to dashboards and saved charts
-    - Format results as a list with clickable URLs and descriptions
+    - Format results as a markdown list with descriptive link titles: e.g. [Dashboard Name](url) and [Chart Name](url). Never output bare URLs.
     - If no results found, offer to create a new chart based on available data
     - Do NOT call "findExplores" or "findFields" when searching for dashboards or charts
 


### PR DESCRIPTION
### Description:

Updated the AI prompt template to improve formatting of dashboard and chart search results. The system now formats results as markdown links with descriptive titles (e.g. `[Dashboard Name](url)` and `[Chart Name](url)`) instead of displaying bare URLs, providing a cleaner and more user-friendly presentation of search results.

![CleanShot 2026-02-26 at 11.20.58@2x.png](https://app.graphite.com/user-attachments/assets/98de0ef9-68c7-4be6-8e68-1880b61c8d5d.png)

_before_
![CleanShot 2026-02-26 at 11.21.09@2x.png](https://app.graphite.com/user-attachments/assets/dc17b28e-8997-454f-8db8-db63cbe921fb.png)

