### PR TITLE
fix: auto-scrolling on space share user

### DIFF
--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.module.css
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.module.css
@@ -1,0 +1,14 @@
+.option[data-checked] {
+    background-color: var(--mantine-primary-color-filled);
+    color: var(--mantine-color-white);
+
+    & * {
+        --mantine-color-dimmed: var(--mantine-color-white);
+        color: var(--mantine-color-white);
+        border-color: rgba(255, 255, 255, 0.4);
+    }
+}
+
+.option[data-checked]:hover {
+    background-color: var(--mantine-primary-color-filled-hover);
+}

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -40,6 +40,7 @@ import {
 import { LightdashUserAvatar } from '../../Avatar';
 import MantineIcon from '../MantineIcon';
 import { DEFAULT_PAGE_SIZE } from '../Table/constants';
+import styles from './ShareSpaceAddUser.module.css';
 import { UserAccessOptions } from './ShareSpaceSelect';
 import { getUserNameOrEmail } from './Utils';
 import { getAccessColor } from './v2/ShareSpaceModalUtils';
@@ -352,6 +353,7 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
         <Group>
             <MultiSelect
                 style={{ flex: 1 }}
+                classNames={{ option: styles.option }}
                 searchable
                 clearable
                 placeholder="Select groups or users to share this space with"


### PR DESCRIPTION
### Description:
**Bug fix:**
- Dropdown no longer jumps when selecting items - Mantine v8 uses stable component references internally

**Mantine v6 → v8 migration:**
- `itemComponent` → `renderOption` (simpler callback API, no `forwardRef` needed)
- `dropdownComponent` → removed (no equivalent needed in v8)
- `clearSearchOnChange` → manual `setSearchQuery('')` in `onChange`
- `nothingFound` → `nothingFoundMessage`
- v6 style props (`position`, `spacing`, `color`) → v8 equivalents (`justify`, `gap`, `c`)

**Infinite scroll replaces "Load more" button:**
- Uses `scrollAreaProps` with `onScrollPositionChange` (matching existing `UserSelect` pattern)
- Users and groups paginate independently - groups stop loading when exhausted
- Guard prevents false scroll triggers when content fits without scrolling

**Visual improvements:**
- Access badges now use colored pills with source prefix (e.g., "Organization · Can view") matching the "Who has access" tab style


### Before (pay attention to the automatic scrolling):

https://github.com/user-attachments/assets/93c23681-55d3-436e-8cc6-2f73554c923e



### After:
Note: the icon colors were actually fixed after recording the video.

https://github.com/user-attachments/assets/b1b1e04b-a031-4e50-baf1-2494905e148d

