### PR TITLE
fix: embed settings save changes is disabled if project has only charts saved in dashboards

### DIFF
--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedAllowListForm.tsx
@@ -103,8 +103,7 @@ const EmbedAllowListForm: FC<{
                         type="submit"
                         disabled={
                             disabled ||
-                            dashboards.length === 0 ||
-                            charts.length === 0
+                            (dashboards.length === 0 && charts.length === 0)
                         }
                     >
                         Save changes


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/20649

### Description:

Fixed the submit button logic in the EmbedAllowListForm to allow saving when either dashboards or charts are selected, rather than requiring both to be present. The button is now only disabled when both dashboards and charts arrays are empty.

**Before**

![CleanShot 2026-02-26 at 11.03.06.png](https://app.graphite.com/user-attachments/assets/d83a5118-3d1a-48b6-9784-67402410535f.png)

**After**

![CleanShot 2026-02-26 at 11.02.50.png](https://app.graphite.com/user-attachments/assets/19ba8861-24b6-4ac9-af55-4f50b1af561a.png)