### PR TITLE
fix: long agent messages dont show up in slack

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -154,6 +154,7 @@ import {
     getFollowUpToolBlocks,
     getProposeChangeBlocks,
     getReferencedArtifactsBlocks,
+    getTextBlocks,
     getThinkingBlocks,
 } from '../ai/utils/getSlackBlocks';
 import { llmAsAJudge } from '../ai/utils/llmAsAJudge';
@@ -3393,16 +3394,15 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 
         // ! This is needed because the markdownToBlocks escapes all characters and slack just needs &, <, > to be escaped
         // ! https://api.slack.com/reference/surfaces/formatting#escaping
-        const slackifiedMarkdown = slackifyMarkdown(response);
+        // Also strip trailing backslashes before newlines — slackifyMarkdown converts
+        // markdown hard line breaks (two trailing spaces) into `\` which Slack renders literally.
+        const slackifiedMarkdown = slackifyMarkdown(response).replace(
+            /\\\n/g,
+            '\n',
+        );
 
         const blocks = [
-            {
-                type: 'section',
-                text: {
-                    type: 'mrkdwn',
-                    text: slackifiedMarkdown,
-                },
-            },
+            ...getTextBlocks(slackifiedMarkdown),
             ...exploreBlocks,
             ...proposeChangeBlocks,
             ...referencedArtifactsBlocks,


### PR DESCRIPTION
Closes: #19688

### Description:

Fixed Slack message formatting by implementing text chunking for responses that exceed Slack's 3000 character limit for section blocks. Long AI agent responses are now automatically split into multiple section blocks to prevent `invalid_blocks` errors when posting to Slack channels.

The implementation uses a regex pattern to split text into chunks of up to 3000 characters while preserving markdown formatting, ensuring all AI responses display correctly regardless of length.