### PR TITLE
fix: show fallback message with Lightdash link when Slack response fails

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3429,7 +3429,19 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 },
                 extra: { responseLength: slackifiedMarkdown.length },
             });
-            throw error;
+
+            const threadUrl = thread.agentUuid
+                ? `${this.lightdashConfig.siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${thread.agentUuid}/threads/${slackPrompt.threadUuid}`
+                : this.lightdashConfig.siteUrl;
+
+            newResponse = await this.slackClient.postMessage({
+                organizationUuid: slackPrompt.organizationUuid,
+                text: `⚠️ The response couldn't be displayed here. <${threadUrl}|View it in Lightdash>.`,
+                username: agent?.name,
+                channel: slackPrompt.slackChannelId,
+                thread_ts: slackPrompt.slackThreadTs,
+                unfurl_links: false,
+            });
         }
 
         await this.aiAgentModel.updateModelResponse({


### PR DESCRIPTION

Closes: #18105

### Description:

When AI agent responses are too long to display in Slack, the system now posts a fallback message with a link to view the full response in Lightdash instead of throwing an error. The fallback message includes a warning emoji and directs users to the specific AI agent thread URL, or falls back to the main site URL if no agent UUID is available.

![CleanShot 2026-02-26 at 12.23.40@2x.png](https://app.graphite.com/user-attachments/assets/ab8bf278-f97e-4b7d-894a-1256c91088fc.png)

