### PR TITLE
fix: dont show space access on home or spaces list

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -1,4 +1,5 @@
 import {
+    FeatureFlags,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
     isResourceViewSpaceItem,
@@ -12,6 +13,7 @@ import {
     IconLayoutDashboard,
 } from '@tabler/icons-react';
 import { Link } from 'react-router';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { ResourceIcon, ResourceIndicator } from '../ResourceIcon';
 import { ResourceInfoPopup } from '../ResourceInfoPopup/ResourceInfoPopup';
 import ResourceAccessInfo from './ResourceAccessInfo';
@@ -100,6 +102,11 @@ const InfiniteResourceTableColumnName = ({
     projectUuid,
     canUserManageValidation,
 }: InfiniteResourceTableColumnNameProps) => {
+    const { data: nestedSpacesPermissionsFlag } = useServerFeatureFlag(
+        FeatureFlags.NestedSpacesPermissions,
+    );
+    const isV2 = !!nestedSpacesPermissionsFlag?.enabled;
+
     const isSpace = isResourceViewSpaceItem(item);
     const isChartOrDashboard =
         isResourceViewItemChart(item) || isResourceViewItemDashboard(item);
@@ -178,14 +185,18 @@ const InfiniteResourceTableColumnName = ({
                     )}
                     {isSpace && item.data.parentSpaceUuid && (
                         <Group gap="xs" wrap="nowrap">
-                            <ResourceAccessInfo
-                                item={item}
-                                type="secondary"
-                                withTooltip
-                            />
-                            <Text fz={12} c="ldGray.6">
-                                •
-                            </Text>
+                            {!isV2 && (
+                                <>
+                                    <ResourceAccessInfo
+                                        item={item}
+                                        type="secondary"
+                                        withTooltip
+                                    />
+                                    <Text fz={12} c="ldGray.6">
+                                        &bull;
+                                    </Text>
+                                </>
+                            )}
                             <Group>
                                 <AttributeCount
                                     Icon={IconLayoutDashboard}

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridSpaceItem.tsx
@@ -1,4 +1,4 @@
-import { type ResourceViewSpaceItem } from '@lightdash/common';
+import { FeatureFlags, type ResourceViewSpaceItem } from '@lightdash/common';
 import { Box, Flex, Group, Paper, Stack, Text, Tooltip } from '@mantine-8/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import {
@@ -7,6 +7,7 @@ import {
     IconLayoutDashboard,
 } from '@tabler/icons-react';
 import { useMemo, type FC, type ReactNode } from 'react';
+import { useServerFeatureFlag } from '../../../../hooks/useServerOrClientFeatureFlag';
 import { ResourceIcon } from '../../ResourceIcon';
 import AccessInfo from '../ResourceAccessInfo';
 import ResourceViewActionMenu, {
@@ -33,6 +34,10 @@ const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
 }) => {
     const { hovered, ref } = useHover();
     const [opened, handlers] = useDisclosure(false);
+    const { data: nestedSpacesPermissionsFlag } = useServerFeatureFlag(
+        FeatureFlags.NestedSpacesPermissions,
+    );
+    const isV2 = !!nestedSpacesPermissionsFlag?.enabled;
 
     const tooltipText = useMemo(() => {
         return getResourceAccessLabel(item);
@@ -87,9 +92,26 @@ const ResourceViewGridSpaceItem: FC<ResourceViewGridSpaceItemProps> = ({
                         </Text>
 
                         <Group gap="sm">
-                            <Flex align="center" gap={4}>
-                                <AccessInfo item={item} />
-                            </Flex>
+                            {isV2 ? (
+                                <>
+                                    <AttributeCount
+                                        Icon={IconLayoutDashboard}
+                                        count={item.data.dashboardCount}
+                                    />
+                                    <AttributeCount
+                                        Icon={IconChartBar}
+                                        count={item.data.chartCount}
+                                    />
+                                    <AttributeCount
+                                        Icon={IconFolder}
+                                        count={item.data.childSpaceCount}
+                                    />
+                                </>
+                            ) : (
+                                <Flex align="center" gap={4}>
+                                    <AccessInfo item={item} />
+                                </Flex>
+                            )}
                         </Group>
                     </Stack>
                 </Tooltip>


### PR DESCRIPTION
### Description:

Don't show access type on pinned items or space summary list. 

These terms are changing and the new terms are less useful in this context. 
