### PR TITLE
fix: improve DB connection resilience with keepalive and scheduler retry

### DIFF
--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -141,14 +141,37 @@ export class SchedulerClient {
         this.analytics = analytics;
         this.schedulerModel = schedulerModel;
         this.featureFlagModel = featureFlagModel;
-        this.graphileUtils = makeWorkerUtils({
-            connectionString: lightdashConfig.database.connectionUri,
-        })
-            .then((utils) => utils)
-            .catch((e: AnyType) => {
-                Logger.error('Error migrating graphile worker', e);
-                process.exit(1);
-            });
+        this.graphileUtils = (async () => {
+            const maxAttempts = 10;
+            const baseDelayMs = 3000;
+            for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+                try {
+                    // eslint-disable-next-line no-await-in-loop
+                    return await makeWorkerUtils({
+                        connectionString:
+                            lightdashConfig.database.connectionUri,
+                    });
+                } catch (e: AnyType) {
+                    if (attempt === maxAttempts) {
+                        Logger.error(
+                            'Error migrating graphile worker, giving up',
+                            e,
+                        );
+                        return process.exit(1);
+                    }
+                    const delay = baseDelayMs * 2 ** (attempt - 1);
+                    Logger.warn(
+                        `Error migrating graphile worker (attempt ${attempt}/${maxAttempts}), retrying in ${delay}ms`,
+                        e,
+                    );
+                    // eslint-disable-next-line no-await-in-loop
+                    await new Promise((resolve) => {
+                        setTimeout(resolve, delay);
+                    });
+                }
+            }
+            return process.exit(1);
+        })() as Promise<WorkerUtils>;
     }
 
     static async processJob<T extends SchedulerTaskName>(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Improves resilience against database restarts (e.g. RDS failover):

- **`knexfile.ts`**: Enable TCP keepalive and add an `afterCreate` hook that runs `SELECT 1` to discard stale connections before they reach callers
- **`SchedulerClient.ts`**: Retry `makeWorkerUtils` with exponential back-off (up to 10 attempts) instead of exiting immediately on failure