### PR TITLE
fix: selected space is agressively highlighted

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -527,12 +527,12 @@ const InfiniteResourceTable = ({
                         opacity: 0,
                     },
                     '&:hover': {
-                        td: {
-                            backgroundColor: isSelected
-                                ? theme.colors.blue[1]
-                                : theme.colors.ldGray[0],
-                            transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
-                        },
+                        td: isSelected
+                            ? {}
+                            : {
+                                  backgroundColor: theme.colors.ldGray[0],
+                                  transition: `background-color ${theme.other.transitionDuration}ms ${theme.other.transitionTimingFunction}`,
+                              },
 
                         'td:first-of-type > div > .explore-button-container': {
                             visibility: 'visible',


### PR DESCRIPTION
### Description:
When hovering an item in the spaces overview, the highlighting was very off.

### Before:
<img width="1569" height="948" alt="Screenshot 2026-02-26 at 13 11 12" src="https://github.com/user-attachments/assets/701123bf-7873-4ed1-a9e3-9876bddecacf" />

Light theme looked fine
<img width="1638" height="916" alt="image" src="https://github.com/user-attachments/assets/b8608d0d-3e2f-4733-93e1-1b725b6363ff" />


### After:
<img width="1638" height="916" alt="image" src="https://github.com/user-attachments/assets/18186078-afd1-41bd-981c-98c047dfdd0d" />

<img width="1638" height="916" alt="image" src="https://github.com/user-attachments/assets/e70e1193-7044-441a-a154-a7efa83b0cb3" />


### Scheduled deliveries already looked neat:
<img width="2222" height="518" alt="Screenshot 2026-02-26 at 13 12 28" src="https://github.com/user-attachments/assets/15d31089-0959-4c4b-aa9e-4147c7e28afa" />
