### PR TITLE
refactor: extract DashboardChartsToolCallDescription component

### DIFF
--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/DashboardChartsToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/DashboardChartsToolCallDescription.tsx
@@ -1,0 +1,29 @@
+import { Badge, rem, Text } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type DashboardChartsToolCallDescriptionProps = {
+    dashboardName: string;
+    page: number | null;
+};
+
+export const DashboardChartsToolCallDescription: FC<
+    DashboardChartsToolCallDescriptionProps
+> = ({ dashboardName, page }) => (
+    <Text c="dimmed" size="xs">
+        Looking up charts in dashboard{' '}
+        <Badge
+            color="gray"
+            variant="light"
+            size="xs"
+            mx={rem(2)}
+            radius="sm"
+            style={{
+                textTransform: 'none',
+                fontWeight: 400,
+            }}
+        >
+            {dashboardName}
+        </Badge>
+        {page !== null && page > 1 && ` (page ${page})`}
+    </Text>
+);

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/ToolCalls/descriptions/ToolCallDescription.tsx
@@ -18,11 +18,11 @@ import {
     type ToolRunQueryArgs,
     type ToolSearchFieldValuesArgs,
 } from '@lightdash/common';
-import { Badge, rem, Text } from '@mantine-8/core';
 import type { FC } from 'react';
 import type { ToolCallSummary } from '../utils/types';
 import { AiChartGenerationToolCallDescription } from './AiChartGenerationToolCallDescription';
 import { ContentSearchToolCallDescription } from './ContentSearchToolCallDescription';
+import { DashboardChartsToolCallDescription } from './DashboardChartsToolCallDescription';
 import { DashboardToolCallDescription } from './DashboardToolCallDescription';
 import { ExploreToolCallDescription } from './ExploreToolCallDescription';
 import { FieldSearchToolCallDescription } from './FieldSearchToolCallDescription';
@@ -101,23 +101,13 @@ export const ToolCallDescription: FC<{
             const getDashboardChartsArgs =
                 toolCall.toolArgs as ToolGetDashboardChartsArgs;
             return (
-                <Text c="dimmed" size="xs">
-                    Looking up charts in dashboard{' '}
-                    <Badge
-                        color="gray"
-                        variant="light"
-                        size="xs"
-                        mx={rem(2)}
-                        radius="sm"
-                        style={{
-                            textTransform: 'none',
-                            fontWeight: 400,
-                        }}
-                    >
-                        {getDashboardChartsArgs.dashboardName ??
-                            getDashboardChartsArgs.dashboardUuid}
-                    </Badge>
-                </Text>
+                <DashboardChartsToolCallDescription
+                    dashboardName={
+                        getDashboardChartsArgs.dashboardName ??
+                        getDashboardChartsArgs.dashboardUuid
+                    }
+                    page={getDashboardChartsArgs.page ?? null}
+                />
             );
         case 'generateDashboard':
             const dashboardToolArgs = toolCall.toolArgs as ToolDashboardArgs;


### PR DESCRIPTION

### Description:

Extracted the dashboard charts tool call description into a dedicated component `DashboardChartsToolCallDescription`. This component displays a message indicating that charts are being looked up in a specific dashboard, with the dashboard name shown in a styled badge. The component also includes pagination support, showing the page number when it's greater than 1.

The inline JSX in `ToolCallDescription.tsx` has been replaced with the new reusable component, improving code organization and maintainability.