### PR TITLE
feat: display dashcache checker on dashboard runs

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7651,11 +7651,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7670,11 +7670,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7705,29 +7705,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 searchRank:
                                                                                                     {
                                                                                                         dataType:
@@ -7751,11 +7728,28 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
                                                                                                     },
                                                                                                 tableName:
                                                                                                     {
@@ -7768,6 +7762,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -7883,11 +7883,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -7963,29 +7963,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    chartUsage:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     searchRank:
                                                                                                         {
                                                                                                             dataType:
@@ -8009,11 +7986,28 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
                                                                                                         },
                                                                                                     tableName:
                                                                                                         {
@@ -8026,6 +8020,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -8057,11 +8057,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8076,11 +8076,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -18178,7 +18178,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -18188,7 +18188,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -18198,7 +18198,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -18211,7 +18211,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -18560,7 +18560,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -18570,7 +18570,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -18580,7 +18580,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -18593,7 +18593,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8930,23 +8930,33 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -8954,14 +8964,17 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -9010,8 +9023,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -9055,18 +9068,15 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -9074,14 +9084,17 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -9109,8 +9122,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -19470,22 +19483,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiChartAsCodeListResponse": {
@@ -19776,22 +19789,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -27083,7 +27096,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2530.1",
+        "version": "0.2532.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -128,6 +128,9 @@ export const BaseResponse: HealthState = {
         enabled: false,
         retentionDays: 30,
     },
+    preAggregates: {
+        enabled: false,
+    },
 };
 
 export const userMock = {

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -229,6 +229,9 @@ export class HealthService extends BaseService {
                 enabled: this.lightdashConfig.softDelete.enabled,
                 retentionDays: this.lightdashConfig.softDelete.retentionDays,
             },
+            preAggregates: {
+                enabled: this.lightdashConfig.preAggregates.enabled,
+            },
         };
     }
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -464,6 +464,9 @@ export type HealthState = {
         enabled: boolean;
         retentionDays: number;
     };
+    preAggregates: {
+        enabled: boolean;
+    };
 };
 
 // Deploy Session Types

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -127,6 +127,28 @@ export type PreAggregateMaterialization = {
     updatedAt: Date;
 };
 
+export const preAggregateMissReasonLabels: Record<
+    PreAggregateMissReason,
+    string
+> = {
+    [PreAggregateMissReason.NO_PRE_AGGREGATES_DEFINED]:
+        'No pre-aggregates defined',
+    [PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE]:
+        'Dimension not in pre-aggregate',
+    [PreAggregateMissReason.METRIC_NOT_IN_PRE_AGGREGATE]:
+        'Metric not in pre-aggregate',
+    [PreAggregateMissReason.NON_ADDITIVE_METRIC]: 'Non-additive metric',
+    [PreAggregateMissReason.CUSTOM_SQL_METRIC]: 'Custom SQL metric',
+    [PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]:
+        'Filter dimension not in pre-aggregate',
+    [PreAggregateMissReason.GRANULARITY_TOO_FINE]: 'Granularity too fine',
+    [PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT]:
+        'Custom dimension present',
+    [PreAggregateMissReason.CUSTOM_METRIC_PRESENT]: 'Custom metric present',
+    [PreAggregateMissReason.TABLE_CALCULATION_PRESENT]:
+        'Table calculation present',
+};
+
 export type PreAggregateSchedulerDetails = {
     projectUuid: string;
     organizationUuid: string;

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -249,6 +249,9 @@ const ValidDashboardChartTile: FC<{
     const addResultsCacheTime = useDashboardContext(
         (c) => c.addResultsCacheTime,
     );
+    const addPreAggregateStatus = useDashboardContext(
+        (c) => c.addPreAggregateStatus,
+    );
     const markTileScreenshotReady = useDashboardContext(
         (c) => c.markTileScreenshotReady,
     );
@@ -277,6 +280,10 @@ const ValidDashboardChartTile: FC<{
     useEffect(() => {
         addResultsCacheTime(cacheMetadata);
     }, [cacheMetadata, addResultsCacheTime]);
+
+    useEffect(() => {
+        addPreAggregateStatus(tileUuid, cacheMetadata);
+    }, [tileUuid, cacheMetadata, addPreAggregateStatus]);
 
     const { validPivotDimensions } = usePivotDimensions(
         chart.pivotConfig?.columns,

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.module.css
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.module.css
@@ -1,0 +1,56 @@
+.menuTargetWrapper {
+    position: relative;
+    display: inline-flex;
+}
+
+.zapIndicator {
+    position: absolute;
+    top: -3px;
+    right: -3px;
+    z-index: 1;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 14px;
+    height: 14px;
+    border-radius: 50%;
+    background: var(--mantine-color-body);
+    box-shadow: 0 0 0 1.5px var(--mantine-color-ldGray-3);
+    pointer-events: none;
+    animation: blink 1s ease-in-out infinite;
+}
+
+/* Settled: solid fill, no blink */
+.zapIndicator[data-settled] {
+    animation: none;
+    background: var(--mantine-color-dark-6);
+    box-shadow: none;
+}
+
+.zapIndicator[data-settled] svg {
+    color: var(--mantine-color-white) !important;
+}
+
+@keyframes blink {
+    0%,
+    100% {
+        opacity: 1;
+    }
+    50% {
+        opacity: 0.2;
+    }
+}
+
+:global([data-mantine-color-scheme='dark']) .zapIndicator {
+    background: var(--mantine-color-ldDark-6);
+    box-shadow: 0 0 0 1.5px var(--mantine-color-ldDark-3);
+}
+
+:global([data-mantine-color-scheme='dark']) .zapIndicator[data-settled] {
+    background: var(--mantine-color-ldGray-2);
+    box-shadow: none;
+}
+
+:global([data-mantine-color-scheme='dark']) .zapIndicator[data-settled] svg {
+    color: var(--mantine-color-ldDark-6) !important;
+}

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.module.css
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.module.css
@@ -1,0 +1,89 @@
+.tileRow {
+    position: relative;
+    padding: 6px 8px;
+    border-radius: var(--mantine-radius-sm);
+    cursor: pointer;
+    transition: background 0.15s ease;
+}
+
+.tileRow:hover {
+    background: var(--mantine-color-ldGray-0);
+}
+
+:global([data-mantine-color-scheme='dark']) .tileRow:hover {
+    background: var(--mantine-color-ldDark-5);
+}
+
+.tileName {
+    flex: 1;
+    min-width: 0;
+}
+
+.tileDetail {
+    color: var(--mantine-color-ldGray-5);
+}
+
+:global([data-mantine-color-scheme='dark']) .tileDetail {
+    color: var(--mantine-color-ldGray-6);
+}
+
+.scrollIcon {
+    flex-shrink: 0;
+    opacity: 0;
+    transition: opacity 0.15s ease;
+}
+
+.tileRow:hover .scrollIcon {
+    opacity: 1;
+}
+
+.ineligibleTile {
+    padding: 4px 8px;
+    color: var(--mantine-color-ldGray-5);
+    @mixin dark {
+        color: var(--mantine-color-ldGray-6);
+    }
+}
+
+/* Tab blocks — vertical line nav */
+.tabBlock {
+    border-left: 2px solid var(--mantine-color-ldGray-2);
+    transition: border-color 0.15s ease;
+    @mixin dark {
+        border-left-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.tabBlock[data-active] {
+    border-left-color: var(--mantine-color-ldGray-5);
+    @mixin dark {
+        border-left-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.tabLabel {
+    padding: 6px 12px;
+    width: 100%;
+    cursor: pointer;
+    transition: background 0.1s ease;
+    border-radius: 0;
+}
+
+.tabLabel:hover {
+    background: var(--mantine-color-ldGray-0);
+    @mixin dark {
+        background: var(--mantine-color-ldDark-5);
+    }
+}
+
+.tabLabel[data-active] {
+    cursor: default;
+}
+
+.tabLabel[data-active]:hover {
+    background: transparent;
+}
+
+.tabBody {
+    padding: 4px 12px 12px;
+}

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
@@ -1,0 +1,371 @@
+import {
+    preAggregateMissReasonLabels,
+    type Dashboard,
+} from '@lightdash/common';
+import {
+    Badge,
+    Box,
+    Collapse,
+    Drawer,
+    Group,
+    Paper,
+    ScrollArea,
+    Stack,
+    Text,
+} from '@mantine-8/core';
+import { useDisclosure } from '@mantine/hooks';
+import {
+    IconBolt,
+    IconChevronDown,
+    IconChevronUp,
+    IconViewfinder,
+} from '@tabler/icons-react';
+import { useCallback, useMemo } from 'react';
+import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types';
+import MantineIcon from '../MantineIcon';
+import { PolymorphicGroupButton } from '../PolymorphicGroupButton';
+import classes from './PreAggregateAuditIndicator.module.css';
+
+const NONE_KEY = 'none';
+
+type Props = {
+    opened: boolean;
+    onClose: () => void;
+    statuses: Record<string, TilePreAggregateStatus>;
+    activeTabUuid: string | undefined;
+    dashboardTabs: Dashboard['tabs'];
+    onSwitchTab: (tab: Dashboard['tabs'][number]) => void;
+};
+
+type TabGroup = {
+    tabUuid: string | undefined;
+    tabName: string;
+    hits: TilePreAggregateStatus[];
+    misses: TilePreAggregateStatus[];
+    ineligible: TilePreAggregateStatus[];
+};
+
+function getDetail(tile: TilePreAggregateStatus): string {
+    if (tile.hit && tile.preAggregateName) {
+        return tile.preAggregateName;
+    }
+    if (!tile.hit && tile.reason) {
+        return preAggregateMissReasonLabels[tile.reason.reason];
+    }
+    return '—';
+}
+
+function scrollToTile(tileUuid: string) {
+    const el = document.querySelector<HTMLElement>(
+        `[data-tile-uuid="${tileUuid}"]`,
+    );
+    if (!el) return;
+
+    el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    el.style.borderRadius = 'var(--mantine-radius-md)';
+    el.animate(
+        [
+            { boxShadow: '0 0 0 0px transparent' },
+            { boxShadow: '0 0 0 2px var(--mantine-color-indigo-4)' },
+            { boxShadow: '0 0 0 0px transparent' },
+        ],
+        { duration: 1200, easing: 'ease-in-out' },
+    );
+}
+
+function TileRow({
+    tile,
+    onClick,
+}: {
+    tile: TilePreAggregateStatus;
+    onClick: (uuid: string) => void;
+}) {
+    return (
+        <Box className={classes.tileRow} onClick={() => onClick(tile.tileUuid)}>
+            <Group gap="xs" justify="space-between" wrap="nowrap">
+                <Text fz="xs" lineClamp={1} className={classes.tileName}>
+                    {tile.tileName}
+                </Text>
+                <Box className={classes.scrollIcon}>
+                    <MantineIcon
+                        icon={IconViewfinder}
+                        size={12}
+                        color="ldDark.9"
+                    />
+                </Box>
+            </Group>
+            <Text fz={10} className={classes.tileDetail}>
+                {getDetail(tile)}
+            </Text>
+        </Box>
+    );
+}
+
+function TileList({
+    tiles,
+    onClick,
+}: {
+    tiles: TilePreAggregateStatus[];
+    onClick: (uuid: string) => void;
+}) {
+    return (
+        <Stack gap={1}>
+            {tiles.map((tile) => (
+                <TileRow key={tile.tileUuid} tile={tile} onClick={onClick} />
+            ))}
+        </Stack>
+    );
+}
+
+function IneligibleSection({ tiles }: { tiles: TilePreAggregateStatus[] }) {
+    const [open, { toggle }] = useDisclosure(false);
+
+    if (tiles.length === 0) return null;
+    return (
+        <Box>
+            <PolymorphicGroupButton gap="xs" onClick={toggle}>
+                <MantineIcon
+                    icon={open ? IconChevronUp : IconChevronDown}
+                    size="xs"
+                    color="ldGray.5"
+                />
+                <Text fz={11} className={classes.tileDetail}>
+                    {tiles.length} without pre-aggregates
+                </Text>
+            </PolymorphicGroupButton>
+            <Collapse in={open}>
+                <Stack gap={1} mt={4}>
+                    {tiles.map((tile) => (
+                        <Text
+                            key={tile.tileUuid}
+                            fz="xs"
+                            className={classes.ineligibleTile}
+                        >
+                            {tile.tileName}
+                        </Text>
+                    ))}
+                </Stack>
+            </Collapse>
+        </Box>
+    );
+}
+
+function buildTabGroup(
+    tiles: TilePreAggregateStatus[],
+    tabUuid: string | undefined,
+    tabName: string,
+): TabGroup {
+    const sort = (a: TilePreAggregateStatus, b: TilePreAggregateStatus) =>
+        a.tileName.localeCompare(b.tileName);
+    return {
+        tabUuid,
+        tabName,
+        hits: tiles
+            .filter((t) => t.hasPreAggregateMetadata && t.hit)
+            .sort(sort),
+        misses: tiles
+            .filter((t) => t.hasPreAggregateMetadata && !t.hit)
+            .sort(sort),
+        ineligible: tiles.filter((t) => !t.hasPreAggregateMetadata).sort(sort),
+    };
+}
+
+function GroupContent({
+    group,
+    onClick,
+}: {
+    group: TabGroup;
+    onClick: (uuid: string) => void;
+}) {
+    const hasHits = group.hits.length > 0;
+    const hasMisses = group.misses.length > 0;
+
+    return (
+        <Stack gap="xs">
+            {hasHits && (
+                <Stack gap={2}>
+                    <Badge size="xs" variant="light" color="green" radius="sm">
+                        {group.hits.length} hit
+                    </Badge>
+                    <TileList tiles={group.hits} onClick={onClick} />
+                </Stack>
+            )}
+            {hasMisses && (
+                <Stack gap={2}>
+                    <Badge size="xs" variant="light" color="red" radius="sm">
+                        {group.misses.length} miss
+                    </Badge>
+                    <TileList tiles={group.misses} onClick={onClick} />
+                </Stack>
+            )}
+            <IneligibleSection tiles={group.ineligible} />
+        </Stack>
+    );
+}
+
+export function PreAggregateAuditDrawer({
+    opened,
+    onClose,
+    statuses,
+    activeTabUuid,
+    dashboardTabs,
+    onSwitchTab,
+}: Props) {
+    const hasTabs = dashboardTabs.length > 1;
+
+    const tabGroups = useMemo(() => {
+        const all = Object.values(statuses);
+
+        if (!hasTabs) {
+            return [buildTabGroup(all, undefined, '')];
+        }
+
+        const tabNameMap: Record<string, string> = {};
+        const tabOrder: string[] = [];
+        for (const tab of dashboardTabs) {
+            tabNameMap[tab.uuid] = tab.name;
+            tabOrder.push(tab.uuid);
+        }
+
+        const grouped: Record<string, TilePreAggregateStatus[]> = {};
+        for (const tile of all) {
+            const key = tile.tabUuid ?? NONE_KEY;
+            if (!grouped[key]) grouped[key] = [];
+            grouped[key].push(tile);
+        }
+
+        const result: TabGroup[] = [];
+        for (const tabUuid of tabOrder) {
+            const tiles = grouped[tabUuid] ?? [];
+            result.push(
+                buildTabGroup(tiles, tabUuid, tabNameMap[tabUuid] ?? tabUuid),
+            );
+        }
+
+        const orphans = grouped[NONE_KEY];
+        if (orphans && orphans.length > 0) {
+            result.push(buildTabGroup(orphans, undefined, 'Other'));
+        }
+
+        return result;
+    }, [statuses, hasTabs, dashboardTabs]);
+
+    const handleTabClick = useCallback(
+        (tabUuid: string | undefined) => {
+            if (!tabUuid) return;
+            const tab = dashboardTabs.find((t) => t.uuid === tabUuid);
+            if (tab) onSwitchTab(tab);
+        },
+        [dashboardTabs, onSwitchTab],
+    );
+
+    const handleTileClick = useCallback((uuid: string) => {
+        scrollToTile(uuid);
+    }, []);
+
+    return (
+        <Drawer
+            opened={opened}
+            onClose={onClose}
+            position="right"
+            lockScroll={false}
+            size="sm"
+            title={
+                <Group gap="xs">
+                    <Paper p="6px" withBorder radius="md" bg="ldGray.0">
+                        <MantineIcon
+                            icon={IconBolt}
+                            size="sm"
+                            color="ldDark.9"
+                        />
+                    </Paper>
+                    <Text fw={600} fz="sm">
+                        Pre-aggregation audit
+                    </Text>
+                </Group>
+            }
+            overlayProps={{ opacity: 0.1, blur: 0 }}
+            withCloseButton
+        >
+            <ScrollArea h="calc(100vh - 80px)">
+                {hasTabs ? (
+                    <Stack gap={0}>
+                        {tabGroups.map((group) => {
+                            const isActive = group.tabUuid === activeTabUuid;
+                            const totalEligible =
+                                group.hits.length + group.misses.length;
+
+                            return (
+                                <Box
+                                    key={group.tabUuid ?? NONE_KEY}
+                                    className={classes.tabBlock}
+                                    data-active={isActive || undefined}
+                                >
+                                    <PolymorphicGroupButton
+                                        gap="xs"
+                                        onClick={() =>
+                                            handleTabClick(group.tabUuid)
+                                        }
+                                        className={classes.tabLabel}
+                                        data-active={isActive || undefined}
+                                    >
+                                        <Text fz="xs" fw={isActive ? 600 : 400}>
+                                            {group.tabName}
+                                        </Text>
+                                        {totalEligible > 0 && (
+                                            <Group gap={4} wrap="nowrap">
+                                                {group.hits.length > 0 && (
+                                                    <Badge
+                                                        size="xs"
+                                                        variant="dot"
+                                                        color="green"
+                                                    >
+                                                        {group.hits.length}
+                                                    </Badge>
+                                                )}
+                                                {group.misses.length > 0 && (
+                                                    <Badge
+                                                        size="xs"
+                                                        variant="dot"
+                                                        color="red"
+                                                    >
+                                                        {group.misses.length}
+                                                    </Badge>
+                                                )}
+                                            </Group>
+                                        )}
+                                    </PolymorphicGroupButton>
+
+                                    <Collapse in={isActive}>
+                                        <Box className={classes.tabBody}>
+                                            {group.hits.length === 0 &&
+                                            group.misses.length === 0 &&
+                                            group.ineligible.length === 0 ? (
+                                                <Text fz="xs" c="dimmed">
+                                                    No results yet — visit this
+                                                    tab to load tiles.
+                                                </Text>
+                                            ) : (
+                                                <GroupContent
+                                                    group={group}
+                                                    onClick={handleTileClick}
+                                                />
+                                            )}
+                                        </Box>
+                                    </Collapse>
+                                </Box>
+                            );
+                        })}
+                    </Stack>
+                ) : (
+                    tabGroups[0] && (
+                        <GroupContent
+                            group={tabGroups[0]}
+                            onClick={handleTileClick}
+                        />
+                    )
+                )}
+            </ScrollArea>
+        </Drawer>
+    );
+}

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -965,6 +965,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                                               key={
                                                                                   tile.uuid
                                                                               }
+                                                                              data-tile-uuid={
+                                                                                  tile.uuid
+                                                                              }
                                                                           >
                                                                               <TrackSection
                                                                                   name={
@@ -1056,6 +1059,9 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                           (tile, idx) => (
                                                               <div
                                                                   key={
+                                                                      tile.uuid
+                                                                  }
+                                                                  data-tile-uuid={
                                                                       tile.uuid
                                                                   }
                                                               >

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -70,6 +70,7 @@ const Dashboard: FC = () => {
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
     const activeTab = useDashboardContext((c) => c.activeTab);
+    const setActiveTab = useDashboardContext((c) => c.setActiveTab);
     const setDashboardFilters = useDashboardContext(
         (c) => c.setDashboardFilters,
     );
@@ -103,6 +104,9 @@ const Dashboard: FC = () => {
         );
     }, [dashboard, isDateZoomDisabled]);
     const oldestCacheTime = useDashboardContext((c) => c.oldestCacheTime);
+    const preAggregateStatuses = useDashboardContext(
+        (c) => c.preAggregateStatuses,
+    );
     const dashboardParameters = useDashboardContext(
         (c) => c.dashboardParameters,
     );
@@ -620,6 +624,8 @@ const Dashboard: FC = () => {
         isEditMode,
         isSaving,
         oldestCacheTime,
+        preAggregateStatuses,
+        allTilesLoaded: areAllChartsLoaded,
         isFullscreen,
         activeTabUuid: activeTab?.uuid,
         dashboardTabs,
@@ -642,6 +648,7 @@ const Dashboard: FC = () => {
         onDelete: deleteModalHandlers.open,
         onExport: exportDashboardModalHandlers.open,
         setAddingTab,
+        onSwitchTab: setActiveTab,
         onEditClicked: handleEnterEditMode,
         ...(isEditMode && { className: styles.stickyHeader }),
     };

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -10,6 +10,7 @@ import {
     type ParameterDefinitions,
     type ParametersValuesMap,
     type ParameterValue,
+    type PreAggregateMatchMiss,
     type ResultColumn,
     type SortField,
 } from '@lightdash/common';
@@ -22,6 +23,17 @@ import {
 export type SqlChartTileMetadata = {
     columns: ResultColumn[];
 };
+
+export type TilePreAggregateStatus = {
+    tileUuid: string;
+    tileName: string;
+    hit: boolean;
+    preAggregateName: string | null;
+    reason: PreAggregateMatchMiss | null;
+    hasPreAggregateMetadata: boolean;
+    tabUuid: string | undefined;
+};
+
 export type DashboardContextType = {
     projectUuid?: string;
     isDashboardLoading: boolean;
@@ -120,6 +132,11 @@ export type DashboardContextType = {
     havePinnedParametersChanged: boolean;
     setHavePinnedParametersChanged: Dispatch<SetStateAction<boolean>>;
     tileNamesById: Record<string, string>;
+    preAggregateStatuses: Record<string, TilePreAggregateStatus>;
+    addPreAggregateStatus: (
+        tileUuid: string,
+        cacheMetadata: CacheMetadata,
+    ) => void;
     refreshDashboardVersion: () => Promise<void>;
     isRefreshingDashboardVersion: boolean;
     markTileScreenshotReady: (tileUuid: string) => void;

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -128,6 +128,9 @@ export default function mockHealthResponse(
             enabled: false,
             retentionDays: 30,
         },
+        preAggregates: {
+            enabled: false,
+        },
         ...overrides,
     };
 }


### PR DESCRIPTION
### Description:

This PR adds pre-aggregation audit functionality to the dashboard interface. The changes include:

- Added `preAggregates.enabled` field to the health state API and service responses
- Created `preAggregateMissReasonLabels` mapping for user-friendly display of miss reasons
- Implemented a new pre-aggregation audit drawer (`PreAggregateAuditDrawer`) that shows:
  - Tiles that hit pre-aggregates (green badges)
  - Tiles that missed pre-aggregates with reasons (red badges) 
  - Tiles without pre-aggregate metadata (collapsible section)
  - Tab-based organization when multiple dashboard tabs exist
- Added a lightning bolt indicator to the dashboard header menu that:
  - Blinks while tiles are loading
  - Becomes solid when all tiles have loaded
  - Only appears when pre-aggregates are enabled
- Enhanced dashboard tiles to track pre-aggregate status via `addPreAggregateStatus`
- Added `data-tile-uuid` attributes to dashboard tiles for scroll-to functionality
- Implemented tile highlighting when clicked from the audit drawer

The audit drawer provides a comprehensive view of pre-aggregation performance across dashboard tiles, helping users understand which visualizations are benefiting from pre-computed data and which ones could be optimized.