### PR TITLE
fix: add `INSTALL httpfs` before `LOAD` in DuckDB bootstrap

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -159,6 +159,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
     }
 
     private async bootstrapSession(db: DuckdbConnection): Promise<void> {
+        await db.run('INSTALL httpfs;');
         await db.run('LOAD httpfs;');
 
         if (!this.s3Config) {


### PR DESCRIPTION
### Description:
Added `INSTALL httpfs;` command before `LOAD httpfs;` in the DuckDB warehouse client's bootstrap session. This ensures the httpfs extension is installed before attempting to load it, which is necessary for proper initialization of S3 connectivity in DuckDB sessions.

This change prevents potential errors when the httpfs extension hasn't been previously installed in the DuckDB environment.

https://claude.ai/code/session_017A5n7hkRp2sv6rdxGmku42