### PR TITLE
feat: add libjemalloc2 package to Dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -339,6 +339,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Required by node-canvas prebuilt binaries for font rendering in chart images
     fontconfig \
     dumb-init \
+    # Optional: jemalloc allocator reduces native memory fragmentation vs glibc malloc.
+    # Dormant unless activated via LD_PRELOAD env var per customer.
+    libjemalloc2 \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Add libjemalloc2 package to Docker image to provide an optional memory allocator that reduces native memory fragmentation compared to glibc malloc. The jemalloc allocator remains dormant unless explicitly activated via the LD_PRELOAD environment variable per customer requirements.

<!-- Even better add a screenshot / gif / loom -->