### PR TITLE
fix: quote CTE names in pivot queries to support spaces in field names

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -419,7 +419,7 @@ export class PivotQueryBuilder {
                         metricFirstValueQueries[colAnchorCteName]
                     ) {
                         acc.push(
-                            `${colAnchorCteName}.${q}${colAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
+                            `${q}${colAnchorCteName}${q}.${q}${colAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
                         );
                     }
                     return acc;
@@ -513,7 +513,7 @@ export class PivotQueryBuilder {
                         sort.nullsFirst,
                     );
                     orderByParts.push(
-                        `${rowAnchorCteName}.${q}${rowAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
+                        `${q}${rowAnchorCteName}${q}.${q}${rowAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
                     );
                 }
             } else if (isIndexColumn) {
@@ -646,10 +646,10 @@ export class PivotQueryBuilder {
             const joinConditions = groupByColumns
                 .map(
                     (col) =>
-                        `g.${q}${col.reference}${q} = ${cteName}.${q}${col.reference}${q}`,
+                        `g.${q}${col.reference}${q} = ${q}${cteName}${q}.${q}${col.reference}${q}`,
                 )
                 .join(' AND ');
-            joins.push(`LEFT JOIN ${cteName} ON ${joinConditions}`);
+            joins.push(`LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`);
         });
 
         if (joins.length > 0) {
@@ -798,8 +798,9 @@ export class PivotQueryBuilder {
             sortBy,
         );
 
+        const q = this.warehouseSqlBuilder.getFieldQuoteChar();
         const columnAnchorCTEs = Object.values(columnAnchorQueries).map(
-            ({ cteName, sql }) => `${cteName} AS (${sql})`,
+            ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
         );
 
         // Check if we need row anchor CTEs (only when sorting by a metric value AND have index columns)
@@ -842,7 +843,7 @@ export class PivotQueryBuilder {
                 sortBy,
             );
             rowAnchorCTEs = Object.values(rowAnchorQueries).map(
-                ({ cteName, sql }) => `${cteName} AS (${sql})`,
+                ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
             );
         }
 
@@ -897,20 +898,22 @@ export class PivotQueryBuilder {
                     const joinConditions = indexColumns
                         .map(
                             (col) =>
-                                `g.${q}${col.reference}${q} = ${cteName}.${q}${col.reference}${q}`,
+                                `g.${q}${col.reference}${q} = ${q}${cteName}${q}.${q}${col.reference}${q}`,
                         )
                         .join(' AND ');
-                    joins.push(`LEFT JOIN ${cteName} ON ${joinConditions}`);
+                    joins.push(
+                        `LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`,
+                    );
                 }
             } else if (cteName.endsWith('_column_anchor')) {
                 // Join on group columns for column anchor CTEs
                 const joinConditions = groupByColumns
                     .map(
                         (col) =>
-                            `g.${q}${col.reference}${q} = ${cteName}.${q}${col.reference}${q}`,
+                            `g.${q}${col.reference}${q} = ${q}${cteName}${q}.${q}${col.reference}${q}`,
                     )
                     .join(' AND ');
-                joins.push(`LEFT JOIN ${cteName} ON ${joinConditions}`);
+                joins.push(`LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`);
             }
         });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [https://linear.app/lightdash/issue/PROD-5670/pivot-query-fails-with-sql-syntax-error-when-metric-or-dimension-names](https://linear.app/lightdash/issue/PROD-5670/pivot-query-fails-with-sql-syntax-error-when-metric-or-dimension-names)

### Description:

Fixed SQL syntax errors in PivotQueryBuilder by properly quoting CTE names and table references. The issue occurred when metric or dimension names contained special characters or reserved words, causing the generated SQL to fail.

**Changes made:**

- Added proper quoting around CTE names in CTE definitions (e.g., `"revenue_row_anchor" AS (...)`)
- Fixed table references in JOIN conditions to use quoted identifiers (e.g., `"revenue_row_anchor"."revenue_row_anchor_value"`)
- Updated ORDER BY clauses to properly quote table and column references
- Applied consistent quoting in LEFT JOIN statements for anchor CTEs

**Steps** **to** **reproduce:**

1. Create a metric with spaces in the name (e.g., `"AVERAGE TAX RATE 2"`)
2. Run a normal query — works fine
3. Add a pivot (group by) column to the query
4. Sort by the metric
5. Query fails with `syntax error at or near "TAX"`

**Before**
<img width="2150" height="1203" alt="CleanShot 2026-02-26 at 18 18 53" src="https://github.com/user-attachments/assets/a79a01f6-1b37-46cb-a26b-f735df497fb3" />

**After**
<img width="2146" height="1155" alt="CleanShot 2026-02-26 at 18 19 35" src="https://github.com/user-attachments/assets/a5f5bfc1-3308-43f9-9974-b1ee32358618" />
