### PR TITLE
refactor: split Databricks credentials into typed authentication variants

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -6,7 +6,7 @@ import {
     AnyType,
     AuthTokenPrefix,
     cleanColorArray,
-    CreateDatabricksCredentials,
+    DatabricksPATCredentials,
     DbtGithubProjectConfig,
     DbtProjectType,
     DbtVersionOption,
@@ -324,12 +324,12 @@ const parseEnum = <T>(
 };
 
 const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
-    const parseCompute = (): CreateDatabricksCredentials['compute'] => {
+    const parseCompute = (): DatabricksPATCredentials['compute'] => {
         // This is a stringified array of objects, in JSON format
         // If format is not correct, it will throw an error
         const compute = process.env.LD_SETUP_PROJECT_COMPUTE;
         if (!compute) return undefined;
-        return JSON.parse(compute) as CreateDatabricksCredentials['compute'];
+        return JSON.parse(compute) as DatabricksPATCredentials['compute'];
     };
 
     try {
@@ -965,7 +965,7 @@ export type LightdashConfig = {
             token: string;
             expirationTime: Date | null;
         };
-        project: CreateDatabricksCredentials & {
+        project: DatabricksPATCredentials & {
             name: string;
             dbtVersion: DbtVersionOption;
         };
@@ -987,9 +987,9 @@ export type LightdashConfig = {
             personal_access_token?: string;
         };
         project: {
-            httpPath?: CreateDatabricksCredentials['httpPath'];
+            httpPath?: DatabricksPATCredentials['httpPath'];
             dbtVersion?: DbtVersionOption;
-            personalAccessToken?: CreateDatabricksCredentials['personalAccessToken'];
+            personalAccessToken?: DatabricksPATCredentials['personalAccessToken'];
         };
         serviceAccount?: {
             token: string;

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -11,6 +11,7 @@ import {
     createVirtualView,
     CreateVirtualViewPayload,
     CreateWarehouseCredentials,
+    DatabricksAuthenticationType,
     DbtProjectConfig,
     DEFAULT_USER_SPACES_PARENT_NAME,
     Explore,
@@ -869,6 +870,13 @@ export class ProjectModel {
                     authenticationType: SnowflakeAuthenticationType.PRIVATE_KEY,
                 };
             }
+            case WarehouseTypes.DATABRICKS:
+                return {
+                    ...nonSensitiveCredentials,
+                    authenticationType:
+                        nonSensitiveCredentials.authenticationType ??
+                        DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN,
+                };
             default:
                 return nonSensitiveCredentials;
         }

--- a/packages/backend/src/services/DatabricksOAuthService/DatabricksOAuthService.ts
+++ b/packages/backend/src/services/DatabricksOAuthService/DatabricksOAuthService.ts
@@ -1,6 +1,5 @@
 import {
     AuthorizationError,
-    CreateDatabricksCredentials,
     DatabricksAuthenticationType,
     DatabricksTokenError,
     getErrorMessage,
@@ -9,6 +8,9 @@ import {
     ParameterError,
     UnexpectedServerError,
     WarehouseTypes,
+    type CreateDatabricksCredentials,
+    type DatabricksOAuthM2MCredentials,
+    type DatabricksOAuthU2MCredentials,
     type SessionUser,
     type UpsertUserWarehouseCredentials,
 } from '@lightdash/common';
@@ -138,8 +140,8 @@ export class DatabricksOAuthService extends BaseService {
     }
 
     private async refreshM2MCredentials(
-        args: CreateDatabricksCredentials,
-    ): Promise<CreateDatabricksCredentials> {
+        args: DatabricksOAuthM2MCredentials,
+    ): Promise<DatabricksOAuthM2MCredentials> {
         try {
             // Try client_credentials grant when we have client creds but no refresh token
             if (
@@ -206,8 +208,8 @@ export class DatabricksOAuthService extends BaseService {
     }
 
     private async refreshU2MCredentials(
-        args: CreateDatabricksCredentials,
-    ): Promise<CreateDatabricksCredentials> {
+        args: DatabricksOAuthU2MCredentials,
+    ): Promise<DatabricksOAuthU2MCredentials> {
         try {
             if (!args.refreshToken) {
                 throw new Error(
@@ -281,8 +283,18 @@ export class DatabricksOAuthService extends BaseService {
                 );
             }
             serverHostName = credentials.serverHostName;
-            projectClientId = credentials.oauthClientId;
-            projectClientSecret = credentials.oauthClientSecret;
+            if (
+                credentials.authenticationType ===
+                DatabricksAuthenticationType.OAUTH_M2M
+            ) {
+                projectClientId = credentials.oauthClientId;
+                projectClientSecret = credentials.oauthClientSecret;
+            } else if (
+                credentials.authenticationType ===
+                DatabricksAuthenticationType.OAUTH_U2M
+            ) {
+                projectClientId = credentials.oauthClientId;
+            }
         }
 
         // Fallback: extract host from OIDC issuer URL

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -308,7 +308,7 @@ We will ask for user credentials again on the Lightdash UI.\n`,
         } else {
             console.error(
                 styles.warning(
-                    `\nUser has externalbrowser snowflake authentication. 
+                    `\nUser has externalbrowser snowflake authentication.
 We will generate programatically a temporary PAT to enable access on Lightdash which expires in 1 day.
 For a better user experience, we recommend enabling Snowflake OAuth authentication on the server.\n`,
                 ),
@@ -341,6 +341,8 @@ For a better user experience, we recommend enabling Snowflake OAuth authenticati
         copyContent: options.copyContent,
         organizationWarehouseCredentialsUuid,
     };
+
+    console.log({ options, zap: project.warehouseConnection });
 
     return lightdashApi<ApiCreateProjectResults>({
         method: 'POST',

--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -403,12 +403,16 @@ export default async function getWarehouseClient(
                 const tokens = await performDatabricksOAuthFlow(
                     credentials.serverHostName,
                     clientId,
-                    credentials.oauthClientSecret,
+                    undefined, // U2M doesn't use client secret
                 );
 
                 // Store tokens in memory only
                 credentials.token = tokens.accessToken;
                 credentials.refreshToken = tokens.refreshToken;
+                console.log(
+                    'getWarehouseClient after OAuth flow tokens:',
+                    tokens,
+                );
             }
 
             GlobalState.debug(
@@ -425,6 +429,7 @@ export default async function getWarehouseClient(
             warehouseClientCache.set(cacheKey, warehouseClient);
         }
     }
+    console.log('getWarehouseClient returning credentials:', credentials);
     return {
         warehouseClient,
         credentials,

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -94,19 +94,13 @@ export enum AthenaAuthenticationType {
     IAM_ROLE = 'iam_role',
 }
 
-export type CreateDatabricksCredentials = {
+export type DatabricksCredentialsBase = {
     type: WarehouseTypes.DATABRICKS;
     catalog?: string;
     // this supposed to be a `schema` but changing it will break for existing customers
     database: string;
     serverHostName: string;
     httpPath: string;
-    authenticationType?: DatabricksAuthenticationType;
-    personalAccessToken?: string; // Optional when using OAuth
-    refreshToken?: string; // Refresh token for OAuth, used to generate a new access token
-    token?: string; // Access token for OAuth, has a low expiry time (1 hour)
-    oauthClientId?: string; // OAuth M2M client ID (Service Principal)
-    oauthClientSecret?: string; // OAuth M2M client secret (Service Principal)
     requireUserCredentials?: boolean;
     startOfWeek?: WeekDay | null;
     compute?: Array<{
@@ -114,6 +108,31 @@ export type CreateDatabricksCredentials = {
         httpPath: string;
     }>;
 };
+
+export type DatabricksPATCredentials = DatabricksCredentialsBase & {
+    authenticationType?: DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN;
+    personalAccessToken?: string;
+};
+
+export type DatabricksOAuthM2MCredentials = DatabricksCredentialsBase & {
+    authenticationType: DatabricksAuthenticationType.OAUTH_M2M;
+    oauthClientId?: string;
+    oauthClientSecret?: string;
+    refreshToken?: string;
+    token?: string;
+};
+
+export type DatabricksOAuthU2MCredentials = DatabricksCredentialsBase & {
+    authenticationType: DatabricksAuthenticationType.OAUTH_U2M;
+    oauthClientId?: string;
+    refreshToken?: string;
+    token?: string;
+};
+
+export type CreateDatabricksCredentials =
+    | DatabricksPATCredentials
+    | DatabricksOAuthM2MCredentials
+    | DatabricksOAuthU2MCredentials;
 export type DatabricksCredentials = Omit<
     CreateDatabricksCredentials,
     SensitiveCredentialsFieldNames

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/CreateCredentialsModal.tsx
@@ -1,4 +1,5 @@
 import {
+    DatabricksAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
@@ -55,7 +56,8 @@ const defaultCredentials: Record<
     },
     [WarehouseTypes.DATABRICKS]: {
         type: WarehouseTypes.DATABRICKS,
-        personalAccessToken: '',
+        authenticationType: DatabricksAuthenticationType.OAUTH_U2M,
+        refreshToken: '',
     },
     [WarehouseTypes.CLICKHOUSE]: {
         type: WarehouseTypes.CLICKHOUSE,

--- a/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
+++ b/packages/frontend/src/components/UserSettings/MyWarehouseConnectionsPanel/EditCredentialsModal.tsx
@@ -1,4 +1,5 @@
 import {
+    DatabricksAuthenticationType,
     WarehouseTypes,
     type UpsertUserWarehouseCredentials,
     type UserWarehouseCredentials,
@@ -33,7 +34,8 @@ const getCredentialsWithPlaceholders = (
         case WarehouseTypes.DATABRICKS:
             return {
                 ...credentials,
-                personalAccessToken: '',
+                authenticationType: DatabricksAuthenticationType.OAUTH_U2M,
+                refreshToken: '',
             };
         default:
             throw new Error(`Credential type not supported`);


### PR DESCRIPTION
### Description:

Refactors Databricks credentials type system to use discriminated unions based on authentication type. Replaces the generic `CreateDatabricksCredentials` type with three specific credential types:

- `DatabricksPATCredentials` for Personal Access Token authentication
- `DatabricksOAuthM2MCredentials` for OAuth Machine-to-Machine authentication  
- `DatabricksOAuthU2MCredentials` for OAuth User-to-Machine authentication

Updates token handling logic throughout the codebase to properly differentiate between `personalAccessToken` (for PAT auth) and `token` (for OAuth auth). Improves type safety by ensuring OAuth client credentials are only accessed when the appropriate authentication type is set.

Modifies the frontend to default new Databricks user credentials to OAuth U2M authentication instead of PAT authentication.