### PR TITLE
fix: filter undefined userAccess values in useCreateInAnySpaceAccess

### DIFF
--- a/packages/frontend/src/hooks/user/useCreateInAnySpaceAccess.ts
+++ b/packages/frontend/src/hooks/user/useCreateInAnySpaceAccess.ts
@@ -30,7 +30,9 @@ const useCreateInAnySpaceAccess = (
             subject(subjectName, {
                 organizationUuid: user.data.organizationUuid,
                 projectUuid,
-                access: spaces.data.map((space) => space.userAccess),
+                access: spaces.data
+                    .map((space) => space.userAccess)
+                    .filter((a) => a !== undefined),
             }),
         )
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->
Closes: https://github.com/lightdash/lightdash/issues/20691

### Description:

Filter out undefined values from space user access array in `useCreateInAnySpaceAccess` hook to prevent potential issues when creating subjects with undefined access permissions.

<!-- Even better add a screenshot / gif / loom -->