### PR TITLE
feat: add case sensitivity configuration for string filters

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/validators.ts
+++ b/packages/backend/src/ee/services/ai/utils/validators.ts
@@ -272,6 +272,8 @@ function validateFilterRule(
                 (string: string) => string.replaceAll('\\', '\\\\'),
                 WeekDay.SUNDAY,
                 SupportedDbtAdapter.BIGQUERY,
+                'UTC',
+                true, // Default to case sensitive for validation
             );
         }
     } catch (e) {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1056,6 +1056,7 @@ export class MetricQueryBuilder {
                 startOfWeek,
                 adapterType,
                 timezone,
+                this.args.explore.caseSensitive ?? true,
             ),
         );
     }

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -144,6 +144,7 @@ export type UncompiledExplore = {
     databricksCompute?: string;
     projectParameters?: LightdashProjectConfig['parameters'];
     preAggregates?: PreAggregateDef[];
+    caseSensitive?: boolean;
 };
 
 const getReferencedTable = (
@@ -201,6 +202,7 @@ export class ExploreCompiler {
         aiHint,
         projectParameters,
         preAggregates,
+        caseSensitive,
     }: UncompiledExplore): Explore {
         // Check that base table exists (always required)
         if (!tables[baseTable]) {
@@ -501,6 +503,7 @@ export class ExploreCompiler {
             ymlPath,
             sqlPath,
             databricksCompute,
+            ...(caseSensitive !== undefined ? { caseSensitive } : {}),
             ...(aiHint ? { aiHint } : {}),
             ...getSpotlightConfigurationForResource({
                 visibility: spotlightVisibility,

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -213,6 +213,9 @@ const convertDimension = (
         ...(meta.dimension?.ai_hint
             ? { aiHint: convertToAiHints(meta.dimension.ai_hint) }
             : {}),
+        ...(meta.dimension?.case_sensitive !== undefined
+            ? { caseSensitive: meta.dimension.case_sensitive }
+            : {}),
         ...(meta.dimension?.spotlight?.filter_by === false ||
         meta.dimension?.spotlight?.segment_by === false
             ? {
@@ -1021,6 +1024,7 @@ export const convertExplores = async (
                 groupLabel: meta.group_label,
                 joins: meta?.joins || [],
                 description: meta.description,
+                caseSensitive: meta.case_sensitive,
                 tables: tableLookup,
             },
             ...(meta.explores
@@ -1070,6 +1074,7 @@ export const convertExplores = async (
                               // Inherit joins from base model if not specified in explore config
                               joins: exploreConfig.joins || meta?.joins || [],
                               description: exploreConfig.description,
+                              caseSensitive: exploreConfig.case_sensitive,
                               tables: {
                                   ...tableLookup,
                                   // Override the base table with required filters and explore-scoped dimensions
@@ -1133,6 +1138,7 @@ export const convertExplores = async (
                     tags: tags || [],
                     baseTable: model.name,
                     groupLabel: exploreToCreate.groupLabel,
+                    caseSensitive: exploreToCreate.caseSensitive,
                     joinedTables: exploreToCreate.joins.map((join) => ({
                         table: join.join,
                         sqlOn: join.sql_on,

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -96,6 +96,7 @@ type ExploreConfig = {
     description?: string;
     group_label?: string;
     joins?: DbtModelJoin[];
+    case_sensitive?: boolean; // When false, all string filters in this explore will be case insensitive. Default is true
     /**
      * Explore-scoped custom dimensions.
      * These dimensions are only available within this specific explore
@@ -213,6 +214,7 @@ export type DbtColumnLightdashDimension = {
     required_attributes?: Record<string, string | string[]>;
     any_attributes?: Record<string, string | string[]>;
     ai_hint?: string | string[];
+    case_sensitive?: boolean; // When false, string filters on this dimension will be case insensitive. Default is true
     image?: {
         url: string;
         width?: number;

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -91,6 +91,7 @@ export type Explore = {
     ymlPath?: string;
     sqlPath?: string;
     type?: ExploreType;
+    caseSensitive?: boolean; // When false, all string filters in this explore will be case insensitive. Default is true
     // Spotlight config for this explore
     spotlight?: {
         visibility: LightdashProjectConfig['spotlight']['default_visibility'];

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -623,6 +623,7 @@ export interface Dimension extends Field {
     isIntervalBase?: boolean;
     aiHint?: string | string[];
     formatOptions?: CustomFormat;
+    caseSensitive?: boolean; // When false, string filters on this dimension will be case insensitive. Default is true
     image?: {
         url: string;
         width?: number;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-5660<!-- reference the related issue e.g. #150 -->

### Description:

This PR adds case sensitivity control for string filters in Lightdash. The feature allows users to configure whether string filters should be case sensitive or case insensitive at both the explore level and individual dimension level.

**Key changes:**

- Added `caseSensitive` property to explore and dimension configurations in dbt YAML files
- Modified string filter SQL generation to apply `UPPER()` transformations when case insensitive filtering is enabled
- Implemented a hierarchy where field-level `caseSensitive` settings override explore-level settings, with a default of `true` (case sensitive)
- Updated filter operators `EQUALS`, `NOT_EQUALS`, `STARTS_WITH`, and `ENDS_WITH` to support case insensitive matching
- Added comprehensive test coverage for case sensitivity behavior across different filter operators
- Extended type definitions to include the new `caseSensitive` property in explore and dimension interfaces

When `caseSensitive` is set to `false`, string filters will convert both the database column values and filter values to uppercase before comparison, enabling case insensitive matching. The feature maintains backward compatibility by defaulting to case sensitive behavior when not explicitly configured.