### PR TITLE
style: improve project & group access table height

### DIFF
--- a/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
+++ b/packages/frontend/src/components/ProjectAccess/ProjectAccess.tsx
@@ -575,7 +575,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
             },
         },
         mantineTableContainerProps: {
-            style: { maxHeight: 'calc(100dvh - 420px)' },
+            style: { maxHeight: 'calc(100dvh - 350px)' },
         },
         mantineTableProps: {
             highlightOnHover: true,
@@ -614,7 +614,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
         mantineTableBodyCellProps: () => {
             return {
                 style: {
-                    padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                    padding: `${theme.spacing.xs} ${theme.spacing.xl}`,
                     borderRight: 'none',
                     borderLeft: 'none',
                     borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
@@ -747,7 +747,7 @@ const ProjectAccess: FC<ProjectAccessProps> = ({ projectUuid }) => {
                 isLoading ||
                 isLoadingOrganizationRoles ||
                 isLoadingOrganizationRoleAssignments,
-            density: 'md',
+            density: 'xs',
         },
     });
 

--- a/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
+++ b/packages/frontend/src/features/projectGroupAccess/components/ProjectGroupAccess.tsx
@@ -413,7 +413,7 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
             },
         },
         mantineTableContainerProps: {
-            style: { maxHeight: 'calc(100dvh - 420px)' },
+            style: { maxHeight: 'calc(100dvh - 300px)' },
         },
         mantineTableProps: {
             highlightOnHover: true,
@@ -450,7 +450,7 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
         mantineTableBodyCellProps: () => {
             return {
                 style: {
-                    padding: `${theme.spacing.md} ${theme.spacing.xl}`,
+                    padding: `${theme.spacing.xs} ${theme.spacing.xl}`,
                     borderRight: 'none',
                     borderLeft: 'none',
                     borderBottom: `1px solid ${theme.colors.ldGray[2]}`,
@@ -488,7 +488,7 @@ const ProjectGroupAccessComponent: FC<ProjectGroupAccessProps> = ({
         },
         state: {
             isLoading: isLoadingProjectGroupAccessList,
-            density: 'md',
+            density: 'xs',
         },
         renderEmptyRowsFallback: () => (
             <Box p="4xl">


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This change makes the project access tables more compact by:

- Reducing table density from `md` to `xs` for both ProjectAccess and ProjectGroupAccess components
- Decreasing cell padding from `theme.spacing.md` to `theme.spacing.xs` for vertical spacing
- Adjusting maximum table height from `calc(100dvh - 420px)` to `calc(100dvh - 350px)` for ProjectAccess and `calc(100dvh - 300px)` for ProjectGroupAccess

These adjustments allow more rows to be visible within the same viewport space, improving the user experience when managing project permissions.