### PR TITLE
feat: add dashboard.uuid tag to Sentry

### DIFF
--- a/packages/backend/src/middlewares/sentry.ts
+++ b/packages/backend/src/middlewares/sentry.ts
@@ -11,6 +11,9 @@ export const sentrySetProjectUuidTagMiddleware: RequestHandler = (
     if (req.params?.projectUuid) {
         setTag('project.uuid', req.params.projectUuid);
     }
+    if (req.params?.dashboardUuid) {
+        setTag('dashboard.uuid', req.params.dashboardUuid);
+    }
 
     if (req.user) {
         if (req.user.userUuid && typeof req.user.userUuid === 'string') {

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -114,13 +114,19 @@ const useSentry = (
         }
     }, [isSentryLoaded, setIsSentryLoaded, sentryConfig, user]);
 
-    const { projectUuid } = useParams<{ projectUuid?: string }>();
+    const { projectUuid, dashboardUuid } = useParams<{
+        projectUuid?: string;
+        dashboardUuid?: string;
+    }>();
     const location = useLocation();
     useEffect(() => {
         if (projectUuid) {
             setTag('project.uuid', projectUuid);
         }
-    }, [location, projectUuid]);
+        if (dashboardUuid) {
+            setTag('dashboard.uuid', dashboardUuid);
+        }
+    }, [location, projectUuid, dashboardUuid]);
 };
 
 export default useSentry;


### PR DESCRIPTION
## Summary
- Adds `dashboard.uuid` as a Sentry tag on both backend and frontend, enabling filtering of performance data by specific dashboard during investigations
- Backend: extracts `dashboardUuid` from route params in the existing Sentry middleware (covers 12+ dashboard endpoints automatically)
- Frontend: extracts `dashboardUuid` via `useParams` in the `useSentry` hook and sets the tag on route changes

## Test plan
- [ ] Start dev server with Spotlight enabled (`VITE_SENTRY_SPOTLIGHT=http://localhost:8969/stream`)
- [ ] Navigate to a dashboard page
- [ ] Verify `dashboard.uuid` tag appears on frontend transactions in Spotlight
- [ ] Make an API call to a dashboard endpoint and verify the backend span also has `dashboard.uuid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)