### PR TITLE
fix: clear stale role_uuid when updating project access via v1 API

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -1527,10 +1527,12 @@ export class ProjectModel {
         userUuid: string,
         role: ProjectMemberRole,
     ): Promise<void> {
+        // Clear role_uuid when switching to a system role so that stale FK
+        // references don't prevent custom role deletion later (see #20690).
         await this.database.raw<(DbProjectMembership & DbProject & DbUser)[]>(
             `
                 UPDATE project_memberships AS m
-                SET role = :role FROM projects AS p, users AS u
+                SET role = :role, role_uuid = NULL FROM projects AS p, users AS u
                 WHERE p.project_id = m.project_id
                   AND u.user_id = m.user_id
                   AND user_uuid = :userUuid


### PR DESCRIPTION
## Summary
- The deprecated v1 `PATCH /api/v1/projects/{projectUuid}/access/{userUuid}` endpoint only updated the `role` column without clearing `role_uuid`, leaving orphaned FK references that prevented custom role deletion
- Added `role_uuid = NULL` to the UPDATE statement in `ProjectModel.updateProjectAccess()`
- Added API test that verifies `role_uuid` is cleared when switching from a custom role to a system role via the v1 endpoint

Closes #20690

## Test plan
- [x] Added E2E API test: `should clear role_uuid when switching to system role via v1 API`
- [x] Verified test fails without the fix (stale custom role UUID persists)
- [x] Verified test passes with the fix
- [x] Verified existing roles tests still pass
- [x] Audited all callers of `updateProjectAccess` - only accepts system roles, so `role_uuid = NULL` is always correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)