### PR TITLE
fix: add PayloadTooLargeError handling for oversized requests

### DIFF
--- a/packages/backend/src/errors.ts
+++ b/packages/backend/src/errors.ts
@@ -2,6 +2,7 @@ import {
     getErrorMessage,
     isUnrecoverableSlackError,
     LightdashError,
+    PayloadTooLargeError,
     ScimError,
     SlackError,
     UnexpectedServerError,
@@ -34,6 +35,13 @@ export const errorHandler = (error: Error): LightdashError => {
             message: errorMessage,
             data: error.fields,
         });
+    }
+    // Handle PayloadTooLargeError from body-parser/express
+    if (
+        error.name === 'PayloadTooLargeError' ||
+        (error.message && error.message.includes('request entity too large'))
+    ) {
+        return new PayloadTooLargeError();
     }
     if (error instanceof LightdashError) {
         return error;

--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -98,6 +98,20 @@ export class ParameterError extends LightdashError {
     }
 }
 
+export class PayloadTooLargeError extends LightdashError {
+    constructor(
+        message: string = 'Request payload exceeds the maximum allowed size',
+        data: Record<string, AnyType> = {},
+    ) {
+        super({
+            message,
+            name: 'PayloadTooLargeError',
+            statusCode: 413,
+            data,
+        });
+    }
+}
+
 export class NonCompiledModelError extends LightdashError {
     constructor(message: string, data: { [key: string]: AnyType } = {}) {
         super({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Added a new `PayloadTooLargeError` class that returns a 413 status code when request payloads exceed the maximum allowed size. The error handler now catches both explicit `PayloadTooLargeError` instances and generic errors containing "request entity too large" messages from body-parser/express middleware.

<!-- Even better add a screenshot / gif / loom -->