### PR TITLE
chore: enrich space delete-impact endpoint

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -15195,6 +15195,30 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 dashboardCount: { dataType: 'double', required: true },
                 chartCount: { dataType: 'double', required: true },
+                dashboards: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            spaceUuid: { dataType: 'string', required: true },
+                            name: { dataType: 'string', required: true },
+                            uuid: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
+                charts: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            spaceUuid: { dataType: 'string', required: true },
+                            name: { dataType: 'string', required: true },
+                            uuid: { dataType: 'string', required: true },
+                        },
+                    },
+                    required: true,
+                },
                 spaces: {
                     dataType: 'array',
                     array: {
@@ -15205,6 +15229,14 @@ const models: TsoaRoute.Models = {
                                 required: true,
                             },
                             chartCount: { dataType: 'double', required: true },
+                            parentSpaceUuid: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { dataType: 'string' },
+                                    { dataType: 'enum', enums: [null] },
+                                ],
+                                required: true,
+                            },
                             name: { dataType: 'string', required: true },
                             uuid: { dataType: 'string', required: true },
                         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -16102,6 +16102,42 @@
                         "type": "number",
                         "format": "double"
                     },
+                    "dashboards": {
+                        "items": {
+                            "properties": {
+                                "spaceUuid": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["spaceUuid", "name", "uuid"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "charts": {
+                        "items": {
+                            "properties": {
+                                "spaceUuid": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["spaceUuid", "name", "uuid"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
                     "spaces": {
                         "items": {
                             "properties": {
@@ -16113,6 +16149,10 @@
                                     "type": "number",
                                     "format": "double"
                                 },
+                                "parentSpaceUuid": {
+                                    "type": "string",
+                                    "nullable": true
+                                },
                                 "name": {
                                     "type": "string"
                                 },
@@ -16123,6 +16163,7 @@
                             "required": [
                                 "dashboardCount",
                                 "chartCount",
+                                "parentSpaceUuid",
                                 "name",
                                 "uuid"
                             ],
@@ -16131,7 +16172,13 @@
                         "type": "array"
                     }
                 },
-                "required": ["dashboardCount", "chartCount", "spaces"],
+                "required": [
+                    "dashboardCount",
+                    "chartCount",
+                    "dashboards",
+                    "charts",
+                    "spaces"
+                ],
                 "type": "object"
             },
             "ApiSpaceDeleteImpactResponse": {

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -599,21 +599,34 @@ export class SpaceService
 
         const spaces = await this.spaceModel.find({ spaceUuids: allUuids });
 
+        const [charts, sqlCharts, dashboards] = await Promise.all([
+            this.spaceModel.getSpaceQueries(allUuids),
+            this.spaceModel.getSpaceSqlCharts(allUuids),
+            this.spaceModel.getSpaceDashboards(allUuids),
+        ]);
+
+        const allCharts = [...charts, ...sqlCharts];
+
         return {
             spaces: spaces.map((s) => ({
                 uuid: s.uuid,
                 name: s.name,
+                parentSpaceUuid: s.parentSpaceUuid,
                 chartCount: Number(s.chartCount),
                 dashboardCount: Number(s.dashboardCount),
             })),
-            chartCount: spaces.reduce(
-                (sum, s) => sum + Number(s.chartCount),
-                0,
-            ),
-            dashboardCount: spaces.reduce(
-                (sum, s) => sum + Number(s.dashboardCount),
-                0,
-            ),
+            charts: allCharts.map((c) => ({
+                uuid: c.uuid,
+                name: c.name,
+                spaceUuid: c.spaceUuid,
+            })),
+            dashboards: dashboards.map((d) => ({
+                uuid: d.uuid,
+                name: d.name,
+                spaceUuid: d.spaceUuid,
+            })),
+            chartCount: allCharts.length,
+            dashboardCount: dashboards.length,
         };
     }
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -173,7 +173,7 @@ import { type SearchResults } from './search';
 import { type ShareUrl } from './share';
 import { type ApiSlackChannelsResponse } from './slack';
 import { type SlackSettings } from './slackSettings';
-import { type Space } from './space';
+import { type ApiSpaceDeleteImpactResponse, type Space } from './space';
 import {
     type ApiCreateSqlChart,
     type ApiCreateVirtualView,
@@ -939,7 +939,8 @@ type ApiResults =
     | ApiFavoriteItems['results']
     | ApiChartValidationResponse['results']
     | ApiDashboardValidationResponse['results']
-    | ApiToggleFavorite['results'];
+    | ApiToggleFavorite['results']
+    | ApiSpaceDeleteImpactResponse['results'];
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'
 

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -192,9 +192,12 @@ export type SpaceDeleteImpact = {
     spaces: {
         uuid: string;
         name: string;
+        parentSpaceUuid: string | null;
         chartCount: number;
         dashboardCount: number;
     }[];
+    charts: { uuid: string; name: string; spaceUuid: string }[];
+    dashboards: { uuid: string; name: string; spaceUuid: string }[];
     chartCount: number;
     dashboardCount: number;
 };


### PR DESCRIPTION
### Description:

- Enrich `GET /projects/:projectUuid/spaces/:spaceUuid/delete-impact` to return individual chart/dashboard names and parent
  space relationships
- Add `charts[]` and `dashboards[]` arrays with uuid, name, and spaceUuid
- Add `parentSpaceUuid` to each space entry for hierarchy reconstruction
- Register `ApiSpaceDeleteImpactResponse` in the `ApiResults` union
