### PR TITLE
feat: add average metric support for pre-aggregations

### DIFF
--- a/packages/common/src/preAggregates/additivity.ts
+++ b/packages/common/src/preAggregates/additivity.ts
@@ -34,5 +34,16 @@ export const getAdditivityType = (metricType: MetricType): AdditivityType => {
     }
 };
 
-export const isReAggregatable = (metricType: MetricType): boolean =>
-    getAdditivityType(metricType) === AdditivityType.ADDITIVE;
+export const isPreAggregateCompatible = (metricType: MetricType): boolean => {
+    const additivityType = getAdditivityType(metricType);
+
+    switch (additivityType) {
+        case AdditivityType.ADDITIVE:
+        case AdditivityType.DECOMPOSABLE:
+            return true;
+        case AdditivityType.NON_ADDITIVE:
+            return false;
+        default:
+            return assertUnreachable(additivityType, `Unknown additivity type`);
+    }
+};

--- a/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts
@@ -172,6 +172,7 @@ const sourceExplore = (): Explore => ({
             metrics: [
                 'total_order_amount',
                 'order_count',
+                'avg_order_amount',
                 'customers.max_customer_age',
             ],
             timeDimension: 'order_date',
@@ -208,6 +209,9 @@ describe('buildPreAggregateExplore', () => {
         ).toBe('SUM(orders.orders_total_order_amount)');
         expect(result.tables.orders.metrics.order_count.compiledSql).toBe(
             'SUM(orders.orders_order_count)',
+        );
+        expect(result.tables.orders.metrics.avg_order_amount.compiledSql).toBe(
+            'CAST(SUM(orders.orders_avg_order_amount__sum) AS DOUBLE) / CAST(NULLIF(SUM(orders.orders_avg_order_amount__count), 0) AS DOUBLE)',
         );
         expect(
             result.tables.customers.metrics.max_customer_age.compiledSql,
@@ -272,14 +276,13 @@ describe('buildPreAggregateExplore', () => {
                 name: 'invalid_rollup',
                 dimensions: ['status'],
                 metrics: [
-                    'avg_order_amount',
                     'distinct_customer_count',
                     'median_order_amount',
                     'custom_sql',
                 ],
             }),
         ).toThrow(
-            'Pre-aggregate "invalid_rollup" references unsupported metrics: "avg_order_amount" (average), "distinct_customer_count" (count_distinct), "median_order_amount" (median), "custom_sql" (number). Supported metric types: sum, count, min, max',
+            'Pre-aggregate "invalid_rollup" references unsupported metrics: "distinct_customer_count" (count_distinct), "median_order_amount" (median), "custom_sql" (number). Supported metric types: sum, count, min, max, average',
         );
     });
 

--- a/packages/common/src/preAggregates/matcher.ts
+++ b/packages/common/src/preAggregates/matcher.ts
@@ -11,7 +11,7 @@ import { type TimeFrames } from '../types/timeFrames';
 import { getMetricsMapFromTables } from '../utils/fields';
 import { getItemId } from '../utils/item';
 import { timeFrameOrder } from '../utils/timeFrames';
-import { isReAggregatable } from './additivity';
+import { isPreAggregateCompatible } from './additivity';
 import { getDimensionReferences, getMetricReferences } from './references';
 
 export type MatchResult =
@@ -175,7 +175,7 @@ const getMissForDef = ({
                 fieldId: metricFieldId,
             };
         }
-        if (!isReAggregatable(metric.type)) {
+        if (!isPreAggregateCompatible(metric.type)) {
             return {
                 reason: PreAggregateMissReason.NON_ADDITIVE_METRIC,
                 fieldId: metricFieldId,

--- a/packages/common/src/preAggregates/naming.ts
+++ b/packages/common/src/preAggregates/naming.ts
@@ -15,6 +15,11 @@ export const getJoinedDimensionColumnName = (
 
 export const getMetricColumnName = (fieldId: string): string => fieldId;
 
+export const getMetricComponentColumnName = (
+    fieldId: string,
+    component: 'sum' | 'count',
+): string => `${fieldId}__${component}`;
+
 export const getTimeDimensionColumnName = (
     dimensionName: string,
     granularity: TimeFrames,


### PR DESCRIPTION
### Description:

Closes: [ZAP-270: Support AVG metrics in pre-aggregates via SUM+COUNT decomposition](https://linear.app/lightdash/issue/ZAP-270/support-avg-metrics-in-pre-aggregates-via-sumcount-decomposition)