### PR TITLE
fix(cli): add spinner progress to upload command

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -732,6 +732,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     skipSpaceCreate?: boolean,
     publicSpaceCreate?: boolean,
     validate?: boolean,
+    spinner?: ReturnType<typeof GlobalState.startSpinner>,
 ): Promise<{ changes: Record<string, number>; total: number }> => {
     const config = await getConfig();
 
@@ -757,7 +758,10 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
         });
     }
 
-    for (const item of filteredItems) {
+    spinner?.start(`Uploading ${type} (0/${filteredItems.length})`);
+
+    for (let i = 0; i < filteredItems.length; i++) {
+        const item = filteredItems[i];
         // If a chart fails to update, we keep updating the rest
         try {
             if (!force && !item.needsUpdating) {
@@ -890,7 +894,11 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 });
             }
         }
+        spinner?.start(
+            `Uploading ${type} (${i + 1}/${filteredItems.length})`,
+        );
     }
+    spinner?.succeed(`Uploaded ${filteredItems.length} ${type}`);
     return { changes, total: filteredItems.length };
 };
 
@@ -964,6 +972,8 @@ export const uploadHandler = async (
         },
     });
 
+    const spinner = GlobalState.startSpinner('Uploading charts');
+
     try {
         // If any filter is provided, we skip those items without filters
         // eg: if a --charts filter is provided, we skip dashboards if no --dashboards filter is provided
@@ -999,10 +1009,13 @@ export const uploadHandler = async (
                     options.skipSpaceCreate,
                     options.public,
                     options.validate,
+                    spinner,
                 );
             changes = chartChanges;
             chartTotal = total;
         }
+
+        spinner.start('Uploading dashboards');
 
         if (hasFilters && options.dashboards.length === 0) {
             console.info(
@@ -1020,6 +1033,7 @@ export const uploadHandler = async (
                     options.skipSpaceCreate,
                     options.public,
                     options.validate,
+                    spinner,
                 );
             changes = dashboardChanges;
             dashboardTotal = total;
@@ -1040,9 +1054,7 @@ export const uploadHandler = async (
 
         logUploadChanges(changes);
     } catch (error) {
-        console.error(
-            styles.error(`\nError downloading: ${getErrorMessage(error)}`),
-        );
+        spinner.fail(`Error uploading: ${getErrorMessage(error)}`);
         await LightdashAnalytics.track({
             event: 'download.error',
             properties: {


### PR DESCRIPTION
## Summary
- Add `ora` spinner progress logging to the CLI `upload` command, matching the existing `download` command pattern
- `upsertResources` now accepts an optional spinner and updates it with `Uploading charts (3/10)` style messages during the loop
- `uploadHandler` creates a spinner before chart upload and reuses it for dashboards; errors use `spinner.fail()`

## Test plan
- [ ] Run `lightdash upload` with multiple charts and verify spinner shows `Uploading charts (0/N)` through `(N/N)` then `Uploaded N charts`
- [ ] Run `lightdash upload` with dashboards and verify same pattern for dashboards
- [ ] Run with `--charts` filter to skip dashboards and confirm spinner still works
- [ ] Trigger an upload error and verify `spinner.fail()` message appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)