### PR TITLE
feat(cli): add generate-docs command to inject Lightdash metrics into dbt lineage

### DIFF
--- a/packages/cli/src/analytics/analytics.ts
+++ b/packages/cli/src/analytics/analytics.ts
@@ -439,6 +439,30 @@ type CliCommandExecuted = BaseTrack & {
     };
 };
 
+type CliGenerateDocsStarted = BaseTrack & {
+    event: 'generate_docs.started';
+    properties: {
+        executionId: string;
+    };
+};
+type CliGenerateDocsCompleted = BaseTrack & {
+    event: 'generate_docs.completed';
+    properties: {
+        executionId: string;
+        durationMs: number;
+        skipInject: boolean;
+        serve: boolean;
+    };
+};
+type CliGenerateDocsError = BaseTrack & {
+    event: 'generate_docs.error';
+    properties: {
+        executionId: string;
+        step: string;
+        error: string;
+    };
+};
+
 type Track =
     | CliGenerateStarted
     | CliGenerateCompleted
@@ -478,7 +502,10 @@ type Track =
     | CliLintError
     | CliRenameCompleted
     | CliRenameError
-    | CliCommandExecuted;
+    | CliCommandExecuted
+    | CliGenerateDocsStarted
+    | CliGenerateDocsCompleted
+    | CliGenerateDocsError;
 
 const ERROR_NAME_TO_CATEGORY: Record<string, string> = {
     ForbiddenError: 'forbidden',

--- a/packages/cli/src/handlers/generateDocs.ts
+++ b/packages/cli/src/handlers/generateDocs.ts
@@ -1,0 +1,175 @@
+import { getErrorMessage } from '@lightdash/common';
+import execa from 'execa';
+import * as path from 'path';
+import { v4 as uuidv4 } from 'uuid';
+import { LightdashAnalytics } from '../analytics/analytics';
+import GlobalState from '../globalState';
+import {
+    getManifestPath,
+    getStaticIndexPath,
+    injectLightdashLineage,
+    patchStaticIndex,
+} from './injectLightdashLineage';
+
+type GenerateDocsHandlerOptions = {
+    projectDir: string;
+    profilesDir: string;
+    target?: string;
+    targetPath?: string;
+    verbose: boolean;
+    skipInject: boolean;
+    static: boolean;
+    serve: boolean;
+    port: number;
+};
+
+export const generateDocsHandler = async (
+    options: GenerateDocsHandlerOptions,
+) => {
+    GlobalState.setVerbose(options.verbose);
+    const executionId = uuidv4();
+
+    const startTime = Date.now();
+    await LightdashAnalytics.track({
+        event: 'generate_docs.started',
+        properties: { executionId },
+    });
+
+    const absoluteProjectDir = path.resolve(options.projectDir);
+    const absoluteTargetPath = options.targetPath
+        ? path.resolve(options.targetPath)
+        : undefined;
+
+    // Step 1: Run dbt docs generate
+    try {
+        const dbtArgs = ['docs', 'generate'];
+        if (options.static) {
+            dbtArgs.push('--static');
+        }
+        if (options.projectDir) {
+            dbtArgs.push('--project-dir', absoluteProjectDir);
+        }
+        if (options.profilesDir) {
+            dbtArgs.push('--profiles-dir', options.profilesDir);
+        }
+        if (options.target) {
+            dbtArgs.push('--target', options.target);
+        }
+        if (absoluteTargetPath) {
+            dbtArgs.push('--target-path', absoluteTargetPath);
+        }
+
+        GlobalState.debug(`> Running: dbt ${dbtArgs.join(' ')}`);
+        await execa('dbt', dbtArgs, { stdio: 'inherit' });
+    } catch (e: unknown) {
+        const msg = getErrorMessage(e);
+        await LightdashAnalytics.track({
+            event: 'generate_docs.error',
+            properties: {
+                executionId,
+                step: 'dbt_docs_generate',
+                error: msg,
+            },
+        });
+        throw new Error(`Failed to run dbt docs generate:\n  ${msg}`);
+    }
+
+    // Step 2: Inject Lightdash lineage into manifest
+    const manifestPath = getManifestPath(
+        absoluteProjectDir,
+        absoluteTargetPath,
+    );
+    if (!options.skipInject) {
+        const injectSpinner = GlobalState.startSpinner(
+            '  Injecting Lightdash metrics into manifest...',
+        );
+        try {
+            const result = await injectLightdashLineage(manifestPath);
+            injectSpinner.succeed(
+                `  Injected ${result.semanticModelCount} semantic models and ${result.metricCount} metrics`,
+            );
+        } catch (e: unknown) {
+            const msg = getErrorMessage(e);
+            injectSpinner.fail('  Failed to inject Lightdash metrics');
+            await LightdashAnalytics.track({
+                event: 'generate_docs.error',
+                properties: {
+                    executionId,
+                    step: 'inject_lineage',
+                    error: msg,
+                },
+            });
+            throw new Error(`Failed to inject Lightdash lineage:\n  ${msg}`);
+        }
+
+        // Step 2b: If --static, patch static_index.html with the injected manifest
+        if (options.static) {
+            const staticSpinner = GlobalState.startSpinner(
+                '  Patching static docs with injected metrics...',
+            );
+            try {
+                const staticIndexPath = getStaticIndexPath(
+                    absoluteProjectDir,
+                    absoluteTargetPath,
+                );
+                await patchStaticIndex(manifestPath, staticIndexPath);
+                staticSpinner.succeed(
+                    '  Static docs updated with Lightdash metrics',
+                );
+            } catch (e: unknown) {
+                const msg = getErrorMessage(e);
+                staticSpinner.fail('  Failed to patch static docs');
+                await LightdashAnalytics.track({
+                    event: 'generate_docs.error',
+                    properties: {
+                        executionId,
+                        step: 'patch_static',
+                        error: msg,
+                    },
+                });
+                throw new Error(`Failed to patch static_index.html:\n  ${msg}`);
+            }
+        }
+    }
+
+    await LightdashAnalytics.track({
+        event: 'generate_docs.completed',
+        properties: {
+            executionId,
+            durationMs: Date.now() - startTime,
+            skipInject: options.skipInject,
+            serve: options.serve,
+        },
+    });
+
+    // Step 3: Serve or output static file path
+    if (options.static) {
+        const staticIndexPath = getStaticIndexPath(
+            absoluteProjectDir,
+            absoluteTargetPath,
+        );
+        console.info(`\n  Static docs written to: ${staticIndexPath}`);
+        console.info('  Open this file directly in your browser.\n');
+    } else if (options.serve) {
+        console.info(
+            `\n  Serving docs on port ${options.port}. Press Ctrl+C to stop.\n`,
+        );
+
+        const serveArgs = ['docs', 'serve', '--port', String(options.port)];
+        if (options.projectDir) {
+            serveArgs.push('--project-dir', absoluteProjectDir);
+        }
+        if (options.profilesDir) {
+            serveArgs.push('--profiles-dir', options.profilesDir);
+        }
+        if (options.target) {
+            serveArgs.push('--target', options.target);
+        }
+        if (absoluteTargetPath) {
+            serveArgs.push('--target-path', absoluteTargetPath);
+        }
+
+        GlobalState.debug(`> Running: dbt ${serveArgs.join(' ')}`);
+        await execa('dbt', serveArgs, { stdio: 'inherit' });
+    }
+};

--- a/packages/cli/src/handlers/generateDocs.ts
+++ b/packages/cli/src/handlers/generateDocs.ts
@@ -1,3 +1,15 @@
+/**
+ * Handler for `lightdash generate-docs`.
+ *
+ * Automates the workflow of generating dbt docs with Lightdash metrics
+ * visible in the lineage graph. Without this command, users would need to
+ * manually run dbt docs generate, then a separate script to inject metric
+ * nodes, then dbt docs serve. This command does all three in one step.
+ *
+ * Supports two output modes:
+ *   - Server mode (default): runs `dbt docs serve` to view interactively
+ *   - Static mode (--static): produces a self-contained HTML file
+ */
 import { getErrorMessage } from '@lightdash/common';
 import execa from 'execa';
 import * as path from 'path';
@@ -41,6 +53,7 @@ export const generateDocsHandler = async (
         : undefined;
 
     // Step 1: Run dbt docs generate
+    // dbt output streams directly to the terminal via stdio: 'inherit'
     try {
         const dbtArgs = ['docs', 'generate'];
         if (options.static) {
@@ -74,7 +87,8 @@ export const generateDocsHandler = async (
         throw new Error(`Failed to run dbt docs generate:\n  ${msg}`);
     }
 
-    // Step 2: Inject Lightdash lineage into manifest
+    // Step 2: Inject Lightdash metric nodes into the manifest so they
+    // appear on the dbt lineage graph (see injectLightdashLineage.ts)
     const manifestPath = getManifestPath(
         absoluteProjectDir,
         absoluteTargetPath,
@@ -102,7 +116,8 @@ export const generateDocsHandler = async (
             throw new Error(`Failed to inject Lightdash lineage:\n  ${msg}`);
         }
 
-        // Step 2b: If --static, patch static_index.html with the injected manifest
+        // Step 2b: If --static, the HTML file was generated BEFORE we injected,
+        // so we need to replace the embedded manifest with our modified version
         if (options.static) {
             const staticSpinner = GlobalState.startSpinner(
                 '  Patching static docs with injected metrics...',
@@ -142,7 +157,9 @@ export const generateDocsHandler = async (
         },
     });
 
-    // Step 3: Serve or output static file path
+    // Step 3: Either print the static file path or start a local server.
+    // --static and --serve are mutually exclusive: static outputs a file,
+    // serve starts dbt's built-in HTTP server for interactive browsing.
     if (options.static) {
         const staticIndexPath = getStaticIndexPath(
             absoluteProjectDir,

--- a/packages/cli/src/handlers/generateDocs.ts
+++ b/packages/cli/src/handlers/generateDocs.ts
@@ -211,7 +211,7 @@ export const generateDocsHandler = async (
 
         GlobalState.debug(`> Running: dbt ${serveArgs.join(' ')}`);
         await execa('dbt', serveArgs, {
-            stdio: ['pipe', 'pipe', 'pipe'],
+            stdio: ['inherit', 'ignore', 'ignore'],
         });
     }
 };

--- a/packages/cli/src/handlers/generateDocs.ts
+++ b/packages/cli/src/handlers/generateDocs.ts
@@ -3,8 +3,18 @@
  *
  * Automates the workflow of generating dbt docs with Lightdash metrics
  * visible in the lineage graph. Without this command, users would need to
- * manually run dbt docs generate, then a separate script to inject metric
- * nodes, then dbt docs serve. This command does all three in one step.
+ * manually run dbt compile, inject metric nodes, then dbt docs generate
+ * and serve. This command does all of that in one step.
+ *
+ * The key insight is that we compile into an isolated directory
+ * (target/lightdash_docs/), inject metrics into that manifest, then run
+ * `dbt docs generate --no-compile` pointing at the same directory. Since
+ * --no-compile skips writing manifest.json, our injected version is picked
+ * up by the docs generator (including the --static HTML embedding).
+ *
+ * This means we never touch the project's real target/ manifest, and we
+ * don't need to post-patch the static HTML. The lightdash_docs/ directory
+ * persists between runs and is overwritten on each invocation.
  *
  * Supports two output modes:
  *   - Server mode (default): runs `dbt docs serve` to view interactively
@@ -12,15 +22,12 @@
  */
 import { getErrorMessage } from '@lightdash/common';
 import execa from 'execa';
+import { promises as fs } from 'fs';
 import * as path from 'path';
 import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import GlobalState from '../globalState';
-import {
-    getTargetFilePath,
-    injectLightdashLineage,
-    patchStaticIndex,
-} from './injectLightdashLineage';
+import { injectLightdashLineage } from './injectLightdashLineage';
 
 type GenerateDocsHandlerOptions = {
     projectDir: string;
@@ -34,14 +41,15 @@ type GenerateDocsHandlerOptions = {
     port: number;
 };
 
-/** Build the common dbt CLI flags shared across generate and serve steps */
+const LIGHTDASH_DOCS_DIR = 'lightdash_docs';
+
+/** Build the common dbt CLI flags shared across compile, generate, and serve steps */
 function buildCommonDbtArgs(
     absoluteProjectDir: string,
     options: Pick<
         GenerateDocsHandlerOptions,
         'projectDir' | 'profilesDir' | 'target'
     >,
-    absoluteTargetPath: string | undefined,
 ): string[] {
     const args: string[] = [];
     if (options.projectDir) {
@@ -52,9 +60,6 @@ function buildCommonDbtArgs(
     }
     if (options.target) {
         args.push('--target', options.target);
-    }
-    if (absoluteTargetPath) {
-        args.push('--target-path', absoluteTargetPath);
     }
     return args;
 }
@@ -72,46 +77,43 @@ export const generateDocsHandler = async (
     });
 
     const absoluteProjectDir = path.resolve(options.projectDir);
-    const absoluteTargetPath = options.targetPath
+    const targetDir = options.targetPath
         ? path.resolve(options.targetPath)
-        : undefined;
-    const commonArgs = buildCommonDbtArgs(
-        absoluteProjectDir,
-        options,
-        absoluteTargetPath,
-    );
+        : path.join(absoluteProjectDir, 'target');
+    const ldDocsDir = path.join(targetDir, LIGHTDASH_DOCS_DIR);
+    const commonArgs = buildCommonDbtArgs(absoluteProjectDir, options);
 
-    // Step 1: Run dbt docs generate
-    // dbt output streams directly to the terminal via stdio: 'inherit'
+    // Create the isolated working directory
+    await fs.mkdir(ldDocsDir, { recursive: true });
+
+    // Step 1: Compile into the isolated directory to produce manifest.json
+    // This leaves the project's real target/ untouched.
     try {
-        const generateArgs = ['docs', 'generate'];
-        if (options.static) {
-            generateArgs.push('--static');
-        }
-        generateArgs.push(...commonArgs);
+        const compileArgs = [
+            'compile',
+            '--target-path',
+            ldDocsDir,
+            ...commonArgs,
+        ];
 
-        GlobalState.debug(`> Running: dbt ${generateArgs.join(' ')}`);
-        await execa('dbt', generateArgs, { stdio: 'inherit' });
+        GlobalState.debug(`> Running: dbt ${compileArgs.join(' ')}`);
+        await execa('dbt', compileArgs, { stdio: 'inherit' });
     } catch (e: unknown) {
         const msg = getErrorMessage(e);
         await LightdashAnalytics.track({
             event: 'generate_docs.error',
             properties: {
                 executionId,
-                step: 'dbt_docs_generate',
+                step: 'dbt_compile',
                 error: msg,
             },
         });
-        throw new Error(`Failed to run dbt docs generate:\n  ${msg}`);
+        throw new Error(`Failed to run dbt compile:\n  ${msg}`);
     }
 
     // Step 2: Inject Lightdash metric nodes into the manifest so they
     // appear on the dbt lineage graph (see injectLightdashLineage.ts)
-    const manifestPath = getTargetFilePath(
-        absoluteProjectDir,
-        absoluteTargetPath,
-        'manifest.json',
-    );
+    const manifestPath = path.join(ldDocsDir, 'manifest.json');
     if (!options.skipInject) {
         const injectSpinner = GlobalState.startSpinner(
             '  Injecting Lightdash metrics into manifest...',
@@ -134,37 +136,37 @@ export const generateDocsHandler = async (
             });
             throw new Error(`Failed to inject Lightdash lineage:\n  ${msg}`);
         }
+    }
 
-        // Step 2b: If --static, the HTML file was generated BEFORE we injected,
-        // so we need to replace the embedded manifest with our modified version
+    // Step 3: Generate docs with --no-compile so dbt doesn't overwrite our
+    // injected manifest. It will generate catalog.json, index.html, and
+    // (if --static) static_index.html reading our manifest from disk.
+    try {
+        const generateArgs = [
+            'docs',
+            'generate',
+            '--no-compile',
+            '--target-path',
+            ldDocsDir,
+            ...commonArgs,
+        ];
         if (options.static) {
-            const staticSpinner = GlobalState.startSpinner(
-                '  Patching static docs with injected metrics...',
-            );
-            try {
-                const staticIndexPath = getTargetFilePath(
-                    absoluteProjectDir,
-                    absoluteTargetPath,
-                    'static_index.html',
-                );
-                await patchStaticIndex(manifestPath, staticIndexPath);
-                staticSpinner.succeed(
-                    '  Static docs updated with Lightdash metrics',
-                );
-            } catch (e: unknown) {
-                const msg = getErrorMessage(e);
-                staticSpinner.fail('  Failed to patch static docs');
-                await LightdashAnalytics.track({
-                    event: 'generate_docs.error',
-                    properties: {
-                        executionId,
-                        step: 'patch_static',
-                        error: msg,
-                    },
-                });
-                throw new Error(`Failed to patch static_index.html:\n  ${msg}`);
-            }
+            generateArgs.push('--static');
         }
+
+        GlobalState.debug(`> Running: dbt ${generateArgs.join(' ')}`);
+        await execa('dbt', generateArgs, { stdio: 'inherit' });
+    } catch (e: unknown) {
+        const msg = getErrorMessage(e);
+        await LightdashAnalytics.track({
+            event: 'generate_docs.error',
+            properties: {
+                executionId,
+                step: 'dbt_docs_generate',
+                error: msg,
+            },
+        });
+        throw new Error(`Failed to run dbt docs generate:\n  ${msg}`);
     }
 
     await LightdashAnalytics.track({
@@ -177,15 +179,9 @@ export const generateDocsHandler = async (
         },
     });
 
-    // Step 3: Either print the static file path or start a local server.
-    // --static and --serve are mutually exclusive: static outputs a file,
-    // serve starts dbt's built-in HTTP server for interactive browsing.
+    // Step 4: Output the result.
     if (options.static) {
-        const staticIndexPath = getTargetFilePath(
-            absoluteProjectDir,
-            absoluteTargetPath,
-            'static_index.html',
-        );
+        const staticIndexPath = path.join(ldDocsDir, 'static_index.html');
         console.info(`\n  Static docs written to: ${staticIndexPath}`);
         console.info('  Open this file directly in your browser.\n');
     } else if (options.serve) {
@@ -198,6 +194,8 @@ export const generateDocsHandler = async (
             'serve',
             '--port',
             String(options.port),
+            '--target-path',
+            ldDocsDir,
             ...commonArgs,
         ];
 

--- a/packages/cli/src/handlers/generateDocs.ts
+++ b/packages/cli/src/handlers/generateDocs.ts
@@ -88,6 +88,9 @@ export const generateDocsHandler = async (
 
     // Step 1: Compile into the isolated directory to produce manifest.json
     // This leaves the project's real target/ untouched.
+    const compileSpinner = GlobalState.startSpinner(
+        '  Compiling dbt project...',
+    );
     try {
         const compileArgs = [
             'compile',
@@ -97,9 +100,11 @@ export const generateDocsHandler = async (
         ];
 
         GlobalState.debug(`> Running: dbt ${compileArgs.join(' ')}`);
-        await execa('dbt', compileArgs, { stdio: 'inherit' });
+        await execa('dbt', compileArgs);
+        compileSpinner.succeed('  Compiled dbt project');
     } catch (e: unknown) {
         const msg = getErrorMessage(e);
+        compileSpinner.fail('  Failed to compile dbt project');
         await LightdashAnalytics.track({
             event: 'generate_docs.error',
             properties: {
@@ -141,6 +146,9 @@ export const generateDocsHandler = async (
     // Step 3: Generate docs with --no-compile so dbt doesn't overwrite our
     // injected manifest. It will generate catalog.json, index.html, and
     // (if --static) static_index.html reading our manifest from disk.
+    const generateSpinner = GlobalState.startSpinner(
+        '  Generating docs catalog...',
+    );
     try {
         const generateArgs = [
             'docs',
@@ -155,9 +163,11 @@ export const generateDocsHandler = async (
         }
 
         GlobalState.debug(`> Running: dbt ${generateArgs.join(' ')}`);
-        await execa('dbt', generateArgs, { stdio: 'inherit' });
+        await execa('dbt', generateArgs);
+        generateSpinner.succeed('  Generated docs catalog');
     } catch (e: unknown) {
         const msg = getErrorMessage(e);
+        generateSpinner.fail('  Failed to generate docs catalog');
         await LightdashAnalytics.track({
             event: 'generate_docs.error',
             properties: {
@@ -185,9 +195,9 @@ export const generateDocsHandler = async (
         console.info(`\n  Static docs written to: ${staticIndexPath}`);
         console.info('  Open this file directly in your browser.\n');
     } else if (options.serve) {
-        console.info(
-            `\n  Serving docs on port ${options.port}. Press Ctrl+C to stop.\n`,
-        );
+        const url = `http://localhost:${options.port}`;
+        console.info(`\n  Serving docs at: ${url}`);
+        console.info('  Press Ctrl+C to stop.\n');
 
         const serveArgs = [
             'docs',
@@ -200,6 +210,8 @@ export const generateDocsHandler = async (
         ];
 
         GlobalState.debug(`> Running: dbt ${serveArgs.join(' ')}`);
-        await execa('dbt', serveArgs, { stdio: 'inherit' });
+        await execa('dbt', serveArgs, {
+            stdio: ['pipe', 'pipe', 'pipe'],
+        });
     }
 };

--- a/packages/cli/src/handlers/injectLightdashLineage.ts
+++ b/packages/cli/src/handlers/injectLightdashLineage.ts
@@ -1,0 +1,503 @@
+import { promises as fs } from 'fs';
+import * as path from 'path';
+import GlobalState from '../globalState';
+
+const LIGHTDASH_MARKER = '_lightdash_injected';
+
+// Lightdash brand purple for dbt docs lineage graph (uses Cytoscape node_color data attr)
+const LIGHTDASH_PURPLE = '#7262FF';
+const LIGHTDASH_PURPLE_LIGHT = '#b8b0ff';
+
+type MetricDef = {
+    type?: string;
+    label?: string;
+    description?: string;
+    sql?: string;
+};
+
+type ManifestNode = {
+    unique_id: string;
+    resource_type: string;
+    name: string;
+    label?: string;
+    package_name: string;
+    original_file_path?: string;
+    columns?: Record<
+        string,
+        { meta?: { metrics?: Record<string, MetricDef> } }
+    >;
+    meta?: { metrics?: Record<string, MetricDef>; [key: string]: unknown };
+    [key: string]: unknown;
+};
+
+type Manifest = {
+    metadata: { generated_at?: string; project_name: string };
+    nodes: Record<string, ManifestNode>;
+    semantic_models: Record<string, Record<string, unknown>>;
+    metrics: Record<string, Record<string, unknown>>;
+    parent_map: Record<string, string[]>;
+    child_map: Record<string, string[]>;
+    [key: string]: unknown;
+};
+
+function extractMetricsFromModel(
+    node: ManifestNode,
+): Array<[string, MetricDef]> {
+    const metrics: Array<[string, MetricDef]> = [];
+
+    const columns = node.columns ?? {};
+    for (const col of Object.values(columns)) {
+        const colMetrics = col.meta?.metrics ?? {};
+        for (const [name, definition] of Object.entries(colMetrics)) {
+            metrics.push([name, definition]);
+        }
+    }
+
+    const tableMetrics = node.meta?.metrics ?? {};
+    for (const [name, definition] of Object.entries(tableMetrics)) {
+        metrics.push([name, definition]);
+    }
+
+    return metrics;
+}
+
+function findModelsNeedingPrefix(
+    modelMetrics: Map<string, Array<[string, MetricDef]>>,
+): Set<string> {
+    const firstSeen: Record<string, string> = {};
+    const modelsToPrefix = new Set<string>();
+
+    for (const [modelId, metrics] of modelMetrics) {
+        for (const [name] of metrics) {
+            if (name in firstSeen) {
+                modelsToPrefix.add(modelId);
+            } else {
+                firstSeen[name] = modelId;
+            }
+        }
+    }
+
+    return modelsToPrefix;
+}
+
+function modelShortName(modelName: string): string {
+    if (modelName.startsWith('dbt_')) {
+        return modelName.slice(4);
+    }
+    return modelName;
+}
+
+function resolveMetricName(
+    metricName: string,
+    modelName: string,
+    needsPrefix: boolean,
+): string {
+    if (needsPrefix) {
+        return `${modelShortName(modelName)}_${metricName}`;
+    }
+    return metricName;
+}
+
+function parseDerivedRefs(sql: string): string[] {
+    const matches = sql.match(/\$\{(\w+)\}/g);
+    if (!matches) return [];
+    return matches.map((m) => m.slice(2, -1));
+}
+
+function getYmlPath(node: ManifestNode): string {
+    const orig = node.original_file_path ?? '';
+    return orig.replace('.sql', '.yml');
+}
+
+function buildSemanticModel(
+    modelNode: ManifestNode,
+    packageName: string,
+    timestamp: number,
+): [string, Record<string, unknown>] {
+    const modelName = modelNode.name;
+    const smLabel = modelNode.label ?? modelName;
+    const uniqueId = `semantic_model.${packageName}.${modelName}`;
+    const modelUid = modelNode.unique_id;
+    const ymlPath = getYmlPath(modelNode);
+
+    return [
+        uniqueId,
+        {
+            unique_id: uniqueId,
+            resource_type: 'semantic_model',
+            name: modelName,
+            label: smLabel,
+            package_name: packageName,
+            path: ymlPath,
+            original_file_path: ymlPath,
+            fqn: [packageName, modelName],
+            description: `Lightdash semantic model for ${modelName}`,
+            model: `ref('${modelName}')`,
+            depends_on: { nodes: [modelUid], macros: [] },
+            config: { enabled: true },
+            tags: [],
+            node_color: LIGHTDASH_PURPLE_LIGHT,
+            meta: { [LIGHTDASH_MARKER]: true },
+            created_at: timestamp,
+            group: null,
+            entities: [],
+            measures: [],
+            dimensions: [],
+            defaults: {},
+            primary_entity: null,
+        },
+    ];
+}
+
+function buildMetric(
+    resolvedName: string,
+    metricDef: MetricDef,
+    smUniqueId: string,
+    packageName: string,
+    ymlPath: string,
+    timestamp: number,
+): [string, Record<string, unknown>] {
+    const uniqueId = `metric.${packageName}.${resolvedName}`;
+    const lightdashType = metricDef.type ?? 'count';
+    const label = metricDef.label ?? resolvedName;
+    const description = metricDef.description ?? '';
+    const metricType = lightdashType === 'number' ? 'derived' : 'simple';
+
+    return [
+        uniqueId,
+        {
+            unique_id: uniqueId,
+            resource_type: 'metric',
+            name: resolvedName,
+            label,
+            description,
+            type: metricType,
+            type_params: { measure: { name: resolvedName } },
+            package_name: packageName,
+            path: ymlPath,
+            original_file_path: ymlPath,
+            fqn: [packageName, resolvedName],
+            depends_on: { nodes: [smUniqueId], macros: [] },
+            config: { enabled: true },
+            tags: [],
+            node_color: LIGHTDASH_PURPLE,
+            meta: { [LIGHTDASH_MARKER]: true },
+            created_at: timestamp,
+            filter: null,
+        },
+    ];
+}
+
+// eslint-disable-next-line no-param-reassign
+function clearPreviousInjections(m: Manifest): void {
+    for (const section of ['semantic_models', 'metrics'] as const) {
+        const sectionData = m[section] ?? {};
+        const toRemove = Object.keys(sectionData).filter((uid) => {
+            const node = sectionData[uid] as Record<string, unknown>;
+            const meta = node.meta as Record<string, unknown> | undefined;
+            return meta?.[LIGHTDASH_MARKER];
+        });
+
+        for (const uid of toRemove) {
+            delete sectionData[uid]; // eslint-disable-line no-param-reassign
+            delete m.parent_map[uid]; // eslint-disable-line no-param-reassign
+
+            for (const children of Object.values(m.child_map)) {
+                const idx = children.indexOf(uid);
+                if (idx !== -1) {
+                    children.splice(idx, 1);
+                }
+            }
+            delete m.child_map[uid]; // eslint-disable-line no-param-reassign
+        }
+    }
+}
+
+function inject(m: Manifest): Manifest {
+    clearPreviousInjections(m);
+
+    // Use manifest generation time for stable timestamps (idempotency)
+    const generatedAt = m.metadata.generated_at ?? '';
+    let timestamp: number;
+    try {
+        const dt = new Date(generatedAt);
+        timestamp = dt.getTime() / 1000;
+        if (Number.isNaN(timestamp)) {
+            timestamp = Date.now() / 1000;
+        }
+    } catch {
+        timestamp = Date.now() / 1000;
+    }
+
+    const packageName = m.metadata.project_name;
+
+    // Ensure top-level dicts exist
+    const result = {
+        ...m,
+        semantic_models: m.semantic_models ?? {},
+        metrics: m.metrics ?? {},
+        parent_map: m.parent_map ?? {},
+        child_map: m.child_map ?? {},
+    };
+
+    // Step 1: Collect all model nodes and their metrics
+    const modelMetrics = new Map<string, Array<[string, MetricDef]>>();
+    const modelNodes = new Map<string, ManifestNode>();
+    for (const [uid, node] of Object.entries(result.nodes)) {
+        if (
+            node.resource_type === 'model' &&
+            node.package_name === packageName
+        ) {
+            const metrics = extractMetricsFromModel(node);
+            if (metrics.length > 0) {
+                modelMetrics.set(uid, metrics);
+                modelNodes.set(uid, node);
+            }
+        }
+    }
+
+    // Step 2: Find which models need all metrics prefixed (collision handling)
+    const modelsToPrefix = findModelsNeedingPrefix(modelMetrics);
+
+    // Map from original metric name -> [{resolved, modelUid, metricUid}]
+    const originalToResolved = new Map<
+        string,
+        Array<{ resolved: string; modelUid: string; metricUid: string }>
+    >();
+
+    // Step 3: Process each model
+    for (const modelUid of modelNodes.keys()) {
+        const node = modelNodes.get(modelUid)!;
+        const metrics = modelMetrics.get(modelUid)!;
+        const ymlPath = getYmlPath(node);
+        const needsPrefix = modelsToPrefix.has(modelUid);
+
+        // Create semantic model
+        const [smUid, smNode] = buildSemanticModel(
+            node,
+            packageName,
+            timestamp,
+        );
+        result.semantic_models[smUid] = smNode;
+
+        // Update parent/child maps for semantic model
+        result.parent_map[smUid] = [modelUid];
+        if (!result.child_map[modelUid]) result.child_map[modelUid] = [];
+        if (!result.child_map[modelUid].includes(smUid)) {
+            result.child_map[modelUid].push(smUid);
+        }
+        if (!result.child_map[smUid]) result.child_map[smUid] = [];
+
+        // Create metric nodes
+        for (const [metricName, metricDef] of metrics) {
+            const resolved = resolveMetricName(
+                metricName,
+                node.name,
+                needsPrefix,
+            );
+            const [metricUid, metricNode] = buildMetric(
+                resolved,
+                metricDef,
+                smUid,
+                packageName,
+                ymlPath,
+                timestamp,
+            );
+            result.metrics[metricUid] = metricNode;
+
+            // Track original name -> resolved for derived metric resolution
+            if (!originalToResolved.has(metricName)) {
+                originalToResolved.set(metricName, []);
+            }
+            originalToResolved.get(metricName)!.push({
+                resolved,
+                modelUid,
+                metricUid,
+            });
+
+            // Update parent/child maps for metric
+            result.parent_map[metricUid] = [smUid];
+            if (!result.child_map[smUid].includes(metricUid)) {
+                result.child_map[smUid].push(metricUid);
+            }
+            if (!result.child_map[metricUid]) result.child_map[metricUid] = [];
+        }
+    }
+
+    // Step 4: Fix up derived metrics - parse SQL refs and set correct depends_on
+    for (const [metricUid, metricNode] of Object.entries(result.metrics)) {
+        const meta = metricNode.meta as Record<string, unknown> | undefined;
+        if (
+            !meta?.[LIGHTDASH_MARKER] ||
+            (metricNode as Record<string, unknown>).type !== 'derived'
+        ) {
+            // eslint-disable-next-line no-continue -- skip non-Lightdash and non-derived metrics
+            continue;
+        }
+
+        const resolvedName = (metricNode as Record<string, unknown>)
+            .name as string;
+        const smParent = result.parent_map[metricUid][0];
+        const modelParent = result.parent_map[smParent][0];
+        const modelNode = result.nodes[modelParent];
+
+        const needsPrefix = modelsToPrefix.has(modelParent);
+        let sql: string | null = null;
+        const tableMetrics = modelNode.meta?.metrics ?? {};
+        for (const [name, defn] of Object.entries(tableMetrics)) {
+            if (defn.type === 'number') {
+                const testResolved = resolveMetricName(
+                    name,
+                    modelNode.name,
+                    needsPrefix,
+                );
+                if (testResolved === resolvedName || name === resolvedName) {
+                    sql = defn.sql ?? '';
+                    break;
+                }
+            }
+        }
+
+        if (!sql) {
+            // eslint-disable-next-line no-continue -- no SQL to parse
+            continue;
+        }
+
+        // Parse ${ref} from SQL to find input metrics
+        const refs = parseDerivedRefs(sql);
+        const depUids: string[] = [];
+        for (const refName of refs) {
+            const candidates = originalToResolved.get(refName) ?? [];
+            let matched: string | null = null;
+            for (const candidate of candidates) {
+                if (candidate.modelUid === modelParent) {
+                    matched = candidate.metricUid;
+                    break;
+                }
+            }
+            if (!matched && candidates.length > 0) {
+                matched = candidates[0].metricUid;
+            }
+            if (matched) {
+                depUids.push(matched);
+            }
+        }
+
+        if (depUids.length > 0) {
+            // Derived metric depends on its input metrics, not the semantic model
+            (
+                metricNode as Record<string, unknown> & {
+                    depends_on: { nodes: string[] };
+                }
+            ).depends_on.nodes = depUids;
+
+            // Update parent_map
+            result.parent_map[metricUid] = depUids;
+
+            // Remove from semantic model's children
+            const smChildren = result.child_map[smParent] ?? [];
+            const idx = smChildren.indexOf(metricUid);
+            if (idx !== -1) {
+                smChildren.splice(idx, 1);
+            }
+
+            // Add as child of each input metric
+            for (const depUid of depUids) {
+                if (!result.child_map[depUid]) result.child_map[depUid] = [];
+                if (!result.child_map[depUid].includes(metricUid)) {
+                    result.child_map[depUid].push(metricUid);
+                }
+            }
+        }
+    }
+
+    return result;
+}
+
+type InjectResult = {
+    semanticModelCount: number;
+    metricCount: number;
+};
+
+export async function injectLightdashLineage(
+    manifestPath: string,
+): Promise<InjectResult> {
+    GlobalState.debug(`Reading manifest from ${manifestPath}`);
+
+    const raw = await fs.readFile(manifestPath, { encoding: 'utf-8' });
+    let manifest: Manifest;
+    try {
+        manifest = JSON.parse(raw) as Manifest;
+    } catch (e) {
+        throw new Error(
+            `Failed to parse manifest.json at ${manifestPath}: ${e instanceof Error ? e.message : String(e)}`,
+        );
+    }
+
+    manifest = inject(manifest);
+
+    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+
+    const semanticModelCount = Object.values(manifest.semantic_models).filter(
+        (n) => {
+            const meta = (n as Record<string, unknown>).meta as
+                | Record<string, unknown>
+                | undefined;
+            return meta?.[LIGHTDASH_MARKER];
+        },
+    ).length;
+
+    const metricCount = Object.values(manifest.metrics).filter((n) => {
+        const meta = (n as Record<string, unknown>).meta as
+            | Record<string, unknown>
+            | undefined;
+        return meta?.[LIGHTDASH_MARKER];
+    }).length;
+
+    return { semanticModelCount, metricCount };
+}
+
+export function getManifestPath(
+    projectDir: string,
+    targetPath?: string,
+): string {
+    const targetDir = targetPath ?? path.join(projectDir, 'target');
+    return path.join(targetDir, 'manifest.json');
+}
+
+export function getStaticIndexPath(
+    projectDir: string,
+    targetPath?: string,
+): string {
+    const targetDir = targetPath ?? path.join(projectDir, 'target');
+    return path.join(targetDir, 'static_index.html');
+}
+
+export async function patchStaticIndex(
+    manifestPath: string,
+    staticIndexPath: string,
+): Promise<void> {
+    const manifestContent = await fs.readFile(manifestPath, {
+        encoding: 'utf-8',
+    });
+    let html = await fs.readFile(staticIndexPath, { encoding: 'utf-8' });
+
+    // The static HTML embeds the manifest as: manifest: {<JSON>}, catalog:
+    // Replace the manifest JSON between "manifest: " and ", catalog:"
+    const startMarker = 'manifest: ';
+    const endMarker = ', catalog:';
+    const startIdx = html.indexOf(startMarker);
+    const endIdx = html.indexOf(endMarker, startIdx);
+
+    if (startIdx === -1 || endIdx === -1) {
+        throw new Error(
+            'Could not find manifest embedding in static_index.html',
+        );
+    }
+
+    const before = html.slice(0, startIdx + startMarker.length);
+    const after = html.slice(endIdx);
+    html = before + manifestContent + after;
+
+    await fs.writeFile(staticIndexPath, html);
+}

--- a/packages/cli/src/handlers/injectLightdashLineage.ts
+++ b/packages/cli/src/handlers/injectLightdashLineage.ts
@@ -37,6 +37,10 @@ const LIGHTDASH_MARKER = '_lightdash_injected';
 const LIGHTDASH_PURPLE = '#7262FF';
 const LIGHTDASH_PURPLE_LIGHT = '#b8b0ff';
 
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
 type MetricDef = {
     type?: string;
     label?: string;
@@ -59,15 +63,107 @@ type ManifestNode = {
     [key: string]: unknown;
 };
 
+type InjectedNodeBase = {
+    unique_id: string;
+    resource_type: string;
+    name: string;
+    label: string;
+    description: string;
+    package_name: string;
+    path: string;
+    original_file_path: string;
+    fqn: string[];
+    depends_on: { nodes: string[]; macros: string[] };
+    config: { enabled: boolean };
+    tags: string[];
+    node_color: string;
+    meta: { [LIGHTDASH_MARKER]: true };
+    created_at: number;
+};
+
+type InjectedSemanticModel = InjectedNodeBase & {
+    resource_type: 'semantic_model';
+    model: string;
+    group: null;
+    entities: never[];
+    measures: never[];
+    dimensions: never[];
+    defaults: Record<string, never>;
+    primary_entity: null;
+};
+
+type InjectedMetric = InjectedNodeBase & {
+    resource_type: 'metric';
+    type: 'simple' | 'derived';
+    type_params: { measure: { name: string } };
+    filter: null;
+};
+
 type Manifest = {
     metadata: { generated_at?: string; project_name: string };
     nodes: Record<string, ManifestNode>;
-    semantic_models: Record<string, Record<string, unknown>>;
-    metrics: Record<string, Record<string, unknown>>;
+    semantic_models: Record<string, InjectedSemanticModel>;
+    metrics: Record<string, InjectedMetric>;
     parent_map: Record<string, string[]>;
     child_map: Record<string, string[]>;
     [key: string]: unknown;
 };
+
+type InjectResult = {
+    manifest: Manifest;
+    semanticModelCount: number;
+    metricCount: number;
+};
+
+/** Info tracked per metric during injection, used to resolve derived metric refs */
+type ResolvedMetricInfo = {
+    resolved: string;
+    modelUid: string;
+    metricUid: string;
+};
+
+// ---------------------------------------------------------------------------
+// Lineage map helpers
+// ---------------------------------------------------------------------------
+
+/** Ensure a uid has an entry in the child_map (even if empty) */
+function ensureChildMapEntry(
+    childMap: Record<string, string[]>,
+    uid: string,
+): void {
+    if (!childMap[uid]) {
+        childMap[uid] = []; // eslint-disable-line no-param-reassign
+    }
+}
+
+/** Add a parent -> child edge in the child_map */
+function addChild(
+    childMap: Record<string, string[]>,
+    parentUid: string,
+    childUid: string,
+): void {
+    ensureChildMapEntry(childMap, parentUid);
+    if (!childMap[parentUid].includes(childUid)) {
+        childMap[parentUid].push(childUid);
+    }
+}
+
+/** Remove a child from a parent's child_map entry */
+function removeChild(
+    childMap: Record<string, string[]>,
+    parentUid: string,
+    childUid: string,
+): void {
+    const children = childMap[parentUid] ?? [];
+    const idx = children.indexOf(childUid);
+    if (idx !== -1) {
+        children.splice(idx, 1);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Metric extraction
+// ---------------------------------------------------------------------------
 
 /**
  * Extract all Lightdash metrics from a dbt model node.
@@ -124,6 +220,10 @@ function findModelsNeedingPrefix(
     return modelsToPrefix;
 }
 
+// ---------------------------------------------------------------------------
+// Name resolution
+// ---------------------------------------------------------------------------
+
 /** Strip the "dbt_" prefix from model names to produce shorter prefixes (e.g. "dbt_orders" -> "orders") */
 function modelShortName(modelName: string): string {
     if (modelName.startsWith('dbt_')) {
@@ -153,6 +253,10 @@ function parseDerivedRefs(sql: string): string[] {
     return matches.map((m) => m.slice(2, -1));
 }
 
+// ---------------------------------------------------------------------------
+// Node builders
+// ---------------------------------------------------------------------------
+
 /** Derive the YAML file path from the model's SQL path (for the injected node metadata) */
 function getYmlPath(node: ManifestNode): string {
     const orig = node.original_file_path ?? '';
@@ -164,40 +268,34 @@ function buildSemanticModel(
     modelNode: ManifestNode,
     packageName: string,
     timestamp: number,
-): [string, Record<string, unknown>] {
+): InjectedSemanticModel {
     const modelName = modelNode.name;
-    const smLabel = modelNode.label ?? modelName;
-    const uniqueId = `semantic_model.${packageName}.${modelName}`;
-    const modelUid = modelNode.unique_id;
     const ymlPath = getYmlPath(modelNode);
 
-    return [
-        uniqueId,
-        {
-            unique_id: uniqueId,
-            resource_type: 'semantic_model',
-            name: modelName,
-            label: smLabel,
-            package_name: packageName,
-            path: ymlPath,
-            original_file_path: ymlPath,
-            fqn: [packageName, modelName],
-            description: `Lightdash semantic model for ${modelName}`,
-            model: `ref('${modelName}')`,
-            depends_on: { nodes: [modelUid], macros: [] },
-            config: { enabled: true },
-            tags: [],
-            node_color: LIGHTDASH_PURPLE_LIGHT,
-            meta: { [LIGHTDASH_MARKER]: true },
-            created_at: timestamp,
-            group: null,
-            entities: [],
-            measures: [],
-            dimensions: [],
-            defaults: {},
-            primary_entity: null,
-        },
-    ];
+    return {
+        unique_id: `semantic_model.${packageName}.${modelName}`,
+        resource_type: 'semantic_model',
+        name: modelName,
+        label: modelNode.label ?? modelName,
+        description: `Lightdash semantic model for ${modelName}`,
+        package_name: packageName,
+        path: ymlPath,
+        original_file_path: ymlPath,
+        fqn: [packageName, modelName],
+        model: `ref('${modelName}')`,
+        depends_on: { nodes: [modelNode.unique_id], macros: [] },
+        config: { enabled: true },
+        tags: [],
+        node_color: LIGHTDASH_PURPLE_LIGHT,
+        meta: { [LIGHTDASH_MARKER]: true },
+        created_at: timestamp,
+        group: null,
+        entities: [],
+        measures: [],
+        dimensions: [],
+        defaults: {},
+        primary_entity: null,
+    };
 }
 
 /**
@@ -212,70 +310,147 @@ function buildMetric(
     packageName: string,
     ymlPath: string,
     timestamp: number,
-): [string, Record<string, unknown>] {
-    const uniqueId = `metric.${packageName}.${resolvedName}`;
+): InjectedMetric {
     const lightdashType = metricDef.type ?? 'count';
-    const label = metricDef.label ?? resolvedName;
-    const description = metricDef.description ?? '';
-    const metricType = lightdashType === 'number' ? 'derived' : 'simple';
 
-    return [
-        uniqueId,
-        {
-            unique_id: uniqueId,
-            resource_type: 'metric',
-            name: resolvedName,
-            label,
-            description,
-            type: metricType,
-            type_params: { measure: { name: resolvedName } },
-            package_name: packageName,
-            path: ymlPath,
-            original_file_path: ymlPath,
-            fqn: [packageName, resolvedName],
-            depends_on: { nodes: [smUniqueId], macros: [] },
-            config: { enabled: true },
-            tags: [],
-            node_color: LIGHTDASH_PURPLE,
-            meta: { [LIGHTDASH_MARKER]: true },
-            created_at: timestamp,
-            filter: null,
-        },
-    ];
+    return {
+        unique_id: `metric.${packageName}.${resolvedName}`,
+        resource_type: 'metric',
+        name: resolvedName,
+        label: metricDef.label ?? resolvedName,
+        description: metricDef.description ?? '',
+        type: lightdashType === 'number' ? 'derived' : 'simple',
+        type_params: { measure: { name: resolvedName } },
+        package_name: packageName,
+        path: ymlPath,
+        original_file_path: ymlPath,
+        fqn: [packageName, resolvedName],
+        depends_on: { nodes: [smUniqueId], macros: [] },
+        config: { enabled: true },
+        tags: [],
+        node_color: LIGHTDASH_PURPLE,
+        meta: { [LIGHTDASH_MARKER]: true },
+        created_at: timestamp,
+        filter: null,
+    };
 }
+
+// ---------------------------------------------------------------------------
+// Injection logic
+// ---------------------------------------------------------------------------
 
 /**
  * Remove all previously injected nodes so we can re-inject cleanly.
  * Nodes are identified by the _lightdash_injected marker in their meta.
  * Also cleans up parent_map and child_map references to removed nodes.
  */
-// eslint-disable-next-line no-param-reassign
-function clearPreviousInjections(m: Manifest): void {
+function clearPreviousInjections(manifest: Manifest): void {
     for (const section of ['semantic_models', 'metrics'] as const) {
-        const sectionData = m[section] ?? {};
-        const toRemove = Object.keys(sectionData).filter((uid) => {
-            const node = sectionData[uid] as Record<string, unknown>;
-            const meta = node.meta as Record<string, unknown> | undefined;
-            return meta?.[LIGHTDASH_MARKER];
-        });
+        const sectionData = manifest[section] ?? {};
+        const toRemove = Object.keys(sectionData).filter(
+            (uid) => sectionData[uid].meta?.[LIGHTDASH_MARKER],
+        );
 
         for (const uid of toRemove) {
             delete sectionData[uid]; // eslint-disable-line no-param-reassign
-            delete m.parent_map[uid]; // eslint-disable-line no-param-reassign
+            delete manifest.parent_map[uid]; // eslint-disable-line no-param-reassign
 
-            for (const children of Object.values(m.child_map)) {
-                const idx = children.indexOf(uid);
-                if (idx !== -1) {
-                    children.splice(idx, 1);
-                }
+            // Remove this uid from any parent's children list
+            for (const parentUid of Object.keys(manifest.child_map)) {
+                removeChild(manifest.child_map, parentUid, uid);
             }
-            delete m.child_map[uid]; // eslint-disable-line no-param-reassign
+            delete manifest.child_map[uid]; // eslint-disable-line no-param-reassign
         }
     }
 }
 
 /**
- * Core injection logic. Takes a parsed manifest, clears old injections,
+ * Fix up derived metrics so their lineage points to input metrics, not the semantic model.
+ *
+ * Derived metrics (Lightdash type: "number") have SQL like "${total_revenue} / ${total_orders}".
+ * We parse those refs, find the corresponding injected metric nodes, and rewire the
+ * depends_on / parent_map / child_map so the lineage accurately reflects the dependency.
+ */
+function fixupDerivedMetricLineage(
+    manifest: Manifest,
+    modelsToPrefix: Set<string>,
+    originalToResolved: Map<string, ResolvedMetricInfo[]>,
+): void {
+    for (const [metricUid, metricNode] of Object.entries(manifest.metrics)) {
+        if (
+            !metricNode.meta?.[LIGHTDASH_MARKER] ||
+            metricNode.type !== 'derived'
+        ) {
+            // eslint-disable-next-line no-continue -- skip non-Lightdash and non-derived metrics
+            continue;
+        }
+
+        // Walk the lineage chain back: metric -> semantic_model -> model
+        const smParent = manifest.parent_map[metricUid][0];
+        const modelParent = manifest.parent_map[smParent][0];
+        const modelNode = manifest.nodes[modelParent];
+
+        // Find the original SQL for this derived metric
+        const needsPrefix = modelsToPrefix.has(modelParent);
+        let sql: string | null = null;
+        const tableMetrics = modelNode.meta?.metrics ?? {};
+        for (const [name, definition] of Object.entries(tableMetrics)) {
+            if (definition.type !== 'number') {
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+            const testResolved = resolveMetricName(
+                name,
+                modelNode.name,
+                needsPrefix,
+            );
+            if (testResolved === metricNode.name || name === metricNode.name) {
+                sql = definition.sql ?? '';
+                break;
+            }
+        }
+
+        if (!sql) {
+            // eslint-disable-next-line no-continue -- no SQL to parse
+            continue;
+        }
+
+        // Parse ${ref} from SQL to find input metrics
+        const refs = parseDerivedRefs(sql);
+        const dependencyIds: string[] = [];
+        for (const refName of refs) {
+            const candidates = originalToResolved.get(refName) ?? [];
+            // Prefer a metric from the same model, fall back to the first match
+            const sameModel = candidates.find(
+                (c) => c.modelUid === modelParent,
+            );
+            const matched = sameModel ?? candidates[0];
+            if (matched) {
+                dependencyIds.push(matched.metricUid);
+            }
+        }
+
+        if (dependencyIds.length === 0) {
+            // eslint-disable-next-line no-continue
+            continue;
+        }
+
+        // Rewire: derived metric depends on its input metrics, not the semantic model
+        metricNode.depends_on.nodes = dependencyIds;
+        manifest.parent_map[metricUid] = dependencyIds; // eslint-disable-line no-param-reassign
+
+        // Remove from semantic model's children
+        removeChild(manifest.child_map, smParent, metricUid);
+
+        // Add as child of each input metric
+        for (const depUid of dependencyIds) {
+            addChild(manifest.child_map, depUid, metricUid);
+        }
+    }
+}
+
+/**
+ * Core injection logic. Mutates the manifest in place: clears old injections,
  * then walks all project models to create semantic_model + metric nodes.
  *
  * The process has 4 steps:
@@ -284,11 +459,11 @@ function clearPreviousInjections(m: Manifest): void {
  *   3. For each model: create a semantic_model, then a metric per Lightdash metric
  *   4. Fix up derived metrics so their lineage points to input metrics, not semantic_model
  */
-function inject(m: Manifest): Manifest {
-    clearPreviousInjections(m);
+function inject(manifest: Manifest): InjectResult {
+    clearPreviousInjections(manifest);
 
     // Use manifest generation time for stable timestamps (idempotency)
-    const generatedAt = m.metadata.generated_at ?? '';
+    const generatedAt = manifest.metadata.generated_at ?? '';
     let timestamp: number;
     try {
         const dt = new Date(generatedAt);
@@ -300,21 +475,18 @@ function inject(m: Manifest): Manifest {
         timestamp = Date.now() / 1000;
     }
 
-    const packageName = m.metadata.project_name;
+    const packageName = manifest.metadata.project_name;
 
-    // Ensure top-level dicts exist
-    const result = {
-        ...m,
-        semantic_models: m.semantic_models ?? {},
-        metrics: m.metrics ?? {},
-        parent_map: m.parent_map ?? {},
-        child_map: m.child_map ?? {},
-    };
+    // Ensure top-level sections exist
+    manifest.semantic_models = manifest.semantic_models ?? {}; // eslint-disable-line no-param-reassign
+    manifest.metrics = manifest.metrics ?? {}; // eslint-disable-line no-param-reassign
+    manifest.parent_map = manifest.parent_map ?? {}; // eslint-disable-line no-param-reassign
+    manifest.child_map = manifest.child_map ?? {}; // eslint-disable-line no-param-reassign
 
     // Step 1: Collect all model nodes and their metrics
     const modelMetrics = new Map<string, Array<[string, MetricDef]>>();
     const modelNodes = new Map<string, ManifestNode>();
-    for (const [uid, node] of Object.entries(result.nodes)) {
+    for (const [uid, node] of Object.entries(manifest.nodes)) {
         if (
             node.resource_type === 'model' &&
             node.package_name === packageName
@@ -330,13 +502,12 @@ function inject(m: Manifest): Manifest {
     // Step 2: Find which models need all metrics prefixed (collision handling)
     const modelsToPrefix = findModelsNeedingPrefix(modelMetrics);
 
-    // Map from original metric name -> [{resolved, modelUid, metricUid}]
-    const originalToResolved = new Map<
-        string,
-        Array<{ resolved: string; modelUid: string; metricUid: string }>
-    >();
+    // Track original metric name -> resolved info for derived metric resolution
+    const originalToResolved = new Map<string, ResolvedMetricInfo[]>();
+    let semanticModelCount = 0;
+    let metricCount = 0;
 
-    // Step 3: Process each model
+    // Step 3: Process each model — create semantic_model + metric nodes
     for (const modelUid of modelNodes.keys()) {
         const node = modelNodes.get(modelUid)!;
         const metrics = modelMetrics.get(modelUid)!;
@@ -344,20 +515,15 @@ function inject(m: Manifest): Manifest {
         const needsPrefix = modelsToPrefix.has(modelUid);
 
         // Create semantic model
-        const [smUid, smNode] = buildSemanticModel(
-            node,
-            packageName,
-            timestamp,
-        );
-        result.semantic_models[smUid] = smNode;
+        const smNode = buildSemanticModel(node, packageName, timestamp);
+        const smUid = smNode.unique_id;
+        manifest.semantic_models[smUid] = smNode; // eslint-disable-line no-param-reassign
+        semanticModelCount += 1;
 
-        // Update parent/child maps for semantic model
-        result.parent_map[smUid] = [modelUid];
-        if (!result.child_map[modelUid]) result.child_map[modelUid] = [];
-        if (!result.child_map[modelUid].includes(smUid)) {
-            result.child_map[modelUid].push(smUid);
-        }
-        if (!result.child_map[smUid]) result.child_map[smUid] = [];
+        // Wire up lineage: model -> semantic_model
+        manifest.parent_map[smUid] = [modelUid]; // eslint-disable-line no-param-reassign
+        addChild(manifest.child_map, modelUid, smUid);
+        ensureChildMapEntry(manifest.child_map, smUid);
 
         // Create metric nodes
         for (const [metricName, metricDef] of metrics) {
@@ -366,7 +532,7 @@ function inject(m: Manifest): Manifest {
                 node.name,
                 needsPrefix,
             );
-            const [metricUid, metricNode] = buildMetric(
+            const metricNode = buildMetric(
                 resolved,
                 metricDef,
                 smUid,
@@ -374,7 +540,9 @@ function inject(m: Manifest): Manifest {
                 ymlPath,
                 timestamp,
             );
-            result.metrics[metricUid] = metricNode;
+            const metricUid = metricNode.unique_id;
+            manifest.metrics[metricUid] = metricNode; // eslint-disable-line no-param-reassign
+            metricCount += 1;
 
             // Track original name -> resolved for derived metric resolution
             if (!originalToResolved.has(metricName)) {
@@ -386,109 +554,22 @@ function inject(m: Manifest): Manifest {
                 metricUid,
             });
 
-            // Update parent/child maps for metric
-            result.parent_map[metricUid] = [smUid];
-            if (!result.child_map[smUid].includes(metricUid)) {
-                result.child_map[smUid].push(metricUid);
-            }
-            if (!result.child_map[metricUid]) result.child_map[metricUid] = [];
+            // Wire up lineage: semantic_model -> metric
+            manifest.parent_map[metricUid] = [smUid]; // eslint-disable-line no-param-reassign
+            addChild(manifest.child_map, smUid, metricUid);
+            ensureChildMapEntry(manifest.child_map, metricUid);
         }
     }
 
-    // Step 4: Fix up derived metrics - parse SQL refs and set correct depends_on
-    for (const [metricUid, metricNode] of Object.entries(result.metrics)) {
-        const meta = metricNode.meta as Record<string, unknown> | undefined;
-        if (
-            !meta?.[LIGHTDASH_MARKER] ||
-            (metricNode as Record<string, unknown>).type !== 'derived'
-        ) {
-            // eslint-disable-next-line no-continue -- skip non-Lightdash and non-derived metrics
-            continue;
-        }
+    // Step 4: Fix up derived metrics so their lineage points to input metrics
+    fixupDerivedMetricLineage(manifest, modelsToPrefix, originalToResolved);
 
-        const resolvedName = (metricNode as Record<string, unknown>)
-            .name as string;
-        const smParent = result.parent_map[metricUid][0];
-        const modelParent = result.parent_map[smParent][0];
-        const modelNode = result.nodes[modelParent];
-
-        const needsPrefix = modelsToPrefix.has(modelParent);
-        let sql: string | null = null;
-        const tableMetrics = modelNode.meta?.metrics ?? {};
-        for (const [name, defn] of Object.entries(tableMetrics)) {
-            if (defn.type === 'number') {
-                const testResolved = resolveMetricName(
-                    name,
-                    modelNode.name,
-                    needsPrefix,
-                );
-                if (testResolved === resolvedName || name === resolvedName) {
-                    sql = defn.sql ?? '';
-                    break;
-                }
-            }
-        }
-
-        if (!sql) {
-            // eslint-disable-next-line no-continue -- no SQL to parse
-            continue;
-        }
-
-        // Parse ${ref} from SQL to find input metrics
-        const refs = parseDerivedRefs(sql);
-        const depUids: string[] = [];
-        for (const refName of refs) {
-            const candidates = originalToResolved.get(refName) ?? [];
-            let matched: string | null = null;
-            for (const candidate of candidates) {
-                if (candidate.modelUid === modelParent) {
-                    matched = candidate.metricUid;
-                    break;
-                }
-            }
-            if (!matched && candidates.length > 0) {
-                matched = candidates[0].metricUid;
-            }
-            if (matched) {
-                depUids.push(matched);
-            }
-        }
-
-        if (depUids.length > 0) {
-            // Derived metric depends on its input metrics, not the semantic model
-            (
-                metricNode as Record<string, unknown> & {
-                    depends_on: { nodes: string[] };
-                }
-            ).depends_on.nodes = depUids;
-
-            // Update parent_map
-            result.parent_map[metricUid] = depUids;
-
-            // Remove from semantic model's children
-            const smChildren = result.child_map[smParent] ?? [];
-            const idx = smChildren.indexOf(metricUid);
-            if (idx !== -1) {
-                smChildren.splice(idx, 1);
-            }
-
-            // Add as child of each input metric
-            for (const depUid of depUids) {
-                if (!result.child_map[depUid]) result.child_map[depUid] = [];
-                if (!result.child_map[depUid].includes(metricUid)) {
-                    result.child_map[depUid].push(metricUid);
-                }
-            }
-        }
-    }
-
-    return result;
+    return { manifest, semanticModelCount, metricCount };
 }
 
-type InjectResult = {
-    semanticModelCount: number;
-    metricCount: number;
-};
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
 
 /**
  * Main entry point: reads a dbt manifest.json, injects Lightdash metric nodes,
@@ -496,7 +577,7 @@ type InjectResult = {
  */
 export async function injectLightdashLineage(
     manifestPath: string,
-): Promise<InjectResult> {
+): Promise<{ semanticModelCount: number; metricCount: number }> {
     GlobalState.debug(`Reading manifest from ${manifestPath}`);
 
     const raw = await fs.readFile(manifestPath, { encoding: 'utf-8' });
@@ -509,45 +590,24 @@ export async function injectLightdashLineage(
         );
     }
 
-    manifest = inject(manifest);
+    const result = inject(manifest);
 
-    await fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2));
+    await fs.writeFile(manifestPath, JSON.stringify(result.manifest, null, 2));
 
-    const semanticModelCount = Object.values(manifest.semantic_models).filter(
-        (n) => {
-            const meta = (n as Record<string, unknown>).meta as
-                | Record<string, unknown>
-                | undefined;
-            return meta?.[LIGHTDASH_MARKER];
-        },
-    ).length;
-
-    const metricCount = Object.values(manifest.metrics).filter((n) => {
-        const meta = (n as Record<string, unknown>).meta as
-            | Record<string, unknown>
-            | undefined;
-        return meta?.[LIGHTDASH_MARKER];
-    }).length;
-
-    return { semanticModelCount, metricCount };
+    return {
+        semanticModelCount: result.semanticModelCount,
+        metricCount: result.metricCount,
+    };
 }
 
-/** Resolve the path to manifest.json, respecting --target-path if provided */
-export function getManifestPath(
+/** Resolve a path inside the dbt target directory, respecting --target-path if provided */
+export function getTargetFilePath(
     projectDir: string,
-    targetPath?: string,
+    targetPath: string | undefined,
+    filename: string,
 ): string {
     const targetDir = targetPath ?? path.join(projectDir, 'target');
-    return path.join(targetDir, 'manifest.json');
-}
-
-/** Resolve the path to static_index.html, respecting --target-path if provided */
-export function getStaticIndexPath(
-    projectDir: string,
-    targetPath?: string,
-): string {
-    const targetDir = targetPath ?? path.join(projectDir, 'target');
-    return path.join(targetDir, 'static_index.html');
+    return path.join(targetDir, filename);
 }
 
 /**
@@ -567,7 +627,7 @@ export async function patchStaticIndex(
     const manifestContent = await fs.readFile(manifestPath, {
         encoding: 'utf-8',
     });
-    let html = await fs.readFile(staticIndexPath, { encoding: 'utf-8' });
+    const html = await fs.readFile(staticIndexPath, { encoding: 'utf-8' });
 
     // The static HTML embeds the manifest as: manifest: {<JSON>}, catalog:
     // Replace the manifest JSON between "manifest: " and ", catalog:"
@@ -582,9 +642,10 @@ export async function patchStaticIndex(
         );
     }
 
-    const before = html.slice(0, startIdx + startMarker.length);
-    const after = html.slice(endIdx);
-    html = before + manifestContent + after;
+    const patched =
+        html.slice(0, startIdx + startMarker.length) +
+        manifestContent +
+        html.slice(endIdx);
 
-    await fs.writeFile(staticIndexPath, html);
+    await fs.writeFile(staticIndexPath, patched);
 }

--- a/packages/cli/src/handlers/injectLightdashLineage.ts
+++ b/packages/cli/src/handlers/injectLightdashLineage.ts
@@ -22,7 +22,6 @@
  * `node_color` data attribute, which dbt docs' Cytoscape config picks up.
  */
 import { promises as fs } from 'fs';
-import * as path from 'path';
 import GlobalState from '../globalState';
 
 /** Marker added to meta on all injected nodes, used to identify and clean them up */
@@ -598,54 +597,4 @@ export async function injectLightdashLineage(
         semanticModelCount: result.semanticModelCount,
         metricCount: result.metricCount,
     };
-}
-
-/** Resolve a path inside the dbt target directory, respecting --target-path if provided */
-export function getTargetFilePath(
-    projectDir: string,
-    targetPath: string | undefined,
-    filename: string,
-): string {
-    const targetDir = targetPath ?? path.join(projectDir, 'target');
-    return path.join(targetDir, filename);
-}
-
-/**
- * Patch static_index.html with the injected manifest.
- *
- * `dbt docs generate --static` produces a self-contained HTML file that embeds
- * the manifest and catalog inline as JavaScript:
- *   var n = { manifest: {<JSON>}, catalog: {<JSON>} }
- *
- * Since we modified manifest.json after dbt generated this file, we need to
- * find and replace the embedded manifest with our injected version.
- */
-export async function patchStaticIndex(
-    manifestPath: string,
-    staticIndexPath: string,
-): Promise<void> {
-    const manifestContent = await fs.readFile(manifestPath, {
-        encoding: 'utf-8',
-    });
-    const html = await fs.readFile(staticIndexPath, { encoding: 'utf-8' });
-
-    // The static HTML embeds the manifest as: manifest: {<JSON>}, catalog:
-    // Replace the manifest JSON between "manifest: " and ", catalog:"
-    const startMarker = 'manifest: ';
-    const endMarker = ', catalog:';
-    const startIdx = html.indexOf(startMarker);
-    const endIdx = html.indexOf(endMarker, startIdx);
-
-    if (startIdx === -1 || endIdx === -1) {
-        throw new Error(
-            'Could not find manifest embedding in static_index.html',
-        );
-    }
-
-    const patched =
-        html.slice(0, startIdx + startMarker.length) +
-        manifestContent +
-        html.slice(endIdx);
-
-    await fs.writeFile(staticIndexPath, patched);
 }

--- a/packages/cli/src/handlers/injectLightdashLineage.ts
+++ b/packages/cli/src/handlers/injectLightdashLineage.ts
@@ -119,7 +119,14 @@ type InjectResult = {
 type ResolvedMetricInfo = {
     resolved: string;
     modelUid: string;
+    modelName: string;
     metricUid: string;
+};
+
+/** A parsed ${ref} from a derived metric's SQL */
+type ParsedRef = {
+    modelName: string | null;
+    metricName: string;
 };
 
 // ---------------------------------------------------------------------------
@@ -244,13 +251,25 @@ function resolveMetricName(
 }
 
 /**
- * Parse ${metric_name} references from a derived metric's SQL expression.
- * e.g. "${total_revenue} / ${total_orders}" -> ["total_revenue", "total_orders"]
+ * Parse ${ref} references from a derived metric's SQL expression.
+ * Supports both same-model refs and cross-model refs:
+ *   "${total_revenue}"                    -> { modelName: null, metricName: "total_revenue" }
+ *   "${dbt_orders.count_distinct_order_id}" -> { modelName: "dbt_orders", metricName: "count_distinct_order_id" }
  */
-function parseDerivedRefs(sql: string): string[] {
-    const matches = sql.match(/\$\{(\w+)\}/g);
+function parseDerivedRefs(sql: string): ParsedRef[] {
+    const matches = sql.match(/\$\{([\w.]+)\}/g);
     if (!matches) return [];
-    return matches.map((m) => m.slice(2, -1));
+    return matches.map((m) => {
+        const inner = m.slice(2, -1);
+        const dotIdx = inner.indexOf('.');
+        if (dotIdx !== -1) {
+            return {
+                modelName: inner.slice(0, dotIdx),
+                metricName: inner.slice(dotIdx + 1),
+            };
+        }
+        return { modelName: null, metricName: inner };
+    });
 }
 
 // ---------------------------------------------------------------------------
@@ -430,15 +449,22 @@ function fixupDerivedMetricLineage(
         }
 
         // Parse ${ref} from SQL to find input metrics
+        // Refs can be same-model (${metric_name}) or cross-model (${model_name.metric_name})
         const refs = parseDerivedRefs(sql);
         const dependencyIds: string[] = [];
-        for (const refName of refs) {
-            const candidates = originalToResolved.get(refName) ?? [];
-            // Prefer a metric from the same model, fall back to the first match
-            const sameModel = candidates.find(
-                (c) => c.modelUid === modelParent,
-            );
-            const matched = sameModel ?? candidates[0];
+        for (const ref of refs) {
+            const candidates = originalToResolved.get(ref.metricName) ?? [];
+            let matched: ResolvedMetricInfo | undefined;
+            if (ref.modelName) {
+                // Cross-model ref: match by model name
+                matched = candidates.find((c) => c.modelName === ref.modelName);
+            } else {
+                // Same-model ref: prefer same model, fall back to first match
+                const sameModel = candidates.find(
+                    (c) => c.modelUid === modelParent,
+                );
+                matched = sameModel ?? candidates[0];
+            }
             if (matched) {
                 dependencyIds.push(matched.metricUid);
             }
@@ -566,6 +592,7 @@ function inject(manifest: Manifest): InjectResult {
             originalToResolved.get(metricName)!.push({
                 resolved,
                 modelUid,
+                modelName: node.name,
                 metricUid,
             });
 

--- a/packages/cli/src/handlers/injectLightdashLineage.ts
+++ b/packages/cli/src/handlers/injectLightdashLineage.ts
@@ -22,6 +22,7 @@
  * `node_color` data attribute, which dbt docs' Cytoscape config picks up.
  */
 import { promises as fs } from 'fs';
+import yaml from 'js-yaml';
 import GlobalState from '../globalState';
 
 /** Marker added to meta on all injected nodes, used to identify and clean them up */
@@ -94,7 +95,7 @@ type InjectedSemanticModel = InjectedNodeBase & {
 type InjectedMetric = InjectedNodeBase & {
     resource_type: 'metric';
     type: 'simple' | 'derived';
-    type_params: { measure: { name: string } };
+    type_params: { measure: { name: string }; expr: string };
     filter: null;
 };
 
@@ -297,12 +298,23 @@ function buildSemanticModel(
     };
 }
 
+/** Format the metric description with the original YAML definition appended */
+function buildMetricDescription(
+    metricName: string,
+    metricDef: MetricDef,
+): string {
+    const baseDescription = metricDef.description ?? '';
+    const yamlBlock = yaml.dump({ [metricName]: metricDef }, { lineWidth: -1 });
+    return `${baseDescription}\n\n---\n\n\`\`\`yaml\n${yamlBlock}\`\`\``;
+}
+
 /**
  * Build a dbt metric manifest node for a Lightdash metric.
  * Lightdash "number" type metrics become dbt "derived" metrics (they reference other metrics).
  * All other types (sum, count, average, etc.) become dbt "simple" metrics.
  */
 function buildMetric(
+    metricName: string,
     resolvedName: string,
     metricDef: MetricDef,
     smUniqueId: string,
@@ -317,9 +329,12 @@ function buildMetric(
         resource_type: 'metric',
         name: resolvedName,
         label: metricDef.label ?? resolvedName,
-        description: metricDef.description ?? '',
+        description: buildMetricDescription(metricName, metricDef),
         type: lightdashType === 'number' ? 'derived' : 'simple',
-        type_params: { measure: { name: resolvedName } },
+        type_params: {
+            measure: { name: resolvedName },
+            expr: metricDef.sql ?? '',
+        },
         package_name: packageName,
         path: ymlPath,
         original_file_path: ymlPath,
@@ -532,6 +547,7 @@ function inject(manifest: Manifest): InjectResult {
                 needsPrefix,
             );
             const metricNode = buildMetric(
+                metricName,
                 resolved,
                 metricDef,
                 smUid,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -24,6 +24,7 @@ import { diagnosticsHandler } from './handlers/diagnostics';
 import { downloadHandler, uploadHandler } from './handlers/download';
 import { exportChartImageHandler } from './handlers/exportChartImage';
 import { generateHandler } from './handlers/generate';
+import { generateDocsHandler } from './handlers/generateDocs';
 import { generateExposuresHandler } from './handlers/generateExposures';
 import { getProjectHandler } from './handlers/getProject';
 import { installSkillsHandler } from './handlers/installSkills';
@@ -1094,6 +1095,53 @@ ${styles.bold('Examples:')}
         undefined,
     )
     .action(generateExposuresHandler);
+
+program
+    .command('generate-docs')
+    .description(
+        'Generates dbt docs with Lightdash metrics injected into the lineage graph',
+    )
+    .addHelpText(
+        'after',
+        `
+${styles.bold('Examples:')}
+  ${styles.title('⚡')}️lightdash ${styles.bold(
+      'generate-docs',
+  )} ${styles.secondary('-- generate docs and serve with Lightdash lineage')}
+  ${styles.title('⚡')}️lightdash ${styles.bold(
+      'generate-docs',
+  )} --no-serve ${styles.secondary('-- generate and inject without serving')}
+  ${styles.title('⚡')}️lightdash ${styles.bold(
+      'generate-docs',
+  )} --skip-inject ${styles.secondary('-- generate and serve without Lightdash injection')}
+`,
+    )
+    .option(
+        '--project-dir <path>',
+        'The directory of the dbt project',
+        defaultProjectDir,
+    )
+    .option(
+        '--profiles-dir <path>',
+        'The directory of the dbt profiles',
+        defaultProfilesDir,
+    )
+    .option('--target <target>', 'The dbt target to use')
+    .option('--target-path <path>', 'Override the target directory for output')
+    .option('--verbose', undefined, false)
+    .option(
+        '--skip-inject',
+        'Skip Lightdash metric injection into manifest',
+        false,
+    )
+    .option(
+        '--static',
+        'Generate a static_index.html with manifest and catalog built-in',
+        false,
+    )
+    .option('--no-serve', 'Do not run dbt docs serve after generation')
+    .option('--port <port>', 'Port for dbt docs serve', parseIntArgument, 8080)
+    .action(generateDocsHandler);
 
 program
     .command('diagnostics')


### PR DESCRIPTION
## Summary

- Adds a new `lightdash generate-docs` CLI command that generates dbt docs and then hijacks dbts metric and semantic layer nodes to display Lightdash nodes.
- Injects semantic_model and metric nodes into `manifest.json` so Lightdash metrics (defined in dbt YAML under `meta.metrics`) appear as purple-colored nodes on the dbt docs lineage graph
- Supports both server mode (`dbt docs serve`) and static mode (`--static` for a self-contained HTML file)

## How it works

1. Compiles the dbt project into an isolated `target/lightdash_docs/` directory (via `dbt compile --target-path`), leaving the project's real `target/` untouched
2. Injects Lightdash metric nodes into the isolated `manifest.json`:
   - One **semantic_model** node per model that has Lightdash metrics (light purple)
   - One **metric** node per Lightdash metric definition (full Lightdash purple)
   - Correct `parent_map`/`child_map` lineage, including derived metric dependencies
   - Cross-model metric references (e.g. `${dbt_orders.count_distinct_order_id}`) are resolved so derived metrics connect to metrics from multiple semantic models
   - Each metric description includes the full Lightdash YAML definition as a code block, and `type_params.expr` is populated with the SQL expression
3. Runs `dbt docs generate --no-compile --target-path target/lightdash_docs/` which picks up the already-injected manifest (since `--no-compile` skips writing `manifest.json`), including for `--static` HTML embedding
4. Serves docs or prints the static file path. All dbt output is suppressed behind spinners for clean CLI output

All injected nodes are tagged with `_lightdash_injected` in their meta for idempotent re-runs.

## Usage

```bash
# Generate docs and serve locally
lightdash generate-docs

# Generate a self-contained static HTML file
lightdash generate-docs --static
```

## Test plan

- [x] `pnpm -F cli build` compiles without errors
- [x] `pnpm -F cli typecheck` passes
- [x] Injection produces correct semantic_model and metric nodes in manifest.json
- [x] Derived metrics have correct lineage (depend on input metrics, not semantic model)
- [x] Cross-model derived metrics connect to metrics from multiple semantic models
- [x] Idempotent: running twice produces identical output
- [x] `--static` flag produces static_index.html with injected manifest embedded
- [x] `--no-serve` flag skips dbt docs serve
- [x] Node colors render correctly in dbt docs lineage graph
- [x] Project's real `target/` directory is never modified

Below is an example of this running locally against Thyme to Shine

<img width="1327" height="678" alt="image" src="https://github.com/user-attachments/assets/0b2f1739-0734-4303-9324-8241af054454" />