### PR TITLE
refactor: extract pre-aggregate metric representation logic

### DIFF
--- a/packages/backend/src/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -180,7 +180,7 @@ describe('buildMaterializationMetricQuery', () => {
                 orders_order_count: [
                     {
                         componentFieldId: 'orders_order_count',
-                        aggregation: 'sum',
+                        aggregation: MetricType.SUM,
                     },
                 ],
             });
@@ -243,11 +243,11 @@ describe('buildMaterializationMetricQuery', () => {
             orders_avg_order_amount: [
                 {
                     componentFieldId: 'orders_avg_order_amount__sum',
-                    aggregation: 'sum',
+                    aggregation: MetricType.SUM,
                 },
                 {
                     componentFieldId: 'orders_avg_order_amount__count',
-                    aggregation: 'sum',
+                    aggregation: MetricType.SUM,
                 },
             ],
         });

--- a/packages/common/src/preAggregates/index.ts
+++ b/packages/common/src/preAggregates/index.ts
@@ -3,5 +3,6 @@ export * from './buildPreAggregateExplore';
 export * from './definition';
 export * from './generatePreAggregateExplores';
 export * from './matcher';
+export * from './metricRepresentation';
 export * from './naming';
 export * from './references';

--- a/packages/common/src/preAggregates/metricRepresentation.ts
+++ b/packages/common/src/preAggregates/metricRepresentation.ts
@@ -1,0 +1,90 @@
+import { MetricType } from '../types/field';
+import assertUnreachable from '../utils/assertUnreachable';
+
+export type SupportedPreAggregateMetricType =
+    | MetricType.SUM
+    | MetricType.COUNT
+    | MetricType.MIN
+    | MetricType.MAX
+    | MetricType.AVERAGE;
+
+export enum PreAggregateMetricRepresentationKind {
+    DIRECT = 'direct',
+    DECOMPOSED = 'decomposed',
+    UNSUPPORTED = 'unsupported',
+}
+
+export type PreAggregateMetricRepresentation =
+    | {
+          kind: PreAggregateMetricRepresentationKind.DIRECT;
+          metricType: MetricType.SUM | MetricType.MIN | MetricType.MAX;
+      }
+    | {
+          kind: PreAggregateMetricRepresentationKind.DECOMPOSED;
+          metricType: MetricType.AVERAGE;
+          components: readonly ['sum', 'count'];
+      }
+    | {
+          kind: PreAggregateMetricRepresentationKind.UNSUPPORTED;
+      };
+
+export const supportedPreAggregateMetricTypes: SupportedPreAggregateMetricType[] =
+    [
+        MetricType.SUM,
+        MetricType.COUNT,
+        MetricType.MIN,
+        MetricType.MAX,
+        MetricType.AVERAGE,
+    ];
+
+export const getPreAggregateMetricRepresentation = (
+    metricType: MetricType,
+): PreAggregateMetricRepresentation => {
+    switch (metricType) {
+        case MetricType.SUM:
+        case MetricType.COUNT:
+            return {
+                kind: PreAggregateMetricRepresentationKind.DIRECT,
+                metricType: MetricType.SUM,
+            };
+        case MetricType.MIN:
+            return {
+                kind: PreAggregateMetricRepresentationKind.DIRECT,
+                metricType: MetricType.MIN,
+            };
+        case MetricType.MAX:
+            return {
+                kind: PreAggregateMetricRepresentationKind.DIRECT,
+                metricType: MetricType.MAX,
+            };
+        case MetricType.AVERAGE:
+            return {
+                kind: PreAggregateMetricRepresentationKind.DECOMPOSED,
+                metricType: MetricType.AVERAGE,
+                components: ['sum', 'count'],
+            };
+        case MetricType.COUNT_DISTINCT:
+        case MetricType.SUM_DISTINCT:
+        case MetricType.MEDIAN:
+        case MetricType.PERCENTILE:
+        case MetricType.NUMBER:
+        case MetricType.STRING:
+        case MetricType.DATE:
+        case MetricType.TIMESTAMP:
+        case MetricType.BOOLEAN:
+        case MetricType.PERCENT_OF_PREVIOUS:
+        case MetricType.PERCENT_OF_TOTAL:
+        case MetricType.RUNNING_TOTAL:
+            return {
+                kind: PreAggregateMetricRepresentationKind.UNSUPPORTED,
+            };
+        default:
+            return assertUnreachable(metricType, `Unknown metric type`);
+    }
+};
+
+export const isSupportedPreAggregateMetricType = (
+    metricType: MetricType,
+): metricType is SupportedPreAggregateMetricType =>
+    getPreAggregateMetricRepresentation(metricType).kind !==
+    PreAggregateMetricRepresentationKind.UNSUPPORTED;

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -1,4 +1,4 @@
-import { type FieldId } from './field';
+import { type FieldId, type MetricType } from './field';
 import { type KnexPaginatedData } from './knex-paginate';
 import { type MetricQuery } from './metricQuery';
 import { type ResultColumns } from './results';
@@ -7,7 +7,7 @@ import { type TimeFrames } from './timeFrames';
 
 export type MaterializationMetricComponent = {
     componentFieldId: string;
-    aggregation: 'sum' | 'count' | 'min' | 'max';
+    aggregation: MetricType.SUM | MetricType.MIN | MetricType.MAX;
 };
 
 export type MaterializationMetricQueryPayload = {


### PR DESCRIPTION
### Description:

Refactored pre-aggregate metric handling by introducing a centralized metric representation system. Created a new `metricRepresentation.ts` module that defines how different metric types are represented in pre-aggregates through `PreAggregateMetricRepresentation` with three kinds: `DIRECT`, `DECOMPOSED`, and `UNSUPPORTED`.

Replaced hardcoded string literals with `MetricType` enum values for aggregation types in `MaterializationMetricComponent`. Updated both the materialization service and explore builder to use the new representation system, consolidating the logic for determining how metrics should be handled in pre-aggregates.
