### PR TITLE
chore: add log whenever role deletion fails

### DIFF
--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -450,7 +450,9 @@ export class RolesService extends BaseService {
             .catch((err) => {
                 this.logger.error(
                     'Failed to send org admin role change notification',
-                    { error: err },
+                    {
+                        error: err,
+                    },
                 );
             });
 
@@ -781,6 +783,12 @@ export class RolesService extends BaseService {
                 error instanceof DatabaseError &&
                 error.code === foreignKeyViolation
             ) {
+                this.logger.error('Role deletion blocked by FK constraint', {
+                    roleUuid,
+                    detail: error.detail,
+                    constraint: error.constraint,
+                    table: error.table,
+                });
                 throw new ParameterError('Role cannot be deleted if assigned');
             }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Enhanced error logging in the RolesService to provide better debugging information when role deletion fails due to foreign key constraints. Added detailed logging that captures the role UUID, error details, constraint name, and affected table when a role cannot be deleted because it's still assigned to users or resources.