### PR TITLE
chore: ts 6 backend

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -191,6 +191,6 @@
         "knex-mock-client": "^1.11.0",
         "nodemon": "^3.1.9",
         "ts-node": "^10.9.2",
-        "typescript": "5.5.4"
+        "typescript": "6.0.0-beta"
     }
 }

--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -1,70 +1,26 @@
 {
     "extends": "./../../tsconfig.json",
     "compilerOptions": {
-        /* Visit https://aka.ms/tsconfig.json to read more about this file */
-        "resolveJsonModule": true,
-        /* Basic Options */
-        "incremental": true /* Enable incremental compilation */,
-        "target": "ES2020" /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */,
-        "module": "CommonJS" /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */,
+        "target": "ES2020",
+        "module": "CommonJS",
         "lib": ["ESNext", "DOM"],
-        "allowJs": false /* Allow javascript files to be compiled. */,
-        // "checkJs": true,                             /* Report errors in .js files. */
-        "jsx": "react" /* Specify JSX code generation: 'preserve', 'react-native', 'react', 'react-jsx' or 'react-jsxdev'. */,
-        "jsxFactory": "xmlBuilder" /* Specify the JSX factory function when targeting React JSX emit. */,
-        "declaration": true /* Generates corresponding '.d.ts' file. */,
-        "declarationMap": true /* Generates a sourcemap for each corresponding '.d.ts' file. */,
-        // "sourceMap": true,                           /* Generates corresponding '.map' file. */
-        // "outFile": "./",                             /* Concatenate and emit output to single file. */
+        "incremental": true,
+        "jsx": "react",
+        "jsxFactory": "xmlBuilder",
+        "declaration": true,
+        "declarationMap": true,
         "outDir": "dist",
         "rootDir": "src",
-        "composite": true /* Enable project compilation */,
-        "tsBuildInfoFile": "dist/.tsbuildinfo" /* Specify file to store incremental compilation information */,
-        // "removeComments": true,                      /* Do not emit comments to output. */
-        // "noEmit": true,                              /* Do not emit outputs. */
-        "importHelpers": true /* Import emit helpers from 'tslib'. */,
-        // "downlevelIteration": true,                  /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
-        "isolatedModules": true /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */,
-        /* Strict Type-Checking Options */
-        "strict": true /* Enable all strict type-checking options. */,
-        "strictNullChecks": true /* Enable strict null checks. */,
-        // "strictFunctionTypes": true,                 /* Enable strict checking of function types. */
-        "strictBindCallApply": true /* Enable strict 'bind', 'call', and 'apply' methods on functions. */,
-        // "strictPropertyInitialization": true,        /* Enable strict checking of property initialization in classes. */
-        // "noImplicitThis": true,                      /* Raise error on 'this' expressions with an implied 'any' type. */
-        // "alwaysStrict": true,                        /* Parse in strict mode and emit "use strict" for each source file. */
-        /* Additional Checks */
-        // "noUnusedLocals": true,                      /* Report errors on unused locals. */
-        // "noUnusedParameters": true,                  /* Report errors on unused parameters. */
-        // "noImplicitReturns": true,                   /* Report error when not all code paths in function return a value. */
-        // "noFallthroughCasesInSwitch": true,          /* Report errors for fallthrough cases in switch statement. */
-        // "noUncheckedIndexedAccess": true,            /* Include 'undefined' in index signature results */
-        // "noPropertyAccessFromIndexSignature": true,  /* Require undeclared properties from index signatures to use element accesses. */
-        /* Module Resolution Options */
-        "moduleResolution": "Node" /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */,
-        // "baseUrl": "./",                             /* Base directory to resolve non-absolute module names. */
-        // "paths": {},                                 /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
-        // "rootDirs": [],                              /* List of root folders whose combined content represents the structure of the project at runtime. */
-        //        "typeRoots": [
-        //            "./src/@types",
-        //            "./node_modules/@types"
-        //        ] /* List of folders to include type definitions from. */,
-        // "types": [],                                 /* Type declaration files to be included in compilation. */
-        // "allowSyntheticDefaultImports": true, /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-        "esModuleInterop": true /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */,
-        // "preserveSymlinks": true,                    /* Do not resolve the real path of symlinks. */
-        // "allowUmdGlobalAccess": true,                /* Allow accessing UMD globals from modules. */
-        /* Source Map Options */
-        // "sourceRoot": "",                            /* Specify the location where debugger should locate TypeScript files instead of source locations. */
-        // "mapRoot": "",                               /* Specify the location where debugger should locate map files instead of generated locations. */
-        // "inlineSourceMap": true,                     /* Emit a single file with source maps instead of having a separate file. */
-        // "inlineSources": true,                       /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
-        /* Experimental Options */
-        "experimentalDecorators": true /* Enables experimental support for ES7 decorators. */,
-        // "emitDecoratorMetadata": true,               /* Enables experimental support for emitting type metadata for decorators. */
-        /* Advanced Options */
-        "skipLibCheck": true /* Skip type checking of declaration files. */,
-        "forceConsistentCasingInFileNames": true /* Disallow inconsistently-cased references to the same file. */
+        "composite": true,
+        "tsBuildInfoFile": "dist/.tsbuildinfo",
+        "importHelpers": true,
+        "isolatedModules": true,
+        "experimentalDecorators": true,
+        "ignoreDeprecations": "6.0",
+        "moduleResolution": "node10",
+        "resolveJsonModule": true,
+        "skipLibCheck": true,
+        "types": ["node", "jest"]
     },
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
     "exclude": ["dist", "node_modules", "src/ee/services/McpService/mcp-chart-app"],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -571,10 +571,10 @@ importers:
         version: 3.1.9
       ts-node:
         specifier: ^10.9.2
-        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@5.5.4)
+        version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.0-beta)
       typescript:
-        specifier: 5.5.4
-        version: 5.5.4
+        specifier: 6.0.0-beta
+        version: 6.0.0-beta
 
   packages/cli:
     dependencies:
@@ -20378,7 +20378,7 @@ snapshots:
       async: 3.2.6
       chalk: 3.0.0
       dayjs: 1.8.36
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eventemitter2: 5.0.1
       fast-json-patch: 3.1.1
       fclone: 1.0.11
@@ -20397,7 +20397,7 @@ snapshots:
   '@pm2/io@6.1.0':
     dependencies:
       async: 2.6.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eventemitter2: 6.4.7
       require-in-the-middle: 5.2.0
       semver: 7.5.4
@@ -20410,7 +20410,7 @@ snapshots:
   '@pm2/js-api@0.8.0':
     dependencies:
       async: 2.6.4
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eventemitter2: 6.4.7
       extrareqp2: 1.0.0(debug@4.3.7)
       ws: 7.5.10
@@ -22914,7 +22914,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/type-utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
       '@typescript-eslint/utils': 5.62.0(eslint@8.57.1)(typescript@5.5.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eslint: 8.57.1
       graphemer: 1.4.0
       ignore: 5.2.0
@@ -22948,7 +22948,7 @@ snapshots:
       '@typescript-eslint/scope-manager': 5.62.0
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/typescript-estree': 5.62.0(typescript@5.5.4)
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 5.5.4
@@ -26647,7 +26647,7 @@ snapshots:
 
   follow-redirects@1.15.9(debug@4.3.7):
     optionalDependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
 
   for-each@0.3.3:
     dependencies:
@@ -29827,7 +29827,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -32115,7 +32115,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.3.7(supports-color@5.5.0)
+      debug: 4.3.7(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -32900,6 +32900,7 @@ snapshots:
       yn: 3.1.1
     optionalDependencies:
       '@swc/core': 1.13.5
+    optional: true
 
   ts-node@10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.0-beta):
     dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Upgrades TypeScript from version 5.5.4 to 6.0.0-beta in the backend package. The TypeScript configuration has been cleaned up by removing extensive comments and consolidating compiler options into a more concise format. 

Key changes include:
- Added `ignoreDeprecations: "6.0"` to handle TypeScript 6.0 deprecation warnings
- Updated `moduleResolution` from "Node" to "node10" 
- Added explicit `types: ["node", "jest"]` configuration
- Removed verbose comments and reorganized compiler options for better readability

The pnpm lockfile has been updated accordingly to reflect the new TypeScript version and its dependencies.