### PR TITLE
feat: move async queries to worker

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -158,6 +158,10 @@ export const lightdashConfigMock: LightdashConfig = {
         pollInterval: 1000,
         jobTimeout: 0,
         tasks: ALL_TASK_NAMES,
+        asyncQueryWorkers: {
+            preAggregatesEnabled: false,
+            warehouseEnabled: false,
+        },
         queryHistory: {
             cleanup: {
                 enabled: true,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -613,6 +613,29 @@ describe('scheduler poll interval', () => {
     });
 });
 
+describe('scheduler async query worker gates', () => {
+    test('should default async query worker gates to disabled', () => {
+        const config = parseConfig();
+
+        expect(config.scheduler.asyncQueryWorkers).toEqual({
+            preAggregatesEnabled: false,
+            warehouseEnabled: false,
+        });
+    });
+
+    test('should parse async query worker gates from environment variables', () => {
+        process.env.SCHEDULER_PRE_AGGREGATE_QUERY_WORKER_ENABLED = 'true';
+        process.env.SCHEDULER_WAREHOUSE_QUERY_WORKER_ENABLED = 'true';
+
+        const config = parseConfig();
+
+        expect(config.scheduler.asyncQueryWorkers).toEqual({
+            preAggregatesEnabled: true,
+            warehouseEnabled: true,
+        });
+    });
+});
+
 test('should set useSqlPivotResults only when the environment variable is set', () => {
     const undefinedConfig = parseConfig();
     expect(undefinedConfig.query.useSqlPivotResults).toBeUndefined();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -919,6 +919,10 @@ export type LightdashConfig = {
         jobTimeout: number;
         screenshotTimeout?: number;
         tasks: Array<SchedulerTaskName>;
+        asyncQueryWorkers: {
+            preAggregatesEnabled: boolean;
+            warehouseEnabled: boolean;
+        };
         queryHistory: {
             cleanup: {
                 enabled: boolean;
@@ -1765,6 +1769,14 @@ export const parseConfig = (): LightdashConfig => {
                 ? parseInt(process.env.SCHEDULER_SCREENSHOT_TIMEOUT, 10)
                 : undefined,
             tasks: parseAndSanitizeSchedulerTasks(),
+            asyncQueryWorkers: {
+                preAggregatesEnabled:
+                    process.env.SCHEDULER_PRE_AGGREGATE_QUERY_WORKER_ENABLED ===
+                    'true',
+                warehouseEnabled:
+                    process.env.SCHEDULER_WAREHOUSE_QUERY_WORKER_ENABLED ===
+                    'true',
+            },
             queryHistory: {
                 cleanup: {
                     enabled:

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -46,6 +46,43 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
     protected getFullTaskList(): TypedEETaskList {
         return {
             ...super.getFullTaskList(),
+            [SCHEDULER_TASKS.RUN_ASYNC_PRE_AGGREGATE_QUERY]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        SCHEDULER_TASKS.RUN_ASYNC_PRE_AGGREGATE_QUERY,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.runAsyncPreAggregateQuery(
+                                helpers.job.id,
+                                helpers.job.run_at,
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    this.lightdashConfig.scheduler.jobTimeout,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: SCHEDULER_TASKS.RUN_ASYNC_PRE_AGGREGATE_QUERY,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                createdByUserUuid: payload.userUuid,
+                                error: getErrorMessage(e),
+                                queryUuid: payload.queryUuid,
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                            },
+                        });
+                    },
+                );
+            },
             [EE_SCHEDULER_TASKS.SLACK_AI_PROMPT]: async (payload, _helpers) => {
                 await this.aiAgentService.replyToSlackPrompt(
                     payload.slackPromptUuid,

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -23,6 +23,8 @@ import {
     NotificationPayloadBase,
     QueueTraceProperties,
     ReplaceCustomFieldsPayload,
+    RunAsyncPreAggregateQueryPayload,
+    RunAsyncWarehouseQueryPayload,
     ScheduledDeliveryPayload,
     ScheduledJobs,
     Scheduler,
@@ -1218,6 +1220,36 @@ export class SchedulerClient {
                 createdByUserUuid: payload.userUuid,
             },
         });
+
+        return { jobId };
+    }
+
+    async runAsyncPreAggregateQuery(payload: RunAsyncPreAggregateQueryPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const jobId = await SchedulerClient.addJob(
+            graphileClient,
+            SCHEDULER_TASKS.RUN_ASYNC_PRE_AGGREGATE_QUERY,
+            payload,
+            now,
+            JobPriority.HIGH,
+            1,
+        );
+
+        return { jobId };
+    }
+
+    async runAsyncWarehouseQuery(payload: RunAsyncWarehouseQueryPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const jobId = await SchedulerClient.addJob(
+            graphileClient,
+            SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY,
+            payload,
+            now,
+            JobPriority.HIGH,
+            1,
+        );
 
         return { jobId };
     }

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -96,6 +96,9 @@ import {
     type MsTeamsNotificationPayload,
     type PartialFailure,
     type PivotConfiguration,
+    type RunAsyncPreAggregateQueryPayload,
+    type RunAsyncWarehouseQueryPayload,
+    type RunQueryTags,
     type SchedulerIndexCatalogJobPayload,
     type SlackBatchNotificationPayload,
 } from '@lightdash/common';
@@ -3712,6 +3715,54 @@ export default class SchedulerTask {
                     account,
                     ...payload,
                 });
+            },
+        );
+    }
+
+    protected async runAsyncPreAggregateQuery(
+        jobId: string,
+        scheduledTime: Date,
+        payload: RunAsyncPreAggregateQueryPayload,
+    ) {
+        await this.logWrapper(
+            {
+                task: SCHEDULER_TASKS.RUN_ASYNC_PRE_AGGREGATE_QUERY,
+                jobId,
+                scheduledTime,
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    queryUuid: payload.queryUuid,
+                    projectUuid: payload.projectUuid,
+                    organizationUuid: payload.organizationUuid,
+                },
+            },
+            async () => {
+                await this.asyncQueryService.runAsyncPreAggregateQuery(payload);
+                return undefined;
+            },
+        );
+    }
+
+    protected async runAsyncWarehouseQuery(
+        jobId: string,
+        scheduledTime: Date,
+        payload: RunAsyncWarehouseQueryPayload,
+    ) {
+        await this.logWrapper(
+            {
+                task: SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY,
+                jobId,
+                scheduledTime,
+                details: {
+                    createdByUserUuid: payload.userUuid,
+                    queryUuid: payload.queryUuid,
+                    projectUuid: payload.projectUuid,
+                    organizationUuid: payload.organizationUuid,
+                },
+            },
+            async () => {
+                await this.asyncQueryService.runAsyncWarehouseQuery(payload);
+                return undefined;
             },
         );
     }

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -128,6 +128,18 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
 
+    [SCHEDULER_TASKS.RUN_ASYNC_PRE_AGGREGATE_QUERY]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
+
+    [SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
+
     [SCHEDULER_TASKS.GENERATE_DAILY_JOBS]: () => ({}),
 
     [SCHEDULER_TASKS.EXPORT_CSV_DASHBOARD]: (payload) => ({

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -975,6 +975,43 @@ export class SchedulerWorker extends SchedulerTask {
                     throw error;
                 }
             },
+            [SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.runAsyncWarehouseQuery(
+                                helpers.job.id,
+                                helpers.job.run_at,
+                                payload,
+                            );
+                        },
+                    ),
+                    helpers.job,
+                    this.lightdashConfig.scheduler.jobTimeout,
+                    async (job, e) => {
+                        await this.schedulerService.logSchedulerJob({
+                            task: SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY,
+                            jobId: job.id,
+                            scheduledTime: job.run_at,
+                            status: SchedulerJobStatus.ERROR,
+                            details: {
+                                createdByUserUuid: payload.userUuid,
+                                error: getErrorMessage(e),
+                                queryUuid: payload.queryUuid,
+                                projectUuid: payload.projectUuid,
+                                organizationUuid: payload.organizationUuid,
+                            },
+                        });
+                    },
+                );
+            },
             [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: async (
                 payload,
                 helpers,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -164,6 +164,8 @@ const getMockedAsyncQueryService = (
         } as unknown as EmailModel,
         schedulerClient: {
             scheduleTask: jest.fn(),
+            runAsyncPreAggregateQuery: jest.fn(),
+            runAsyncWarehouseQuery: jest.fn(),
         } as unknown as SchedulerClient,
         downloadFileModel: {} as unknown as DownloadFileModel,
         fileStorageClient: {} as FileStorageClient,
@@ -451,11 +453,11 @@ describe('AsyncQueryService', () => {
             // THEN: runAsyncWarehouseQuery IS called with correct parameters
             expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    userId: sessionAccount.user.id,
+                    userUuid: sessionAccount.user.id,
                     isRegisteredUser: sessionAccount.isRegisteredUser(),
                     projectUuid,
                     query: 'SELECT * FROM test',
-                    queryHistoryUuid: 'test-query-uuid',
+                    queryUuid: 'test-query-uuid',
                     fieldsMap: {},
                     queryTags: { query_context: QueryExecutionContext.EXPLORE },
                 } satisfies Partial<RunAsyncWarehouseQueryArgs>),
@@ -528,11 +530,11 @@ describe('AsyncQueryService', () => {
             // THEN: runAsyncWarehouseQuery IS called with correct parameters
             expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    userId: sessionAccount.user.id,
+                    userUuid: sessionAccount.user.id,
                     isRegisteredUser: sessionAccount.isRegisteredUser(),
                     projectUuid,
                     query: 'SELECT * FROM test',
-                    queryHistoryUuid: 'test-query-uuid',
+                    queryUuid: 'test-query-uuid',
                     fieldsMap: {},
                     queryTags: { query_context: QueryExecutionContext.EXPLORE },
                 } satisfies Partial<RunAsyncWarehouseQueryArgs>),
@@ -624,11 +626,11 @@ describe('AsyncQueryService', () => {
             // THEN: runAsyncWarehouseQuery IS always called with correct parameters
             expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledWith(
                 expect.objectContaining({
-                    userId: sessionAccount.user.id,
+                    userUuid: sessionAccount.user.id,
                     isRegisteredUser: sessionAccount.isRegisteredUser(),
                     projectUuid,
                     query: 'SELECT * FROM test',
-                    queryHistoryUuid: 'test-query-uuid',
+                    queryUuid: 'test-query-uuid',
                     fieldsMap: {},
                     queryTags: { query_context: QueryExecutionContext.EXPLORE },
                 } satisfies Partial<RunAsyncWarehouseQueryArgs>),
@@ -729,6 +731,86 @@ describe('AsyncQueryService', () => {
             );
 
             // THEN: runAsyncWarehouseQuery is NOT called (error prevents execution)
+            expect(runAsyncWarehouseQuerySpy).not.toHaveBeenCalled();
+        });
+
+        test('enqueues warehouse queries on dedicated workers when the gate is enabled', async () => {
+            const schedulerClientMock = {
+                scheduleTask: jest.fn(),
+                runAsyncPreAggregateQuery: jest.fn(),
+                runAsyncWarehouseQuery: jest.fn(),
+            };
+            const service = getMockedAsyncQueryService(
+                {
+                    ...lightdashConfigMock,
+                    scheduler: {
+                        ...lightdashConfigMock.scheduler,
+                        asyncQueryWorkers: {
+                            preAggregatesEnabled: false,
+                            warehouseEnabled: true,
+                        },
+                    },
+                },
+                {
+                    schedulerClient:
+                        schedulerClientMock as unknown as SchedulerClient,
+                },
+            );
+
+            service.findResultsCache = jest.fn().mockResolvedValueOnce({
+                cacheHit: false,
+                updatedAt: undefined,
+                expiresAt: undefined,
+            } satisfies MissCacheResult);
+            (service.queryHistoryModel.create as jest.Mock).mockResolvedValue({
+                queryUuid: 'test-query-uuid',
+            });
+
+            const runAsyncWarehouseQuerySpy = jest.spyOn(
+                service,
+                'runAsyncWarehouseQuery',
+            );
+
+            const result = await service.executeAsyncQuery(
+                {
+                    account: sessionAccount,
+                    projectUuid,
+                    metricQuery: metricQueryMock,
+                    context: QueryExecutionContext.EXPLORE,
+                    dateZoom: undefined,
+                    queryTags: {
+                        query_context: QueryExecutionContext.EXPLORE,
+                    },
+                    explore: validExplore,
+                    invalidateCache: false,
+                    sql: 'SELECT * FROM test',
+                    fields: {},
+                    missingParameterReferences: [],
+                },
+                { query: metricQueryMock },
+            );
+
+            expect(result).toEqual({
+                queryUuid: 'test-query-uuid',
+                cacheMetadata: {
+                    cacheHit: false,
+                    cacheUpdatedTime: undefined,
+                    cacheExpiresAt: undefined,
+                },
+            } satisfies ExecuteAsyncQueryReturn);
+
+            expect(
+                schedulerClientMock.runAsyncWarehouseQuery,
+            ).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    organizationUuid:
+                        sessionAccount.organization.organizationUuid,
+                    userUuid: sessionAccount.user.id,
+                    projectUuid,
+                    queryUuid: 'test-query-uuid',
+                    query: 'SELECT * FROM test',
+                }),
+            );
             expect(runAsyncWarehouseQuerySpy).not.toHaveBeenCalled();
         });
 
@@ -1216,14 +1298,14 @@ describe('AsyncQueryService', () => {
                 );
 
                 const runAsyncArgs: RunAsyncWarehouseQueryArgs = {
-                    userId: sessionAccount.user.id,
+                    userUuid: sessionAccount.user.id,
                     isRegisteredUser: true,
                     projectUuid,
                     query: 'SELECT * FROM test',
                     fieldsMap: {},
                     queryTags: { query_context: QueryExecutionContext.EXPLORE },
                     warehouseCredentialsOverrides: undefined,
-                    queryHistoryUuid: 'test-query-uuid',
+                    queryUuid: 'test-query-uuid',
                     cacheKey: 'test-cache-key',
                     pivotConfiguration: undefined,
                     originalColumns: undefined,
@@ -1309,14 +1391,14 @@ describe('AsyncQueryService', () => {
             );
 
             const runAsyncArgs: RunAsyncWarehouseQueryArgs = {
-                userId: sessionAccount.user.id,
+                userUuid: sessionAccount.user.id,
                 isRegisteredUser: true,
                 projectUuid,
                 query: 'SELECT * FROM test_table',
                 fieldsMap: {},
                 queryTags: { query_context: QueryExecutionContext.EXPLORE },
                 warehouseCredentialsOverrides: undefined,
-                queryHistoryUuid: 'test-query-uuid',
+                queryUuid: 'test-query-uuid',
                 cacheKey: 'test-cache-key',
                 pivotConfiguration: undefined,
                 originalColumns: undefined,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -158,6 +158,7 @@ import {
     type ExecuteAsyncUnderlyingDataQueryArgs,
     type GetAsyncQueryResultsArgs,
     type PreAggregationRoute,
+    type RunAsyncPreAggregateQueryArgs,
     type RunAsyncWarehouseQueryArgs,
     type ScheduleDownloadAsyncQueryResultsArgs,
 } from './types';
@@ -173,6 +174,17 @@ type PreAggregationRoutingDecision =
           target: 'pre_aggregate';
           preAggregateMetadata: CacheMetadata['preAggregate'];
           route: PreAggregationRoute;
+      };
+
+type AsyncQueryExecutionPlan =
+    | {
+          target: 'warehouse';
+          warehouseQuery: string;
+      }
+    | {
+          target: 'pre_aggregate';
+          preAggregateQuery: string;
+          warehouseQuery: string;
       };
 
 type AsyncQueryServiceArguments = ProjectServiceArguments & {
@@ -1501,12 +1513,145 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    private async isWorkerAsyncQueryExecutionEnabled(
+        target: AsyncQueryExecutionPlan['target'],
+        account: Account,
+    ): Promise<boolean> {
+        assertIsAccountWithOrg(account);
+
+        return target === 'pre_aggregate'
+            ? this.lightdashConfig.scheduler.asyncQueryWorkers
+                  .preAggregatesEnabled
+            : this.lightdashConfig.scheduler.asyncQueryWorkers.warehouseEnabled;
+    }
+
+    private async resolveAsyncQueryExecutionPlan({
+        projectUuid,
+        warehouseQuery,
+        metricQuery,
+        dateZoom,
+        parameters,
+        preAggregationRoute,
+        fieldsMap,
+        pivotConfiguration,
+        startOfWeek,
+        userAccessControls,
+        availableParameterDefinitions,
+        queryUuid,
+    }: {
+        projectUuid: string;
+        warehouseQuery: string;
+        metricQuery: MetricQuery;
+        dateZoom: ExecuteAsyncMetricQueryArgs['dateZoom'];
+        parameters: ExecuteAsyncMetricQueryArgs['parameters'];
+        preAggregationRoute?: PreAggregationRoute;
+        fieldsMap: ItemsMap;
+        pivotConfiguration?: PivotConfiguration;
+        startOfWeek: CreateWarehouseCredentials['startOfWeek'];
+        userAccessControls?: UserAccessControls;
+        availableParameterDefinitions?: ParameterDefinitions;
+        queryUuid: string;
+    }): Promise<AsyncQueryExecutionPlan> {
+        const preAggResolution =
+            this.lightdashConfig.preAggregates.enabled &&
+            preAggregationRoute &&
+            userAccessControls &&
+            availableParameterDefinitions
+                ? await this.preAggregationDuckDbClient.resolve({
+                      projectUuid,
+                      metricQuery,
+                      dateZoom,
+                      parameters,
+                      preAggregationRoute,
+                      fieldsMap,
+                      pivotConfiguration,
+                      startOfWeek,
+                      userAccessControls,
+                      availableParameterDefinitions,
+                  })
+                : undefined;
+
+        if (preAggResolution?.resolved) {
+            this.logger.info(
+                `DuckDB pre-agg route selected for ${queryUuid}: ${preAggregationRoute!.sourceExploreName}/${preAggregationRoute!.preAggregateName}`,
+            );
+            return {
+                target: 'pre_aggregate',
+                preAggregateQuery: preAggResolution.query,
+                warehouseQuery,
+            };
+        }
+
+        return {
+            target: 'warehouse',
+            warehouseQuery,
+        };
+    }
+
+    public async runAsyncPreAggregateQuery({
+        userUuid,
+        isRegisteredUser,
+        isServiceAccount,
+        projectUuid,
+        queryUuid,
+        queryTags,
+        fieldsMap,
+        cacheKey,
+        warehouseCredentialsOverrides,
+        pivotConfiguration,
+        originalColumns,
+        preAggregateQuery,
+        warehouseQuery,
+    }: RunAsyncPreAggregateQueryArgs) {
+        try {
+            const duckDbWarehouseClient =
+                this.preAggregationDuckDbClient.createExecutionWarehouseClient();
+
+            await this.runAsyncWarehouseQuery({
+                userUuid,
+                isRegisteredUser,
+                isServiceAccount,
+                projectUuid,
+                queryUuid,
+                queryTags,
+                query: preAggregateQuery,
+                fieldsMap,
+                cacheKey,
+                warehouseCredentialsOverrides,
+                pivotConfiguration,
+                originalColumns,
+                warehouseClientOverride: duckDbWarehouseClient,
+                warehouseCredentialsTypeOverride:
+                    duckDbWarehouseClient.credentials.type,
+            });
+        } catch (duckdbError) {
+            this.logger.warn(
+                `DuckDB pre-agg execution failed for ${queryUuid}: ${getErrorMessage(
+                    duckdbError,
+                )}. Falling back to warehouse`,
+            );
+            await this.runAsyncWarehouseQuery({
+                userUuid,
+                isRegisteredUser,
+                isServiceAccount,
+                projectUuid,
+                queryUuid,
+                queryTags,
+                query: warehouseQuery,
+                fieldsMap,
+                cacheKey,
+                warehouseCredentialsOverrides,
+                pivotConfiguration,
+                originalColumns,
+            });
+        }
+    }
+
     /**
      * Runs the query the warehouse and updates the query history and cache (if cache is enabled and cache is not hit) when complete
-     * TODO: Remove once feature flag `WorkerQueryExecution` is completely removed as this is duplicated in SchedulerTask.runAsyncWarehouseQuery
      */
     public async runAsyncWarehouseQuery({
-        userId,
+        userUuid,
         isRegisteredUser,
         isServiceAccount,
         projectUuid,
@@ -1514,7 +1659,7 @@ export class AsyncQueryService extends ProjectService {
         fieldsMap,
         queryTags,
         warehouseCredentialsOverrides,
-        queryHistoryUuid,
+        queryUuid,
         cacheKey,
         pivotConfiguration,
         originalColumns,
@@ -1539,12 +1684,12 @@ export class AsyncQueryService extends ProjectService {
         let warehouseClient: WarehouseClient;
 
         const analyticsIdentity = isRegisteredUser
-            ? { userId }
+            ? { userId: userUuid }
             : { anonymousId: 'embed' };
         const queryHistoryAccount = {
             isRegisteredUser: () => isRegisteredUser,
             user: {
-                id: userId,
+                id: userUuid,
             },
         };
 
@@ -1558,7 +1703,7 @@ export class AsyncQueryService extends ProjectService {
                 const warehouseCredentials = await this.getWarehouseCredentials(
                     {
                         projectUuid,
-                        userId,
+                        userId: userUuid,
                         isRegisteredUser,
                         isServiceAccount,
                     },
@@ -1577,10 +1722,10 @@ export class AsyncQueryService extends ProjectService {
             }
 
             const executionSource = warehouseClientOverride
-                ? 'pre_aggregate_duckdb'
+                ? 'pre_aggregate'
                 : 'warehouse';
             this.logger.info(
-                `Running query ${queryHistoryUuid} source=${executionSource}`,
+                `Running query ${queryUuid} source=${executionSource}`,
             );
 
             const fileName =
@@ -1613,7 +1758,9 @@ export class AsyncQueryService extends ProjectService {
                     totalRowCount: null,
                     createdAt,
                     expiresAt: newExpiresAt,
-                    ...(isRegisteredUser ? undefined : { externalId: userId }),
+                    ...(isRegisteredUser
+                        ? undefined
+                        : { externalId: userUuid }),
                 },
             });
             const {
@@ -1638,7 +1785,7 @@ export class AsyncQueryService extends ProjectService {
                 ...analyticsIdentity,
                 event: 'query.ready',
                 properties: {
-                    queryId: queryHistoryUuid,
+                    queryId: queryUuid,
                     projectId: projectUuid,
                     warehouseType: warehouseClient.credentials.type,
                     warehouseExecutionTimeMs: durationMs,
@@ -1647,7 +1794,9 @@ export class AsyncQueryService extends ProjectService {
                         Object.keys(fieldsMap).length,
                     totalRowCount: pivotDetails?.totalRows ?? totalRows,
                     isPivoted: pivotDetails !== null,
-                    ...(isRegisteredUser ? undefined : { externalId: userId }),
+                    ...(isRegisteredUser
+                        ? undefined
+                        : { externalId: userUuid }),
                 },
             });
 
@@ -1659,7 +1808,7 @@ export class AsyncQueryService extends ProjectService {
                     ...analyticsIdentity,
                     event: 'results_cache.write',
                     properties: {
-                        queryId: queryHistoryUuid,
+                        queryId: queryUuid,
                         projectId: projectUuid,
                         cacheKey,
                         totalRowCount: pivotDetails?.totalRows ?? totalRows,
@@ -1667,13 +1816,13 @@ export class AsyncQueryService extends ProjectService {
                         isPivoted: pivotDetails !== null,
                         ...(isRegisteredUser
                             ? undefined
-                            : { externalId: userId }),
+                            : { externalId: userUuid }),
                     },
                 });
             }
 
             await this.queryHistoryModel.update(
-                queryHistoryUuid,
+                queryUuid,
                 projectUuid,
                 {
                     warehouse_query_id: queryId,
@@ -1709,14 +1858,16 @@ export class AsyncQueryService extends ProjectService {
                 ...analyticsIdentity,
                 event: 'query.error',
                 properties: {
-                    queryId: queryHistoryUuid,
+                    queryId: queryUuid,
                     projectId: projectUuid,
                     warehouseType: warehouseCredentialsType,
-                    ...(isRegisteredUser ? undefined : { externalId: userId }),
+                    ...(isRegisteredUser
+                        ? undefined
+                        : { externalId: userUuid }),
                 },
             });
             await this.queryHistoryModel.update(
-                queryHistoryUuid,
+                queryUuid,
                 projectUuid,
                 {
                     status: QueryHistoryStatus.ERROR,
@@ -1745,7 +1896,7 @@ export class AsyncQueryService extends ProjectService {
             await stream?.close();
         } catch (e) {
             await this.queryHistoryModel.update(
-                queryHistoryUuid,
+                queryUuid,
                 projectUuid,
                 {
                     status: QueryHistoryStatus.ERROR,
@@ -2134,81 +2285,92 @@ export class AsyncQueryService extends ProjectService {
                         } satisfies ExecuteAsyncQueryReturn;
                     }
 
-                    this.logger.info(
-                        `Executing query ${queryHistoryUuid} in the main loop`,
-                    );
+                    const executionPlan =
+                        await this.resolveAsyncQueryExecutionPlan({
+                            projectUuid,
+                            warehouseQuery: query,
+                            metricQuery,
+                            dateZoom,
+                            parameters,
+                            preAggregationRoute,
+                            fieldsMap,
+                            pivotConfiguration,
+                            startOfWeek: warehouseCredentials.startOfWeek,
+                            userAccessControls,
+                            availableParameterDefinitions,
+                            queryUuid: queryHistoryUuid,
+                        });
 
                     const warehouseArgs: RunAsyncWarehouseQueryArgs = {
-                        userId: account.user.id,
+                        userUuid: account.user.id,
                         isRegisteredUser: account.isRegisteredUser(),
                         isServiceAccount: account.isServiceAccount(),
                         projectUuid,
-                        query,
+                        query: executionPlan.warehouseQuery,
                         fieldsMap,
                         queryTags,
                         warehouseCredentialsOverrides,
-                        queryHistoryUuid,
+                        queryUuid: queryHistoryUuid,
                         pivotConfiguration,
                         cacheKey,
                         originalColumns,
                     };
 
-                    void (async () => {
-                        const preAggResolution =
-                            this.lightdashConfig.preAggregates.enabled &&
-                            preAggregationRoute &&
-                            userAccessControls &&
-                            availableParameterDefinitions
-                                ? await this.preAggregationDuckDbClient.resolve(
-                                      {
-                                          projectUuid,
-                                          metricQuery,
-                                          dateZoom,
-                                          parameters,
-                                          preAggregationRoute,
-                                          fieldsMap,
-                                          pivotConfiguration,
-                                          startOfWeek:
-                                              warehouseCredentials.startOfWeek,
-                                          userAccessControls,
-                                          availableParameterDefinitions,
-                                      },
-                                  )
-                                : undefined;
+                    if (
+                        await this.isWorkerAsyncQueryExecutionEnabled(
+                            executionPlan.target,
+                            account,
+                        )
+                    ) {
+                        this.logger.info(
+                            `Enqueueing query ${queryHistoryUuid} on the ${executionPlan.target} worker fleet`,
+                        );
 
-                        if (preAggResolution?.resolved) {
-                            this.logger.info(
-                                `DuckDB pre-agg route selected for ${queryHistoryUuid}: ${preAggregationRoute!.sourceExploreName}/${preAggregationRoute!.preAggregateName}`,
-                            );
-                            try {
-                                await this.runAsyncWarehouseQuery({
+                        if (executionPlan.target === 'pre_aggregate') {
+                            await this.schedulerClient.runAsyncPreAggregateQuery(
+                                {
+                                    organizationUuid,
                                     ...warehouseArgs,
-                                    query: preAggResolution.query,
-                                    warehouseClientOverride:
-                                        preAggResolution.warehouseClient,
-                                    warehouseCredentialsTypeOverride:
-                                        preAggResolution.warehouseClient
-                                            .credentials.type,
+                                    preAggregateQuery:
+                                        executionPlan.preAggregateQuery,
+                                    warehouseQuery:
+                                        executionPlan.warehouseQuery,
+                                },
+                            );
+                        } else {
+                            await this.schedulerClient.runAsyncWarehouseQuery({
+                                organizationUuid,
+                                ...warehouseArgs,
+                            });
+                        }
+                    } else {
+                        this.logger.info(
+                            `Executing query ${queryHistoryUuid} in the main loop`,
+                        );
+
+                        void (async () => {
+                            if (executionPlan.target === 'pre_aggregate') {
+                                await this.runAsyncPreAggregateQuery({
+                                    ...warehouseArgs,
+                                    preAggregateQuery:
+                                        executionPlan.preAggregateQuery,
+                                    warehouseQuery:
+                                        executionPlan.warehouseQuery,
                                 });
-                            } catch (duckdbError) {
-                                this.logger.warn(
-                                    `DuckDB pre-agg execution failed for ${queryHistoryUuid}: ${getErrorMessage(duckdbError)}. Falling back to warehouse`,
-                                );
+                            } else {
                                 await this.runAsyncWarehouseQuery(
                                     warehouseArgs,
                                 );
                             }
-                        } else {
-                            await this.runAsyncWarehouseQuery(warehouseArgs);
-                        }
-                    })().catch((e) => {
-                        // There's no point in throwing the error here as this promise is called with void
-                        // Set the status of the span to ERROR
-                        span.setStatus({
-                            code: 2, // ERROR
-                            message: getErrorMessage(e),
+                        })().catch((e) => {
+                            // There's no point in throwing the error here as this promise is called with void
+                            // Set the status of the span to ERROR
+                            span.setStatus({
+                                code: 2, // ERROR
+                                message: getErrorMessage(e),
+                            });
                         });
-                    });
+                    }
 
                     return {
                         queryUuid: queryHistoryUuid,

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -81,6 +81,20 @@ export class PreAggregationDuckDbClient {
             ((warehouseArgs) => new DuckdbWarehouseClient(warehouseArgs));
     }
 
+    createExecutionWarehouseClient(): WarehouseClient {
+        const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
+            this.lightdashConfig.preAggregates.s3,
+        );
+
+        if (!duckdbRuntimeConfig) {
+            throw new Error('Missing DuckDB runtime config');
+        }
+
+        return this.createDuckdbWarehouseClient({
+            s3Config: duckdbRuntimeConfig,
+        });
+    }
+
     async resolve(
         args: ResolvePreAggregationDuckDbArgs,
     ): Promise<PreAggregationDuckDbResolution> {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -4,6 +4,8 @@ import {
     MetricQuery,
     PivotConfig,
     PivotConfiguration,
+    RunAsyncPreAggregateQueryPayload,
+    RunAsyncWarehouseQueryPayload,
     type CacheMetadata,
     type DashboardFilters,
     type DateZoom,
@@ -151,20 +153,13 @@ export const isExecuteAsyncSqlChartByUuid = (
 ): args is ExecuteAsyncSqlChartByUuidArgs => 'savedSqlUuid' in args;
 
 export type RunAsyncWarehouseQueryArgs = {
-    userId: string;
-    // Is the user in the database?
-    isRegisteredUser: boolean;
-    isServiceAccount?: boolean;
-    projectUuid: string;
-    queryTags: RunQueryTags;
-    query: string;
-    fieldsMap: ItemsMap;
-    queryHistoryUuid: string;
-    cacheKey: string;
-    warehouseCredentialsOverrides?: {
-        snowflakeVirtualWarehouse?: string;
-        databricksCompute?: string;
-    };
-    pivotConfiguration?: PivotConfiguration;
-    originalColumns?: ResultColumns;
-};
+    query: RunAsyncWarehouseQueryPayload['query'];
+} & Omit<
+    RunAsyncWarehouseQueryPayload,
+    'organizationUuid' | 'schedulerUuid' | 'query'
+>;
+
+export type RunAsyncPreAggregateQueryArgs = Omit<
+    RunAsyncPreAggregateQueryPayload,
+    'organizationUuid' | 'schedulerUuid'
+>;

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -3,14 +3,17 @@ import { type AnyType } from './any';
 import { type ApiSuccess } from './api/success';
 import type { DownloadFileType } from './downloadFile';
 import { type Explore, type ExploreError } from './explore';
+import { type ItemsMap } from './field';
 import { type DashboardFilterRule, type DashboardFilters } from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
 import { type MetricQuery } from './metricQuery';
 import { type ParametersValuesMap } from './parameters';
-import { type PivotConfig } from './pivot';
+import { type PivotConfig, type PivotConfiguration } from './pivot';
+import { type ResultColumns } from './results';
 import type { PartialFailure, SchedulerRun } from './schedulerLog';
 import { type DateGranularity } from './timeFrames';
 import { type ValidationTarget } from './validation';
+import { type RunQueryTags } from './warehouse';
 
 export type SchedulerCsvOptions = {
     formatted: boolean;
@@ -620,6 +623,32 @@ export type DownloadAsyncQueryResultsPayload = TraceTaskBase & {
     pivotConfig?: PivotConfig;
     attachmentDownloadName?: string;
     encodedJwt?: string;
+};
+
+export type AsyncQueryWarehouseCredentialsOverrides = {
+    snowflakeVirtualWarehouse?: string;
+    databricksCompute?: string;
+};
+
+export type AsyncQueryWorkerPayloadBase = TraceTaskBase & {
+    queryUuid: string;
+    isRegisteredUser: boolean;
+    isServiceAccount?: boolean;
+    queryTags: RunQueryTags;
+    fieldsMap: ItemsMap;
+    cacheKey: string;
+    warehouseCredentialsOverrides?: AsyncQueryWarehouseCredentialsOverrides;
+    pivotConfiguration?: PivotConfiguration;
+    originalColumns?: ResultColumns;
+};
+
+export type RunAsyncWarehouseQueryPayload = AsyncQueryWorkerPayloadBase & {
+    query: string;
+};
+
+export type RunAsyncPreAggregateQueryPayload = AsyncQueryWorkerPayloadBase & {
+    preAggregateQuery: string;
+    warehouseQuery: string;
 };
 
 export type SyncSlackChannelsPayload = Pick<

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -20,6 +20,8 @@ import {
     type MsTeamsBatchNotificationPayload,
     type MsTeamsNotificationPayload,
     type ReplaceCustomFieldsPayload,
+    type RunAsyncPreAggregateQueryPayload,
+    type RunAsyncWarehouseQueryPayload,
     type ScheduledDeliveryPayload,
     type SchedulerCreateProjectWithCompilePayload,
     type SlackBatchNotificationPayload,
@@ -34,6 +36,7 @@ import {
 } from './sqlRunner';
 
 export const EE_SCHEDULER_TASKS = {
+    RUN_ASYNC_PRE_AGGREGATE_QUERY: 'runAsyncPreAggregateQuery',
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
@@ -61,6 +64,7 @@ export const SCHEDULER_TASKS = {
     SQL_RUNNER_PIVOT_QUERY: 'sqlRunnerPivotQuery',
     REPLACE_CUSTOM_FIELDS: 'replaceCustomFields',
     INDEX_CATALOG: 'indexCatalog',
+    RUN_ASYNC_WAREHOUSE_QUERY: 'runAsyncWarehouseQuery',
     GENERATE_DAILY_JOBS: 'generateDailyJobs',
     EXPORT_CSV_DASHBOARD: 'exportCsvDashboard',
     RENAME_RESOURCES: 'renameResources',
@@ -99,6 +103,8 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.SQL_RUNNER_PIVOT_QUERY]: SqlRunnerPivotQueryPayload;
     [SCHEDULER_TASKS.REPLACE_CUSTOM_FIELDS]: ReplaceCustomFieldsPayload;
     [SCHEDULER_TASKS.INDEX_CATALOG]: SchedulerIndexCatalogJobPayload;
+    [SCHEDULER_TASKS.RUN_ASYNC_PRE_AGGREGATE_QUERY]: RunAsyncPreAggregateQueryPayload;
+    [SCHEDULER_TASKS.RUN_ASYNC_WAREHOUSE_QUERY]: RunAsyncWarehouseQueryPayload;
     [SCHEDULER_TASKS.GENERATE_DAILY_JOBS]: TraceTaskBase;
     [SCHEDULER_TASKS.EXPORT_CSV_DASHBOARD]: ExportCsvDashboardPayload;
     [SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
@@ -116,6 +122,7 @@ export interface TaskPayloadMap {
 }
 
 export interface EETaskPayloadMap {
+    [EE_SCHEDULER_TASKS.RUN_ASYNC_PRE_AGGREGATE_QUERY]: RunAsyncPreAggregateQueryPayload;
     [EE_SCHEDULER_TASKS.SLACK_AI_PROMPT]: SlackPromptJobPayload;
     [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;


### PR DESCRIPTION
### Description:

This PR introduces dedicated worker queues for async query execution, allowing queries to be processed on specialized worker fleets instead of the main application loop.

**Key Changes:**

- Added new scheduler tasks `RUN_ASYNC_PRE_AGGREGATE_QUERY` and `RUN_ASYNC_WAREHOUSE_QUERY` for dedicated async query processing
- Introduced feature gates `SCHEDULER_PRE_AGGREGATE_QUERY_WORKER_ENABLED` and `SCHEDULER_WAREHOUSE_QUERY_WORKER_ENABLED` to control worker queue usage
- Refactored async query execution to support both in-process and worker-based execution paths
- Added `AsyncQueryExecutionPlan` to determine whether queries should run on pre-aggregate or warehouse targets
- Updated `RunAsyncWarehouseQueryArgs` to use `userUuid` and `queryUuid` instead of `userId` and `queryHistoryUuid` for consistency
- Implemented fallback mechanism where pre-aggregate queries automatically retry on warehouse if they fail
- Added comprehensive test coverage for the new worker queue functionality

When the feature gates are enabled, async queries are enqueued on dedicated worker fleets. When disabled, queries continue to execute in the main application loop as before, ensuring backward compatibility.