### PR TITLE
fix: prevent event propagation on comment menu dropdown

### DIFF
--- a/packages/frontend/src/features/comments/components/CommentDetail.tsx
+++ b/packages/frontend/src/features/comments/components/CommentDetail.tsx
@@ -96,7 +96,10 @@ export const CommentDetail: FC<Props> = ({
                                             />
                                         </ActionIcon>
                                     </Menu.Target>
-                                    <Menu.Dropdown p={0}>
+                                    <Menu.Dropdown
+                                        p={0}
+                                        onMouseDown={(e) => e.stopPropagation()}
+                                    >
                                         <Menu.Item
                                             p="xs"
                                             fz="xs"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-3572/unable-to-delete-comments-on-charts

The fix is a single line: onMouseDown={(e) =>                
  e.stopPropagation()} on Menu.Dropdown in CommentDetail.tsx:102. This prevents 
  the Popover from closing when you interact with the Menu's portal-rendered    
  dropdown, allowing the delete onClick to fire properly.

### Description:
Added `onMouseDown` event handler to the comment menu dropdown that prevents event propagation. This prevents unintended interactions when clicking on the dropdown menu in the CommentDetail component.