### PR TITLE
fix: preserve filter group IDs to prevent UI jump when editing filters

### DIFF
--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -642,7 +642,10 @@ export const getFiltersFromGroup = (
                     ...accumulator.dimensions,
                     [getFilterGroupItemsPropertyName(flatFilterGroup)]: [
                         ...getItemsFromFilterGroup(accumulator.dimensions),
-                        filters.dimensions,
+                        // Preserve the original group ID so React can maintain
+                        // stable keys and avoid unmounting/remounting nested
+                        // FilterGroupForm components on every filter edit
+                        { ...filters.dimensions, id: item.id },
                     ],
                 } as FilterGroup;
             }
@@ -653,7 +656,7 @@ export const getFiltersFromGroup = (
                     ...accumulator.metrics,
                     [getFilterGroupItemsPropertyName(flatFilterGroup)]: [
                         ...getItemsFromFilterGroup(accumulator.metrics),
-                        filters.metrics,
+                        { ...filters.metrics, id: item.id },
                     ],
                 } as FilterGroup;
             }
@@ -666,7 +669,7 @@ export const getFiltersFromGroup = (
                         ...getItemsFromFilterGroup(
                             accumulator.tableCalculations,
                         ),
-                        filters.tableCalculations,
+                        { ...filters.tableCalculations, id: item.id },
                     ],
                 } as FilterGroup;
             }

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -25,7 +25,7 @@ import {
     useMantineColorScheme,
 } from '@mantine-8/core';
 import { IconAlertCircle, IconPlus, IconX } from '@tabler/icons-react';
-import { memo, useCallback, useMemo, type FC } from 'react';
+import { memo, useCallback, useMemo, useRef, type FC } from 'react';
 import { useToggle } from 'react-use';
 import { v4 as uuidv4 } from 'uuid';
 import {
@@ -228,11 +228,15 @@ const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
         return groups;
     }, [filters.dimensions, filters.metrics, filters.tableCalculations]);
 
+    // Use a stable ID for the root filter group to avoid unnecessary re-renders
+    // when filter values change (uuidv4() would generate a new ID on every memo recalculation)
+    const rootFilterGroupId = useRef(uuidv4());
+
     const rootFilterGroup: FilterGroup = useMemo(() => {
         // If there are no ORs, we can just return the AND group items as a new root group
         if (orRootFilterGroups.length === 0) {
             return {
-                id: uuidv4(),
+                id: rootFilterGroupId.current,
                 and: andRootFilterGroupItems,
             };
         }
@@ -243,14 +247,14 @@ const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
             return orRootFilterGroups.length === 1
                 ? orRootFilterGroups[0]
                 : {
-                      id: uuidv4(),
+                      id: rootFilterGroupId.current,
                       and: orRootFilterGroups,
                   };
         }
 
         // If there are both ANDs and ORs, we need to create a new root group that contains both
         return {
-            id: uuidv4(),
+            id: rootFilterGroupId.current,
             and: [...andRootFilterGroupItems, ...orRootFilterGroups],
         };
     }, [andRootFilterGroupItems, orRootFilterGroups]);


### PR DESCRIPTION
## Summary

Fixes [PROD-2691](https://linear.app/lightdash/issue/PROD-2691): When a chart has multiple filter groups, editing a filter value near the top of the filter panel caused the UI to jump to the last filter after every keystroke.

There is an example of this behaviour using analytics project in the linked issue above.

**Root cause:** `getFiltersFromGroup()` generated new `uuidv4()` IDs for nested filter groups on every call. When these groups were rendered with `key={item.id}` in `FilterGroupForm`, React treated them as entirely new components — unmounting/remounting the subtree. Combined with `autoFocus={true}` on filter input components, the last-mounted input grabbed focus, causing the browser to scroll to it.

**Changes:**
- **`packages/common/src/utils/filters.ts`** — Preserve original filter group IDs through the `getFiltersFromGroup` round-trip by reusing `item.id` instead of generating new UUIDs for nested groups
- **`packages/frontend/src/components/common/Filters/index.tsx`** — Use a stable `useRef`-based ID for the root filter group instead of `uuidv4()` inside `useMemo`, preventing unnecessary identity changes on every filter edit

## Test plan

- [x] Open a chart with multiple filter groups (at least one OR group)
- [x] Edit a filter value near the top of the filter panel
- [x] Verify the UI no longer jumps to the last filter after each keystroke
- [x] Verify filter values are still correctly applied
- [x] Verify adding/removing filter rules still works
- [x] Verify converting filter rules to groups still works
- [x] Verify clearing all filters still works

Confirmed that this fix is working in preview env - ephemeral link here: https://lightdash-preview-pr-20740.lightdash.okteto.dev/projects/3675b69e-8324-4110-bdca-059031aa8da3/saved/19da986f-322b-4977-a846-d256fdc3ce83/view

🤖 Generated with [Claude Code](https://claude.com/claude-code)