### PR TITLE
chore: add test trigger instructions to fix-vulnerability skill

### DIFF
--- a/.claude/skills/fix-vulnerability/SKILL.md
+++ b/.claude/skills/fix-vulnerability/SKILL.md
@@ -37,6 +37,16 @@ Replace the Snyk-generated title with a descriptive one following conventional c
 gh pr edit <PR_NUMBER> --title "fix: upgrade <package1> <oldVersion>→<newVersion> and <package2> <oldVersion>→<newVersion>"
 ```
 
+Also update the PR description to append test trigger keywords so all test suites run on the next push:
+
+```bash
+# Get current body, append test keywords
+CURRENT_BODY=$(gh pr view <PR_NUMBER> --json body -q '.body')
+gh pr edit <PR_NUMBER> --body "${CURRENT_BODY}
+
+test-frontend test-backend test-cli"
+```
+
 Rules for the title:
 - Use `fix:` prefix (these are vulnerability fixes)
 - List all upgraded packages with their version ranges


### PR DESCRIPTION
### Description:

Added instructions to automatically trigger all test suites when fixing vulnerability PRs by appending test keywords to the PR description. The new step uses the GitHub CLI to fetch the current PR body and append "test-frontend test-backend test-cli" keywords, ensuring comprehensive testing runs on the next push after vulnerability fixes are applied.