### PR TITLE
fix: use CREATE INDEX CONCURRENTLY in soft-delete migrations

### DIFF
--- a/packages/backend/src/database/migrations/20260205132424_add_soft_delete_to_saved_queries.ts
+++ b/packages/backend/src/database/migrations/20260205132424_add_soft_delete_to_saved_queries.ts
@@ -2,32 +2,59 @@ import { Knex } from 'knex';
 
 const SavedQueriesTableName = 'saved_queries';
 
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used.
+// Regular CREATE INDEX takes a SHARE lock blocking all writes for the duration
+// of the index build. On shared instances with multiple tenants migrating
+// simultaneously, this causes I/O contention and connection pool exhaustion.
+export const config = { transaction: false };
+
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.alterTable(SavedQueriesTableName, (table) => {
-        table.timestamp('deleted_at', { useTz: false }).nullable();
-        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
-    });
+    const hasColumn = await knex.schema.hasColumn(
+        SavedQueriesTableName,
+        'deleted_at',
+    );
+    if (!hasColumn) {
+        await knex.schema.alterTable(SavedQueriesTableName, (table) => {
+            table.timestamp('deleted_at', { useTz: false }).nullable();
+            table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+        });
+    }
 
     // Partial index for fast queries on non-deleted items
+    // We DROP first to clean up any invalid indexes left by a previous failed attempt.
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_saved_queries_not_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_saved_queries_not_deleted
+        CREATE INDEX CONCURRENTLY idx_saved_queries_not_deleted
         ON ${SavedQueriesTableName} (saved_query_uuid)
         WHERE deleted_at IS NULL
     `);
 
     // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_saved_queries_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_saved_queries_deleted
+        CREATE INDEX CONCURRENTLY idx_saved_queries_deleted
         ON ${SavedQueriesTableName} (saved_query_uuid)
         WHERE deleted_at IS NOT NULL
     `);
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.raw('DROP INDEX IF EXISTS idx_saved_queries_deleted');
-    await knex.raw('DROP INDEX IF EXISTS idx_saved_queries_not_deleted');
-    await knex.schema.alterTable(SavedQueriesTableName, (table) => {
-        table.dropColumn('deleted_at');
-        table.dropColumn('deleted_by_user_uuid');
-    });
+    await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_saved_queries_deleted');
+    await knex.raw(
+        'DROP INDEX CONCURRENTLY IF EXISTS idx_saved_queries_not_deleted',
+    );
+    const hasColumn = await knex.schema.hasColumn(
+        SavedQueriesTableName,
+        'deleted_at',
+    );
+    if (hasColumn) {
+        await knex.schema.alterTable(SavedQueriesTableName, (table) => {
+            table.dropColumn('deleted_at');
+            table.dropColumn('deleted_by_user_uuid');
+        });
+    }
 }

--- a/packages/backend/src/database/migrations/20260205192030_add_soft_delete_to_dashboards.ts
+++ b/packages/backend/src/database/migrations/20260205192030_add_soft_delete_to_dashboards.ts
@@ -2,32 +2,59 @@ import { Knex } from 'knex';
 
 const DashboardsTableName = 'dashboards';
 
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used.
+// Regular CREATE INDEX takes a SHARE lock blocking all writes for the duration
+// of the index build. On shared instances with multiple tenants migrating
+// simultaneously, this causes I/O contention and connection pool exhaustion.
+export const config = { transaction: false };
+
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.alterTable(DashboardsTableName, (table) => {
-        table.timestamp('deleted_at', { useTz: false }).nullable();
-        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
-    });
+    const hasColumn = await knex.schema.hasColumn(
+        DashboardsTableName,
+        'deleted_at',
+    );
+    if (!hasColumn) {
+        await knex.schema.alterTable(DashboardsTableName, (table) => {
+            table.timestamp('deleted_at', { useTz: false }).nullable();
+            table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+        });
+    }
 
     // Partial index for fast queries on non-deleted items
+    // We DROP first to clean up any invalid indexes left by a previous failed attempt.
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_dashboards_not_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_dashboards_not_deleted
+        CREATE INDEX CONCURRENTLY idx_dashboards_not_deleted
         ON ${DashboardsTableName} (dashboard_uuid)
         WHERE deleted_at IS NULL
     `);
 
     // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_dashboards_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_dashboards_deleted
+        CREATE INDEX CONCURRENTLY idx_dashboards_deleted
         ON ${DashboardsTableName} (dashboard_uuid)
         WHERE deleted_at IS NOT NULL
     `);
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.raw('DROP INDEX IF EXISTS idx_dashboards_deleted');
-    await knex.raw('DROP INDEX IF EXISTS idx_dashboards_not_deleted');
-    await knex.schema.alterTable(DashboardsTableName, (table) => {
-        table.dropColumn('deleted_at');
-        table.dropColumn('deleted_by_user_uuid');
-    });
+    await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_dashboards_deleted');
+    await knex.raw(
+        'DROP INDEX CONCURRENTLY IF EXISTS idx_dashboards_not_deleted',
+    );
+    const hasColumn = await knex.schema.hasColumn(
+        DashboardsTableName,
+        'deleted_at',
+    );
+    if (hasColumn) {
+        await knex.schema.alterTable(DashboardsTableName, (table) => {
+            table.dropColumn('deleted_at');
+            table.dropColumn('deleted_by_user_uuid');
+        });
+    }
 }

--- a/packages/backend/src/database/migrations/20260206064344_add_soft_delete_to_saved_sql.ts
+++ b/packages/backend/src/database/migrations/20260206064344_add_soft_delete_to_saved_sql.ts
@@ -2,32 +2,59 @@ import { Knex } from 'knex';
 
 const SavedSqlTableName = 'saved_sql';
 
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used.
+// Regular CREATE INDEX takes a SHARE lock blocking all writes for the duration
+// of the index build. On shared instances with multiple tenants migrating
+// simultaneously, this causes I/O contention and connection pool exhaustion.
+export const config = { transaction: false };
+
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.alterTable(SavedSqlTableName, (table) => {
-        table.timestamp('deleted_at', { useTz: false }).nullable();
-        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
-    });
+    const hasColumn = await knex.schema.hasColumn(
+        SavedSqlTableName,
+        'deleted_at',
+    );
+    if (!hasColumn) {
+        await knex.schema.alterTable(SavedSqlTableName, (table) => {
+            table.timestamp('deleted_at', { useTz: false }).nullable();
+            table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+        });
+    }
 
     // Partial index for fast queries on non-deleted items
+    // We DROP first to clean up any invalid indexes left by a previous failed attempt.
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_saved_sql_not_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_saved_sql_not_deleted
+        CREATE INDEX CONCURRENTLY idx_saved_sql_not_deleted
         ON ${SavedSqlTableName} (saved_sql_uuid)
         WHERE deleted_at IS NULL
     `);
 
     // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_saved_sql_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_saved_sql_deleted
+        CREATE INDEX CONCURRENTLY idx_saved_sql_deleted
         ON ${SavedSqlTableName} (saved_sql_uuid)
         WHERE deleted_at IS NOT NULL
     `);
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.raw('DROP INDEX IF EXISTS idx_saved_sql_deleted');
-    await knex.raw('DROP INDEX IF EXISTS idx_saved_sql_not_deleted');
-    await knex.schema.alterTable(SavedSqlTableName, (table) => {
-        table.dropColumn('deleted_at');
-        table.dropColumn('deleted_by_user_uuid');
-    });
+    await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_saved_sql_deleted');
+    await knex.raw(
+        'DROP INDEX CONCURRENTLY IF EXISTS idx_saved_sql_not_deleted',
+    );
+    const hasColumn = await knex.schema.hasColumn(
+        SavedSqlTableName,
+        'deleted_at',
+    );
+    if (hasColumn) {
+        await knex.schema.alterTable(SavedSqlTableName, (table) => {
+            table.dropColumn('deleted_at');
+            table.dropColumn('deleted_by_user_uuid');
+        });
+    }
 }

--- a/packages/backend/src/database/migrations/20260206092529_add_soft_delete_to_scheduler.ts
+++ b/packages/backend/src/database/migrations/20260206092529_add_soft_delete_to_scheduler.ts
@@ -2,32 +2,59 @@ import { Knex } from 'knex';
 
 const SchedulerTableName = 'scheduler';
 
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used.
+// Regular CREATE INDEX takes a SHARE lock blocking all writes for the duration
+// of the index build. On shared instances with multiple tenants migrating
+// simultaneously, this causes I/O contention and connection pool exhaustion.
+export const config = { transaction: false };
+
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.alterTable(SchedulerTableName, (table) => {
-        table.timestamp('deleted_at', { useTz: false }).nullable();
-        table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
-    });
+    const hasColumn = await knex.schema.hasColumn(
+        SchedulerTableName,
+        'deleted_at',
+    );
+    if (!hasColumn) {
+        await knex.schema.alterTable(SchedulerTableName, (table) => {
+            table.timestamp('deleted_at', { useTz: false }).nullable();
+            table.uuid('deleted_by_user_uuid').nullable(); // No FK constraint - user may be deleted
+        });
+    }
 
     // Partial index for fast queries on non-deleted items
+    // We DROP first to clean up any invalid indexes left by a previous failed attempt.
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_scheduler_not_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_scheduler_not_deleted
+        CREATE INDEX CONCURRENTLY idx_scheduler_not_deleted
         ON ${SchedulerTableName} (scheduler_uuid)
         WHERE deleted_at IS NULL
     `);
 
     // Partial index for fast queries on deleted items
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_scheduler_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_scheduler_deleted
+        CREATE INDEX CONCURRENTLY idx_scheduler_deleted
         ON ${SchedulerTableName} (scheduler_uuid)
         WHERE deleted_at IS NOT NULL
     `);
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.raw('DROP INDEX IF EXISTS idx_scheduler_deleted');
-    await knex.raw('DROP INDEX IF EXISTS idx_scheduler_not_deleted');
-    await knex.schema.alterTable(SchedulerTableName, (table) => {
-        table.dropColumn('deleted_at');
-        table.dropColumn('deleted_by_user_uuid');
-    });
+    await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_scheduler_deleted');
+    await knex.raw(
+        'DROP INDEX CONCURRENTLY IF EXISTS idx_scheduler_not_deleted',
+    );
+    const hasColumn = await knex.schema.hasColumn(
+        SchedulerTableName,
+        'deleted_at',
+    );
+    if (hasColumn) {
+        await knex.schema.alterTable(SchedulerTableName, (table) => {
+            table.dropColumn('deleted_at');
+            table.dropColumn('deleted_by_user_uuid');
+        });
+    }
 }

--- a/packages/backend/src/database/migrations/20260206163809_add_soft_delete_to_spaces.ts
+++ b/packages/backend/src/database/migrations/20260206163809_add_soft_delete_to_spaces.ts
@@ -2,32 +2,59 @@ import { Knex } from 'knex';
 
 const SpacesTableName = 'spaces';
 
+// Disable transaction wrapping so CREATE INDEX CONCURRENTLY can be used.
+// Regular CREATE INDEX takes a SHARE lock blocking all writes for the duration
+// of the index build. On shared instances with multiple tenants migrating
+// simultaneously, this causes I/O contention and connection pool exhaustion.
+export const config = { transaction: false };
+
 export async function up(knex: Knex): Promise<void> {
-    await knex.schema.alterTable(SpacesTableName, (table) => {
-        table.timestamp('deleted_at', { useTz: false }).nullable();
-        table.uuid('deleted_by_user_uuid').nullable();
-    });
+    const hasColumn = await knex.schema.hasColumn(
+        SpacesTableName,
+        'deleted_at',
+    );
+    if (!hasColumn) {
+        await knex.schema.alterTable(SpacesTableName, (table) => {
+            table.timestamp('deleted_at', { useTz: false }).nullable();
+            table.uuid('deleted_by_user_uuid').nullable();
+        });
+    }
 
     // Partial index for fast queries on non-deleted items
+    // We DROP first to clean up any invalid indexes left by a previous failed attempt.
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_spaces_not_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_spaces_not_deleted
+        CREATE INDEX CONCURRENTLY idx_spaces_not_deleted
         ON ${SpacesTableName} (space_uuid)
         WHERE deleted_at IS NULL
     `);
 
     // Partial index for fast queries on deleted items (Recently Deleted page)
+    await knex.raw(
+        `DROP INDEX CONCURRENTLY IF EXISTS idx_spaces_deleted`,
+    );
     await knex.raw(`
-        CREATE INDEX idx_spaces_deleted
+        CREATE INDEX CONCURRENTLY idx_spaces_deleted
         ON ${SpacesTableName} (space_uuid)
         WHERE deleted_at IS NOT NULL
     `);
 }
 
 export async function down(knex: Knex): Promise<void> {
-    await knex.raw('DROP INDEX IF EXISTS idx_spaces_deleted');
-    await knex.raw('DROP INDEX IF EXISTS idx_spaces_not_deleted');
-    await knex.schema.alterTable(SpacesTableName, (table) => {
-        table.dropColumn('deleted_at');
-        table.dropColumn('deleted_by_user_uuid');
-    });
+    await knex.raw('DROP INDEX CONCURRENTLY IF EXISTS idx_spaces_deleted');
+    await knex.raw(
+        'DROP INDEX CONCURRENTLY IF EXISTS idx_spaces_not_deleted',
+    );
+    const hasColumn = await knex.schema.hasColumn(
+        SpacesTableName,
+        'deleted_at',
+    );
+    if (hasColumn) {
+        await knex.schema.alterTable(SpacesTableName, (table) => {
+            table.dropColumn('deleted_at');
+            table.dropColumn('deleted_by_user_uuid');
+        });
+    }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: N/A

### Description

 Soft-delete migrations (saved_queries, dashboards, saved_sql, scheduler, spaces) used regular `CREATE INDEX` inside a transaction, which takes a SHARE lock blocking all writes for the duration of the index build.

  Switch to `CREATE INDEX CONCURRENTLY` with `transaction: false` to avoid write-blocking locks.
Instances that already ran the original migrations are unaffected — Knex skips already-executed migrations. New/upgrading instances get the non-locking version.