### PR TITLE
feat: add organization and project UUID configuration for setup

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -442,6 +442,8 @@ export const getUpdateSetupConfig = (): LightdashConfig['updateSetup'] => {
     }
 
     return {
+        organizationUuid: process.env.LD_SETUP_ORGANIZATION_UUID,
+        projectUuid: process.env.LD_SETUP_PROJECT_UUID,
         organization: {
             admin: {
                 email: process.env.LD_SETUP_ADMIN_EMAIL,
@@ -972,6 +974,8 @@ export type LightdashConfig = {
         dbt: DbtGithubProjectConfig;
     };
     updateSetup?: {
+        organizationUuid?: string;
+        projectUuid?: string;
         organization?: {
             admin: {
                 email?: string;

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -459,20 +459,46 @@ export class InstanceConfigurationService extends BaseService {
     }
 
     private async getSingleOrg() {
+        const configOrgUuid =
+            this.lightdashConfig.updateSetup?.organizationUuid;
+
+        if (configOrgUuid) {
+            const orgUuids = await this.organizationModel.getOrgUuids();
+            if (!orgUuids.includes(configOrgUuid)) {
+                throw new ParameterError(
+                    `Organization with UUID "${configOrgUuid}" (from LD_SETUP_ORGANIZATION_UUID) not found`,
+                );
+            }
+            return configOrgUuid;
+        }
+
         const orgUuids = await this.organizationModel.getOrgUuids();
         if (orgUuids.length !== 1) {
             throw new ParameterError(
-                `There must be exactly 1 organization to update instance configuration, remove all the LD_SETUP* env variables or keep only one organization to continue`,
+                `There must be exactly 1 organization to update instance configuration. Set LD_SETUP_ORGANIZATION_UUID to target a specific organization, remove all the LD_SETUP* env variables, or keep only one organization to continue`,
             );
         }
         return orgUuids[0];
     }
 
     private async getSingleProject() {
+        const configProjectUuid = this.lightdashConfig.updateSetup?.projectUuid;
+
+        if (configProjectUuid) {
+            const projectUuids =
+                await this.projectModel.getDefaultProjectUuids();
+            if (!projectUuids.includes(configProjectUuid)) {
+                throw new ParameterError(
+                    `Project with UUID "${configProjectUuid}" (from LD_SETUP_PROJECT_UUID) not found`,
+                );
+            }
+            return configProjectUuid;
+        }
+
         const projectUuids = await this.projectModel.getDefaultProjectUuids();
         if (projectUuids.length !== 1) {
             throw new ParameterError(
-                `There must be exactly 1 project to update instance configuration, remove all the LD_SETUP* env variables or keep only one project to continue`,
+                `There must be exactly 1 project to update instance configuration. Set LD_SETUP_PROJECT_UUID to target a specific project, remove all the LD_SETUP* env variables, or keep only one project to continue`,
             );
         }
         return projectUuids[0];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-5697/support-multi-projectmulti-org-instances-with-ld-setup-project-uuid

After

<img width="820" height="217" alt="Screenshot from 2026-03-02 14-23-08" src="https://github.com/user-attachments/assets/381dd06e-384b-4704-ad84-f5eb0b1a4569" />
<img width="830" height="237" alt="Screenshot from 2026-03-02 14-23-33" src="https://github.com/user-attachments/assets/c2c0bdb6-31e9-4e7c-9723-b3118ba86398" />
<img width="830" height="237" alt="image" src="https://github.com/user-attachments/assets/c42f0b1d-e2ce-44bd-8f37-10b1c1ba694e" />


### Description:

Adds support for `LD_SETUP_ORGANIZATION_UUID` and `LD_SETUP_PROJECT_UUID` environment variables to allow targeting specific organizations and projects during instance configuration setup.

When these environment variables are set, the system will use the specified UUIDs instead of requiring exactly one organization or project to exist. If the specified UUIDs are not found, appropriate error messages are thrown. The error messages for cases where multiple organizations or projects exist have been updated to mention these new environment variables as a solution.

<!-- Even better add a screenshot / gif / loom -->