### PR TITLE
fix: apply query filters to PoP pop_metrics, shifting time filters to prior period

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -1,6 +1,7 @@
 import {
     AnyType,
     BinType,
+    CompiledMetricQuery,
     CustomDimensionType,
     DimensionType,
     Explore,
@@ -10,6 +11,7 @@ import {
     JoinRelationship,
     MetricType,
     SortByDirection,
+    SupportedDbtAdapter,
     TimeFrames,
     VizAggregationOptions,
     VizIndexType,
@@ -107,6 +109,364 @@ const buildQuery = (
         ...args,
         parameterDefinitions: {},
     }).compileQuery();
+
+const POP_TEST_POP_METRIC_NAME = 'total_order_amount__pop__year_1__testpop';
+const POP_TEST_POP_METRIC_ID = `orders_${POP_TEST_POP_METRIC_NAME}`;
+const POP_TEST_FANOUT_POP_METRIC_NAME = 'metric_amount__pop__year_1__fanout';
+const POP_TEST_FANOUT_POP_METRIC_ID = `table2_${POP_TEST_FANOUT_POP_METRIC_NAME}`;
+
+const POP_TEST_EXPLORE: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'orders',
+    label: 'orders',
+    baseTable: 'orders',
+    tags: [],
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'orders',
+            database: 'postgres',
+            schema: 'jaffle',
+            sqlTable: '"postgres"."jaffle"."orders"',
+            primaryKey: ['order_id'],
+            dimensions: {
+                order_id: {
+                    type: DimensionType.NUMBER,
+                    name: 'order_id',
+                    label: 'order_id',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_id',
+                    compiledSql: '"orders".order_id',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                order_date: {
+                    type: DimensionType.DATE,
+                    name: 'order_date',
+                    label: 'order_date',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_date',
+                    compiledSql: '"orders".order_date',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                order_date_year: {
+                    type: DimensionType.DATE,
+                    name: 'order_date_year',
+                    label: 'order_date_year',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: "DATE_TRUNC('YEAR', ${TABLE}.order_date)",
+                    compiledSql: `DATE_TRUNC('YEAR', "orders".order_date)`,
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                    timeInterval: TimeFrames.YEAR,
+                    timeIntervalBaseDimensionName: 'order_date',
+                },
+                is_completed: {
+                    type: DimensionType.BOOLEAN,
+                    name: 'is_completed',
+                    label: 'is_completed',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.is_completed',
+                    compiledSql: '"orders".is_completed',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_order_amount: {
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    name: 'total_order_amount',
+                    label: 'total_order_amount',
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("orders".amount)',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+const POP_TEST_METRIC_QUERY: CompiledMetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_order_date_year'],
+    metrics: ['orders_total_order_amount', POP_TEST_POP_METRIC_ID],
+    filters: {
+        dimensions: {
+            id: 'root',
+            and: [
+                {
+                    id: 'is-completed',
+                    target: {
+                        fieldId: 'orders_is_completed',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: [true],
+                },
+                {
+                    id: 'base-year',
+                    target: {
+                        fieldId: 'orders_order_date_year',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2025-01-01'],
+                },
+            ],
+        },
+    },
+    sorts: [{ fieldId: 'orders_order_date_year', descending: true }],
+    limit: 500,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    additionalMetrics: [
+        {
+            table: 'orders',
+            name: POP_TEST_POP_METRIC_NAME,
+            label: 'Previous year total_order_amount',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+            generationType: 'periodOverPeriod' as const,
+            baseMetricId: 'orders_total_order_amount',
+            timeDimensionId: 'orders_order_date_year',
+            granularity: TimeFrames.YEAR,
+            periodOffset: 1,
+        },
+    ],
+    compiledAdditionalMetrics: [
+        {
+            type: MetricType.SUM,
+            fieldType: FieldType.METRIC,
+            table: 'orders',
+            tableLabel: 'orders',
+            name: POP_TEST_POP_METRIC_NAME,
+            label: 'Previous year total_order_amount',
+            sql: '${TABLE}.amount',
+            compiledSql: 'SUM("orders".amount)',
+            tablesReferences: ['orders'],
+            hidden: true,
+        },
+    ],
+    compiledCustomDimensions: [],
+};
+
+const POP_TEST_FANOUT_EXPLORE: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'base',
+    label: 'base',
+    baseTable: 'table1',
+    tags: [],
+    joinedTables: [
+        {
+            table: 'table2',
+            sqlOn: '${table1.shared} = ${table2.shared}',
+            compiledSqlOn: '("table1".shared) = ("table2".shared)',
+            type: undefined,
+            tablesReferences: ['table1', 'table2'],
+            relationship: JoinRelationship.MANY_TO_ONE,
+        },
+    ],
+    tables: {
+        table1: {
+            name: 'table1',
+            label: 'table1',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."table1"',
+            primaryKey: ['id'],
+            dimensions: {
+                id: {
+                    type: DimensionType.NUMBER,
+                    name: 'id',
+                    label: 'id',
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.id',
+                    compiledSql: '"table1".id',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                },
+                shared: {
+                    type: DimensionType.STRING,
+                    name: 'shared',
+                    label: 'shared',
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.shared',
+                    compiledSql: '"table1".shared',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+        table2: {
+            name: 'table2',
+            label: 'table2',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."table2"',
+            primaryKey: ['id'],
+            dimensions: {
+                id: {
+                    type: DimensionType.NUMBER,
+                    name: 'id',
+                    label: 'id',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.id',
+                    compiledSql: '"table2".id',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+                shared: {
+                    type: DimensionType.STRING,
+                    name: 'shared',
+                    label: 'shared',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.shared',
+                    compiledSql: '"table2".shared',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+                order_date: {
+                    type: DimensionType.DATE,
+                    name: 'order_date',
+                    label: 'order_date',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_date',
+                    compiledSql: '"table2".order_date',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+                order_date_year: {
+                    type: DimensionType.DATE,
+                    name: 'order_date_year',
+                    label: 'order_date_year',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: "DATE_TRUNC('YEAR', ${TABLE}.order_date)",
+                    compiledSql: `DATE_TRUNC('YEAR', "table2".order_date)`,
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                    timeInterval: TimeFrames.YEAR,
+                    timeIntervalBaseDimensionName: 'order_date',
+                },
+                is_completed: {
+                    type: DimensionType.BOOLEAN,
+                    name: 'is_completed',
+                    label: 'is_completed',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.is_completed',
+                    compiledSql: '"table2".is_completed',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                metric_amount: {
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    name: 'metric_amount',
+                    label: 'metric_amount',
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("table2".amount)',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+const POP_TEST_FANOUT_METRIC_QUERY: CompiledMetricQuery = {
+    exploreName: 'base',
+    dimensions: ['table2_order_date_year'],
+    metrics: ['table2_metric_amount', POP_TEST_FANOUT_POP_METRIC_ID],
+    filters: {
+        dimensions: {
+            id: 'root',
+            and: [
+                {
+                    id: 'is-completed',
+                    target: {
+                        fieldId: 'table2_is_completed',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: [true],
+                },
+                {
+                    id: 'base-year',
+                    target: {
+                        fieldId: 'table2_order_date_year',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2025-01-01'],
+                },
+            ],
+        },
+    },
+    sorts: [{ fieldId: 'table2_order_date_year', descending: true }],
+    limit: 100,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    additionalMetrics: [
+        {
+            table: 'table2',
+            name: POP_TEST_FANOUT_POP_METRIC_NAME,
+            label: 'Previous year metric_amount',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+            generationType: 'periodOverPeriod' as const,
+            baseMetricId: 'table2_metric_amount',
+            timeDimensionId: 'table2_order_date_year',
+            granularity: TimeFrames.YEAR,
+            periodOffset: 1,
+        },
+    ],
+    compiledAdditionalMetrics: [
+        {
+            type: MetricType.SUM,
+            fieldType: FieldType.METRIC,
+            table: 'table2',
+            tableLabel: 'table2',
+            name: POP_TEST_FANOUT_POP_METRIC_NAME,
+            label: 'Previous year metric_amount',
+            sql: '${TABLE}.amount',
+            compiledSql: 'SUM("table2".amount)',
+            tablesReferences: ['table2'],
+            hidden: true,
+        },
+    ],
+    compiledCustomDimensions: [],
+};
 
 describe('Query builder', () => {
     test('Should build simple metric query', () => {
@@ -259,6 +619,50 @@ describe('Query builder', () => {
             replaceWhitespace(
                 METRIC_QUERY_WITH_METRIC_FILTER_AND_ONE_DISABLED_SQL,
             ),
+        );
+    });
+
+    test('Should reuse non-time filters for PoP metrics while shifting the comparison period', () => {
+        const { query } = buildQuery({
+            explore: POP_TEST_EXPLORE,
+            compiledMetricQuery: POP_TEST_METRIC_QUERY,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(
+            query.match(/\("orders"\.is_completed\) = true/g) ?? [],
+        ).toHaveLength(2);
+        expect(query.match(/\('2025-01-01'\)/g) ?? []).toHaveLength(1);
+        expect(query).toMatch(
+            /DATE_TRUNC\('YEAR', "orders"\.order_date\) >= pop_min_max_[a-z0-9_]+\.min_date - INTERVAL '1 YEAR'/,
+        );
+        expect(query).toMatch(
+            /DATE_TRUNC\('YEAR', "orders"\.order_date\) <= pop_min_max_[a-z0-9_]+\.max_date - INTERVAL '1 YEAR'/,
+        );
+    });
+
+    test('Should reuse non-time filters for PoP metrics in fanout-protected CTEs while shifting the comparison period', () => {
+        const { query } = buildQuery({
+            explore: POP_TEST_FANOUT_EXPLORE,
+            compiledMetricQuery: POP_TEST_FANOUT_METRIC_QUERY,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(query).toContain('cte_pop_keys_');
+        expect(query).toContain('cte_pop_metrics_');
+        expect(
+            query.match(/\("table2"\.is_completed\) = true/g) ?? [],
+        ).toHaveLength(3);
+        expect(query.match(/\('2025-01-01'\)/g) ?? []).toHaveLength(2);
+        expect(query).toMatch(
+            /DATE_TRUNC\('YEAR', "table2"\.order_date\) >= cte_pop_min_max_[a-z0-9_]+__year_1__[a-z0-9_]+\.min_date - INTERVAL '1 YEAR'/,
+        );
+        expect(query).toMatch(
+            /DATE_TRUNC\('YEAR', "table2"\.order_date\) <= cte_pop_min_max_[a-z0-9_]+__year_1__[a-z0-9_]+\.max_date - INTERVAL '1 YEAR'/,
         );
     });
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -11,6 +11,7 @@ import {
     FieldReferenceError,
     FieldType,
     FilterGroup,
+    FilterGroupItem,
     FilterRule,
     getCustomMetricDimensionId,
     getDimensionMapFromTables,
@@ -390,6 +391,19 @@ export class MetricQueryBuilder {
         return parts.filter((l) => l !== undefined).join('\n');
     }
 
+    private static combineWhereClauses(
+        ...clauses: Array<string | undefined>
+    ): string | undefined {
+        const conditions = clauses
+            .filter((clause): clause is string => clause !== undefined)
+            .map((clause) => clause.replace(/^WHERE\s+/i, '').trim())
+            .filter((clause) => clause.length > 0);
+
+        return conditions.length > 0
+            ? `WHERE ${conditions.join(' AND ')}`
+            : undefined;
+    }
+
     private getMetricFromId(metricId: string): CompiledMetric {
         const metric = this.availableMetrics[metricId];
         if (!metric) {
@@ -400,7 +414,122 @@ export class MetricQueryBuilder {
         return metric;
     }
 
-    private getDimensionsFilterSQL() {
+    private isFilterOnPopComparisonTimeDimension(
+        filter: FilterRule,
+        timeDimensionId: string,
+    ): boolean {
+        if (filter.target.fieldId === timeDimensionId) {
+            return true;
+        }
+
+        const { compiledMetricQuery, warehouseSqlBuilder } = this.args;
+        const adapterType: SupportedDbtAdapter =
+            warehouseSqlBuilder.getAdapterType();
+        const startOfWeek = warehouseSqlBuilder.getStartOfWeek();
+
+        const popDimension = getDimensionFromId({
+            dimId: timeDimensionId,
+            dimensions: this.exploreDimensions,
+            dimensionsWithoutAccess: this.exploreDimensionsWithoutAccess,
+            adapterType,
+            startOfWeek,
+        });
+        const popDimensionBaseId = `${popDimension.table}_${
+            popDimension.timeIntervalBaseDimensionName ?? popDimension.name
+        }`;
+
+        try {
+            const filterDimension = getDimensionFromFilterTargetId({
+                filterTargetId: filter.target.fieldId,
+                dimensions: this.exploreDimensions,
+                dimensionsWithoutAccess: this.exploreDimensionsWithoutAccess,
+                compiledCustomDimensions:
+                    compiledMetricQuery.compiledCustomDimensions.filter(
+                        isCompiledCustomSqlDimension,
+                    ),
+                adapterType,
+                startOfWeek,
+            });
+
+            if (isCompiledCustomSqlDimension(filterDimension)) {
+                return false;
+            }
+
+            return (
+                `${filterDimension.table}_${
+                    filterDimension.timeIntervalBaseDimensionName ??
+                    filterDimension.name
+                }` === popDimensionBaseId
+            );
+        } catch (error) {
+            if (
+                this.args.continueOnError &&
+                error instanceof FieldReferenceError
+            ) {
+                this.compilationErrors.push(error.message);
+                return false;
+            }
+            throw error;
+        }
+    }
+
+    private getDimensionsFilterGroupWithoutPopTimeFilters(
+        timeDimensionId: string,
+        filterGroup: FilterGroup | undefined,
+    ): FilterGroup | undefined {
+        if (!filterGroup) {
+            return undefined;
+        }
+
+        const items = isAndFilterGroup(filterGroup)
+            ? filterGroup.and
+            : filterGroup.or;
+
+        const filteredItems = items.reduce<FilterGroupItem[]>((acc, item) => {
+            if (isFilterGroup(item)) {
+                const nestedGroup =
+                    this.getDimensionsFilterGroupWithoutPopTimeFilters(
+                        timeDimensionId,
+                        item,
+                    );
+                return nestedGroup ? [...acc, nestedGroup] : acc;
+            }
+
+            return this.isFilterOnPopComparisonTimeDimension(
+                item,
+                timeDimensionId,
+            )
+                ? acc
+                : [...acc, item];
+        }, []);
+
+        if (filteredItems.length === 0) {
+            return undefined;
+        }
+
+        return isAndFilterGroup(filterGroup)
+            ? {
+                  ...filterGroup,
+                  and: filteredItems,
+              }
+            : {
+                  ...filterGroup,
+                  or: filteredItems,
+              };
+    }
+
+    private getPopDimensionsFilterSQL(
+        timeDimensionId: string,
+    ): string | undefined {
+        return this.getDimensionsFilterSQL(
+            this.getDimensionsFilterGroupWithoutPopTimeFilters(
+                timeDimensionId,
+                this.args.compiledMetricQuery.filters.dimensions,
+            ),
+        );
+    }
+
+    private getDimensionsFilterSQL(filterGroup?: FilterGroup) {
         const {
             explore,
             compiledMetricQuery,
@@ -408,12 +537,13 @@ export class MetricQueryBuilder {
             userAttributes = {},
             intrinsicUserAttributes,
         } = this.args;
-        const { filters } = compiledMetricQuery;
+        const dimensionsFilterGroup =
+            filterGroup ?? compiledMetricQuery.filters.dimensions;
 
         const requiredDimensionFilterSql =
             this.getNestedDimensionFilterSQLFromModelFilters(
                 explore.tables[explore.baseTable],
-                filters.dimensions,
+                dimensionsFilterGroup,
             );
         const tableCompiledSqlWhere =
             explore.tables[explore.baseTable].sqlWhere;
@@ -430,7 +560,7 @@ export class MetricQueryBuilder {
             : [];
 
         const nestedFilterSql = this.getNestedFilterSQLFromGroup(
-            filters.dimensions,
+            dimensionsFilterGroup,
             FieldType.DIMENSION,
         );
         const requiredFiltersWhere = requiredDimensionFilterSql
@@ -1652,6 +1782,8 @@ export class MetricQueryBuilder {
                             adapterType,
                             startOfWeek,
                         });
+                        const popDimensionFilters =
+                            this.getPopDimensionsFilterSQL(popFieldId);
                         const popKeysCteParts = [
                             `SELECT DISTINCT`,
                             [
@@ -1666,23 +1798,26 @@ export class MetricQueryBuilder {
                                 ...joins,
                                 `LEFT JOIN ${popMinMaxCteName} ON TRUE`,
                             ],
-                            `WHERE ${getIntervalSyntax(
-                                adapterType,
-                                popField.compiledSql,
-                                `${popMinMaxCteName}.min_date`,
-                                '>=',
-                                cfg.periodOffset,
-                                cfg.granularity,
-                                false,
-                            )} AND ${getIntervalSyntax(
-                                adapterType,
-                                popField.compiledSql,
-                                `${popMinMaxCteName}.max_date`,
-                                '<=',
-                                cfg.periodOffset,
-                                cfg.granularity,
-                                false,
-                            )}`,
+                            MetricQueryBuilder.combineWhereClauses(
+                                popDimensionFilters,
+                                `WHERE ${getIntervalSyntax(
+                                    adapterType,
+                                    popField.compiledSql,
+                                    `${popMinMaxCteName}.min_date`,
+                                    '>=',
+                                    cfg.periodOffset,
+                                    cfg.granularity,
+                                    false,
+                                )} AND ${getIntervalSyntax(
+                                    adapterType,
+                                    popField.compiledSql,
+                                    `${popMinMaxCteName}.max_date`,
+                                    '<=',
+                                    cfg.periodOffset,
+                                    cfg.granularity,
+                                    false,
+                                )}`,
+                            ),
                         ];
                         ctes.push(
                             `${popKeysCteName} AS (\n${MetricQueryBuilder.assembleSqlParts(
@@ -1849,10 +1984,13 @@ export class MetricQueryBuilder {
                         adapterType,
                         startOfWeek,
                     });
+                    const popDimensionFilters =
+                        this.getPopDimensionsFilterSQL(popFieldId);
 
                     /**
                      * CTE for PoP unaffected metrics
-                     * Filters are PoP specific rather than metric query filters
+                     * Reuse query filters except the comparison time dimension,
+                     * which is constrained by the shifted min/max bounds.
                      */
                     const popUnaffectedMetricsCteName = `cte_pop_unaffected_${popConfigSuffix}`;
                     const popUnaffectedMetricsCteParts = [
@@ -1874,23 +2012,26 @@ export class MetricQueryBuilder {
                             ...joins,
                             `LEFT JOIN ${popUnaffectedMinMaxCteName} ON TRUE`,
                         ],
-                        `WHERE ${getIntervalSyntax(
-                            adapterType,
-                            popField.compiledSql,
-                            `${popUnaffectedMinMaxCteName}.min_date`,
-                            '>=',
-                            cfg.periodOffset,
-                            cfg.granularity,
-                            false,
-                        )} AND ${getIntervalSyntax(
-                            adapterType,
-                            popField.compiledSql,
-                            `${popUnaffectedMinMaxCteName}.max_date`,
-                            '<=',
-                            cfg.periodOffset,
-                            cfg.granularity,
-                            false,
-                        )}`,
+                        MetricQueryBuilder.combineWhereClauses(
+                            popDimensionFilters,
+                            `WHERE ${getIntervalSyntax(
+                                adapterType,
+                                popField.compiledSql,
+                                `${popUnaffectedMinMaxCteName}.min_date`,
+                                '>=',
+                                cfg.periodOffset,
+                                cfg.granularity,
+                                false,
+                            )} AND ${getIntervalSyntax(
+                                adapterType,
+                                popField.compiledSql,
+                                `${popUnaffectedMinMaxCteName}.max_date`,
+                                '<=',
+                                cfg.periodOffset,
+                                cfg.granularity,
+                                false,
+                            )}`,
+                        ),
                         dimensionGroupBy,
                     ];
                     ctes.push(
@@ -2571,6 +2712,8 @@ export class MetricQueryBuilder {
                     adapterType,
                     startOfWeek,
                 });
+                const popDimensionFilters =
+                    this.getPopDimensionsFilterSQL(popFieldId);
 
                 const popMetricSelectsInPopCte = popEntries.map((entry) => {
                     const metric = this.getMetricFromId(entry.baseMetricId);
@@ -2586,23 +2729,26 @@ export class MetricQueryBuilder {
                     joins.joinSQL,
                     ...dimensionsSQL.joins,
                     ...[`LEFT JOIN ${popMinMaxCteName} ON TRUE`],
-                    `WHERE ${getIntervalSyntax(
-                        adapterType,
-                        popField.compiledSql,
-                        `${popMinMaxCteName}.min_date`,
-                        '>=',
-                        cfg.periodOffset,
-                        cfg.granularity,
-                        false,
-                    )} AND ${getIntervalSyntax(
-                        adapterType,
-                        popField.compiledSql,
-                        `${popMinMaxCteName}.max_date`,
-                        '<=',
-                        cfg.periodOffset,
-                        cfg.granularity,
-                        false,
-                    )}`,
+                    MetricQueryBuilder.combineWhereClauses(
+                        popDimensionFilters,
+                        `WHERE ${getIntervalSyntax(
+                            adapterType,
+                            popField.compiledSql,
+                            `${popMinMaxCteName}.min_date`,
+                            '>=',
+                            cfg.periodOffset,
+                            cfg.granularity,
+                            false,
+                        )} AND ${getIntervalSyntax(
+                            adapterType,
+                            popField.compiledSql,
+                            `${popMinMaxCteName}.max_date`,
+                            '<=',
+                            cfg.periodOffset,
+                            cfg.granularity,
+                            false,
+                        )}`,
+                    ),
                     dimensionsSQL.groupBySQL,
                 ];
 


### PR DESCRIPTION
Closes: [PROD-2798](https://linear.app/lightdash/issue/PROD-2798/metricquerybuilder-apply-query-filters-to-pop-pop-metrics-shifting)

### Description:

This PR fixes an issue with Period-over-Period (PoP) metrics where non-time dimension filters were not being properly applied to the comparison period queries.

**Changes made:**

- Added logic to identify filters on PoP comparison time dimensions and exclude them when building PoP queries
- Implemented `getDimensionsFilterGroupWithoutPopTimeFilters()` to recursively filter out time-based filters while preserving other dimension filters
- Added `getPopDimensionsFilterSQL()` to generate appropriate WHERE clauses for PoP queries
- Updated PoP CTE generation to combine filtered dimension conditions with time interval constraints using the new `combineWhereClauses()` helper method
- Applied the fix to both simple PoP queries and fanout-protected PoP CTEs

**Test coverage:**

- Added comprehensive test data including `POP_TEST_EXPLORE` and `POP_TEST_FANOUT_EXPLORE` with realistic table structures
- Added test cases verifying that non-time filters (like `is_completed = true`) are properly reused in PoP queries
- Verified that time dimension filters are correctly shifted to the comparison period using interval arithmetic
- Confirmed the fix works for both single-table and joined table scenarios with fanout protection

The fix ensures that PoP metrics now correctly apply all relevant filters from the base query to the comparison period, while properly adjusting time-based constraints to the shifted time range.