### PR TITLE
feat: add dedicated S3 storage for pre-aggregate materializations

### DIFF
--- a/packages/backend/src/clients/Aws/S3CacheClient.ts
+++ b/packages/backend/src/clients/Aws/S3CacheClient.ts
@@ -21,14 +21,15 @@ import { S3BaseClient } from './S3BaseClient';
 
 export type S3CacheClientArguments = {
     lightdashConfig: LightdashConfig;
+    s3Config?: LightdashConfig['results']['s3'];
 };
 
 export class S3CacheClient extends S3BaseClient {
     configuration: LightdashConfig['results']['s3'];
 
-    constructor({ lightdashConfig }: S3CacheClientArguments) {
-        super(lightdashConfig.results.s3);
-        this.configuration = lightdashConfig.results.s3;
+    constructor({ lightdashConfig, s3Config }: S3CacheClientArguments) {
+        super(s3Config ?? lightdashConfig.results.s3);
+        this.configuration = s3Config ?? lightdashConfig.results.s3;
 
         if (this.s3) {
             Logger.debug('Initialized S3 results cache client');

--- a/packages/backend/src/clients/ClientRepository.ts
+++ b/packages/backend/src/clients/ClientRepository.ts
@@ -23,6 +23,7 @@ export interface ClientManifest {
     schedulerClient: SchedulerClient;
     slackClient: SlackClient;
     msTeamsClient: MicrosoftTeamsClient;
+    preAggregateResultsFileStorageClient: S3ResultsFileStorageClient;
     resultsFileStorageClient: S3ResultsFileStorageClient;
 }
 
@@ -188,6 +189,17 @@ export class ClientRepository
             () =>
                 new S3ResultsFileStorageClient({
                     lightdashConfig: this.context.lightdashConfig,
+                }),
+        );
+    }
+
+    public getPreAggregateResultsFileStorageClient(): S3ResultsFileStorageClient {
+        return this.getClient(
+            'preAggregateResultsFileStorageClient',
+            () =>
+                new S3ResultsFileStorageClient({
+                    lightdashConfig: this.context.lightdashConfig,
+                    s3Config: this.context.lightdashConfig.preAggregates.s3,
                 }),
         );
     }

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -341,5 +341,10 @@ export const lightdashConfigMock: LightdashConfig = {
     preAggregates: {
         enabled: false,
         debug: false,
+        s3: {
+            endpoint: 'mock_endpoint',
+            bucket: 'mock_preagg_bucket',
+            region: 'mock_region',
+        },
     },
 };

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -83,6 +83,42 @@ test('Should prioritize new results S3 config over deprecated config when both a
     });
 });
 
+test('Should fall back to base S3 credentials for pre-aggregate results S3 config', () => {
+    process.env.S3_ACCESS_KEY = 'base_access_key';
+    process.env.S3_SECRET_KEY = 'base_secret_key';
+    process.env.PRE_AGGREGATE_RESULTS_S3_BUCKET = 'preagg_bucket';
+    process.env.PRE_AGGREGATE_RESULTS_S3_REGION = 'preagg_region';
+
+    const config = parseConfig();
+    expect(config.preAggregates.s3).toEqual({
+        endpoint: 'mock_endpoint',
+        bucket: 'preagg_bucket',
+        region: 'preagg_region',
+        accessKey: 'base_access_key',
+        secretKey: 'base_secret_key',
+        forcePathStyle: false,
+    });
+});
+
+test('Should use explicit pre-aggregate S3 credentials when set', () => {
+    process.env.S3_ACCESS_KEY = 'base_access_key';
+    process.env.S3_SECRET_KEY = 'base_secret_key';
+    process.env.PRE_AGGREGATE_RESULTS_S3_BUCKET = 'preagg_bucket';
+    process.env.PRE_AGGREGATE_RESULTS_S3_REGION = 'preagg_region';
+    process.env.PRE_AGGREGATE_RESULTS_S3_ACCESS_KEY = 'preagg_access_key';
+    process.env.PRE_AGGREGATE_RESULTS_S3_SECRET_KEY = 'preagg_secret_key';
+
+    const config = parseConfig();
+    expect(config.preAggregates.s3).toEqual({
+        endpoint: 'mock_endpoint',
+        bucket: 'preagg_bucket',
+        region: 'preagg_region',
+        accessKey: 'preagg_access_key',
+        secretKey: 'preagg_secret_key',
+        forcePathStyle: false,
+    });
+});
+
 test('Should parse rudder config from env', () => {
     const expected = {
         dataPlaneUrl: 'customurl',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -570,6 +570,56 @@ export const parseResultsS3Config = (): LightdashConfig['results']['s3'] => {
     };
 };
 
+export const parsePreAggregateResultsS3Config = ():
+    | Omit<S3Config, 'expirationTime'>
+    | undefined => {
+    const baseS3Config = parseBaseS3Config();
+
+    if (!baseS3Config) {
+        return undefined;
+    }
+
+    const bucket = process.env.PRE_AGGREGATE_RESULTS_S3_BUCKET;
+    const region = process.env.PRE_AGGREGATE_RESULTS_S3_REGION;
+    const accessKey = process.env.PRE_AGGREGATE_RESULTS_S3_ACCESS_KEY;
+    const secretKey = process.env.PRE_AGGREGATE_RESULTS_S3_SECRET_KEY;
+
+    const hasAnyPreAggregateS3Config =
+        bucket !== undefined ||
+        region !== undefined ||
+        accessKey !== undefined ||
+        secretKey !== undefined;
+
+    if (!hasAnyPreAggregateS3Config) {
+        return undefined;
+    }
+
+    const {
+        endpoint,
+        forcePathStyle,
+        useCredentialsFrom,
+        accessKey: baseAccessKey,
+        secretKey: baseSecretKey,
+    } = baseS3Config;
+
+    if (!endpoint || !bucket || !region) {
+        throw new ParseError(
+            'PRE_AGGREGATE_RESULTS_S3_BUCKET, PRE_AGGREGATE_RESULTS_S3_REGION, and S3_ENDPOINT must be set when configuring pre-aggregate result storage.',
+            {},
+        );
+    }
+
+    return {
+        endpoint,
+        forcePathStyle,
+        bucket,
+        region,
+        accessKey: accessKey ?? baseAccessKey,
+        secretKey: secretKey ?? baseSecretKey,
+        useCredentialsFrom,
+    };
+};
+
 const validateTaskList = (tasks: string[], envVarName: string) => {
     const validTasks: SchedulerTaskName[] = [];
     const invalidTasks: string[] = [];
@@ -1051,6 +1101,7 @@ export type LightdashConfig = {
     preAggregates: {
         enabled: boolean;
         debug: boolean;
+        s3?: Omit<S3Config, 'expirationTime'>;
     };
 };
 
@@ -1320,6 +1371,13 @@ export const parseConfig = (): LightdashConfig => {
     }
 
     const licenseKey = process.env.LIGHTDASH_LICENSE_KEY || null;
+    const preAggregatesEnabled =
+        licenseKey !== null && process.env.PRE_AGGREGATES_ENABLED === 'true';
+    const preAggregatesS3 = parsePreAggregateResultsS3Config();
+
+    if (preAggregatesEnabled && !preAggregatesS3) {
+        throw new ParseError('Pre-aggregates require S3 configuration', {});
+    }
 
     return {
         mode,
@@ -1918,12 +1976,11 @@ export const parseConfig = (): LightdashConfig => {
                 ) ?? 30,
         },
         preAggregates: {
-            enabled:
-                licenseKey !== null &&
-                process.env.PRE_AGGREGATES_ENABLED === 'true',
+            enabled: preAggregatesEnabled,
             debug:
                 licenseKey !== null &&
                 process.env.DEBUG_PRE_AGGREGATES === 'true',
+            s3: preAggregatesS3,
         },
     };
 };

--- a/packages/backend/src/database/entities/preAggregates.ts
+++ b/packages/backend/src/database/entities/preAggregates.ts
@@ -55,6 +55,7 @@ export type DbPreAggregateMaterialization = {
     status: PreAggregateMaterializationStatus;
     trigger: PreAggregateMaterializationTrigger;
     query_uuid: string | null;
+    materialization_uri: string | null;
     materialized_at: Date | null;
     row_count: number | null;
     columns: ResultColumns | null;
@@ -73,6 +74,7 @@ export type DbPreAggregateMaterializationUpdate = Partial<
         DbPreAggregateMaterialization,
         | 'status'
         | 'query_uuid'
+        | 'materialization_uri'
         | 'materialized_at'
         | 'row_count'
         | 'columns'

--- a/packages/backend/src/database/migrations/20260302120000_add_materialization_uri_to_pre_aggregate_materializations.ts
+++ b/packages/backend/src/database/migrations/20260302120000_add_materialization_uri_to_pre_aggregate_materializations.ts
@@ -1,0 +1,22 @@
+import { Knex } from 'knex';
+
+const PRE_AGGREGATE_MATERIALIZATIONS_TABLE = 'pre_aggregate_materializations';
+const MATERIALIZATION_URI_COLUMN = 'materialization_uri';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(
+        PRE_AGGREGATE_MATERIALIZATIONS_TABLE,
+        (table) => {
+            table.text(MATERIALIZATION_URI_COLUMN).nullable();
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(
+        PRE_AGGREGATE_MATERIALIZATIONS_TABLE,
+        (table) => {
+            table.dropColumn(MATERIALIZATION_URI_COLUMN);
+        },
+    );
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -298,6 +298,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),
                     resultsStorageClient: clients.getResultsFileStorageClient(),
+                    preAggregateResultsStorageClient:
+                        clients.getPreAggregateResultsFileStorageClient(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:

--- a/packages/backend/src/models/PreAggregateModel.test.ts
+++ b/packages/backend/src/models/PreAggregateModel.test.ts
@@ -1,0 +1,76 @@
+import { DimensionType } from '@lightdash/common';
+import knex from 'knex';
+import { getTracker, MockClient, Tracker } from 'knex-mock-client';
+import { PreAggregateMaterializationsTableName } from '../database/entities/preAggregates';
+import { PreAggregateModel } from './PreAggregateModel';
+
+describe('PreAggregateModel', () => {
+    const database = knex({ client: MockClient, dialect: 'pg' });
+    const model = new PreAggregateModel({ database });
+    let tracker: Tracker;
+
+    beforeAll(() => {
+        tracker = getTracker();
+    });
+
+    afterEach(() => {
+        tracker.reset();
+    });
+
+    test('gets active materialization without joining query_history', async () => {
+        tracker.on.select(PreAggregateMaterializationsTableName).responseOnce([
+            {
+                pre_aggregate_materialization_uuid: 'mat-1',
+                query_uuid: 'query-1',
+                materialization_uri: 's3://preagg-bucket/materialization.jsonl',
+                columns: {
+                    orders_total: {
+                        reference: 'orders.total',
+                        type: DimensionType.NUMBER,
+                    },
+                },
+                materialized_at: new Date('2024-02-01T00:00:00.000Z'),
+            },
+        ]);
+
+        const result = await model.getActiveMaterialization(
+            'project-1',
+            '__preagg__orders__daily',
+        );
+
+        expect(result).toEqual({
+            materializationUuid: 'mat-1',
+            queryUuid: 'query-1',
+            materializationUri: 's3://preagg-bucket/materialization.jsonl',
+            format: 'jsonl',
+            columns: {
+                orders_total: {
+                    reference: 'orders.total',
+                    type: DimensionType.NUMBER,
+                },
+            },
+            materializedAt: new Date('2024-02-01T00:00:00.000Z'),
+        });
+        expect(tracker.history.select).toHaveLength(1);
+        expect(tracker.history.select[0].sql).not.toContain('query_history');
+    });
+
+    test('ignores active rows without a persisted materialization uri', async () => {
+        tracker.on.select(PreAggregateMaterializationsTableName).responseOnce([
+            {
+                pre_aggregate_materialization_uuid: 'mat-1',
+                query_uuid: 'query-1',
+                materialization_uri: null,
+                columns: null,
+                materialized_at: new Date('2024-02-01T00:00:00.000Z'),
+            },
+        ]);
+
+        const result = await model.getActiveMaterialization(
+            'project-1',
+            '__preagg__orders__daily',
+        );
+
+        expect(result).toBeUndefined();
+    });
+});

--- a/packages/backend/src/models/PreAggregateModel.ts
+++ b/packages/backend/src/models/PreAggregateModel.ts
@@ -17,10 +17,6 @@ import {
     type DbPreAggregateMaterialization,
 } from '../database/entities/preAggregates';
 import { CachedExploreTableName } from '../database/entities/projects';
-import {
-    QueryHistoryTableName,
-    type DbQueryHistory,
-} from '../database/entities/queryHistory';
 
 type DbPreAggregateDefinitionWithExploreName = DbPreAggregateDefinition & {
     pre_agg_explore_name: string;
@@ -50,6 +46,7 @@ const toPreAggregateMaterialization = (
     status: row.status,
     trigger: row.trigger,
     queryUuid: row.query_uuid,
+    materializationUri: row.materialization_uri,
     materializedAt: row.materialized_at,
     rowCount: row.row_count,
     columns: row.columns,
@@ -217,6 +214,7 @@ export class PreAggregateModel {
                 status: 'in_progress',
                 trigger: args.trigger,
                 query_uuid: null,
+                materialization_uri: null,
                 materialized_at: null,
                 row_count: null,
                 columns: null,
@@ -261,6 +259,7 @@ export class PreAggregateModel {
     async promoteToActive(args: {
         materializationUuid: string;
         queryUuid: string;
+        materializationUri: string;
         materializedAt: Date;
         rowCount: number | null;
         columns: ResultColumns | null;
@@ -299,6 +298,7 @@ export class PreAggregateModel {
 
                 const commonUpdate = {
                     query_uuid: args.queryUuid,
+                    materialization_uri: args.materializationUri,
                     materialized_at: args.materializedAt,
                     row_count: args.rowCount,
                     columns: args.columns,
@@ -358,6 +358,7 @@ export class PreAggregateModel {
             await this.database(PreAggregateMaterializationsTableName)
                 .update({
                     query_uuid: args.queryUuid,
+                    materialization_uri: args.materializationUri,
                     materialized_at: args.materializedAt,
                     row_count: args.rowCount,
                     columns: args.columns,
@@ -389,11 +390,6 @@ export class PreAggregateModel {
                 `${PreAggregateDefinitionsTableName}.pre_agg_cached_explore_uuid`,
                 `${CachedExploreTableName}.cached_explore_uuid`,
             )
-            .innerJoin(
-                QueryHistoryTableName,
-                `${PreAggregateMaterializationsTableName}.query_uuid`,
-                `${QueryHistoryTableName}.query_uuid`,
-            )
             .where(
                 `${PreAggregateMaterializationsTableName}.project_uuid`,
                 projectUuid,
@@ -405,20 +401,20 @@ export class PreAggregateModel {
             )
             .whereNotNull(`${PreAggregateMaterializationsTableName}.query_uuid`)
             .select<
-                (Pick<
+                Pick<
                     DbPreAggregateMaterialization,
                     | 'pre_aggregate_materialization_uuid'
                     | 'query_uuid'
+                    | 'materialization_uri'
                     | 'columns'
                     | 'materialized_at'
-                > &
-                    Pick<DbQueryHistory, 'results_file_name'>)[]
+                >[]
             >([
                 `${PreAggregateMaterializationsTableName}.pre_aggregate_materialization_uuid`,
                 `${PreAggregateMaterializationsTableName}.query_uuid`,
+                `${PreAggregateMaterializationsTableName}.materialization_uri`,
                 `${PreAggregateMaterializationsTableName}.columns`,
                 `${PreAggregateMaterializationsTableName}.materialized_at`,
-                `${QueryHistoryTableName}.results_file_name`,
             ])
             .orderBy(
                 `${PreAggregateMaterializationsTableName}.materialized_at`,
@@ -429,7 +425,7 @@ export class PreAggregateModel {
         if (
             !row ||
             !row.query_uuid ||
-            !row.results_file_name ||
+            !row.materialization_uri ||
             !row.materialized_at
         ) {
             return undefined;
@@ -438,7 +434,7 @@ export class PreAggregateModel {
         return {
             materializationUuid: row.pre_aggregate_materialization_uuid,
             queryUuid: row.query_uuid,
-            resultsFileName: row.results_file_name,
+            materializationUri: row.materialization_uri,
             format: 'jsonl',
             columns: row.columns,
             materializedAt: row.materialized_at,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -194,6 +194,30 @@ const getMockedAsyncQueryService = (
                 });
                 return readable;
             }),
+            getFirstLine: jest.fn(async () => '{}'),
+            getFileUrl: jest.fn(
+                async () => 'https://example.com/results.jsonl',
+            ),
+            createUploadStream: jest.fn(() => ({
+                write: jest.fn(),
+                close: jest.fn(),
+            })),
+        } as unknown as S3ResultsFileStorageClient,
+        preAggregateResultsStorageClient: {
+            isEnabled: true,
+            getDownloadStream: jest.fn(() => {
+                const readable = new Readable({
+                    read() {
+                        this.push('{}');
+                        this.push(null);
+                    },
+                });
+                return readable;
+            }),
+            getFirstLine: jest.fn(async () => '{}'),
+            getFileUrl: jest.fn(
+                async () => 'https://example.com/preagg-results.jsonl',
+            ),
             createUploadStream: jest.fn(() => ({
                 write: jest.fn(),
                 close: jest.fn(),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -181,6 +181,7 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     cacheService?: ICacheService;
     savedSqlModel: SavedSqlModel;
     resultsStorageClient: S3ResultsFileStorageClient;
+    preAggregateResultsStorageClient: S3ResultsFileStorageClient;
     pivotTableService: PivotTableService;
     prometheusMetrics?: PrometheusMetrics;
     schedulerClient: SchedulerClient;
@@ -200,6 +201,8 @@ export class AsyncQueryService extends ProjectService {
     savedSqlModel: SavedSqlModel;
 
     resultsStorageClient: S3ResultsFileStorageClient;
+
+    preAggregateResultsStorageClient: S3ResultsFileStorageClient;
 
     exportsStorageClient: FileStorageClient;
 
@@ -224,6 +227,8 @@ export class AsyncQueryService extends ProjectService {
         this.cacheService = args.cacheService;
         this.savedSqlModel = args.savedSqlModel;
         this.resultsStorageClient = args.resultsStorageClient;
+        this.preAggregateResultsStorageClient =
+            args.preAggregateResultsStorageClient;
         this.exportsStorageClient = this.fileStorageClient;
         this.pivotTableService = args.pivotTableService;
         this.prometheusMetrics = args.prometheusMetrics;
@@ -342,6 +347,14 @@ export class AsyncQueryService extends ProjectService {
         return { target: 'warehouse', preAggregateMetadata };
     }
 
+    private getResultsStorageClientForContext(
+        context?: QueryExecutionContext | null,
+    ): S3ResultsFileStorageClient {
+        return context === QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
+            ? this.preAggregateResultsStorageClient
+            : this.resultsStorageClient;
+    }
+
     public getCacheExpiresAt(baseDate: Date) {
         return new Date(
             baseDate.getTime() +
@@ -377,11 +390,15 @@ export class AsyncQueryService extends ProjectService {
     async getResultsPageFromS3(
         queryUuid: string,
         fileName: string | null,
+        queryContext: QueryExecutionContext | null | undefined,
         page: number,
         pageSize: number,
         formatter: (row: ResultRow) => ResultRow,
     ) {
-        if (!this.resultsStorageClient.isEnabled) {
+        const resultsStorageClient =
+            this.getResultsStorageClientForContext(queryContext);
+
+        if (!resultsStorageClient.isEnabled) {
             throw new S3Error('S3 is not enabled');
         }
 
@@ -392,7 +409,7 @@ export class AsyncQueryService extends ProjectService {
         }
 
         const cacheStream =
-            await this.resultsStorageClient.getDownloadStream(fileName);
+            await resultsStorageClient.getDownloadStream(fileName);
 
         const rows: ResultRow[] = [];
         const rl = createInterface({
@@ -643,11 +660,12 @@ export class AsyncQueryService extends ProjectService {
             durationMs,
         } = await measureTime(
             () =>
-                this.resultsStorageClient.isEnabled ||
-                this.cacheService?.isEnabled
+                this.getResultsStorageClientForContext(queryHistory.context)
+                    .isEnabled || this.cacheService?.isEnabled
                     ? this.getResultsPageFromS3(
                           queryUuid,
                           resultsFileName,
+                          queryHistory.context,
                           page,
                           defaultedPageSize,
                           formatter,
@@ -791,7 +809,9 @@ export class AsyncQueryService extends ProjectService {
                 throw new Error('Results file name not found for query');
             }
 
-            return this.resultsStorageClient.getDownloadStream(resultsFileName);
+            return this.getResultsStorageClientForContext(
+                queryHistory.context,
+            ).getDownloadStream(resultsFileName);
         }
 
         throw new Error('Invalid query status');
@@ -916,6 +936,9 @@ export class AsyncQueryService extends ProjectService {
         }
 
         const { status, resultsFileName, fields, columns } = queryHistory;
+        const resultsStorageClient = this.getResultsStorageClientForContext(
+            queryHistory.context,
+        );
 
         // First check the query status
         switch (status) {
@@ -947,9 +970,7 @@ export class AsyncQueryService extends ProjectService {
         if (columnOrder.length === 0) {
             try {
                 const firstLine =
-                    await this.resultsStorageClient.getFirstLine(
-                        resultsFileName,
-                    );
+                    await resultsStorageClient.getFirstLine(resultsFileName);
                 if (firstLine) {
                     const firstRow = JSON.parse(firstLine);
                     validColumnOrder = Object.keys(firstRow);
@@ -1016,7 +1037,7 @@ export class AsyncQueryService extends ProjectService {
                         fields,
                         metricQuery: queryHistory.metricQuery,
                         projectUuid,
-                        storageClient: this.resultsStorageClient,
+                        storageClient: resultsStorageClient,
                         pivotDetails:
                             AsyncQueryService.getPivotDetailsFromQueryHistory(
                                 queryHistory,
@@ -1039,6 +1060,7 @@ export class AsyncQueryService extends ProjectService {
                 }
                 return this.downloadAsyncQueryResultsAsFormattedFile(
                     resultsFileName,
+                    queryHistory.context,
                     resultFields,
                     {
                         generateFileId: CsvService.generateFileId,
@@ -1071,7 +1093,7 @@ export class AsyncQueryService extends ProjectService {
                               resultsFileName,
                               fields,
                               metricQuery: queryHistory.metricQuery,
-                              resultsStorageClient: this.resultsStorageClient,
+                              resultsStorageClient,
                               exportsStorageClient: this.exportsStorageClient,
                               lightdashConfig: this.lightdashConfig,
                               pivotDetails:
@@ -1093,8 +1115,7 @@ export class AsyncQueryService extends ProjectService {
                               resultsFileName,
                               resultFields,
                               {
-                                  resultsStorageClient:
-                                      this.resultsStorageClient,
+                                  resultsStorageClient,
                                   exportsStorageClient:
                                       this.exportsStorageClient,
                               },
@@ -1127,7 +1148,10 @@ export class AsyncQueryService extends ProjectService {
             }
             case undefined:
             case DownloadFileType.JSONL:
-                return this.downloadAsyncQueryResultsAsJson(resultsFileName);
+                return this.downloadAsyncQueryResultsAsJson(
+                    resultsFileName,
+                    queryHistory.context,
+                );
             case DownloadFileType.S3_JSONL:
                 throw new Error('S3_JSONL download not supported yet');
             case DownloadFileType.IMAGE:
@@ -1144,6 +1168,7 @@ export class AsyncQueryService extends ProjectService {
 
     private async downloadAsyncQueryResultsAsFormattedFile(
         resultsFileName: string,
+        queryContext: QueryExecutionContext | null | undefined,
         fields: ItemsMap,
         service: {
             generateFileId: (fileName: string) => string;
@@ -1221,7 +1246,8 @@ export class AsyncQueryService extends ProjectService {
                 };
             },
             {
-                resultsStorageClient: this.resultsStorageClient,
+                resultsStorageClient:
+                    this.getResultsStorageClientForContext(queryContext),
                 exportsStorageClient: this.fileStorageClient,
             },
             {
@@ -1251,10 +1277,13 @@ export class AsyncQueryService extends ProjectService {
 
     private async downloadAsyncQueryResultsAsJson(
         resultsFileName: string,
+        queryContext?: QueryExecutionContext | null,
     ): Promise<ApiDownloadAsyncQueryResults> {
         return {
             fileUrl:
-                await this.resultsStorageClient.getFileUrl(resultsFileName),
+                await this.getResultsStorageClientForContext(
+                    queryContext,
+                ).getFileUrl(resultsFileName),
         };
     }
 
@@ -1556,11 +1585,14 @@ export class AsyncQueryService extends ProjectService {
 
             const fileName =
                 QueryHistoryModel.createUniqueResultsFileName(cacheKey);
+            const resultsStorageClient = this.getResultsStorageClientForContext(
+                queryTags.query_context,
+            );
 
             // Create upload stream for storing results
             // If S3 is not configured, we don't write to S3
-            stream = this.resultsStorageClient.isEnabled
-                ? this.resultsStorageClient.createUploadStream(
+            stream = resultsStorageClient.isEnabled
+                ? resultsStorageClient.createUploadStream(
                       S3ResultsFileStorageClient.sanitizeFileExtension(
                           fileName,
                       ),
@@ -3727,9 +3759,9 @@ export class AsyncQueryService extends ProjectService {
             account,
         );
 
-        const resultsStream = await this.resultsStorageClient.getDownloadStream(
-            queryHistory.resultsFileName!,
-        );
+        const resultsStream = await this.getResultsStorageClientForContext(
+            queryHistory.context,
+        ).getDownloadStream(queryHistory.resultsFileName!);
 
         const rows: Record<string, unknown>[] = [];
         await streamJsonlData<void>({

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -16,7 +16,7 @@ describe('PreAggregationDuckDbClient', () => {
         activeMaterialization = {
             materializationUuid: 'mat-1',
             queryUuid: 'mat-query-1',
-            resultsFileName: 'abc123',
+            materializationUri: 's3://mock_preagg_bucket/abc123.jsonl',
             format: 'jsonl' as const,
             columns: null,
             materializedAt: new Date('2024-01-01T00:00:00.000Z'),
@@ -118,16 +118,13 @@ describe('PreAggregationDuckDbClient', () => {
         expect(projectModel.getExploreFromCache).not.toHaveBeenCalled();
     });
 
-    test('returns unresolved when results S3 bucket config is missing', async () => {
+    test('returns unresolved when pre-aggregate S3 config is missing', async () => {
         const { client, preAggregateModel } = getClient({
             lightdashConfig: {
                 ...lightdashConfigMock,
                 preAggregates: {
                     ...lightdashConfigMock.preAggregates,
                     enabled: true,
-                },
-                results: {
-                    ...lightdashConfigMock.results,
                     s3: undefined,
                 },
             },
@@ -137,7 +134,7 @@ describe('PreAggregationDuckDbClient', () => {
 
         expect(result).toEqual({
             resolved: false,
-            reason: 'missing_results_s3_bucket',
+            reason: 'missing_pre_aggregate_s3_config',
         });
         expect(
             preAggregateModel.getActiveMaterialization,
@@ -161,11 +158,11 @@ describe('PreAggregationDuckDbClient', () => {
                     tables: expect.objectContaining({
                         a: expect.objectContaining({
                             sqlTable:
-                                "read_json_auto('s3://mock_bucket/abc123.jsonl')",
+                                "read_json_auto('s3://mock_preagg_bucket/abc123.jsonl')",
                         }),
                         b: expect.objectContaining({
                             sqlTable:
-                                "read_json_auto('s3://mock_bucket/abc123.jsonl')",
+                                "read_json_auto('s3://mock_preagg_bucket/abc123.jsonl')",
                         }),
                     }),
                 }),
@@ -179,7 +176,7 @@ describe('PreAggregationDuckDbClient', () => {
             activeMaterialization: {
                 materializationUuid: 'mat-1',
                 queryUuid: 'mat-query-1',
-                resultsFileName: 'abc123',
+                materializationUri: 's3://mock_preagg_bucket/abc123.jsonl',
                 format: 'jsonl',
                 columns: {
                     a_dim1: {
@@ -206,10 +203,10 @@ describe('PreAggregationDuckDbClient', () => {
                 explore: expect.objectContaining({
                     tables: expect.objectContaining({
                         a: expect.objectContaining({
-                            sqlTable: `read_json('s3://mock_bucket/abc123.jsonl', columns={"a_dim1": 'VARCHAR', "a_met_count": 'DOUBLE', "a_created_at": 'TIMESTAMP'}, format='newline_delimited')`,
+                            sqlTable: `read_json('s3://mock_preagg_bucket/abc123.jsonl', columns={"a_dim1": 'VARCHAR', "a_met_count": 'DOUBLE', "a_created_at": 'TIMESTAMP'}, format='newline_delimited')`,
                         }),
                         b: expect.objectContaining({
-                            sqlTable: `read_json('s3://mock_bucket/abc123.jsonl', columns={"a_dim1": 'VARCHAR', "a_met_count": 'DOUBLE', "a_created_at": 'TIMESTAMP'}, format='newline_delimited')`,
+                            sqlTable: `read_json('s3://mock_preagg_bucket/abc123.jsonl', columns={"a_dim1": 'VARCHAR', "a_met_count": 'DOUBLE', "a_created_at": 'TIMESTAMP'}, format='newline_delimited')`,
                         }),
                     }),
                 }),
@@ -222,7 +219,7 @@ describe('PreAggregationDuckDbClient', () => {
             activeMaterialization: {
                 materializationUuid: 'mat-1',
                 queryUuid: 'mat-query-1',
-                resultsFileName: 'abc123',
+                materializationUri: 's3://mock_preagg_bucket/abc123.jsonl',
                 format: 'jsonl',
                 columns: {
                     a_avg_revenue__sum: {
@@ -245,10 +242,10 @@ describe('PreAggregationDuckDbClient', () => {
                 explore: expect.objectContaining({
                     tables: expect.objectContaining({
                         a: expect.objectContaining({
-                            sqlTable: `read_json('s3://mock_bucket/abc123.jsonl', columns={"a_avg_revenue__sum": 'DOUBLE', "a_avg_revenue__count": 'DOUBLE'}, format='newline_delimited')`,
+                            sqlTable: `read_json('s3://mock_preagg_bucket/abc123.jsonl', columns={"a_avg_revenue__sum": 'DOUBLE', "a_avg_revenue__count": 'DOUBLE'}, format='newline_delimited')`,
                         }),
                         b: expect.objectContaining({
-                            sqlTable: `read_json('s3://mock_bucket/abc123.jsonl', columns={"a_avg_revenue__sum": 'DOUBLE', "a_avg_revenue__count": 'DOUBLE'}, format='newline_delimited')`,
+                            sqlTable: `read_json('s3://mock_preagg_bucket/abc123.jsonl', columns={"a_avg_revenue__sum": 'DOUBLE', "a_avg_revenue__count": 'DOUBLE'}, format='newline_delimited')`,
                         }),
                     }),
                 }),

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -111,17 +111,16 @@ export class PreAggregationDuckDbClient {
             return { resolved: false, reason: 'pre_aggregates_disabled' };
         }
 
-        const resultsBucket = this.lightdashConfig.results.s3?.bucket;
-        if (!resultsBucket) {
+        const preAggregateS3Config = this.lightdashConfig.preAggregates.s3;
+        if (!preAggregateS3Config) {
             return {
                 resolved: false,
-                reason: 'missing_results_s3_bucket',
+                reason: 'missing_pre_aggregate_s3_config',
             };
         }
 
-        const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
-            this.lightdashConfig,
-        );
+        const duckdbRuntimeConfig =
+            getDuckdbRuntimeConfig(preAggregateS3Config);
         if (!duckdbRuntimeConfig) {
             return {
                 resolved: false,
@@ -148,8 +147,7 @@ export class PreAggregationDuckDbClient {
         }
 
         const locator = getPreAggregateDuckdbLocator({
-            bucket: resultsBucket,
-            resultsFileName: activeMaterialization.resultsFileName,
+            uri: activeMaterialization.materializationUri,
             format: 'jsonl',
         });
         const sqlTable = getDuckdbPreAggregateSqlTable(

--- a/packages/backend/src/services/AsyncQueryService/getDuckdbRuntimeConfig.ts
+++ b/packages/backend/src/services/AsyncQueryService/getDuckdbRuntimeConfig.ts
@@ -36,24 +36,20 @@ const parseDuckdbS3Endpoint = (
 };
 
 export const getDuckdbRuntimeConfig = (
-    lightdashConfig: Pick<LightdashConfig, 'results'>,
+    s3Config: LightdashConfig['preAggregates']['s3'],
 ): DuckdbRuntimeConfig | undefined => {
-    const resultsS3Config = lightdashConfig.results.s3;
-
-    if (!resultsS3Config) {
+    if (!s3Config) {
         return undefined;
     }
 
-    const { endpoint, useSsl } = parseDuckdbS3Endpoint(
-        resultsS3Config.endpoint,
-    );
+    const { endpoint, useSsl } = parseDuckdbS3Endpoint(s3Config.endpoint);
 
     return {
         endpoint,
-        region: resultsS3Config.region,
-        accessKey: resultsS3Config.accessKey,
-        secretKey: resultsS3Config.secretKey,
-        forcePathStyle: resultsS3Config.forcePathStyle === true,
+        region: s3Config.region,
+        accessKey: s3Config.accessKey,
+        secretKey: s3Config.secretKey,
+        forcePathStyle: s3Config.forcePathStyle === true,
         useSsl,
     };
 };

--- a/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
@@ -1,4 +1,9 @@
-import { QueryHistoryStatus, type Account } from '@lightdash/common';
+import {
+    QueryExecutionContext,
+    QueryHistoryStatus,
+    type Account,
+} from '@lightdash/common';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { type PreAggregateModel } from '../../models/PreAggregateModel';
 import { type QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import { type AsyncQueryService } from '../AsyncQueryService/AsyncQueryService';
@@ -23,6 +28,7 @@ describe('PreAggregateMaterializationService', () => {
     };
 
     const service = new PreAggregateMaterializationService({
+        lightdashConfig: lightdashConfigMock,
         preAggregateModel: preAggregateModel as unknown as PreAggregateModel,
         queryHistoryModel: queryHistoryModel as unknown as QueryHistoryModel,
         asyncQueryService: asyncQueryService as unknown as AsyncQueryService,
@@ -90,6 +96,7 @@ describe('PreAggregateMaterializationService', () => {
         });
         queryHistoryModel.pollForQueryCompletion.mockResolvedValue({
             status: QueryHistoryStatus.READY,
+            resultsFileName: 'query-1-results',
             resultsUpdatedAt: queryUpdatedAt,
             totalRowCount: 123,
             columns: null,
@@ -113,6 +120,7 @@ describe('PreAggregateMaterializationService', () => {
         expect(asyncQueryService.executeAsyncMetricQuery).toHaveBeenCalledWith(
             expect.objectContaining({
                 projectUuid: 'project-1',
+                context: QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
                 metricQuery: {
                     exploreName: 'orders',
                     dimensions: [],
@@ -128,9 +136,58 @@ describe('PreAggregateMaterializationService', () => {
         expect(preAggregateModel.promoteToActive).toHaveBeenCalledWith({
             materializationUuid: 'mat-1',
             queryUuid: 'query-1',
+            materializationUri: 's3://mock_preagg_bucket/query-1-results.jsonl',
             materializedAt: queryUpdatedAt,
             rowCount: 123,
             columns: null,
         });
+    });
+
+    test('marks run as failed when ready query has no persisted results file', async () => {
+        preAggregateModel.getPreAggregateDefinitionByUuid.mockResolvedValue({
+            preAggregateDefinitionUuid: 'def-1',
+            materializationMetricQuery: {
+                metricQuery: {
+                    exploreName: 'orders',
+                    dimensions: [],
+                    metrics: [],
+                    filters: {},
+                    sorts: [],
+                    limit: 100,
+                    tableCalculations: [],
+                },
+                metricComponents: {},
+            },
+            materializationQueryError: null,
+        });
+        asyncQueryService.executeAsyncMetricQuery.mockResolvedValue({
+            queryUuid: 'query-1',
+        });
+        queryHistoryModel.pollForQueryCompletion.mockResolvedValue({
+            status: QueryHistoryStatus.READY,
+            resultsFileName: null,
+            resultsUpdatedAt: new Date('2024-02-01T10:00:00.000Z'),
+            totalRowCount: 123,
+            columns: null,
+        });
+
+        const result = await service.materializePreAggregate({
+            account: {} as Account,
+            projectUuid: 'project-1',
+            preAggregateDefinitionUuid: 'def-1',
+            trigger: 'manual',
+        });
+
+        expect(result).toEqual({
+            materializationUuid: 'mat-1',
+            status: 'failed',
+            queryUuid: 'query-1',
+        });
+        expect(preAggregateModel.markFailed).toHaveBeenCalledWith({
+            materializationUuid: 'mat-1',
+            errorMessage:
+                'Materialization query completed without a persisted results file',
+        });
+        expect(preAggregateModel.promoteToActive).not.toHaveBeenCalled();
     });
 });

--- a/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -6,6 +6,7 @@ import {
     type ActiveMaterializationDetails,
     type PreAggregateMaterializationTrigger,
 } from '@lightdash/common';
+import { type LightdashConfig } from '../../config/parseConfig';
 import { PreAggregateModel } from '../../models/PreAggregateModel';
 import { type QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import type PrometheusMetrics from '../../prometheus';
@@ -15,6 +16,8 @@ const QUERY_POLL_INTERVAL_MS = 1000;
 const QUERY_POLL_TIMEOUT_MS = 30 * 60 * 1000;
 
 export class PreAggregateMaterializationService {
+    private readonly lightdashConfig: LightdashConfig;
+
     private readonly preAggregateModel: PreAggregateModel;
 
     private readonly queryHistoryModel: QueryHistoryModel;
@@ -24,15 +27,29 @@ export class PreAggregateMaterializationService {
     private readonly prometheusMetrics: PrometheusMetrics | undefined;
 
     constructor(args: {
+        lightdashConfig: LightdashConfig;
         preAggregateModel: PreAggregateModel;
         queryHistoryModel: QueryHistoryModel;
         asyncQueryService: AsyncQueryService;
         prometheusMetrics?: PrometheusMetrics;
     }) {
+        this.lightdashConfig = args.lightdashConfig;
         this.preAggregateModel = args.preAggregateModel;
         this.queryHistoryModel = args.queryHistoryModel;
         this.asyncQueryService = args.asyncQueryService;
         this.prometheusMetrics = args.prometheusMetrics;
+    }
+
+    private getMaterializationUri(resultsFileName: string): string {
+        const bucket = this.lightdashConfig.preAggregates.s3?.bucket;
+
+        if (!bucket) {
+            throw new Error(
+                'Missing pre-aggregate S3 bucket configuration for materializations',
+            );
+        }
+
+        return `s3://${bucket}/${resultsFileName}.jsonl`;
     }
 
     async materializePreAggregate(args: {
@@ -138,9 +155,26 @@ export class PreAggregateMaterializationService {
                 };
             }
 
+            if (!queryHistory.resultsFileName) {
+                await this.preAggregateModel.markFailed({
+                    materializationUuid,
+                    errorMessage:
+                        'Materialization query completed without a persisted results file',
+                });
+
+                return {
+                    materializationUuid,
+                    status: 'failed',
+                    queryUuid,
+                };
+            }
+
             const { status } = await this.preAggregateModel.promoteToActive({
                 materializationUuid,
                 queryUuid,
+                materializationUri: this.getMaterializationUri(
+                    queryHistory.resultsFileName,
+                ),
                 materializedAt: queryHistory.resultsUpdatedAt || new Date(),
                 rowCount: queryHistory.totalRowCount,
                 columns: queryHistory.columns,
@@ -197,7 +231,7 @@ export class PreAggregateMaterializationService {
     ): Promise<
         | {
               queryUuid: string;
-              resultsFileName: string;
+              materializationUri: string;
               format: 'jsonl';
               columns: ActiveMaterializationDetails['columns'];
               materializedAt: Date;
@@ -216,7 +250,7 @@ export class PreAggregateMaterializationService {
 
         return {
             queryUuid: activeMaterialization.queryUuid,
-            resultsFileName: activeMaterialization.resultsFileName,
+            materializationUri: activeMaterialization.materializationUri,
             format: activeMaterialization.format,
             columns: activeMaterialization.columns,
             materializedAt: activeMaterialization.materializedAt,

--- a/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.test.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.test.ts
@@ -1,17 +1,26 @@
 import { DimensionType, type ResultColumns } from '@lightdash/common';
 import {
     getDuckdbPreAggregateSqlTable,
+    getPreAggregateDuckdbLocator,
     type PreAggregateDuckdbLocator,
 } from './getDuckdbPreAggregateSqlTable';
 
 const locator: PreAggregateDuckdbLocator = {
     storage: 's3',
     format: 'jsonl',
-    key: 'abc123.jsonl',
     uri: 's3://bucket/abc123.jsonl',
 };
 
 describe('getDuckdbPreAggregateSqlTable', () => {
+    test('builds a locator directly from a persisted S3 URI', () => {
+        expect(
+            getPreAggregateDuckdbLocator({
+                uri: 's3://bucket/abc123.jsonl',
+                format: 'jsonl',
+            }),
+        ).toEqual(locator);
+    });
+
     test('generates read_json with typed schema when columns are provided', () => {
         const columns: ResultColumns = {
             orders_total: {

--- a/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable.ts
@@ -7,7 +7,6 @@ import {
 export type PreAggregateDuckdbLocator = {
     storage: 's3';
     format: 'jsonl';
-    key: string;
     uri: string;
 };
 
@@ -37,38 +36,16 @@ const resultFieldTypeToDuckdbType = (type: DimensionType): string => {
 };
 
 export const getPreAggregateDuckdbLocator = ({
-    bucket,
-    resultsFileName,
+    uri,
     format,
 }: {
-    bucket: string;
-    resultsFileName: string;
+    uri: string;
     format: 'jsonl';
-}): PreAggregateDuckdbLocator => {
-    const trimmedBucket = bucket.trim();
-    const trimmedResultsFileName = resultsFileName.trim();
-
-    if (trimmedBucket.length === 0) {
-        throw new Error(
-            'Cannot build pre-aggregate DuckDB locator without S3 bucket',
-        );
-    }
-
-    if (trimmedResultsFileName.length === 0) {
-        throw new Error(
-            'Cannot build pre-aggregate DuckDB locator without results file name',
-        );
-    }
-
-    const key = `${trimmedResultsFileName}.${format}`;
-
-    return {
-        storage: 's3',
-        format,
-        key,
-        uri: `s3://${trimmedBucket}/${key}`,
-    };
-};
+}): PreAggregateDuckdbLocator => ({
+    storage: 's3',
+    format,
+    uri,
+});
 
 export const getDuckdbPreAggregateSqlTable = (
     locator: PreAggregateDuckdbLocator,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -546,6 +546,7 @@ export class ServiceRepository
             'preAggregateMaterializationService',
             () =>
                 new PreAggregateMaterializationService({
+                    lightdashConfig: this.context.lightdashConfig,
                     preAggregateModel: this.models.getPreAggregateModel(),
                     queryHistoryModel: this.models.getQueryHistoryModel(),
                     asyncQueryService: this.getAsyncQueryService(),
@@ -685,6 +686,8 @@ export class ServiceRepository
                     savedSqlModel: this.models.getSavedSqlModel(),
                     resultsStorageClient:
                         this.clients.getResultsFileStorageClient(),
+                    preAggregateResultsStorageClient:
+                        this.clients.getPreAggregateResultsFileStorageClient(),
                     featureFlagModel: this.models.getFeatureFlagModel(),
                     projectParametersModel:
                         this.models.getProjectParametersModel(),

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -24,7 +24,7 @@ export type PreAggregateMaterializationStatus =
 export type ActiveMaterializationDetails = {
     materializationUuid: string;
     queryUuid: string;
-    resultsFileName: string;
+    materializationUri: string;
     format: 'jsonl';
     columns: ResultColumns | null;
     materializedAt: Date;
@@ -120,6 +120,7 @@ export type PreAggregateMaterialization = {
     status: PreAggregateMaterializationStatus;
     trigger: PreAggregateMaterializationTrigger;
     queryUuid: string | null;
+    materializationUri: string | null;
     materializedAt: Date | null;
     rowCount: number | null;
     columns: ResultColumns | null;


### PR DESCRIPTION
### Description:

Closes: [ZAP-266: Query history cleanup breaks active pre-agg materializations](https://linear.app/lightdash/issue/ZAP-266/query-history-cleanup-breaks-active-pre-agg-materializations)

Persist pre-aggregate materialization S3 URIs on `pre_aggregate_materializations` and stop resolving active pre-aggs through `query_history`, so query-history cleanup no longer breaks DuckDB routing.

## Changes
- Add `materialization_uri` to `pre_aggregate_materializations`
- Persist the full `s3://...jsonl` locator when a materialization is promoted
- Ignore older materialization rows that do not have a persisted URI
- Remove the `query_history` join from active materialization lookup
- Add dedicated pre-aggregate S3 config with no fallback to the normal results bucket
- Route `PRE_AGGREGATE_MATERIALIZATION` query writes/reads through the dedicated pre-agg results storage client
- Update DuckDB pre-agg resolution to use the persisted URI directly

## Why
Active pre-agg routing depended on `query_history.results_file_name` at read time. Once query-history cleanup deleted old rows, valid materializations became unreadable even though the materialization record still existed.

## Verification
- Added/updated config, materialization, DuckDB, and regression tests
- Verified targeted backend test suites pass