### PR TITLE
feat: add DeployProject permission scope for dbt CLI deployment

### DIFF
--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -51,22 +51,20 @@ export class DeployService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<{ deploySessionUuid: string }> {
-        // Check permissions - same as setExplores in original ProjectService
+        // Check deploy-specific permission
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
         if (
             user.ability.cannot(
-                'update',
-                subject('Project', {
+                'manage',
+                subject('DeployProject', {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
-                    type: project.type,
-                    createdByUserUuid: project.createdByUserUuid,
                 }),
             )
         ) {
             throw new ForbiddenError(
-                `User does not have permission to update project`,
+                `User does not have permission to deploy to this project`,
             );
         }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2109,17 +2109,15 @@ export class ProjectService extends BaseService {
             await this.projectModel.getWithSensitiveFields(projectUuid);
         if (
             user.ability.cannot(
-                'update',
-                subject('Project', {
+                'manage',
+                subject('DeployProject', {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
-                    type: project.type,
-                    createdByUserUuid: project.createdByUserUuid,
                 }),
             )
         ) {
             throw new ForbiddenError(
-                `User does not have permission to update project`,
+                `User does not have permission to deploy to this project`,
             );
         }
 

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -269,6 +269,9 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('update', 'Project', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'DeployProject', {
+            organizationUuid: member.organizationUuid,
+        });
         can('delete', 'Project', {
             organizationUuid: member.organizationUuid,
             type: ProjectType.PREVIEW,
@@ -305,6 +308,7 @@ const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
             type: { $in: [ProjectType.DEFAULT, ProjectType.PREVIEW] },
         });
+
         can('delete', 'Project', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -209,6 +209,10 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
         });
 
+        can('manage', 'DeployProject', {
+            projectUuid: member.projectUuid,
+        });
+
         can('delete', 'Project', {
             projectUuid: member.projectUuid,
             type: ProjectType.PREVIEW,

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -73,6 +73,7 @@ const BASE_ROLE_SCOPES = {
         'manage:SqlRunner',
         'manage:Validation',
         'manage:CompileProject',
+        'manage:DeployProject',
         'create:Project@preview', // Preview projects
         'delete:Project@self', // Preview projects created by user
         'update:Project',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -303,6 +303,13 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:DeployProject',
+        description: 'Deploy dbt projects via CLI',
+        isEnterprise: false,
+        group: ScopeGroup.PROJECT_MANAGEMENT,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:Validation',
         description: 'Manage data validation rules',
         isEnterprise: false,

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -28,6 +28,7 @@ export type CaslSubjectNames =
     | 'ContentAsCode'
     | 'CustomSql'
     | 'Dashboard'
+    | 'DeployProject'
     | 'DashboardComments'
     | 'DashboardCsv'
     | 'DashboardImage'


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-3019/i-want-to-restrict-lightdash-deploy-in-the-cli-for-some-users

<img width="940" height="244" alt="image" src="https://github.com/user-attachments/assets/5d1c0b11-42f5-45e2-8d20-edc0dcdbc41c" />

Created via custom role 

### Description:

This PR introduces a new `DeployProject` permission system to provide more granular control over deployment operations. 

**Key Changes:**
- Added new `manage:DeployProject` scope and `DeployProject` subject type to the authorization system
- Updated `DeployService.startDeploySession()` and `ProjectService.setExplores()` to use the new deployment-specific permission instead of generic project update permissions
- Granted `manage:DeployProject` permissions to developers, admins, and project members who can update projects
- Enhanced error messages to be more specific about deployment permission failures

This change allows organizations to have finer control over who can deploy dbt projects via CLI while maintaining existing access patterns for current users.