### PR TITLE
style: decrease tooltip span size on TitleBreadcrumbs

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/TitleBreadcrumbs.tsx
@@ -41,7 +41,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                             label={
                                 <Text fz="xs">
                                     Space:{' '}
-                                    <Text span fw={500}>
+                                    <Text span fz="xs" fw="bold">
                                         {spaceName}
                                     </Text>
                                 </Text>
@@ -91,7 +91,7 @@ export const TitleBreadCrumbs: FC<Props> = ({
                         label={
                             <Text fz="xs">
                                 Dashboard:{' '}
-                                <Text span fw={500}>
+                                <Text span fz="xs" fw="bold">
                                     {dashboardName}
                                 </Text>
                             </Text>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Updated the font styling for space and dashboard names in the breadcrumb tooltips. Changed the font weight from `500` to `"bold"` and added explicit font size `"xs"` to ensure consistent styling across both the space and dashboard name elements in the TitleBreadcrumbs component.

