### PR TITLE
fix: truncate long Google Sheet names in sync modal

### DIFF
--- a/packages/frontend/src/features/sync/components/SelectGoogleSheetButton.tsx
+++ b/packages/frontend/src/features/sync/components/SelectGoogleSheetButton.tsx
@@ -16,6 +16,7 @@ import useDrivePicker from 'react-google-drive-picker';
 import { GSheetsIcon } from '../../../components/common/GSheetsIcon';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { PolymorphicGroupButton } from '../../../components/common/PolymorphicGroupButton';
+import TruncatedText from '../../../components/common/TruncatedText';
 import { useGdriveAccessToken } from '../../../hooks/gdrive/useGdrive';
 import useHealth from '../../../hooks/health/useHealth';
 import classes from './SelectGoogleSheetButton.module.css';
@@ -84,11 +85,11 @@ export const SelectGoogleSheetButton: FC = () => {
                 className={`${classes.sheetSelector} ${classes.sheetSelectorFilled}`}
             >
                 <Group gap="sm" wrap="nowrap" justify="space-between" w="100%">
-                    <Group gap="xs" wrap="nowrap">
+                    <Group gap="xs" wrap="nowrap" miw={0}>
                         <MantineIcon icon={GSheetsIcon} size={16} />
-                        <Text size="sm" fw={500}>
+                        <TruncatedText maxWidth="auto">
                             {googleDriveName}
-                        </Text>
+                        </TruncatedText>
                         <Tooltip
                             withinPortal
                             label={googleDriveId}

--- a/packages/frontend/src/features/sync/components/SyncModalForm.module.css
+++ b/packages/frontend/src/features/sync/components/SyncModalForm.module.css
@@ -1,0 +1,3 @@
+.form {
+    contain: inline-size;
+}

--- a/packages/frontend/src/features/sync/components/SyncModalForm.tsx
+++ b/packages/frontend/src/features/sync/components/SyncModalForm.tsx
@@ -16,6 +16,7 @@ import { CronInternalInputs } from '../../../components/CronInput';
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useProject } from '../../../hooks/useProject';
 import { SelectGoogleSheetButton } from './SelectGoogleSheetButton';
+import classes from './SyncModalForm.module.css';
 import {
     useSyncModalFormContext,
     type SyncModalFormValues,
@@ -41,7 +42,11 @@ export const SyncModalForm: FC<Props> = ({ id, onSubmit }) => {
     const form = useSyncModalFormContext();
 
     return (
-        <form id={id} onSubmit={form.onSubmit(onSubmit)}>
+        <form
+            id={id}
+            onSubmit={form.onSubmit(onSubmit)}
+            className={classes.form}
+        >
             <Stack>
                 <TextInput
                     label="Name the Sync"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #20758

### Description:

Fixed text overflow issue in the Google Sheets sync modal by replacing the standard Text component with TruncatedText for the sheet name display. Added container query containment to the sync modal form and adjusted the Group component's minimum width to ensure proper text truncation behavior when sheet names are too long to fit within the available space.

<!-- Even better add a screenshot / gif / loom -->

<details>
<summary>Demo</summary>
<img width="1560" height="774" alt="localhost_3000_projects_3675b69e-8324-4110-bdca-059031aa8da3_saved_51399f5f-11aa-418d-95d4-cbf8bf32b5a2 (2)" src="https://github.com/user-attachments/assets/96864eac-83fa-4ebb-a8e1-bbea0c88c4b2" />
</details>
