### PR TITLE
feat: support dynamic expressions in offset table calculation functions

### DIFF
--- a/packages/common/src/utils/tableCalculationFunctions.test.ts
+++ b/packages/common/src/utils/tableCalculationFunctions.test.ts
@@ -268,6 +268,42 @@ describe('tableCalculationFunctions', () => {
                     );
                 }
             });
+
+            it('should parse offset with nested parentheses in expression', () => {
+                const sql = 'offset(revenue, COALESCE(offset_var, ABS(-1)))';
+                const result = parseTableCalculationFunctions(sql);
+
+                expect(result).toHaveLength(1);
+                expect(result[0].type).toBe(
+                    TableCalculationFunctionType.OFFSET,
+                );
+                if (result[0].type === TableCalculationFunctionType.OFFSET) {
+                    expect(result[0].column).toBe('revenue');
+                    expect(result[0].rowOffset).toBe(
+                        'COALESCE(offset_var, ABS(-1))',
+                    );
+                    expect(result[0].rawSql).toBe(
+                        'offset(revenue, COALESCE(offset_var, ABS(-1)))',
+                    );
+                }
+            });
+
+            it('should parse multiple offsets with complex expressions', () => {
+                const sql =
+                    'offset(a, ROUND(b * 2)) + offset(c, IF(d > 0, 1, -1))';
+                const result = parseTableCalculationFunctions(sql);
+
+                expect(result).toHaveLength(2);
+                // Functions are parsed last to first
+                if (result[0].type === TableCalculationFunctionType.OFFSET) {
+                    expect(result[0].column).toBe('c');
+                    expect(result[0].rowOffset).toBe('IF(d > 0, 1, -1)');
+                }
+                if (result[1].type === TableCalculationFunctionType.OFFSET) {
+                    expect(result[1].column).toBe('a');
+                    expect(result[1].rowOffset).toBe('ROUND(b * 2)');
+                }
+            });
         });
 
         describe('index parsing (row function)', () => {

--- a/packages/common/src/utils/tableCalculationFunctions.ts
+++ b/packages/common/src/utils/tableCalculationFunctions.ts
@@ -301,21 +301,46 @@ export function parseTableCalculationFunctions(
         match = rowRegex.exec(sql);
     }
 
-    // Parse offset function calls (but not pivot_offset)
-    // Updated regex to capture any expression as the second argument
-    const offsetRegex =
-        /\boffset\s*\(\s*([^,()]+(?:\([^)]*\))?[^,()]*)\s*,\s*([^)]+)\s*\)/gi;
+    // Parse offset function calls
+    // The \b word boundary ensures we don't match pivot_offset
+    const offsetRegex = /\boffset\(/gi;
     match = offsetRegex.exec(sql);
     while (match !== null) {
-        // Skip if this is actually a pivot_offset
         const startIdx = match.index;
-        const beforeMatch = sql.slice(Math.max(0, startIdx - 6), startIdx);
-        if (!beforeMatch.endsWith('pivot_')) {
+
+        // Parse the function arguments properly, handling nested parentheses
+        let parenDepth = 1;
+        let i = startIdx + match[0].length;
+        const argStart = i;
+        let firstArgEnd = -1;
+        let secondArgStart = -1;
+
+        while (i < sql.length && parenDepth > 0) {
+            if (sql[i] === '(') {
+                parenDepth += 1;
+            } else if (sql[i] === ')') {
+                parenDepth -= 1;
+            } else if (
+                sql[i] === ',' &&
+                parenDepth === 1 &&
+                firstArgEnd === -1
+            ) {
+                firstArgEnd = i;
+                secondArgStart = i + 1;
+            }
+            i += 1;
+        }
+
+        if (firstArgEnd !== -1 && parenDepth === 0) {
+            const column = sql.slice(argStart, firstArgEnd).trim();
+            const rowOffset = sql.slice(secondArgStart, i - 1).trim();
+            const rawSql = sql.slice(startIdx, i);
+
             functions.push({
                 type: TableCalculationFunctionType.OFFSET,
-                column: match[1].trim(),
-                rowOffset: match[2].trim(),
-                rawSql: match[0],
+                column,
+                rowOffset,
+                rawSql,
             });
         }
         match = offsetRegex.exec(sql);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-5729/sql-compilation-error-unknown-functions-offset-offset-dynamic-offset<!-- reference the related issue e.g. #150 -->

### Description:

Enhanced the `offset` table calculation function to support dynamic expressions and complex SQL constructs beyond simple numeric values.

**Key Changes:**
- Modified `rowOffset` type from `number` to `string` in `OffsetFunctionCall` interface to accommodate expressions
- Updated the offset parsing regex to capture complex expressions including parentheses and nested functions
- Enhanced the offset compiler to handle both numeric values and dynamic expressions:
  - Numeric offsets continue to use existing LAG/LEAD logic based on sign
  - Dynamic expressions default to LAG function (assuming backwards-looking period comparisons)
- Added comprehensive test coverage for dynamic variable expressions (`${y_oy_calculation_offset}`) and CASE statements

This enables more flexible offset calculations for advanced use cases like period-over-period comparisons with variable time periods.