### PR TITLE
perf: combine double sort calls into single comparator in dashboard filter config

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -127,13 +127,11 @@ const TileFilterConfiguration: FC<Props> = ({
     );
 
     const sortedTileWithFilters = useMemo(() => {
-        return Object.entries(availableTileFilters)
-            .sort(([, a], [, b]) =>
-                sortTilesByFieldMatch(matchFieldByTypeAndName, a, b),
-            )
-            .sort(([, a], [, b]) =>
-                sortTilesByFieldMatch(matchFieldExact, a, b),
-            );
+        return Object.entries(availableTileFilters).sort(([, a], [, b]) => {
+            const exactResult = sortTilesByFieldMatch(matchFieldExact, a, b);
+            if (exactResult !== 0) return exactResult;
+            return sortTilesByFieldMatch(matchFieldByTypeAndName, a, b);
+        });
     }, [sortTilesByFieldMatch, availableTileFilters]);
 
     const tileTargetList = useMemo(() => {
@@ -184,16 +182,19 @@ const TileFilterConfiguration: FC<Props> = ({
                     const sortedFilters = field
                         ? filters
                               ?.filter(matchFieldByType(field))
-                              .sort((a, b) =>
-                                  sortFieldsByMatch(
+                              .sort((a, b) => {
+                                  const exactResult = sortFieldsByMatch(
+                                      matchFieldExact,
+                                      a,
+                                      b,
+                                  );
+                                  if (exactResult !== 0) return exactResult;
+                                  return sortFieldsByMatch(
                                       matchFieldByTypeAndName,
                                       a,
                                       b,
-                                  ),
-                              )
-                              .sort((a, b) =>
-                                  sortFieldsByMatch(matchFieldExact, a, b),
-                              )
+                                  );
+                              })
                         : filters;
 
                     const tileWithoutTitle =


### PR DESCRIPTION
## Summary

- Replace two consecutive `.sort()` calls with a single `.sort()` using a combined comparator in `TileFilterConfiguration.tsx`
- The combined comparator checks exact match first, then falls back to type+name match, preserving the same sorting priority as before
- Applies to both the `sortedTileWithFilters` memo and the per-tile `sortedFilters` computation

## Why

Calling `.sort()` twice in succession is wasteful for two reasons:

1. **Sort stability is not guaranteed by the JS spec.** While modern engines (V8, SpiderMonkey, JSC) all use stable sort algorithms like TimSort, the ECMAScript specification only requires stability as of ES2019, and relying on it for correctness is fragile. The original code sorted by type+name first, then by exact match second, relying on stability to preserve the type+name ordering as a tiebreaker within the exact match sort.

2. **Two O(n log n) passes are worse than one.** Each `.sort()` call is an independent O(n log n) operation. A single combined comparator achieves the same result in one pass, cutting the sorting work roughly in half.

The fix combines both comparators into a single sort: check exact match first, and if the result is a tie (returns 0), fall back to the type+name match. This is both more correct (no stability dependency) and more efficient.

## Test plan

- [ ] Verify dashboard filter tile ordering still prioritizes exact field matches over type+name matches
- [ ] Verify per-tile field dropdown still shows exact matches first, then type+name matches
- [ ] No visual or behavioral changes expected -- this is a pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)