### PR TITLE
perf: build field lookup maps to reduce O(N×M) scans in dashboard filter config

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -137,11 +137,41 @@ const TileFilterConfiguration: FC<Props> = ({
     }, [sortTilesByFieldMatch, availableTileFilters]);
 
     const tileTargetList = useMemo(() => {
+        // Pre-build lookup maps for O(1) field access instead of repeated O(N) scans
+        const fieldIdMaps = new Map<string, Map<string, Field>>();
+        const typeFilteredFieldsCache = new Map<
+            string,
+            Field[] | undefined
+        >();
+
+        for (const [tileUuid, filters] of Object.entries(
+            availableTileFilters,
+        )) {
+            // Build fieldId -> Field map for each tile
+            const idMap = new Map<string, Field>();
+            filters?.forEach((f) => idMap.set(getItemId(f), f));
+            fieldIdMaps.set(tileUuid, idMap);
+
+            // Cache type-filtered and sorted fields per tile
+            if (field && filters) {
+                const typeFiltered = filters.filter(matchFieldByType(field));
+                typeFiltered
+                    .sort((a, b) =>
+                        sortFieldsByMatch(matchFieldByTypeAndName, a, b),
+                    )
+                    .sort((a, b) =>
+                        sortFieldsByMatch(matchFieldExact, a, b),
+                    );
+                typeFilteredFieldsCache.set(tileUuid, typeFiltered);
+            }
+        }
+
         const tileWithTargetFields =
             sortedTileWithFilters.map<TileWithTargetFields>(
                 ([tileUuid, filters], index) => {
                     const tile = tiles.find((t) => t.uuid === tileUuid);
                     const tabUuidFromTile = tile?.tabUuid;
+                    const idMap = fieldIdMaps.get(tileUuid);
 
                     // Use shared utility to determine filter-tile relationship
                     const { relation, tileConfig } = getFilterTileRelation(
@@ -149,17 +179,14 @@ const TileFilterConfiguration: FC<Props> = ({
                         tileUuid,
                     );
 
-                    let selectedField;
+                    let selectedFieldForTile;
                     let invalidField: string | undefined;
                     if (relation !== 'disabled') {
-                        selectedField =
+                        selectedFieldForTile =
                             relation === 'mapped' &&
                             tileConfig &&
                             isDashboardFieldTarget(tileConfig)
-                                ? filters?.find(
-                                      (f) =>
-                                          tileConfig?.fieldId === getItemId(f),
-                                  )
+                                ? idMap?.get(tileConfig.fieldId) // O(1) instead of .find()
                                 : field
                                   ? filters?.find((f) =>
                                         matchFieldExact(f)(field),
@@ -172,28 +199,18 @@ const TileFilterConfiguration: FC<Props> = ({
                             tileConfig &&
                             isDashboardFieldTarget(tileConfig) &&
                             tileConfig?.fieldId !== undefined &&
-                            selectedField === undefined
+                            selectedFieldForTile === undefined
                                 ? tileConfig?.fieldId
                                 : undefined;
                     }
 
                     const isFilterAvailable = field
-                        ? (filters?.some(matchFieldByType(field)) ?? false)
+                        ? (typeFilteredFieldsCache.get(tileUuid)?.length ??
+                              0) > 0 // O(1) instead of .some()
                         : false;
 
                     const sortedFilters = field
-                        ? filters
-                              ?.filter(matchFieldByType(field))
-                              .sort((a, b) =>
-                                  sortFieldsByMatch(
-                                      matchFieldByTypeAndName,
-                                      a,
-                                      b,
-                                  ),
-                              )
-                              .sort((a, b) =>
-                                  sortFieldsByMatch(matchFieldExact, a, b),
-                              )
+                        ? typeFilteredFieldsCache.get(tileUuid) // Reuse cached result instead of filter+sort+sort
                         : filters;
 
                     const tileWithoutTitle =
@@ -220,7 +237,8 @@ const TileFilterConfiguration: FC<Props> = ({
                     return {
                         key: tileUuid + index,
                         label: tileLabel,
-                        checked: !!selectedField || !!invalidField,
+                        checked:
+                            !!selectedFieldForTile || !!invalidField,
                         disabled: !isFilterAvailable,
                         invalidField,
                         tileUuid,
@@ -231,7 +249,7 @@ const TileFilterConfiguration: FC<Props> = ({
                                     undefined,
                             }),
                         sortedFilters,
-                        selectedField,
+                        selectedField: selectedFieldForTile,
                         tabUuid: tabUuidFromTile,
                         hasExactMatch,
                     };
@@ -311,6 +329,7 @@ const TileFilterConfiguration: FC<Props> = ({
         filterRule,
         field,
         sortFieldsByMatch,
+        availableTileFilters,
     ]);
 
     const filteredTileTargetList = (tabUUid: string) => {


### PR DESCRIPTION
## Summary

- Pre-build `Map<fieldId, Field>` lookup maps and cache type-filtered/sorted field lists at the top of the `tileTargetList` useMemo in `TileFilterConfiguration.tsx`
- Replace per-tile `.find()`, `.some()`, and `.filter().sort().sort()` calls with O(1) Map lookups and cached array reuse
- Add `availableTileFilters` to the useMemo dependency array since it is now referenced directly in the pre-computation phase

## Motivation

The `tileTargetList` useMemo previously iterated through every tile and for each tile performed:
1. `.find()` scanning the entire filters array to locate a field by ID (line 159-162)
2. `.some()` scanning the filters array to check type compatibility (line 181)
3. `.filter().sort().sort()` creating a new filtered+sorted array per tile (lines 184-197)

This is O(N x M) where N = number of tiles and M = number of fields per tile. On dashboards with many tiles and many fields, this creates unnecessary repeated work.

## Approach

**Before:** Each tile iteration performs its own linear scans:
```typescript
// O(M) per tile - repeated N times
filters?.find((f) => tileConfig?.fieldId === getItemId(f))
filters?.some(matchFieldByType(field))
filters?.filter(matchFieldByType(field)).sort(...).sort(...)
```

**After:** Build lookup structures once, then use O(1) access:
```typescript
// Pre-computation: O(T x M) total, done once
for (const [tileUuid, filters] of Object.entries(availableTileFilters)) {
    const idMap = new Map<string, Field>();
    filters?.forEach((f) => idMap.set(getItemId(f), f));
    fieldIdMaps.set(tileUuid, idMap);
    // ... cache type-filtered and sorted fields
}

// Per-tile: O(1) lookups
idMap?.get(tileConfig.fieldId)                          // was .find()
(typeFilteredFieldsCache.get(tileUuid)?.length ?? 0) > 0  // was .some()
typeFilteredFieldsCache.get(tileUuid)                   // was .filter().sort().sort()
```

**Complexity improvement:**
- Field lookup by ID: O(M) per tile -> O(1) per tile (Map lookup)
- Type availability check: O(M) per tile -> O(1) per tile (cached length check)
- Sorted filters: O(M log M) per tile -> O(1) per tile (cached result reuse)
- Overall: O(N x M log M) -> O(T x M log M) + O(N) where T = unique tiles in availableTileFilters

## Test plan

- [ ] Verify dashboard filter configuration opens correctly for dashboards with multiple tiles
- [ ] Verify tile checkboxes enable/disable correctly based on field type compatibility
- [ ] Verify mapped field targets display the correct selected field
- [ ] Verify invalid field indicators appear when a mapped field is missing from the tile
- [ ] Verify the sorted field dropdown shows fields in the correct order (exact match first, then type+name match)

🤖 Generated with [Claude Code](https://claude.com/claude-code)