### PR TITLE
perf: defer heavy tile filter computation to unblock dialog open

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/TileFilterConfiguration.tsx
@@ -22,6 +22,7 @@ import {
     Collapse,
     Flex,
     Select,
+    Skeleton,
     Stack,
     Text,
     Tooltip,
@@ -29,7 +30,14 @@ import {
     type PopoverProps,
 } from '@mantine/core';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
-import { useCallback, useMemo, useState, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useState,
+    useTransition,
+    type FC,
+} from 'react';
 import FieldSelect from '../../../components/common/FieldSelect';
 import MantineIcon from '../../../components/common/MantineIcon';
 import { getChartIcon } from '../../../components/common/ResourceIcon/utils';
@@ -94,6 +102,20 @@ const TileFilterConfiguration: FC<Props> = ({
     const [collapsedTabs, setCollapsedTabs] = useState<Record<string, boolean>>(
         {},
     );
+
+    // Defer heavy tile target computation to after initial paint so the
+    // dialog can open instantly without blocking the main thread.
+    const [isReady, setIsReady] = useState(false);
+    const [, startTransition] = useTransition();
+    useEffect(() => {
+        const id = requestAnimationFrame(() => {
+            startTransition(() => {
+                setIsReady(true);
+            });
+        });
+        return () => cancelAnimationFrame(id);
+    }, []);
+
     const sqlChartTilesMetadata = useDashboardContext(
         (c) => c.sqlChartTilesMetadata,
     );
@@ -137,6 +159,8 @@ const TileFilterConfiguration: FC<Props> = ({
     }, [sortTilesByFieldMatch, availableTileFilters]);
 
     const tileTargetList = useMemo(() => {
+        if (!isReady) return [];
+
         const tileWithTargetFields =
             sortedTileWithFilters.map<TileWithTargetFields>(
                 ([tileUuid, filters], index) => {
@@ -305,6 +329,7 @@ const TileFilterConfiguration: FC<Props> = ({
 
         return [...tileWithTargetFields, ...tileWithTargetColumns];
     }, [
+        isReady,
         sortedTileWithFilters,
         sqlChartTilesMetadata,
         tiles,
@@ -627,6 +652,17 @@ const TileFilterConfiguration: FC<Props> = ({
         ) : (
             <StackSubComponent tileList={tileTargetList} isNested={false} />
         );
+
+    if (!isReady) {
+        return (
+            <Stack spacing="md" p="md">
+                <Skeleton height={20} width="60%" />
+                <Skeleton height={16} width="80%" />
+                <Skeleton height={16} width="70%" />
+                <Skeleton height={16} width="75%" />
+            </Stack>
+        );
+    }
 
     return (
         <Stack spacing="xl" mah={600} style={{ overflow: 'auto' }}>


### PR DESCRIPTION
## Summary

- **Defers the expensive `tileTargetList` useMemo computation** in `TileFilterConfiguration` to after the initial paint, so the filter dialog opens instantly instead of blocking the UI for seconds on dashboards with many tiles
- Uses `requestAnimationFrame` + `startTransition` to schedule the heavy work after the browser has painted the initial frame
- Shows a lightweight `Skeleton` placeholder while the deferred computation runs

## Problem

When a user opens the filter configuration dialog on a dashboard with many chart tiles, the `TileFilterConfiguration` component mounts and immediately runs an expensive `tileTargetList` `useMemo` synchronously on the main thread. This blocks the UI, making the dialog feel sluggish to open (can take multiple seconds on large dashboards).

## Solution

1. Added an `isReady` state flag that starts as `false`
2. After the first paint (`requestAnimationFrame`), sets `isReady` to `true` inside a `startTransition` to keep it non-blocking
3. The `tileTargetList` useMemo early-returns `[]` when `!isReady`, skipping the expensive computation on initial render
4. A `Skeleton` loading state is shown while `!isReady`, so the user sees the dialog open immediately with a brief loading indicator before the full tile list appears

## Test plan

- [ ] Open a dashboard with many chart tiles (20+)
- [ ] Click to add/edit a filter and observe the dialog opens without delay
- [ ] Verify the tile configuration list appears after a brief skeleton flash
- [ ] Verify all tile checkboxes, field selects, and tab toggles work correctly after loading
- [ ] Verify the "Select all" checkbox works correctly
- [ ] Test with dashboards that have multiple tabs

🤖 Generated with [Claude Code](https://claude.com/claude-code)