### PR TITLE
feat: fix model selector search in validator fix flow

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
@@ -284,23 +284,17 @@ export const FixValidationErrorModal: FC<Props> = ({
                                 </Text>
                             )}
                             <Select
-                                searchValue={search}
-                                onSearchChange={setSearch}
-                                renderOption={({ option }) => (
-                                    <Highlight
-                                        highlight={search}
-                                        {...option}
-                                        fz="sm"
-                                        color="yellow"
-                                    >
-                                        {option.label}
-                                    </Highlight>
-                                )}
-                                data={explores?.map((e) => e.name) || []}
+                                data={
+                                    explores
+                                        ?.map((e) => e.name)
+                                        .sort((a, b) => a.localeCompare(b)) ??
+                                    []
+                                }
                                 required
                                 searchable
+                                nothingFoundMessage="No models found"
                                 label="New model"
-                                placeholder={`Select a model to rename to`}
+                                placeholder="Select a model to rename to"
                                 onChange={(e) => {
                                     if (e) setNewName(e);
                                 }}


### PR DESCRIPTION
## Summary
- Fixes the model selector in the Validator fix/rename flow not accepting typed input
- Removes controlled search state (`searchValue`/`onSearchChange`) and `renderOption` from the model selector that was preventing typing — lets Mantine's built-in `searchable` handle it natively
- Sorts model options alphabetically for easier scanning in large projects
- Adds `nothingFoundMessage` for when search yields no results

Closes #20771

## Test plan
- [ ] Open the Validator page in project settings
- [ ] Click "Fix" on a chart validation error to open the fix modal
- [ ] Switch to "Model" radio button
- [ ] Verify you can type in the model selector to filter options
- [ ] Verify model options are sorted alphabetically
- [ ] Verify "No models found" appears when search doesn't match

🤖 Generated with [Claude Code](https://claude.com/claude-code)