### PR TITLE
fix: only show tiles panel when tiles tab is selected

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/FilterConfiguration/index.tsx
@@ -480,7 +480,7 @@ const FilterConfiguration: FC<Props> = ({
                     </Stack>
                 </Tabs.Panel>
 
-                {draftFilterRule && (
+                {draftFilterRule && selectedTabId === FilterTabs.TILES && (
                     <Tabs.Panel
                         value={FilterTabs.TILES}
                         w={500}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

<img width="640" height="496" alt="Screenshot from 2026-03-03 10-47-02" src="https://github.com/user-attachments/assets/3e4726b0-f3aa-4e08-a6be-6b27ca22d8ef" />

Before

[Screencast from 2026-03-03 10-05-10.webm](https://github.com/user-attachments/assets/5bf7d671-dbc7-4ef4-925f-e3f97e10fce9)

[Screencast from 2026-03-03 10-14-28.webm](https://github.com/user-attachments/assets/88fa60b8-4eeb-4765-a421-1c0ad017e95f)

After

[Screencast from 2026-03-03 10-05-30.webm](https://github.com/user-attachments/assets/0d32ef78-6f2c-4475-8c48-7c581810f728)

[Screencast from 2026-03-03 10-16-34.webm](https://github.com/user-attachments/assets/b48a490a-5a68-4118-9b6c-3e054a33c0f4)



### Description:
Fixed the tiles panel in FilterConfiguration to only render when both a draft filter rule exists and the tiles tab is selected. This prevents the panel from being displayed when it shouldn't be visible.

<!-- Even better add a screenshot / gif / loom -->