### PR TITLE
fix: add passport to backend tsconfig types to fix knex migrate

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -20,7 +20,7 @@
         "moduleResolution": "node10",
         "resolveJsonModule": true,
         "skipLibCheck": true,
-        "types": ["node", "jest"]
+        "types": ["node", "jest", "passport"]
     },
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
     "exclude": ["dist", "node_modules", "src/ee/services/McpService/mcp-chart-app"],


### PR DESCRIPTION
### Description:

- The TS6 upgrade (#20727) added `"types": ["node", "jest"]` to the backend tsconfig, which restricts TypeScript's auto-discovery of `@types/*` packages
- This excluded `@types/passport`'s global augmentation that adds `.user` to Express `Request`, breaking any ts-node code path (e.g. `knex migrate`)
- `pnpm dev` was unaffected because `tsx` skips type-checking

## Test plan
- [x] `knex migrate` no longer throws `TS2339: Property 'user' does not exist on type 'Request'`

