### PR TITLE
fix: require linked Lightdash account to vote on AI Agent responses

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3712,9 +3712,30 @@ Use them as a reference, but do all the due dilligence and follow the instructio
     public handlePromptUpvote(app: App) {
         app.action(
             'prompt_human_score.upvote',
-            async ({ ack, body, respond, context }) => {
+            async ({ ack, body, respond, context, client }) => {
                 await ack();
                 const { user } = body;
+                const { teamId } = context;
+
+                // Auth check: require linked Lightdash account to vote
+                const openIdIdentity =
+                    await this.openIdIdentityModel.findIdentityByOpenId(
+                        OpenIdIdentityIssuerType.SLACK,
+                        user.id,
+                        teamId,
+                    );
+
+                if (!openIdIdentity) {
+                    if (body.type === 'block_actions' && body.channel?.id) {
+                        await client.chat.postEphemeral({
+                            channel: body.channel.id,
+                            user: user.id,
+                            text: 'You need to link your Slack account to Lightdash to vote on AI responses. Please use the AI Agent first to complete the OAuth linking process.',
+                        });
+                    }
+                    return;
+                }
+
                 const newBlock = {
                     type: 'context',
                     elements: [
@@ -3731,7 +3752,6 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                         if (!promptUuid) {
                             return;
                         }
-                        const { teamId } = context;
                         const organizationUuid = teamId
                             ? await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
                                   teamId,
@@ -3768,6 +3788,27 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             async ({ ack, body, respond, client, context }) => {
                 await ack();
                 const { user } = body;
+                const { teamId } = context;
+
+                // Auth check: require linked Lightdash account to vote
+                const openIdIdentity =
+                    await this.openIdIdentityModel.findIdentityByOpenId(
+                        OpenIdIdentityIssuerType.SLACK,
+                        user.id,
+                        teamId,
+                    );
+
+                if (!openIdIdentity) {
+                    if (body.type === 'block_actions' && body.channel?.id) {
+                        await client.chat.postEphemeral({
+                            channel: body.channel.id,
+                            user: user.id,
+                            text: 'You need to link your Slack account to Lightdash to vote on AI responses. Please use the AI Agent first to complete the OAuth linking process.',
+                        });
+                    }
+                    return;
+                }
+
                 const newBlock = {
                     type: 'context',
                     elements: [
@@ -3784,7 +3825,6 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                         if (!promptUuid) {
                             return;
                         }
-                        const { teamId } = context;
 
                         const organizationUuid = teamId
                             ? await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(


### PR DESCRIPTION
Previously, any Slack user in the workspace could upvote/downvote AI Agent responses, even if they weren't a Lightdash user. This adds an authentication check that requires users to have linked their Slack account to Lightdash (via OAuth) before they can vote.

Unauthenticated voters now see an ephemeral message explaining they need to link their account first.

https://lightdash.slack.com/archives/C03MCQ08UKS/p1772530889475289?thread_ts=1772469482.325739&cid=C03MCQ08UKS

https://claude.ai/code/session_01Hzigf1MTgjoJtvCXMX5YXC

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
