### PR TITLE
fix: improve pre-aggregate analytics copy

### DIFF
--- a/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/PreAggregateStatsTable.tsx
@@ -222,7 +222,7 @@ const PreAggregateStatsTable: FC<Props> = ({
             },
             {
                 id: 'queries',
-                header: 'Queries',
+                header: 'Cache',
                 enableSorting: true,
                 size: 160,
                 accessorFn: (row) => row.hitCount + row.missCount,
@@ -236,8 +236,8 @@ const PreAggregateStatsTable: FC<Props> = ({
                     const { hitCount, missCount } = row.original;
                     return (
                         <Group gap={8} wrap="nowrap">
-                            <Text size="xs" c="ldGray.6" ff="monospace">
-                                {hitCount} hit{hitCount !== 1 ? 's' : ''}
+                            <Text size="xs" c="green.7" ff="monospace">
+                                {hitCount} cached
                             </Text>
                             <Text size="xs" c="ldGray.4" ff="monospace">
                                 /
@@ -245,10 +245,10 @@ const PreAggregateStatsTable: FC<Props> = ({
                             <Text
                                 size="xs"
                                 ff="monospace"
-                                c={missCount > 0 ? 'ldGray.8' : 'ldGray.4'}
+                                c={missCount > 0 ? 'orange.7' : 'ldGray.4'}
                                 fw={missCount > 0 ? 500 : 400}
                             >
-                                {missCount} miss{missCount !== 1 ? 'es' : ''}
+                                {missCount} uncached
                             </Text>
                         </Group>
                     );

--- a/packages/frontend/src/components/PreAggregateAudit/index.tsx
+++ b/packages/frontend/src/components/PreAggregateAudit/index.tsx
@@ -82,9 +82,9 @@ const PreAggregateAudit: FC<PreAggregateAuditProps> = ({ projectUuid }) => {
             <Stack gap="md">
                 <Group justify="space-between">
                     <Stack gap={2}>
-                        <Title order={5}>Pre-Aggregate Audit</Title>
+                        <Title order={5}>Pre-Aggregate Analytics</Title>
                         <Text c="dimmed" size="xs">
-                            Track how often your pre-aggregates are being used.
+                            Track cache performance for your pre-aggregates.
                             Data is retained for 3 days.
                         </Text>
                     </Stack>
@@ -102,7 +102,7 @@ const PreAggregateAudit: FC<PreAggregateAuditProps> = ({ projectUuid }) => {
                 <SimpleGrid cols={3}>
                     <Card withBorder p="md">
                         <Text size="xs" c="dimmed" tt="uppercase" fw={700}>
-                            Hit Rate (3 days)
+                            Cache Rate (3 days)
                         </Text>
                         <Text size="xl" fw={700}>
                             {summary.totalQueries > 0

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -840,7 +840,7 @@ const Settings: FC = () => {
 
                                     {health.preAggregates.enabled && (
                                         <RouterNavLink
-                                            label="Pre-aggregate audit"
+                                            label="Pre-aggregate analytics"
                                             exact
                                             to={`/generalSettings/projectManagement/${project.projectUuid}/preAggregateAudit`}
                                             leftSection={


### PR DESCRIPTION
- Rename sidebar label from "Pre-aggregate audit" to "Pre-aggregate analytics"
- Update page title and description to reflect analytics focus
- Change "Queries" column header to "Cache" for clarity
- Replace "hit/miss" terminology with "cached/uncached" for better understanding
- Add semantic colors (green for cached, orange for uncached)
- Rename "Hit Rate" card to "Cache Rate"

https://claude.ai/code/session_0149KjnD3m6WwQyvysGkobv8

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
