### PR TITLE
feat: add DeployProject@self permission scope for preview projects

### DIFF
--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -5,6 +5,7 @@ import {
     ExploreError,
     ForbiddenError,
     NotFoundError,
+    ProjectType,
     SessionUser,
 } from '@lightdash/common';
 import { DeploySessionModel } from '../models/DeploySessionModel';
@@ -51,15 +52,20 @@ export class DeployService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<{ deploySessionUuid: string }> {
-        // Check deploy-specific permission
+        // Check deploy permission
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        // manage:DeployProject for non-preview projects (restrictable via custom roles)
+        // manage:DeployProject@self for preview projects created by the user
         if (
             user.ability.cannot(
                 'manage',
                 subject('DeployProject', {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    type: project.type,
+                    createdByUserUuid: project.createdByUserUuid,
                 }),
             )
         ) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2107,12 +2107,17 @@ export class ProjectService extends BaseService {
     ): Promise<void> {
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        // manage:DeployProject for non-preview projects (restrictable via custom roles)
+        // manage:DeployProject@self for preview projects created by the user
         if (
             user.ability.cannot(
                 'manage',
                 subject('DeployProject', {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    type: project.type,
+                    createdByUserUuid: project.createdByUserUuid,
                 }),
             )
         ) {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -271,6 +271,8 @@ const applyOrganizationMemberStaticAbilities: Record<
         });
         can('manage', 'DeployProject', {
             organizationUuid: member.organizationUuid,
+            type: ProjectType.PREVIEW,
+            createdByUserUuid: member.userUuid,
         });
         can('delete', 'Project', {
             organizationUuid: member.organizationUuid,
@@ -349,6 +351,9 @@ const applyOrganizationMemberStaticAbilities: Record<
             organizationUuid: member.organizationUuid,
         });
         can('manage', 'GitIntegration', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('manage', 'DeployProject', {
             organizationUuid: member.organizationUuid,
         });
     },

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -212,6 +212,11 @@ export const projectMemberAbilities: Record<
         can('manage', 'DeployProject', {
             projectUuid: member.projectUuid,
         });
+        can('manage', 'DeployProject', {
+            projectUuid: member.projectUuid,
+            type: ProjectType.PREVIEW,
+            createdByUserUuid: member.userUuid,
+        });
 
         can('delete', 'Project', {
             projectUuid: member.projectUuid,

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -74,6 +74,7 @@ const BASE_ROLE_SCOPES = {
         'manage:Validation',
         'manage:CompileProject',
         'manage:DeployProject',
+        'manage:DeployProject@self',
         'create:Project@preview', // Preview projects
         'delete:Project@self', // Preview projects created by user
         'update:Project',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -310,6 +310,19 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:DeployProject@self',
+        description: 'Deploy to preview projects created by the user',
+        isEnterprise: false,
+        group: ScopeGroup.PROJECT_MANAGEMENT,
+        getConditions: (context) => [
+            {
+                projectUuid: context.projectUuid,
+                createdByUserUuid: context.userUuid || false,
+                type: ProjectType.PREVIEW,
+            },
+        ],
+    },
+    {
         name: 'manage:Validation',
         description: 'Manage data validation rules',
         isEnterprise: false,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

Here's the full test results summary:                                                                 
                                                                                                        
  Scenario: Deploy to project                                                                           
  User: demo@ (org admin)                                                                               
  Project: jaffle cli 2                                                                                 
  Role: org admin                                                                                       
  Result: PASS                                                                                          
  ────────────────────────────────────────                                                              
  Scenario: Deploy to project                                                                           
  User: demo2@ (org viewer)                                                                             
  Project: jaffle cli 2                                                                                 
  Role: custom role WITHOUT deploy                                                                      
  Result: BLOCKED                                                                                       
  ────────────────────────────────────────                                                              
  Scenario: Deploy to project                                                                           
  User: demo2@ (org viewer)
  Project: Jaffle shop
  Role: system developer
  Result: PASS
  ────────────────────────────────────────
  Scenario: Start preview (create + deploy)
  User: demo2@ (org viewer)
  Project: Jaffle shop
  Role: system developer
  Result: PASS
  ────────────────────────────────────────
  Scenario: Update preview
  User: demo2@ (org viewer)
  Project: Jaffle shop
  Role: system developer
  Result: PASS
  ────────────────────────────────────────
  Scenario: Start preview
  User: demo2@ (org viewer)
  Project: jaffle cli 2
  Role: custom role WITHOUT deploy
  Result: BLOCKED (create OK, deploy blocked)

  All scenarios behave correctly. The manage:DeployProject@self scope properly allows system developers
  to deploy to their own preview projects, while custom roles without deploy permissions are correctly
  blocked from both regular and preview deploys.

                                                                                                        
● The @self scope works exactly as intended:                            
                                                                                                        
  ┌────────────────────────────────────────────────┬────────────────────────────────┬─────────┐         
  │                    Scenario                    │             Scopes             │ Result  │         
  ├────────────────────────────────────────────────┼────────────────────────────────┼─────────┤         
  │ Deploy to non-preview project                  │ manage:DeployProject@self only │ BLOCKED │
  ├────────────────────────────────────────────────┼────────────────────────────────┼─────────┤
  │ Start preview (create + deploy to own preview) │ manage:DeployProject@self only │ PASS    │
  └────────────────────────────────────────────────┴────────────────────────────────┴─────────┘

  So a custom role can grant preview-deploy without granting production-deploy by including
  manage:DeployProject@self but excluding manage:DeployProject.



### Description:

This PR implements granular deployment permissions for preview projects by introducing a new `manage:DeployProject@self` scope. 

**Key Changes:**

- Added `manage:DeployProject@self` scope that allows users to deploy only to preview projects they created
- Enhanced deployment permission checks in `DeployService` and `ProjectService` to consider project type and creator
- Updated organization member abilities to grant `manage:DeployProject@self` for preview projects and full `manage:DeployProject` for admin roles
- Modified project member abilities to include the new self-scoped deployment permission
- Added the new scope to the base role scope mappings

This change provides more secure and granular control over deployment permissions, ensuring users can only deploy to their own preview projects while maintaining broader deployment access for appropriate roles.