### PR TITLE
fix: better query duration tracking for duckdb client

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -275,7 +275,32 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             WarehouseBaseClient<CreatePostgresCredentials>['executeAsyncQuery']
         >
     ) {
-        return super.executeAsyncQuery(...args);
+        const [queryArgs, resultsStreamCallback] = args;
+        const startTime = performance.now();
+        let callbackTimeMs = 0;
+
+        const result = await super.executeAsyncQuery(
+            queryArgs,
+            resultsStreamCallback
+                ? async (rows, fields) => {
+                      const callbackStartTime = performance.now();
+                      try {
+                          await resultsStreamCallback(rows, fields);
+                      } finally {
+                          callbackTimeMs +=
+                              performance.now() - callbackStartTime;
+                      }
+                  }
+                : undefined,
+        );
+
+        return {
+            ...result,
+            durationMs: Math.max(
+                0,
+                performance.now() - startTime - callbackTimeMs,
+            ),
+        };
     }
 
     async runQuery(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Add performance timing to DuckDB warehouse client's `executeAsyncQuery` method. The implementation tracks the total execution time and excludes callback processing time to provide accurate query duration metrics. The method now returns the original result enhanced with a `durationMs` field that measures only the actual query execution time.

<!-- Even better add a screenshot / gif / loom -->