### PR TITLE
docs: add meaningful custom_sql_sorts examples to jaffle shop demo

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -178,6 +178,9 @@ models:
                 # Hex colors are supported in both chart config and echarts
                 "placed": "#e6fa0f"
                 "completed": "#00FF00"
+              custom_sql_sorts:
+                - name: lifecycle_stage
+                  sql: "CASE WHEN ${status} = 'placed' THEN 1 WHEN ${status} = 'shipped' THEN 2 WHEN ${status} = 'completed' THEN 3 WHEN ${status} = 'return_pending' THEN 4 WHEN ${status} = 'returned' THEN 5 ELSE 0 END"
         tests:
           - accepted_values:
               values:
@@ -366,6 +369,10 @@ models:
         description: Priority level assigned to the order
         config:
           meta:
+            dimension:
+              custom_sql_sorts:
+                - name: urgency_level
+                  sql: "CASE WHEN ${order_priority} = 'urgent' THEN 1 WHEN ${order_priority} = 'high' THEN 2 WHEN ${order_priority} = 'normal' THEN 3 ELSE 4 END"
             metrics:
               avg_delivery_time_by_priority:
                 type: average

--- a/examples/full-jaffle-shop-demo/dbt/models/subscriptions.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/subscriptions.yml
@@ -75,6 +75,9 @@ models:
                 "gold": "#FFD700"
                 "platinum": "#E5E4E2"
                 "diamond": "#B9F2FF"
+              custom_sql_sorts:
+                - name: plan_tier
+                  sql: "CASE WHEN ${plan_name} = 'free' THEN 1 WHEN ${plan_name} = 'silver' THEN 2 WHEN ${plan_name} = 'gold' THEN 3 WHEN ${plan_name} = 'platinum' THEN 4 WHEN ${plan_name} = 'diamond' THEN 5 ELSE 0 END"
             metrics:
               subscriptions_by_plan_name:
                 type: count_distinct


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added custom SQL sorting configurations for dimension fields in the jaffle shop demo:

- **Order status**: Added `lifecycle_stage` sort to order status by lifecycle progression (placed → shipped → completed → return_pending → returned)
- **Order priority**: Added `urgency_level` sort to order priority by urgency level (urgent → high → normal → other)  
- **Subscription plan**: Added `plan_tier` sort to plan names by tier hierarchy (free → silver → gold → platinum → diamond)

These custom sorts ensure logical ordering of categorical values in charts and reports rather than alphabetical sorting.