### PR TITLE
feat: add timeout configuration for Snowflake queries

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -260,6 +260,7 @@ export type CreateSnowflakeCredentials = {
     startOfWeek?: WeekDay | null;
     quotedIdentifiersIgnoreCase?: boolean;
     disableTimestampConversion?: boolean; // Disable timestamp conversion to UTC - only disable if all timestamp values are already in UTC
+    timeoutSeconds?: number;
     override?: boolean;
     organizationWarehouseCredentialsUuid?: string;
 };

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/SnowflakeForm.tsx
@@ -4,6 +4,7 @@ import {
     Button,
     FileInput,
     Group,
+    NumberInput,
     PasswordInput,
     Radio,
     Select,
@@ -617,6 +618,27 @@ const SnowflakeForm: FC<{
                                         'warehouse.disableTimestampConversion',
                                         { type: 'checkbox' },
                                     )}
+                                />
+                                <NumberInput
+                                    name="warehouse.timeoutSeconds"
+                                    {...form.getInputProps(
+                                        'warehouse.timeoutSeconds',
+                                    )}
+                                    label="Timeout in seconds"
+                                    defaultValue={
+                                        SnowflakeDefaultValues.timeoutSeconds
+                                    }
+                                    description={
+                                        <p>
+                                            Sets the maximum execution time for
+                                            queries. If a query takes longer
+                                            than this timeout, Snowflake will
+                                            cancel it. This uses Snowflake's
+                                            STATEMENT_TIMEOUT_IN_SECONDS session
+                                            parameter.
+                                        </p>
+                                    }
+                                    disabled={disabled}
                                 />
                             </Stack>
                         </FormSection>

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/defaultValues.ts
@@ -115,6 +115,7 @@ export const SnowflakeDefaultValues: CreateSnowflakeCredentials = {
     authenticationType: undefined,
     privateKey: '',
     privateKeyPass: '',
+    timeoutSeconds: 300,
 };
 
 export const TrinoDefaultValues: CreateTrinoCredentials = {

--- a/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/SnowflakeCredentialsForm.tsx
+++ b/packages/frontend/src/components/UserSettings/OrganizationWarehouseCredentialsPanel/SnowflakeCredentialsForm.tsx
@@ -1,5 +1,6 @@
 import {
     Anchor,
+    NumberInput,
     Select,
     Stack,
     Switch,
@@ -211,6 +212,14 @@ export const SnowflakeCredentialsForm: FC<Props> = ({
                                 value ? parseInt(value) : null,
                             )
                         }
+                    />
+
+                    <NumberInput
+                        size="xs"
+                        label="Timeout in seconds"
+                        description="Sets the maximum execution time for queries. If a query takes longer than this timeout, Snowflake will cancel it."
+                        disabled={disabled}
+                        {...form.getInputProps('credentials.timeoutSeconds')}
                     />
                 </Stack>
             </FormSection>

--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -517,6 +517,15 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             `ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;`,
         );
 
+        if (this.credentials.timeoutSeconds !== undefined) {
+            console.debug(
+                `Setting Snowflake session STATEMENT_TIMEOUT_IN_SECONDS = ${this.credentials.timeoutSeconds}`,
+            );
+            sqlStatements.push(
+                `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${this.credentials.timeoutSeconds};`,
+            );
+        }
+
         await this.executeStatements(
             connection,
             sqlStatements.join('\n'),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-5739 <!-- reference the related issue e.g. #150 -->

### Description:

Adds configurable query timeout support for Snowflake connections. This introduces a new `timeoutSeconds` field that allows users to set the maximum execution time for queries using Snowflake's `STATEMENT_TIMEOUT_IN_SECONDS` session parameter.

**Changes:**
- Added `timeoutSeconds` field to Snowflake credentials type with a default value of 300 seconds
- Added timeout configuration input to both project connection and organization warehouse credential forms
- Implemented session parameter setting in the Snowflake warehouse client to apply the timeout when establishing connections

When configured, queries that exceed the specified timeout duration will be automatically cancelled by Snowflake, providing better control over long-running query execution.