### PR TITLE
feat: Add materializations endpoint + refactor pre aggregate controller 

### DIFF
--- a/packages/backend/src/controllers/v2/PreAggregateController.ts
+++ b/packages/backend/src/controllers/v2/PreAggregateController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    type ApiGetPreAggregateMaterializationsResponse,
     type ApiGetPreAggregateStatsResponse,
 } from '@lightdash/common';
 import {
@@ -18,17 +19,17 @@ import express from 'express';
 import { allowApiKeyAuthentication, isAuthenticated } from '../authentication';
 import { BaseController } from '../baseController';
 
-@Route('/api/v2/projects/{projectUuid}/pre-aggregate-stats')
+@Route('/api/v2/projects/{projectUuid}/pre-aggregates')
 @Response<ApiErrorPayload>('default', 'Error')
 @Tags('v2', 'Pre-Aggregates')
-export class PreAggregateStatsController extends BaseController {
+export class PreAggregateController extends BaseController {
     /**
      * Retrieves aggregated pre-aggregate hit/miss statistics for a project
      * @summary Get pre-aggregate stats
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Get('/')
+    @Get('/stats')
     @OperationId('getPreAggregateStats')
     async getPreAggregateStats(
         @Path() projectUuid: string,
@@ -55,6 +56,34 @@ export class PreAggregateStatsController extends BaseController {
                 paginateArgs,
                 filters,
             );
+
+        return {
+            status: 'ok',
+            results,
+        };
+    }
+
+    /**
+     * Retrieves pre-aggregate definitions with their latest materialization status
+     * @summary Get pre-aggregate materializations
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/materializations')
+    @OperationId('getPreAggregateMaterializations')
+    async getPreAggregateMaterializations(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Query() page?: number,
+        @Query() pageSize?: number,
+    ): Promise<ApiGetPreAggregateMaterializationsResponse> {
+        this.setStatus(200);
+
+        const paginateArgs = page && pageSize ? { page, pageSize } : undefined;
+
+        const results = await this.services
+            .getPreAggregateMaterializationService()
+            .getMaterializations(projectUuid, paginateArgs);
 
         return {
             status: 'ok',

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -97,7 +97,7 @@ import { FeatureFlagController } from './../controllers/v2/FeatureFlagController
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ParametersController } from './../controllers/v2/ParametersController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-import { PreAggregateStatsController } from './../controllers/v2/PreAggregateStatsController';
+import { PreAggregateController } from './../controllers/v2/PreAggregateController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
 import { ProjectDefaultsController } from './../controllers/v2/ProjectDefaultsController';
 // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
@@ -7621,11 +7621,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8103,11 +8103,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8122,11 +8122,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8141,11 +8141,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8160,11 +8160,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8179,11 +8179,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9635,6 +9635,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    timeoutSeconds: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     override: {
                         dataType: 'union',
                         subSchemas: [
@@ -9705,6 +9712,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    timeoutSeconds: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     useSshTunnel: {
                         dataType: 'union',
                         subSchemas: [
@@ -9761,13 +9775,6 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'boolean' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    timeoutSeconds: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -9834,6 +9841,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    timeoutSeconds: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     useSshTunnel: {
                         dataType: 'union',
                         subSchemas: [
@@ -9883,13 +9897,6 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             { dataType: 'string' },
-                            { dataType: 'undefined' },
-                        ],
-                    },
-                    timeoutSeconds: {
-                        dataType: 'union',
-                        subSchemas: [
-                            { dataType: 'double' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -10239,8 +10246,6 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
-                    host: { dataType: 'string', required: true },
-                    port: { dataType: 'double', required: true },
                     timeoutSeconds: {
                         dataType: 'union',
                         subSchemas: [
@@ -10248,6 +10253,8 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    host: { dataType: 'string', required: true },
+                    port: { dataType: 'double', required: true },
                     secure: {
                         dataType: 'union',
                         subSchemas: [
@@ -10727,6 +10734,7 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 organizationWarehouseCredentialsUuid: { dataType: 'string' },
                 override: { dataType: 'boolean' },
+                timeoutSeconds: { dataType: 'double' },
                 disableTimestampConversion: { dataType: 'boolean' },
                 quotedIdentifiersIgnoreCase: { dataType: 'boolean' },
                 startOfWeek: {
@@ -25100,6 +25108,214 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PreAggregateMaterializationStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['in_progress'] },
+                { dataType: 'enum', enums: ['active'] },
+                { dataType: 'enum', enums: ['superseded'] },
+                { dataType: 'enum', enums: ['failed'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PreAggregateMaterializationTrigger: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { dataType: 'enum', enums: ['compile'] },
+                { dataType: 'enum', enums: ['cron'] },
+                { dataType: 'enum', enums: ['manual'] },
+                { dataType: 'enum', enums: ['webhook'] },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PreAggregateMaterializationSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                materialization: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                trigger: {
+                                    ref: 'PreAggregateMaterializationTrigger',
+                                    required: true,
+                                },
+                                errorMessage: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'string' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                columns: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { ref: 'ResultColumns' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                rowCount: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'double' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                materializedAt: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        { dataType: 'datetime' },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                    required: true,
+                                },
+                                status: {
+                                    ref: 'PreAggregateMaterializationStatus',
+                                    required: true,
+                                },
+                                materializationUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                definitionError: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                refreshCron: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                granularity: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'TimeFrames' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                timeDimension: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                metrics: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                dimensions: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                sourceExploreName: { dataType: 'string', required: true },
+                preAggregateName: { dataType: 'string', required: true },
+                preAggregateDefinitionUuid: {
+                    dataType: 'string',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiPreAggregateMaterializationsResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                materializations: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'PreAggregateMaterializationSummary',
+                    },
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    KnexPaginatedData_ApiPreAggregateMaterializationsResults_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                pagination: {
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'KnexPaginateArgs' },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                totalResults: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                                totalPageCount: {
+                                    dataType: 'double',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
+                },
+                data: {
+                    ref: 'ApiPreAggregateMaterializationsResults',
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetPreAggregateMaterializationsResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'KnexPaginatedData_ApiPreAggregateMaterializationsResults_',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ProjectParameterSummary: {
         dataType: 'refAlias',
         type: {
@@ -25259,48 +25475,6 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Tsoa.TypeStringLiteral': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'union',
-            subSchemas: [
-                { dataType: 'enum', enums: ['string'] },
-                { dataType: 'enum', enums: ['boolean'] },
-                { dataType: 'enum', enums: ['double'] },
-                { dataType: 'enum', enums: ['float'] },
-                { dataType: 'enum', enums: ['file'] },
-                { dataType: 'enum', enums: ['integer'] },
-                { dataType: 'enum', enums: ['long'] },
-                { dataType: 'enum', enums: ['enum'] },
-                { dataType: 'enum', enums: ['array'] },
-                { dataType: 'enum', enums: ['datetime'] },
-                { dataType: 'enum', enums: ['date'] },
-                { dataType: 'enum', enums: ['binary'] },
-                { dataType: 'enum', enums: ['buffer'] },
-                { dataType: 'enum', enums: ['byte'] },
-                { dataType: 'enum', enums: ['void'] },
-                { dataType: 'enum', enums: ['object'] },
-                { dataType: 'enum', enums: ['any'] },
-                { dataType: 'enum', enums: ['refEnum'] },
-                { dataType: 'enum', enums: ['refObject'] },
-                { dataType: 'enum', enums: ['refAlias'] },
-                { dataType: 'enum', enums: ['nestedObjectLiteral'] },
-                { dataType: 'enum', enums: ['union'] },
-                { dataType: 'enum', enums: ['intersection'] },
-                { dataType: 'enum', enums: ['undefined'] },
-            ],
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Tsoa.AnyType': {
-        dataType: 'refObject',
-        properties: {
-            dataType: { dataType: 'enum', enums: ['any'], required: true },
-        },
-        additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DeploySessionStatus: {
@@ -52378,7 +52552,7 @@ export function RegisterRoutes(app: Router) {
         },
     );
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    const argsPreAggregateStatsController_getPreAggregateStats: Record<
+    const argsPreAggregateController_getPreAggregateStats: Record<
         string,
         TsoaRoute.ParameterSchema
     > = {
@@ -52405,13 +52579,13 @@ export function RegisterRoutes(app: Router) {
         },
     };
     app.get(
-        '/api/v2/projects/:projectUuid/pre-aggregate-stats',
-        ...fetchMiddlewares<RequestHandler>(PreAggregateStatsController),
+        '/api/v2/projects/:projectUuid/pre-aggregates/stats',
+        ...fetchMiddlewares<RequestHandler>(PreAggregateController),
         ...fetchMiddlewares<RequestHandler>(
-            PreAggregateStatsController.prototype.getPreAggregateStats,
+            PreAggregateController.prototype.getPreAggregateStats,
         ),
 
-        async function PreAggregateStatsController_getPreAggregateStats(
+        async function PreAggregateController_getPreAggregateStats(
             request: ExRequest,
             response: ExResponse,
             next: any,
@@ -52421,7 +52595,7 @@ export function RegisterRoutes(app: Router) {
             let validatedArgs: any[] = [];
             try {
                 validatedArgs = templateService.getValidatedArgs({
-                    args: argsPreAggregateStatsController_getPreAggregateStats,
+                    args: argsPreAggregateController_getPreAggregateStats,
                     request,
                     response,
                 });
@@ -52432,8 +52606,8 @@ export function RegisterRoutes(app: Router) {
                         : iocContainer;
 
                 const controller: any =
-                    await container.get<PreAggregateStatsController>(
-                        PreAggregateStatsController,
+                    await container.get<PreAggregateController>(
+                        PreAggregateController,
                     );
                 if (typeof controller['setStatus'] === 'function') {
                     controller.setStatus(undefined);
@@ -52441,6 +52615,69 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getPreAggregateStats',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsPreAggregateController_getPreAggregateMaterializations: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        page: { in: 'query', name: 'page', dataType: 'double' },
+        pageSize: { in: 'query', name: 'pageSize', dataType: 'double' },
+    };
+    app.get(
+        '/api/v2/projects/:projectUuid/pre-aggregates/materializations',
+        ...fetchMiddlewares<RequestHandler>(PreAggregateController),
+        ...fetchMiddlewares<RequestHandler>(
+            PreAggregateController.prototype.getPreAggregateMaterializations,
+        ),
+
+        async function PreAggregateController_getPreAggregateMaterializations(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsPreAggregateController_getPreAggregateMaterializations,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<PreAggregateController>(
+                        PreAggregateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getPreAggregateMaterializations',
                     controller,
                     response,
                     next,
@@ -52803,7 +53040,7 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'string',
         },
-        body: { in: 'body', name: 'body', required: true, ref: 'Tsoa.AnyType' },
+        body: { in: 'body', name: 'body', required: true, ref: 'AnyType' },
     };
     app.post(
         '/api/v2/projects/:projectUuid/deploy/:sessionUuid/batch',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2801,6 +2801,9 @@
                     "formatOptions": {
                         "$ref": "#/components/schemas/CustomFormat"
                     },
+                    "caseSensitive": {
+                        "type": "boolean"
+                    },
                     "image": {
                         "properties": {
                             "fit": {
@@ -5945,6 +5948,9 @@
                     "formatOptions": {
                         "$ref": "#/components/schemas/CustomFormat"
                     },
+                    "caseSensitive": {
+                        "type": "boolean"
+                    },
                     "image": {
                         "properties": {
                             "fit": {
@@ -6537,6 +6543,9 @@
                         },
                         "required": ["visibility"],
                         "type": "object"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean"
                     },
                     "type": {
                         "$ref": "#/components/schemas/ExploreType"
@@ -8924,19 +8933,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "success",
                                                             "error"
                                                         ]
@@ -10469,6 +10465,10 @@
                     "disableTimestampConversion": {
                         "type": "boolean"
                     },
+                    "timeoutSeconds": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "override": {
                         "type": "boolean"
                     },
@@ -10520,6 +10520,10 @@
                         ],
                         "nullable": true
                     },
+                    "timeoutSeconds": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "useSshTunnel": {
                         "type": "boolean"
                     },
@@ -10555,10 +10559,6 @@
                     },
                     "ra3Node": {
                         "type": "boolean"
-                    },
-                    "timeoutSeconds": {
-                        "type": "number",
-                        "format": "double"
                     }
                 },
                 "required": ["type", "schema", "host", "port", "dbname"],
@@ -10602,6 +10602,10 @@
                         ],
                         "nullable": true
                     },
+                    "timeoutSeconds": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "useSshTunnel": {
                         "type": "boolean"
                     },
@@ -10634,10 +10638,6 @@
                     },
                     "sslmode": {
                         "type": "string"
-                    },
-                    "timeoutSeconds": {
-                        "type": "number",
-                        "format": "double"
                     },
                     "sslcertFileName": {
                         "type": "string"
@@ -10881,14 +10881,14 @@
                         ],
                         "nullable": true
                     },
+                    "timeoutSeconds": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "host": {
                         "type": "string"
                     },
                     "port": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "timeoutSeconds": {
                         "type": "number",
                         "format": "double"
                     },
@@ -10951,6 +10951,12 @@
                         "type": "string"
                     },
                     "s3DataDir": {
+                        "type": "string"
+                    },
+                    "assumeRoleArn": {
+                        "type": "string"
+                    },
+                    "assumeRoleExternalId": {
                         "type": "string"
                     },
                     "workGroup": {
@@ -11391,6 +11397,10 @@
                     "override": {
                         "type": "boolean"
                     },
+                    "timeoutSeconds": {
+                        "type": "number",
+                        "format": "double"
+                    },
                     "disableTimestampConversion": {
                         "type": "boolean"
                     },
@@ -11662,6 +11672,12 @@
                         "format": "double"
                     },
                     "workGroup": {
+                        "type": "string"
+                    },
+                    "assumeRoleExternalId": {
+                        "type": "string"
+                    },
+                    "assumeRoleArn": {
                         "type": "string"
                     },
                     "secretAccessKey": {
@@ -12428,6 +12444,126 @@
                 },
                 "required": ["status"],
                 "type": "object"
+            },
+            "Pick_ValidationErrorChartResponse.error-or-errorType-or-fieldName-or-name-or-projectUuid-or-chartUuid-or-source-or-chartName_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "source": {
+                        "$ref": "#/components/schemas/ValidationSourceType"
+                    },
+                    "errorType": {
+                        "$ref": "#/components/schemas/ValidationErrorType"
+                    },
+                    "fieldName": {
+                        "type": "string"
+                    },
+                    "chartUuid": {
+                        "type": "string"
+                    },
+                    "chartName": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "projectUuid", "error", "errorType"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "CreateChartValidation": {
+                "$ref": "#/components/schemas/Pick_ValidationErrorChartResponse.error-or-errorType-or-fieldName-or-name-or-projectUuid-or-chartUuid-or-source-or-chartName_"
+            },
+            "ApiSuccess__errors-CreateChartValidation-Array__": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "errors": {
+                                "items": {
+                                    "$ref": "#/components/schemas/CreateChartValidation"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["errors"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiChartValidationResponse": {
+                "$ref": "#/components/schemas/ApiSuccess__errors-CreateChartValidation-Array__"
+            },
+            "Pick_ValidationErrorDashboardResponse.error-or-errorType-or-fieldName-or-name-or-projectUuid-or-dashboardUuid-or-chartName-or-source_": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "error": {
+                        "type": "string"
+                    },
+                    "source": {
+                        "$ref": "#/components/schemas/ValidationSourceType"
+                    },
+                    "errorType": {
+                        "$ref": "#/components/schemas/ValidationErrorType"
+                    },
+                    "fieldName": {
+                        "type": "string"
+                    },
+                    "chartName": {
+                        "type": "string"
+                    },
+                    "dashboardUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "projectUuid", "error", "errorType"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
+            "CreateDashboardValidation": {
+                "$ref": "#/components/schemas/Pick_ValidationErrorDashboardResponse.error-or-errorType-or-fieldName-or-name-or-projectUuid-or-dashboardUuid-or-chartName-or-source_"
+            },
+            "ApiSuccess__errors-CreateDashboardValidation-Array__": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "errors": {
+                                "items": {
+                                    "$ref": "#/components/schemas/CreateDashboardValidation"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": ["errors"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiDashboardValidationResponse": {
+                "$ref": "#/components/schemas/ApiSuccess__errors-CreateDashboardValidation-Array__"
             },
             "LightdashUser": {
                 "properties": {
@@ -13270,7 +13406,7 @@
             },
             "url.URL": {
                 "type": "string",
-                "description": "The URL interface represents an object providing static methods used for creating object URLs.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/URL)\n`URL` class is a global reference for `import { URL } from 'url'`\nhttps://nodejs.org/api/url.html#the-whatwg-url-api"
+                "description": "The **`URL`** interface is used to parse, construct, normalize, and encode URL.\n\n[MDN Reference](https://developer.mozilla.org/docs/Web/API/URL)\n`URL` class is a global reference for `import { URL } from 'url'`\nhttps://nodejs.org/api/url.html#the-whatwg-url-api"
             },
             "OauthAuth": {
                 "properties": {
@@ -15115,6 +15251,10 @@
                     "spaceUuid": {
                         "type": "string"
                     },
+                    "dashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "pinnedListUuid": {
                         "type": "string",
                         "nullable": true
@@ -15188,10 +15328,6 @@
                         "type": "object",
                         "description": "Table view configuration"
                     },
-                    "dashboardUuid": {
-                        "type": "string",
-                        "nullable": true
-                    },
                     "dashboardName": {
                         "type": "string",
                         "nullable": true
@@ -15211,6 +15347,7 @@
                     "updatedAt",
                     "chartConfig",
                     "spaceUuid",
+                    "dashboardUuid",
                     "pinnedListUuid",
                     "pinnedListOrder",
                     "slug",
@@ -15218,7 +15355,6 @@
                     "tableName",
                     "metricQuery",
                     "tableConfig",
-                    "dashboardUuid",
                     "dashboardName",
                     "colorPalette"
                 ],
@@ -15564,6 +15700,10 @@
                     "spaceUuid": {
                         "type": "string"
                     },
+                    "dashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "pinnedListUuid": {
                         "type": "string",
                         "nullable": true
@@ -15574,10 +15714,6 @@
                     },
                     "spaceName": {
                         "type": "string"
-                    },
-                    "dashboardUuid": {
-                        "type": "string",
-                        "nullable": true
                     },
                     "dashboardName": {
                         "type": "string",
@@ -15590,10 +15726,10 @@
                     "organizationUuid",
                     "uuid",
                     "spaceUuid",
+                    "dashboardUuid",
                     "pinnedListUuid",
                     "slug",
                     "spaceName",
-                    "dashboardUuid",
                     "dashboardName"
                 ],
                 "type": "object",
@@ -15986,6 +16122,42 @@
                         "type": "number",
                         "format": "double"
                     },
+                    "dashboards": {
+                        "items": {
+                            "properties": {
+                                "spaceUuid": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["spaceUuid", "name", "uuid"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
+                    "charts": {
+                        "items": {
+                            "properties": {
+                                "spaceUuid": {
+                                    "type": "string"
+                                },
+                                "name": {
+                                    "type": "string"
+                                },
+                                "uuid": {
+                                    "type": "string"
+                                }
+                            },
+                            "required": ["spaceUuid", "name", "uuid"],
+                            "type": "object"
+                        },
+                        "type": "array"
+                    },
                     "spaces": {
                         "items": {
                             "properties": {
@@ -15997,6 +16169,10 @@
                                     "type": "number",
                                     "format": "double"
                                 },
+                                "parentSpaceUuid": {
+                                    "type": "string",
+                                    "nullable": true
+                                },
                                 "name": {
                                     "type": "string"
                                 },
@@ -16007,6 +16183,7 @@
                             "required": [
                                 "dashboardCount",
                                 "chartCount",
+                                "parentSpaceUuid",
                                 "name",
                                 "uuid"
                             ],
@@ -16015,7 +16192,13 @@
                         "type": "array"
                     }
                 },
-                "required": ["dashboardCount", "chartCount", "spaces"],
+                "required": [
+                    "dashboardCount",
+                    "chartCount",
+                    "dashboards",
+                    "charts",
+                    "spaces"
+                ],
                 "type": "object"
             },
             "ApiSpaceDeleteImpactResponse": {
@@ -18250,8 +18433,21 @@
                     }
                 ]
             },
+            "ProjectDefaults": {
+                "properties": {
+                    "case_sensitive": {
+                        "type": "boolean",
+                        "description": "Default case sensitivity for string filters across the project.\nWhen false, all string filters will be case insensitive by default.\nCan be overridden at explore or field level.\nDefaults to true if not specified."
+                    }
+                },
+                "type": "object",
+                "description": "Project-wide default settings that can be overridden at explore or field level"
+            },
             "Project": {
                 "properties": {
+                    "projectDefaults": {
+                        "$ref": "#/components/schemas/ProjectDefaults"
+                    },
                     "hasDefaultUserSpaces": {
                         "type": "boolean"
                     },
@@ -19608,15 +19804,15 @@
                     "title": {
                         "type": "string"
                     },
+                    "chartName": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "hideTitle": {
                         "type": "boolean"
                     },
                     "chartSlug": {
                         "type": "string"
-                    },
-                    "chartName": {
-                        "type": "string",
-                        "nullable": true
                     }
                 },
                 "type": "object",
@@ -20344,6 +20540,9 @@
                     },
                     "type": {
                         "$ref": "#/components/schemas/ExploreType"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean"
                     },
                     "spotlight": {
                         "properties": {
@@ -21935,6 +22134,9 @@
                     "dbtVersion": {
                         "$ref": "#/components/schemas/DbtVersionOption"
                     },
+                    "projectDefaults": {
+                        "$ref": "#/components/schemas/ProjectDefaults"
+                    },
                     "copyWarehouseConnectionFromUpstreamProject": {
                         "type": "boolean"
                     },
@@ -23141,6 +23343,9 @@
                     "sqlPath": {
                         "type": "string"
                     },
+                    "caseSensitive": {
+                        "type": "boolean"
+                    },
                     "aiHint": {
                         "anyOf": [
                             {
@@ -24312,12 +24517,12 @@
                     "spaceUuid": {
                         "type": "string"
                     },
-                    "spaceName": {
-                        "type": "string"
-                    },
                     "dashboardUuid": {
                         "type": "string",
                         "nullable": true
+                    },
+                    "spaceName": {
+                        "type": "string"
                     },
                     "dashboardName": {
                         "type": "string",
@@ -24331,8 +24536,8 @@
                     "name",
                     "uuid",
                     "spaceUuid",
-                    "spaceName",
                     "dashboardUuid",
+                    "spaceName",
                     "dashboardName"
                 ],
                 "type": "object",
@@ -25802,6 +26007,319 @@
                 "$ref": "#/components/schemas/Pick_DownloadAsyncQueryResultsRequestParams.Exclude_keyofDownloadAsyncQueryResultsRequestParams.queryUuid__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
+            "ApiSuccess_ProjectDefaults-or-undefined_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ProjectDefaults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            },
+            "ApiSuccess_undefined_": {
+                "properties": {
+                    "results": {},
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["status"],
+                "type": "object"
+            },
+            "PreAggregateDailyStatResult": {
+                "properties": {
+                    "updatedAt": {
+                        "type": "string"
+                    },
+                    "preAggregateName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "missReason": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "missCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "hitCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "queryContext": {
+                        "type": "string"
+                    },
+                    "dashboardName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "dashboardUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "chartName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "chartUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "date": {
+                        "type": "string"
+                    },
+                    "exploreName": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "updatedAt",
+                    "preAggregateName",
+                    "missReason",
+                    "missCount",
+                    "hitCount",
+                    "queryContext",
+                    "dashboardName",
+                    "dashboardUuid",
+                    "chartName",
+                    "chartUuid",
+                    "date",
+                    "exploreName"
+                ],
+                "type": "object"
+            },
+            "ApiPreAggregateStatsResults": {
+                "properties": {
+                    "stats": {
+                        "items": {
+                            "$ref": "#/components/schemas/PreAggregateDailyStatResult"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["stats"],
+                "type": "object"
+            },
+            "KnexPaginatedData_ApiPreAggregateStatsResults_": {
+                "properties": {
+                    "pagination": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/KnexPaginateArgs"
+                            },
+                            {
+                                "properties": {
+                                    "totalResults": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "totalPageCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    }
+                                },
+                                "required": ["totalResults", "totalPageCount"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/ApiPreAggregateStatsResults"
+                    }
+                },
+                "required": ["data"],
+                "type": "object"
+            },
+            "ApiGetPreAggregateStatsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/KnexPaginatedData_ApiPreAggregateStatsResults_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "PreAggregateMaterializationStatus": {
+                "type": "string",
+                "enum": ["in_progress", "active", "superseded", "failed"]
+            },
+            "PreAggregateMaterializationTrigger": {
+                "type": "string",
+                "enum": ["compile", "cron", "manual", "webhook"]
+            },
+            "PreAggregateMaterializationSummary": {
+                "properties": {
+                    "materialization": {
+                        "properties": {
+                            "trigger": {
+                                "$ref": "#/components/schemas/PreAggregateMaterializationTrigger"
+                            },
+                            "errorMessage": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "columns": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/ResultColumns"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "rowCount": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            },
+                            "materializedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true
+                            },
+                            "status": {
+                                "$ref": "#/components/schemas/PreAggregateMaterializationStatus"
+                            },
+                            "materializationUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "trigger",
+                            "errorMessage",
+                            "columns",
+                            "rowCount",
+                            "materializedAt",
+                            "status",
+                            "materializationUuid"
+                        ],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "definitionError": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "refreshCron": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "granularity": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/TimeFrames"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "timeDimension": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "metrics": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "dimensions": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "sourceExploreName": {
+                        "type": "string"
+                    },
+                    "preAggregateName": {
+                        "type": "string"
+                    },
+                    "preAggregateDefinitionUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "materialization",
+                    "definitionError",
+                    "refreshCron",
+                    "granularity",
+                    "timeDimension",
+                    "metrics",
+                    "dimensions",
+                    "sourceExploreName",
+                    "preAggregateName",
+                    "preAggregateDefinitionUuid"
+                ],
+                "type": "object"
+            },
+            "ApiPreAggregateMaterializationsResults": {
+                "properties": {
+                    "materializations": {
+                        "items": {
+                            "$ref": "#/components/schemas/PreAggregateMaterializationSummary"
+                        },
+                        "type": "array"
+                    }
+                },
+                "required": ["materializations"],
+                "type": "object"
+            },
+            "KnexPaginatedData_ApiPreAggregateMaterializationsResults_": {
+                "properties": {
+                    "pagination": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/KnexPaginateArgs"
+                            },
+                            {
+                                "properties": {
+                                    "totalResults": {
+                                        "type": "number",
+                                        "format": "double"
+                                    },
+                                    "totalPageCount": {
+                                        "type": "number",
+                                        "format": "double"
+                                    }
+                                },
+                                "required": ["totalResults", "totalPageCount"],
+                                "type": "object"
+                            }
+                        ]
+                    },
+                    "data": {
+                        "$ref": "#/components/schemas/ApiPreAggregateMaterializationsResults"
+                    }
+                },
+                "required": ["data"],
+                "type": "object"
+            },
+            "ApiGetPreAggregateMaterializationsResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/KnexPaginatedData_ApiPreAggregateMaterializationsResults_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "ProjectParameterSummary": {
                 "properties": {
                     "modelName": {
@@ -25891,18 +26409,6 @@
                 "required": ["results", "status"],
                 "type": "object"
             },
-            "ApiSuccess_undefined_": {
-                "properties": {
-                    "results": {},
-                    "status": {
-                        "type": "string",
-                        "enum": ["ok"],
-                        "nullable": false
-                    }
-                },
-                "required": ["status"],
-                "type": "object"
-            },
             "FeatureFlag": {
                 "properties": {
                     "enabled": {
@@ -25958,29 +26464,6 @@
                     }
                 },
                 "required": ["results", "status"],
-                "type": "object"
-            },
-            "ApiAddDeployBatchRequest": {
-                "properties": {
-                    "batchNumber": {
-                        "type": "number",
-                        "format": "double"
-                    },
-                    "explores": {
-                        "items": {
-                            "anyOf": [
-                                {
-                                    "$ref": "#/components/schemas/Explore"
-                                },
-                                {
-                                    "$ref": "#/components/schemas/ExploreError"
-                                }
-                            ]
-                        },
-                        "type": "array"
-                    }
-                },
-                "required": ["batchNumber", "explores"],
                 "type": "object"
             },
             "DeploySessionStatus": {
@@ -27100,7 +27583,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2536.1",
+        "version": "0.2561.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -29526,6 +30009,108 @@
                         "schema": {
                             "format": "double",
                             "type": "number"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/validate/chart/{chartUuid}": {
+            "post": {
+                "operationId": "ValidateChart",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiChartValidationResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Validates a specific chart and updates validation entries in database.",
+                "summary": "Validate specific chart",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the project UUID",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the chart UUID to validate",
+                        "in": "path",
+                        "name": "chartUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/validate/dashboard/{dashboardUuid}": {
+            "post": {
+                "operationId": "ValidateDashboard",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiDashboardValidationResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Validates a specific dashboard and updates validation entries in database.",
+                "summary": "Validate specific dashboard",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "description": "the project UUID",
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "description": "the dashboard UUID to validate",
+                        "in": "path",
+                        "name": "dashboardUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ]
@@ -44330,6 +44915,240 @@
                 }
             }
         },
+        "/api/v2/projects/{projectUuid}/defaults": {
+            "get": {
+                "operationId": "getProjectDefaults",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccess_ProjectDefaults-or-undefined_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Get project defaults configuration",
+                "summary": "Get project defaults",
+                "tags": ["v2", "Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            },
+            "put": {
+                "operationId": "replaceProjectDefaults",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccess_undefined_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Replace project defaults configuration",
+                "summary": "Replace project defaults",
+                "tags": ["v2", "Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ProjectDefaults"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v2/projects/{projectUuid}/pre-aggregates/stats": {
+            "get": {
+                "operationId": "getPreAggregateStats",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGetPreAggregateStatsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Retrieves aggregated pre-aggregate hit/miss statistics for a project",
+                "summary": "Get pre-aggregate stats",
+                "tags": ["v2", "Pre-Aggregates"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "days",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "exploreName",
+                        "required": false,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "queryType",
+                        "required": false,
+                        "schema": {
+                            "type": "string",
+                            "enum": ["chart", "dashboard", "explorer"]
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v2/projects/{projectUuid}/pre-aggregates/materializations": {
+            "get": {
+                "operationId": "getPreAggregateMaterializations",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGetPreAggregateMaterializationsResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Retrieves pre-aggregate definitions with their latest materialization status",
+                "summary": "Get pre-aggregate materializations",
+                "tags": ["v2", "Pre-Aggregates"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "page",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    },
+                    {
+                        "in": "query",
+                        "name": "pageSize",
+                        "required": false,
+                        "schema": {
+                            "format": "double",
+                            "type": "number"
+                        }
+                    }
+                ]
+            }
+        },
         "/api/v2/projects/{projectUuid}/parameters/list": {
             "get": {
                 "operationId": "getProjectParametersList",
@@ -44661,7 +45480,7 @@
                     "content": {
                         "application/json": {
                             "schema": {
-                                "$ref": "#/components/schemas/ApiAddDeployBatchRequest"
+                                "$ref": "#/components/schemas/AnyType"
                             }
                         }
                     }

--- a/packages/backend/src/models/PreAggregateModel.ts
+++ b/packages/backend/src/models/PreAggregateModel.ts
@@ -1,9 +1,14 @@
 import {
     NotFoundError,
     type ActiveMaterializationDetails,
+    type ApiPreAggregateMaterializationsResults,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
     type PreAggregateDefinition,
     type PreAggregateDefinitionWithExploreName,
     type PreAggregateMaterialization,
+    type PreAggregateMaterializationStatus,
+    type PreAggregateMaterializationSummary,
     type PreAggregateMaterializationTrigger,
     type PreAggregateSchedulerDetails,
     type ResultColumns,
@@ -17,6 +22,7 @@ import {
     type DbPreAggregateMaterialization,
 } from '../database/entities/preAggregates';
 import { CachedExploreTableName } from '../database/entities/projects';
+import KnexPaginate from '../database/pagination';
 
 type DbPreAggregateDefinitionWithExploreName = DbPreAggregateDefinition & {
     pre_agg_explore_name: string;
@@ -438,6 +444,104 @@ export class PreAggregateModel {
             format: 'jsonl',
             columns: row.columns,
             materializedAt: row.materialized_at,
+        };
+    }
+
+    async getDefinitionsWithLatestMaterialization(
+        projectUuid: string,
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<ApiPreAggregateMaterializationsResults>> {
+        type DbDefinitionWithLatestMaterialization = Pick<
+            DbPreAggregateDefinition,
+            | 'pre_aggregate_definition_uuid'
+            | 'pre_aggregate_definition'
+            | 'refresh_cron'
+            | 'materialization_query_error'
+        > & {
+            source_explore_name: string;
+            // Latest materialization fields (nullable from LEFT JOIN)
+            mat_uuid: string | null;
+            mat_status: PreAggregateMaterializationStatus | null;
+            mat_materialized_at: Date | null;
+            mat_row_count: number | null;
+            mat_columns: ResultColumns | null;
+            mat_error_message: string | null;
+            mat_trigger: PreAggregateMaterializationTrigger | null;
+        };
+
+        const query = this.database
+            .with('latest_mat', (qb) => {
+                void qb
+                    .select(
+                        `${PreAggregateMaterializationsTableName}.*`,
+                        this.database.raw(
+                            `ROW_NUMBER() OVER (PARTITION BY pre_aggregate_definition_uuid ORDER BY created_at DESC) as rn`,
+                        ),
+                    )
+                    .from(PreAggregateMaterializationsTableName);
+            })
+            .from(PreAggregateDefinitionsTableName)
+            .leftJoin('latest_mat', function joinLatestMat() {
+                this.on(
+                    'latest_mat.pre_aggregate_definition_uuid',
+                    `${PreAggregateDefinitionsTableName}.pre_aggregate_definition_uuid`,
+                ).andOnVal('latest_mat.rn', 1);
+            })
+            .innerJoin(
+                `${CachedExploreTableName} as source_ce`,
+                `source_ce.cached_explore_uuid`,
+                `${PreAggregateDefinitionsTableName}.source_cached_explore_uuid`,
+            )
+            .where(
+                `${PreAggregateDefinitionsTableName}.project_uuid`,
+                projectUuid,
+            )
+            .select<DbDefinitionWithLatestMaterialization[]>([
+                `${PreAggregateDefinitionsTableName}.pre_aggregate_definition_uuid`,
+                `${PreAggregateDefinitionsTableName}.pre_aggregate_definition`,
+                `source_ce.name as source_explore_name`,
+                `${PreAggregateDefinitionsTableName}.refresh_cron`,
+                `${PreAggregateDefinitionsTableName}.materialization_query_error`,
+                `latest_mat.pre_aggregate_materialization_uuid as mat_uuid`,
+                `latest_mat.status as mat_status`,
+                `latest_mat.materialized_at as mat_materialized_at`,
+                `latest_mat.row_count as mat_row_count`,
+                `latest_mat.columns as mat_columns`,
+                `latest_mat.error_message as mat_error_message`,
+                `latest_mat.trigger as mat_trigger`,
+            ])
+            .orderBy(`${PreAggregateDefinitionsTableName}.created_at`, 'desc');
+
+        const result = await KnexPaginate.paginate(query, paginateArgs);
+
+        const materializations: PreAggregateMaterializationSummary[] =
+            result.data.map((row) => ({
+                preAggregateDefinitionUuid: row.pre_aggregate_definition_uuid,
+                preAggregateName: row.pre_aggregate_definition.name,
+                sourceExploreName: row.source_explore_name,
+                dimensions: row.pre_aggregate_definition.dimensions ?? [],
+                metrics: row.pre_aggregate_definition.metrics ?? [],
+                timeDimension:
+                    row.pre_aggregate_definition.timeDimension ?? null,
+                granularity: row.pre_aggregate_definition.granularity ?? null,
+                refreshCron: row.refresh_cron,
+                definitionError: row.materialization_query_error,
+                materialization: row.mat_uuid
+                    ? {
+                          materializationUuid: row.mat_uuid,
+                          status: row.mat_status!,
+                          materializedAt: row.mat_materialized_at,
+                          rowCount: row.mat_row_count,
+                          columns: row.mat_columns,
+                          errorMessage: row.mat_error_message,
+                          trigger: row.mat_trigger!,
+                      }
+                    : null,
+            }));
+
+        return {
+            data: { materializations },
+            pagination: result.pagination,
         };
     }
 }

--- a/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -4,6 +4,9 @@ import {
     QueryHistoryStatus,
     type Account,
     type ActiveMaterializationDetails,
+    type ApiPreAggregateMaterializationsResults,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
     type PreAggregateMaterializationTrigger,
 } from '@lightdash/common';
 import { type LightdashConfig } from '../../config/parseConfig';
@@ -223,6 +226,16 @@ export class PreAggregateMaterializationService {
 
             throw error;
         }
+    }
+
+    async getMaterializations(
+        projectUuid: string,
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<ApiPreAggregateMaterializationsResults>> {
+        return this.preAggregateModel.getDefinitionsWithLatestMaterialization(
+            projectUuid,
+            paginateArgs,
+        );
     }
 
     async getActiveMaterialization(

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -133,6 +133,7 @@ import {
 import { type ApiTogglePinnedItem, type PinnedItems } from './pinning';
 import { type PivotConfiguration } from './pivot';
 import type {
+    ApiGetPreAggregateMaterializationsResponse,
     ApiGetPreAggregateStatsResponse,
     PreAggregateMatchMiss,
 } from './preAggregate';
@@ -944,7 +945,8 @@ type ApiResults =
     | ApiDashboardValidationResponse['results']
     | ApiToggleFavorite['results']
     | ApiSpaceDeleteImpactResponse['results']
-    | ApiGetPreAggregateStatsResponse['results'];
+    | ApiGetPreAggregateStatsResponse['results']
+    | ApiGetPreAggregateMaterializationsResponse['results'];
 // Note: EE API types removed from ApiResults to avoid circular imports
 // They can still be used with ApiResponse<T> by importing from '@lightdash/common'
 

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -151,6 +151,36 @@ export const preAggregateMissReasonLabels: Record<
         'Table calculation present',
 };
 
+export type PreAggregateMaterializationSummary = {
+    preAggregateDefinitionUuid: string;
+    preAggregateName: string;
+    sourceExploreName: string;
+    dimensions: string[];
+    metrics: string[];
+    timeDimension: string | null;
+    granularity: TimeFrames | null;
+    refreshCron: string | null;
+    definitionError: string | null;
+    materialization: {
+        materializationUuid: string;
+        status: PreAggregateMaterializationStatus;
+        materializedAt: Date | null;
+        rowCount: number | null;
+        columns: ResultColumns | null;
+        errorMessage: string | null;
+        trigger: PreAggregateMaterializationTrigger;
+    } | null;
+};
+
+export type ApiPreAggregateMaterializationsResults = {
+    materializations: PreAggregateMaterializationSummary[];
+};
+
+export type ApiGetPreAggregateMaterializationsResponse = {
+    status: 'ok';
+    results: KnexPaginatedData<ApiPreAggregateMaterializationsResults>;
+};
+
 export type PreAggregateSchedulerDetails = {
     projectUuid: string;
     organizationUuid: string;

--- a/packages/frontend/src/hooks/usePreAggregateStats.ts
+++ b/packages/frontend/src/hooks/usePreAggregateStats.ts
@@ -13,7 +13,7 @@ const getPreAggregateStats = async (
 ) =>
     lightdashApi<ApiGetPreAggregateStatsResponse['results']>({
         version: 'v2',
-        url: `/projects/${projectUuid}/pre-aggregate-stats?days=${days}${
+        url: `/projects/${projectUuid}/pre-aggregates/stats?days=${days}${
             paginateArgs
                 ? `&page=${paginateArgs.page}&pageSize=${paginateArgs.pageSize}`
                 : ''


### PR DESCRIPTION
### Description:

Refactored the pre-aggregate API structure by renaming `PreAggregateStatsController` to `PreAggregateController` and reorganizing the endpoints under a unified `/api/v2/projects/{projectUuid}/pre-aggregates` route.

**Changes:**
- Renamed controller from `PreAggregateStatsController` to `PreAggregateController`
- Moved stats endpoint from `/pre-aggregate-stats` to `/pre-aggregates/stats`
- Added new `/pre-aggregates/materializations` endpoint to retrieve pre-aggregate definitions with their latest materialization status
- Updated frontend hook to use the new stats endpoint URL
- Added new types for materialization data including `PreAggregateMaterializationSummary`, `ApiPreAggregateMaterializationsResults`, and `ApiGetPreAggregateMaterializationsResponse`
- Implemented `getDefinitionsWithLatestMaterialization` method in `PreAggregateModel` with pagination support
- Added `getMaterializations` method to `PreAggregateMaterializationService`

