### PR TITLE
Refactor DroppableItemsList to use CSS modules and Mantine v8

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.module.css
@@ -1,0 +1,36 @@
+.droppableContainer {
+    padding: var(--mantine-spacing-xs);
+    background-color: var(--mantine-color-ldGray-0);
+    border-radius: var(--mantine-radius-sm);
+}
+
+.droppableArea {
+    transition: background-color 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.droppableAreaDraggingOver {
+    background-color: var(--mantine-color-ldGray-1);
+}
+
+.droppableAreaDragging {
+    background-color: var(--mantine-color-ldGray-0);
+}
+
+.draggableItem {
+    will-change: transform;
+    transition:
+        opacity 180ms cubic-bezier(0.22, 1, 0.36, 1),
+        filter 180ms cubic-bezier(0.22, 1, 0.36, 1),
+        transform 180ms cubic-bezier(0.22, 1, 0.36, 1);
+}
+
+.draggableItemDragging {
+    opacity: 0.98;
+    filter: drop-shadow(0 8px 18px rgb(20 25 35 / 22%));
+    background-color: var(--mantine-color-body);
+    border-radius: var(--mantine-radius-sm);
+}
+
+.draggableItemHidden {
+    visibility: hidden;
+}

--- a/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/TableConfigPanel/DroppableItemsList.tsx
@@ -3,11 +3,13 @@ import {
     Droppable,
     type DraggableStateSnapshot,
 } from '@hello-pangea/dnd';
-import { Group, Stack, Text } from '@mantine/core';
+import { clsx } from '@mantine/core';
+import { Group, Stack, Text } from '@mantine-8/core';
 import React, { type FC } from 'react';
 import { createPortal } from 'react-dom';
 import { GrabIcon } from '../common/GrabIcon';
 import ColumnConfiguration from './ColumnConfiguration';
+import classes from './DroppableItemsList.module.css';
 
 type DraggablePortalHandlerProps = {
     snapshot: DraggableStateSnapshot;
@@ -37,31 +39,25 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
 }) => {
     const hasItems = itemIds.length > 0;
     return (
-        <Stack
-            spacing="xs"
-            sx={(theme) => ({
-                padding: theme.spacing.xs,
-                backgroundColor: theme.colors.ldGray['0'],
-                borderRadius: theme.radius.sm,
-            })}
-        >
+        <Stack gap="xs" className={classes.droppableContainer}>
             <Droppable droppableId={droppableId}>
                 {(dropProps, droppableSnapshot) => (
                     <Stack
                         {...dropProps.droppableProps}
-                        spacing="xs"
+                        gap="xs"
                         ref={dropProps.innerRef}
                         mih={isDragging ? '30px' : undefined}
-                        bg={
-                            droppableSnapshot.isDraggingOver
-                                ? 'ldGray.1'
-                                : isDragging
-                                  ? 'ldGray.0'
-                                  : undefined
-                        }
+                        className={clsx(
+                            classes.droppableArea,
+                            droppableSnapshot.isDraggingOver &&
+                                classes.droppableAreaDraggingOver,
+                            isDragging &&
+                                !droppableSnapshot.isDraggingOver &&
+                                classes.droppableAreaDragging,
+                        )}
                     >
                         {!isDragging && !hasItems ? (
-                            <Text size="xs" color="ldGray.6" m="xs" ta="center">
+                            <Text fz="xs" c="ldGray.6" m="xs" ta="center">
                                 {placeholder}
                             </Text>
                         ) : null}
@@ -81,19 +77,20 @@ const DroppableItemsList: FC<DroppableItemsListProps> = ({
                                 ) => (
                                     <DraggablePortalHandler snapshot={snapshot}>
                                         <Group
-                                            noWrap
-                                            spacing="xs"
+                                            wrap="nowrap"
+                                            gap="xs"
                                             ref={innerRef}
                                             {...draggableProps}
-                                            style={{
-                                                visibility:
-                                                    isDragging &&
+                                            style={draggableProps.style}
+                                            className={clsx(
+                                                classes.draggableItem,
+                                                snapshot.isDragging &&
+                                                    classes.draggableItemDragging,
+                                                isDragging &&
                                                     disableReorder &&
-                                                    !snapshot.isDragging
-                                                        ? 'hidden'
-                                                        : undefined,
-                                                ...draggableProps.style,
-                                            }}
+                                                    !snapshot.isDragging &&
+                                                    classes.draggableItemHidden,
+                                            )}
                                         >
                                             <GrabIcon
                                                 dragHandleProps={


### PR DESCRIPTION
### Description:

This PR refactors the `DroppableItemsList` component to improve maintainability and align with Mantine v8 API changes:

**Key Changes:**
- Migrated inline `sx` styles to a dedicated CSS module (`DroppableItemsList.module.css`) for better separation of concerns
- Updated Mantine imports to use v8 API (`@mantine-8/core`)
- Replaced deprecated Mantine props with v8 equivalents:
  - `spacing` → `gap`
  - `noWrap` → `wrap="nowrap"`
  - `size` → `fz`
  - `color` → `c`
  - `bg` prop → `className` with CSS modules
- Added smooth transitions and visual polish to draggable items and drop zones
- Improved code organization by extracting style logic into CSS classes

**Benefits:**
- Better performance through CSS-based styling instead of inline `sx` props
- Cleaner component code with reduced cognitive load
- Easier to maintain and modify styles in the future
- Smooth animations for drag-and-drop interactions
- Full compatibility with Mantine v8

https://claude.ai/code/session_01PeQEs4kgAxoQEJc6gDysSp