### PR TITLE
feat: add configurable scheduler poll interval

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -155,6 +155,7 @@ export const lightdashConfigMock: LightdashConfig = {
     scheduler: {
         concurrency: 0,
         enabled: false,
+        pollInterval: 1000,
         jobTimeout: 0,
         tasks: ALL_TASK_NAMES,
         queryHistory: {

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -597,6 +597,22 @@ describe('parseAndSanitizeSchedulerTasks', () => {
     });
 });
 
+describe('scheduler poll interval', () => {
+    test('should default poll interval to 1000', () => {
+        const config = parseConfig();
+
+        expect(config.scheduler.pollInterval).toBe(1000);
+    });
+
+    test('should parse poll interval from environment variable', () => {
+        process.env.SCHEDULER_POLL_INTERVAL = '2500';
+
+        const config = parseConfig();
+
+        expect(config.scheduler.pollInterval).toBe(2500);
+    });
+});
+
 test('should set useSqlPivotResults only when the environment variable is set', () => {
     const undefinedConfig = parseConfig();
     expect(undefinedConfig.query.useSqlPivotResults).toBeUndefined();

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -915,6 +915,7 @@ export type LightdashConfig = {
     scheduler: {
         enabled: boolean;
         concurrency: number;
+        pollInterval: number;
         jobTimeout: number;
         screenshotTimeout?: number;
         tasks: Array<SchedulerTaskName>;
@@ -1754,6 +1755,9 @@ export const parseConfig = (): LightdashConfig => {
         scheduler: {
             enabled: process.env.SCHEDULER_ENABLED !== 'false',
             concurrency: parseInt(process.env.SCHEDULER_CONCURRENCY || '3', 10),
+            pollInterval:
+                getIntegerFromEnvironmentVariable('SCHEDULER_POLL_INTERVAL') ||
+                1000,
             jobTimeout: process.env.SCHEDULER_JOB_TIMEOUT
                 ? parseInt(process.env.SCHEDULER_JOB_TIMEOUT, 10)
                 : DEFAULT_JOB_TIMEOUT,

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -70,7 +70,7 @@ export class SchedulerWorker extends SchedulerTask {
             logger: workerLogger,
             concurrency: this.lightdashConfig.scheduler.concurrency,
             noHandleSignals: true,
-            pollInterval: 1000,
+            pollInterval: this.lightdashConfig.scheduler.pollInterval,
             maxPoolSize,
             parsedCronItems: parseCronItems([
                 {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added configurable poll interval for the scheduler worker. The scheduler now accepts a `SCHEDULER_POLL_INTERVAL` environment variable to control how frequently it polls for new jobs, with a default value of 1000ms. This allows for better tuning of scheduler performance based on deployment needs.

The poll interval is now part of the scheduler configuration and can be customized through environment variables rather than being hardcoded.