### PR TITLE
chore(devx): ignore all node_modules to .gitignore to prevent subdirectory node_modules from entering Docker build context

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 
 # dependencies
 node_modules/
+**/node_modules
 /.pnp
 .pnp.js
 


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

`.dockerignore` is a symlink to `.gitignore`, but `.gitignore` only had `node_modules/` which only ignores the **root-level** `node_modules/`.

Subdirectory `node_modules` (e.g. `packages/frontend/node_modules/`, `packages/backend/node_modules/`) were being included in the Docker build context, causing build failures due to conflicts between locally installed binaries in `node_modules/.bin/` and the packages installed during the Docker build.

**Root cause:** The pattern `node_modules/` only matches at the root level. The `**/node_modules` glob is required to also exclude nested directories. Since `.dockerignore` is a symlink to `.gitignore`, fixing `.gitignore` fixes the Docker build context as well.

**Impact:**
- Prevents accidental inclusion of local `node_modules` in Docker build context
- Fixes Docker build errors caused by binary conflicts in `node_modules/.bin/`
- Reduces Docker build context size in environments where subdirectory `node_modules` exist locally
