### PR TITLE
feat: add performance warning for dashboards exceeding tile/tab limits

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -20,6 +20,7 @@ import {
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine/hooks';
 import {
+    IconAlertTriangle,
     IconBolt,
     IconCopy,
     IconDatabase,
@@ -61,6 +62,7 @@ import useApp from '../../../providers/App/useApp';
 import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
+import useDashboardPerformanceWarning from '../../../hooks/dashboard/useDashboardPerformanceWarning';
 import AddTileButton from '../../DashboardTiles/AddTileButton';
 import MantineIcon from '../MantineIcon';
 import DashboardUpdateModal from '../modal/DashboardUpdateModal';
@@ -91,6 +93,7 @@ type DashboardHeaderProps = {
     allTilesLoaded?: boolean;
     activeTabUuid?: string;
     dashboardTabs?: Dashboard['tabs'];
+    dashboardTiles?: Dashboard['tiles'];
     isMovingDashboardToSpace: boolean;
     onSwitchTab?: (tab: Dashboard['tabs'][number] | undefined) => void;
     onAddTiles: (tiles: Dashboard['tiles'][number][]) => void;
@@ -121,6 +124,7 @@ const DashboardHeader = ({
     allTilesLoaded,
     activeTabUuid,
     dashboardTabs,
+    dashboardTiles,
     onAddTiles,
     onCancel,
     onSaveDashboard,
@@ -133,6 +137,10 @@ const DashboardHeader = ({
     onEditClicked,
     className,
 }: DashboardHeaderProps) => {
+    const performanceWarning = useDashboardPerformanceWarning(
+        dashboardTiles,
+        dashboardTabs,
+    );
     const isDashboardSummariesEnabled = useClientFeatureFlag(
         'ai-dashboard-summary' as FeatureFlags,
     );
@@ -344,6 +352,7 @@ const DashboardHeader = ({
                     </Popover.Dropdown>
                 </Popover>
 
+
                 {isEditMode && userCanManageDashboard && (
                     <ActionIcon
                         variant="subtle"
@@ -397,6 +406,45 @@ const DashboardHeader = ({
 
             {userCanManageDashboard && isEditMode ? (
                 <Group gap="xs">
+                    {performanceWarning.hasWarning && (
+                        <Tooltip
+                            label={
+                                <Box>
+                                    <Text size="sm" fw={500} mb={6}>
+                                        Speed up this dashboard
+                                    </Text>
+                                    <Text size="xs">
+                                        With{' '}
+                                        {performanceWarning.totalChartCount}{' '}
+                                        charts, load times can be slower
+                                        depending on the user's machine.{' '}
+                                        {performanceWarning.totalTabs <= 1
+                                            ? `We recommend splitting this into multiple dashboard tabs, limited to ${performanceWarning.tabsExceedingLimit[0]?.limit ?? 10} charts per tab to keep things snappy for your team.`
+                                            : `We recommend splitting this into multiple dashboards to keep things snappy for your team.`}
+                                    </Text>
+                                </Box>
+                            }
+                            withinPortal
+                            position="bottom"
+                            multiline
+                            maw={320}
+                            openDelay={200}
+                            transitionProps={{
+                                transition: 'fade',
+                                duration: 150,
+                            }}
+                        >
+                            <ActionIcon
+                                variant="subtle"
+                                size="md"
+                                radius="md"
+                                color="orange.6"
+                            >
+                                <MantineIcon icon={IconAlertTriangle} />
+                            </ActionIcon>
+                        </Tooltip>
+                    )}
+
                     <AddTileButton
                         onAddTiles={onAddTiles}
                         disabled={isSaving}

--- a/packages/frontend/src/hooks/dashboard/useDashboardPerformanceWarning.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardPerformanceWarning.ts
@@ -1,0 +1,108 @@
+import { DashboardTileTypes, type Dashboard } from '@lightdash/common';
+import { useMemo } from 'react';
+import useApp from '../../providers/App/useApp';
+
+type ChartTileType =
+    | typeof DashboardTileTypes.SAVED_CHART
+    | typeof DashboardTileTypes.SQL_CHART;
+
+const CHART_TILE_TYPES: ChartTileType[] = [
+    DashboardTileTypes.SAVED_CHART,
+    DashboardTileTypes.SQL_CHART,
+];
+
+const isChartTile = (tile: Dashboard['tiles'][number]): boolean =>
+    CHART_TILE_TYPES.includes(tile.type as ChartTileType);
+
+type TabWarning = {
+    tabUuid: string | undefined;
+    tabName: string;
+    chartCount: number;
+    limit: number;
+};
+
+type PerformanceWarning = {
+    hasWarning: boolean;
+    tabsExceedingLimit: TabWarning[];
+    totalChartCount: number;
+    totalTabs: number;
+    maxTabsLimit: number;
+    exceedsTabs: boolean;
+};
+
+/**
+ * Analyzes a dashboard for performance issues related to:
+ * - Tabs with more than the recommended number of chart tiles (SAVED_CHART or SQL_CHART)
+ * - Dashboards with more than the recommended number of tabs
+ *
+ * These limits are based on DOM node constraints that can cause browser performance issues.
+ */
+const useDashboardPerformanceWarning = (
+    dashboardTiles: Dashboard['tiles'] | undefined,
+    dashboardTabs: Dashboard['tabs'] | undefined,
+): PerformanceWarning => {
+    const { health } = useApp();
+
+    const maxTilesPerTab = health.data?.dashboard?.maxTilesPerTab ?? 50;
+    const maxTabsPerDashboard =
+        health.data?.dashboard?.maxTabsPerDashboard ?? 20;
+
+    return useMemo(() => {
+        if (!dashboardTiles) {
+            return {
+                hasWarning: false,
+                tabsExceedingLimit: [],
+                totalChartCount: 0,
+                totalTabs: 0,
+                maxTabsLimit: maxTabsPerDashboard,
+                exceedsTabs: false,
+            };
+        }
+
+        // Group chart tiles by tab
+        const chartTilesByTab = new Map<string | undefined, number>();
+
+        dashboardTiles.forEach((tile) => {
+            if (isChartTile(tile)) {
+                const tabUuid = tile.tabUuid;
+                const currentCount = chartTilesByTab.get(tabUuid) ?? 0;
+                chartTilesByTab.set(tabUuid, currentCount + 1);
+            }
+        });
+
+        // Find tabs that exceed the limit
+        const tabsExceedingLimit: TabWarning[] = [];
+
+        chartTilesByTab.forEach((chartCount, tabUuid) => {
+            if (chartCount > maxTilesPerTab) {
+                const tab = dashboardTabs?.find((t) => t.uuid === tabUuid);
+                tabsExceedingLimit.push({
+                    tabUuid,
+                    tabName: tab?.name ?? 'Default',
+                    chartCount,
+                    limit: maxTilesPerTab,
+                });
+            }
+        });
+
+        // Check total tabs
+        const totalTabs = dashboardTabs?.length ?? 1;
+        const exceedsTabs = totalTabs > maxTabsPerDashboard;
+
+        const totalChartCount = Array.from(chartTilesByTab.values()).reduce(
+            (sum, count) => sum + count,
+            0,
+        );
+
+        return {
+            hasWarning: tabsExceedingLimit.length > 0 || exceedsTabs,
+            tabsExceedingLimit,
+            totalChartCount,
+            totalTabs,
+            maxTabsLimit: maxTabsPerDashboard,
+            exceedsTabs,
+        };
+    }, [dashboardTiles, dashboardTabs, maxTilesPerTab, maxTabsPerDashboard]);
+};
+
+export default useDashboardPerformanceWarning;

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -629,6 +629,7 @@ const Dashboard: FC = () => {
         isFullscreen,
         activeTabUuid: activeTab?.uuid,
         dashboardTabs,
+        dashboardTiles,
         isFullScreenFeatureEnabled,
         onToggleFullscreen: handleToggleFullscreen,
         hasDashboardChanged:


### PR DESCRIPTION
Add a subtle warning icon with tooltip in the dashboard header (edit mode only) that appears when a dashboard exceeds the recommended limits:
- More than 50 chart tiles (SAVED_CHART or SQL_CHART) per tab
- More than 20 tabs per dashboard

This helps users with pre-existing large dashboards understand why they may experience performance issues, and suggests splitting into multiple dashboards.

The warning is intentionally subtle (orange triangle icon with informative tooltip) to not be intrusive while still providing actionable guidance.

Slack thread: https://lightdash.slack.com/archives/C08PW3909TK/p1772622376098779

https://claude.ai/code/session_01SX1xvZDiXmvsRAZ9rnjYWd

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
