### PR TITLE
fix: set default 300 second timeout for Snowflake sessions

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -517,14 +517,14 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
             `ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = FALSE;`,
         );
 
-        if (this.credentials.timeoutSeconds !== undefined) {
-            console.debug(
-                `Setting Snowflake session STATEMENT_TIMEOUT_IN_SECONDS = ${this.credentials.timeoutSeconds}`,
-            );
-            sqlStatements.push(
-                `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${this.credentials.timeoutSeconds};`,
-            );
-        }
+        // Default timeout to 300 seconds if not specified
+        const timeoutSeconds = this.credentials.timeoutSeconds ?? 300;
+        console.debug(
+            `Setting Snowflake session STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds}`,
+        );
+        sqlStatements.push(
+            `ALTER SESSION SET STATEMENT_TIMEOUT_IN_SECONDS = ${timeoutSeconds};`,
+        );
 
         await this.executeStatements(
             connection,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Set default timeout of 300 seconds for Snowflake warehouse connections when no timeout is explicitly configured. Previously, the statement timeout was only set when explicitly provided in credentials, now it will always be configured with either the provided value or the 300-second default.

<!-- Even better add a screenshot / gif / loom -->