### PR TITLE
feat: way to query the materialized pre-aggregate directly

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -66,6 +66,7 @@ import {
     job,
     lightdashConfigWithNoSMTP,
     metricQueryMock,
+    preAggregateExplore,
     projectSummary,
     projectWithSensitiveFields,
     resultsWith1Row,
@@ -76,7 +77,10 @@ import {
 } from '../ProjectService/ProjectService.mock';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import { AsyncQueryService } from './AsyncQueryService';
-import type { PreAggregationDuckDbClient } from './PreAggregationDuckDbClient';
+import {
+    PreAggregationDuckDbResolveReason,
+    type PreAggregationDuckDbClient,
+} from './PreAggregationDuckDbClient';
 import type {
     ExecuteAsyncQueryReturn,
     RunAsyncWarehouseQueryArgs,
@@ -240,7 +244,7 @@ const getMockedAsyncQueryService = (
         preAggregationDuckDbClient: {
             resolve: jest.fn(async () => ({
                 resolved: false as const,
-                reason: 'test_default_unresolved',
+                reason: PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
             })),
         } as unknown as PreAggregationDuckDbClient,
         projectCompileLogModel: {} as ProjectCompileLogModel,
@@ -735,7 +739,7 @@ describe('AsyncQueryService', () => {
         test('does not resolve pre-aggregates when flag is disabled', async () => {
             const resolveSpy = jest.fn(async () => ({
                 resolved: false as const,
-                reason: 'should_not_be_called',
+                reason: PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
             }));
             const service = getMockedAsyncQueryService({
                 ...lightdashConfigMock,
@@ -770,6 +774,7 @@ describe('AsyncQueryService', () => {
                     preAggregationRoute: {
                         sourceExploreName: metricQueryMock.exploreName,
                         preAggregateName: 'orders_daily',
+                        mode: 'opportunistic',
                     },
                     userAccessControls: {
                         userAttributes: {},
@@ -782,6 +787,283 @@ describe('AsyncQueryService', () => {
 
             expect(resolveSpy).not.toHaveBeenCalled();
             expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledTimes(1);
+        });
+
+        test('required pre-aggregate routes do not fall back when DuckDB cannot resolve', async () => {
+            const resolveSpy = jest.fn(async () => ({
+                resolved: false as const,
+                reason: PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION,
+            }));
+            const service = getMockedAsyncQueryService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+            (service as AnyType).preAggregationDuckDbClient = {
+                resolve: resolveSpy,
+            } as unknown as PreAggregationDuckDbClient;
+
+            (service.queryHistoryModel.create as jest.Mock).mockResolvedValue({
+                queryUuid: 'test-query-uuid',
+            });
+
+            const runAsyncWarehouseQuerySpy = jest
+                .spyOn(service, 'runAsyncWarehouseQuery')
+                .mockResolvedValue();
+
+            await service.executeAsyncQuery(
+                {
+                    account: sessionAccount,
+                    projectUuid,
+                    metricQuery: {
+                        ...metricQueryMock,
+                        exploreName: preAggregateExplore.name,
+                    },
+                    context: QueryExecutionContext.EXPLORE,
+                    dateZoom: undefined,
+                    queryTags: {
+                        query_context: QueryExecutionContext.EXPLORE,
+                    },
+                    explore: preAggregateExplore,
+                    invalidateCache: false,
+                    sql: 'SELECT * FROM test',
+                    fields: {},
+                    missingParameterReferences: [],
+                    preAggregationRoute: {
+                        ...preAggregateExplore.preAggregateSource!,
+                        mode: 'required',
+                    },
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                    availableParameterDefinitions: {},
+                },
+                {
+                    query: {
+                        ...metricQueryMock,
+                        exploreName: preAggregateExplore.name,
+                    },
+                },
+            );
+
+            await new Promise(setImmediate);
+
+            expect(resolveSpy).toHaveBeenCalledTimes(1);
+            expect(runAsyncWarehouseQuerySpy).not.toHaveBeenCalled();
+            expect(service.queryHistoryModel.update).toHaveBeenCalledWith(
+                'test-query-uuid',
+                projectUuid,
+                {
+                    status: QueryHistoryStatus.ERROR,
+                    error: 'No active materialization found for pre-aggregate explore "__preagg__valid_explore__rollup"',
+                },
+                sessionAccount,
+            );
+        });
+
+        test('required pre-aggregate routes do not fall back when DuckDB execution fails', async () => {
+            const service = getMockedAsyncQueryService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+            (service as AnyType).preAggregationDuckDbClient = {
+                resolve: jest.fn(async () => ({
+                    resolved: true as const,
+                    query: 'SELECT * FROM duckdb_preagg',
+                    warehouseClient: warehouseClientMock,
+                })),
+            } as unknown as PreAggregationDuckDbClient;
+
+            (service.queryHistoryModel.create as jest.Mock).mockResolvedValue({
+                queryUuid: 'test-query-uuid',
+            });
+
+            const runAsyncWarehouseQuerySpy = jest
+                .spyOn(service, 'runAsyncWarehouseQuery')
+                .mockRejectedValueOnce(new Error('duckdb failed'));
+
+            await service.executeAsyncQuery(
+                {
+                    account: sessionAccount,
+                    projectUuid,
+                    metricQuery: {
+                        ...metricQueryMock,
+                        exploreName: preAggregateExplore.name,
+                    },
+                    context: QueryExecutionContext.EXPLORE,
+                    dateZoom: undefined,
+                    queryTags: {
+                        query_context: QueryExecutionContext.EXPLORE,
+                    },
+                    explore: preAggregateExplore,
+                    invalidateCache: false,
+                    sql: 'SELECT * FROM warehouse',
+                    fields: {},
+                    missingParameterReferences: [],
+                    preAggregationRoute: {
+                        ...preAggregateExplore.preAggregateSource!,
+                        mode: 'required',
+                    },
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                    availableParameterDefinitions: {},
+                },
+                {
+                    query: {
+                        ...metricQueryMock,
+                        exploreName: preAggregateExplore.name,
+                    },
+                },
+            );
+
+            await new Promise(setImmediate);
+
+            expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledTimes(1);
+            expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    query: 'SELECT * FROM duckdb_preagg',
+                    warehouseClientOverride: warehouseClientMock,
+                }),
+            );
+        });
+
+        test('opportunistic pre-aggregate routes still fall back to the warehouse when DuckDB cannot resolve', async () => {
+            const resolveSpy = jest.fn(async () => ({
+                resolved: false as const,
+                reason: PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION,
+            }));
+            const service = getMockedAsyncQueryService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+            (service as AnyType).preAggregationDuckDbClient = {
+                resolve: resolveSpy,
+            } as unknown as PreAggregationDuckDbClient;
+
+            (service.queryHistoryModel.create as jest.Mock).mockResolvedValue({
+                queryUuid: 'test-query-uuid',
+            });
+
+            const runAsyncWarehouseQuerySpy = jest
+                .spyOn(service, 'runAsyncWarehouseQuery')
+                .mockResolvedValue();
+
+            await service.executeAsyncQuery(
+                {
+                    account: sessionAccount,
+                    projectUuid,
+                    metricQuery: metricQueryMock,
+                    context: QueryExecutionContext.EXPLORE,
+                    dateZoom: undefined,
+                    queryTags: {
+                        query_context: QueryExecutionContext.EXPLORE,
+                    },
+                    explore: validExplore,
+                    invalidateCache: false,
+                    sql: 'SELECT * FROM warehouse',
+                    fields: {},
+                    missingParameterReferences: [],
+                    preAggregationRoute: {
+                        sourceExploreName: metricQueryMock.exploreName,
+                        preAggregateName: 'orders_daily',
+                        mode: 'opportunistic',
+                    },
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                    availableParameterDefinitions: {},
+                },
+                { query: metricQueryMock },
+            );
+
+            await new Promise(setImmediate);
+
+            expect(resolveSpy).toHaveBeenCalledTimes(1);
+            expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledTimes(1);
+            expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    query: 'SELECT * FROM warehouse',
+                }),
+            );
+        });
+    });
+
+    describe('executeAsyncMetricQuery', () => {
+        test('attaches required pre-aggregate routing metadata for direct pre-aggregate explores', async () => {
+            const service = getMockedAsyncQueryService(lightdashConfigMock);
+            service.getExplore = jest
+                .fn()
+                .mockResolvedValue(preAggregateExplore);
+            (service as AnyType).getWarehouseCredentials = jest
+                .fn()
+                .mockResolvedValue(warehouseClientMock.credentials);
+            service.combineParameters = jest.fn().mockResolvedValue(undefined);
+            (service as AnyType).prepareMetricQueryAsyncQueryArgs = jest
+                .fn()
+                .mockResolvedValue({
+                    sql: 'SELECT * FROM duckdb_preagg',
+                    fields: {},
+                    warnings: [],
+                    parameterReferences: [],
+                    missingParameterReferences: [],
+                    usedParameters: {},
+                    responseMetricQuery: {
+                        ...metricQueryMock,
+                        exploreName: preAggregateExplore.name,
+                    },
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                    availableParameterDefinitions: {},
+                });
+            service.executeAsyncQuery = jest.fn().mockResolvedValue({
+                queryUuid: 'queryUuid',
+                cacheMetadata: {
+                    cacheHit: false,
+                },
+            });
+
+            const result = await service.executeAsyncMetricQuery({
+                account: sessionAccount,
+                projectUuid,
+                metricQuery: {
+                    ...metricQueryMock,
+                    exploreName: preAggregateExplore.name,
+                },
+                context: QueryExecutionContext.EXPLORE,
+                invalidateCache: false,
+                dateZoom: undefined,
+                parameters: undefined,
+                pivotConfiguration: undefined,
+            });
+
+            expect(service.executeAsyncQuery).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    preAggregationRoute: {
+                        sourceExploreName: 'valid_explore',
+                        preAggregateName: 'rollup',
+                        mode: 'required',
+                    },
+                }),
+                expect.any(Object),
+            );
+            expect(result.cacheMetadata.preAggregate).toEqual({
+                hit: true,
+                name: 'rollup',
+            });
         });
     });
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -22,6 +22,7 @@ import {
     DownloadFileType,
     Explore,
     ExploreCompiler,
+    ExploreType,
     FieldType,
     findMatch,
     ForbiddenError,
@@ -143,7 +144,10 @@ import {
 } from '../ProjectService/resultsPagination';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
-import type { PreAggregationDuckDbClient } from './PreAggregationDuckDbClient';
+import {
+    PreAggregationDuckDbClient,
+    PreAggregationDuckDbResolveReason,
+} from './PreAggregationDuckDbClient';
 import {
     ExecuteAsyncSqlQueryArgs,
     isExecuteAsyncDashboardSqlChartByUuid,
@@ -315,6 +319,26 @@ export class AsyncQueryService extends ProjectService {
         explore: Explore;
         context: QueryExecutionContext;
     }): PreAggregationRoutingDecision {
+        if (explore.type === ExploreType.PRE_AGGREGATE) {
+            if (!explore.preAggregateSource) {
+                throw new UnexpectedServerError(
+                    `Pre-aggregate explore "${explore.name}" is missing source metadata`,
+                );
+            }
+
+            return {
+                target: 'pre_aggregate',
+                preAggregateMetadata: {
+                    hit: true,
+                    name: explore.preAggregateSource.preAggregateName,
+                },
+                route: {
+                    ...explore.preAggregateSource,
+                    mode: 'required',
+                },
+            };
+        }
+
         if (
             !this.lightdashConfig.preAggregates.enabled ||
             (explore.preAggregates || []).length === 0
@@ -340,6 +364,7 @@ export class AsyncQueryService extends ProjectService {
                 route: {
                     sourceExploreName: metricQuery.exploreName,
                     preAggregateName: matchResult.preAggregateName,
+                    mode: 'opportunistic',
                 },
             };
         }
@@ -2155,51 +2180,110 @@ export class AsyncQueryService extends ProjectService {
                     };
 
                     void (async () => {
-                        const preAggResolution =
-                            this.lightdashConfig.preAggregates.enabled &&
-                            preAggregationRoute &&
-                            userAccessControls &&
-                            availableParameterDefinitions
-                                ? await this.preAggregationDuckDbClient.resolve(
-                                      {
-                                          projectUuid,
-                                          metricQuery,
-                                          dateZoom,
-                                          parameters,
-                                          preAggregationRoute,
-                                          fieldsMap,
-                                          pivotConfiguration,
-                                          startOfWeek:
-                                              warehouseCredentials.startOfWeek,
-                                          userAccessControls,
-                                          availableParameterDefinitions,
-                                      },
-                                  )
-                                : undefined;
+                        if (!preAggregationRoute) {
+                            await this.runAsyncWarehouseQuery(warehouseArgs);
+                            return;
+                        }
 
-                        if (preAggResolution?.resolved) {
-                            this.logger.info(
-                                `DuckDB pre-agg route selected for ${queryHistoryUuid}: ${preAggregationRoute!.sourceExploreName}/${preAggregationRoute!.preAggregateName}`,
+                        const isRequiredPreAggregationRoute =
+                            preAggregationRoute.mode === 'required';
+                        const isPreAggregationEnabled =
+                            this.lightdashConfig.preAggregates.enabled;
+                        const canResolvePreAggregation =
+                            isPreAggregationEnabled &&
+                            !!userAccessControls &&
+                            !!availableParameterDefinitions;
+
+                        const updateRequiredPreAggregationError = async (
+                            reason: PreAggregationDuckDbResolveReason,
+                        ) =>
+                            this.queryHistoryModel.update(
+                                queryHistoryUuid,
+                                projectUuid,
+                                {
+                                    status: QueryHistoryStatus.ERROR,
+                                    error: PreAggregationDuckDbClient.getPreAggregationResolutionErrorMessage(
+                                        {
+                                            route: preAggregationRoute,
+                                            reason,
+                                        },
+                                    ),
+                                },
+                                account,
                             );
-                            try {
-                                await this.runAsyncWarehouseQuery({
-                                    ...warehouseArgs,
-                                    query: preAggResolution.query,
-                                    warehouseClientOverride:
-                                        preAggResolution.warehouseClient,
-                                    warehouseCredentialsTypeOverride:
-                                        preAggResolution.warehouseClient
-                                            .credentials.type,
-                                });
-                            } catch (duckdbError) {
-                                this.logger.warn(
-                                    `DuckDB pre-agg execution failed for ${queryHistoryUuid}: ${getErrorMessage(duckdbError)}. Falling back to warehouse`,
-                                );
-                                await this.runAsyncWarehouseQuery(
-                                    warehouseArgs,
-                                );
+
+                        const handlePreAggregationMiss = async (
+                            reason: PreAggregationDuckDbResolveReason,
+                        ) => {
+                            if (isRequiredPreAggregationRoute) {
+                                await updateRequiredPreAggregationError(reason);
+                                return;
                             }
-                        } else {
+
+                            await this.runAsyncWarehouseQuery(warehouseArgs);
+                        };
+
+                        if (!isPreAggregationEnabled) {
+                            await handlePreAggregationMiss(
+                                PreAggregationDuckDbResolveReason.PRE_AGGREGATES_DISABLED,
+                            );
+                            return;
+                        }
+
+                        if (!canResolvePreAggregation) {
+                            await handlePreAggregationMiss(
+                                PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
+                            );
+                            return;
+                        }
+
+                        const preAggResolution =
+                            await this.preAggregationDuckDbClient.resolve({
+                                projectUuid,
+                                metricQuery,
+                                dateZoom,
+                                parameters,
+                                preAggregationRoute,
+                                fieldsMap,
+                                pivotConfiguration,
+                                startOfWeek: warehouseCredentials.startOfWeek,
+                                userAccessControls,
+                                availableParameterDefinitions,
+                            });
+
+                        if (!preAggResolution?.resolved) {
+                            await handlePreAggregationMiss(
+                                preAggResolution?.reason ??
+                                    PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
+                            );
+                            return;
+                        }
+
+                        this.logger.info(
+                            `DuckDB pre-agg route selected for ${queryHistoryUuid}: ${preAggregationRoute.sourceExploreName}/${preAggregationRoute.preAggregateName}`,
+                        );
+
+                        try {
+                            await this.runAsyncWarehouseQuery({
+                                ...warehouseArgs,
+                                query: preAggResolution.query,
+                                warehouseClientOverride:
+                                    preAggResolution.warehouseClient,
+                                warehouseCredentialsTypeOverride:
+                                    preAggResolution.warehouseClient.credentials
+                                        .type,
+                            });
+                        } catch (duckdbError) {
+                            if (isRequiredPreAggregationRoute) {
+                                this.logger.warn(
+                                    `DuckDB pre-agg execution failed for ${queryHistoryUuid}: ${getErrorMessage(duckdbError)}`,
+                                );
+                                return;
+                            }
+
+                            this.logger.warn(
+                                `DuckDB pre-agg execution failed for ${queryHistoryUuid}: ${getErrorMessage(duckdbError)}. Falling back to warehouse`,
+                            );
                             await this.runAsyncWarehouseQuery(warehouseArgs);
                         }
                     })().catch((e) => {

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.test.ts
@@ -8,7 +8,10 @@ import {
     metricQueryMock,
     preAggregateExplore,
 } from '../ProjectService/ProjectService.mock';
-import { PreAggregationDuckDbClient } from './PreAggregationDuckDbClient';
+import {
+    PreAggregationDuckDbClient,
+    PreAggregationDuckDbResolveReason,
+} from './PreAggregationDuckDbClient';
 
 describe('PreAggregationDuckDbClient', () => {
     const getClient = ({
@@ -77,6 +80,7 @@ describe('PreAggregationDuckDbClient', () => {
         preAggregationRoute: {
             sourceExploreName: 'valid_explore',
             preAggregateName: 'rollup',
+            mode: 'required' as const,
         },
         fieldsMap: {},
         pivotConfiguration: undefined,
@@ -109,7 +113,7 @@ describe('PreAggregationDuckDbClient', () => {
 
         expect(result).toEqual({
             resolved: false,
-            reason: 'no_active_materialization',
+            reason: PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION,
         });
         expect(preAggregateModel.getActiveMaterialization).toHaveBeenCalledWith(
             'projectUuid',
@@ -134,7 +138,7 @@ describe('PreAggregationDuckDbClient', () => {
 
         expect(result).toEqual({
             resolved: false,
-            reason: 'missing_pre_aggregate_s3_config',
+            reason: PreAggregationDuckDbResolveReason.MISSING_PRE_AGGREGATE_S3_CONFIG,
         });
         expect(
             preAggregateModel.getActiveMaterialization,

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -1,4 +1,5 @@
 import {
+    assertUnreachable,
     getErrorMessage,
     getPreAggregateExploreName,
     isExploreError,
@@ -55,8 +56,16 @@ export type ResolvePreAggregationDuckDbArgs = {
 };
 
 export type PreAggregationDuckDbResolution =
-    | { resolved: false; reason: string }
+    | { resolved: false; reason: PreAggregationDuckDbResolveReason }
     | { resolved: true; query: string; warehouseClient: WarehouseClient };
+
+export enum PreAggregationDuckDbResolveReason {
+    PRE_AGGREGATES_DISABLED = 'pre_aggregates_disabled',
+    MISSING_PRE_AGGREGATE_S3_CONFIG = 'missing_pre_aggregate_s3_config',
+    MISSING_DUCKDB_RUNTIME_CONFIG = 'missing_duckdb_runtime_config',
+    NO_ACTIVE_MATERIALIZATION = 'no_active_materialization',
+    RESOLVE_ERROR = 'resolve_error',
+}
 
 export class PreAggregationDuckDbClient {
     private readonly lightdashConfig: LightdashConfig;
@@ -81,6 +90,37 @@ export class PreAggregationDuckDbClient {
             ((warehouseArgs) => new DuckdbWarehouseClient(warehouseArgs));
     }
 
+    static getPreAggregationResolutionErrorMessage({
+        route,
+        reason,
+    }: {
+        route: PreAggregationRoute;
+        reason: PreAggregationDuckDbResolveReason;
+    }): string {
+        const preAggregateExploreName = getPreAggregateExploreName(
+            route.sourceExploreName,
+            route.preAggregateName,
+        );
+
+        switch (reason) {
+            case PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION:
+                return `No active materialization found for pre-aggregate explore "${preAggregateExploreName}"`;
+            case PreAggregationDuckDbResolveReason.MISSING_PRE_AGGREGATE_S3_CONFIG:
+                return 'Pre-aggregate DuckDB routing is unavailable: missing S3 configuration';
+            case PreAggregationDuckDbResolveReason.MISSING_DUCKDB_RUNTIME_CONFIG:
+                return 'Pre-aggregate DuckDB routing is unavailable: missing DuckDB runtime configuration';
+            case PreAggregationDuckDbResolveReason.PRE_AGGREGATES_DISABLED:
+                return 'Pre-aggregate DuckDB routing is unavailable: pre-aggregates are disabled';
+            case PreAggregationDuckDbResolveReason.RESOLVE_ERROR:
+                return `Failed to resolve pre-aggregate explore "${preAggregateExploreName}" in DuckDB`;
+            default:
+                return assertUnreachable(
+                    reason,
+                    'Unknown pre-aggregate resolution reason',
+                );
+        }
+    }
+
     async resolve(
         args: ResolvePreAggregationDuckDbArgs,
     ): Promise<PreAggregationDuckDbResolution> {
@@ -100,7 +140,10 @@ export class PreAggregationDuckDbClient {
             Logger.warn(
                 `DuckDB pre-agg resolve failed: ${getErrorMessage(error)}. Returning unresolved`,
             );
-            return { resolved: false, reason: 'resolve_error' };
+            return {
+                resolved: false,
+                reason: PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
+            };
         }
     }
 
@@ -108,14 +151,17 @@ export class PreAggregationDuckDbClient {
         args: ResolvePreAggregationDuckDbArgs,
     ): Promise<PreAggregationDuckDbResolution> {
         if (!this.lightdashConfig.preAggregates.enabled) {
-            return { resolved: false, reason: 'pre_aggregates_disabled' };
+            return {
+                resolved: false,
+                reason: PreAggregationDuckDbResolveReason.PRE_AGGREGATES_DISABLED,
+            };
         }
 
         const preAggregateS3Config = this.lightdashConfig.preAggregates.s3;
         if (!preAggregateS3Config) {
             return {
                 resolved: false,
-                reason: 'missing_pre_aggregate_s3_config',
+                reason: PreAggregationDuckDbResolveReason.MISSING_PRE_AGGREGATE_S3_CONFIG,
             };
         }
 
@@ -124,7 +170,7 @@ export class PreAggregationDuckDbClient {
         if (!duckdbRuntimeConfig) {
             return {
                 resolved: false,
-                reason: 'missing_duckdb_runtime_config',
+                reason: PreAggregationDuckDbResolveReason.MISSING_DUCKDB_RUNTIME_CONFIG,
             };
         }
 
@@ -142,7 +188,7 @@ export class PreAggregationDuckDbClient {
         if (!activeMaterialization) {
             return {
                 resolved: false,
-                reason: 'no_active_materialization',
+                reason: PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION,
             };
         }
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -94,9 +94,12 @@ export type ExecuteAsyncQueryReturn = {
     cacheMetadata: CacheMetadata;
 };
 
+export type PreAggregationRouteMode = 'required' | 'opportunistic';
+
 export type PreAggregationRoute = {
     sourceExploreName: string;
     preAggregateName: string;
+    mode: PreAggregationRouteMode;
 };
 
 export type ExecuteAsyncSqlQueryArgs = CommonAsyncQueryArgs & {

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -198,6 +198,10 @@ export const preAggregateExplore: Explore = {
     name: '__preagg__valid_explore__rollup',
     label: 'Pre-agg Explore',
     type: ExploreType.PRE_AGGREGATE,
+    preAggregateSource: {
+        sourceExploreName: 'valid_explore',
+        preAggregateName: 'rollup',
+    },
     tags: [],
 };
 

--- a/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts
@@ -191,6 +191,10 @@ describe('buildPreAggregateExplore', () => {
         expect(result.name).toBe('__preagg__orders__orders_rollup');
         expect(result.type).toBe(ExploreType.PRE_AGGREGATE);
         expect(result.baseTable).toBe('orders');
+        expect(result.preAggregateSource).toEqual({
+            sourceExploreName: 'orders',
+            preAggregateName: 'orders_rollup',
+        });
         expect(result.joinedTables).toEqual([]);
         expect(result.preAggregates).toEqual([]);
         expect(result.tables.orders.sqlTable).toBe(

--- a/packages/common/src/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/common/src/preAggregates/buildPreAggregateExplore.ts
@@ -427,6 +427,10 @@ export const buildPreAggregateExplore = (
             preAggregateDef.name,
         ),
         type: ExploreType.PRE_AGGREGATE,
+        preAggregateSource: {
+            sourceExploreName: sourceExplore.name,
+            preAggregateName: preAggregateDef.name,
+        },
         joinedTables: [],
         tables,
         preAggregates: [],

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -76,6 +76,11 @@ export type InlineError = {
     message: string;
 };
 
+export type PreAggregateSource = {
+    sourceExploreName: string;
+    preAggregateName: string;
+};
+
 export type Explore = {
     name: string; // Must be sql friendly (a-Z, 0-9, _)
     label: string; // Friendly name
@@ -101,6 +106,7 @@ export type Explore = {
     aiHint?: string | string[];
     parameters?: LightdashProjectConfig['parameters'];
     preAggregates?: PreAggregateDef[];
+    preAggregateSource?: PreAggregateSource;
     /**
      * Non-fatal warnings from partial compilation.
      * Present when some joins or fields failed to compile but the explore is still usable.


### PR DESCRIPTION
Fix direct querying of debug pre-aggregate explores

## Summary
When `DEBUG_PRE_AGGREGATES` exposes generated pre-aggregate explores in the explorer, users could select them but not actually run them. The backend treated those explores like normal warehouse explores, so query execution and displayed compiled SQL behavior diverged.

This change teaches the backend to recognize generated pre-aggregate explores as a dedicated execution path and route them through DuckDB-backed pre-aggregate materializations.

## What changed
- Added explicit `preAggregateSource` metadata to generated pre-aggregate explores
- Routed `ExploreType.PRE_AGGREGATE` queries directly through `PreAggregationDuckDbClient`
- Kept normal explore pre-aggregate matching behavior unchanged
- Made direct pre-aggregate routes fail clearly instead of falling back to the warehouse
- Moved pre-aggregate DuckDB resolve reasons and error formatting into `PreAggregationDuckDbClient`
- Nested `mode` under `preAggregationRoute` for cleaner internal routing state

## Behavior changes
- Direct queries against debug-visible pre-aggregate explores now go to DuckDB
- If pre-aggregates are disabled, or no active materialization exists, direct pre-aggregate queries now fail with a clear backend-generated error
- Opportunistic pre-aggregate routing for normal explores still falls back to the warehouse when DuckDB resolution/execution is unavailable

## Notes
- This does not yet update the `compiledSql` shown in the frontend/query history for direct pre-aggregate queries. The executed SQL is correct, but the displayed compiled SQL is still the earlier warehouse-compiled query.
