### PR TITLE
fix: update user attributes tests for menu dropdown interaction

### DIFF
--- a/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
+++ b/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
@@ -67,6 +67,7 @@ describe('User attributes sql_filter', () => {
         cy.visit(`/generalSettings/userAttributes`);
 
         cy.contains('customer_id').parents('tr').find('button').first().click();
+        cy.findByText('Edit').click();
         cy.get('input[name="users.0.value"]').clear().type('30');
         cy.findByText('Update').click();
         cy.contains('Success', { timeout: 10000 });
@@ -158,6 +159,7 @@ describe('User attributes dimension required_attribute', () => {
         cy.visit(`/generalSettings/userAttributes`);
 
         cy.contains('is_admin').parents('tr').find('button').first().click();
+        cy.findByText('Edit').click();
         cy.get('input[name="users.0.value"]').clear().type('false');
         cy.findByText('Update').click();
         cy.contains('Success', { timeout: 10000 });


### PR DESCRIPTION
### Description:
- Fix 4 failing e2e tests in `userAttributes.cy.ts` caused by the mantine-react-table migration (#20760)
  - The edit button moved from an inline button to a three-dot menu dropdown, but tests weren't updated to click "Edit" from the menu

<img width="3065" height="1774" alt="Screenshot 2026-03-04 at 14 54 14" src="https://github.com/user-attachments/assets/a2fc5a33-3a51-4982-a304-367a4cd32750" />
