### PR TITLE
feat: migrate threshold alerts off old query pipeline

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3244,10 +3244,13 @@ export default class SchedulerTask {
                 if (savedChartUuid) {
                     // We are fetching here the results before getting image or CSV
                     const { rows } =
-                        await this.projectService.getResultsForChart(
-                            account,
-                            savedChartUuid,
-                            QueryExecutionContext.SCHEDULED_CHART,
+                        await this.asyncQueryService.executeSavedChartQueryAndGetResults(
+                            {
+                                account,
+                                projectUuid: schedulerPayload.projectUuid,
+                                chartUuid: savedChartUuid,
+                                context: QueryExecutionContext.SCHEDULED_CHART,
+                            },
                         );
 
                     if (

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3784,6 +3784,49 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    /**
+     * Execute saved chart query and wait for all results.
+     * Returns raw rows from warehouse.
+     */
+    async executeSavedChartQueryAndGetResults(
+        args: ExecuteAsyncSavedChartQueryArgs,
+    ): Promise<{
+        rows: Record<string, unknown>[];
+        cacheMetadata: CacheMetadata;
+        fields: ItemsMap;
+    }> {
+        const { account, projectUuid } = args;
+
+        const { queryUuid, cacheMetadata, fields } =
+            await this.executeAsyncSavedChartQuery(args);
+
+        await this.pollForQueryCompletion({ account, projectUuid, queryUuid });
+
+        const queryHistory = await this.queryHistoryModel.get(
+            queryUuid,
+            projectUuid,
+            account,
+        );
+
+        const resultsStream = await this.getResultsStorageClientForContext(
+            queryHistory.context,
+        ).getDownloadStream(queryHistory.resultsFileName!);
+
+        const rows: Record<string, unknown>[] = [];
+        await streamJsonlData<void>({
+            readStream: resultsStream,
+            onRow: (rawRow) => {
+                rows.push(rawRow);
+            },
+        });
+
+        return {
+            rows,
+            cacheMetadata,
+            fields,
+        };
+    }
+
     async getPreAggregateStats(
         account: Account,
         projectUuid: string,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3552,6 +3552,11 @@ export class ProjectService extends BaseService {
         );
     }
 
+    /**
+     * @deprecated Use {@link AsyncQueryService.executeSavedChartQueryAndGetResults} instead.
+     * Remaining callers are in the GSheets scheduled delivery code (GLITCH-182).
+     * Remove in GLITCH-186 once all callers are migrated.
+     */
     async getResultsForChart(
         account: Account,
         chartUuid: string,
@@ -7418,10 +7423,10 @@ export class ProjectService extends BaseService {
     }
 
     async replaceProjectDefaults({
-                                     user,
-                                     projectUuid,
-                                     defaults,
-                                 }: {
+        user,
+        projectUuid,
+        defaults,
+    }: {
         user: SessionUser;
         projectUuid: string;
         defaults: ProjectDefaults;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-184

### Description:

Migrates the scheduler task to use the new `AsyncQueryService.executeSavedChartQueryAndGetResults` method instead of the deprecated `ProjectService.getResultsForChart` method. 

The new method provides a cleaner interface for executing saved chart queries and retrieving results, accepting a structured arguments object with account, projectUuid, chartUuid, and context parameters.

The deprecated `getResultsForChart` method has been marked with deprecation comments indicating it will be removed in GLITCH-186 once all remaining callers (primarily in GSheets scheduled delivery code) are migrated.

<!-- Even better add a screenshot / gif / loom -->