### PR TITLE
feat: add refresh all pre-agg materializations action

### DIFF
--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -17,7 +17,7 @@ import {
     Title,
     Tooltip,
 } from '@mantine-8/core';
-import { useDisclosure } from '@mantine-8/hooks';
+import { useDisclosure, useLocalStorage } from '@mantine-8/hooks';
 import {
     IconArrowDown,
     IconArrowsSort,
@@ -43,8 +43,10 @@ import {
 } from 'mantine-react-table';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import { usePreAggregateMaterializations } from '../../hooks/usePreAggregateMaterializations';
+import { useRefreshAllPreAggregates } from '../../hooks/usePreAggregateRefresh';
 import { useProject } from '../../hooks/useProject';
 import MantineIcon from '../common/MantineIcon';
+import MantineModal from '../common/MantineModal';
 import MaterializationDetailDrawer from './MaterializationDetailDrawer';
 import classes from './PreAggregateMaterializations.module.css';
 import { StatusBadge } from './StatusBadge';
@@ -157,6 +159,31 @@ const StatusFilter: FC<{
 const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
     const { isLoading: isLoadingProject } = useProject(projectUuid);
     const queryClient = useQueryClient();
+    const { mutate: refreshAll, isLoading: isRefreshingAll } =
+        useRefreshAllPreAggregates(projectUuid);
+    const [
+        isRefreshModalOpen,
+        { open: openRefreshModal, close: closeRefreshModal },
+    ] = useDisclosure(false);
+    const [hasConfirmedRefreshAll, setHasConfirmedRefreshAll] =
+        useLocalStorage<boolean>({
+            key: 'preAggregateRefreshAllConfirmed',
+            defaultValue: false,
+        });
+
+    const handleRefreshAllClick = useCallback(() => {
+        if (hasConfirmedRefreshAll) {
+            refreshAll();
+        } else {
+            openRefreshModal();
+        }
+    }, [hasConfirmedRefreshAll, refreshAll, openRefreshModal]);
+
+    const handleRefreshAllConfirm = useCallback(() => {
+        setHasConfirmedRefreshAll(true);
+        closeRefreshModal();
+        refreshAll();
+    }, [setHasConfirmedRefreshAll, refreshAll, closeRefreshModal]);
     const {
         data,
         isLoading,
@@ -578,18 +605,33 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                         </Text>
                     </Stack>
 
-                    <Button
-                        component="a"
-                        href="https://docs.lightdash.com/references/pre-aggregates"
-                        target="_blank"
-                        variant="default"
-                        size="xs"
-                        rightSection={
-                            <MantineIcon icon={IconExternalLink} size="sm" />
-                        }
-                    >
-                        Documentation
-                    </Button>
+                    <Group gap="xs">
+                        <Button
+                            component="a"
+                            href="https://docs.lightdash.com/references/pre-aggregates"
+                            target="_blank"
+                            variant="default"
+                            size="xs"
+                            rightSection={
+                                <MantineIcon
+                                    icon={IconExternalLink}
+                                    size="sm"
+                                />
+                            }
+                        >
+                            Documentation
+                        </Button>
+                        <Button
+                            size="xs"
+                            leftSection={
+                                <MantineIcon icon={IconRefresh} size="sm" />
+                            }
+                            loading={isRefreshingAll}
+                            onClick={handleRefreshAllClick}
+                        >
+                            Refresh all
+                        </Button>
+                    </Group>
                 </Group>
 
                 <MantineReactTable table={table} />
@@ -600,6 +642,25 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                 opened={isDrawerOpen}
                 onClose={closeDrawer}
             />
+
+            <MantineModal
+                opened={isRefreshModalOpen}
+                onClose={closeRefreshModal}
+                title="Refresh all pre-aggregates"
+                icon={IconRefresh}
+                size="lg"
+                onConfirm={handleRefreshAllConfirm}
+                confirmLabel="Refresh all"
+                confirmLoading={isRefreshingAll}
+                description="This will refresh all pre-aggregate definitions in this project by re-running their warehouse queries to rebuild the cached data."
+            >
+                <Text fz="xs" c="ldGray.6">
+                    Depending on the number of pre-aggregates and the size of
+                    your data, this may take several minutes and will use
+                    warehouse resources. You can track the progress in the table
+                    below.
+                </Text>
+            </MantineModal>
         </>
     );
 };

--- a/packages/frontend/src/hooks/usePreAggregateRefresh.ts
+++ b/packages/frontend/src/hooks/usePreAggregateRefresh.ts
@@ -1,0 +1,40 @@
+import { type ApiError } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+import useToaster from './toaster/useToaster';
+
+const refreshAllPreAggregates = async (projectUuid: string) =>
+    lightdashApi<{ jobIds: string[] }>({
+        url: `/projects/${projectUuid}/pre-aggregates/refresh`,
+        method: 'POST',
+        body: undefined,
+    });
+
+export const useRefreshAllPreAggregates = (projectUuid: string) => {
+    const { showToastSuccess, showToastApiError } = useToaster();
+    const queryClient = useQueryClient();
+
+    return useMutation<{ jobIds: string[] }, ApiError>(
+        () => refreshAllPreAggregates(projectUuid),
+        {
+            mutationKey: ['refreshAllPreAggregates', projectUuid],
+            onSuccess: async () => {
+                showToastSuccess({
+                    title: 'Pre-aggregate refresh started',
+                    subtitle:
+                        'All pre-aggregates are being refreshed in the background.',
+                });
+                await queryClient.invalidateQueries([
+                    'preAggregateMaterializations',
+                    projectUuid,
+                ]);
+            },
+            onError: ({ error }) => {
+                showToastApiError({
+                    title: 'Failed to refresh pre-aggregates',
+                    apiError: error,
+                });
+            },
+        },
+    );
+};


### PR DESCRIPTION
### Description:

Added a "Refresh all" button to the pre-aggregate materializations page that allows users to refresh all pre-aggregates in a project with a single click.

**Key changes:**
- Added a new `useRefreshAllPreAggregates` hook that calls the `/projects/{projectUuid}/pre-aggregates/refresh` API endpoint
- Implemented a confirmation modal that appears on first use, with the option to skip confirmation for future refreshes using local storage
- Added the refresh button next to the existing documentation button in the page header
- The button shows a loading state while the refresh operation is in progress
- Success and error toast notifications provide feedback on the operation status
- The pre-aggregates table automatically refreshes after a successful bulk refresh operation

The confirmation modal warns users about potential warehouse resource usage and processing time, helping them make informed decisions before triggering the refresh.

![CleanShot 2026-03-04 at 17.12.28.png](https://app.graphite.com/user-attachments/assets/bd3ce6e3-4bd9-4960-bcd4-81551b94e0cc.png)

