### PR TITLE
feat: show pre-aggregates in the explorer sidebar

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -142,6 +142,7 @@ type RawSummaryRow = {
     tags: Explore['tags'];
     groupLabel: Explore['groupLabel'] | null;
     type: Explore['type'] | null;
+    preAggregateSource: Explore['preAggregateSource'] | null;
     errors: ExploreError['errors'] | null; // Fatal errors from ExploreError
     warnings: Explore['warnings'] | null; // Non-fatal warnings from partial compilation
     baseTable: Explore['baseTable'];
@@ -1182,6 +1183,7 @@ export class ProjectModel {
                     explore->'tags' as tags,
                     explore->'groupLabel' as "groupLabel",
                     explore->'type' as type,
+                    explore->'preAggregateSource' as "preAggregateSource",
                     explore->'errors' as errors,
                     explore->'warnings' as warnings,
                     explore->'baseTable' as "baseTable",
@@ -1205,6 +1207,7 @@ export class ProjectModel {
             description: row.baseTableDescription ?? undefined,
             aiHint: row.aiHint ?? undefined,
             type: row.type ?? undefined,
+            preAggregateSource: row.preAggregateSource ?? undefined,
             baseTableRequiredAttributes:
                 row.baseTableRequiredAttributes ?? undefined,
             baseTableAnyAttributes: row.baseTableAnyAttributes ?? undefined,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -596,6 +596,7 @@ export const exploreToSummaryWithAttributes = (
         schemaName: baseTable.schema,
         description: baseTable.description,
         type: explore.type,
+        preAggregateSource: explore.preAggregateSource,
         baseTableRequiredAttributes: baseTable.requiredAttributes,
         ...(explore.warnings ? { warnings: explore.warnings } : {}),
     };

--- a/packages/common/src/types/explore.ts
+++ b/packages/common/src/types/explore.ts
@@ -134,6 +134,7 @@ type SummaryExploreFields =
     | 'tags'
     | 'groupLabel'
     | 'type'
+    | 'preAggregateSource'
     | 'aiHint'
     | 'warnings';
 type SummaryExploreErrorFields =

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -22,6 +22,11 @@ import LoadingSkeleton from '../ExploreTree/LoadingSkeleton';
 import { ItemDetailProvider } from '../ExploreTree/TableTree/ItemDetailProvider';
 import VirtualizedExploreList from './VirtualizedExploreList';
 
+const getPreAggregateName = (explore: SummaryExplore) =>
+    'preAggregateSource' in explore
+        ? explore.preAggregateSource?.preAggregateName
+        : undefined;
+
 const BasePanel = () => {
     const navigate = useNavigate();
     const location = useLocation();
@@ -40,7 +45,11 @@ const BasePanel = () => {
             let explores = Object.values(exploresResult.data);
             if (validSearch !== '') {
                 explores = new Fuse(Object.values(exploresResult.data), {
-                    keys: ['label'],
+                    keys: [
+                        'label',
+                        'preAggregateSource.preAggregateName',
+                        'preAggregateSource.sourceExploreName',
+                    ],
                     ignoreLocation: true,
                     threshold: 0.3,
                 })
@@ -57,10 +66,12 @@ const BasePanel = () => {
         exploreGroupMap,
         defaultUngroupedExplores,
         customUngroupedExplores,
+        sortedPreAggregateExplores,
     ] = useMemo<
         [
             string[],
             Record<string, SummaryExplore[]>,
+            SummaryExplore[],
             SummaryExplore[],
             SummaryExplore[],
         ]
@@ -70,10 +81,13 @@ const BasePanel = () => {
             const groupMap: Record<string, SummaryExplore[]> = {};
             const defaultExplores: SummaryExplore[] = [];
             const customExplores: SummaryExplore[] = [];
+            const preAggregateExplores: SummaryExplore[] = [];
 
             // Single-pass categorization without object spreads
             for (const explore of filteredExplores) {
-                if (explore.groupLabel) {
+                if (explore.type === ExploreType.PRE_AGGREGATE) {
+                    preAggregateExplores.push(explore);
+                } else if (explore.groupLabel) {
                     if (groupMap[explore.groupLabel]) {
                         groupMap[explore.groupLabel].push(explore);
                     } else {
@@ -101,9 +115,21 @@ const BasePanel = () => {
             // Sort ungrouped explores
             defaultExplores.sort((a, b) => a.label.localeCompare(b.label));
             customExplores.sort((a, b) => a.label.localeCompare(b.label));
-            return [sortedLabels, groupMap, defaultExplores, customExplores];
+            preAggregateExplores.sort((a, b) =>
+                (getPreAggregateName(a) ?? '').localeCompare(
+                    getPreAggregateName(b) ?? '',
+                ),
+            );
+
+            return [
+                sortedLabels,
+                groupMap,
+                defaultExplores,
+                customExplores,
+                preAggregateExplores,
+            ];
         }
-        return [[], {}, [], []];
+        return [[], {}, [], [], []];
     }, [filteredExplores]);
 
     const handleExploreClick = useCallback(
@@ -168,6 +194,7 @@ const BasePanel = () => {
                             exploreGroupMap={exploreGroupMap}
                             defaultUngroupedExplores={defaultUngroupedExplores}
                             customUngroupedExplores={customUngroupedExplores}
+                            preAggregateExplores={sortedPreAggregateExplores}
                             searchQuery={debouncedSearch}
                             onExploreClick={handleExploreClick}
                         />

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -1,4 +1,5 @@
 import {
+    friendlyName,
     InlineErrorType,
     isSummaryExploreError,
     type SummaryExplore,
@@ -22,6 +23,9 @@ import React from 'react';
 import MantineIcon from '../../common/MantineIcon';
 import { TableItemDetailPreview } from '../ExploreTree/TableTree/ItemDetailPreview';
 import WarningsHoverCardContent from '../WarningsHoverCardContent';
+
+const getPreAggregateSource = (explore: SummaryExplore) =>
+    'preAggregateSource' in explore ? explore.preAggregateSource : undefined;
 
 type ExploreNavLinkProps = {
     explore: SummaryExplore;
@@ -48,6 +52,15 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
         explore.errors.every(
             (error) => error.type === InlineErrorType.NO_DIMENSIONS_FOUND,
         );
+    const preAggregateSource = getPreAggregateSource(explore);
+    const displayLabel =
+        explore.type === 'pre_aggregate' && preAggregateSource
+            ? friendlyName(preAggregateSource.preAggregateName)
+            : explore.label;
+    const displayDescription =
+        explore.type === 'pre_aggregate' && preAggregateSource
+            ? `Pre-aggregate for ${preAggregateSource.sourceExploreName}`
+            : explore.description;
 
     // Determine rightSection
     let rightSection;
@@ -100,12 +113,12 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                         highlight={query ?? ''}
                         truncate
                     >
-                        {explore.label}
+                        {displayLabel}
                     </Highlight>
                 ) : (
                     <TableItemDetailPreview
-                        label={explore.label}
-                        description={explore.description}
+                        label={displayLabel}
+                        description={displayDescription}
                         showPreview={needsHoverCard ? false : isHover}
                         closePreview={() => toggleHover(false)}
                         offset={0}
@@ -118,7 +131,7 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                             fw={500}
                             c="ldDark.8"
                         >
-                            {explore.label}
+                            {displayLabel}
                         </Highlight>
                     </TableItemDetailPreview>
                 )

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/VirtualizedExploreList.tsx
@@ -11,7 +11,6 @@ export type VirtualListItem =
           type: 'group-header';
           id: string;
           label: string;
-          explores: SummaryExplore[];
           isExpanded: boolean;
       }
     | {
@@ -28,6 +27,7 @@ interface VirtualizedExploreListProps {
     exploreGroupMap: Record<string, SummaryExplore[]>;
     defaultUngroupedExplores: SummaryExplore[];
     customUngroupedExplores: SummaryExplore[];
+    preAggregateExplores: SummaryExplore[];
     searchQuery: string;
     onExploreClick: (explore: SummaryExplore) => void;
 }
@@ -42,6 +42,7 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
     exploreGroupMap,
     defaultUngroupedExplores,
     customUngroupedExplores,
+    preAggregateExplores,
     searchQuery,
     onExploreClick,
 }) => {
@@ -77,7 +78,6 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
                 type: 'group-header',
                 id: `group-${itemId++}`,
                 label: groupLabel,
-                explores,
                 isExpanded,
             });
 
@@ -124,12 +124,34 @@ const VirtualizedExploreList: FC<VirtualizedExploreListProps> = ({
             }
         }
 
+        // Add pre-aggregates section if there are pre-aggregate explores
+        if (preAggregateExplores.length > 0) {
+            items.push({
+                type: 'divider',
+                id: `divider-${itemId++}`,
+            });
+            items.push({
+                type: 'section-header',
+                id: `section-${itemId++}`,
+                label: 'Pre-aggregates',
+            });
+
+            for (const explore of preAggregateExplores) {
+                items.push({
+                    type: 'explore',
+                    id: `pre-aggregate-${itemId++}`,
+                    explore,
+                });
+            }
+        }
+
         return items;
     }, [
         sortedGroupLabels,
         exploreGroupMap,
         defaultUngroupedExplores,
         customUngroupedExplores,
+        preAggregateExplores,
         expandedGroups,
     ]);
 


### PR DESCRIPTION
### Description:

Closes: [ZAP-276: Make pre-aggregates visible to developers to debug and verify data​](https://linear.app/lightdash/issue/ZAP-276/make-pre-aggregates-visible-to-developers-to-debug-and-verify-data)

This PR adds support for pre-aggregate explores in the project explorer interface.

**Backend Changes:**

- Added `preAggregateSource` field to the `RawSummaryRow` type and corresponding SQL query in `ProjectModel`
- Updated the explore data mapping to include the new `preAggregateSource` field
- Modified mock service to include `preAggregateSource` in test data

**Frontend Changes:**

- Enhanced search functionality to include pre-aggregate names and source explore names in search results
- Added a dedicated "Pre-aggregates" section in the explorer sidebar that displays below virtual views
- Updated explore display logic to show friendly names for pre-aggregates and descriptive text indicating their source explore
- Added proper sorting for pre-aggregate explores by their pre-aggregate name
- Extended the virtualized list component to handle the new pre-aggregate section

**Type System Updates:**

- Added `preAggregateSource` to the `SummaryExploreFields` union type to ensure it's included in explore summaries

The pre-aggregates now appear as a separate organized section in the explorer, making them easily discoverable while maintaining clear separation from regular explores and virtual views.