### PR TITLE
fix: skip pre-aggregate generation for additional explores

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1460,6 +1460,72 @@ describe('pre-aggregate virtual explore generation', () => {
         );
     });
 
+    it('does not generate pre-aggregate explores for additional explores', async () => {
+        process.env.PRE_AGGREGATES_ENABLED = 'true';
+
+        const explores = await convertExplores(
+            [
+                {
+                    ...MODEL_WITH_METRIC,
+                    meta: {
+                        pre_aggregates: [
+                            {
+                                name: 'rollup',
+                                dimensions: ['user_id'],
+                                metrics: [
+                                    'myTable_total_num_participating_athletes',
+                                ],
+                            },
+                        ],
+                        explores: {
+                            myTable_with_custom_dims: {
+                                label: 'MyTable with Custom Dims',
+                                additional_dimensions: {
+                                    athlete_band: {
+                                        type: DimensionType.STRING,
+                                        sql: "CASE WHEN ${myTable.num_participating_athletes} > 10 THEN 'high' ELSE 'low' END",
+                                    },
+                                },
+                            },
+                        },
+                    },
+                },
+            ],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            [],
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+        );
+
+        expect(explores).toHaveLength(3);
+        expect(
+            explores.filter(
+                (explore) =>
+                    !('errors' in explore) &&
+                    explore.type === ExploreType.PRE_AGGREGATE,
+            ),
+        ).toHaveLength(1);
+        expect(explores).toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({ name: 'myTable' }),
+                expect.objectContaining({ name: 'myTable_with_custom_dims' }),
+                expect.objectContaining({
+                    name: '__preagg__myTable__rollup',
+                }),
+            ]),
+        );
+        expect(explores).not.toEqual(
+            expect.arrayContaining([
+                expect.objectContaining({
+                    name: '__preagg__myTable_with_custom_dims__rollup',
+                }),
+            ]),
+        );
+    });
+
     it('keeps the base explore when pre-aggregate generation fails', async () => {
         process.env.PRE_AGGREGATES_ENABLED = 'true';
 

--- a/packages/common/src/preAggregates/generatePreAggregateExplores.ts
+++ b/packages/common/src/preAggregates/generatePreAggregateExplores.ts
@@ -10,6 +10,9 @@ import { buildPreAggregateExplore } from './buildPreAggregateExplore';
 const isPreAggregateVirtualExploreGenerationEnabled = (): boolean =>
     process.env.PRE_AGGREGATES_ENABLED === 'true';
 
+const shouldGeneratePreAggregatesForExplore = (explore: Explore): boolean =>
+    explore.name === explore.baseTable;
+
 export const generatePreAggregateExplores = ({
     compiledExplores,
     parsedPreAggregates,
@@ -26,6 +29,9 @@ export const generatePreAggregateExplores = ({
 
     return compiledExplores.flatMap<Explore | ExploreError>((compiled) => {
         if (isExploreError(compiled)) {
+            return [compiled];
+        }
+        if (!shouldGeneratePreAggregatesForExplore(compiled)) {
             return [compiled];
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:

This change prevents pre-aggregate explores from being generated for additional explores (custom explores that extend base tables). Pre-aggregate explores will now only be created for base table explores where the explore name matches the base table name.

The implementation adds a new function `shouldGeneratePreAggregatesForExplore` that checks if an explore is a base table explore by comparing the explore name with its base table. This check is applied in the `generatePreAggregateExplores` function to skip pre-aggregate generation for additional explores.
