### PR TITLE
fix: enforce UUID format validation in dashboard-as-code schema

### DIFF
--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -90,7 +90,10 @@
                         "maximum": 36
                     },
                     "tabUuid": {
-                        "type": ["string", "null"],
+                        "oneOf": [
+                            { "type": "string", "format": "uuid" },
+                            { "type": "null" }
+                        ],
                         "description": "UUID of the tab this tile belongs to, or null for default tab"
                     },
                     "properties": {
@@ -238,6 +241,7 @@
                 "properties": {
                     "uuid": {
                         "type": "string",
+                        "format": "uuid",
                         "description": "Unique identifier for the tab"
                     },
                     "name": {


### PR DESCRIPTION
## Summary
- Add `format: uuid` constraint to `tabs[].uuid` field in dashboard-as-code JSON schema
- Change `tiles[].tabUuid` to use `oneOf` with UUID format validation while still allowing `null`

This ensures `lightdash lint` catches invalid UUID strings in dashboard YAML files.

## Test plan
- [x] Verified `lightdash lint` catches invalid UUIDs (e.g., `uuid: not-a-valid-uuid`)
- [x] Verified valid UUIDs pass validation
- [x] Verified `tabUuid: null` still works for tiles on the default tab