### PR TITLE
feat: add Liquid template support for dynamic SQL dimensions

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
+++ b/examples/full-jaffle-shop-demo/dbt/lightdash.config.yml
@@ -85,5 +85,15 @@ parameters:
     description: "The first date in comparing who's moved from segment to segment"
     default: '2025-08-06'
     type: date
+  date_granularity:
+    label: "Date Granularity"
+    description: "Dynamic date granularity for Liquid template demo"
+    default: "Day"
+    options:
+      - "Day"
+      - "Week"
+      - "Month"
+      - "Quarter"
+      - "Year"
 defaults:
   case_sensitive: true

--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -70,6 +70,47 @@ models:
                 url:
                   'https://calendar.google.com/calendar/u/0/r/day/${ value.formatted |split:
                   "-" |join: "/"}'
+      - name: dynamic_date
+        description: "Dynamic date dimension that changes granularity based on the date_granularity parameter. Uses Liquid template syntax for conditional SQL."
+        meta:
+          dimension:
+            type: string
+            sql: >
+              {% raw %}{% if ld.parameters.date_granularity == 'Day' %} ${TABLE}.date
+              {% elsif ld.parameters.date_granularity == 'Week' %} DATE_TRUNC('week', ${TABLE}.date)
+              {% elsif ld.parameters.date_granularity == 'Month' %} DATE_TRUNC('month', ${TABLE}.date)
+              {% elsif ld.parameters.date_granularity == 'Quarter' %} DATE_TRUNC('quarter', ${TABLE}.date)
+              {% elsif ld.parameters.date_granularity == 'Year' %} DATE_TRUNC('year', ${TABLE}.date)
+              {% else %} ${TABLE}.date
+              {% endif %}{% endraw %}
+      - name: dynamic_date_case
+        description: "Same as dynamic_date but using Liquid case/when syntax instead of if/elsif."
+        meta:
+          dimension:
+            type: string
+            sql: >
+              {% raw %}{% case ld.parameters.date_granularity %}
+              {% when 'Day' %} ${TABLE}.date
+              {% when 'Week' %} DATE_TRUNC('week', ${TABLE}.date)
+              {% when 'Month' %} DATE_TRUNC('month', ${TABLE}.date)
+              {% when 'Quarter' %} DATE_TRUNC('quarter', ${TABLE}.date)
+              {% when 'Year' %} DATE_TRUNC('year', ${TABLE}.date)
+              {% else %} ${TABLE}.date
+              {% endcase %}{% endraw %}
+      - name: dynamic_metric
+        description: "Switches between counting events or summing event IDs based on the metric_type parameter. Demonstrates Liquid column-switching pattern from Looker migrations."
+        meta:
+          dimension:
+            hidden: true
+            type: number
+            sql: >
+              {% raw %}{% if ld.parameters.metric_type == 'count' %} 1
+              {% else %} ${TABLE}.event_id
+              {% endif %}{% endraw %}
+          metrics:
+            dynamic_total:
+              type: sum
+              description: "When metric_type=count, counts events. When metric_type=revenue, sums event IDs."
       - name: event
         description: ""
         meta:

--- a/packages/backend/src/utils/QueryBuilder/parameters.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.ts
@@ -1,5 +1,6 @@
 import {
     parameterRegex,
+    renderLiquidSql,
     UnexpectedServerError,
     type ParameterDefinitions,
     type ParametersValuesMap,
@@ -168,10 +169,15 @@ export const safeReplaceParametersWithTypes = ({
     sqlBuilder: WarehouseSqlBuilder;
     wrapChar?: string;
 }) => {
+    // Render Liquid template blocks ({% if %}/{% elsif %}/{% else %}/{% endif %})
+    // before parameter substitution. This evaluates conditional SQL based on parameter values,
+    // e.g., {% if ld.parameters.grain == "day" %} ${snapshot_date} {% endif %}
+    const liquidRenderedSql = renderLiquidSql(sql, parameterValuesMap);
+
     // First, get all parameter references from the original SQL using the standard function
     // This ensures we capture ALL parameter references, not just the ones we have values for
     const allParametersResult = safeReplaceParameters({
-        sql,
+        sql: liquidRenderedSql,
         parameterValuesMap,
         escapeString: sqlBuilder.escapeString.bind(sqlBuilder),
         quoteChar: sqlBuilder.getStringQuoteChar(),
@@ -214,7 +220,7 @@ export const safeReplaceParametersWithTypes = ({
     });
 
     // First replace string parameters (with quotes and escaping)
-    let processedSql = sql;
+    let processedSql = liquidRenderedSql;
     if (Object.keys(stringParameters).length > 0) {
         const stringResult = safeReplaceParameters({
             sql: processedSql,

--- a/packages/common/src/compiler/parameters.ts
+++ b/packages/common/src/compiler/parameters.ts
@@ -10,7 +10,8 @@ import type { LightdashProjectParameter } from '../types/lightdashProjectConfig'
 export const parameterRegex =
     /\$\{(?:lightdash|ld)\.parameters\.(\w+(?:\.\w+)?)\}/g;
 
-// Regex for extracting parameter references - works with format strings and ternary expressions
+// Regex for extracting parameter references - works with format strings, ternary expressions,
+// and Liquid template blocks like {% if ld.parameters.grain == "day" %}
 const parameterReferencePattern =
     /(?:lightdash|ld)\.parameters\.(\w+(?:\.\w+)?)/g;
 
@@ -53,14 +54,24 @@ export const getParameterReferencesFromSqlAndFormat = (
 ): string[] => {
     const sqlParameterReferences = getParameterReferences(compiledSql);
 
+    // Also extract parameter references from Liquid template blocks
+    // e.g., {% if ld.parameters.grain == "day" %}
+    const liquidParameterReferences = compiledSql.includes('{%')
+        ? getParameterReferences(compiledSql, parameterReferencePattern)
+        : [];
+
     const formatParameterReferences =
         format && typeof format === 'string'
             ? getParameterReferences(format, parameterReferencePattern)
             : [];
 
-    // Combine and deduplicate parameter references from both sources
+    // Combine and deduplicate parameter references from all sources
     return Array.from(
-        new Set([...sqlParameterReferences, ...formatParameterReferences]),
+        new Set([
+            ...sqlParameterReferences,
+            ...liquidParameterReferences,
+            ...formatParameterReferences,
+        ]),
     );
 };
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -78,6 +78,7 @@ export { default as dashboardAsCodeSchema } from './schemas/json/dashboard-as-co
 export { default as lightdashDbtYamlSchema } from './schemas/json/lightdash-dbt-2.0.json';
 export { default as lightdashProjectConfigSchema } from './schemas/json/lightdash-project-config-1.0.json';
 export { default as modelAsCodeSchema } from './schemas/json/model-as-code-1.0.json';
+export * from './templating/liquidSql';
 export * from './templating/template';
 export * from './types/account';
 export * from './types/adminNotifications';

--- a/packages/common/src/templating/CLAUDE.md
+++ b/packages/common/src/templating/CLAUDE.md
@@ -1,0 +1,105 @@
+<summary>
+Templating engines for Lightdash. Two separate engines: `template.ts` for URL/label templates using custom `${}` delimiters, and `liquidSql.ts` for conditional SQL using standard Liquid `{% %}` delimiters with Lightdash parameters.
+</summary>
+
+# Liquid SQL Templating (`liquidSql.ts`)
+
+## What It Does
+
+Evaluates Liquid template blocks in dimension/metric SQL at **query time**, enabling parameter-driven conditional SQL. This supports Looker migration patterns where dimensions switch between SQL expressions based on parameter values.
+
+## Syntax
+
+Use `{% %}` Liquid tags with `ld.parameters.<name>` or `lightdash.parameters.<name>`.
+
+**Important**: Liquid blocks must be wrapped in `{% raw %}...{% endraw %}` in dbt YAML files so dbt's Jinja engine passes them through without trying to parse them. dbt processes `{% raw %}` and strips the wrapper, leaving clean Liquid syntax in the manifest for Lightdash to evaluate at query time.
+
+### if/elsif/else (most common)
+
+```yaml
+dimension:
+  type: string
+  sql: >
+    {% raw %}{% if ld.parameters.date_granularity == 'Day' %} ${TABLE}.date
+    {% elsif ld.parameters.date_granularity == 'Week' %} DATE_TRUNC('week', ${TABLE}.date)
+    {% elsif ld.parameters.date_granularity == 'Month' %} DATE_TRUNC('month', ${TABLE}.date)
+    {% else %} ${TABLE}.date
+    {% endif %}{% endraw %}
+```
+
+### case/when (cleaner for many values)
+
+```yaml
+dimension:
+  type: string
+  sql: >
+    {% raw %}{% case ld.parameters.date_granularity %}
+    {% when 'Day' %} ${TABLE}.date
+    {% when 'Week' %} DATE_TRUNC('week', ${TABLE}.date)
+    {% when 'Month' %} DATE_TRUNC('month', ${TABLE}.date)
+    {% else %} ${TABLE}.date
+    {% endcase %}{% endraw %}
+```
+
+### Column switching (metrics)
+
+```yaml
+dimension:
+  hidden: true
+  type: number
+  sql: >
+    {% raw %}{% if ld.parameters.metric_type == 'count' %} 1
+    {% else %} ${TABLE}.event_id
+    {% endif %}{% endraw %}
+metrics:
+  dynamic_total:
+    type: sum
+```
+
+## Why `{% raw %}` Is Needed
+
+dbt uses Jinja, which also uses `{% %}` delimiters. When dbt encounters `{% if %}` blocks, it tries to parse them as Jinja. Lightdash uses `{% elsif %}` (Liquid syntax), but Jinja expects `{% elif %}`, causing a compilation error.
+
+Wrapping in `{% raw %}...{% endraw %}` tells dbt's Jinja engine to pass the content through untouched. After dbt processes `{% raw %}`, the manifest contains the clean Liquid syntax for Lightdash to evaluate at query time.
+
+## How It Works — Query-Time Rendering
+
+When a query runs:
+
+1. `safeReplaceParametersWithTypes()` in `QueryBuilder/parameters.ts` calls `renderLiquidSql(sql, parameterValues)`
+2. `renderLiquidSql` checks for `{%` — if absent, returns SQL unchanged (zero overhead)
+3. If present, builds a Liquid context with `ld.parameters` and `lightdash.parameters` namespaces
+4. LiquidJS evaluates the template, resolving if/case/for blocks based on parameter values
+5. The resulting SQL then goes through normal `${ld.parameters.x}` substitution
+
+### Parameter Detection for UI
+
+`getParameterReferencesFromSqlAndFormat()` in `compiler/parameters.ts` extracts parameter names from both `${ld.parameters.x}` syntax and `{% if ld.parameters.x %}` syntax, so the UI shows the parameter selector.
+
+## Safety Mechanisms
+
+- **Try/catch in `renderLiquidSql`**: If Liquid parsing fails, falls back to original SQL
+- **Fast `{%` check**: Skips all Liquid processing for SQL that doesn't contain `{%` (zero overhead for existing queries)
+- **`strictVariables: false`**: Missing parameters resolve to falsy instead of throwing
+
+## Key Files
+
+- `liquidSql.ts` — Core engine: `renderLiquidSql()`, `buildLiquidContext()`
+- `liquidSql.test.ts` — Tests for rendering and context building
+- `@/packages/backend/src/utils/QueryBuilder/parameters.ts` — Query-time integration
+- `@/packages/common/src/compiler/parameters.ts` — Parameter reference extraction
+
+## Supported Liquid Syntax
+
+LiquidJS supports the full Liquid spec. The engine already handles any valid Liquid syntax at query time. Currently tested:
+
+- `{% if %}` / `{% elsif %}` / `{% else %}` / `{% endif %}`
+- `{% case %}` / `{% when %}` / `{% else %}` / `{% endcase %}`
+
+Other Liquid features (e.g., `{% for %}`, `{% unless %}`, `{% assign %}`, filters) work at query time automatically. No code changes needed — just wrap in `{% raw %}` in the YAML.
+
+## Relationship to Other Templating
+
+- **`template.ts`** — URL/label templates using `${}` delimiters for row value interpolation. Completely separate from Liquid SQL.
+- **`${ld.parameters.x}`** — Regex-based parameter substitution (existing system). Liquid blocks are evaluated **before** this substitution, so both can coexist in the same SQL.
+- **User attributes** — `${ld.attribute.x}` uses regex substitution, not Liquid. Separate system.

--- a/packages/common/src/templating/liquidSql.test.ts
+++ b/packages/common/src/templating/liquidSql.test.ts
@@ -1,0 +1,243 @@
+import { buildLiquidContext, renderLiquidSql } from './liquidSql';
+
+describe('buildLiquidContext', () => {
+    it('should nest parameters under ld.parameters and lightdash.parameters', () => {
+        const context = buildLiquidContext({ grain: 'day' });
+        expect(context).toEqual({
+            ld: { parameters: { grain: 'day' } },
+            lightdash: { parameters: { grain: 'day' } },
+        });
+    });
+
+    it('should expose dotted names via both full and short keys', () => {
+        const context = buildLiquidContext({ 'events.grain': 'week' });
+        expect(context.ld.parameters).toEqual({
+            'events.grain': 'week',
+            grain: 'week',
+        });
+        expect(context.lightdash.parameters).toEqual({
+            'events.grain': 'week',
+            grain: 'week',
+        });
+    });
+
+    it('should handle multiple parameters', () => {
+        const context = buildLiquidContext({
+            grain: 'day',
+            currency: 'usd',
+        });
+        expect(context.ld.parameters).toEqual({
+            grain: 'day',
+            currency: 'usd',
+        });
+        expect(context.lightdash.parameters).toEqual({
+            grain: 'day',
+            currency: 'usd',
+        });
+    });
+
+    it('should handle numeric parameter values', () => {
+        const context = buildLiquidContext({ threshold: 42 });
+        expect(context).toEqual({
+            ld: { parameters: { threshold: 42 } },
+            lightdash: { parameters: { threshold: 42 } },
+        });
+    });
+});
+
+describe('renderLiquidSql', () => {
+    it('should pass through SQL without Liquid tags unchanged', () => {
+        const sql = '"events".snapshot_date';
+        expect(renderLiquidSql(sql, { grain: 'day' })).toBe(sql);
+    });
+
+    it('should evaluate simple if/else', () => {
+        const sql = [
+            '{% if ld.parameters.grain == "day" %}',
+            '  "events".snapshot_date',
+            '{% else %}',
+            '  "events".snapshot_week',
+            '{% endif %}',
+        ].join('\n');
+
+        const result = renderLiquidSql(sql, { grain: 'day' });
+        expect(result.trim()).toBe('"events".snapshot_date');
+    });
+
+    it('should evaluate elsif branch', () => {
+        const sql = [
+            '{% if ld.parameters.grain == "day" %}',
+            '  "events".snapshot_date',
+            '{% elsif ld.parameters.grain == "week" %}',
+            '  "events".snapshot_week',
+            '{% elsif ld.parameters.grain == "month" %}',
+            '  "events".snapshot_month',
+            '{% else %}',
+            '  "events".snapshot_date',
+            '{% endif %}',
+        ].join('\n');
+
+        expect(renderLiquidSql(sql, { grain: 'week' }).trim()).toBe(
+            '"events".snapshot_week',
+        );
+        expect(renderLiquidSql(sql, { grain: 'month' }).trim()).toBe(
+            '"events".snapshot_month',
+        );
+    });
+
+    it('should fall through to else when no condition matches', () => {
+        const sql = [
+            '{% if ld.parameters.grain == "day" %}',
+            '  "events".snapshot_date',
+            '{% else %}',
+            '  "events".snapshot_raw',
+            '{% endif %}',
+        ].join('\n');
+
+        expect(renderLiquidSql(sql, { grain: 'unknown' }).trim()).toBe(
+            '"events".snapshot_raw',
+        );
+    });
+
+    it('should fall through to else with empty parameters', () => {
+        const sql = [
+            '{% if ld.parameters.grain == "day" %}',
+            '  "events".snapshot_date',
+            '{% else %}',
+            '  "events".snapshot_raw',
+            '{% endif %}',
+        ].join('\n');
+
+        expect(renderLiquidSql(sql, {}).trim()).toBe('"events".snapshot_raw');
+    });
+
+    it('should handle full dynamic date granularity pattern', () => {
+        const sql = [
+            '{% if ld.parameters.date_granularity == "Day" %} ("events".snapshot_date)',
+            '{% elsif ld.parameters.date_granularity == "Week" %} ("events".snapshot_week)',
+            '{% elsif ld.parameters.date_granularity == "Month" %} ("events".snapshot_month)',
+            '{% elsif ld.parameters.date_granularity == "Quarter" %} ("events".snapshot_quarter)',
+            '{% elsif ld.parameters.date_granularity == "Year" %} ("events".snapshot_year)',
+            '{% else %} ("events".snapshot_date)',
+            '{% endif %}',
+        ].join('\n');
+
+        expect(renderLiquidSql(sql, { date_granularity: 'Day' }).trim()).toBe(
+            '("events".snapshot_date)',
+        );
+        expect(
+            renderLiquidSql(sql, { date_granularity: 'Quarter' }).trim(),
+        ).toBe('("events".snapshot_quarter)');
+        expect(renderLiquidSql(sql, { date_granularity: 'Year' }).trim()).toBe(
+            '("events".snapshot_year)',
+        );
+    });
+
+    it('should handle dotted parameter names from Lightdash format', () => {
+        const sql = [
+            '{% if ld.parameters.grain == "day" %}',
+            '  "events".snapshot_date',
+            '{% else %}',
+            '  "events".snapshot_week',
+            '{% endif %}',
+        ].join('\n');
+
+        // Lightdash parameters may come as "model.param" — the short name should work
+        expect(renderLiquidSql(sql, { 'events.grain': 'day' }).trim()).toBe(
+            '"events".snapshot_date',
+        );
+    });
+
+    it('should preserve ${ld.parameters.*} references for later substitution', () => {
+        // Liquid blocks may coexist with Lightdash parameter references
+        const sql = [
+            '{% if ld.parameters.grain == "day" %}',
+            '  ${ld.parameters.some_other_param}',
+            '{% else %}',
+            '  "events".fallback',
+            '{% endif %}',
+        ].join('\n');
+
+        // The ${ld.parameters.*} should pass through — it uses $ not {% %}
+        expect(renderLiquidSql(sql, { grain: 'day' }).trim()).toBe(
+            '${ld.parameters.some_other_param}',
+        );
+    });
+
+    it('should handle SQL with mixed content around Liquid blocks', () => {
+        const sql =
+            'SELECT {% if ld.parameters.grain == "day" %}"events".date{% else %}"events".week{% endif %} AS dynamic_col FROM events';
+
+        expect(renderLiquidSql(sql, { grain: 'day' })).toBe(
+            'SELECT "events".date AS dynamic_col FROM events',
+        );
+    });
+
+    it('should support lightdash.parameters long syntax', () => {
+        const sql = [
+            '{% if lightdash.parameters.grain == "day" %}',
+            '  "events".snapshot_date',
+            '{% else %}',
+            '  "events".snapshot_week',
+            '{% endif %}',
+        ].join('\n');
+
+        expect(renderLiquidSql(sql, { grain: 'day' }).trim()).toBe(
+            '"events".snapshot_date',
+        );
+    });
+
+    it('should handle two-value column switching pattern', () => {
+        const sql = [
+            '{% if ld.parameters.weekend_treatment == "include" %}',
+            '  ${TABLE}.first_response_time_hours',
+            '{% else %}',
+            '  ${TABLE}.first_response_time_weekday_hours',
+            '{% endif %}',
+        ].join('\n');
+
+        expect(
+            renderLiquidSql(sql, { weekend_treatment: 'include' }).trim(),
+        ).toBe('${TABLE}.first_response_time_hours');
+        expect(
+            renderLiquidSql(sql, { weekend_treatment: 'exclude' }).trim(),
+        ).toBe('${TABLE}.first_response_time_weekday_hours');
+    });
+
+    it('should evaluate case/when syntax', () => {
+        const sql = [
+            '{% case ld.parameters.date_granularity %}',
+            '{% when "Day" %} ${TABLE}.date',
+            '{% when "Week" %} DATE_TRUNC(\'week\', ${TABLE}.date)',
+            '{% when "Month" %} DATE_TRUNC(\'month\', ${TABLE}.date)',
+            '{% else %} ${TABLE}.date',
+            '{% endcase %}',
+        ].join('\n');
+
+        expect(renderLiquidSql(sql, { date_granularity: 'Week' }).trim()).toBe(
+            "DATE_TRUNC('week', ${TABLE}.date)",
+        );
+        expect(renderLiquidSql(sql, { date_granularity: 'Month' }).trim()).toBe(
+            "DATE_TRUNC('month', ${TABLE}.date)",
+        );
+        expect(
+            renderLiquidSql(sql, { date_granularity: 'unknown' }).trim(),
+        ).toBe('${TABLE}.date');
+    });
+
+    it('should fall back to original SQL on malformed Liquid syntax', () => {
+        const sql = '{% if ld.parameters.grain == "day" %} foo {% bad_tag %}';
+        expect(renderLiquidSql(sql, { grain: 'day' })).toBe(sql);
+    });
+
+    it('should skip Liquid tags that do not reference ld.parameters', () => {
+        // Non-Lightdash Liquid syntax should be returned as-is
+        const sql = '{% if 1 == 1 %} foo {% else %} bar {% endif %}';
+        expect(renderLiquidSql(sql, {})).toBe(sql);
+    });
+
+    it('should skip unrelated {% in SQL strings', () => {
+        const sql = "SELECT '{%something%}' AS col";
+        expect(renderLiquidSql(sql, { grain: 'day' })).toBe(sql);
+    });
+});

--- a/packages/common/src/templating/liquidSql.ts
+++ b/packages/common/src/templating/liquidSql.ts
@@ -1,0 +1,101 @@
+import { Liquid } from 'liquidjs';
+
+/**
+ * Liquid template engine for SQL rendering.
+ * Uses default Liquid delimiters ({% %} for tags, {{ }} for output)
+ * to support conditional SQL syntax like:
+ *   {% if ld.parameters.grain == "day" %} ${snapshot_date} {% endif %}
+ *
+ * This is consistent with the existing Lightdash parameter syntax
+ * (${ld.parameters.x}) — just using Liquid delimiters instead of ${}.
+ *
+ * This is separate from the URL template engine (template.ts) which
+ * uses custom delimiters (${} for output).
+ */
+const liquidSqlEngine = new Liquid({
+    cache: true,
+    strictVariables: false, // Allow missing variables to resolve to falsy
+    strictFilters: false,
+});
+
+// Only activate Liquid rendering when the SQL contains Lightdash parameter
+// references inside {% %} tags. A bare {%  without ld.parameters/lightdash.parameters
+// could be unrelated syntax and should not be processed.
+const LIGHTDASH_LIQUID_PATTERN = /\{%[^%]*(?:ld|lightdash)\.parameters\b/;
+
+type ParameterValue = string | number | string[] | number[];
+
+/**
+ * Build a Liquid context from a parameter values map.
+ * Maps parameter values into a nested `ld.parameters` structure
+ * to match Lightdash's existing parameter syntax:
+ *   {% if ld.parameters.grain == "day" %} ...
+ *
+ * For dotted parameter names like "model.grain", the value is also
+ * accessible via just the short name ("grain").
+ */
+export const buildLiquidContext = (
+    parameterValuesMap: Record<string, ParameterValue>,
+): {
+    ld: { parameters: Record<string, ParameterValue> };
+    lightdash: { parameters: Record<string, ParameterValue> };
+} => {
+    const parameters: Record<string, ParameterValue> = {};
+
+    for (const [key, value] of Object.entries(parameterValuesMap)) {
+        parameters[key] = value;
+
+        // For dotted names like "model.grain", also expose as "grain"
+        const parts = key.split('.');
+        const shortName = parts[parts.length - 1];
+        if (shortName !== key) {
+            parameters[shortName] = value;
+        }
+    }
+
+    return {
+        ld: { parameters },
+        lightdash: { parameters }, // Support both {% if ld.parameters.x %} and {% if lightdash.parameters.x %}
+    };
+};
+
+/**
+ * Render Liquid template blocks in SQL using parameter values.
+ *
+ * This function evaluates Liquid if/elsif/else/endif blocks in dimension/metric
+ * SQL at query time, when parameter values are known.
+ *
+ * @param sql - The compiled SQL that may contain Liquid template blocks
+ * @param parameterValuesMap - Map of parameter names to their current values
+ * @returns The SQL with Liquid blocks evaluated and resolved
+ *
+ * @example
+ * ```ts
+ * const sql = `{% if ld.parameters.grain == "day" %} DATE_TRUNC('day', "events".report_date)
+ *   {% elsif ld.parameters.grain == "week" %} DATE_TRUNC('week', "events".report_date)
+ *   {% else %} "events".report_date
+ *   {% endif %}`;
+ *
+ * renderLiquidSql(sql, { grain: 'day' });
+ * // => ' DATE_TRUNC(\'day\', "events".report_date)\n'
+ * ```
+ */
+export const renderLiquidSql = (
+    sql: string,
+    parameterValuesMap: Record<string, ParameterValue>,
+): string => {
+    // Only process SQL that contains Lightdash parameter references in Liquid tags.
+    // This avoids accidentally processing unrelated {% %} syntax.
+    if (!LIGHTDASH_LIQUID_PATTERN.test(sql)) {
+        return sql;
+    }
+
+    try {
+        const context = buildLiquidContext(parameterValuesMap);
+        return liquidSqlEngine.parseAndRenderSync(sql, context);
+    } catch {
+        // If Liquid parsing fails (e.g., malformed syntax or unrelated {% in SQL),
+        // fall back to the original SQL so we don't break existing queries
+        return sql;
+    }
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-5654/unsupported-liquidjs

### Description:


There was a small blocker: liquidjs syntax {% %} was in conflict with jinja dbt syntax, so we need to find a way to support without reinventing the liquidjs syntax. For that, I suggested to detect liquidjs syntax and wrap it in a compatible {% raw %} block so dbt doesn't break

<img width="1076" height="544" alt="Screenshot from 2026-03-04 16-58-55" src="https://github.com/user-attachments/assets/60515438-3a44-4b0f-b1d2-945756279769" />

<img width="1097" height="881" alt="Screenshot from 2026-03-04 16-53-12" src="https://github.com/user-attachments/assets/c124362d-c382-4405-954b-b1a7d276868a" />

<img width="1965" height="904" alt="Screenshot from 2026-03-04 16-56-13" src="https://github.com/user-attachments/assets/049c5e18-c8e9-4ed0-ab7b-75ece02fb318" />

---

This PR adds Liquid template support for dynamic SQL in Lightdash dimensions and metrics, enabling conditional SQL generation based on parameter values.

**Key Features:**
- **Liquid Template Engine**: Introduces a new SQL templating system using Liquid syntax (`{% if %}`, `{% elsif %}`, `{% else %}`, `{% endif %}`) for conditional SQL blocks
- **Dynamic Date Granularity**: Adds a `date_granularity` parameter to the jaffle shop demo with options for Day, Week, Month, Quarter, and Year
- **Dynamic Dimensions**: Implements `dynamic_date` dimension that changes SQL based on the `date_granularity` parameter value
- **Dynamic Metrics**: Adds `dynamic_metric` that switches between counting events or summing event IDs based on parameter configuration

**Technical Implementation:**
- **dbt Integration**: Preprocesses YAML files before dbt compilation by wrapping Lightdash Liquid blocks in `{% raw %}` tags to prevent dbt's Jinja engine from processing them
- **Query-time Rendering**: Evaluates Liquid templates during query execution when parameter values are known, before standard parameter substitution
- **Parameter Context**: Builds Liquid context with parameters accessible via both `ld.parameters.x` and `lightdash.parameters.x` syntax
- **Chart Stability**: Improves pivot series ordering to be deterministic regardless of backend value column ordering, with proper handling of dotted values like version strings

**Example Usage:**
```sql
{% if ld.parameters.date_granularity == 'Day' %} 
  ${TABLE}.date
{% elsif ld.parameters.date_granularity == 'Week' %} 
  DATE_TRUNC('week', ${TABLE}.date)
{% else %} 
  ${TABLE}.date
{% endif %}
```

This enables powerful dynamic SQL patterns similar to Looker's Liquid templating, allowing dimensions and metrics to adapt their behavior based on user-selected parameter values.

test-frontend test-backend