### PR TITLE
feat: premissions for viewing a pre-aggregate

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -341,7 +341,6 @@ export const lightdashConfigMock: LightdashConfig = {
     },
     preAggregates: {
         enabled: false,
-        debug: false,
         s3: {
             endpoint: 'mock_endpoint',
             bucket: 'mock_preagg_bucket',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1102,7 +1102,6 @@ export type LightdashConfig = {
     };
     preAggregates: {
         enabled: boolean;
-        debug: boolean;
         s3?: Omit<S3Config, 'expirationTime'>;
     };
 };
@@ -1993,9 +1992,6 @@ export const parseConfig = (): LightdashConfig => {
         },
         preAggregates: {
             enabled: preAggregatesEnabled,
-            debug:
-                licenseKey !== null &&
-                process.env.DEBUG_PRE_AGGREGATES === 'true',
             s3: preAggregatesS3,
         },
     };

--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -84,6 +84,8 @@ export class ExploreController extends BaseController {
                 req.account!,
                 projectUuid,
                 req.query.filtered === 'true',
+                true,
+                req.query.includePreAggregates === 'true',
             );
 
         return {

--- a/packages/backend/src/models/ModelRepository.ts
+++ b/packages/backend/src/models/ModelRepository.ts
@@ -490,11 +490,7 @@ export class ModelRepository
     public getSearchModel(): SearchModel {
         return this.getModel(
             'searchModel',
-            () =>
-                new SearchModel({
-                    database: this.database,
-                    lightdashConfig: this.lightdashConfig,
-                }),
+            () => new SearchModel({ database: this.database }),
         );
     }
 

--- a/packages/backend/src/models/SearchModel/index.ts
+++ b/packages/backend/src/models/SearchModel/index.ts
@@ -22,7 +22,6 @@ import {
     TableSelectionType,
 } from '@lightdash/common';
 import { Knex } from 'knex';
-import { type LightdashConfig } from '../../config/parseConfig';
 import {
     DashboardsTableName,
     DashboardTabsTableName,
@@ -51,7 +50,6 @@ import {
 
 type SearchModelArguments = {
     database: Knex;
-    lightdashConfig: LightdashConfig;
 };
 
 const SEARCH_LIMIT_PER_ITEM_TYPE = 10;
@@ -59,11 +57,8 @@ const SEARCH_LIMIT_PER_ITEM_TYPE = 10;
 export class SearchModel {
     private database: Knex;
 
-    private lightdashConfig: LightdashConfig;
-
     constructor(args: SearchModelArguments) {
         this.database = args.database;
-        this.lightdashConfig = args.lightdashConfig;
     }
 
     private async searchSpaces(
@@ -1254,14 +1249,9 @@ export class SearchModel {
             .limit(1);
 
         if (explores.length > 0 && explores[0].explores) {
-            const includePreAggregateDebugExplores =
-                this.lightdashConfig.preAggregates.debug;
             return explores[0].explores.filter(
                 (explore: Explore | ExploreError) => {
-                    if (
-                        !includePreAggregateDebugExplores &&
-                        explore.type === ExploreType.PRE_AGGREGATE
-                    ) {
+                    if (explore.type === ExploreType.PRE_AGGREGATE) {
                         return false;
                     }
                     if (tableSelection.type === TableSelectionType.WITH_TAGS) {
@@ -1270,9 +1260,7 @@ export class SearchModel {
                                 explore.tags || [],
                                 tableSelection.value || [],
                             ) ||
-                            explore.type === ExploreType.VIRTUAL ||
-                            (includePreAggregateDebugExplores &&
-                                explore.type === ExploreType.PRE_AGGREGATE)
+                            explore.type === ExploreType.VIRTUAL
                         );
                     }
                     if (tableSelection.type === TableSelectionType.WITH_NAMES) {
@@ -1280,9 +1268,7 @@ export class SearchModel {
                             (tableSelection.value || []).includes(
                                 explore.name,
                             ) ||
-                            explore.type === ExploreType.VIRTUAL ||
-                            (includePreAggregateDebugExplores &&
-                                explore.type === ExploreType.PRE_AGGREGATE)
+                            explore.type === ExploreType.VIRTUAL
                         );
                     }
                     return true;

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -745,7 +745,6 @@ describe('AsyncQueryService', () => {
                 ...lightdashConfigMock,
                 preAggregates: {
                     enabled: false,
-                    debug: false,
                 },
             });
             (service as AnyType).preAggregationDuckDbClient = {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1,3 +1,4 @@
+import { Ability } from '@casl/ability';
 import {
     defineUserAbility,
     FilterOperator,
@@ -6,6 +7,7 @@ import {
     OrganizationMemberRole,
     ParameterError,
     SessionUser,
+    type PossibleAbilities,
     WarehouseTypes,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
@@ -64,6 +66,7 @@ import {
     job,
     lightdashConfigWithNoSMTP,
     metricQueryMock,
+    preAggregateExplore,
     projectSummary,
     projectWithSensitiveFields,
     resultsWith1Row,
@@ -190,6 +193,19 @@ const account = buildAccount({
     accountType: 'session',
     userType: 'registered',
 });
+const developerAccount = {
+    ...account,
+    user: {
+        ...account.user,
+        ability: new Ability<PossibleAbilities>([
+            { subject: 'Project', action: ['update', 'view'] },
+            { subject: 'Job', action: ['view'] },
+            { subject: 'SqlRunner', action: ['manage'] },
+            { subject: 'Explore', action: ['manage'] },
+            { subject: 'PreAggregation', action: ['manage'] },
+        ]),
+    },
+} as typeof account;
 
 describe('ProjectService', () => {
     const { projectUuid } = defaultProject;
@@ -649,6 +665,68 @@ describe('ProjectService', () => {
             expect(result[0].type).toEqual('virtual');
         });
 
+        test('should include pre-aggregate explores for developer users when requested', async () => {
+            const serviceWithPreAggregatesEnabled = getMockedProjectService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+            const exploresWithPreAggregates = [
+                ...allExplores,
+                preAggregateExplore,
+            ];
+            (
+                projectModel.getAllExploreSummaries as jest.Mock
+            ).mockImplementationOnce(async () =>
+                exploresWithPreAggregates.map(exploreToSummaryWithAttributes),
+            );
+
+            const result = await serviceWithPreAggregatesEnabled.getAllExploresSummary(
+                developerAccount,
+                projectUuid,
+                true,
+                true,
+                true,
+            );
+
+            expect(result.map((explore) => explore.name)).toContain(
+                preAggregateExplore.name,
+            );
+        });
+
+        test('should exclude pre-aggregate explores for non-developer users even when requested', async () => {
+            const serviceWithPreAggregatesEnabled = getMockedProjectService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+            const exploresWithPreAggregates = [
+                ...allExplores,
+                preAggregateExplore,
+            ];
+            (
+                projectModel.getAllExploreSummaries as jest.Mock
+            ).mockImplementationOnce(async () =>
+                exploresWithPreAggregates.map(exploreToSummaryWithAttributes),
+            );
+
+            const result = await serviceWithPreAggregatesEnabled.getAllExploresSummary(
+                account,
+                projectUuid,
+                true,
+                true,
+                true,
+            );
+
+            expect(result.map((explore) => explore.name)).not.toContain(
+                preAggregateExplore.name,
+            );
+        });
+
         test('should exclude explores when user does not have required attributes', async () => {
             const exploresWithRequiredAttrs = [
                 validExplore,
@@ -712,6 +790,52 @@ describe('ProjectService', () => {
             expect(result.map((e) => e.name)).toContain('valid_explore');
             expect(result.map((e) => e.name)).toContain(
                 'explore_with_required_attributes',
+            );
+        });
+    });
+
+    describe('getExplore', () => {
+        test('should allow developer users to get a pre-aggregate explore', async () => {
+            const serviceWithPreAggregatesEnabled = getMockedProjectService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+            (
+                projectModel.findExploresFromCache as jest.Mock
+            ).mockImplementationOnce(async () => [preAggregateExplore]);
+
+            const result = await serviceWithPreAggregatesEnabled.getExplore(
+                developerAccount,
+                projectUuid,
+                preAggregateExplore.name,
+            );
+
+            expect(result.name).toEqual(preAggregateExplore.name);
+        });
+
+        test('should not allow non-developer users to get a pre-aggregate explore', async () => {
+            const serviceWithPreAggregatesEnabled = getMockedProjectService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+            (
+                projectModel.findExploresFromCache as jest.Mock
+            ).mockImplementationOnce(async () => [preAggregateExplore]);
+
+            await expect(
+                serviceWithPreAggregatesEnabled.getExplore(
+                    account,
+                    projectUuid,
+                    preAggregateExplore.name,
+                ),
+            ).rejects.toThrow(
+                `Explore "${preAggregateExplore.name}" does not exist.`,
             );
         });
     });

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5182,11 +5182,30 @@ export class ProjectService extends BaseService {
         }, []);
     }
 
+    private canViewPreAggregateExplores(
+        account: Account,
+        organizationUuid: string,
+        projectUuid: string,
+    ): boolean {
+        if (!this.lightdashConfig.preAggregates.enabled) {
+            return false;
+        }
+
+        return account.user.ability.can(
+            'manage',
+            subject('PreAggregation', {
+                organizationUuid,
+                projectUuid,
+            }),
+        );
+    }
+
     async getAllExploresSummary(
         account: Account,
         projectUuid: string,
         filtered: boolean,
         includeErrors: boolean = true,
+        includePreAggregates: boolean = false,
     ): Promise<SummaryExplore[]> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
@@ -5206,9 +5225,14 @@ export class ProjectService extends BaseService {
             projectUuid,
             includeErrors,
         );
-        const includePreAggregateDebugExplores =
-            this.lightdashConfig.preAggregates.debug;
-        const visibleExploreSummaries = includePreAggregateDebugExplores
+        const shouldIncludePreAggregateExplores =
+            includePreAggregates &&
+            this.canViewPreAggregateExplores(
+                account,
+                organizationUuid,
+                projectUuid,
+            );
+        const visibleExploreSummaries = shouldIncludePreAggregateExplores
             ? allExploreSummaries
             : allExploreSummaries.filter(
                   (explore) => explore.type !== ExploreType.PRE_AGGREGATE,
@@ -5223,7 +5247,7 @@ export class ProjectService extends BaseService {
                     (explore) =>
                         hasIntersection(explore.tags || [], value || []) ||
                         explore.type === ExploreType.VIRTUAL || // Custom explores/Virtual views are included by default
-                        (includePreAggregateDebugExplores &&
+                        (shouldIncludePreAggregateExplores &&
                             explore.type === ExploreType.PRE_AGGREGATE),
                 );
             }
@@ -5232,7 +5256,7 @@ export class ProjectService extends BaseService {
                     (explore) =>
                         (value || []).includes(explore.name) ||
                         explore.type === ExploreType.VIRTUAL || // Custom explores/Virtual views are included by default
-                        (includePreAggregateDebugExplores &&
+                        (shouldIncludePreAggregateExplores &&
                             explore.type === ExploreType.PRE_AGGREGATE),
                 );
             }
@@ -5332,6 +5356,12 @@ export class ProjectService extends BaseService {
                     'name',
                     exploreNames,
                 );
+                const canViewPreAggregateExplores =
+                    this.canViewPreAggregateExplores(
+                        account,
+                        project.organizationUuid,
+                        projectUuid,
+                    );
 
                 const { userAttributes } = await this.getUserAttributes({
                     account,
@@ -5340,6 +5370,12 @@ export class ProjectService extends BaseService {
                 return Object.values(explores).reduce<
                     Record<string, Explore | ExploreError>
                 >((acc, explore) => {
+                    if (
+                        explore.type === ExploreType.PRE_AGGREGATE &&
+                        !canViewPreAggregateExplores
+                    ) {
+                        return acc;
+                    }
                     if (isExploreError(explore)) {
                         acc[explore.name] = explore;
                     } else {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -243,6 +243,9 @@ const applyOrganizationMemberStaticAbilities: Record<
     },
     developer(member, { can }) {
         applyOrganizationMemberStaticAbilities.editor(member, { can });
+        can('manage', 'PreAggregation', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'VirtualView', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -205,6 +205,9 @@ export const projectMemberAbilities: Record<
     },
     developer(member, { can }) {
         projectMemberAbilities.editor(member, { can });
+        can('manage', 'PreAggregation', {
+            projectUuid: member.projectUuid,
+        });
         can('manage', 'VirtualView', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -68,6 +68,7 @@ const BASE_ROLE_SCOPES = {
 
     [ProjectMemberRole.DEVELOPER]: [
         // Developer-specific permissions
+        'manage:PreAggregation',
         'manage:VirtualView',
         'manage:CustomSql',
         'manage:SqlRunner',
@@ -167,6 +168,7 @@ export const getNonEnterpriseScopesForRole = (
         'manage:AiAgentThread',
         'manage:ContentAsCode',
         'manage:PersonalAccessToken',
+        'manage:PreAggregation',
     ]);
 
     return PROJECT_ROLE_TO_SCOPES_MAP[role].filter(

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -127,6 +127,7 @@ const ENTERPRISE_SUBJECTS = new Set([
     'AiAgent',
     'AiAgentThread',
     'ContentAsCode',
+    'PreAggregation',
 ]);
 
 /**

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -571,6 +571,13 @@ const scopes: Scope[] = [
         getConditions: addDefaultUuidCondition,
     },
     {
+        name: 'manage:PreAggregation',
+        description: 'View and query pre-aggregates in explore',
+        isEnterprise: true,
+        group: ScopeGroup.DATA,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
         name: 'manage:ExportCsv',
         description: 'Export data to CSV',
         isEnterprise: false,

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -234,6 +234,9 @@ const applyServiceAccountStaticAbilities: Record<
             organizationUuid,
             builder: { can },
         });
+        can('manage', 'PreAggregation', {
+            organizationUuid,
+        });
         can('manage', 'VirtualView', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -47,6 +47,7 @@ export type CaslSubjectNames =
     | 'OrganizationMemberProfile'
     | 'OrganizationWarehouseCredentials'
     | 'PersonalAccessToken'
+    | 'PreAggregation'
     | 'PinnedItems'
     | 'Project'
     | 'SavedChart'

--- a/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/BasePanel.tsx
@@ -34,7 +34,7 @@ const BasePanel = () => {
     const [search, setSearch] = useState<string>('');
     const [debouncedSearch] = useDebouncedValue(search, 300);
     const [, startTransition] = useTransition();
-    const exploresResult = useExplores(projectUuid, true);
+    const exploresResult = useExplores(projectUuid, true, true);
     const { data: org } = useOrganization();
 
     const filteredExplores = useMemo(() => {

--- a/packages/frontend/src/hooks/useExplores.tsx
+++ b/packages/frontend/src/hooks/useExplores.tsx
@@ -3,11 +3,15 @@ import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import useQueryError from './useQueryError';
 
-const getExplores = async (projectUuid: string, filtered?: boolean) =>
+const getExplores = async (
+    projectUuid: string,
+    filtered?: boolean,
+    includePreAggregates?: boolean,
+) =>
     lightdashApi<ApiExploresResults>({
         url: `/projects/${projectUuid}/explores?filtered=${
             filtered ? 'true' : 'false'
-        }`,
+        }&includePreAggregates=${includePreAggregates ? 'true' : 'false'}`,
         method: 'GET',
         body: undefined,
     });
@@ -15,13 +19,20 @@ const getExplores = async (projectUuid: string, filtered?: boolean) =>
 export const useExplores = (
     projectUuid: string | undefined,
     filtered?: boolean,
+    includePreAggregates?: boolean,
     useQueryFetchOptions?: UseQueryOptions<ApiExploresResults, ApiError>,
 ) => {
     const setErrorResponse = useQueryError();
-    const queryKey = ['tables', projectUuid, filtered ? 'filtered' : 'all'];
+    const queryKey = [
+        'tables',
+        projectUuid,
+        filtered ? 'filtered' : 'all',
+        includePreAggregates ? 'with-pre-aggregates' : 'without-pre-aggregates',
+    ];
     return useQuery<ApiExploresResults, ApiError>({
         queryKey,
-        queryFn: () => getExplores(projectUuid!, filtered),
+        queryFn: () =>
+            getExplores(projectUuid!, filtered, includePreAggregates),
         onError: (result) => setErrorResponse(result),
         retry: false,
         enabled: !!projectUuid,


### PR DESCRIPTION
### Description:

This PR refactors pre-aggregate explore visibility from a global debug configuration to a permission-based system. 

**Key Changes:**

- Removed the `debug` field from the `preAggregates` configuration and related environment variable `DEBUG_PRE_AGGREGATES`
- Added permission-based access control for pre-aggregate explores using the `VirtualView` manage permission
- Introduced an `includePreAggregates` query parameter to the explores endpoint, allowing clients to explicitly request pre-aggregate explores
- Updated the frontend to pass the `includePreAggregates` parameter when fetching explores
- Added comprehensive test coverage for both developer and non-developer user access scenarios
