### PR TITLE
feat: enable color by category in 1-series bar charts

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -3692,6 +3692,20 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                colorByCategory: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                categoryColorOverrides: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'Record_string.string_' },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },
@@ -18914,7 +18928,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -18924,7 +18938,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -18934,7 +18948,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -18947,7 +18961,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -4196,6 +4196,14 @@
                     "connectNulls": {
                         "type": "boolean",
                         "description": "Connect null data points with a line"
+                    },
+                    "colorByCategory": {
+                        "type": "boolean",
+                        "description": "Color each bar by its category value instead of using a single series color"
+                    },
+                    "categoryColorOverrides": {
+                        "$ref": "#/components/schemas/Record_string.string_",
+                        "description": "Per-category color overrides (maps category value to hex color)"
                     }
                 },
                 "type": "object",
@@ -20118,22 +20126,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -27772,7 +27780,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2579.0",
+        "version": "0.2580.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -658,6 +658,10 @@ export type CompleteCartesianChartLayout = {
     stack?: boolean | string | undefined;
     /** Connect null data points with a line */
     connectNulls?: boolean | undefined;
+    /** Color each bar by its category value instead of using a single series color */
+    colorByCategory?: boolean | undefined;
+    /** Per-category color overrides (maps category value to hex color) */
+    categoryColorOverrides?: Record<string, string> | undefined;
 };
 
 export type CartesianChartLayout = Partial<CompleteCartesianChartLayout>;

--- a/packages/common/src/visualizations/types/index.ts
+++ b/packages/common/src/visualizations/types/index.ts
@@ -372,9 +372,16 @@ export type EChartsSeries = {
     showSymbol?: boolean;
     symbolSize?: number;
     markLine?: Record<string, unknown>;
+    colorBy?: 'series' | 'data';
     itemStyle?: {
         borderRadius?: number | number[];
-        color?: string;
+        color?:
+            | string
+            | ((params: {
+                  dataIndex: number;
+                  name: string;
+                  data: Record<string, unknown>;
+              }) => string);
         opacity?: number;
     };
     lineStyle?: {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -14,13 +14,23 @@ import {
     type Series as SeriesType,
     type TableCalculation,
 } from '@lightdash/common';
-import { Checkbox, Divider, Stack } from '@mantine/core';
+import { ScrollArea } from '@mantine-8/core';
+import {
+    Box,
+    Checkbox,
+    Divider,
+    Group,
+    Stack,
+    Switch,
+    Text,
+} from '@mantine/core';
 import { produce } from 'immer';
 import React, { Fragment, useCallback, useMemo, type FC } from 'react';
 import { createPortal } from 'react-dom';
 import { getSeriesGroupedByField } from '../../../../hooks/cartesianChartConfig/utils';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
 import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
+import ColorSelector from '../../ColorSelector';
 import BasicSeriesConfiguration from './BasicSeriesConfiguration';
 import GroupedSeriesConfiguration from './GroupedSeriesConfiguration';
 import InvalidSeriesConfiguration from './InvalidSeriesConfiguration';
@@ -40,12 +50,15 @@ type Props = {
     items: (Field | TableCalculation | CustomDimension)[];
 };
 
+const MAX_COLOR_VALUES = 50;
+
 export const Series: FC<Props> = ({ items }) => {
     const {
         visualizationConfig,
         getSeriesColor,
         pivotDimensions,
         resultsData,
+        colorPalette,
     } = useVisualizationContext();
 
     const sortedByPivot = useMemo(
@@ -105,15 +118,67 @@ export const Series: FC<Props> = ({ items }) => {
         [seriesGroupedByField, chartConfig, getSeriesColor],
     );
 
+    // Collect unique category values using raw values as keys (matching echarts dataset)
+    // and formatted values for display labels
+    const { uniqueCategories, remainingCount } = useMemo(() => {
+        if (!isCartesianChart)
+            return { uniqueCategories: [], remainingCount: 0 };
+
+        const {
+            dirtyLayout: layout,
+            dirtyChartType: chartType,
+            dirtyEchartsConfig: echartsConfig,
+        } = visualizationConfig.chartConfig;
+        const series = echartsConfig?.series ?? [];
+
+        const isSingle =
+            chartType === CartesianSeriesType.BAR &&
+            !pivotDimensions?.length &&
+            series.length <= 1;
+
+        if (!isSingle || !layout?.colorByCategory || !resultsData?.rows)
+            return { uniqueCategories: [], remainingCount: 0 };
+
+        const xField = layout.xField;
+        if (!xField) return { uniqueCategories: [], remainingCount: 0 };
+
+        const seen = new Map<string, string>(); // raw -> formatted
+        for (const row of resultsData.rows) {
+            const cell = row[xField];
+            if (cell?.value?.raw != null && cell.value.raw !== '') {
+                const rawKey = String(cell.value.raw ?? cell.value.formatted);
+                if (!seen.has(rawKey)) {
+                    seen.set(
+                        rawKey,
+                        String(cell.value.formatted ?? cell.value.raw),
+                    );
+                }
+            }
+        }
+        const entries = Array.from(seen.entries());
+        return {
+            uniqueCategories: entries.slice(0, MAX_COLOR_VALUES),
+            remainingCount: Math.max(0, entries.length - MAX_COLOR_VALUES),
+        };
+    }, [
+        isCartesianChart,
+        visualizationConfig,
+        pivotDimensions,
+        resultsData?.rows,
+    ]);
+
     if (!isCartesianChart) return null;
 
     const {
         dirtyEchartsConfig,
         dirtyLayout,
+        dirtyChartType,
         updateSeries,
         getSingleSeries,
         updateSingleSeries,
         updateAllGroupedSeries,
+        setColorByCategory,
+        setCategoryColorOverride,
     } = visualizationConfig.chartConfig;
 
     const allSeries = dirtyEchartsConfig?.series ?? [];
@@ -141,6 +206,15 @@ export const Series: FC<Props> = ({ items }) => {
         });
         updateSeries(updatedSeries);
     };
+
+    // Color by category: available for single-series bar charts without pivots
+    const isSingleSeriesBar =
+        dirtyChartType === CartesianSeriesType.BAR &&
+        !pivotDimensions?.length &&
+        allSeries.length <= 1;
+
+    const colorByCategory = dirtyLayout?.colorByCategory ?? false;
+    const categoryColorOverrides = dirtyLayout?.categoryColorOverrides ?? {};
 
     return (
         <Stack spacing="md">
@@ -257,6 +331,116 @@ export const Series: FC<Props> = ({ items }) => {
                                                                 sortedByPivot
                                                             }
                                                         />
+                                                    )}
+                                                    {isSingleSeriesBar && (
+                                                        <Stack
+                                                            spacing="xs"
+                                                            mt="xs"
+                                                            ml="lg"
+                                                        >
+                                                            <Switch
+                                                                label="Color by category"
+                                                                checked={
+                                                                    colorByCategory
+                                                                }
+                                                                onChange={(e) =>
+                                                                    setColorByCategory(
+                                                                        e
+                                                                            .currentTarget
+                                                                            .checked,
+                                                                    )
+                                                                }
+                                                            />
+                                                            {colorByCategory &&
+                                                                uniqueCategories.length >
+                                                                    0 && (
+                                                                    <Box
+                                                                        bg="ldGray.1"
+                                                                        p="xxs"
+                                                                        py="xs"
+                                                                        sx={(
+                                                                            theme,
+                                                                        ) => ({
+                                                                            borderRadius:
+                                                                                theme
+                                                                                    .radius
+                                                                                    .sm,
+                                                                        })}
+                                                                    >
+                                                                        <ScrollArea.Autosize
+                                                                            mah={
+                                                                                300
+                                                                            }
+                                                                        >
+                                                                            <Stack spacing="xs">
+                                                                                {uniqueCategories.map(
+                                                                                    (
+                                                                                        [
+                                                                                            rawKey,
+                                                                                            label,
+                                                                                        ],
+                                                                                        idx,
+                                                                                    ) => (
+                                                                                        <Group
+                                                                                            key={
+                                                                                                rawKey
+                                                                                            }
+                                                                                            spacing="xs"
+                                                                                            noWrap
+                                                                                        >
+                                                                                            <ColorSelector
+                                                                                                color={
+                                                                                                    categoryColorOverrides[
+                                                                                                        rawKey
+                                                                                                    ] ??
+                                                                                                    colorPalette[
+                                                                                                        idx %
+                                                                                                            colorPalette.length
+                                                                                                    ]
+                                                                                                }
+                                                                                                swatches={
+                                                                                                    colorPalette
+                                                                                                }
+                                                                                                onColorChange={(
+                                                                                                    c,
+                                                                                                ) =>
+                                                                                                    setCategoryColorOverride(
+                                                                                                        rawKey,
+                                                                                                        c,
+                                                                                                    )
+                                                                                                }
+                                                                                            />
+                                                                                            <Text
+                                                                                                fz="xs"
+                                                                                                truncate
+                                                                                            >
+                                                                                                {
+                                                                                                    label
+                                                                                                }
+                                                                                            </Text>
+                                                                                        </Group>
+                                                                                    ),
+                                                                                )}
+                                                                                {remainingCount >
+                                                                                    0 && (
+                                                                                    <Text
+                                                                                        fz="xs"
+                                                                                        c="dimmed"
+                                                                                        fs="italic"
+                                                                                    >
+                                                                                        {
+                                                                                            remainingCount
+                                                                                        }{' '}
+                                                                                        more
+                                                                                        colored
+                                                                                        automatically
+                                                                                    </Text>
+                                                                                )}
+                                                                            </Stack>
+                                                                        </ScrollArea.Autosize>
+                                                                    </Box>
+                                                                )}
+                                                        </Stack>
                                                     )}
                                                     {hasDivider && (
                                                         <Divider my="md" />

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -432,6 +432,28 @@ const useCartesianChartConfig = ({
         }));
     }, []);
 
+    const setColorByCategory = useCallback((enabled: boolean) => {
+        setDirtyLayout((prev) => ({
+            ...prev,
+            colorByCategory: enabled,
+            // Clear overrides when disabling
+            ...(!enabled && { categoryColorOverrides: undefined }),
+        }));
+    }, []);
+
+    const setCategoryColorOverride = useCallback(
+        (categoryValue: string, color: string) => {
+            setDirtyLayout((prev) => ({
+                ...prev,
+                categoryColorOverrides: {
+                    ...prev?.categoryColorOverrides,
+                    [categoryValue]: color,
+                },
+            }));
+        },
+        [],
+    );
+
     const setAxisLabelFontSize = useCallback((fontSize: number | undefined) => {
         setDirtyEchartsConfig((prev) => ({
             ...prev,
@@ -478,6 +500,11 @@ const useCartesianChartConfig = ({
         setDirtyLayout((prev) => ({
             ...prev,
             yField: [...(prev?.yField || []), yField],
+            // Color by category only works for single-series; clear when adding another
+            ...((prev?.yField?.length ?? 0) >= 1 && {
+                colorByCategory: undefined,
+                categoryColorOverrides: undefined,
+            }),
         }));
     }, []);
 
@@ -1162,6 +1189,8 @@ const useCartesianChartConfig = ({
         setShowRightYAxis,
         setShowAxisTicks,
         setConnectNulls,
+        setColorByCategory,
+        setCategoryColorOverride,
         setAxisLabelFontSize,
         setAxisTitleFontSize,
         setXAxisSort,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2277,6 +2277,7 @@ const useEchartsCartesianConfig = (
         minimal,
         parameters,
         isTouchDevice,
+        colorPalette,
     } = useVisualizationContext();
 
     const theme = useMantineTheme();
@@ -2407,6 +2408,14 @@ const useEchartsCartesianConfig = (
         if (!itemsMap) return;
 
         const isHorizontal = Boolean(validCartesianConfig?.layout.flipAxes);
+        const isColorByCategory = Boolean(
+            validCartesianConfig?.layout?.colorByCategory,
+        );
+        const categoryColorOverrides =
+            validCartesianConfig?.layout?.categoryColorOverrides;
+        const categoryFieldId = isHorizontal
+            ? validCartesianConfig?.layout?.yField?.[0]
+            : validCartesianConfig?.layout?.xField;
 
         // Calculate dynamic border radius based on chart characteristics
         const barSeries = series.filter(
@@ -2457,7 +2466,7 @@ const useEchartsCartesianConfig = (
 
                 // Apply bar styling for bar charts
                 if (serie.type === CartesianSeriesType.BAR) {
-                    return {
+                    const barConfig = {
                         ...baseConfig,
                         ...getBarStyle(),
                         // Non-stacked bars get border radius on all bars
@@ -2472,6 +2481,41 @@ const useEchartsCartesianConfig = (
                             },
                         }),
                     };
+
+                    // Color by category: each bar gets a unique color
+                    if (isColorByCategory) {
+                        return {
+                            ...barConfig,
+                            colorBy: 'data' as const,
+                            itemStyle: {
+                                ...barConfig.itemStyle,
+                                color: (params: {
+                                    dataIndex: number;
+                                    name: string;
+                                    data: Record<string, unknown>;
+                                }) => {
+                                    const categoryValue = categoryFieldId
+                                        ? String(
+                                              params.data[categoryFieldId] ??
+                                                  '',
+                                          )
+                                        : '';
+                                    if (
+                                        categoryColorOverrides?.[categoryValue]
+                                    ) {
+                                        return categoryColorOverrides[
+                                            categoryValue
+                                        ];
+                                    }
+                                    return colorPalette[
+                                        params.dataIndex % colorPalette.length
+                                    ];
+                                },
+                            },
+                        };
+                    }
+
+                    return barConfig;
                 }
 
                 return baseConfig;
@@ -2519,10 +2563,15 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout.flipAxes,
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout.connectNulls,
+        validCartesianConfig?.layout?.colorByCategory,
+        validCartesianConfig?.layout?.categoryColorOverrides,
+        validCartesianConfig?.layout?.xField,
+        validCartesianConfig?.layout?.yField,
         series,
         rows,
         validCartesianConfigLegend,
         getSeriesColor,
+        colorPalette,
         theme.colors.background,
     ]);
     const sortedResults = useMemo(() => {


### PR DESCRIPTION
Closes: #20144

### Description:

Makes it possible to pick colors per-bar in a single series

<img width="1136" height="528" alt="Screenshot 2026-03-04 at 17 33 01" src="https://github.com/user-attachments/assets/9586f6b2-bf88-4b8a-99d5-d04916bfd010" />

