### PR TITLE
fix: install arrow from community after duckdb-async upgrade

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getPivotedResults.ts
+++ b/packages/backend/src/ee/services/ai/utils/getPivotedResults.ts
@@ -17,7 +17,7 @@ export const getPivotedResults = async (
     const fields = Object.keys(fieldsMap);
     const arrowTable = tableFromJSON(rows);
     const db = await Database.create(':memory:');
-    await db.exec('INSTALL arrow; LOAD arrow;');
+    await db.exec('INSTALL arrow FROM community; LOAD arrow;');
     await db.register_buffer('results_data', [tableToIPC(arrowTable)], true);
     const usingFields = metrics.map((metric) => `FIRST(${metric})`);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Updated the DuckDB arrow extension installation command to explicitly specify the `community` repository source. The installation now uses `INSTALL arrow FROM community` instead of the default `INSTALL arrow` to ensure the extension is loaded from the correct repository.

Followed guidance from: https://github.com/duckdb/arrow/blob/aa244456bbbb805a9837cdd405d6f022d9e8d9ef/README.md?plain=1#L6

related to: https://github.com/lightdash/lightdash/pull/20643