### PR TITLE
feat: add FE_HOST environment variable support

### DIFF
--- a/packages/frontend/vite.config.ts
+++ b/packages/frontend/vite.config.ts
@@ -7,6 +7,7 @@ import svgrPlugin from 'vite-plugin-svgr';
 import { defineConfig } from 'vitest/config';
 
 const FE_PORT = process.env.FE_PORT ? parseInt(process.env.FE_PORT) : 3000;
+const FE_HOST = process.env.FE_HOST;
 const BE_PORT = process.env.PORT ? parseInt(process.env.PORT) : 8080;
 
 export default defineConfig({
@@ -141,7 +142,8 @@ export default defineConfig({
         },
         allowedHosts: [
             'lightdash-dev', // for local development with docker
-            '.lightdash.dev', // for cloudflared tunnels
+            '.lightdash.dev', // for cloudflared tunnels,
+            ...(FE_HOST ? [FE_HOST] : []),
         ],
         watch: {
             ignored: ['!**/node_modules/@lightdash/common/**'],


### PR DESCRIPTION
### Description:
Add support for configurable frontend host via `FE_HOST` environment variable. The Vite dev server now accepts the custom host specified in `FE_HOST` as an allowed host, enabling more flexible development environment configurations beyond the default `lightdash-dev` and `.lightdash.dev` hosts.