### PR TITLE
fix: ensure Snowflake connections are properly destroyed after async queries

### DIFF
--- a/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/SnowflakeWarehouseClient.ts
@@ -461,6 +461,8 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
 
             return { tokenSecret, tokenName };
         } catch (e: unknown) {
+            // Note: External browser connections are not destroyed as they're cached
+            // for the lifetime of the client, but we still need proper error handling
             throw new WarehouseConnectionError(
                 `Failed to create Snowflake PAT: ${getErrorMessage(e)}`,
             );
@@ -670,27 +672,35 @@ export class SnowflakeWarehouseClient extends WarehouseBaseClient<CreateSnowflak
         ) => void | Promise<void>,
     ): Promise<WarehouseExecuteAsyncQuery> {
         const connection = await this.getConnection();
-        await this.prepareWarehouse(connection, {
-            timezone,
-            tags,
-        });
 
-        const { queryId, durationMs, totalRows } =
-            await this.executeAsyncStatement(
+        try {
+            await this.prepareWarehouse(connection, {
+                timezone,
+                tags,
+            });
+
+            const { queryId, durationMs, totalRows } =
+                await this.executeAsyncStatement(
+                    connection,
+                    sql,
+                    resultsStreamCallback,
+                    {
+                        values,
+                    },
+                );
+
+            return {
+                queryId,
+                queryMetadata: null,
+                totalRows,
+                durationMs,
+            };
+        } finally {
+            await this.destroyConnection(
                 connection,
-                sql,
-                resultsStreamCallback,
-                {
-                    values,
-                },
+                this.connectionOptions.authenticator,
             );
-
-        return {
-            queryId,
-            queryMetadata: null,
-            totalRows,
-            durationMs,
-        };
+        }
     }
 
     private async executeAsyncStatement(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR improves connection management in the Snowflake warehouse client by ensuring connections are properly cleaned up after async query execution. The `executeAsyncQuery` method now uses a try-finally block to guarantee that `destroyConnection` is called even if an error occurs during warehouse preparation or query execution.

Additionally, adds a clarifying comment about external browser connection caching behavior in the PAT creation error handling section.