### PR TITLE
feat: add chart-level color palette override via eChartsConfig.colors

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5911,6 +5911,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                colors: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'undefined' },
+                    ],
+                },
             },
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6661,6 +6661,13 @@
                         "type": "number",
                         "format": "double",
                         "description": "Font size for axis titles"
+                    },
+                    "colors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "description": "Chart-level color palette. Overrides the organization color palette for this chart."
                     }
                 },
                 "type": "object",

--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -2154,6 +2154,13 @@
                     "format": "double",
                     "type": "number"
                 },
+                "colors": {
+                    "description": "Chart-level color palette. Overrides the organization color palette for this chart.",
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
                 "grid": {
                     "$ref": "#/$defs/EchartsGrid",
                     "description": "Grid (chart area) configuration"

--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -671,6 +671,8 @@ export type CompleteEChartsConfig = {
     axisLabelFontSize?: number;
     /** Font size for axis titles */
     axisTitleFontSize?: number;
+    /** Chart-level color palette. Overrides the organization color palette for this chart. */
+    colors?: string[];
 };
 
 export type EChartsConfig = Partial<CompleteEChartsConfig>;

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -197,6 +197,16 @@ const VisualizationProvider: FC<
      * On charts, these are computed from the chartConfig
      * Colors are pre-calculated per-series, and re-calculated when series change.
      */
+    const effectivePalette = useMemo(
+        () =>
+            chartConfig?.type === ChartType.CARTESIAN &&
+            chartConfig.config?.eChartsConfig?.colors &&
+            chartConfig.config.eChartsConfig.colors.length > 0
+                ? chartConfig.config.eChartsConfig.colors
+                : colorPalette,
+        [chartConfig, colorPalette],
+    );
+
     const fallbackColors = useMemo<Record<string, string>>(() => {
         if (!chartConfig?.config || chartConfig.type !== ChartType.CARTESIAN) {
             return {};
@@ -213,10 +223,13 @@ const VisualizationProvider: FC<
 
         return Object.fromEntries(
             sortedSeriesIdentifiers.map((identifier, i) => {
-                return [identifier, colorPalette[i % colorPalette.length]];
+                return [
+                    identifier,
+                    effectivePalette[i % effectivePalette.length],
+                ];
             }),
         );
-    }, [chartConfig, colorPalette, computedSeries]);
+    }, [chartConfig, effectivePalette, computedSeries]);
 
     const handleChartConfigChange = useCallback(
         (newChartConfig: ChartConfig) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

When deploying charts via chart-as-code YAML, there was no way to specify a chart-level color palette. Colors either came from the organization's active palette — which may differ between environments — or had to be set individually on each series, which requires knowing all series names upfront and is impractical for pivot charts where series are generated dynamically from query results.

This PR adds an optional `colors` field to `eChartsConfig`, allowing a chart-level palette to be declared directly in the YAML:

```yaml
chartConfig:
  type: cartesian
  config:
    eChartsConfig:
      colors:
        - '#4C78A8'
        - '#F58518'
        - '#E45756'
```

When eChartsConfig.colors is set, it takes precedence over the organization palette when assigning fallback colors to series. If not set, behavior is unchanged.

<!-- Even better add a screenshot / gif / loom -->
