### PR TITLE
fix: prevent all series sharing same color in pivot stacked bar charts

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -264,7 +264,7 @@ const VisualizationProvider: FC<
      * Gets a shared color for a given series.
      */
     const getSeriesColor = useCallback(
-        (seriesLike: SeriesLike) => {
+        (seriesLike: SeriesLike, index?: number) => {
             if (seriesLike.color) return seriesLike.color;
 
             // Check if color is stored in metadata
@@ -303,18 +303,27 @@ const VisualizationProvider: FC<
             /**
              * If this series is grouped, figure out a shared color assignment from the series;
              * otherwise, pick a series color from the palette based on its order.
+             * If the fallback lookup fails (e.g. pivot-expanded series not in fallbackColors),
+             * fall back to index-based palette assignment to avoid all series sharing one color.
              */
-            return isGroupedSeries(seriesLike) && isCalculateSeriesColorEnabled
-                ? calculateSeriesColorAssignment(seriesLike)
-                : fallbackColors[
-                      // Note: we don't use getSeriesId since we may not be dealing with a Series type here
-                      calculateSeriesLikeIdentifier(seriesLike).join('|')
-                  ];
+            if (isGroupedSeries(seriesLike) && isCalculateSeriesColorEnabled) {
+                return calculateSeriesColorAssignment(seriesLike);
+            }
+            const paletteColor =
+                fallbackColors[
+                    // Note: we don't use getSeriesId since we may not be dealing with a Series type here
+                    calculateSeriesLikeIdentifier(seriesLike).join('|')
+                ];
+            if (paletteColor !== undefined) return paletteColor;
+
+            // Fallback for pivot-expanded series whose identifiers are not in fallbackColors
+            return colorPalette[(index ?? 0) % colorPalette.length];
         },
 
         [
             calculateSeriesColorAssignment,
             fallbackColors,
+            colorPalette,
             chartConfig,
             itemsMap,
             isCalculateSeriesColorEnabled,

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -44,7 +44,7 @@ type VisualizationContext = {
     setChartType: (value: ChartType) => void;
     setPivotDimensions: (value: string[] | undefined) => void;
 
-    getSeriesColor: (seriesLike: SeriesLike) => string;
+    getSeriesColor: (seriesLike: SeriesLike, index?: number) => string;
     getGroupColor: (groupPrefix: string, groupName: string) => string;
     colorPalette: string[];
     chartConfig: ChartConfig;

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2882,7 +2882,9 @@ const useEchartsCartesianConfig = (
             !hasCustomColorsStacking &&
             Boolean(conditionalFormattings?.length);
 
-        const seriesColors = series.map((serie) => getSeriesColor(serie));
+        const seriesColors = series.map((serie, index) =>
+            getSeriesColor(serie, index),
+        );
 
         const seriesWithValidStack = series.map<EChartsSeries>(
             (serie, index) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

In cartesian charts with pivot dimensions, all series in a stacked bar chart could end up with the same color instead of each getting a distinct color from the palette.

**Root cause:** `fallbackColors` (the identifier → color map used for series color assignment) is computed from either `computedSeries` or the static `eChartsConfig.series` saved in the chart config. For pivot charts, neither of these contains the dynamically expanded series that are actually rendered — those are generated at render time by `getEchartsSeriesFromPivotedData` / `getEchartsSeries` with pivot values like `challenge_type|type_1`, `challenge_type|type_2`, etc. The saved config only has a template entry, so every lookup in `fallbackColors` returns `undefined`, and ECharts falls back to its default behavior of repeating the first palette color across all series.

**Fix:** `getSeriesColor` now accepts an optional `index` parameter. When the identifier-based lookup in `fallbackColors` misses (pivot-expanded series not in the map), the index is used to pick a color from the palette directly — ensuring each series gets a distinct color.

The fix is minimal and does not affect non-pivot charts or any other color assignment path (explicit `series.color`, `metadata`, dimension colors, grouped series).

<!-- Even better add a screenshot / gif / loom -->
