### PR TITLE
refactor: drop isPrivate casl abilities

### DIFF
--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -40,19 +40,9 @@ const applyOrganizationMemberStaticAbilities: Record<
     },
     viewer(member, { can }) {
         applyOrganizationMemberStaticAbilities.member(member, { can });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'Dashboard', {
-            organizationUuid: member.organizationUuid,
-            isPrivate: false,
-        });
         can('view', 'Dashboard', {
             organizationUuid: member.organizationUuid,
             inheritsFromOrgOrProject: true,
-        });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'SavedChart', {
-            organizationUuid: member.organizationUuid,
-            isPrivate: false,
         });
         can('view', 'SavedChart', {
             organizationUuid: member.organizationUuid,
@@ -69,11 +59,6 @@ const applyOrganizationMemberStaticAbilities: Record<
             access: {
                 $elemMatch: { userUuid: member.userUuid },
             },
-        });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'Space', {
-            organizationUuid: member.organizationUuid,
-            isPrivate: false,
         });
         can('view', 'Space', {
             organizationUuid: member.organizationUuid,
@@ -208,11 +193,6 @@ const applyOrganizationMemberStaticAbilities: Record<
     editor(member, { can }) {
         applyOrganizationMemberStaticAbilities.interactive_viewer(member, {
             can,
-        });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('manage', 'Space', {
-            organizationUuid: member.organizationUuid,
-            isPrivate: false,
         });
         can('manage', 'Space', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -14,11 +14,6 @@ export const projectMemberAbilities: Record<
     ) => void
 > = {
     viewer(member, { can }) {
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'Dashboard', {
-            projectUuid: member.projectUuid,
-            isPrivate: false,
-        });
         can('view', 'Dashboard', {
             projectUuid: member.projectUuid,
             inheritsFromOrgOrProject: true,
@@ -26,11 +21,6 @@ export const projectMemberAbilities: Record<
         can('view', 'JobStatus', {
             createdByUserUuid: member.userUuid,
         });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'SavedChart', {
-            projectUuid: member.projectUuid,
-            isPrivate: false,
-        });
         can('view', 'SavedChart', {
             projectUuid: member.projectUuid,
             inheritsFromOrgOrProject: true,
@@ -46,11 +36,6 @@ export const projectMemberAbilities: Record<
             access: {
                 $elemMatch: { userUuid: member.userUuid },
             },
-        });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'Space', {
-            projectUuid: member.projectUuid,
-            isPrivate: false,
         });
         can('view', 'Space', {
             projectUuid: member.projectUuid,
@@ -173,11 +158,6 @@ export const projectMemberAbilities: Record<
         projectMemberAbilities.interactive_viewer(member, { can });
         can('create', 'Space', {
             projectUuid: member.projectUuid,
-        });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('manage', 'Space', {
-            projectUuid: member.projectUuid,
-            isPrivate: false,
         });
         can('manage', 'Space', {
             projectUuid: member.projectUuid,

--- a/packages/common/src/authorization/roleToScopeParity.test.ts
+++ b/packages/common/src/authorization/roleToScopeParity.test.ts
@@ -145,15 +145,6 @@ const filterEnterpriseRules = (
 };
 
 /**
- * Filter temporary backward-compatibility rules that use the deprecated `isPrivate` condition.
- * TODO: remove this filter once the temporary isPrivate rules are removed from projectMemberAbility.ts and organizationMemberAbility.ts
- */
-const filterDeprecatedIsPrivateRules = (rules: CASLRule[]): CASLRule[] =>
-    rules.filter(
-        (rule) => !rule.conditions || !('isPrivate' in rule.conditions),
-    );
-
-/**
  * Test role-to-scope parity for a specific role
  */
 const testRoleScopeParity = (
@@ -176,9 +167,10 @@ const testRoleScopeParity = (
     projectMemberAbilities[role](member, roleBuilder);
     const roleAbility = roleBuilder.build();
 
-    // Filter enterprise rules and deprecated isPrivate rules from role-based abilities
-    const filteredRoleRules = filterDeprecatedIsPrivateRules(
-        filterEnterpriseRules(roleAbility.rules as CASLRule[], isEnterprise),
+    // Filter enterprise rules from role-based abilities if not enterprise
+    const filteredRoleRules = filterEnterpriseRules(
+        roleAbility.rules as CASLRule[],
+        isEnterprise,
     );
 
     // Build abilities using scope-based approach
@@ -196,13 +188,12 @@ const testRoleScopeParity = (
     );
     const scopeAbility = scopeBuilder.build();
 
-    // Filter deprecated isPrivate rules from scope-based abilities too
-    const filteredScopeRules = filterDeprecatedIsPrivateRules(
-        scopeAbility.rules as CASLRule[],
-    );
-
     // Compare the filtered rule sets
-    const result = compareRuleSets(filteredRoleRules, filteredScopeRules, role);
+    const result = compareRuleSets(
+        filteredRoleRules,
+        scopeAbility.rules as CASLRule[],
+        role,
+    );
 
     return result;
 };

--- a/packages/common/src/authorization/scopeAbilityBuilder.test.ts
+++ b/packages/common/src/authorization/scopeAbilityBuilder.test.ts
@@ -825,11 +825,11 @@ describe('scopeAbilityBuilder', () => {
             );
             const ability = builder.build();
 
-            // We have 4 valid rules, 3 for dashboard (isPrivate, inheritsFromOrgOrProject, access) and 1 for project, dropping the invalid scope
-            expect(ability.rules.length).toBe(4);
+            // We have 3 valid rules, 2 for dashboard and 1 for project, dropping the invalid scope
+            expect(ability.rules.length).toBe(3);
             expect(
                 ability.rules.filter((r) => r.subject === 'Dashboard'),
-            ).toHaveLength(3);
+            ).toHaveLength(2);
             expect(
                 ability.rules.find((r) => r.subject === 'Project'),
             ).toBeDefined();

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -13,7 +13,6 @@ const addUuidCondition = (
     context: ScopeContext,
     modifiers?:
         | { inheritsFromOrgOrProject: true }
-        | { isPrivate: false }
         | { userUuid: string | boolean },
 ) => {
     const projectOrOrg = context.organizationUuid
@@ -47,8 +46,6 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
-            // TODO: remove once we're confident that nobody is stuck on an old frontend version
-            addUuidCondition(context, { isPrivate: false }),
             addUuidCondition(context, { inheritsFromOrgOrProject: true }),
             addAccessCondition(context),
         ],
@@ -77,8 +74,6 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
-            // TODO: remove once we're confident that nobody is stuck on an old frontend version
-            addUuidCondition(context, { isPrivate: false }),
             addUuidCondition(context, { inheritsFromOrgOrProject: true }),
             addAccessCondition(context),
         ],
@@ -107,8 +102,6 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
-            // TODO: remove once we're confident that nobody is stuck on an old frontend version
-            addUuidCondition(context, { isPrivate: false }),
             addUuidCondition(context, { inheritsFromOrgOrProject: true }),
             addAccessCondition(context),
         ],
@@ -133,8 +126,6 @@ const scopes: Scope[] = [
         isEnterprise: false,
         group: ScopeGroup.CONTENT,
         getConditions: (context) => [
-            // TODO: remove once we're confident that nobody is stuck on an old frontend version
-            addUuidCondition(context, { isPrivate: false }),
             addUuidCondition(context, { inheritsFromOrgOrProject: true }),
         ],
     },

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -26,19 +26,9 @@ const applyServiceAccountStaticAbilities: Record<
             organizationUuid,
         });
 
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'Dashboard', {
-            organizationUuid,
-            isPrivate: false,
-        });
         can('view', 'Dashboard', {
             organizationUuid,
             inheritsFromOrgOrProject: true,
-        });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'SavedChart', {
-            organizationUuid,
-            isPrivate: false,
         });
         can('view', 'SavedChart', {
             organizationUuid,
@@ -56,11 +46,6 @@ const applyServiceAccountStaticAbilities: Record<
            access: {
                 $elemMatch: { userUuid: userUuid },
             }, */
-        });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('view', 'Space', {
-            organizationUuid,
-            isPrivate: false,
         });
         can('view', 'Space', {
             organizationUuid,
@@ -193,11 +178,6 @@ const applyServiceAccountStaticAbilities: Record<
         applyServiceAccountStaticAbilities[ServiceAccountScope.ORG_READ]({
             organizationUuid,
             builder: { can },
-        });
-        // TODO: remove once we're confident that nobody is stuck on an old frontend version
-        can('manage', 'Space', {
-            organizationUuid,
-            isPrivate: false,
         });
         can('manage', 'Space', {
             organizationUuid,


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-178/remove-isprivate-completely

### Description:
We temporarily kept the old `isPrivate` abilities while adding the new `inheritsFromOrgOrProject` based abilities, to make sure that people running outdated frontends don't run into any issues.

### Testing:
Overall space interactions (creation/updating/moving/...) work fine.
As an additional step I also temporarily dropped the `spaces.is_private` column locally and it kept working as usual, incl. the API tests.
