### PR TITLE
fix: clean up LabelEditor and BigNumber config

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberComparison.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberComparison.tsx
@@ -197,7 +197,7 @@ export const Comparison: React.FC = () => {
                                 value={comparisonLabel ?? ''}
                                 placeholder="Add an optional label"
                                 onChange={setComparisonLabel}
-                                fields={granularityFields ?? []}
+                                fields={granularityFields}
                             />
                         </>
                     ) : null}

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberLayout.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/BigNumberLayout.tsx
@@ -82,7 +82,7 @@ export const Layout: FC = () => {
                             value={bigNumberLabel ?? ''}
                             placeholder={defaultLabel}
                             onChange={setBigNumberLabel}
-                            fields={granularityFields ?? []}
+                            fields={granularityFields}
                             readOnly={!showBigNumberLabel}
                         />
                     </div>
@@ -108,11 +108,6 @@ export const Layout: FC = () => {
                                     }
                                 }}
                                 disabled={!!bigNumberLabel}
-                                style={{
-                                    cursor: bigNumberLabel
-                                        ? 'not-allowed'
-                                        : 'pointer',
-                                }}
                             >
                                 <MantineIcon
                                     icon={

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/LabelEditor.module.css
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/LabelEditor.module.css
@@ -37,4 +37,5 @@
 
 .placeholderText {
     pointer-events: none;
+    z-index: var(--mantine-z-index-overlay);
 }

--- a/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/LabelEditor.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/BigNumberConfig/LabelEditor.tsx
@@ -1,10 +1,4 @@
-import {
-    getDefaultZIndex,
-    Input,
-    Paper,
-    Text,
-    useMantineColorScheme,
-} from '@mantine-8/core';
+import { Input, Paper, Text, useMantineColorScheme } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
     Editor,
@@ -13,7 +7,7 @@ import {
     type Monaco,
     type OnMount,
 } from '@monaco-editor/react';
-import { type editor, type IDisposable, type languages } from 'monaco-editor';
+import { type IDisposable, type languages } from 'monaco-editor';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useDeepCompareEffect } from 'react-use';
 import { getLightdashMonacoTheme } from '../../../features/sqlRunner/utils/monaco';
@@ -110,7 +104,6 @@ export const LabelEditor: FC<LabelEditorProps> = ({
     const { colorScheme } = useMantineColorScheme();
     const [localValue, setLocalValue] = useState(value);
     const [debouncedValue] = useDebouncedValue(localValue, 500);
-    const editorRef = useRef<editor.IStandaloneCodeEditor | null>(null);
     const contentDisposableRef = useRef<IDisposable | null>(null);
     const completionDisposableRef = useRef<IDisposable | null>(null);
     const [editorHeight, setEditorHeight] = useState(calculateEditorHeight(1));
@@ -186,7 +179,6 @@ export const LabelEditor: FC<LabelEditorProps> = ({
     );
 
     const onMount: OnMount = useCallback((monacoEditor) => {
-        editorRef.current = monacoEditor;
         const model = monacoEditor.getModel();
         if (model) {
             setEditorHeight(calculateEditorHeight(model.getLineCount()));
@@ -213,7 +205,6 @@ export const LabelEditor: FC<LabelEditorProps> = ({
                         c="ldGray.5"
                         fz="xs"
                         className={styles.placeholderText}
-                        style={{ zIndex: getDefaultZIndex('overlay') }}
                     >
                         {placeholder}
                     </Text>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- reference the related issue e.g. #150 -->

Relates to: [**feat: add resolveGranularityInLabel utility for big number labels**](https://github.com/lightdash/lightdash/pull/20829)

### Description

- Cleans up the unused `editorRef`
- Remove `styles` usage

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->