### PR TITLE
fix: preserve canonical order when toggling date zoom granularities

### DIFF
--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -65,9 +65,16 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                 return; // Must keep at least one granularity
             }
 
-            const newGranularities = isEnabled
-                ? dateZoomGranularities.filter((g) => g !== granularity)
-                : [...dateZoomGranularities, granularity];
+            const enabledSet = new Set(dateZoomGranularities);
+            if (isEnabled) {
+                enabledSet.delete(granularity);
+            } else {
+                enabledSet.add(granularity);
+            }
+            // Maintain canonical enum order
+            const newGranularities = Object.values(DateGranularity).filter(
+                (g) => enabledSet.has(g),
+            );
 
             setDateZoomGranularities(newGranularities);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/20800<!-- reference the related issue e.g. #150 -->

### Description

Fixes a bug where the order of the `view` mode `DateZoom` popover wasn't following the conventional order of granularities (Day, Week, Month, Quarter, Year) after editing

**Before**

[CleanShot 2026-03-05 at 12.18.02.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/d94e4ef8-8f60-406d-9090-3de6bee8c55e.mp4" />](https://app.graphite.com/user-attachments/video/d94e4ef8-8f60-406d-9090-3de6bee8c55e.mp4)



**After**

[CleanShot 2026-03-05 at 12.16.55.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/8d3184d8-743b-4653-8aaf-a2be79c4ff23.mp4" />](https://app.graphite.com/user-attachments/video/8d3184d8-743b-4653-8aaf-a2be79c4ff23.mp4)

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->