### PR TITLE
fix: don't show original explore table name in pre-aggregation compiled queries

### DIFF
--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -3,6 +3,7 @@ import { ExploreType, InlineErrorType, type Explore } from '../types/explore';
 import { DimensionType, FieldType } from '../types/field';
 import { DEFAULT_SPOTLIGHT_CONFIG } from '../types/lightdashProjectConfig';
 import { TimeFrames } from '../types/timeFrames';
+import { PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER } from '../preAggregates/buildPreAggregateExplore';
 import { warehouseClientMock } from './exploreCompiler.mock';
 import {
     attachTypesToModels,
@@ -1407,7 +1408,7 @@ describe('pre-aggregate virtual explore generation', () => {
         expect(preAggregateExplore.preAggregates).toEqual([]);
         expect(
             preAggregateExplore.tables[preAggregateExplore.baseTable].sqlTable,
-        ).toBe(MODEL_WITH_METRIC.relation_name);
+        ).toBe(PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER);
     });
 
     it('generates an internal pre-aggregate explore for average metrics without warnings', async () => {

--- a/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/common/src/preAggregates/buildPreAggregateExplore.test.ts
@@ -8,7 +8,10 @@ import {
     type CompiledMetric,
 } from '../types/field';
 import { TimeFrames } from '../types/timeFrames';
-import { buildPreAggregateExplore } from './buildPreAggregateExplore';
+import {
+    buildPreAggregateExplore,
+    PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
+} from './buildPreAggregateExplore';
 
 const makeDimension = ({
     name,
@@ -198,7 +201,7 @@ describe('buildPreAggregateExplore', () => {
         expect(result.joinedTables).toEqual([]);
         expect(result.preAggregates).toEqual([]);
         expect(result.tables.orders.sqlTable).toBe(
-            sourceExplore().tables.orders.sqlTable,
+            PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
         );
     });
 

--- a/packages/common/src/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/common/src/preAggregates/buildPreAggregateExplore.ts
@@ -359,12 +359,13 @@ const getEmptyTable = (
     metrics: {},
 });
 
+export const PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER =
+    '${materialized_table}';
+
 export const buildPreAggregateExplore = (
     sourceExplore: Explore,
     preAggregateDef: PreAggregateDef,
 ): Explore => {
-    const baseTableSqlTable =
-        sourceExplore.tables[sourceExplore.baseTable].sqlTable;
     const includedDimensions = getIncludedDimensions(
         sourceExplore,
         preAggregateDef,
@@ -386,7 +387,10 @@ export const buildPreAggregateExplore = (
                 `Pre-aggregate "${preAggregateDef.name}" references unknown table "${tableName}"`,
             );
         }
-        acc[tableName] = getEmptyTable(sourceTable, baseTableSqlTable);
+        acc[tableName] = getEmptyTable(
+            sourceTable,
+            PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
+        );
         return acc;
     }, {});
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:

Replace hardcoded SQL table references with a materialized table placeholder in pre-aggregate explore generation. The `buildPreAggregateExplore` function now uses `PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER` constant (`'${materialized_table}'`) instead of the source explore's base table SQL table name when creating pre-aggregate explores.

This change ensures that pre-aggregate explores reference the correct materialized table rather than the original source table, and the corresponding tests have been updated to verify this new behavior.