### PR TITLE
feat: add pre-aggregate cache toggle and SQL compilation

### DIFF
--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -7,6 +7,7 @@ import {
     ApiSuccessEmpty,
     MetricQuery,
     PivotConfig,
+    type ApiCompiledPreAggregateQueryResults,
     type ParametersValuesMap,
     type PivotConfiguration,
 } from '@lightdash/common';
@@ -154,6 +155,47 @@ export class ExploreController extends BaseController {
                 parameterReferences,
                 ...(pivotQuery && { pivotQuery }),
             },
+        };
+    }
+
+    /**
+     * Compile a metric query using the pre-aggregate DuckDB path
+     * @summary Compile pre-aggregate query
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('{exploreId}/compilePreAggregateQuery')
+    @OperationId('CompilePreAggregateQuery')
+    async CompilePreAggregateQuery(
+        @Path() exploreId: string,
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Body()
+        body: MetricQuery & {
+            parameters?: ParametersValuesMap;
+            pivotConfiguration?: PivotConfiguration;
+            preAggregateName: string;
+        },
+    ): Promise<{
+        status: 'ok';
+        results: ApiCompiledPreAggregateQueryResults;
+    }> {
+        this.setStatus(200);
+
+        const { preAggregateName, ...compileBody } = body;
+        const results = await this.services
+            .getProjectService()
+            .compilePreAggregateQuery({
+                account: req.account!,
+                body: compileBody,
+                projectUuid,
+                exploreName: exploreId,
+                preAggregateName,
+            });
+
+        return {
+            status: 'ok',
+            results,
         };
     }
 

--- a/packages/backend/src/controllers/v2/QueryController.ts
+++ b/packages/backend/src/controllers/v2/QueryController.ts
@@ -163,6 +163,7 @@ export class QueryController extends BaseController {
                 account: req.account!,
                 projectUuid,
                 invalidateCache: body.invalidateCache,
+                usePreAggregateCache: body.usePreAggregateCache,
                 metricQuery,
                 context: context ?? QueryExecutionContext.API,
                 dateZoom: body.dateZoom,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2013,11 +2013,21 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DateGranularity: {
+        dataType: 'refEnum',
+        enums: ['Day', 'Week', 'Month', 'Quarter', 'Year'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardConfig: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                defaultDateZoomGranularity: { ref: 'DateGranularity' },
+                dateZoomGranularities: {
+                    dataType: 'array',
+                    array: { dataType: 'refEnum', ref: 'DateGranularity' },
+                },
                 pinnedParameters: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -2068,6 +2078,10 @@ const models: TsoaRoute.Models = {
                         },
                         { dataType: 'enum', enums: [null] },
                     ],
+                    required: true,
+                },
+                inheritsFromOrgOrProject: {
+                    dataType: 'boolean',
                     required: true,
                 },
                 isPrivate: {
@@ -4660,6 +4674,10 @@ const models: TsoaRoute.Models = {
                     array: { dataType: 'refAlias', ref: 'SpaceAccess' },
                     required: true,
                 },
+                inheritsFromOrgOrProject: {
+                    dataType: 'boolean',
+                    required: true,
+                },
                 isPrivate: { dataType: 'boolean', required: true },
                 colorPalette: {
                     dataType: 'array',
@@ -5886,11 +5904,6 @@ const models: TsoaRoute.Models = {
             },
             validators: {},
         },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    DateGranularity: {
-        dataType: 'refEnum',
-        enums: ['Day', 'Week', 'Month', 'Quarter', 'Year'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiExecuteAsyncQueryResultsCommon: {
@@ -7629,11 +7642,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8111,11 +8124,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8130,11 +8143,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8149,11 +8162,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8168,11 +8181,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8187,11 +8200,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -14250,133 +14263,137 @@ const models: TsoaRoute.Models = {
         type: { ref: 'SpaceSummaryBase', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-access__': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                description: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                name: { dataType: 'string', required: true },
-                projectUuid: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-                uuid: { dataType: 'string', required: true },
-                parameters: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'DashboardParameters' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                updatedAt: { dataType: 'datetime', required: true },
-                versionUuid: { dataType: 'string', required: true },
-                spaceUuid: { dataType: 'string', required: true },
-                pinnedListUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                pinnedListOrder: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'double' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                slug: { dataType: 'string', required: true },
-                dashboardVersionId: { dataType: 'double', required: true },
-                tiles: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'DashboardTile' },
-                    required: true,
-                },
-                filters: { ref: 'DashboardFilters', required: true },
-                updatedByUser: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'UpdatedByUser' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                spaceName: { dataType: 'string', required: true },
-                views: { dataType: 'double', required: true },
-                firstViewedAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'datetime' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                tabs: {
-                    dataType: 'array',
-                    array: { dataType: 'refAlias', ref: 'DashboardTab' },
-                    required: true,
-                },
-                config: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'DashboardConfig' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                deletedAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'datetime' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                deletedBy: {
-                    dataType: 'union',
-                    subSchemas: [
-                        {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                lastName: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                firstName: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                userUuid: {
-                                    dataType: 'string',
-                                    required: true,
+    'Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-inheritsFromOrgOrProject-or-access__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    description: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    name: { dataType: 'string', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    parameters: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'DashboardParameters' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    versionUuid: { dataType: 'string', required: true },
+                    spaceUuid: { dataType: 'string', required: true },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    slug: { dataType: 'string', required: true },
+                    dashboardVersionId: { dataType: 'double', required: true },
+                    tiles: {
+                        dataType: 'array',
+                        array: { dataType: 'refAlias', ref: 'DashboardTile' },
+                        required: true,
+                    },
+                    filters: { ref: 'DashboardFilters', required: true },
+                    updatedByUser: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'UpdatedByUser' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    spaceName: { dataType: 'string', required: true },
+                    views: { dataType: 'double', required: true },
+                    firstViewedAt: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'datetime' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    tabs: {
+                        dataType: 'array',
+                        array: { dataType: 'refAlias', ref: 'DashboardTab' },
+                        required: true,
+                    },
+                    config: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'DashboardConfig' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    deletedAt: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'datetime' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    deletedBy: {
+                        dataType: 'union',
+                        subSchemas: [
+                            {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    lastName: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                    firstName: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                    userUuid: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
                                 },
                             },
-                        },
-                        { dataType: 'enum', enums: [null] },
-                        { dataType: 'undefined' },
-                    ],
+                            { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                 },
+                validators: {},
             },
-            validators: {},
         },
-    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_Dashboard.isPrivate-or-access_': {
+    'Omit_Dashboard.isPrivate-or-inheritsFromOrgOrProject-or-access_': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-access__',
+            ref: 'Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-inheritsFromOrgOrProject-or-access__',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DashboardDAO: {
         dataType: 'refAlias',
-        type: { ref: 'Omit_Dashboard.isPrivate-or-access_', validators: {} },
+        type: {
+            ref: 'Omit_Dashboard.isPrivate-or-inheritsFromOrgOrProject-or-access_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PromotedDashboard: {
@@ -14397,154 +14414,158 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_SavedChart.Exclude_keyofSavedChart.isPrivate-or-access__': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                description: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                name: { dataType: 'string', required: true },
-                projectUuid: { dataType: 'string', required: true },
-                organizationUuid: { dataType: 'string', required: true },
-                uuid: { dataType: 'string', required: true },
-                parameters: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'ParametersValuesMap' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                updatedAt: { dataType: 'datetime', required: true },
-                chartConfig: { ref: 'ChartConfig', required: true },
-                spaceUuid: { dataType: 'string', required: true },
-                dashboardUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                pinnedListUuid: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                pinnedListOrder: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'double' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                slug: { dataType: 'string', required: true },
-                updatedByUser: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'UpdatedByUser' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                spaceName: { dataType: 'string', required: true },
-                deletedAt: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'datetime' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                deletedBy: {
-                    dataType: 'union',
-                    subSchemas: [
-                        {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                lastName: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                firstName: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                                userUuid: {
-                                    dataType: 'string',
-                                    required: true,
-                                },
-                            },
-                        },
-                        { dataType: 'enum', enums: [null] },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                tableName: { dataType: 'string', required: true },
-                metricQuery: { ref: 'MetricQuery', required: true },
-                pivotConfig: {
-                    dataType: 'union',
-                    subSchemas: [
-                        {
-                            dataType: 'nestedObjectLiteral',
-                            nestedProperties: {
-                                columns: {
-                                    dataType: 'array',
-                                    array: { dataType: 'string' },
-                                    required: true,
-                                },
-                            },
-                        },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                tableConfig: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        columnOrder: {
-                            dataType: 'array',
-                            array: { dataType: 'string' },
-                            required: true,
-                        },
+    'Pick_SavedChart.Exclude_keyofSavedChart.isPrivate-or-inheritsFromOrgOrProject-or-access__':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    description: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
                     },
-                    required: true,
+                    name: { dataType: 'string', required: true },
+                    projectUuid: { dataType: 'string', required: true },
+                    organizationUuid: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                    parameters: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'ParametersValuesMap' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    updatedAt: { dataType: 'datetime', required: true },
+                    chartConfig: { ref: 'ChartConfig', required: true },
+                    spaceUuid: { dataType: 'string', required: true },
+                    dashboardUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListUuid: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    slug: { dataType: 'string', required: true },
+                    updatedByUser: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'UpdatedByUser' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    spaceName: { dataType: 'string', required: true },
+                    deletedAt: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'datetime' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    deletedBy: {
+                        dataType: 'union',
+                        subSchemas: [
+                            {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    lastName: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                    firstName: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                    userUuid: {
+                                        dataType: 'string',
+                                        required: true,
+                                    },
+                                },
+                            },
+                            { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    tableName: { dataType: 'string', required: true },
+                    metricQuery: { ref: 'MetricQuery', required: true },
+                    pivotConfig: {
+                        dataType: 'union',
+                        subSchemas: [
+                            {
+                                dataType: 'nestedObjectLiteral',
+                                nestedProperties: {
+                                    columns: {
+                                        dataType: 'array',
+                                        array: { dataType: 'string' },
+                                        required: true,
+                                    },
+                                },
+                            },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    tableConfig: {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            columnOrder: {
+                                dataType: 'array',
+                                array: { dataType: 'string' },
+                                required: true,
+                            },
+                        },
+                        required: true,
+                    },
+                    dashboardName: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
+                    colorPalette: {
+                        dataType: 'array',
+                        array: { dataType: 'string' },
+                        required: true,
+                    },
                 },
-                dashboardName: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'string' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
-                },
-                colorPalette: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                    required: true,
-                },
+                validators: {},
             },
-            validators: {},
         },
-    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Omit_SavedChart.isPrivate-or-access_': {
+    'Omit_SavedChart.isPrivate-or-inheritsFromOrgOrProject-or-access_': {
         dataType: 'refAlias',
         type: {
-            ref: 'Pick_SavedChart.Exclude_keyofSavedChart.isPrivate-or-access__',
+            ref: 'Pick_SavedChart.Exclude_keyofSavedChart.isPrivate-or-inheritsFromOrgOrProject-or-access__',
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SavedChartDAO: {
         dataType: 'refAlias',
-        type: { ref: 'Omit_SavedChart.isPrivate-or-access_', validators: {} },
+        type: {
+            ref: 'Omit_SavedChart.isPrivate-or-inheritsFromOrgOrProject-or-access_',
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PromotedChart: {
@@ -15205,6 +15226,10 @@ const models: TsoaRoute.Models = {
                 queries: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'SpaceQuery' },
+                    required: true,
+                },
+                inheritsFromOrgOrProject: {
+                    dataType: 'boolean',
                     required: true,
                 },
                 isPrivate: { dataType: 'boolean', required: true },
@@ -22280,6 +22305,39 @@ const models: TsoaRoute.Models = {
         type: { ref: 'Omit_Explore.unfilteredTables_', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCompiledPreAggregateQueryResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        pivotQuery: { dataType: 'string' },
+                        query: { dataType: 'string', required: true },
+                        available: {
+                            dataType: 'enum',
+                            enums: [true],
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        reason: { dataType: 'string', required: true },
+                        available: {
+                            dataType: 'enum',
+                            enums: [false],
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiPromoteDashboardResponse: {
         dataType: 'refAlias',
         type: {
@@ -24359,6 +24417,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 parameters: { ref: 'ParametersValuesMap' },
+                usePreAggregateCache: { dataType: 'boolean' },
                 invalidateCache: { dataType: 'boolean' },
                 context: { ref: 'QueryExecutionContext' },
             },
@@ -25262,6 +25321,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 sourceExploreName: { dataType: 'string', required: true },
+                preAggExploreName: { dataType: 'string', required: true },
                 preAggregateName: { dataType: 'string', required: true },
                 preAggregateDefinitionUuid: {
                     dataType: 'string',
@@ -47642,6 +47702,91 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'CompileQuery',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsExploreController_CompilePreAggregateQuery: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        exploreId: {
+            in: 'path',
+            name: 'exploreId',
+            required: true,
+            dataType: 'string',
+        },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'MetricQuery' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        preAggregateName: {
+                            dataType: 'string',
+                            required: true,
+                        },
+                        pivotConfiguration: { ref: 'PivotConfiguration' },
+                        parameters: { ref: 'ParametersValuesMap' },
+                    },
+                },
+            ],
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/explores/:exploreId/compilePreAggregateQuery',
+        ...fetchMiddlewares<RequestHandler>(ExploreController),
+        ...fetchMiddlewares<RequestHandler>(
+            ExploreController.prototype.CompilePreAggregateQuery,
+        ),
+
+        async function ExploreController_CompilePreAggregateQuery(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsExploreController_CompilePreAggregateQuery,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ExploreController>(ExploreController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'CompilePreAggregateQuery',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2155,8 +2155,21 @@
                 "required": ["hasDirectAccess", "role", "userUuid"],
                 "type": "object"
             },
+            "DateGranularity": {
+                "enum": ["Day", "Week", "Month", "Quarter", "Year"],
+                "type": "string"
+            },
             "DashboardConfig": {
                 "properties": {
+                    "defaultDateZoomGranularity": {
+                        "$ref": "#/components/schemas/DateGranularity"
+                    },
+                    "dateZoomGranularities": {
+                        "items": {
+                            "$ref": "#/components/schemas/DateGranularity"
+                        },
+                        "type": "array"
+                    },
                     "pinnedParameters": {
                         "items": {
                             "type": "string"
@@ -2204,6 +2217,9 @@
                         },
                         "type": "array",
                         "nullable": true
+                    },
+                    "inheritsFromOrgOrProject": {
+                        "type": "boolean"
                     },
                     "isPrivate": {
                         "type": "boolean",
@@ -2291,6 +2307,7 @@
                 "required": [
                     "slug",
                     "access",
+                    "inheritsFromOrgOrProject",
                     "isPrivate",
                     "tabs",
                     "pinnedListOrder",
@@ -5470,6 +5487,9 @@
                         },
                         "type": "array"
                     },
+                    "inheritsFromOrgOrProject": {
+                        "type": "boolean"
+                    },
                     "isPrivate": {
                         "type": "boolean"
                     },
@@ -5575,6 +5595,7 @@
                 "required": [
                     "slug",
                     "access",
+                    "inheritsFromOrgOrProject",
                     "isPrivate",
                     "colorPalette",
                     "dashboardName",
@@ -7107,10 +7128,6 @@
                 },
                 "required": ["results", "status"],
                 "type": "object"
-            },
-            "DateGranularity": {
-                "enum": ["Day", "Week", "Month", "Quarter", "Year"],
-                "type": "string"
             },
             "ApiExecuteAsyncQueryResultsCommon": {
                 "properties": {
@@ -8936,6 +8953,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "error",
+                                                            "success"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -15074,7 +15104,7 @@
             "PromotedSpace": {
                 "$ref": "#/components/schemas/SpaceSummaryBase"
             },
-            "Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-access__": {
+            "Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-inheritsFromOrgOrProject-or-access__": {
                 "properties": {
                     "description": {
                         "type": "string"
@@ -15203,12 +15233,12 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_Dashboard.isPrivate-or-access_": {
-                "$ref": "#/components/schemas/Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-access__",
+            "Omit_Dashboard.isPrivate-or-inheritsFromOrgOrProject-or-access_": {
+                "$ref": "#/components/schemas/Pick_Dashboard.Exclude_keyofDashboard.isPrivate-or-inheritsFromOrgOrProject-or-access__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "DashboardDAO": {
-                "$ref": "#/components/schemas/Omit_Dashboard.isPrivate-or-access_"
+                "$ref": "#/components/schemas/Omit_Dashboard.isPrivate-or-inheritsFromOrgOrProject-or-access_"
             },
             "PromotedDashboard": {
                 "allOf": [
@@ -15229,7 +15259,7 @@
                     }
                 ]
             },
-            "Pick_SavedChart.Exclude_keyofSavedChart.isPrivate-or-access__": {
+            "Pick_SavedChart.Exclude_keyofSavedChart.isPrivate-or-inheritsFromOrgOrProject-or-access__": {
                 "properties": {
                     "description": {
                         "type": "string",
@@ -15374,12 +15404,12 @@
                 "type": "object",
                 "description": "From T, pick a set of properties whose keys are in the union K"
             },
-            "Omit_SavedChart.isPrivate-or-access_": {
-                "$ref": "#/components/schemas/Pick_SavedChart.Exclude_keyofSavedChart.isPrivate-or-access__",
+            "Omit_SavedChart.isPrivate-or-inheritsFromOrgOrProject-or-access_": {
+                "$ref": "#/components/schemas/Pick_SavedChart.Exclude_keyofSavedChart.isPrivate-or-inheritsFromOrgOrProject-or-access__",
                 "description": "Construct a type with the properties of T except for those in type K."
             },
             "SavedChartDAO": {
-                "$ref": "#/components/schemas/Omit_SavedChart.isPrivate-or-access_"
+                "$ref": "#/components/schemas/Omit_SavedChart.isPrivate-or-inheritsFromOrgOrProject-or-access_"
             },
             "PromotedChart": {
                 "allOf": [
@@ -16078,6 +16108,9 @@
                         },
                         "type": "array"
                     },
+                    "inheritsFromOrgOrProject": {
+                        "type": "boolean"
+                    },
                     "isPrivate": {
                         "type": "boolean"
                     },
@@ -16104,6 +16137,7 @@
                     "dashboards",
                     "projectUuid",
                     "queries",
+                    "inheritsFromOrgOrProject",
                     "isPrivate",
                     "name",
                     "uuid",
@@ -23412,6 +23446,41 @@
             "ApiExploreResults": {
                 "$ref": "#/components/schemas/Omit_Explore.unfilteredTables_"
             },
+            "ApiCompiledPreAggregateQueryResults": {
+                "anyOf": [
+                    {
+                        "properties": {
+                            "pivotQuery": {
+                                "type": "string"
+                            },
+                            "query": {
+                                "type": "string"
+                            },
+                            "available": {
+                                "type": "boolean",
+                                "enum": [true],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["query", "available"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "reason": {
+                                "type": "string"
+                            },
+                            "available": {
+                                "type": "boolean",
+                                "enum": [false],
+                                "nullable": false
+                            }
+                        },
+                        "required": ["reason", "available"],
+                        "type": "object"
+                    }
+                ]
+            },
             "ApiPromoteDashboardResponse": {
                 "properties": {
                     "results": {
@@ -25469,6 +25538,9 @@
                     "parameters": {
                         "$ref": "#/components/schemas/ParametersValuesMap"
                     },
+                    "usePreAggregateCache": {
+                        "type": "boolean"
+                    },
                     "invalidateCache": {
                         "type": "boolean"
                     },
@@ -26269,6 +26341,9 @@
                     "sourceExploreName": {
                         "type": "string"
                     },
+                    "preAggExploreName": {
+                        "type": "string"
+                    },
                     "preAggregateName": {
                         "type": "string"
                     },
@@ -26285,6 +26360,7 @@
                     "metrics",
                     "dimensions",
                     "sourceExploreName",
+                    "preAggExploreName",
                     "preAggregateName",
                     "preAggregateDefinitionUuid"
                 ],
@@ -27609,7 +27685,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2561.0",
+        "version": "0.2571.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -41139,6 +41215,95 @@
                                                 "$ref": "#/components/schemas/ParametersValuesMap"
                                             }
                                         },
+                                        "type": "object"
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/explores/{exploreId}/compilePreAggregateQuery": {
+            "post": {
+                "operationId": "CompilePreAggregateQuery",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "properties": {
+                                        "results": {
+                                            "$ref": "#/components/schemas/ApiCompiledPreAggregateQueryResults"
+                                        },
+                                        "status": {
+                                            "type": "string",
+                                            "enum": ["ok"],
+                                            "nullable": false
+                                        }
+                                    },
+                                    "required": ["results", "status"],
+                                    "type": "object"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Compile a metric query using the pre-aggregate DuckDB path",
+                "summary": "Compile pre-aggregate query",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "exploreId",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/MetricQuery"
+                                    },
+                                    {
+                                        "properties": {
+                                            "preAggregateName": {
+                                                "type": "string"
+                                            },
+                                            "pivotConfiguration": {
+                                                "$ref": "#/components/schemas/PivotConfiguration"
+                                            },
+                                            "parameters": {
+                                                "$ref": "#/components/schemas/ParametersValuesMap"
+                                            }
+                                        },
+                                        "required": ["preAggregateName"],
                                         "type": "object"
                                     }
                                 ]

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -310,10 +310,12 @@ export class AsyncQueryService extends ProjectService {
         metricQuery,
         explore,
         context,
+        usePreAggregateCache,
     }: {
         metricQuery: MetricQuery;
         explore: Explore;
         context: QueryExecutionContext;
+        usePreAggregateCache?: boolean;
     }): PreAggregationRoutingDecision {
         if (
             !this.lightdashConfig.preAggregates.enabled ||
@@ -332,6 +334,7 @@ export class AsyncQueryService extends ProjectService {
         if (
             matchResult.hit &&
             matchResult.preAggregateName &&
+            usePreAggregateCache !== false &&
             context !== QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
         ) {
             return {
@@ -2238,6 +2241,7 @@ export class AsyncQueryService extends ProjectService {
         context,
         metricQuery,
         invalidateCache,
+        usePreAggregateCache,
         parameters,
         pivotConfiguration,
     }: ExecuteAsyncMetricQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
@@ -2337,6 +2341,7 @@ export class AsyncQueryService extends ProjectService {
             metricQuery,
             explore,
             context,
+            usePreAggregateCache,
         });
 
         if (routingDecision.preAggregateMetadata) {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -22,6 +22,7 @@ export type CommonAsyncQueryArgs = {
     account: Account;
     projectUuid: string;
     invalidateCache?: boolean;
+    usePreAggregateCache?: boolean;
     context: QueryExecutionContext;
     parameters?: ParametersValuesMap;
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -138,6 +138,7 @@ import {
     SqlRunnerPayload,
     SqlRunnerPivotQueryPayload,
     SummaryExplore,
+    SupportedDbtAdapter,
     TablesConfiguration,
     TableSelectionType,
     UnexpectedServerError,
@@ -158,6 +159,7 @@ import {
     WarehouseTablesCatalog,
     WarehouseTableSchema,
     WarehouseTypes,
+    type ApiCompiledPreAggregateQueryResults,
     type ApiCreateProjectResults,
     type CalculateSubtotalsFromQuery,
     type CreateDatabricksCredentials,
@@ -246,6 +248,10 @@ import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
 import { buildMaterializationMetricQuery } from '../PreAggregateMaterializationService/buildMaterializationMetricQuery';
+import {
+    getDuckdbPreAggregateSqlTable,
+    getPreAggregateDuckdbLocator,
+} from '../PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import {
     doesExploreMatchRequiredAttributes,
@@ -3072,6 +3078,136 @@ export class ProjectService extends BaseService {
                 compilationErrors: compiledQuery.compilationErrors,
             }),
             // Include pivot query if pivot configuration was provided
+            ...(pivotQuery && { pivotQuery }),
+        };
+    }
+
+    async compilePreAggregateQuery(args: {
+        account: Account;
+        body: MetricQuery & {
+            parameters?: ParametersValuesMap;
+            pivotConfiguration?: PivotConfiguration;
+        };
+        projectUuid: string;
+        exploreName: string;
+        preAggregateName: string;
+    }): Promise<ApiCompiledPreAggregateQueryResults> {
+        const {
+            account,
+            body: { parameters, pivotConfiguration, ...metricQuery },
+            projectUuid,
+            exploreName,
+            preAggregateName,
+        } = args;
+
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+
+        if (
+            account.user.ability.cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const preAggExploreName = getPreAggregateExploreName(
+            exploreName,
+            preAggregateName,
+        );
+
+        const activeMaterialization =
+            await this.preAggregateModel.getActiveMaterialization(
+                projectUuid,
+                preAggExploreName,
+            );
+
+        if (!activeMaterialization) {
+            return {
+                available: false,
+                reason: 'no_active_materialization',
+            };
+        }
+
+        const preAggExplore = await this.projectModel.getExploreFromCache(
+            projectUuid,
+            preAggExploreName,
+        );
+
+        if (isExploreError(preAggExplore)) {
+            return {
+                available: false,
+                reason: 'pre_aggregate_explore_error',
+            };
+        }
+
+        const locator = getPreAggregateDuckdbLocator({
+            uri: activeMaterialization.materializationUri,
+            format: 'jsonl',
+        });
+        const sqlTable = getDuckdbPreAggregateSqlTable(
+            locator,
+            activeMaterialization.columns,
+        );
+
+        const patchedExplore = {
+            ...preAggExplore,
+            tables: Object.fromEntries(
+                Object.entries(preAggExplore.tables).map(
+                    ([tableName, table]) => [tableName, { ...table, sqlTable }],
+                ),
+            ),
+        };
+
+        const warehouseCredentials =
+            await this.projectModel.getWarehouseCredentialsForProject(
+                projectUuid,
+            );
+
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            SupportedDbtAdapter.DUCKDB,
+            warehouseCredentials.startOfWeek,
+        );
+
+        const { userAttributes, intrinsicUserAttributes } =
+            await this.getUserAttributes({ account });
+
+        const availableParameterDefinitions = await this.getAvailableParameters(
+            projectUuid,
+            preAggExplore,
+        );
+
+        const compiledQuery = await ProjectService._compileQuery({
+            metricQuery,
+            explore: patchedExplore,
+            warehouseSqlBuilder,
+            intrinsicUserAttributes,
+            userAttributes,
+            timezone: this.lightdashConfig.query.timezone || 'UTC',
+            parameters,
+            availableParameterDefinitions,
+            pivotConfiguration,
+            continueOnError: true,
+        });
+
+        let pivotQuery: string | undefined;
+        if (pivotConfiguration) {
+            const pivotQueryBuilder = new PivotQueryBuilder(
+                compiledQuery.query,
+                pivotConfiguration,
+                warehouseSqlBuilder,
+                metricQuery.limit,
+                compiledQuery.fields,
+            );
+            pivotQuery = pivotQueryBuilder.toSql({
+                columnLimit: this.lightdashConfig.pivotTable.maxColumnLimit,
+            });
+        }
+
+        return {
+            available: true,
+            query: compiledQuery.query,
             ...(pivotQuery && { pivotQuery }),
         };
     }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -244,6 +244,10 @@ export type ApiCompiledQueryResults = {
     compilationErrors?: string[];
 };
 
+export type ApiCompiledPreAggregateQueryResults =
+    | { available: true; query: string; pivotQuery?: string }
+    | { available: false; reason: string };
+
 export type ApiExploresResults = SummaryExplore[];
 
 export type ApiExploreResults = Omit<Explore, 'unfilteredTables'>;
@@ -780,6 +784,7 @@ type ApiResults =
     | ApiQueryResults
     | ApiSqlQueryResults
     | ApiCompiledQueryResults
+    | ApiCompiledPreAggregateQueryResults
     | ApiExploresResults
     | ApiExploreResults
     | ApiStatusResults

--- a/packages/common/src/types/api/paginatedQuery.ts
+++ b/packages/common/src/types/api/paginatedQuery.ts
@@ -9,6 +9,7 @@ import type { DateGranularity } from '../timeFrames';
 type CommonExecuteQueryRequestParams = {
     context?: QueryExecutionContext;
     invalidateCache?: boolean;
+    usePreAggregateCache?: boolean;
     parameters?: ParametersValuesMap;
 };
 

--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -1,4 +1,5 @@
 import { subject } from '@casl/ability';
+import { useLocalStorage } from '@mantine-8/hooks';
 import {
     ActionIcon,
     CopyButton,
@@ -9,7 +10,15 @@ import {
 } from '@mantine/core';
 import { useHover } from '@mantine/hooks';
 import { IconCheck, IconClipboard } from '@tabler/icons-react';
-import { lazy, memo, Suspense, useCallback, useState, type FC } from 'react';
+import {
+    lazy,
+    memo,
+    Suspense,
+    useCallback,
+    useMemo,
+    useState,
+    type FC,
+} from 'react';
 import {
     explorerActions,
     selectIsSqlExpanded,
@@ -17,13 +26,19 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useCompiledPreAggregateSql } from '../../../hooks/useCompiledPreAggregateSql';
 import { useCompiledSql } from '../../../hooks/useCompiledSql';
+import { usePreAggregateMatch } from '../../../hooks/usePreAggregateMatch';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
 import { type SqlViewType } from '../../RenderedSql';
+import {
+    PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    PRE_AGGREGATE_CACHE_ENABLED_KEY,
+} from '../../RunQuerySettings/defaults';
 import OpenInSqlRunnerButton from './OpenInSqlRunnerButton';
 
 interface SqlCardProps {
@@ -58,9 +73,38 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
         enabled: !!unsavedChartVersionTableName,
     });
 
+    // Pre-aggregate SQL view
+    const [preAggCacheEnabled] = useLocalStorage({
+        key: PRE_AGGREGATE_CACHE_ENABLED_KEY,
+        defaultValue: PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    });
+    const { matchResult } = usePreAggregateMatch();
+    const preAggregateName =
+        matchResult?.hit === true ? matchResult.preAggregateName : null;
+
+    const {
+        data: preAggData,
+        isInitialLoading: preAggIsLoading,
+        error: preAggError,
+    } = useCompiledPreAggregateSql({
+        preAggregateName,
+        enabled: preAggCacheEnabled && preAggregateName !== null,
+    });
+
+    const isPreAggView = preAggCacheEnabled && preAggregateName !== null;
+
+    const preAggSqlOverride = useMemo(() => {
+        if (!isPreAggView || !preAggData || !preAggData.available)
+            return undefined;
+        return selectedView === 'pivotQuery' && preAggData.pivotQuery
+            ? preAggData.pivotQuery
+            : preAggData.query;
+    }, [isPreAggView, preAggData, selectedView]);
+
     const hasPivotQuery = !!data?.pivotQuery;
     const selectedSql =
         selectedView === 'pivotQuery' ? data?.pivotQuery : data?.query;
+    const effectiveCopySql = preAggSqlOverride ?? selectedSql ?? '';
 
     return (
         <CollapsableCard
@@ -71,8 +115,9 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
             onToggle={() => toggleExpandedSection(ExplorerSection.SQL)}
             disabled={!unsavedChartVersionTableName}
             headerElement={
-                (hovered || sqlIsOpen) && data && isSuccess ? (
-                    <CopyButton value={selectedSql ?? ''} timeout={2000}>
+                (hovered || sqlIsOpen) &&
+                (preAggSqlOverride !== undefined || (data && isSuccess)) ? (
+                    <CopyButton value={effectiveCopySql} timeout={2000}>
                         {({ copied, copy }) => (
                             <Tooltip
                                 variant="xs"
@@ -131,7 +176,7 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
                         >
                             <OpenInSqlRunnerButton
                                 projectUuid={projectUuid}
-                                sql={selectedSql}
+                                sql={preAggSqlOverride ?? selectedSql}
                                 disabled={isInitialLoading || !!error}
                             />
                         </Can>
@@ -140,7 +185,14 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
             }
         >
             <Suspense fallback={<Skeleton height={60} radius="sm" />}>
-                <LazyRenderedSql selectedView={selectedView} />
+                <LazyRenderedSql
+                    selectedView={selectedView}
+                    sqlOverride={preAggSqlOverride}
+                    isLoadingOverride={
+                        isPreAggView ? preAggIsLoading : undefined
+                    }
+                    errorOverride={isPreAggView ? preAggError : undefined}
+                />
             </Suspense>
         </CollapsableCard>
     );

--- a/packages/frontend/src/components/RefreshButton.tsx
+++ b/packages/frontend/src/components/RefreshButton.tsx
@@ -1,15 +1,19 @@
+import { preAggregateMissReasonLabels } from '@lightdash/common';
 import {
+    Box,
     Button,
+    getDefaultZIndex,
     Group,
     Kbd,
     rgba,
     Text,
+    ThemeIcon,
     Tooltip,
     type MantineSize,
 } from '@mantine-8/core';
-import { useHotkeys, useOs } from '@mantine-8/hooks';
-import { IconPlayerPlay, IconX } from '@tabler/icons-react';
-import { memo, useCallback, useTransition, type FC } from 'react';
+import { useHotkeys, useLocalStorage, useOs } from '@mantine-8/hooks';
+import { IconBolt, IconPlayerPlay, IconX } from '@tabler/icons-react';
+import { memo, useCallback, useMemo, useTransition, type FC } from 'react';
 import {
     explorerActions,
     selectIsValidQuery,
@@ -19,10 +23,15 @@ import {
 } from '../features/explorer/store';
 import useHealth from '../hooks/health/useHealth';
 import { useExplorerQuery } from '../hooks/useExplorerQuery';
+import { usePreAggregateMatch } from '../hooks/usePreAggregateMatch';
 import useTracking from '../providers/Tracking/useTracking';
 import { EventName } from '../types/Events';
 import MantineIcon from './common/MantineIcon';
-import RunQuerySettings from './RunQuerySettings';
+import RunQuerySettings, { type PreAggregateStatus } from './RunQuerySettings';
+import {
+    PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    PRE_AGGREGATE_CACHE_ENABLED_KEY,
+} from './RunQuerySettings/defaults';
 
 export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     const [, startTransition] = useTransition();
@@ -38,6 +47,46 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
 
     // Get query state and actions from hooks
     const { isLoading, fetchResults, cancelQuery } = useExplorerQuery();
+
+    const { matchResult, isEnabled: isPreAggEnabled } = usePreAggregateMatch();
+    const hasPreAggregates = isPreAggEnabled && matchResult !== null;
+    const isPreAggHit = matchResult?.hit === true;
+
+    const [preAggCacheEnabled] = useLocalStorage({
+        key: PRE_AGGREGATE_CACHE_ENABLED_KEY,
+        defaultValue: PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    });
+
+    const preAggStatus = useMemo((): PreAggregateStatus => {
+        if (!hasPreAggregates) return null;
+
+        if (preAggCacheEnabled && isPreAggHit) {
+            return {
+                color: 'green',
+                tooltip: `Pre-aggregate cache active: ${matchResult.preAggregateName}`,
+            };
+        }
+
+        if (!preAggCacheEnabled && isPreAggHit) {
+            return {
+                color: 'yellow',
+                tooltip: `Pre-aggregate cache available: ${matchResult.preAggregateName} (enable in settings)`,
+            };
+        }
+
+        if (preAggCacheEnabled && !isPreAggHit) {
+            const missLabel =
+                matchResult && !matchResult.hit
+                    ? preAggregateMissReasonLabels[matchResult.miss.reason]
+                    : '';
+            return {
+                color: 'gray',
+                tooltip: `Pre-aggregate cache miss: ${missLabel}`,
+            };
+        }
+
+        return null;
+    }, [hasPreAggregates, preAggCacheEnabled, isPreAggHit, matchResult]);
 
     const setRowLimit = useCallback(
         (newLimit: number) => {
@@ -60,84 +109,111 @@ export const RefreshButton: FC<{ size?: MantineSize }> = memo(({ size }) => {
     useHotkeys([['mod + enter', onClick, { preventDefault: true }]]);
 
     return (
-        <Button.Group>
-            <Tooltip
-                label={
-                    <Group gap="xxs">
-                        <Kbd fw={600}>
-                            {os === 'macos' || os === 'ios' ? '⌘' : 'ctrl'}
-                        </Kbd>
-
-                        <Text fw={600}>+</Text>
-
-                        <Kbd fw={600}>Enter</Kbd>
-                    </Group>
-                }
-                position="bottom"
-                withArrow
-                withinPortal
-                disabled={isLoading || !isValidQuery}
-            >
-                <Button
-                    size={size}
-                    pr={limit ? 'xs' : undefined}
-                    disabled={!isValidQuery}
-                    leftSection={<MantineIcon icon={IconPlayerPlay} />}
-                    loading={isLoading}
-                    onClick={onClick}
-                    style={(theme) => ({
-                        flex: 1,
-                        borderRight: isValidQuery
-                            ? `1px solid ${rgba(theme.colors.ldGray[5], 0.6)}`
-                            : undefined,
-                        borderTopRightRadius: 0,
-                        borderBottomRightRadius: 0,
-                    })}
-                    data-testid="RefreshButton/RunQueryButton"
-                >
-                    Run query ({limit})
-                </Button>
-            </Tooltip>
-
-            {isLoading ? (
+        <Box pos="relative">
+            <Button.Group>
                 <Tooltip
-                    label={'Cancel query'}
+                    label={
+                        <Group gap="xxs">
+                            <Kbd fw={600}>
+                                {os === 'macos' || os === 'ios' ? '⌘' : 'ctrl'}
+                            </Kbd>
+
+                            <Text fw={600}>+</Text>
+
+                            <Kbd fw={600}>Enter</Kbd>
+                        </Group>
+                    }
                     position="bottom"
                     withArrow
                     withinPortal
+                    disabled={isLoading || !isValidQuery}
                 >
                     <Button
                         size={size}
-                        p="xs"
-                        onClick={() =>
-                            startTransition(() => {
-                                cancelQuery();
-                            })
-                        }
-                        style={{
-                            borderTopLeftRadius: 0,
-                            borderBottomLeftRadius: 0,
-                        }}
+                        pr={limit ? 'xs' : undefined}
+                        disabled={!isValidQuery}
+                        leftSection={<MantineIcon icon={IconPlayerPlay} />}
+                        loading={isLoading}
+                        onClick={onClick}
+                        style={(theme) => ({
+                            flex: 1,
+                            borderRight: isValidQuery
+                                ? `1px solid ${rgba(theme.colors.ldGray[5], 0.6)}`
+                                : undefined,
+                            borderTopRightRadius: 0,
+                            borderBottomRightRadius: 0,
+                        })}
+                        data-testid="RefreshButton/RunQueryButton"
                     >
-                        <MantineIcon icon={IconX} size="sm" />
+                        Run query ({limit})
                     </Button>
                 </Tooltip>
-            ) : (
-                <RunQuerySettings
-                    disabled={!isValidQuery}
-                    size={size}
-                    maxLimit={maxLimit}
-                    limit={limit}
-                    onLimitChange={setRowLimit}
-                    showAutoFetchSetting
-                    targetProps={{
-                        style: {
-                            borderTopLeftRadius: 0,
-                            borderBottomLeftRadius: 0,
-                        },
-                    }}
-                />
+
+                {isLoading ? (
+                    <Tooltip
+                        label={'Cancel query'}
+                        position="bottom"
+                        withArrow
+                        withinPortal
+                    >
+                        <Button
+                            size={size}
+                            p="xs"
+                            onClick={() =>
+                                startTransition(() => {
+                                    cancelQuery();
+                                })
+                            }
+                            style={{
+                                borderTopLeftRadius: 0,
+                                borderBottomLeftRadius: 0,
+                            }}
+                        >
+                            <MantineIcon icon={IconX} size="sm" />
+                        </Button>
+                    </Tooltip>
+                ) : (
+                    <RunQuerySettings
+                        disabled={!isValidQuery}
+                        size={size}
+                        maxLimit={maxLimit}
+                        limit={limit}
+                        onLimitChange={setRowLimit}
+                        showAutoFetchSetting
+                        showPreAggregateSetting={hasPreAggregates}
+                        preAggregateStatus={preAggStatus}
+                        targetProps={{
+                            style: {
+                                borderTopLeftRadius: 0,
+                                borderBottomLeftRadius: 0,
+                            },
+                        }}
+                    />
+                )}
+            </Button.Group>
+
+            {preAggStatus && (
+                <Tooltip
+                    label={preAggStatus.tooltip}
+                    position="top"
+                    withArrow
+                    withinPortal
+                    zIndex={getDefaultZIndex('max') + 1}
+                >
+                    <ThemeIcon
+                        variant="filled"
+                        color={preAggStatus.color}
+                        radius="xl"
+                        size={18}
+                        pos="absolute"
+                        top={-7}
+                        right={-7}
+                        style={{ zIndex: 1 }}
+                    >
+                        <IconBolt size={10} />
+                    </ThemeIcon>
+                </Tooltip>
             )}
-        </Button.Group>
+        </Box>
     );
 });

--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -1,3 +1,4 @@
+import { type ApiError } from '@lightdash/common';
 import {
     Alert,
     Box,
@@ -33,10 +34,16 @@ export type SqlViewType = 'query' | 'pivotQuery';
 
 interface RenderedSqlProps {
     selectedView?: SqlViewType;
+    sqlOverride?: string;
+    isLoadingOverride?: boolean;
+    errorOverride?: ApiError | null;
 }
 
 export const RenderedSql: FC<RenderedSqlProps> = ({
     selectedView = 'query',
+    sqlOverride,
+    isLoadingOverride,
+    errorOverride,
 }) => {
     const { colorScheme } = useMantineColorScheme();
     const { projectUuid } = useParams<{ projectUuid: string }>();
@@ -46,6 +53,9 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
         [project],
     );
     const { data, error, isInitialLoading } = useCompiledSql();
+
+    const effectiveIsLoading = isLoadingOverride ?? isInitialLoading;
+    const effectiveError = errorOverride !== undefined ? errorOverride : error;
 
     const beforeMount: BeforeMount = useCallback(
         (monaco) => {
@@ -92,12 +102,15 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
     );
 
     const formattedSql = useMemo(() => {
+        if (sqlOverride !== undefined) {
+            return formatSql(sqlOverride);
+        }
         const sqlToFormat =
             effectiveView === 'pivotQuery' ? data?.pivotQuery : data?.query;
         return formatSql(sqlToFormat);
-    }, [data?.query, data?.pivotQuery, effectiveView, formatSql]);
+    }, [sqlOverride, data?.query, data?.pivotQuery, effectiveView, formatSql]);
 
-    if (isInitialLoading) {
+    if (effectiveIsLoading) {
         return (
             <Stack my="xs" align="center">
                 <Loader size="lg" color="gray" mt="xs" />
@@ -108,7 +121,7 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
         );
     }
 
-    if (error?.error.message) {
+    if (effectiveError?.error.message) {
         return (
             <div style={{ margin: 10 }}>
                 <Alert
@@ -117,11 +130,11 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
                     color="red"
                     variant="filled"
                 >
-                    <p>{error.error.message}</p>
+                    <p>{effectiveError.error.message}</p>
                 </Alert>
             </div>
         );
-    } else if (error?.error.data) {
+    } else if (effectiveError?.error.data) {
         // Validation error
         return (
             <div style={{ margin: 10 }}>
@@ -131,7 +144,7 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
                     color="red"
                     variant="filled"
                 >
-                    {Object.entries(error.error.data).map(
+                    {Object.entries(effectiveError.error.data).map(
                         ([key, validation]) => {
                             return (
                                 <p key={key}>{JSON.stringify(validation)}</p>

--- a/packages/frontend/src/components/RunQuerySettings/PreAggregateSqlSwitch.tsx
+++ b/packages/frontend/src/components/RunQuerySettings/PreAggregateSqlSwitch.tsx
@@ -1,0 +1,34 @@
+import { Switch, Tooltip, type MantineSize } from '@mantine-8/core';
+import { useLocalStorage } from '@mantine-8/hooks';
+import { memo, type FC } from 'react';
+import {
+    PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    PRE_AGGREGATE_CACHE_ENABLED_KEY,
+} from './defaults';
+
+const PreAggregateCacheSwitch: FC<{ size?: MantineSize }> = memo(({ size }) => {
+    const [preAggCacheEnabled, setPreAggCacheEnabled] = useLocalStorage({
+        key: PRE_AGGREGATE_CACHE_ENABLED_KEY,
+        defaultValue: PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    });
+
+    return (
+        <Tooltip
+            label="When enabled, matching queries run against pre-aggregate cache (DuckDB) instead of the warehouse"
+            position="bottom"
+            refProp="rootRef"
+            withArrow
+            withinPortal
+        >
+            <Switch
+                size={size}
+                label="Use pre-aggregate cache"
+                checked={preAggCacheEnabled}
+                onChange={() => setPreAggCacheEnabled(!preAggCacheEnabled)}
+                thumbIcon={<></>}
+            />
+        </Tooltip>
+    );
+});
+
+export default PreAggregateCacheSwitch;

--- a/packages/frontend/src/components/RunQuerySettings/defaults.ts
+++ b/packages/frontend/src/components/RunQuerySettings/defaults.ts
@@ -1,2 +1,6 @@
 export const AUTO_FETCH_ENABLED_KEY = 'lightdash-explorer-auto-fetch-enabled';
 export const AUTO_FETCH_ENABLED_DEFAULT = false;
+
+export const PRE_AGGREGATE_CACHE_ENABLED_KEY =
+    'lightdash-explorer-pre-aggregate-cache-enabled';
+export const PRE_AGGREGATE_CACHE_ENABLED_DEFAULT = false;

--- a/packages/frontend/src/components/RunQuerySettings/index.tsx
+++ b/packages/frontend/src/components/RunQuerySettings/index.tsx
@@ -12,6 +12,12 @@ import { memo, useEffect, useState, type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
 import AutoFetchResultsSwitch from './AutoFetchResultsSwitch';
 import LimitInput from './LimitInput';
+import PreAggregateCacheSwitch from './PreAggregateSqlSwitch';
+
+export type PreAggregateStatus = {
+    color: 'green' | 'yellow' | 'gray';
+    tooltip: string;
+} | null;
 
 export type Props = {
     size?: MantineSize;
@@ -20,6 +26,8 @@ export type Props = {
     limit: number;
     onLimitChange: (value: number) => void;
     showAutoFetchSetting?: boolean;
+    showPreAggregateSetting?: boolean;
+    preAggregateStatus?: PreAggregateStatus;
     targetProps?: ButtonProps;
 };
 
@@ -31,6 +39,7 @@ const RunQuerySettings: FC<Props> = memo(
         limit,
         onLimitChange,
         showAutoFetchSetting = false,
+        showPreAggregateSetting = false,
         targetProps,
     }) => {
         const [opened, { open, close }] = useDisclosure(false);
@@ -93,6 +102,12 @@ const RunQuerySettings: FC<Props> = memo(
                                 onBlur: handleLimitBlur,
                             }}
                         />
+                        {showPreAggregateSetting && (
+                            <>
+                                <Divider />
+                                <PreAggregateCacheSwitch size={size} />
+                            </>
+                        )}
                     </Stack>
                 </Popover.Dropdown>
             </Popover>

--- a/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
+++ b/packages/frontend/src/hooks/explorer/buildQueryArgs.ts
@@ -32,6 +32,7 @@ export function buildQueryArgs(options: {
     dateZoomGranularity?: DateGranularity;
     minimal: boolean;
     savedChart: Pick<SavedChartDAO, 'chartConfig' | 'pivotConfig'>;
+    usePreAggregateCache?: boolean;
 }): QueryResultsProps | null {
     const {
         activeFields,
@@ -76,6 +77,7 @@ export function buildQueryArgs(options: {
         ...(isEditMode ? {} : viewModeQueryArgs),
         dateZoomGranularity,
         invalidateCache: minimal,
+        usePreAggregateCache: options.usePreAggregateCache,
         parameters: parameters || {},
         pivotConfiguration,
     };

--- a/packages/frontend/src/hooks/useCompiledPreAggregateSql.ts
+++ b/packages/frontend/src/hooks/useCompiledPreAggregateSql.ts
@@ -1,0 +1,105 @@
+import {
+    type ApiCompiledPreAggregateQueryResults,
+    type ApiError,
+    type MetricQuery,
+    type ParametersValuesMap,
+    type PivotConfiguration,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../api';
+import {
+    selectAdditionalMetrics,
+    selectCustomDimensions,
+    selectDimensions,
+    selectFilters,
+    selectMetrics,
+    selectParameters,
+    selectQueryLimit,
+    selectSorts,
+    selectTableCalculations,
+    selectTableName,
+    selectTimezone,
+    useExplorerSelector,
+} from '../features/explorer/store';
+import { convertDateFilters } from '../utils/dateFilter';
+import { useProjectUuid } from './useProjectUuid';
+
+const getCompiledPreAggregateQuery = async (
+    projectUuid: string,
+    tableId: string,
+    query: MetricQuery,
+    preAggregateName: string,
+    queryParameters?: ParametersValuesMap,
+    pivotConfiguration?: PivotConfiguration,
+) => {
+    const timezoneFixQuery = {
+        ...query,
+        filters: convertDateFilters(query.filters),
+        parameters: queryParameters,
+        ...(pivotConfiguration && { pivotConfiguration }),
+        preAggregateName,
+    };
+
+    return lightdashApi<ApiCompiledPreAggregateQueryResults>({
+        url: `/projects/${projectUuid}/explores/${tableId}/compilePreAggregateQuery`,
+        method: 'POST',
+        body: JSON.stringify(timezoneFixQuery),
+    });
+};
+
+export const useCompiledPreAggregateSql = ({
+    preAggregateName,
+    enabled,
+}: {
+    preAggregateName: string | null;
+    enabled: boolean;
+}) => {
+    const projectUuid = useProjectUuid();
+    const tableId = useExplorerSelector(selectTableName);
+    const dimensions = useExplorerSelector(selectDimensions);
+    const metrics = useExplorerSelector(selectMetrics);
+    const filters = useExplorerSelector(selectFilters);
+    const sorts = useExplorerSelector(selectSorts);
+    const limit = useExplorerSelector(selectQueryLimit);
+    const tableCalculations = useExplorerSelector(selectTableCalculations);
+    const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+    const customDimensions = useExplorerSelector(selectCustomDimensions);
+    const timezone = useExplorerSelector(selectTimezone);
+    const queryParameters = useExplorerSelector(selectParameters);
+
+    const metricQuery: MetricQuery = {
+        exploreName: tableId,
+        dimensions: Array.from(dimensions),
+        metrics: Array.from(metrics),
+        sorts,
+        filters,
+        limit: limit || 500,
+        tableCalculations,
+        additionalMetrics,
+        customDimensions,
+        timezone: timezone ?? undefined,
+    };
+
+    const queryKey = [
+        'compiledPreAggregateQuery',
+        tableId,
+        metricQuery,
+        projectUuid,
+        preAggregateName,
+        queryParameters,
+    ];
+
+    return useQuery<ApiCompiledPreAggregateQueryResults, ApiError>({
+        queryKey,
+        queryFn: () =>
+            getCompiledPreAggregateQuery(
+                projectUuid!,
+                tableId || '',
+                metricQuery,
+                preAggregateName!,
+                queryParameters,
+            ),
+        keepPreviousData: true,
+        enabled: enabled && !!tableId && !!projectUuid && !!preAggregateName,
+    });
+};

--- a/packages/frontend/src/hooks/useExplorerQueryEffects.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryEffects.ts
@@ -3,11 +3,14 @@ import {
     FeatureFlags,
     getFieldsFromMetricQuery,
 } from '@lightdash/common';
+import { useLocalStorage as useLocalStorageV8 } from '@mantine-8/hooks';
 import { useLocalStorage } from '@mantine/hooks';
-import { useEffect, useMemo } from 'react';
+import { useEffect, useMemo, useRef } from 'react';
 import {
     AUTO_FETCH_ENABLED_DEFAULT,
     AUTO_FETCH_ENABLED_KEY,
+    PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    PRE_AGGREGATE_CACHE_ENABLED_KEY,
 } from '../components/RunQuerySettings/defaults';
 import {
     explorerActions,
@@ -136,6 +139,22 @@ export const useExplorerQueryEffects = ({
             dispatch(explorerActions.setUnpivotedQueryArgs(null));
         }
     }, [validQueryArgs, needsUnpivotedData, isResultsOpen, dispatch]);
+
+    // Effect 4: Re-run query when pre-aggregate cache toggle changes
+    const [preAggCacheEnabled] = useLocalStorageV8({
+        key: PRE_AGGREGATE_CACHE_ENABLED_KEY,
+        defaultValue: PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    });
+    const prevPreAggCacheRef = useRef(preAggCacheEnabled);
+    useEffect(() => {
+        if (
+            prevPreAggCacheRef.current !== preAggCacheEnabled &&
+            query.isFetched
+        ) {
+            runQuery();
+        }
+        prevPreAggCacheRef.current = preAggCacheEnabled;
+    }, [preAggCacheEnabled, query.isFetched, runQuery]);
 
     // No return - this hook just orchestrates effects
 };

--- a/packages/frontend/src/hooks/useExplorerQueryManager.ts
+++ b/packages/frontend/src/hooks/useExplorerQueryManager.ts
@@ -1,6 +1,11 @@
 import { FeatureFlags, type FieldId } from '@lightdash/common';
+import { useLocalStorage } from '@mantine-8/hooks';
 import { useCallback, useMemo } from 'react';
 import { useParams } from 'react-router';
+import {
+    PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    PRE_AGGREGATE_CACHE_ENABLED_KEY,
+} from '../components/RunQuerySettings/defaults';
 import useEmbed from '../ee/providers/Embed/useEmbed';
 import {
     explorerActions,
@@ -91,6 +96,11 @@ export const useExplorerQueryManager = () => {
         FeatureFlags.UseSqlPivotResults,
     );
 
+    const [preAggCacheEnabled] = useLocalStorage({
+        key: PRE_AGGREGATE_CACHE_ENABLED_KEY,
+        defaultValue: PRE_AGGREGATE_CACHE_ENABLED_DEFAULT,
+    });
+
     // Compute active fields and query validity
     const activeFields = useMemo<Set<FieldId>>(() => {
         return new Set([
@@ -165,6 +175,7 @@ export const useExplorerQueryManager = () => {
             dateZoomGranularity,
             minimal,
             savedChart: chartConfigForQuery,
+            usePreAggregateCache: preAggCacheEnabled,
         });
 
         if (mainQueryArgs) {
@@ -183,6 +194,7 @@ export const useExplorerQueryManager = () => {
         dateZoomGranularity,
         minimal,
         chartConfigForQuery,
+        preAggCacheEnabled,
         dispatch,
     ]);
 

--- a/packages/frontend/src/hooks/usePreAggregateMatch.ts
+++ b/packages/frontend/src/hooks/usePreAggregateMatch.ts
@@ -1,0 +1,86 @@
+import {
+    findMatch,
+    type MatchResult,
+    type MetricQuery,
+} from '@lightdash/common';
+import { useMemo } from 'react';
+import {
+    selectAdditionalMetrics,
+    selectCustomDimensions,
+    selectDimensions,
+    selectFilters,
+    selectMetrics,
+    selectQueryLimit,
+    selectSorts,
+    selectTableCalculations,
+    selectTableName,
+    selectTimezone,
+    useExplorerSelector,
+} from '../features/explorer/store';
+import useHealth from './health/useHealth';
+import { useExplore } from './useExplore';
+
+type PreAggregateMatchResult = {
+    matchResult: MatchResult | null;
+    isEnabled: boolean;
+    exploreName: string | undefined;
+};
+
+export const usePreAggregateMatch = (): PreAggregateMatchResult => {
+    const { data: health } = useHealth();
+    const isEnabled = health?.preAggregates?.enabled ?? false;
+
+    const tableName = useExplorerSelector(selectTableName);
+    const dimensions = useExplorerSelector(selectDimensions);
+    const metrics = useExplorerSelector(selectMetrics);
+    const filters = useExplorerSelector(selectFilters);
+    const sorts = useExplorerSelector(selectSorts);
+    const limit = useExplorerSelector(selectQueryLimit);
+    const tableCalculations = useExplorerSelector(selectTableCalculations);
+    const additionalMetrics = useExplorerSelector(selectAdditionalMetrics);
+    const customDimensions = useExplorerSelector(selectCustomDimensions);
+    const timezone = useExplorerSelector(selectTimezone);
+
+    const { data: explore } = useExplore(tableName);
+
+    const matchResult = useMemo(() => {
+        if (
+            !isEnabled ||
+            !explore ||
+            !explore.preAggregates ||
+            explore.preAggregates.length === 0
+        ) {
+            return null;
+        }
+
+        const metricQuery: MetricQuery = {
+            exploreName: tableName,
+            dimensions: Array.from(dimensions),
+            metrics: Array.from(metrics),
+            sorts,
+            filters,
+            limit: limit || 500,
+            tableCalculations,
+            additionalMetrics,
+            customDimensions,
+            timezone: timezone ?? undefined,
+        };
+
+        return findMatch(metricQuery, explore);
+    }, [
+        isEnabled,
+        explore,
+        tableName,
+        dimensions,
+        metrics,
+        sorts,
+        filters,
+        limit,
+        tableCalculations,
+        additionalMetrics,
+        customDimensions,
+        timezone,
+    ]);
+
+    return { matchResult, isEnabled, exploreName: tableName };
+};

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -41,6 +41,7 @@ export type QueryResultsProps = {
     dateZoomGranularity?: DateGranularity;
     context?: QueryExecutionContext;
     invalidateCache?: boolean;
+    usePreAggregateCache?: boolean;
     parameters?: ParametersValuesMap;
     pivotConfiguration?: PivotConfiguration;
     pivotResults?: boolean;
@@ -164,6 +165,7 @@ const executeAsyncQuery = (
                         : undefined,
                 },
                 invalidateCache: true, // Note: do not cache explore queries
+                usePreAggregateCache: data.usePreAggregateCache,
                 parameters: data.parameters,
                 pivotConfiguration: data.pivotConfiguration,
             },


### PR DESCRIPTION
### Description:

This PR adds pre-aggregate cache functionality to the query execution system, allowing queries to be routed through DuckDB pre-aggregates when available and enabled.

**Key Changes:**

- **New API endpoint**: Added `CompilePreAggregateQuery` endpoint to compile queries using the pre-aggregate DuckDB path
- **Pre-aggregate cache toggle**: Added a user setting to enable/disable pre-aggregate cache usage with visual indicators showing cache status (green for active, yellow for available but disabled, gray for miss)
- **Query routing enhancement**: Modified query execution to check for pre-aggregate matches and route accordingly when cache is enabled
- **SQL view integration**: Enhanced the SQL card to display pre-aggregate queries when available, with proper fallback to regular warehouse queries
- **Auto-refresh on toggle**: Queries automatically re-run when the pre-aggregate cache setting is toggled to immediately reflect the change
- **Type safety improvements**: Added proper TypeScript types for pre-aggregate query results and routing decisions

The feature includes comprehensive UI feedback through tooltips and status indicators, making it clear to users when pre-aggregate cache is being used, available but disabled, or unavailable due to query mismatches.