### PR TITLE
chore: update ESLint config and replace no-throw-literal rule

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -1,5 +1,8 @@
 module.exports = {
-    ignorePatterns: ['src/ee/services/McpService/mcp-chart-app/**'],
+    ignorePatterns: [
+        'src/ee/services/McpService/mcp-chart-app/**',
+        'src/generated/**',
+    ],
     parserOptions: {
         project: './tsconfig.json',
     },
@@ -30,7 +33,8 @@ module.exports = {
         'no-restricted-syntax': 'off',
         eqeqeq: 'error',
         '@typescript-eslint/no-floating-promises': 'error',
-        '@typescript-eslint/no-throw-literal': 'error',
+        '@typescript-eslint/no-throw-literal': 'off',
+        // no-throw-literal replaced with only-throw-error
         '@typescript-eslint/only-throw-error': 'error',
     },
     overrides: [

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,7 +22,7 @@
         "test:dev:nowatch": "TZ=UTC LANG=en_US.UTF-8 jest --config jest.config.dev.js --onlyChanged",
         "test:integration": "vitest run --config vitest.config.integration.ts",
         "test:integration:dev": "vitest run --config vitest.config.integration.ts --watch",
-        "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore --ignore-pattern './src/generated/*'",
+        "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore",
         "formatter": "oxfmt",
         "lint": "pnpm run linter ./src",
         "fix-lint": "pnpm run linter ./src --fix",


### PR DESCRIPTION
### Description:

This PR updates the ESLint configuration for the backend package. The changes include:

- Added `src/generated/**` to the ignore patterns in `.eslintrc.js` to exclude generated files from linting
- Disabled the `@typescript-eslint/no-throw-literal` rule and enabled `@typescript-eslint/only-throw-error` as its replacement
- Removed the redundant `--ignore-pattern './src/generated/*'` flag from the linter script in `package.json` since this is now handled by the ESLint configuration file