### PR TITLE
feat: pre-aggregate refresh in dashboards and tiles

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -54,6 +54,7 @@ import {
     IconCopy,
     IconFilter,
     IconFolders,
+    IconRefresh,
     IconTableExport,
     IconTelescope,
     IconVariable,
@@ -101,6 +102,7 @@ import useToaster from '../../hooks/toaster/useToaster';
 import { useContextMenuPermissions } from '../../hooks/useContextMenuPermissions';
 import { getExplorerUrlFromCreateSavedChartVersion } from '../../hooks/useExplorerRoute';
 import usePivotDimensions from '../../hooks/usePivotDimensions';
+import { useRefreshPreAggregateByDefinitionName } from '../../hooks/usePreAggregateRefresh';
 import { useProjectUuid } from '../../hooks/useProjectUuid';
 import {
     useInfiniteQueryResults,
@@ -628,6 +630,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
         'manage',
         subject('SavedChart', { ...chart }),
     );
+    const userCanRefreshPreAggregates =
+        ability.can(
+            'create',
+            subject('Job', { organizationUuid, projectUuid }),
+        ) && ability.can('manage', 'CompileProject');
     const userCanViewExplore = canViewExplore;
     const userCanExportData = ability.can(
         'manage',
@@ -654,6 +661,18 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
     const parameterDefinitions = useDashboardContext(
         (c) => c.parameterDefinitions,
     );
+
+    const preAggregateStatuses = useDashboardContext(
+        (c) => c.preAggregateStatuses,
+    );
+    const tilePreAggStatus = preAggregateStatuses[tileUuid];
+    const tilePreAggregateName =
+        tilePreAggStatus?.hit && tilePreAggStatus.preAggregateName
+            ? tilePreAggStatus.preAggregateName
+            : null;
+
+    const { mutate: refreshPreAggregate, isLoading: isRefreshingPreAgg } =
+        useRefreshPreAggregateByDefinitionName(projectUuid ?? '');
 
     const { openUnderlyingDataModal } = useMetricQueryDataContext();
 
@@ -1343,6 +1362,28 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                 disabled={isEditMode}
                                             >
                                                 Move to space
+                                            </Menu.Item>
+                                        )}
+
+                                    {tilePreAggregateName &&
+                                        userCanRefreshPreAggregates && (
+                                            <Menu.Item
+                                                leftSection={
+                                                    <MantineIcon
+                                                        icon={IconRefresh}
+                                                    />
+                                                }
+                                                disabled={
+                                                    isEditMode ||
+                                                    isRefreshingPreAgg
+                                                }
+                                                onClick={() =>
+                                                    refreshPreAggregate(
+                                                        tilePreAggregateName,
+                                                    )
+                                                }
+                                            >
+                                                Refresh pre-aggregate
                                             </Menu.Item>
                                         )}
                                 </Box>

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -35,6 +35,7 @@ import {
     IconPencil,
     IconPin,
     IconPinnedOff,
+    IconRefresh,
     IconSend,
     IconStar,
     IconStarFilled,
@@ -77,6 +78,7 @@ import {
     DASHBOARD_HEADER_ZINDEX,
 } from './dashboard.constants';
 import headerClasses from './DashboardHeader.module.css';
+import DashboardPreAggRefreshModal from './DashboardPreAggRefreshModal';
 import { DashboardRefreshButton } from './DashboardRefreshButton';
 import { PreAggregateAuditDrawer } from './PreAggregateAuditIndicator';
 
@@ -163,6 +165,18 @@ const DashboardHeader = ({
     const [isTransferToSpaceModalOpen, transferToSpaceModalHandlers] =
         useDisclosure(false);
     const [isPreAggAuditOpen, preAggAuditHandlers] = useDisclosure(false);
+    const [isPreAggRefreshOpen, preAggRefreshHandlers] = useDisclosure(false);
+
+    const uniquePreAggregateNames = useMemo(() => {
+        if (!preAggregateStatuses) return [];
+        return [
+            ...new Set(
+                Object.values(preAggregateStatuses)
+                    .filter((s) => s.hit && s.preAggregateName !== null)
+                    .map((s) => s.preAggregateName as string),
+            ),
+        ];
+    }, [preAggregateStatuses]);
     const handleEditClick = () => {
         setIsUpdating(true);
         track({ name: EventName.UPDATE_DASHBOARD_NAME_CLICKED });
@@ -239,6 +253,11 @@ const DashboardHeader = ({
         'manage',
         subject('Dashboard', dashboard),
     );
+    const userCanRefreshPreAggregates =
+        user.data?.ability.can(
+            'create',
+            subject('Job', { organizationUuid, projectUuid }),
+        ) && user.data?.ability.can('manage', 'CompileProject');
     const userCanCreateDeliveries = user.data?.ability?.can(
         'create',
         subject('ScheduledDeliveries', {
@@ -670,6 +689,25 @@ const DashboardHeader = ({
                                                     >
                                                         Pre-aggregation audit
                                                     </Menu.Item>
+                                                    {userCanRefreshPreAggregates &&
+                                                        uniquePreAggregateNames.length >
+                                                            0 && (
+                                                            <Menu.Item
+                                                                leftSection={
+                                                                    <MantineIcon
+                                                                        icon={
+                                                                            IconRefresh
+                                                                        }
+                                                                    />
+                                                                }
+                                                                onClick={
+                                                                    preAggRefreshHandlers.open
+                                                                }
+                                                            >
+                                                                Refresh
+                                                                pre-aggregates
+                                                            </Menu.Item>
+                                                        )}
                                                     <Menu.Divider />
                                                 </>
                                             )}
@@ -866,6 +904,16 @@ const DashboardHeader = ({
                     onSwitchTab={(tab) => onSwitchTab?.(tab)}
                 />
             )}
+            {preAggregatesEnabled &&
+                projectUuid &&
+                uniquePreAggregateNames.length > 0 && (
+                    <DashboardPreAggRefreshModal
+                        opened={isPreAggRefreshOpen}
+                        onClose={preAggRefreshHandlers.close}
+                        projectUuid={projectUuid}
+                        preAggregateNames={uniquePreAggregateNames}
+                    />
+                )}
         </PageHeader>
     );
 };

--- a/packages/frontend/src/components/common/Dashboard/DashboardPreAggRefreshModal.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardPreAggRefreshModal.tsx
@@ -1,0 +1,55 @@
+import { Code, List, Text } from '@mantine-8/core';
+import { IconRefresh } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useRefreshPreAggregateByDefinitionName } from '../../../hooks/usePreAggregateRefresh';
+import MantineModal from '../MantineModal';
+
+type DashboardPreAggRefreshModalProps = {
+    opened: boolean;
+    onClose: () => void;
+    projectUuid: string;
+    preAggregateNames: string[];
+};
+
+const DashboardPreAggRefreshModal: FC<DashboardPreAggRefreshModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    preAggregateNames,
+}) => {
+    const { mutateAsync: refreshByName, isLoading } =
+        useRefreshPreAggregateByDefinitionName(projectUuid);
+
+    const handleConfirm = async () => {
+        await Promise.all(preAggregateNames.map((name) => refreshByName(name)));
+        onClose();
+    };
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Refresh pre-aggregates"
+            icon={IconRefresh}
+            size="lg"
+            onConfirm={handleConfirm}
+            confirmLabel="Refresh"
+            confirmLoading={isLoading}
+        >
+            <Text fz="sm">
+                This will refresh {preAggregateNames.length} pre-aggregate
+                {preAggregateNames.length === 1 ? '' : 's'} used by this
+                dashboard:
+            </Text>
+            <List fz="sm" spacing={4}>
+                {preAggregateNames.map((name) => (
+                    <List.Item key={name}>
+                        <Code>{name}</Code>
+                    </List.Item>
+                ))}
+            </List>
+        </MantineModal>
+    );
+};
+
+export default DashboardPreAggRefreshModal;


### PR DESCRIPTION
Related: ZAP-273 

### Description:
Added controls over pre-aggregates on chart tiles and dashboards

![CleanShot 2026-03-05 at 16.22.13.png](https://app.graphite.com/user-attachments/assets/9a5e7422-6f40-4591-b9a4-d728183ec43c.png)

![CleanShot 2026-03-05 at 16.22.20.png](https://app.graphite.com/user-attachments/assets/5a12fe09-1037-4800-a007-41a533fd6651.png)

![CleanShot 2026-03-05 at 16.22.28.png](https://app.graphite.com/user-attachments/assets/d5553ada-de8a-4a21-a242-d56bfa88cec8.png)

