### PR TITLE
fix: allow apostrophes in email validation

### DIFF
--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -187,6 +187,7 @@ describe('email validation', () => {
         'user@sub.domain.com',
         'user@domain.info',
         'user123@domain.org',
+        "o'brien@company.com",
     ])('valid email: %s', (email) => {
         expect(isValidEmailAddress(email)).toBe(true);
     });

--- a/packages/common/src/utils/email.ts
+++ b/packages/common/src/utils/email.ts
@@ -88,4 +88,4 @@ export const validateOrganizationEmailDomains = (domains: string[]) => {
 };
 
 export const isValidEmailAddress = (email: string): boolean =>
-    /^[\w.+-]+@[\w-]+\.[A-Za-z]{2,}(?:\.[A-Za-z]{2,})*$/.test(email);
+    /^[\w.+'-]+@[\w-]+\.[A-Za-z]{2,}(?:\.[A-Za-z]{2,})*$/.test(email);


### PR DESCRIPTION
Per RFC 5322, apostrophes are valid in the local part of email addresses. 

Closes #20874

https://claude.ai/code/session_0189y5D7pXQvigGmCf5hAmbv

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
