### PR TITLE
fix: skip pre_agg parsing for empty string values

### DIFF
--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -585,10 +585,7 @@ export const parsePreAggregateResultsS3Config = ():
     const secretKey = process.env.PRE_AGGREGATE_RESULTS_S3_SECRET_KEY;
 
     const hasAnyPreAggregateS3Config =
-        bucket !== undefined ||
-        region !== undefined ||
-        accessKey !== undefined ||
-        secretKey !== undefined;
+        bucket || region || accessKey || secretKey;
 
     if (!hasAnyPreAggregateS3Config) {
         return undefined;


### PR DESCRIPTION
### Description:
Docker compose doesn't actually initialize the env vars with `undefined` but empty string, so the server has been crashing on start-up for me:

```
packages/backend dev: /usr/app/packages/backend/src/config/parseConfig.ts:603
packages/backend dev:         throw new ParseError(
packages/backend dev:               ^
packages/backend dev: ParseError: PRE_AGGREGATE_RESULTS_S3_BUCKET, PRE_AGGREGATE_RESULTS_S3_REGION, and S3_ENDPOINT must be set when configuring pre-aggregate result storage.
packages/backend dev:     at parsePreAggregateResultsS3Config (/usr/app/packages/backend/src/config/parseConfig.ts:603:15)
packages/backend dev:     at parseConfig (/usr/app/packages/backend/src/config/parseConfig.ts:1374:29)
packages/backend dev:     at <anonymous> (/usr/app/packages/backend/src/config/lightdashConfig.ts:3:32)
packages/backend dev:     at Object.<anonymous> (/usr/app/packages/backend/src/config/lightdashConfig.ts:3:44)
packages/backend dev:     at Module._compile (node:internal/modules/cjs/loader:1521:14)
packages/backend dev:     at Object.transformer (/usr/app/node_modules/.pnpm/tsx@4.19.2/node_modules/tsx/dist/register-DCnOAxY2.cjs:2:1186)
packages/backend dev:     at Module.load (node:internal/modules/cjs/loader:1266:32)
packages/backend dev:     at Module._load (node:internal/modules/cjs/loader:1091:12)
packages/backend dev:     at Module.require (node:internal/modules/cjs/loader:1289:19)
packages/backend dev:     at require (node:internal/modules/helpers:182:18) {
packages/backend dev:   statusCode: 400,
packages/backend dev:   data: {}
packages/backend dev: }
```