### PR TITLE
feat: add custom_granularities types and schemas

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2541,6 +2541,7 @@ const models: TsoaRoute.Models = {
             anyAttributes: { ref: 'Record_string.string-or-string-Array_' },
             timeInterval: { ref: 'TimeFrames' },
             timeIntervalBaseDimensionName: { dataType: 'string' },
+            customTimeInterval: { dataType: 'string' },
             isAdditionalDimension: { dataType: 'boolean' },
             colors: { ref: 'Record_string.string_' },
             isIntervalBase: { dataType: 'boolean' },
@@ -5133,6 +5134,7 @@ const models: TsoaRoute.Models = {
             anyAttributes: { ref: 'Record_string.string-or-string-Array_' },
             timeInterval: { ref: 'TimeFrames' },
             timeIntervalBaseDimensionName: { dataType: 'string' },
+            customTimeInterval: { dataType: 'string' },
             isAdditionalDimension: { dataType: 'boolean' },
             colors: { ref: 'Record_string.string_' },
             isIntervalBase: { dataType: 'boolean' },
@@ -7782,11 +7784,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8264,11 +8266,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8283,11 +8285,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8302,11 +8304,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8321,11 +8323,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8340,11 +8342,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2793,6 +2793,9 @@
                     "timeIntervalBaseDimensionName": {
                         "type": "string"
                     },
+                    "customTimeInterval": {
+                        "type": "string"
+                    },
                     "isAdditionalDimension": {
                         "type": "boolean"
                     },
@@ -6141,6 +6144,9 @@
                     "timeIntervalBaseDimensionName": {
                         "type": "string"
                     },
+                    "customTimeInterval": {
+                        "type": "string"
+                    },
                     "isAdditionalDimension": {
                         "type": "boolean"
                     },
@@ -9164,19 +9170,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],

--- a/packages/common/src/schemas/json/lightdash-dbt-2.0.json
+++ b/packages/common/src/schemas/json/lightdash-dbt-2.0.json
@@ -1002,30 +1002,37 @@
                                                         {
                                                             "type": "array",
                                                             "items": {
-                                                                "type": "string",
-                                                                "enum": [
-                                                                    "RAW",
-                                                                    "DAY",
-                                                                    "WEEK",
-                                                                    "MONTH",
-                                                                    "QUARTER",
-                                                                    "YEAR",
-                                                                    "HOUR",
-                                                                    "MINUTE",
-                                                                    "SECOND",
-                                                                    "MILLISECOND",
-                                                                    "WEEK_NUM",
-                                                                    "MONTH_NUM",
-                                                                    "MONTH_NAME",
-                                                                    "DAY_OF_WEEK_NAME",
-                                                                    "QUARTER_NAME",
-                                                                    "DAY_OF_WEEK_INDEX",
-                                                                    "DAY_OF_MONTH_NUM",
-                                                                    "DAY_OF_YEAR_NUM",
-                                                                    "QUARTER_NUM",
-                                                                    "YEAR_NUM",
-                                                                    "HOUR_OF_DAY_NUM",
-                                                                    "MINUTE_OF_HOUR_NUM"
+                                                                "anyOf": [
+                                                                    {
+                                                                        "type": "string",
+                                                                        "enum": [
+                                                                            "RAW",
+                                                                            "DAY",
+                                                                            "WEEK",
+                                                                            "MONTH",
+                                                                            "QUARTER",
+                                                                            "YEAR",
+                                                                            "HOUR",
+                                                                            "MINUTE",
+                                                                            "SECOND",
+                                                                            "MILLISECOND",
+                                                                            "WEEK_NUM",
+                                                                            "MONTH_NUM",
+                                                                            "MONTH_NAME",
+                                                                            "DAY_OF_WEEK_NAME",
+                                                                            "QUARTER_NAME",
+                                                                            "DAY_OF_WEEK_INDEX",
+                                                                            "DAY_OF_MONTH_NUM",
+                                                                            "DAY_OF_YEAR_NUM",
+                                                                            "QUARTER_NUM",
+                                                                            "YEAR_NUM",
+                                                                            "HOUR_OF_DAY_NUM",
+                                                                            "MINUTE_OF_HOUR_NUM"
+                                                                        ]
+                                                                    },
+                                                                    {
+                                                                        "type": "string"
+                                                                    }
                                                                 ]
                                                             }
                                                         },
@@ -1216,30 +1223,37 @@
                                                                 {
                                                                     "type": "array",
                                                                     "items": {
-                                                                        "type": "string",
-                                                                        "enum": [
-                                                                            "RAW",
-                                                                            "DAY",
-                                                                            "WEEK",
-                                                                            "MONTH",
-                                                                            "QUARTER",
-                                                                            "YEAR",
-                                                                            "HOUR",
-                                                                            "MINUTE",
-                                                                            "SECOND",
-                                                                            "MILLISECOND",
-                                                                            "WEEK_NUM",
-                                                                            "MONTH_NUM",
-                                                                            "MONTH_NAME",
-                                                                            "DAY_OF_WEEK_NAME",
-                                                                            "QUARTER_NAME",
-                                                                            "DAY_OF_WEEK_INDEX",
-                                                                            "DAY_OF_MONTH_NUM",
-                                                                            "DAY_OF_YEAR_NUM",
-                                                                            "QUARTER_NUM",
-                                                                            "YEAR_NUM",
-                                                                            "HOUR_OF_DAY_NUM",
-                                                                            "MINUTE_OF_HOUR_NUM"
+                                                                        "anyOf": [
+                                                                            {
+                                                                                "type": "string",
+                                                                                "enum": [
+                                                                                    "RAW",
+                                                                                    "DAY",
+                                                                                    "WEEK",
+                                                                                    "MONTH",
+                                                                                    "QUARTER",
+                                                                                    "YEAR",
+                                                                                    "HOUR",
+                                                                                    "MINUTE",
+                                                                                    "SECOND",
+                                                                                    "MILLISECOND",
+                                                                                    "WEEK_NUM",
+                                                                                    "MONTH_NUM",
+                                                                                    "MONTH_NAME",
+                                                                                    "DAY_OF_WEEK_NAME",
+                                                                                    "QUARTER_NAME",
+                                                                                    "DAY_OF_WEEK_INDEX",
+                                                                                    "DAY_OF_MONTH_NUM",
+                                                                                    "DAY_OF_YEAR_NUM",
+                                                                                    "QUARTER_NUM",
+                                                                                    "YEAR_NUM",
+                                                                                    "HOUR_OF_DAY_NUM",
+                                                                                    "MINUTE_OF_HOUR_NUM"
+                                                                                ]
+                                                                            },
+                                                                            {
+                                                                                "type": "string"
+                                                                            }
                                                                         ]
                                                                     }
                                                                 },

--- a/packages/common/src/schemas/json/lightdash-project-config-1.0.json
+++ b/packages/common/src/schemas/json/lightdash-project-config-1.0.json
@@ -133,6 +133,33 @@
                     ]
                 }
             }
+        },
+        "custom_granularities": {
+            "type": ["object", "null"],
+            "description": "Define reusable custom time granularities referenced in column time_intervals",
+            "patternProperties": {
+                "^[a-z0-9_]+$": {
+                    "type": "object",
+                    "properties": {
+                        "label": {
+                            "description": "Display name for the granularity",
+                            "type": "string"
+                        },
+                        "sql": {
+                            "description": "SQL template with ${COLUMN} placeholder that gets replaced with the base dimension SQL",
+                            "type": "string",
+                            "minLength": 1
+                        },
+                        "type": {
+                            "description": "Output dimension type (defaults to date)",
+                            "type": "string",
+                            "enum": ["date", "timestamp", "string"],
+                            "default": "date"
+                        }
+                    },
+                    "required": ["label", "sql"]
+                }
+            }
         }
     }
 }

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -656,6 +656,7 @@ export interface Dimension extends Field {
     anyAttributes?: Record<string, string | string[]>;
     timeInterval?: TimeFrames;
     timeIntervalBaseDimensionName?: string;
+    customTimeInterval?: string;
     isAdditionalDimension?: boolean;
     colors?: Record<string, string>;
     isIntervalBase?: boolean;

--- a/packages/common/src/types/lightdashProjectConfig.ts
+++ b/packages/common/src/types/lightdashProjectConfig.ts
@@ -52,11 +52,18 @@ export type ProjectDefaults = {
     // number_format?: string;
 };
 
+export type CustomGranularity = {
+    label: string;
+    sql: string;
+    type?: 'date' | 'timestamp' | 'string';
+};
+
 export type LightdashProjectConfig = {
     spotlight: SpotlightConfig;
     parameters?: Record<string, LightdashProjectParameter>; // keys must be ^[a-zA-Z0-9_-]+$
     warehouse?: WarehouseConfig; // Required for Lightdash-only projects (no dbt)
     defaults?: ProjectDefaults; // Project-wide defaults for various settings
+    custom_granularities?: Record<string, CustomGranularity>;
 };
 
 export const DEFAULT_SPOTLIGHT_CONFIG: SpotlightConfig = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/issues/20921

### Context

Users need custom time granularities (e.g., Monday-to-Sunday weeks, fiscal quarters) that appear in the date zoom dropdown alongside standard Day/Week/Month/Quarter/Year options.

We evaluated two approaches:
1. **Extending `additional_dimensions`** — add a `date_zoom: true` flag to existing additional dimensions. Minimal new surface area but per-column and harder to reuse across models.
2. **Dedicated `custom_granularities` config** — a new model-level section in the Lightdash YAML with `${COLUMN}` templates.

We chose **approach 2** because:
- Granularity definitions are **reusable** across columns via `${COLUMN}` templating
- A dedicated config surface makes it **easier to build features on top** (e.g., field picker grouping, explore integration)
- It keeps the concept separate from additional dimensions, which have different semantics

### Description
- Add `CustomGranularity` types and schemas for the new `custom_granularities` config
- Loosen the `time_intervals` type on date dimensions to accept custom granularity names alongside standard intervals