### PR TITLE
feat: introduce scheduler jobs provider

### DIFF
--- a/packages/frontend/src/App.tsx
+++ b/packages/frontend/src/App.tsx
@@ -18,6 +18,7 @@ import FullscreenProvider from './providers/Fullscreen/FullscreenProvider';
 import Mantine8Provider from './providers/Mantine8Provider';
 import MantineProvider from './providers/MantineProvider';
 import ReactQueryProvider from './providers/ReactQuery/ReactQueryProvider';
+import SchedulerJobsProvider from './providers/SchedulerJobs/SchedulerJobsProvider';
 import ThirdPartyProvider from './providers/ThirdPartyServicesProvider';
 import TrackingProvider from './providers/Tracking/TrackingProvider';
 import Routes from './Routes';
@@ -49,11 +50,13 @@ const router = sentryCreateBrowserRouter([
                             >
                                 <AbilityProvider>
                                     <ActiveJobProvider>
-                                        <ChartColorMappingContextProvider>
-                                            <SourceCodeEditorProvider>
-                                                <Outlet />
-                                            </SourceCodeEditorProvider>
-                                        </ChartColorMappingContextProvider>
+                                        <SchedulerJobsProvider>
+                                            <ChartColorMappingContextProvider>
+                                                <SourceCodeEditorProvider>
+                                                    <Outlet />
+                                                </SourceCodeEditorProvider>
+                                            </ChartColorMappingContextProvider>
+                                        </SchedulerJobsProvider>
                                     </ActiveJobProvider>
                                 </AbilityProvider>
                             </TrackingProvider>

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -35,7 +35,6 @@ import {
     IconSearch,
     IconTable,
 } from '@tabler/icons-react';
-import { useQueryClient } from '@tanstack/react-query';
 import cronstrue from 'cronstrue';
 import {
     MantineReactTable,
@@ -51,6 +50,7 @@ import {
 } from '../../hooks/usePreAggregateRefresh';
 import { useProject } from '../../hooks/useProject';
 import { useTimeAgo } from '../../hooks/useTimeAgo';
+import useSchedulerJobsContext from '../../providers/SchedulerJobs/useSchedulerJobsContext';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
@@ -159,14 +159,16 @@ const StatusFilter: FC<{
 
 const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
     const { isLoading: isLoadingProject } = useProject(projectUuid);
-    const queryClient = useQueryClient();
+    const { hasActiveJobs } = useSchedulerJobsContext();
     const { mutate: refreshAll, isLoading: isRefreshingAll } =
-        useRefreshAllPreAggregates(projectUuid);
+        useRefreshAllPreAggregates(projectUuid, { showToast: true });
     const {
         mutate: refreshByName,
         isLoading: isRefreshingOne,
         variables: refreshingDefinitionName,
-    } = useRefreshPreAggregateByDefinitionName(projectUuid);
+    } = useRefreshPreAggregateByDefinitionName(projectUuid, {
+        showToast: false,
+    });
     const [
         isRefreshModalOpen,
         { open: openRefreshModal, close: closeRefreshModal },
@@ -198,13 +200,6 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
         hasNextPage,
         isFetchingNextPage,
     } = usePreAggregateMaterializations(projectUuid);
-
-    const handleRefresh = () => {
-        void queryClient.invalidateQueries([
-            'preAggregateMaterializations',
-            projectUuid,
-        ]);
-    };
 
     useEffect(() => {
         if (hasNextPage && !isFetchingNextPage) {
@@ -540,16 +535,6 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                     <Text size="xs" c="dimmed">
                         {summary.active}/{summary.total} active
                     </Text>
-                    <Tooltip label="Refresh">
-                        <ActionIcon
-                            variant="subtle"
-                            color="gray"
-                            size="sm"
-                            onClick={handleRefresh}
-                        >
-                            <MantineIcon icon={IconRefresh} />
-                        </ActionIcon>
-                    </Tooltip>
                 </Group>
             </Group>
         ),
@@ -657,7 +642,7 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                             leftSection={
                                 <MantineIcon icon={IconRefresh} size="sm" />
                             }
-                            loading={isRefreshingAll}
+                            loading={isRefreshingAll || hasActiveJobs}
                             onClick={handleRefreshAllClick}
                         >
                             Refresh all

--- a/packages/frontend/src/hooks/usePreAggregateRefresh.ts
+++ b/packages/frontend/src/hooks/usePreAggregateRefresh.ts
@@ -1,7 +1,13 @@
 import { type ApiError } from '@lightdash/common';
+import { IconLayersIntersect } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
+import useSchedulerJobsContext from '../providers/SchedulerJobs/useSchedulerJobsContext';
 import useToaster from './toaster/useToaster';
+
+type RefreshOptions = {
+    showToast?: boolean;
+};
 
 const refreshAllPreAggregates = async (projectUuid: string) =>
     lightdashApi<{ jobIds: string[] }>({
@@ -10,24 +16,35 @@ const refreshAllPreAggregates = async (projectUuid: string) =>
         body: undefined,
     });
 
-export const useRefreshAllPreAggregates = (projectUuid: string) => {
-    const { showToastSuccess, showToastApiError } = useToaster();
+export const useRefreshAllPreAggregates = (
+    projectUuid: string,
+    options: RefreshOptions = {},
+) => {
+    const { showToast = true } = options;
+    const { showToastApiError } = useToaster();
+    const { registerJobs } = useSchedulerJobsContext();
     const queryClient = useQueryClient();
 
     return useMutation<{ jobIds: string[] }, ApiError>(
         () => refreshAllPreAggregates(projectUuid),
         {
             mutationKey: ['refreshAllPreAggregates', projectUuid],
-            onSuccess: async () => {
-                showToastSuccess({
-                    title: 'Pre-aggregate refresh started',
-                    subtitle:
-                        'All pre-aggregates are being refreshed in the background.',
+            onSuccess: (data) => {
+                registerJobs({
+                    jobIds: data.jobIds,
+                    showToast,
+                    toastKey: 'pre-aggregate-refresh',
+                    toastTitle: 'Pre-aggregate refresh',
+                    toastIcon: IconLayersIntersect,
+                    onComplete: () => {
+                        void queryClient.invalidateQueries({
+                            queryKey: [
+                                'preAggregateMaterializations',
+                                projectUuid,
+                            ],
+                        });
+                    },
                 });
-                await queryClient.invalidateQueries([
-                    'preAggregateMaterializations',
-                    projectUuid,
-                ]);
             },
             onError: ({ error }) => {
                 showToastApiError({
@@ -51,8 +68,11 @@ const refreshPreAggregateByDefinitionName = async (
 
 export const useRefreshPreAggregateByDefinitionName = (
     projectUuid: string,
+    options: RefreshOptions = {},
 ) => {
-    const { showToastApiError, showToastInfo } = useToaster();
+    const { showToast = true } = options;
+    const { showToastApiError } = useToaster();
+    const { registerJobs } = useSchedulerJobsContext();
     const queryClient = useQueryClient();
 
     return useMutation<{ jobIds: string[] }, ApiError, string>(
@@ -62,20 +82,24 @@ export const useRefreshPreAggregateByDefinitionName = (
                 preAggregateDefinitionName,
             ),
         {
-            mutationKey: [
-                'refreshPreAggregateByDefinitionName',
-                projectUuid,
-            ],
-            onSuccess: async () => {
-                showToastInfo({
-                    title: 'Pre-aggregate refresh started',
-                    subtitle:
-                        'The pre-aggregate is being refreshed in the background.',
+            mutationKey: ['refreshPreAggregateByDefinitionName', projectUuid],
+            onSuccess: (data, preAggregateDefinitionName) => {
+                registerJobs({
+                    jobIds: data.jobIds,
+                    label: preAggregateDefinitionName,
+                    showToast,
+                    toastKey: 'pre-aggregate-refresh',
+                    toastTitle: 'Pre-aggregate refresh',
+                    toastIcon: IconLayersIntersect,
+                    onComplete: () => {
+                        void queryClient.invalidateQueries({
+                            queryKey: [
+                                'preAggregateMaterializations',
+                                projectUuid,
+                            ],
+                        });
+                    },
                 });
-                await queryClient.invalidateQueries([
-                    'preAggregateMaterializations',
-                    projectUuid,
-                ]);
             },
             onError: ({ error }) => {
                 showToastApiError({

--- a/packages/frontend/src/providers/SchedulerJobs/JobProgressToastBody.tsx
+++ b/packages/frontend/src/providers/SchedulerJobs/JobProgressToastBody.tsx
@@ -1,0 +1,68 @@
+import { SchedulerJobStatus } from '@lightdash/common';
+import { Progress, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import { type TrackedJob } from './types';
+
+type Props = {
+    jobs: TrackedJob[];
+    label: string | null;
+};
+
+const JobProgressToastBody: FC<Props> = ({ jobs, label }) => {
+    const completedCount = jobs.filter(
+        (j) =>
+            j.status === SchedulerJobStatus.COMPLETED ||
+            j.status === SchedulerJobStatus.ERROR,
+    ).length;
+
+    const erroredCount = jobs.filter(
+        (j) => j.status === SchedulerJobStatus.ERROR,
+    ).length;
+
+    const successCount = completedCount - erroredCount;
+    const allDone = completedCount === jobs.length;
+
+    if (jobs.length === 1) {
+        if (allDone && erroredCount === 0) {
+            return <Text fz="xs">{label ?? 'Job'} completed</Text>;
+        }
+        if (allDone && erroredCount > 0) {
+            return (
+                <Text fz="xs" c="red">
+                    {label ?? 'Job'} failed
+                </Text>
+            );
+        }
+        return <Text fz="xs">{label ?? 'Job'} in progress...</Text>;
+    }
+
+    const progressPct =
+        jobs.length > 0 ? (successCount / jobs.length) * 100 : 0;
+    const errorPct = jobs.length > 0 ? (erroredCount / jobs.length) * 100 : 0;
+
+    return (
+        <>
+            {label && (
+                <Text fz="xs" ff="monospace" mb={4}>
+                    {label}
+                </Text>
+            )}
+            <Text fz="xs" mb={4}>
+                {completedCount} of {jobs.length} completed
+            </Text>
+            <Progress.Root size="sm">
+                <Progress.Section value={progressPct} color="green" />
+                {erroredCount > 0 && (
+                    <Progress.Section value={errorPct} color="red" />
+                )}
+            </Progress.Root>
+            {erroredCount > 0 && (
+                <Text fz="xs" c="red" mt={4}>
+                    {erroredCount} job{erroredCount === 1 ? '' : 's'} failed
+                </Text>
+            )}
+        </>
+    );
+};
+
+export default JobProgressToastBody;

--- a/packages/frontend/src/providers/SchedulerJobs/SchedulerJobsProvider.tsx
+++ b/packages/frontend/src/providers/SchedulerJobs/SchedulerJobsProvider.tsx
@@ -1,0 +1,244 @@
+import { SchedulerJobStatus } from '@lightdash/common';
+import { type Icon as TablerIconType } from '@tabler/icons-react';
+import { useQueries } from '@tanstack/react-query';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import MantineIcon from '../../components/common/MantineIcon';
+import { getSchedulerJobStatus } from '../../features/scheduler/hooks/useScheduler';
+import useToaster from '../../hooks/toaster/useToaster';
+import SchedulerJobsContext from './context';
+import JobProgressToastBody from './JobProgressToastBody';
+import { type RegisterJobsParams, type TrackedJob } from './types';
+
+type JobCallbacks = {
+    onComplete?: (jobId: string) => void;
+    onError?: (jobId: string, errorMessage: string) => void;
+};
+
+const TERMINAL_STATUSES = new Set<SchedulerJobStatus>([
+    SchedulerJobStatus.COMPLETED,
+    SchedulerJobStatus.ERROR,
+]);
+
+const DEFAULT_TOAST_KEY = 'scheduler-jobs-progress';
+
+const SchedulerJobsProvider: FC<React.PropsWithChildren> = ({ children }) => {
+    const [jobs, setJobs] = useState<TrackedJob[]>([]);
+    const [toastKey, setToastKey] = useState<string>(DEFAULT_TOAST_KEY);
+    const [toastTitle, setToastTitle] = useState<string | null>(null);
+    const [toastIcon, setToastIcon] = useState<TablerIconType | null>(null);
+    const [toastLabel, setToastLabel] = useState<string | null>(null);
+    const [showToastEnabled, setShowToastEnabled] = useState(false);
+
+    const callbacksRef = useRef<Map<string, JobCallbacks>>(new Map());
+    const processedRef = useRef<Map<string, SchedulerJobStatus>>(new Map());
+
+    const { showToastInfo, showToastSuccess, showToastError } = useToaster();
+
+    const activeJobs = useMemo(
+        () => jobs.filter((j) => !TERMINAL_STATUSES.has(j.status)),
+        [jobs],
+    );
+
+    const registerJobs = useCallback((params: RegisterJobsParams) => {
+        const { jobIds, onComplete, onError } = params;
+
+        const shouldShowToast = params.showToast !== false;
+        setShowToastEnabled(shouldShowToast);
+
+        if (shouldShowToast) {
+            if (params.toastKey) setToastKey(params.toastKey);
+            if (params.toastTitle) setToastTitle(params.toastTitle);
+            if (params.toastIcon) setToastIcon(() => params.toastIcon ?? null);
+        }
+
+        const now = new Date();
+
+        const newEntries: TrackedJob[] = jobIds.map((jobId) => ({
+            jobId,
+            status: SchedulerJobStatus.SCHEDULED,
+            startedAt: now,
+            errorMessage: null,
+        }));
+
+        newEntries.forEach((entry) => {
+            callbacksRef.current.set(entry.jobId, {
+                onComplete,
+                onError,
+            });
+        });
+
+        setJobs((prev) => {
+            const hasExistingActiveJobs = prev.some(
+                (j) => !TERMINAL_STATUSES.has(j.status),
+            );
+            // Clear label when multiple registrations happen (e.g. Promise.all)
+            // so the toast falls back to progress bar view
+            if (hasExistingActiveJobs) {
+                setToastLabel(null);
+            } else {
+                setToastLabel(params.label ?? null);
+            }
+
+            const existingIds = new Set(prev.map((j) => j.jobId));
+            const fresh = newEntries.filter((e) => !existingIds.has(e.jobId));
+            return [...prev, ...fresh];
+        });
+    }, []);
+
+    // Poll active jobs
+    const queryResults = useQueries({
+        queries: activeJobs.map((job) => ({
+            queryKey: ['schedulerJobStatus', job.jobId],
+            queryFn: () => getSchedulerJobStatus(job.jobId),
+            refetchInterval: 2000,
+            enabled: !TERMINAL_STATUSES.has(job.status),
+        })),
+    });
+
+    useEffect(() => {
+        queryResults.forEach((result, index) => {
+            if (!result.data) return;
+
+            const job = activeJobs[index];
+            if (!job) return;
+
+            const prevStatus = processedRef.current.get(job.jobId);
+            if (prevStatus === result.data.status) return;
+
+            processedRef.current.set(job.jobId, result.data.status);
+
+            const newStatus = result.data.status;
+            const details = result.data.details;
+
+            const errorMessage =
+                newStatus === SchedulerJobStatus.ERROR
+                    ? ((details?.error as string) ?? 'Unknown error')
+                    : null;
+
+            setJobs((prev) =>
+                prev.map((j) => {
+                    if (j.jobId !== job.jobId) return j;
+                    if (j.status === newStatus) return j;
+                    return {
+                        ...j,
+                        status: newStatus,
+                        errorMessage: errorMessage ?? j.errorMessage,
+                    };
+                }),
+            );
+
+            if (TERMINAL_STATUSES.has(newStatus)) {
+                const callbacks = callbacksRef.current.get(job.jobId);
+                if (callbacks) {
+                    if (
+                        newStatus === SchedulerJobStatus.COMPLETED &&
+                        callbacks.onComplete
+                    ) {
+                        callbacks.onComplete(job.jobId);
+                    }
+                    if (
+                        newStatus === SchedulerJobStatus.ERROR &&
+                        callbacks.onError
+                    ) {
+                        callbacks.onError(
+                            job.jobId,
+                            errorMessage ?? 'Unknown error',
+                        );
+                    }
+                }
+            }
+        });
+    }, [queryResults, activeJobs]);
+
+    // Show/update toast based on job progress
+    useEffect(() => {
+        if (!showToastEnabled || jobs.length === 0) return;
+
+        const completedCount = jobs.filter((j) =>
+            TERMINAL_STATUSES.has(j.status),
+        ).length;
+        const erroredCount = jobs.filter(
+            (j) => j.status === SchedulerJobStatus.ERROR,
+        ).length;
+        const allDone = completedCount === jobs.length;
+
+        const title = toastTitle ?? 'Background jobs';
+        const icon = toastIcon ? (
+            <MantineIcon icon={toastIcon} size="xl" />
+        ) : undefined;
+
+        if (allDone) {
+            if (erroredCount > 0) {
+                showToastError({
+                    key: toastKey,
+                    title,
+                    icon,
+                    subtitle: (
+                        <JobProgressToastBody jobs={jobs} label={toastLabel} />
+                    ),
+                    autoClose: 8000,
+                });
+            } else {
+                showToastSuccess({
+                    key: toastKey,
+                    title,
+                    icon,
+                    subtitle: (
+                        <JobProgressToastBody jobs={jobs} label={toastLabel} />
+                    ),
+                    autoClose: 5000,
+                });
+            }
+            // Clear jobs after all done
+            setJobs([]);
+            setShowToastEnabled(false);
+        } else {
+            showToastInfo({
+                key: toastKey,
+                title,
+                icon,
+                loading: true,
+                autoClose: false,
+                subtitle: (
+                    <JobProgressToastBody jobs={jobs} label={toastLabel} />
+                ),
+            });
+        }
+    }, [
+        jobs,
+        showToastEnabled,
+        toastKey,
+        toastTitle,
+        toastIcon,
+        toastLabel,
+        showToastInfo,
+        showToastSuccess,
+        showToastError,
+    ]);
+
+    const hasActiveJobs = activeJobs.length > 0;
+
+    const contextValue = useMemo(
+        () => ({
+            jobs,
+            registerJobs,
+            hasActiveJobs,
+        }),
+        [jobs, registerJobs, hasActiveJobs],
+    );
+
+    return (
+        <SchedulerJobsContext.Provider value={contextValue}>
+            {children}
+        </SchedulerJobsContext.Provider>
+    );
+};
+
+export default SchedulerJobsProvider;

--- a/packages/frontend/src/providers/SchedulerJobs/context.ts
+++ b/packages/frontend/src/providers/SchedulerJobs/context.ts
@@ -1,0 +1,8 @@
+import { createContext } from 'react';
+import { type SchedulerJobsContextType } from './types';
+
+const SchedulerJobsContext = createContext<SchedulerJobsContextType>(
+    undefined as any,
+);
+
+export default SchedulerJobsContext;

--- a/packages/frontend/src/providers/SchedulerJobs/types.ts
+++ b/packages/frontend/src/providers/SchedulerJobs/types.ts
@@ -1,0 +1,26 @@
+import { type SchedulerJobStatus } from '@lightdash/common';
+import { type Icon as TablerIconType } from '@tabler/icons-react';
+
+export type TrackedJob = {
+    jobId: string;
+    status: SchedulerJobStatus;
+    startedAt: Date;
+    errorMessage: string | null;
+};
+
+export type RegisterJobsParams = {
+    jobIds: string[];
+    label?: string;
+    showToast?: boolean;
+    toastKey?: string;
+    toastTitle?: string;
+    toastIcon?: TablerIconType;
+    onComplete?: (jobId: string) => void;
+    onError?: (jobId: string, errorMessage: string) => void;
+};
+
+export type SchedulerJobsContextType = {
+    jobs: TrackedJob[];
+    registerJobs: (params: RegisterJobsParams) => void;
+    hasActiveJobs: boolean;
+};

--- a/packages/frontend/src/providers/SchedulerJobs/useSchedulerJobsContext.ts
+++ b/packages/frontend/src/providers/SchedulerJobs/useSchedulerJobsContext.ts
@@ -1,0 +1,15 @@
+import { useContext } from 'react';
+import SchedulerJobsContext from './context';
+import { type SchedulerJobsContextType } from './types';
+
+function useSchedulerJobsContext(): SchedulerJobsContextType {
+    const context = useContext(SchedulerJobsContext);
+    if (context === undefined) {
+        throw new Error(
+            'useSchedulerJobsContext must be used within a SchedulerJobsProvider',
+        );
+    }
+    return context;
+}
+
+export default useSchedulerJobsContext;


### PR DESCRIPTION
### Description:

Added a new `SchedulerJobsProvider` context to track and display progress of background scheduler jobs with toast notifications.

This pr also uses this new provider to display status about pre-aggregates jobs



[CleanShot 2026-03-05 at 19.06.57.mp4 <span class="graphite__hidden">(uploaded via Graphite)</span> <img class="graphite__hidden" src="https://app.graphite.com/user-attachments/thumbnails/47da5148-695b-42cf-8860-b1d6ef7c7f7c.mp4" />](https://app.graphite.com/user-attachments/video/47da5148-695b-42cf-8860-b1d6ef7c7f7c.mp4)

