### PR TITLE
feat: add failure count to dashboard CSV export with warning toast

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3861,7 +3861,7 @@ export default class SchedulerTask {
                     },
                 });
 
-                return { url };
+                return { url, numFailures: failedCount };
             },
         );
     }

--- a/packages/frontend/src/hooks/dashboard/useDashboard.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboard.ts
@@ -263,6 +263,7 @@ export const useExportCsvDashboard = () => {
         showToastError,
         showToastApiError,
         showToastInfo,
+        showToastWarning,
     } = useToaster();
 
     return useMutation<
@@ -306,10 +307,23 @@ export const useExportCsvDashboard = () => {
                             document.body.appendChild(link);
                             link.click();
                             link.remove(); // Remove the link from the DOM
-                            showToastSuccess({
-                                key: 'dashboard_export_toast',
-                                title: `Success! ${data.dashboard.name} was exported.`,
-                            });
+
+                            const numFailures = Number(
+                                details.numFailures ?? 0,
+                            );
+                            if (numFailures > 0) {
+                                showToastWarning({
+                                    key: 'dashboard_export_toast',
+                                    title: `${data.dashboard.name} was exported with ${numFailures} failed chart(s).`,
+                                    subtitle:
+                                        'Some charts could not be exported. The download contains only the successful ones.',
+                                });
+                            } else {
+                                showToastSuccess({
+                                    key: 'dashboard_export_toast',
+                                    title: `Success! ${data.dashboard.name} was exported.`,
+                                });
+                            }
                         } else {
                             showToastError({
                                 key: 'dashboard_export_toast',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: GLITCH-183

### Description:

Added failure tracking and improved user feedback for dashboard CSV exports. The backend now returns the number of failed charts in the export response, and the frontend displays appropriate toast notifications based on the export results.

When all charts export successfully, users see the existing success message. When some charts fail to export, users receive a warning toast indicating how many charts failed and explaining that the download contains only the successful exports.

<!-- Even better add a screenshot / gif / loom -->