### PR TITLE
chore: clean turbo cache in build cache script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,9 @@ http-client.private.env.json
 # turbo
 .turbo
 
+# janix
+.janix
+
 # HAR replay
 scripts/har-replay-server.ts
 *.har

--- a/scripts/clean-build-cache.sh
+++ b/scripts/clean-build-cache.sh
@@ -3,6 +3,9 @@
 # Remove tsbuildinfo files
 rm -rf packages/*/tsconfig*.tsbuildinfo
 
+# Remove turbo cache
+rm -rf .turbo
+
 # Remove build/dist and next build cache
 rm -rf packages/*/build
 rm -rf packages/*/dist


### PR DESCRIPTION
### Description:
Added turbo cache cleanup to the build cache cleaning script. The script now removes the `.turbo` directory along with the existing TypeScript build info files and package build/dist directories.