### PR TITLE
fix: bar-in-cell colors in pivot tables use configured color

### DIFF
--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -111,12 +111,15 @@ const formatBarDisplayCell = (
     const columnId = info.column.id;
     const columnProperties = info.table?.options.meta?.columnProperties;
     const minMaxMap = info.table?.options.meta?.minMaxMap;
-    const color = columnProperties?.[columnId]?.color;
 
     // For pivot tables, get the base field ID from the item in meta
     // This is needed because pivoted columns have different IDs than the base field
     const item = info.column.columnDef.meta?.item;
     const baseFieldId = item ? getItemId(item) : columnId;
+
+    const color =
+        columnProperties?.[baseFieldId]?.color ??
+        columnProperties?.[columnId]?.color;
 
     let formatted, value: number;
 


### PR DESCRIPTION
## Summary

- Fixes bar-in-cell color always showing default blue (#5470c6) in pivot tables instead of the configured color, users were not able to change this.
- The color lookup used the pivoted column ID (e.g. `metric_pivotValue`) but `columnProperties` is keyed by the base field ID (e.g. `metric`), so the lookup always failed
- Now tries `baseFieldId` first then falls back to `columnId`, matching the existing `minMaxMap` pattern on the same function

Fixes PROD-5788
Closes #20894

See below screenshot where bars are changed to red, which isn't possible right now in the live app.

<img width="1489" height="492" alt="image" src="https://github.com/user-attachments/assets/118cb127-abf6-41df-b397-f60136f449aa" />


## Test plan

- [x] Open a pivot table with bar-in-cell display enabled and a custom color configured
- [x] Verify bars show the configured color instead of default blue
- [x] Verify non-pivoted tables still display the correct configured color
- [x] Verify tables with no custom color still default to blue

🤖 Generated with [Claude Code](https://claude.com/claude-code)