### PR TITLE
fix: subtotal rows show '-' when all underlying values have no result

### DIFF
--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -65,8 +65,14 @@ export function getGroupingValuesAndSubtotalKey(
 export function getSubtotalValueFromGroup(
     subtotal: Record<string, number> | undefined,
     columnId: string,
-) {
-    const subtotalColumnIds = Object.keys(subtotal ?? {});
+): number | null | undefined {
+    // No matching subtotal record exists (no data for this combination)
+    // Return undefined so formatItemValue will show '-'
+    if (subtotal === undefined) {
+        return undefined;
+    }
+
+    const subtotalColumnIds = Object.keys(subtotal);
 
     // If the subtotal column is not in the subtotalsGroup, return null
     // This is needed to prevent showing '-' when processing a value for the last grouped dimension column which is not taken into account for subtotals
@@ -75,7 +81,9 @@ export function getSubtotalValueFromGroup(
         return null;
     }
 
-    return subtotal?.[columnId];
+    // Convert null to undefined so formatItemValue shows '-' instead of '∅'
+    // SQL returns null when all aggregated values are null (no data)
+    return subtotal[columnId] ?? undefined;
 }
 
 const getImageSize = (item: ItemsMap[string] | undefined) => {


### PR DESCRIPTION
## Summary

Fixes #20900 - the issue being end users were confused when sub total values were just blank. this introduces a '-' instead. See the screenshot below where there is completely blank field that leads to confusion:

<img width="2186" height="560" alt="image" src="https://github.com/user-attachments/assets/b047bfc5-05aa-40c7-be0d-b85e3739d83a" />

- `getSubtotalValueFromGroup` previously returned `null` for both "column not applicable for subtotals" (e.g. the last grouped dimension column) and "no data for this combination" (no matching subtotal record, or SQL null from aggregating all nulls). The PivotTable treated all `null` returns as "don't render", producing blank cells.
- Now the function distinguishes the two cases:
  - `null` → column not applicable (render nothing, preserving existing behavior)
  - `undefined` → no data (`formatItemValue` renders `'-'`, matching regular row behavior)

## Test plan

- [ ] Create a pivot table with subtotals enabled where some pivoted columns have no data (shown as `-` in raw rows)
- [ ] Verify subtotal rows now show `-` for those columns instead of blank
- [ ] Verify subtotal rows still show correct aggregated values where data exists
- [ ] Verify the last grouped dimension column still shows nothing (not `-`) when expanding groups

🤖 Generated with [Claude Code](https://claude.com/claude-code)