### PR TITLE
fix: re-create soft-deleted space with cli upload

### DIFF
--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -939,6 +939,7 @@ export class SpaceModel {
             )
             .whereRaw('?::ltree <@ path', [path])
             .andWhere(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNull(`${SpaceTableName}.deleted_at`)
             .orderByRaw('nlevel(path) DESC')
             .first();
 


### PR DESCRIPTION
### Description:
When a space was soft-deleted and you execute the cli `upload --force` (to re-create it), it fails with:

```
Error upserting dashboards:
	"Dashi" (slug: "dashi")
	Space with spaceUuid 972e8d0a-a442-4e7b-a36e-23e308d18a98 does not exist
```

This was due to:
1. spaceModel.find() correctly excluded the soft-deleted space → CREATE path
2. findClosestAncestorByPath() found the soft-deleted space as an ancestor (no deleted_at filter)
3. getSpaceSummary() on that UUID failed because it correctly filters out deleted spaces


One caveat is that the space is re-created, meaning that the originally soft-deleted space is still soft-deleted. But changing that behavior might be a bit overkill for a quick hotfix.
