### PR TITLE
fix: loosen gchat notification

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -4823,10 +4823,6 @@ export default class SchedulerTask {
         });
 
         try {
-            if (!this.lightdashConfig.googleChat.enabled) {
-                throw new MissingConfigError('Google Chat is not configured');
-            }
-
             const {
                 format,
                 savedChartUuid,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: **#20910**<!-- reference the related issue e.g. #150 -->

### Description:

Removed the Google Chat configuration validation check from the SchedulerTask. The task will no longer throw a `MissingConfigError` when Google Chat is not enabled in the lightdash configuration.

<!-- Even better add a screenshot / gif / loom -->