### PR TITLE
feat: add nested aggregate CTE support for metrics

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -301,3 +301,39 @@ models:
               type: number
               description: "Count of events where event is song_played using TABLE reference"
               sql: count(case when ${TABLE}.event = 'song_played' then 1 end)
+            # --- Nested aggregate test metrics ---
+            # Inner aggregate metric (similar to the customer's ltv_12m_gbp_new_metric)
+            max_event_id:
+              type: max
+              description: "Maximum event ID per group"
+            # Nested aggregate: type:number wrapping aggregate metric reference
+            # This pattern currently fails with "Aggregate functions cannot be nested"
+            # because it compiles to SUM(MAX("events"."event_id")) which is invalid SQL
+            sum_of_max_event_id:
+              type: number
+              description: "Sum of max event IDs - nested aggregate pattern (SUM wrapping MAX)"
+              sql: sum(${max_event_id})
+            # More complex nested aggregate with division (matches customer pattern)
+            avg_max_event_id:
+              type: number
+              description: "Average of max event IDs - sum(max_metric) / count_metric"
+              sql: sum(${max_event_id}) / NULLIF(${unique_event_count}, 0)
+            # COUNT(DISTINCT) wrapping aggregate metric (PROD-5657: 1 chart with this pattern)
+            count_distinct_of_max:
+              type: number
+              description: "Count distinct of max event IDs - COUNT(DISTINCT MAX(...)) pattern"
+              sql: count(distinct ${max_event_id})
+            # Conditional SUM wrapping aggregate metric (common Looker migration pattern)
+            # e.g. SUM(CASE WHEN condition THEN ${aggregate_metric} END)
+            conditional_sum_of_max:
+              type: number
+              description: "Conditional sum of max event IDs - SUM(CASE WHEN ... THEN MAX(...) END)"
+              sql: sum(case when ${max_event_id} > 100 then ${max_event_id} else 0 end)
+            # Multiplication of two aggregate metrics (customer LTV pattern)
+            # This does NOT produce nested aggregation - it compiles to MAX(...) * COUNT(DISTINCT ...)
+            # which is valid SQL (sibling aggregates, not nested). No CTE needed.
+            product_of_aggregates:
+              type: number
+              group: "aggregates"
+              description: "Product of two aggregate metrics - valid SQL, no nesting"
+              sql: ${max_event_id} * ${unique_event_count}

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -2537,3 +2537,226 @@ WHERE ((
 GROUP BY 1
 ORDER BY "orders_created_at"
 LIMIT 10`;
+
+// ---- Nested aggregate test fixtures ----
+// Explore with a type:number metric that wraps an aggregate metric reference
+// This creates the nested aggregate pattern: SUM(MAX(...))
+export const EXPLORE_WITH_NESTED_AGG: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'my_table',
+    label: 'my_table',
+    baseTable: 'my_table',
+    tags: [],
+    joinedTables: [],
+    tables: {
+        my_table: {
+            name: 'my_table',
+            label: 'my_table',
+            database: 'db',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."my_table"',
+            primaryKey: ['id'],
+            dimensions: {
+                category: {
+                    type: DimensionType.STRING,
+                    name: 'category',
+                    label: 'category',
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.category',
+                    compiledSql: '"my_table".category',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                max_value: {
+                    type: MetricType.MAX,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'max_value',
+                    label: 'max_value',
+                    sql: '${TABLE}.value',
+                    compiledSql: 'MAX("my_table".value)',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+                count_records: {
+                    type: MetricType.COUNT,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'count_records',
+                    label: 'count_records',
+                    sql: '${TABLE}.id',
+                    compiledSql: 'COUNT("my_table".id)',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+                // type:number with aggregation wrapping an aggregate metric reference
+                // This compiles to SUM(MAX(...)) which is invalid SQL
+                sum_of_max: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'sum_of_max',
+                    label: 'sum_of_max',
+                    sql: 'sum(${max_value})',
+                    compiledSql: 'SUM(MAX("my_table".value))',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+                // More complex: aggregation wrapping metric ref + division by another metric
+                avg_of_max: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'avg_of_max',
+                    label: 'avg_of_max',
+                    sql: 'sum(${max_value}) / NULLIF(${count_records}, 0)',
+                    compiledSql:
+                        'SUM(MAX("my_table".value)) / NULLIF(COUNT("my_table".id), 0)',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+                // COUNT(DISTINCT) wrapping aggregate metric (PROD-5657: 1 chart)
+                count_distinct_of_max: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'count_distinct_of_max',
+                    label: 'count_distinct_of_max',
+                    sql: 'count(distinct ${max_value})',
+                    compiledSql: 'COUNT(DISTINCT MAX("my_table".value))',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+                // Conditional SUM wrapping aggregate metric (Looker migration pattern)
+                conditional_sum_of_max: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'conditional_sum_of_max',
+                    label: 'conditional_sum_of_max',
+                    sql: 'sum(case when ${max_value} > 100 then ${max_value} else 0 end)',
+                    compiledSql:
+                        'SUM(CASE WHEN MAX("my_table".value) > 100 THEN MAX("my_table".value) ELSE 0 END)',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+                // Product of aggregates - NO outer aggregation, valid SQL without CTE
+                product_of_aggregates: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'product_of_aggregates',
+                    label: 'product_of_aggregates',
+                    sql: '${max_value} * ${count_records}',
+                    compiledSql: 'MAX("my_table".value) * COUNT("my_table".id)',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+export const METRIC_QUERY_NESTED_AGG_WITH_DIMS: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['my_table_category'],
+    metrics: ['my_table_sum_of_max'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_sum_of_max', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+export const METRIC_QUERY_NESTED_AGG_NO_DIMS: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: [],
+    metrics: ['my_table_sum_of_max'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_sum_of_max', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+export const METRIC_QUERY_NESTED_AGG_COMPLEX: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['my_table_category'],
+    metrics: ['my_table_avg_of_max'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_avg_of_max', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+export const METRIC_QUERY_NESTED_AGG_COUNT_DISTINCT: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['my_table_category'],
+    metrics: ['my_table_count_distinct_of_max'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_count_distinct_of_max', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+export const METRIC_QUERY_NESTED_AGG_CONDITIONAL: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['my_table_category'],
+    metrics: ['my_table_conditional_sum_of_max'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_conditional_sum_of_max', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+export const METRIC_QUERY_NESTED_AGG_PRODUCT: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['my_table_category'],
+    metrics: ['my_table_product_of_aggregates'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_product_of_aggregates', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+// Mixed: nested agg metric + non-nested metric together (reproduces GROUP BY issue)
+export const METRIC_QUERY_NESTED_AGG_MIXED: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: [],
+    metrics: ['my_table_sum_of_max', 'my_table_product_of_aggregates'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_sum_of_max', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -42,6 +42,7 @@ import {
     EXPLORE_WITH_CROSS_TABLE_METRICS,
     EXPLORE_WITH_DATE_DIMENSION,
     EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
+    EXPLORE_WITH_NESTED_AGG,
     EXPLORE_WITH_REQUIRED_FILTERS,
     EXPLORE_WITH_SQL_FILTER,
     EXPLORE_WITH_SUM_DISTINCT,
@@ -55,6 +56,13 @@ import {
     METRIC_QUERY_CROSS_TABLE,
     METRIC_QUERY_JOIN_CHAIN,
     METRIC_QUERY_JOIN_CHAIN_SQL,
+    METRIC_QUERY_NESTED_AGG_COMPLEX,
+    METRIC_QUERY_NESTED_AGG_CONDITIONAL,
+    METRIC_QUERY_NESTED_AGG_COUNT_DISTINCT,
+    METRIC_QUERY_NESTED_AGG_MIXED,
+    METRIC_QUERY_NESTED_AGG_NO_DIMS,
+    METRIC_QUERY_NESTED_AGG_PRODUCT,
+    METRIC_QUERY_NESTED_AGG_WITH_DIMS,
     METRIC_QUERY_SQL,
     METRIC_QUERY_SQL_BIGQUERY,
     METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
@@ -4480,5 +4488,150 @@ describe('Default sort behavior', () => {
 
         // Should have no ORDER BY clause at all
         expect(result.query).not.toContain('ORDER BY');
+    });
+});
+
+describe('Nested aggregate metrics', () => {
+    test('should generate nested_agg CTE for metrics with nested aggregates and dimensions', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_WITH_DIMS,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should contain both CTEs
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).toContain('nested_agg_results AS (');
+        // CTE 1 should compute the inner metric
+        expect(result.query).toContain(
+            'MAX("my_table".value) AS "my_table_max_value"',
+        );
+        // Final query should NOT contain nested aggregate
+        expect(result.query).not.toContain('SUM(MAX(');
+        // Results CTE should reference CTE 1 columns
+        expect(result.query).toContain('nested_agg."my_table_max_value"');
+        // Outer SELECT should reference nested_agg_results (no aggregates)
+        expect(result.query).toContain('INNER JOIN nested_agg_results ON');
+        expect(result.query).toContain(
+            'nested_agg_results."my_table_sum_of_max"',
+        );
+    });
+
+    test('should select FROM nested_agg when no dimensions are selected', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_NO_DIMS,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).not.toContain('SUM(MAX(');
+        // With no dimensions and no other metrics, selects directly from the CTE
+        expect(result.query).toContain('FROM nested_agg');
+    });
+
+    test('should handle complex nested aggregate with mixed refs (agg + non-agg)', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_COMPLEX,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should contain the nested_agg CTE
+        expect(result.query).toContain('nested_agg AS (');
+        // Should NOT contain nested aggregate
+        expect(result.query).not.toContain('SUM(MAX(');
+        // The count_records metric ref (non-nested) should still compile normally
+        expect(result.query).toContain('COUNT("my_table".id)');
+    });
+
+    test('should handle COUNT(DISTINCT) wrapping aggregate metric (PROD-5657)', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_COUNT_DISTINCT,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should contain both CTEs
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).toContain('nested_agg_results AS (');
+        // CTE 1 should compute the inner metric
+        expect(result.query).toContain(
+            'MAX("my_table".value) AS "my_table_max_value"',
+        );
+        // Should NOT contain nested aggregate COUNT(DISTINCT MAX(...))
+        expect(result.query).not.toContain('COUNT(DISTINCT MAX(');
+        // Results CTE should reference CTE 1 columns
+        expect(result.query).toContain('nested_agg."my_table_max_value"');
+        // Outer SELECT should reference nested_agg_results (no aggregates)
+        expect(result.query).toContain(
+            'nested_agg_results."my_table_count_distinct_of_max"',
+        );
+    });
+
+    test('should handle conditional SUM wrapping aggregate metric', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_CONDITIONAL,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should contain the nested_agg CTE
+        expect(result.query).toContain('nested_agg AS (');
+        // Should NOT contain nested aggregate SUM(CASE WHEN MAX(...)...)
+        expect(result.query).not.toContain('SUM(CASE WHEN MAX(');
+        // Should reference the CTE column in the outer SQL
+        expect(result.query).toContain('nested_agg."my_table_max_value"');
+    });
+
+    test('should NOT generate CTE for product of aggregates (no outer aggregation)', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_PRODUCT,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should NOT contain nested_agg CTE — no outer aggregation wrapping
+        expect(result.query).not.toContain('nested_agg AS (');
+        // SQL is valid: MAX(...) * COUNT(...) — sibling aggregates, not nested
+        expect(result.query).toContain('MAX("my_table".value)');
+        expect(result.query).toContain('COUNT("my_table".id)');
+    });
+
+    test('should route non-wrapping aggregate-referencing metrics through CTE when mixed with wrapping metrics', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_MIXED,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should contain both CTEs
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).toContain('nested_agg_results AS (');
+        // Should NOT contain nested aggregate
+        expect(result.query).not.toContain('SUM(MAX(');
+        // Results CTE should compute product_of_aggregates using CTE refs
+        expect(result.query).toContain('nested_agg."my_table_max_value"');
+        // Outer SELECT should reference nested_agg_results columns (no aggregates)
+        expect(result.query).toContain(
+            'nested_agg_results."my_table_product_of_aggregates"',
+        );
+        expect(result.query).toContain(
+            'nested_agg_results."my_table_sum_of_max"',
+        );
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -29,6 +29,7 @@ import {
     hasPivotFunctions,
     hasRowFunctions,
     IntrinsicUserAttributes,
+    isAggregateMetricType,
     isAndFilterGroup,
     isCompiledCustomSqlDimension,
     isCustomBinDimension,
@@ -50,6 +51,7 @@ import {
     renderTableCalculationFilterRuleSql,
     snakeCaseName,
     SortField,
+    sqlContainsAggregation,
     SupportedDbtAdapter,
     TableCalculationFunctionCompiler,
     TimeFrames,
@@ -877,6 +879,11 @@ export class MetricQueryBuilder {
 
         const selects = new Set<string>();
         const tables = new Set<string>();
+        const nestedAggOuterIds = new Set(
+            this.getMetricsWithNestedAggregates().map(
+                ({ outerMetricId }) => outerMetricId,
+            ),
+        );
         metrics.forEach((field) => {
             try {
                 const alias = field;
@@ -887,6 +894,13 @@ export class MetricQueryBuilder {
                     metric.type === MetricType.AVERAGE_DISTINCT
                 ) {
                     // Still track table references for JOIN generation
+                    (metric.tablesReferences || [metric.table]).forEach(
+                        (table) => tables.add(table),
+                    );
+                    return;
+                }
+                // Metrics with nested aggregate dependencies are handled via CTE
+                if (nestedAggOuterIds.has(field)) {
                     (metric.tablesReferences || [metric.table]).forEach(
                         (table) => tables.add(table),
                     );
@@ -2390,6 +2404,295 @@ export class MetricQueryBuilder {
         return { ctes, ddJoins, ddMetricSelects };
     }
 
+    /**
+     * Detects metrics that have nested aggregate problems.
+     * A metric has a nested aggregate problem when:
+     * 1. It is a non-aggregate metric (type: number, etc.)
+     * 2. Its raw SQL contains aggregation functions (sqlContainsAggregation)
+     * 3. It references another metric that is an aggregate type (sum, max, count, etc.)
+     */
+    private getMetricsWithNestedAggregates(): Array<{
+        outerMetricId: string;
+        outerMetric: CompiledMetric;
+        wrapsAggregation: boolean;
+        innerDeps: Array<{
+            fieldId: string;
+            metric: CompiledMetric;
+        }>;
+    }> {
+        if (this._nestedAggCache !== undefined) {
+            return this._nestedAggCache;
+        }
+
+        // First pass: find metrics with explicit SQL aggregation wrapping aggregate refs
+        // (the core nested aggregate pattern, e.g., sum(${max_metric}))
+        const allMetricIds = this.getSelectedAndReferencedMetricIds();
+
+        const findAggRefMetrics = (
+            requireSqlAggregation: boolean,
+        ): Array<{
+            outerMetricId: string;
+            outerMetric: CompiledMetric;
+            wrapsAggregation: boolean;
+            innerDeps: Array<{ fieldId: string; metric: CompiledMetric }>;
+        }> =>
+            allMetricIds.reduce<
+                Array<{
+                    outerMetricId: string;
+                    outerMetric: CompiledMetric;
+                    wrapsAggregation: boolean;
+                    innerDeps: Array<{
+                        fieldId: string;
+                        metric: CompiledMetric;
+                    }>;
+                }>
+            >((acc, metricId) => {
+                let metric: CompiledMetric;
+                try {
+                    metric = this.getMetricFromId(metricId);
+                } catch {
+                    return acc;
+                }
+                if (!isNonAggregateMetric(metric)) return acc;
+
+                const hasSqlAgg = sqlContainsAggregation(metric.sql);
+                if (requireSqlAggregation && !hasSqlAgg) return acc;
+
+                const refs = parseAllReferences(metric.sql, metric.table);
+                // Collect all metric references — both aggregate (type: max/sum/etc)
+                // and non-aggregate with SQL aggregation (type: number with count(...))
+                // because ALL metric refs need CTE pre-computation to avoid
+                // referencing the base table in the outer query context.
+                const allMetricDeps: Array<{
+                    fieldId: string;
+                    metric: CompiledMetric;
+                }> = [];
+                let hasAggregateRef = false;
+                for (const ref of refs) {
+                    if (ref.refName !== 'TABLE') {
+                        const refMetricId = getItemId({
+                            table: ref.refTable,
+                            name: ref.refName,
+                        });
+                        try {
+                            const refMetric = this.getMetricFromId(refMetricId);
+                            allMetricDeps.push({
+                                fieldId: refMetricId,
+                                metric: refMetric,
+                            });
+                            if (isAggregateMetricType(refMetric.type)) {
+                                hasAggregateRef = true;
+                            }
+                        } catch {
+                            // Not a metric reference (could be a dimension), skip
+                        }
+                    }
+                }
+                // Only treat as nested aggregate if at least one ref is an
+                // aggregate metric type (to avoid pulling in normal
+                // type:number → type:number chains)
+                const innerDeps = hasAggregateRef ? allMetricDeps : [];
+
+                if (innerDeps.length > 0) {
+                    acc.push({
+                        outerMetricId: metricId,
+                        outerMetric: metric,
+                        wrapsAggregation: hasSqlAgg,
+                        innerDeps,
+                    });
+                }
+                return acc;
+            }, []);
+
+        // First: find metrics that truly nest aggregates (have SQL aggregation wrapping)
+        const wrappingMetrics = findAggRefMetrics(true);
+
+        // If there are wrapping metrics, also include non-wrapping metrics that
+        // reference aggregates (e.g., ${max_metric} * ${count_metric}).
+        // These are valid SQL alone but need CTE routing when mixed with
+        // wrapping metrics to avoid GROUP BY issues in the outer query.
+        let result: typeof wrappingMetrics;
+        if (wrappingMetrics.length > 0) {
+            const allAggRefMetrics = findAggRefMetrics(false);
+            result = allAggRefMetrics;
+        } else {
+            result = wrappingMetrics;
+        }
+
+        this._nestedAggCache = result;
+        return result;
+    }
+
+    private _nestedAggCache:
+        | Array<{
+              outerMetricId: string;
+              outerMetric: CompiledMetric;
+              wrapsAggregation: boolean;
+              innerDeps: Array<{ fieldId: string; metric: CompiledMetric }>;
+          }>
+        | undefined = undefined;
+
+    /**
+     * Builds two CTEs for metrics that have nested aggregate dependencies.
+     *
+     * CTE 1 (`nested_agg`): Pre-computes inner aggregate metrics (e.g., MAX, COUNT)
+     * at the dimension grain from the base table.
+     *
+     * CTE 2 (`nested_agg_results`): Computes the outer metric expressions
+     * (e.g., sum(max_col) / count_col) by referencing CTE 1 columns. Wrapping
+     * metrics can safely use aggregate functions here since refs are plain columns.
+     * GROUP BY on dims + inner deps is added so aggregates are valid SQL.
+     *
+     * The final outer SELECT then references `nested_agg_results` columns
+     * as simple column references — no aggregates, no GROUP BY needed.
+     */
+    private buildNestedAggregateCtes({
+        dimensionSelects,
+        dimensionFilters,
+        sqlFrom,
+        joinsSql,
+        dimensionJoins,
+        baseCteName,
+    }: {
+        dimensionSelects: Record<string, string>;
+        dimensionFilters: string | undefined;
+        sqlFrom: string;
+        joinsSql: string | undefined;
+        dimensionJoins: string[];
+        baseCteName: string;
+    }): {
+        ctes: string[];
+        naJoins: string[];
+        naMetricSelects: string[];
+        outerMetricIds: string[];
+    } {
+        const { warehouseSqlBuilder } = this.args;
+        const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
+
+        const nestedAggMetrics = this.getMetricsWithNestedAggregates();
+        if (nestedAggMetrics.length === 0) {
+            return {
+                ctes: [],
+                naJoins: [],
+                naMetricSelects: [],
+                outerMetricIds: [],
+            };
+        }
+
+        // Collect all unique inner dependencies
+        const allInnerDeps = new Map<string, CompiledMetric>();
+        for (const { innerDeps } of nestedAggMetrics) {
+            for (const dep of innerDeps) {
+                if (!allInnerDeps.has(dep.fieldId)) {
+                    allInnerDeps.set(dep.fieldId, dep.metric);
+                }
+            }
+        }
+
+        const dimensionAlias = Object.keys(dimensionSelects).map(
+            (alias) => `${fieldQuoteChar}${alias}${fieldQuoteChar}`,
+        );
+
+        const innerDepAliases = Array.from(allInnerDeps.keys()).map(
+            (depId) => `${fieldQuoteChar}${depId}${fieldQuoteChar}`,
+        );
+
+        // --- CTE 1: nested_agg — pre-compute inner deps from base table ---
+        const naCteName = 'nested_agg';
+        const innerMetricSelects = Array.from(allInnerDeps.entries()).map(
+            ([depId, depMetric]) =>
+                `  ${depMetric.compiledSql} AS ${fieldQuoteChar}${depId}${fieldQuoteChar}`,
+        );
+
+        const naGroupBy =
+            dimensionAlias.length > 0
+                ? `GROUP BY ${dimensionAlias.map((_, i) => i + 1).join(',')}`
+                : undefined;
+
+        const cte1Sql = MetricQueryBuilder.wrapAsCte(naCteName, [
+            `SELECT\n${[...Object.values(dimensionSelects), ...innerMetricSelects].join(',\n')}`,
+            sqlFrom,
+            joinsSql,
+            ...dimensionJoins,
+            dimensionFilters,
+            naGroupBy,
+        ]);
+
+        // --- CTE 2: nested_agg_results — compute outer metrics from CTE 1 ---
+        const naResultsCteName = 'nested_agg_results';
+        const metricCteLookup: Array<{ name: string; metrics: string[] }> = [
+            {
+                name: naCteName,
+                metrics: Array.from(allInnerDeps.keys()),
+            },
+        ];
+
+        const resultsMetricSelects: string[] = [];
+        for (const { outerMetricId, outerMetric } of nestedAggMetrics) {
+            // Replace all metric refs with CTE column refs and re-compile
+            // remaining dimension refs. For wrapping metrics this keeps outer
+            // aggregation (e.g., sum(nested_agg."col")). For non-wrapping
+            // metrics this produces e.g., nested_agg."col1" * nested_agg."col2".
+            const processedSql = this.replaceMetricReferencesWithCteReferences(
+                outerMetric,
+                metricCteLookup,
+            );
+            resultsMetricSelects.push(
+                `  ${processedSql} AS ${fieldQuoteChar}${outerMetricId}${fieldQuoteChar}`,
+            );
+        }
+
+        // GROUP BY dims + inner deps so aggregate functions are valid
+        // Since CTE 1 has one row per dim group, this is effectively identity
+        const allGroupByCols = [
+            ...dimensionAlias.map((a) => `${naCteName}.${a}`),
+            ...innerDepAliases.map((a) => `${naCteName}.${a}`),
+        ];
+        const resultsGroupBy =
+            allGroupByCols.length > 0
+                ? `GROUP BY ${allGroupByCols.join(', ')}`
+                : undefined;
+
+        const resultsDimSelects = dimensionAlias.map(
+            (a) => `  ${naCteName}.${a}`,
+        );
+        const cte2Sql = MetricQueryBuilder.wrapAsCte(naResultsCteName, [
+            `SELECT\n${[...resultsDimSelects, ...resultsMetricSelects].join(',\n')}`,
+            `FROM ${naCteName}`,
+            resultsGroupBy,
+        ]);
+
+        // --- JOIN nested_agg_results to na_base ---
+        const naJoins: string[] = [];
+        if (dimensionAlias.length === 0) {
+            naJoins.push(`CROSS JOIN ${naResultsCteName}`);
+        } else {
+            naJoins.push(
+                `INNER JOIN ${naResultsCteName} ON ${dimensionAlias
+                    .map(
+                        (alias) =>
+                            `( ${baseCteName}.${alias} = ${naResultsCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${naResultsCteName}.${alias} IS NULL ) )`,
+                    )
+                    .join(' AND ')}`,
+            );
+        }
+
+        // Outer SELECT just references nested_agg_results columns — no aggregates
+        const naMetricSelects = nestedAggMetrics.map(
+            ({ outerMetricId }) =>
+                `  ${naResultsCteName}.${fieldQuoteChar}${outerMetricId}${fieldQuoteChar}`,
+        );
+
+        return {
+            ctes: [cte1Sql, cte2Sql],
+            naJoins,
+            naMetricSelects,
+            outerMetricIds: nestedAggMetrics.map(
+                ({ outerMetricId }) => outerMetricId,
+            ),
+        };
+    }
+
     // Build the optional metric_filters CTE; return next cte name + cte text (if created)
     static buildMetricFiltersCte(
         currentName: string,
@@ -3136,6 +3439,57 @@ export class MetricQueryBuilder {
             }
         }
 
+        // Nested aggregate CTEs: build CTE for type:number metrics that wrap
+        // aggregate metric references (e.g., sum(${max_metric})) to avoid
+        // invalid nested SQL like SUM(MAX(...))
+        const nestedAggMetrics = this.getMetricsWithNestedAggregates();
+        if (nestedAggMetrics.length > 0) {
+            const naBaseCteName = 'na_base';
+
+            const hasNonNaSelects =
+                Object.keys(dimensionsSQL.selects).length > 0 ||
+                metricsSQL.selects.length > 0;
+
+            const {
+                ctes: naCtes,
+                naJoins,
+                naMetricSelects,
+            } = this.buildNestedAggregateCtes({
+                dimensionSelects: dimensionsSQL.selects,
+                dimensionFilters: dimensionsSQL.filtersSQL,
+                sqlFrom,
+                joinsSql: joins.joinSQL,
+                dimensionJoins: dimensionsSQL.joins,
+                baseCteName: naBaseCteName,
+            });
+            ctes.push(...naCtes);
+
+            if (hasNonNaSelects) {
+                ctes.push(
+                    MetricQueryBuilder.wrapAsCte(
+                        naBaseCteName,
+                        finalSelectParts,
+                    ),
+                );
+
+                // Outer SELECT references nested_agg_results columns as
+                // simple column refs — no aggregate functions, no GROUP BY.
+                finalSelectParts = [
+                    `SELECT`,
+                    [`  ${naBaseCteName}.*`, ...naMetricSelects].join(',\n'),
+                    `FROM ${naBaseCteName}`,
+                    ...naJoins,
+                ];
+            } else {
+                // Only nested aggregate metrics, no dimensions or regular metrics
+                finalSelectParts = [
+                    `SELECT`,
+                    naMetricSelects.join(',\n'),
+                    `FROM nested_agg_results`,
+                ];
+            }
+        }
+
         const { simpleTableCalcs, interdependentTableCalcs } =
             this.getPartitionedTableCalculations();
 
@@ -3161,6 +3515,8 @@ export class MetricQueryBuilder {
             totalFields.length > 0 || (rowTotalFields.length > 0 && hasPivot);
 
         if (needsPostAgg) {
+            const fieldQuoteChar =
+                this.args.warehouseSqlBuilder.getFieldQuoteChar();
             const ctesToAdd: string[] = [];
 
             // base metrics CTE = dimensions + metrics only (no filters, no table calcs)
@@ -3236,9 +3592,6 @@ export class MetricQueryBuilder {
             const filterOnlyMetricIds = getFilterRulesFromGroup(filters.metrics)
                 .map((filter) => filter.target.fieldId)
                 .filter((metricId) => !metrics.includes(metricId));
-
-            const fieldQuoteChar =
-                this.args.warehouseSqlBuilder.getFieldQuoteChar();
 
             // Build explicit column list excluding filter-only metrics
             const finalSelectColumns =

--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -804,6 +804,20 @@ export const isMetric = (
 export const isNonAggregateMetric = (field: Field): boolean =>
     isMetric(field) && NonAggregateMetricTypes.includes(field.type);
 
+export const AggregateMetricTypes = [
+    MetricType.SUM,
+    MetricType.COUNT,
+    MetricType.COUNT_DISTINCT,
+    MetricType.AVERAGE,
+    MetricType.MIN,
+    MetricType.MAX,
+    MetricType.MEDIAN,
+    MetricType.PERCENTILE,
+] as const;
+
+export const isAggregateMetricType = (type: MetricType): boolean =>
+    (AggregateMetricTypes as readonly MetricType[]).includes(type);
+
 export const isPostCalculationMetricType = (type: MetricType): boolean =>
     PostCalculationMetricTypes.includes(type);
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/CENG-5657

Related PR: https://github.com/lightdash/looker2dbt/pull/313


  Problem: type: number metrics wrapping aggregate metrics (e.g. sql: sum(${max_event_id})) compiled to 
  invalid SQL like SUM(MAX(...)).                                                                       
                                                                                                        
  Solution: Two-CTE pipeline that only activates when metrics reference aggregate metrics:

  1. CTE 1 (nested_agg): Pre-computes inner aggregate metrics from the base table, grouped by
  dimensions. MAX(events.event_id) becomes a plain column.
  2. CTE 2 (nested_agg_results): Computes outer metrics using CTE 1 columns.
  SUM(nested_agg."max_event_id") is now valid SQL since it's aggregating a regular column.
  3. Outer SELECT: Just reads columns from nested_agg_results — no aggregation, no GROUP BY.

  Backwards compatible — completely isolated behind getMetricsWithNestedAggregates() which returns empty
   for normal queries.

  looker2dbt fix: Stop extracting type: number, sql: sum(${measure}) into type: sum, sql: ${measure}
  (which got nullified as unsupported). Leave it as type: number since Lightdash now handles it.


---

  Our implementation now handles all the patterns from PROD-5657:                                       
  1. sum(${max_metric}) → CTE resolves MAX, outer does SUM on CTE ref                                 
  2. count(distinct ${max_metric}) → CTE resolves MAX, outer does COUNT DISTINCT
  3. sum(${max_metric}) / ${count_metric} → CTE resolves MAX, COUNT stays normal
  4. ${max_metric} * ${count_metric} (no wrapping agg) → When mixed with wrapping metrics, goes into CTE
   too

<img width="1971" height="989" alt="image" src="https://github.com/user-attachments/assets/0ce0f162-d35f-4d1e-ab39-1a321799b184" />

### Description:

Adds support for nested aggregate metrics by implementing a CTE-based solution to handle cases where type:number metrics with aggregation functions reference other aggregate metrics (e.g., `sum(${max_metric})`).

The implementation:
- Detects metrics that would generate invalid nested SQL like `SUM(MAX(...))` 
- Creates a `nested_agg` CTE that pre-computes inner aggregate metrics at the dimension grain
- Rewrites outer metric SQL to reference CTE columns instead of nesting aggregates
- Handles both simple cases (`sum(${max_value})`) and complex expressions (`sum(${max_value}) / NULLIF(${count_records}, 0)`)
- Supports queries with and without dimensions through appropriate JOIN strategies

Test coverage includes scenarios with dimensions, without dimensions, and complex mixed metric references to ensure the nested aggregate pattern compiles to valid SQL.