### PR TITLE
fix: address infinite mcp app chart height growth

### DIFF
--- a/packages/backend/src/ee/services/McpService/mcp-chart-app/src/chart-app.ts
+++ b/packages/backend/src/ee/services/McpService/mcp-chart-app/src/chart-app.ts
@@ -239,10 +239,13 @@ app.ontoolresult = (result) => {
     }
 };
 
+let resizeTimeout: ReturnType<typeof setTimeout> | null = null;
 const resizeObserver = new ResizeObserver(() => {
     if (chart) {
-        // Important to call resize method to ensure the chart is responsive
-        chart.resize();
+        if (resizeTimeout) clearTimeout(resizeTimeout);
+        resizeTimeout = setTimeout(() => {
+            chart?.resize();
+        }, 100);
     }
 });
 resizeObserver.observe(chartContainer);

--- a/packages/backend/src/ee/services/McpService/mcp-chart-app/src/global.css
+++ b/packages/backend/src/ee/services/McpService/mcp-chart-app/src/global.css
@@ -8,7 +8,6 @@ html,
 body {
     width: 100%;
     height: 100%;
-    min-height: 480px;
     overflow: hidden;
     font-family:
         'Inter',
@@ -17,17 +16,19 @@ body {
         'Segoe UI',
         Roboto,
         sans-serif;
-    background: var(--color-background-primary, #ffffff);
-    border: 1px solid var(--color-border-primary, #f1f1f1);
-    border-radius: 8px;
+    background: transparent;
     color: var(--color-text-primary, #1a1a1a);
 }
 
 #chart {
-    width: 100%;
-    height: 100%;
-    padding: 16px;
+    width: auto;
+    height: auto;
     min-height: 480px;
+    margin: 8px;
+    padding: 16px;
+    background: var(--color-background-primary, #ffffff);
+    border-radius: 12px;
+    outline: 0.5px solid var(--color-border-primary, #e0e0e0);
 }
 
 #table-fallback {
@@ -73,7 +74,7 @@ body {
     font-weight: 400;
     font-family: 'Inter', sans-serif;
     color: #363636;
-    background: #f7f7f7;
+    background: #ffffff;
     border: 1px solid #e0e0e0;
     border-radius: 8px;
     cursor: pointer;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-5731/mcp-chart-artifacts-grow-indefinitely-on-page-refresh-at-non-default

### Description:

This PR improves the chart application's performance and visual design:

**Performance Improvements:**
- Added debouncing to the ResizeObserver with a 100ms timeout to prevent excessive chart resize calls during window resizing

**Visual Design Updates:**
- Removed minimum height constraint from the body element
- Changed body background to transparent and removed border styling
- Updated chart container to use auto width/height with 8px margin
- Applied background color, border radius, and outline styling directly to the chart container
- Changed table fallback button background from gray (#f7f7f7) to white (#ffffff)

These changes optimize resize handling performance while creating a cleaner visual presentation with better container styling separation.