### PR TITLE
fix: include NULL values in NOT_INCLUDE string filter results

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.mock.ts
+++ b/packages/common/src/compiler/filtersCompiler.mock.ts
@@ -444,12 +444,12 @@ export const stringFilterRuleMocks = {
         ...stringSingleValueFilter,
         operator: FilterOperator.NOT_INCLUDE,
     },
-    notIncludeFilterWithSingleValSQL: `LOWER(${stringFilterDimension}) NOT LIKE LOWER('%Bob%')`,
+    notIncludeFilterWithSingleValSQL: `(LOWER(${stringFilterDimension}) NOT LIKE LOWER('%Bob%') OR (${stringFilterDimension}) IS NULL)`,
     notIncludeFilterWithMultiVal: {
         ...stringMultiValueFilter,
         operator: FilterOperator.NOT_INCLUDE,
     },
-    notIncludeFilterWithMultiValSQL: `LOWER(${stringFilterDimension}) NOT LIKE LOWER('%Tom%')\n  AND\n  LOWER(${stringFilterDimension}) NOT LIKE LOWER('%Jerry%')`,
+    notIncludeFilterWithMultiValSQL: `(LOWER(${stringFilterDimension}) NOT LIKE LOWER('%Tom%')\n  AND\n  LOWER(${stringFilterDimension}) NOT LIKE LOWER('%Jerry%') OR (${stringFilterDimension}) IS NULL)`,
     notIncludeFilterWithNoVal: {
         ...noValueFilter,
         operator: FilterOperator.NOT_INCLUDE,

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -143,7 +143,7 @@ export const renderStringFilterSql = (
                 const notIncludeQuery = nonEmptyFilterValues.map(
                     (v) => `LOWER(${dimensionSql}) NOT LIKE LOWER('%${v}%')`,
                 );
-                return notIncludeQuery.join('\n  AND\n  ');
+                return `(${notIncludeQuery.join('\n  AND\n  ')} OR (${dimensionSql}) IS NULL)`;
             }
             return 'true';
         case FilterOperator.NULL:


### PR DESCRIPTION
Closes: [#20906](https://github.com/lightdash/lightdash/issues/20906)

### Description:
Updated the NOT_INCLUDE filter to not exclude NULLs. This is consistent with how NOT_EQUALS is handled as per https://github.com/lightdash/lightdash/issues/4593. 

Changes: 
- Updated NOT_INCLUDE where clause to include NULLs 
- Added test to filterCompiler.mock.ts

Tested locally: 
<img width="788" height="639" alt="image" src="https://github.com/user-attachments/assets/993139c6-e8e9-4087-a792-a18267921c34" />

``` sql 
SELECT
  "customers".customer_id AS "customers_customer_id",
  "customers".first_name AS "customers_first_name"
FROM "postgres"."jaffle"."customers" AS "customers"

WHERE ((
  (LOWER("customers".first_name) NOT LIKE LOWER('%Aaron%')
  AND
  LOWER("customers".first_name) NOT LIKE LOWER('%Alan%')
  AND
  LOWER("customers".first_name) NOT LIKE LOWER('%Amanda%') OR ("customers".first_name) IS NULL)
))
GROUP BY 1,2
ORDER BY "customers_customer_id"
LIMIT 500
```
