### PR TITLE
chore: fix breakup-pr skill regex error

### DIFF
--- a/.claude/skills/breakup-pr/SKILL.md
+++ b/.claude/skills/breakup-pr/SKILL.md
@@ -17,7 +17,8 @@ triggers:
   - phased delivery
   - vertical features
 invocation: user
-arguments: "[PR URL or branch name] - the PR to break up"
+argument-hint: "[PR URL or branch name]"
+arguments: pr-url
 ---
 
 # Break Up PR into Vertical Feature Slices


### PR DESCRIPTION
## Summary
- The `arguments` field in the breakup-pr skill contained `"[PR URL or branch name] - the PR to break up"` which was split by whitespace into argument names like `[PR`, `name]`, etc.
- These tokens contain regex-special characters (`[`, `]`) and were interpolated into `new RegExp(...)` during skill invocation, causing `SyntaxError: Invalid regular expression: unmatched parentheses`
- Split into `argument-hint` (human-readable display) and `arguments: pr-url` (simple regex-safe identifier)

## Test plan
- [ ] Run `/breakup-pr` — should no longer throw a regex SyntaxError

🤖 Generated with [Claude Code](https://claude.com/claude-code)