### PR TITLE
fix: reduce navbar z index

### DIFF
--- a/packages/frontend/src/components/NavBar/index.module.css
+++ b/packages/frontend/src/components/NavBar/index.module.css
@@ -3,7 +3,7 @@
     top: 0;
     left: 0;
     right: 0;
-    z-index: var(--mantine-z-index-max);
+    z-index: var(--mantine-z-index-popover);
 }
 
 .header {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Changed the NavBar z-index from `--mantine-z-index-max` to `--mantine-z-index-popover` to fix layering issues where the navigation bar was appearing above modal dialogs and other high-priority UI elements.

<!-- Even better add a screenshot / gif / loom -->