### PR TITLE
refactor: drop `spaces.is_private` column

### DIFF
--- a/packages/backend/src/database/migrations/20260306144545_drop_spaces_is_private_column.ts
+++ b/packages/backend/src/database/migrations/20260306144545_drop_spaces_is_private_column.ts
@@ -1,0 +1,20 @@
+import { Knex } from 'knex';
+
+const SPACES_TABLE = 'spaces';
+const IS_PRIVATE_COLUMN = 'is_private';
+
+export async function up(knex: Knex): Promise<void> {
+    if (await knex.schema.hasColumn(SPACES_TABLE, IS_PRIVATE_COLUMN)) {
+        await knex.schema.alterTable(SPACES_TABLE, (table) => {
+            table.dropColumn(IS_PRIVATE_COLUMN);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasColumn(SPACES_TABLE, IS_PRIVATE_COLUMN))) {
+        await knex.schema.alterTable(SPACES_TABLE, (table) => {
+            table.boolean(IS_PRIVATE_COLUMN).notNullable().defaultTo(true);
+        });
+    }
+}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-178/remove-isprivate-completely

### Description:
Last but not least, dropping the now unused column, as it was replaced by `inherit_parent_permissions`.



test-all