### PR TITLE
fix: preserve undefined dateZoomGranularities on dashboard save

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -655,8 +655,12 @@ const Dashboard: FC = () => {
             config: {
                 isDateZoomDisabled,
                 pinnedParameters,
-                dateZoomGranularities,
-                defaultDateZoomGranularity,
+                dateZoomGranularities: haveDateZoomGranularitiesChanged
+                    ? dateZoomGranularities
+                    : dashboard.config?.dateZoomGranularities,
+                defaultDateZoomGranularity: hasDefaultDateZoomGranularityChanged
+                    ? defaultDateZoomGranularity
+                    : dashboard.config?.defaultDateZoomGranularity,
             },
             parameters: dashboardParameters,
         });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Updated the dashboard configuration logic to conditionally preserve existing date zoom settings. The `dateZoomGranularities` and `defaultDateZoomGranularity` fields now only update when their respective change flags (`haveDateZoomGranularitiesChanged` and `hasDefaultDateZoomGranularityChanged`) are true, otherwise they retain the current dashboard configuration values.

This fixes an issue where new dashboard always passed in the explicit list of granularities instead of defaulting to `undefined` (all)