### PR TITLE
feat: add cron job to auto-delete expired preview projects (#3733)

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -689,10 +689,7 @@ export class ProjectModel {
             .where('projects.project_type', ProjectType.PREVIEW)
             .whereNotNull('projects.expires_at')
             .where('projects.expires_at', '<=', this.database.fn.now())
-            .select(
-                'projects.project_uuid',
-                'organizations.organization_uuid',
-            );
+            .select('projects.project_uuid', 'organizations.organization_uuid');
 
         return results.map((r) => ({
             projectUuid: r.project_uuid,

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -677,6 +677,29 @@ export class ProjectModel {
         });
     }
 
+    async getExpiredPreviewProjects(): Promise<
+        { projectUuid: string; organizationUuid: string }[]
+    > {
+        const results = await this.database('projects')
+            .join(
+                'organizations',
+                'projects.organization_id',
+                'organizations.organization_id',
+            )
+            .where('projects.project_type', ProjectType.PREVIEW)
+            .whereNotNull('projects.expires_at')
+            .where('projects.expires_at', '<=', this.database.fn.now())
+            .select(
+                'projects.project_uuid',
+                'organizations.organization_uuid',
+            );
+
+        return results.map((r) => ({
+            projectUuid: r.project_uuid,
+            organizationUuid: r.organization_uuid,
+        }));
+    }
+
     async delete(projectUuid: string): Promise<void> {
         // Invalidate warehouse credentials cache
         warehouseCredentialsCache?.del(projectUuid);

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -192,6 +192,7 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
+    [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: () => ({}),
 } as const;
 
 const getTagsFromPayload = <T extends SchedulerTaskName>(

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -215,6 +215,14 @@ export class SchedulerWorker extends SchedulerTask {
                     maxAttempts: 3,
                 },
             },
+            {
+                task: SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS,
+                pattern: '0 * * * *', // Every hour
+                options: {
+                    backfillPeriod: 2 * 3600 * 1000, // 2 hours in ms
+                    maxAttempts: 3,
+                },
+            },
             // worker-process pg liveness is driven by a setInterval (see startPgPing);
             // managed-agent heartbeat is self-scheduling (see SchedulerClient.scheduleManagedAgentHeartbeat).
         ];
@@ -1106,6 +1114,24 @@ export class SchedulerWorker extends SchedulerTask {
                 } catch (error) {
                     Logger.error(
                         'Error during deploy sessions cleanup:',
+                        error,
+                    );
+                    throw error;
+                }
+            },
+            [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: async () => {
+                Logger.info('Starting expired preview projects cleanup job');
+
+                try {
+                    const deletedCount =
+                        await this.projectService.deleteExpiredPreviewProjects();
+
+                    Logger.info(
+                        `Expired preview projects cleanup completed. Deleted: ${deletedCount}`,
+                    );
+                } catch (error) {
+                    Logger.error(
+                        'Error during expired preview projects cleanup:',
                         error,
                     );
                     throw error;

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2991,6 +2991,29 @@ export class ProjectService extends BaseService {
         });
     }
 
+    async deleteExpiredPreviewProjects(): Promise<number> {
+        const expiredProjects =
+            await this.projectModel.getExpiredPreviewProjects();
+
+        let deletedCount = 0;
+        for (const { projectUuid } of expiredProjects) {
+            try {
+                await this.projectModel.delete(projectUuid);
+                deletedCount++;
+                this.logger.info(
+                    `Deleted expired preview project: ${projectUuid}`,
+                );
+            } catch (error) {
+                this.logger.error(
+                    `Failed to delete expired preview project ${projectUuid}`,
+                    { error },
+                );
+            }
+        }
+
+        return deletedCount;
+    }
+
     private async buildAdapter(
         projectUuid: string,
         user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3005,14 +3005,14 @@ export class ProjectService extends BaseService {
             ),
         );
 
-        results
-            .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
-            .forEach((r, i) => {
+        results.forEach((r, i) => {
+            if (r.status === 'rejected') {
                 this.logger.error(
                     `Failed to delete expired preview project ${expiredProjects[i].projectUuid}`,
                     { error: r.reason },
                 );
-            });
+            }
+        });
 
         return results.filter((r) => r.status === 'fulfilled').length;
     }

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2995,23 +2995,26 @@ export class ProjectService extends BaseService {
         const expiredProjects =
             await this.projectModel.getExpiredPreviewProjects();
 
-        let deletedCount = 0;
-        for (const { projectUuid } of expiredProjects) {
-            try {
-                await this.projectModel.delete(projectUuid);
-                deletedCount++;
-                this.logger.info(
-                    `Deleted expired preview project: ${projectUuid}`,
-                );
-            } catch (error) {
-                this.logger.error(
-                    `Failed to delete expired preview project ${projectUuid}`,
-                    { error },
-                );
-            }
-        }
+        const results = await Promise.allSettled(
+            expiredProjects.map(({ projectUuid }) =>
+                this.projectModel.delete(projectUuid).then(() => {
+                    this.logger.info(
+                        `Deleted expired preview project: ${projectUuid}`,
+                    );
+                }),
+            ),
+        );
 
-        return deletedCount;
+        results
+            .filter((r): r is PromiseRejectedResult => r.status === 'rejected')
+            .forEach((r, i) => {
+                this.logger.error(
+                    `Failed to delete expired preview project ${expiredProjects[i].projectUuid}`,
+                    { error: r.reason },
+                );
+            });
+
+        return results.filter((r) => r.status === 'fulfilled').length;
     }
 
     private async buildAdapter(

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -89,6 +89,7 @@ export const SCHEDULER_TASKS = {
     CHECK_FOR_STUCK_JOBS: 'checkForStuckJobs',
     CLEAN_DEPLOY_SESSIONS: 'cleanDeploySessions',
     MANAGED_AGENT_HEARTBEAT: 'managedAgentHeartbeat',
+    CLEAN_EXPIRED_PREVIEWS: 'cleanExpiredPreviews',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -130,6 +131,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: TraceTaskBase;
     [SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS]: TraceTaskBase;
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: ManagedAgentHeartbeatPayload;
+    [SCHEDULER_TASKS.CLEAN_EXPIRED_PREVIEWS]: TraceTaskBase;
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;


### PR DESCRIPTION
Closes SPK-455

### Description:

Step 2 of 5 in the preview-cleanup stack for [SPK-438](https://linear.app/lightdash/issue/SPK-438). Adds the scheduled background job that finds preview projects past their expiration timestamp and deletes them.

Depends on the expiration column added in PR #20936.

Related upstream: lightdash/lightdash#3733

### Stack:

| # | PR | Description |
|---|---|---|
| 1 | #20936 | Expiration tracking + UI display |
| ✅ 2 | #20937 | Cron job to auto-delete expired previews |
| 3 | #20938 | `--expires-in` CLI flag |
| 4 | #20939 | Hide previews from non-admin/developer users |
| 5 | #20950 | Feature flag gating |
