### PR TITLE
feat: add --expires-in CLI flag for custom preview TTL (#3733)

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2083,7 +2083,10 @@ export class ProjectService extends BaseService {
                 user.userUuid,
                 user.organizationUuid,
                 createProject,
-                ProjectService.getPreviewExpiresAt(createProject.type),
+                ProjectService.getPreviewExpiresAt(
+                    createProject.type,
+                    createProject.expiresInHours,
+                ),
             );
 
         // Do not give this user admin permissions on this new project,
@@ -2288,13 +2291,16 @@ export class ProjectService extends BaseService {
 
     static PREVIEW_PROJECT_TTL_DAYS = 30;
 
-    static getPreviewExpiresAt(type: ProjectType): Date | null {
+    static getPreviewExpiresAt(
+        type: ProjectType,
+        expiresInHours?: number,
+    ): Date | null {
         if (type !== ProjectType.PREVIEW) return null;
         const now = new Date();
-        return new Date(
-            now.getTime() +
-                ProjectService.PREVIEW_PROJECT_TTL_DAYS * 24 * 60 * 60 * 1000,
-        );
+        const ttlMs = expiresInHours
+            ? Number(expiresInHours) * 60 * 60 * 1000
+            : ProjectService.PREVIEW_PROJECT_TTL_DAYS * 24 * 60 * 60 * 1000;
+        return new Date(now.getTime() + ttlMs);
     }
 
     static getAnalyticProperties(
@@ -2388,7 +2394,10 @@ export class ProjectService extends BaseService {
                         user.userUuid,
                         user.organizationUuid,
                         createProject,
-                        ProjectService.getPreviewExpiresAt(createProject.type),
+                        ProjectService.getPreviewExpiresAt(
+                            createProject.type,
+                            createProject.expiresInHours,
+                        ),
                     );
                     // Give admin user permissions to user who created this project even if he is an admin
                     if (user.email) {

--- a/packages/cli/src/handlers/createProject.ts
+++ b/packages/cli/src/handlers/createProject.ts
@@ -135,6 +135,7 @@ type CreateProjectOptions = {
     organizationCredentials?: string;
     targetPath?: string;
     assumeYes?: boolean;
+    expiresIn?: number;
 };
 
 const isSnowflakeSsoEnabled = async (): Promise<boolean> => {
@@ -397,6 +398,9 @@ export const createProject = async (
         tableConfiguration: options.tableConfiguration,
         copyContent: options.copyContent,
         organizationWarehouseCredentialsUuid,
+        ...(options.expiresIn !== undefined
+            ? { expiresInHours: options.expiresIn }
+            : {}),
     };
 
     return lightdashApi<ApiCreateProjectResults>({

--- a/packages/cli/src/handlers/preview.ts
+++ b/packages/cli/src/handlers/preview.ts
@@ -40,6 +40,7 @@ type PreviewHandlerOptions = DbtCompileOptions & {
     useBatchedDeploy?: boolean;
     batchSize?: string;
     parallelBatches?: string;
+    expiresIn?: string;
 };
 
 type StopPreviewHandlerOptions = {
@@ -243,6 +244,9 @@ export const previewHandler = async (
                     : undefined,
             copyContent: !options.skipCopyContent && upstreamProjectValid,
             warehouseCredentials: projectTypeConfig.warehouseCredentials,
+            expiresIn: options.expiresIn
+                ? parseInt(options.expiresIn, 10)
+                : undefined,
         });
 
         project = results?.project;
@@ -496,6 +500,9 @@ export const startPreviewHandler = async (
             upstreamProjectUuid: config.context?.project,
             copyContent: !options.skipCopyContent,
             warehouseCredentials: projectTypeConfig.warehouseCredentials,
+            expiresIn: options.expiresIn
+                ? parseInt(options.expiresIn, 10)
+                : undefined,
         });
 
         const project = results?.project;

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -574,6 +574,10 @@ program
         'Number of batches to send in parallel (default: 1, use higher values with caution)',
         '1',
     )
+    .option(
+        '--expires-in <hours>',
+        'Number of hours until the preview project auto-expires (default: 720, i.e. 30 days)',
+    )
     .action(previewHandler);
 
 program
@@ -696,6 +700,10 @@ program
         '--parallel-batches <number>',
         'Number of batches to send in parallel (default: 1, use higher values with caution)',
         '1',
+    )
+    .option(
+        '--expires-in <hours>',
+        'Number of hours until the preview project auto-expires (default: 720, i.e. 30 days)',
     )
     .action(startPreviewHandler);
 

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -621,6 +621,7 @@ export type CreateProject = Omit<
     copyWarehouseConnectionFromUpstreamProject?: boolean;
     tableConfiguration?: CreateProjectTableConfiguration;
     copyContent?: boolean;
+    expiresInHours?: number;
 };
 
 export type CreateProjectOptionalCredentials = Omit<


### PR DESCRIPTION
Closes SPK-456

### Description:

Step 3 of 5 in the preview-cleanup stack for [SPK-438](https://linear.app/lightdash/issue/SPK-438). Lets users override the default preview lifetime when creating a preview from the CLI via `--expires-in`.

Related upstream: lightdash/lightdash#3733

### Stack:

| # | PR | Description |
|---|---|---|
| 1 | #20936 | Expiration tracking + UI display |
| 2 | #20937 | Cron job to auto-delete expired previews |
| ✅ 3 | #20938 | `--expires-in` CLI flag |
| 4 | #20939 | Hide previews from non-admin/developer users |
| 5 | #20950 | Feature flag gating |
