### PR TITLE
chore: deprecate old sync CSV download methods

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -1942,6 +1942,11 @@ export default class SchedulerTask {
         }
     }
 
+    /**
+     * @deprecated Uses old sync query pipeline via CsvService.downloadCsv().
+     * Only kept alive by deprecated v1 downloadCsv endpoints for external API consumers.
+     * Internal frontend uses v2 async query + schedule-download flow instead.
+     */
     protected async downloadCsv(
         jobId: string,
         scheduledTime: Date,

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -1031,10 +1031,9 @@ export class CsvService extends BaseService {
     }
 
     /**
-     * This method is used to schedule a CSV download for a chart.
-     * It will unfold all the arguments required to schedule a CSV download from a chartUuid
-     * This will allow users to download CSVs with custom dimensions
-     * We check permissions on scheduleDownloadCsv call
+     * @deprecated Uses old sync query pipeline (runMetricQuery + pivotDetails: null).
+     * Only kept alive by deprecated v1 downloadCsv endpoints for external API consumers.
+     * Internal frontend uses v2 schedule-download flow instead.
      */
     async scheduleDownloadCsvForChart(
         user: SessionUser,
@@ -1101,6 +1100,11 @@ export class CsvService extends BaseService {
         });
     }
 
+    /**
+     * @deprecated Uses old sync query pipeline (runMetricQuery + pivotDetails: null).
+     * Only kept alive by deprecated v1 downloadCsv endpoints for external API consumers.
+     * Internal frontend uses v2 schedule-download flow instead.
+     */
     async scheduleDownloadCsv(
         user: SessionUser,
         csvOptions: DownloadMetricCsv,
@@ -1161,6 +1165,11 @@ export class CsvService extends BaseService {
         return { jobId };
     }
 
+    /**
+     * @deprecated Uses old sync query pipeline (runMetricQuery + pivotDetails: null).
+     * Only kept alive by deprecated v1 downloadCsv endpoints for external API consumers.
+     * Internal frontend uses v2 schedule-download flow instead.
+     */
     async downloadCsv(
         jobId: string,
         {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-185

### Description:

Added deprecation warnings to legacy CSV download methods in the scheduler and CSV service. The deprecated methods `downloadCsv`, `scheduleDownloadCsv`, and `scheduleDownloadCsvForChart` now include JSDoc comments indicating they use the old synchronous query pipeline and are only maintained for backward compatibility with v1 API endpoints. The internal frontend has migrated to the v2 asynchronous query and schedule-download flow.

<!-- Even better add a screenshot / gif / loom -->