### PR TITLE
feat: gate preview cleanup behind feature flag (#3733)

### DIFF
--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -45,6 +45,7 @@ import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberP
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { UserModel } from '../../models/UserModel';
+import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { wrapSentryTransaction } from '../../utils';
 import { BaseService } from '../BaseService';
 
@@ -321,7 +322,7 @@ export class OrganizationService extends BaseService {
             ),
         );
 
-        // Hide preview projects from non-admin/developer users
+        // When feature flag is enabled, hide preview projects from non-admin/developer users
         if (account.isRegisteredUser()) {
             const registeredUser = account.user as {
                 userUuid: string;
@@ -332,9 +333,21 @@ export class OrganizationService extends BaseService {
                 registeredUser.role === OrganizationMemberRole.DEVELOPER;
 
             if (!isAdminOrDeveloper) {
-                return viewableProjects.filter(
-                    (p) => p.type !== ProjectType.PREVIEW,
-                );
+                const flag = await this.featureFlagModel.get({
+                    user: {
+                        userUuid: registeredUser.userUuid,
+                        organizationUuid: organizationUuid!,
+                        organizationName:
+                            account.organization.name ?? organizationUuid!,
+                    },
+                    featureFlagId: FeatureFlags.PreviewAutoCleanup,
+                });
+
+                if (flag.enabled) {
+                    return viewableProjects.filter(
+                        (p) => p.type !== ProjectType.PREVIEW,
+                    );
+                }
             }
         }
 

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -45,7 +45,6 @@ import { OrganizationMemberProfileModel } from '../../models/OrganizationMemberP
 import { OrganizationModel } from '../../models/OrganizationModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { UserModel } from '../../models/UserModel';
-import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { wrapSentryTransaction } from '../../utils';
 import { BaseService } from '../BaseService';
 

--- a/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
+++ b/packages/frontend/src/components/NavBar/ProjectSwitcher.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     assertUnreachable,
+    FeatureFlags,
     ProjectType,
     type OrganizationProject,
 } from '@lightdash/common';
@@ -39,6 +40,7 @@ import {
 import { useIsTruncated } from '../../hooks/useIsTruncated';
 import { useProject } from '../../hooks/useProject';
 import { useProjects } from '../../hooks/useProjects';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import MantineIcon from '../common/MantineIcon';
 import { PolymorphicGroupButton } from '../common/PolymorphicGroupButton';
@@ -239,6 +241,12 @@ const ProjectSwitcher = () => {
     const { mutate: setLastProjectMutation } = useUpdateActiveProjectMutation();
     const location = useLocation();
     const isHomePage = !!useMatch(`/projects/${activeProjectUuid}/home`);
+
+    const { data: previewAutoCleanupFlag } = useServerFeatureFlag(
+        FeatureFlags.PreviewAutoCleanup,
+    );
+    const isPreviewAutoCleanupEnabled =
+        previewAutoCleanupFlag?.enabled ?? false;
 
     const [isCreatePreviewOpen, setIsCreatePreview] = useState(false);
     const [groupStates, setGroupStates] = useState<GroupStates>({
@@ -543,7 +551,9 @@ const ProjectSwitcher = () => {
                                 <Menu.Divider />
                                 <GroupHeader
                                     title={
-                                        'Your Previews'
+                                        isPreviewAutoCleanupEnabled
+                                            ? 'Your Previews'
+                                            : 'Preview'
                                     }
                                     count={previewProjects.length}
                                     state={groupStates.preview}
@@ -570,7 +580,9 @@ const ProjectSwitcher = () => {
                                                         item.projectUuid ===
                                                         activeProjectUuid
                                                     }
-                                                    showExpiration
+                                                    showExpiration={
+                                                        isPreviewAutoCleanupEnabled
+                                                    }
                                                 />
                                             ))}
                                         </Stack>


### PR DESCRIPTION
Closes SPK-458

### Description:

Step 5 of 5 in the preview-cleanup stack for [SPK-438](https://linear.app/lightdash/issue/SPK-438). Puts the auto-deletion behaviour behind a feature flag so we can roll out the cleanup safely and disable it quickly if it misbehaves.

Related upstream: lightdash/lightdash#3733

### Stack:

| # | PR | Description |
|---|---|---|
| 1 | #20936 | Expiration tracking + UI display |
| 2 | #20937 | Cron job to auto-delete expired previews |
| 3 | #20938 | `--expires-in` CLI flag |
| 4 | #20939 | Hide previews from non-admin/developer users |
| ✅ 5 | #20950 | Feature flag gating |
