### PR TITLE
fix: replace Arrow IPC with DuckDB native JSON for pivot queries

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getPivotedResults.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/getPivotedResults.test.ts
@@ -1,0 +1,120 @@
+import { SortField } from '@lightdash/common';
+import { getPivotedResults } from './getPivotedResults';
+
+describe('getPivotedResults', () => {
+    it('should pivot rows with a single pivot field', async () => {
+        const rows = [
+            { region: 'US', quarter: 'Q1', revenue: 100 },
+            { region: 'US', quarter: 'Q2', revenue: 200 },
+            { region: 'EU', quarter: 'Q1', revenue: 150 },
+            { region: 'EU', quarter: 'Q2', revenue: 250 },
+        ];
+        const fieldsMap = { region: {}, quarter: {}, revenue: {} };
+        const pivotFields = ['quarter'];
+        const metrics = ['revenue'];
+        const sorts: SortField[] = [];
+
+        const result = await getPivotedResults(
+            rows,
+            fieldsMap,
+            pivotFields,
+            metrics,
+            sorts,
+        );
+
+        expect(result.results).toHaveLength(2);
+        expect(result.metrics).toEqual(expect.arrayContaining(['Q1', 'Q2']));
+        // Each row should have region + pivoted quarter columns
+        for (const row of result.results) {
+            expect(row).toHaveProperty('region');
+            expect(row).toHaveProperty('Q1');
+            expect(row).toHaveProperty('Q2');
+        }
+    });
+
+    it('should pivot rows with composite pivot fields', async () => {
+        const rows = [
+            { region: 'US', year: '2024', quarter: 'Q1', revenue: 100 },
+            { region: 'US', year: '2024', quarter: 'Q2', revenue: 200 },
+            { region: 'EU', year: '2024', quarter: 'Q1', revenue: 150 },
+        ];
+        const fieldsMap = {
+            region: {},
+            year: {},
+            quarter: {},
+            revenue: {},
+        };
+        const pivotFields = ['year', 'quarter'];
+        const metrics = ['revenue'];
+        const sorts: SortField[] = [];
+
+        const result = await getPivotedResults(
+            rows,
+            fieldsMap,
+            pivotFields,
+            metrics,
+            sorts,
+        );
+
+        expect(result.results).toHaveLength(2);
+        expect(result.metrics.length).toBeGreaterThan(0);
+    });
+
+    it('should handle string values with special characters', async () => {
+        const rows = [
+            { category: "it's a test", segment: 'A', value: 10 },
+            { category: "it's a test", segment: 'B', value: 20 },
+            { category: 'normal', segment: 'A', value: 30 },
+        ];
+        const fieldsMap = { category: {}, segment: {}, value: {} };
+
+        const result = await getPivotedResults(
+            rows,
+            fieldsMap,
+            ['segment'],
+            ['value'],
+            [],
+        );
+
+        expect(result.results).toHaveLength(2);
+    });
+
+    it('should handle null values', async () => {
+        const rows = [
+            { region: 'US', quarter: 'Q1', revenue: null },
+            { region: null, quarter: 'Q2', revenue: 200 },
+        ];
+        const fieldsMap = { region: {}, quarter: {}, revenue: {} };
+
+        const result = await getPivotedResults(
+            rows,
+            fieldsMap,
+            ['quarter'],
+            ['revenue'],
+            [],
+        );
+
+        expect(result.results).toHaveLength(2);
+    });
+
+    it('should respect sort order', async () => {
+        const rows = [
+            { region: 'US', quarter: 'Q1', revenue: 100 },
+            { region: 'EU', quarter: 'Q1', revenue: 150 },
+            { region: 'US', quarter: 'Q2', revenue: 200 },
+            { region: 'EU', quarter: 'Q2', revenue: 250 },
+        ];
+        const fieldsMap = { region: {}, quarter: {}, revenue: {} };
+
+        const result = await getPivotedResults(
+            rows,
+            fieldsMap,
+            ['quarter'],
+            ['revenue'],
+            [{ fieldId: 'region', descending: true }],
+        );
+
+        expect(result.results[0].region).toBe('US');
+        expect(result.results[1].region).toBe('EU');
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/getPivotedResults.ts
+++ b/packages/backend/src/ee/services/ai/utils/getPivotedResults.ts
@@ -1,6 +1,8 @@
 import { SortField } from '@lightdash/common';
-import { tableFromJSON, tableToIPC } from 'apache-arrow';
 import { Database } from 'duckdb-async';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
 
 const getNullsFirstLast = (sort: SortField) => {
     if (sort.nullsFirst === undefined) return '';
@@ -15,10 +17,19 @@ export const getPivotedResults = async (
     sorts: SortField[],
 ) => {
     const fields = Object.keys(fieldsMap);
-    const arrowTable = tableFromJSON(rows);
+    const tmpFile = path.join(
+        os.tmpdir(),
+        `lightdash_pivot_${Date.now()}_${Math.random().toString(36).slice(2)}.json`,
+    );
     const db = await Database.create(':memory:');
-    await db.exec('INSTALL arrow FROM community; LOAD arrow;');
-    await db.register_buffer('results_data', [tableToIPC(arrowTable)], true);
+    try {
+        await fs.writeFile(tmpFile, JSON.stringify(rows));
+        await db.exec(
+            `CREATE TABLE results_data AS SELECT * FROM read_json_auto('${tmpFile}')`,
+        );
+    } finally {
+        await fs.unlink(tmpFile).catch(() => {});
+    }
     const usingFields = metrics.map((metric) => `FIRST(${metric})`);
 
     // Get the grouping columns (all non-pivot, non-metric fields)


### PR DESCRIPTION
### Description:
Arrow's tableFromJSON creates dictionary-encoded string columns that DuckDB's community arrow extension cannot decode, breaking all AI/MCP charts with groupBy since the duckdb-async 0.10.2→1.2.0 upgrade.

The new tests all fail with the error from the bug report when running them without the fix in this PR:

```commandline
getPivotedResults
    ✕ should pivot rows with a single pivot field (36 ms)
    ✕ should pivot rows with composite pivot fields (16 ms)
    ✕ should handle string values with special characters (11 ms)
    ✕ should handle null values (12 ms)
    ✕ should respect sort order (11 ms)

  ● getPivotedResults › should pivot rows with a single pivot field

    IO Error: ArrowIpcDecoderDecodeSchema(decoder.get(), base_schema.get(), &error) failed with errno 45: Schema message field with DictionaryEncoding not supported



  ● getPivotedResults › should pivot rows with composite pivot fields

    IO Error: ArrowIpcDecoderDecodeSchema(decoder.get(), base_schema.get(), &error) failed with errno 45: Schema message field with DictionaryEncoding not supported



  ● getPivotedResults › should handle string values with special characters

    IO Error: ArrowIpcDecoderDecodeSchema(decoder.get(), base_schema.get(), &error) failed with errno 45: Schema message field with DictionaryEncoding not supported



  ● getPivotedResults › should handle null values

    IO Error: ArrowIpcDecoderDecodeSchema(decoder.get(), base_schema.get(), &error) failed with errno 45: Schema message field with DictionaryEncoding not supported



  ● getPivotedResults › should respect sort order

    IO Error: ArrowIpcDecoderDecodeSchema(decoder.get(), base_schema.get(), &error) failed with errno 45: Schema message field with DictionaryEncoding not supported
```


### Testing via MCP:
Before:
<img width="1458" height="236" alt="image" src="https://github.com/user-attachments/assets/5fdfc108-3f1b-4306-baff-1c2e78ec8634" />

After:
<img width="1458" height="1407" alt="image" src="https://github.com/user-attachments/assets/1dfb97d9-8320-4940-92ef-9b255bd36c7b" />
