### PR TITLE
feat: add more o11y to preaggs and queries

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -97,6 +97,7 @@ export const lightdashConfigMock: LightdashConfig = {
         port: 9090,
         path: '/metrics',
         eventMetricsEnabled: false,
+        allQueryMetricsEnabled: false,
     },
     chart: { versionHistory: { daysLimit: 0 } },
     dashboard: {
@@ -181,6 +182,7 @@ export const lightdashConfigMock: LightdashConfig = {
         release: '',
         environment: '',
         tracesSampleRate: 0,
+        queryTracesSampleRate: null,
         profilesSampleRate: 0,
         anr: {
             enabled: false,

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -141,6 +141,7 @@ test('Should use default sentry configuration if no environment vars', () => {
         release: VERSION,
         environment: LightdashMode.DEFAULT,
         tracesSampleRate: 0.1,
+        queryTracesSampleRate: null,
         profilesSampleRate: 0.2,
         anr: {
             enabled: false,
@@ -163,6 +164,7 @@ test('Should parse sentry config from env', () => {
         release: VERSION,
         environment: 'development',
         tracesSampleRate: 0.8,
+        queryTracesSampleRate: null,
         profilesSampleRate: 1.0,
         anr: {
             enabled: true,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -862,6 +862,7 @@ export type LightdashConfig = {
         labels?: Object;
         eventMetricsEnabled: boolean;
         eventMetricsConfigPath?: string;
+        allQueryMetricsEnabled: boolean;
     };
     database: {
         connectionUri: string | undefined;
@@ -1459,6 +1460,10 @@ export const parseConfig = (): LightdashConfig => {
             tracesSampleRate:
                 getFloatFromEnvironmentVariable('SENTRY_TRACES_SAMPLE_RATE') ||
                 0.1,
+            queryTracesSampleRate:
+                getFloatFromEnvironmentVariable(
+                    'SENTRY_QUERY_TRACES_SAMPLE_RATE',
+                ) ?? null, // defaults to null (use global tracesSampleRate), set to 1.0 to capture all query traces
             profilesSampleRate:
                 getFloatFromEnvironmentVariable(
                     'SENTRY_PROFILES_SAMPLE_RATE',
@@ -1648,6 +1653,9 @@ export const parseConfig = (): LightdashConfig => {
             eventMetricsConfigPath:
                 process.env.LIGHTDASH_CUSTOM_METRICS_CONFIG_PATH ||
                 process.env.CUSTOM_METRICS_CONFIG_PATH,
+            allQueryMetricsEnabled:
+                process.env.LIGHTDASH_PROMETHEUS_ALL_QUERY_METRICS_ENABLED ===
+                'true', // defaults to false, tracks execution duration & S3 upload for all queries (not just pre-aggregate)
         },
         allowMultiOrgs: process.env.ALLOW_MULTIPLE_ORGS === 'true',
         maxPayloadSize: process.env.LIGHTDASH_MAX_PAYLOAD || '5mb',

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -313,6 +313,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                         lightdashConfig: context.lightdashConfig,
                         preAggregateModel: models.getPreAggregateModel(),
                         projectModel: models.getProjectModel(),
+                        prometheusMetrics,
                     }),
                     projectCompileLogModel: models.getProjectCompileLogModel(),
                     adminNotificationService:

--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -69,6 +69,23 @@ export default class PrometheusMetrics {
     public preAggregateActiveMaterializationsGauge: prometheus.Gauge | null =
         null;
 
+    // Pre-aggregate query execution metrics
+    public queryExecutionDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
+    public duckdbResolutionCounter: prometheus.Counter<string> | null = null;
+
+    public duckdbResolutionDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
+    public preAggregateFallbackCounter: prometheus.Counter<string> | null =
+        null;
+
+    public s3ResultsUploadDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
+    public queryCacheHitCounter: prometheus.Counter<string> | null = null;
+
     constructor(config: LightdashConfig['prometheus']) {
         this.config = config;
     }
@@ -207,7 +224,7 @@ export default class PrometheusMetrics {
 
                 // Initialize pre-aggregate metrics
                 this.preAggregateMatchCounter = new prometheus.Counter({
-                    name: 'pre_aggregate_match_total',
+                    name: 'assessment_pre_aggregate_match_total',
                     help: 'Total number of pre-aggregate match attempts',
                     labelNames: ['result', 'miss_reason'],
                     ...rest,
@@ -215,7 +232,7 @@ export default class PrometheusMetrics {
 
                 this.preAggregateMaterializationCounter =
                     new prometheus.Counter({
-                        name: 'pre_aggregate_materialization_total',
+                        name: 'assessment_pre_aggregate_materialization_total',
                         help: 'Total number of pre-aggregate materializations by outcome',
                         labelNames: ['status', 'trigger'],
                         ...rest,
@@ -223,7 +240,7 @@ export default class PrometheusMetrics {
 
                 this.preAggregateMaterializationDurationHistogram =
                     new prometheus.Histogram({
-                        name: 'pre_aggregate_materialization_duration_ms',
+                        name: 'assessment_pre_aggregate_materialization_duration_ms',
                         help: 'Histogram of pre-aggregate materialization duration in milliseconds',
                         labelNames: ['status', 'trigger'],
                         buckets: [
@@ -240,6 +257,93 @@ export default class PrometheusMetrics {
                         ],
                         ...rest,
                     });
+
+                // Pre-aggregate query execution metrics
+                this.queryExecutionDurationHistogram = new prometheus.Histogram(
+                    {
+                        name: 'assessment_query_execution_duration_ms',
+                        help: 'Histogram of query execution duration in milliseconds by source',
+                        labelNames: ['source', 'context', 'status'],
+                        buckets: [
+                            100, // 100ms
+                            500, // 500ms
+                            1000, // 1s
+                            2500, // 2.5s
+                            5000, // 5s
+                            10000, // 10s
+                            30000, // 30s
+                            60000, // 1min
+                            120000, // 2min
+                            300000, // 5min
+                            600000, // 10min
+                        ],
+                        ...rest,
+                    },
+                );
+
+                this.duckdbResolutionCounter = new prometheus.Counter({
+                    name: 'assessment_pre_aggregate_duckdb_resolution_total',
+                    help: 'Total number of DuckDB pre-aggregate resolution attempts',
+                    labelNames: ['status', 'reason'],
+                    ...rest,
+                });
+
+                this.duckdbResolutionDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'assessment_pre_aggregate_duckdb_resolution_duration_ms',
+                        help: 'Histogram of DuckDB pre-aggregate resolution duration in milliseconds',
+                        labelNames: ['status'],
+                        buckets: [
+                            10, // 10ms
+                            50, // 50ms
+                            100, // 100ms
+                            250, // 250ms
+                            500, // 500ms
+                            1000, // 1s
+                            2500, // 2.5s
+                            5000, // 5s
+                            10000, // 10s
+                        ],
+                        ...rest,
+                    });
+
+                this.preAggregateFallbackCounter = new prometheus.Counter({
+                    name: 'assessment_pre_aggregate_fallback_total',
+                    help: 'Total number of opportunistic pre-aggregate fallbacks to warehouse',
+                    labelNames: ['reason'],
+                    ...rest,
+                });
+
+                this.s3ResultsUploadDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'assessment_s3_results_upload_duration_ms',
+                        help: 'Histogram of S3 results upload duration in milliseconds',
+                        labelNames: ['source'],
+                        buckets: [
+                            100, // 100ms
+                            500, // 500ms
+                            1000, // 1s
+                            2500, // 2.5s
+                            5000, // 5s
+                            10000, // 10s
+                            30000, // 30s
+                            60000, // 1min
+                            120000, // 2min
+                            300000, // 5min
+                        ],
+                        ...rest,
+                    });
+
+                this.queryCacheHitCounter = new prometheus.Counter({
+                    name: 'assessment_pre_aggregate_cache_hit_total',
+                    help: 'Total number of query cache hits and misses',
+                    labelNames: [
+                        'result',
+                        'context',
+                        'has_pre_aggregate_match',
+                    ],
+                    ...rest,
+                });
 
                 const app = express();
                 this.server = http.createServer(app);
@@ -501,6 +605,54 @@ export default class PrometheusMetrics {
         }
     }
 
+    public observeQueryExecutionDuration(
+        durationMs: number,
+        source: 'warehouse' | 'pre_aggregate_duckdb',
+        context: string,
+        status: 'success' | 'error',
+    ) {
+        this.queryExecutionDurationHistogram?.observe(
+            { source, context, status },
+            durationMs,
+        );
+    }
+
+    public trackDuckdbResolution(
+        resolved: boolean,
+        reason: string | undefined,
+        durationMs: number,
+    ) {
+        const status = resolved ? 'success' : 'failed';
+        this.duckdbResolutionCounter?.inc({
+            status,
+            reason: resolved ? 'none' : reason || 'unknown',
+        });
+        this.duckdbResolutionDurationHistogram?.observe({ status }, durationMs);
+    }
+
+    public incrementPreAggregateFallback(reason: string) {
+        this.preAggregateFallbackCounter?.inc({ reason });
+    }
+
+    public observeS3ResultsUploadDuration(
+        durationMs: number,
+        source: 'warehouse' | 'pre_aggregate_duckdb',
+    ) {
+        this.s3ResultsUploadDurationHistogram?.observe({ source }, durationMs);
+    }
+
+    public incrementQueryCacheHit(
+        cacheHit: boolean,
+        context: string,
+        hasPreAggregateMatch: boolean,
+    ) {
+        this.queryCacheHitCounter?.inc({
+            result: cacheHit ? 'hit' : 'miss',
+            context,
+            has_pre_aggregate_match: hasPreAggregateMatch ? 'true' : 'false',
+        });
+    }
+
     public monitorPreAggregates(knex: Knex) {
         const { enabled, ...rest } = this.config;
         if (!enabled) {
@@ -508,7 +660,7 @@ export default class PrometheusMetrics {
         }
 
         this.preAggregateActiveMaterializationsGauge = new prometheus.Gauge({
-            name: 'pre_aggregate_active_materializations',
+            name: 'assessment_pre_aggregate_active_materializations',
             help: 'Current number of active pre-aggregate materializations',
             ...rest,
             async collect() {

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -85,6 +85,37 @@ Sentry.init({
             return context.parentSampled;
         }
 
+        // Boost sampling for async query execution when queryTracesSampleRate is set
+        // This captures more pre-aggregate vs warehouse traces for comparison
+        const { queryTracesSampleRate } = lightdashConfig.sentry;
+        if (queryTracesSampleRate !== null) {
+            // Match by span/transaction name (e.g. scheduler-triggered queries)
+            const spanName = context.name ?? '';
+            if (spanName.includes('ProjectService.executeAsyncQuery')) {
+                return queryTracesSampleRate;
+            }
+
+            // Match by URL for HTTP-rooted dashboard chart query requests
+            // Targets POST /api/v2/projects/{uuid}/query/dashboard-chart
+            if (request?.url) {
+                try {
+                    const url = new URL(
+                        request.url,
+                        `http://${request.headers?.host || 'localhost'}`,
+                    );
+                    if (
+                        /\/api\/v2\/projects\/[^/]+\/query\/dashboard-chart/.test(
+                            url.pathname,
+                        )
+                    ) {
+                        return queryTracesSampleRate;
+                    }
+                } catch {
+                    // Ignore URL parse errors, fall through to default
+                }
+            }
+        }
+
         return lightdashConfig.sentry.tracesSampleRate;
     },
     profilesSampleRate: lightdashConfig.sentry.profilesSampleRate, // x% of samples will be profiled

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -95,6 +95,7 @@ import {
     type WarehouseSqlBuilder,
 } from '@lightdash/common';
 import { SshTunnel, warehouseSqlBuilderFromType } from '@lightdash/warehouses';
+import * as Sentry from '@sentry/node';
 import { createInterface } from 'readline';
 import { Readable, Writable } from 'stream';
 import { v4 as uuidv4 } from 'uuid';
@@ -1573,6 +1574,10 @@ export class AsyncQueryService extends ProjectService {
             },
         };
 
+        const executionSource: 'warehouse' | 'pre_aggregate_duckdb' =
+            warehouseClientOverride ? 'pre_aggregate_duckdb' : 'warehouse';
+        let queryStartTime = Date.now();
+
         try {
             if (warehouseClientOverride) {
                 warehouseClient = warehouseClientOverride;
@@ -1601,9 +1606,6 @@ export class AsyncQueryService extends ProjectService {
                 sshTunnel = warehouseConnection.sshTunnel;
             }
 
-            const executionSource = warehouseClientOverride
-                ? 'pre_aggregate_duckdb'
-                : 'warehouse';
             this.logger.info(
                 `Running query ${queryHistoryUuid} source=${executionSource}`,
             );
@@ -1641,6 +1643,7 @@ export class AsyncQueryService extends ProjectService {
                     ...(isRegisteredUser ? undefined : { externalId: userId }),
                 },
             });
+            queryStartTime = Date.now();
             const {
                 warehouseResults: {
                     durationMs,
@@ -1650,14 +1653,42 @@ export class AsyncQueryService extends ProjectService {
                 },
                 pivotDetails,
                 columns,
-            } = await AsyncQueryService.runQueryAndTransformRows({
-                warehouseClient,
-                query,
-                queryTags,
-                write: stream?.write,
-                pivotConfiguration,
-                itemsMap: fieldsMap,
-            });
+            } = await Sentry.startSpan(
+                {
+                    op: 'query.execute',
+                    name: `query.execute.${executionSource}`,
+                    attributes: {
+                        'lightdash.executionSource': executionSource,
+                        'lightdash.queryContext':
+                            queryTags.query_context || 'unknown',
+                        'lightdash.projectUuid': projectUuid,
+                        'lightdash.isPivoted': !!pivotConfiguration,
+                    },
+                },
+                () =>
+                    AsyncQueryService.runQueryAndTransformRows({
+                        warehouseClient,
+                        query,
+                        queryTags,
+                        write: stream?.write,
+                        pivotConfiguration,
+                        itemsMap: fieldsMap,
+                    }),
+            );
+
+            // Track query execution duration — scoped to pre-aggregate DuckDB queries by default
+            // Set LIGHTDASH_PROMETHEUS_ALL_QUERY_METRICS_ENABLED=true to track all queries
+            if (
+                executionSource === 'pre_aggregate_duckdb' ||
+                this.lightdashConfig.prometheus.allQueryMetricsEnabled
+            ) {
+                this.prometheusMetrics?.observeQueryExecutionDuration(
+                    durationMs,
+                    executionSource,
+                    queryTags.query_context || 'unknown',
+                    'success',
+                );
+            }
 
             this.analytics.track({
                 ...analyticsIdentity,
@@ -1678,7 +1709,17 @@ export class AsyncQueryService extends ProjectService {
 
             if (stream) {
                 // Wait for the file to be written before marking the query as ready
+                const s3UploadStart = Date.now();
                 await stream.close();
+                if (
+                    executionSource === 'pre_aggregate_duckdb' ||
+                    this.lightdashConfig.prometheus.allQueryMetricsEnabled
+                ) {
+                    this.prometheusMetrics?.observeS3ResultsUploadDuration(
+                        Date.now() - s3UploadStart,
+                        executionSource,
+                    );
+                }
 
                 this.analytics.track({
                     ...analyticsIdentity,
@@ -1730,6 +1771,18 @@ export class AsyncQueryService extends ProjectService {
                 queryTags.query_context,
             );
         } catch (e) {
+            if (
+                executionSource === 'pre_aggregate_duckdb' ||
+                this.lightdashConfig.prometheus.allQueryMetricsEnabled
+            ) {
+                this.prometheusMetrics?.observeQueryExecutionDuration(
+                    Date.now() - queryStartTime,
+                    executionSource,
+                    queryTags.query_context || 'unknown',
+                    'error',
+                );
+            }
+
             this.analytics.track({
                 ...analyticsIdentity,
                 event: 'query.error',
@@ -1998,6 +2051,26 @@ export class AsyncQueryService extends ProjectService {
                         'warehouse.type',
                         warehouseCredentialsType,
                     );
+                    span.setAttribute('lightdash.context', context);
+                    span.setAttribute('lightdash.exploreName', explore.name);
+                    span.setAttribute(
+                        'lightdash.preAggregate.hasRoute',
+                        !!preAggregationRoute,
+                    );
+                    if (preAggregationRoute) {
+                        span.setAttribute(
+                            'lightdash.preAggregate.mode',
+                            preAggregationRoute.mode,
+                        );
+                        span.setAttribute(
+                            'lightdash.preAggregate.name',
+                            preAggregationRoute.preAggregateName,
+                        );
+                        span.setAttribute(
+                            'lightdash.preAggregate.sourceExplore',
+                            preAggregationRoute.sourceExploreName,
+                        );
+                    }
 
                     const warehouseSqlBuilder = warehouseSqlBuilderFromType(
                         warehouseCredentialsType,
@@ -2098,6 +2171,13 @@ export class AsyncQueryService extends ProjectService {
                             },
                         },
                     });
+
+                    // Track cache hit/miss
+                    this.prometheusMetrics?.incrementQueryCacheHit(
+                        resultsCache.cacheHit || false,
+                        queryTags.query_context || 'unknown',
+                        !!preAggregationRoute,
+                    );
 
                     if (resultsCache.cacheHit) {
                         await this.queryHistoryModel.update(
@@ -2220,6 +2300,9 @@ export class AsyncQueryService extends ProjectService {
                                 return;
                             }
 
+                            this.prometheusMetrics?.incrementPreAggregateFallback(
+                                reason,
+                            );
                             await this.runAsyncWarehouseQuery(warehouseArgs);
                         };
 
@@ -2252,12 +2335,29 @@ export class AsyncQueryService extends ProjectService {
                             });
 
                         if (!preAggResolution?.resolved) {
+                            span.setAttribute(
+                                'lightdash.preAggregate.resolved',
+                                false,
+                            );
+                            span.setAttribute(
+                                'lightdash.preAggregate.resolveReason',
+                                preAggResolution?.reason ?? 'resolve_error',
+                            );
                             await handlePreAggregationMiss(
                                 preAggResolution?.reason ??
                                     PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
                             );
                             return;
                         }
+
+                        span.setAttribute(
+                            'lightdash.preAggregate.resolved',
+                            true,
+                        );
+                        span.setAttribute(
+                            'lightdash.executionSource',
+                            'pre_aggregate_duckdb',
+                        );
 
                         this.logger.info(
                             `DuckDB pre-agg route selected for ${queryHistoryUuid}: ${preAggregationRoute.sourceExploreName}/${preAggregationRoute.preAggregateName}`,
@@ -2283,6 +2383,17 @@ export class AsyncQueryService extends ProjectService {
 
                             this.logger.warn(
                                 `DuckDB pre-agg execution failed for ${queryHistoryUuid}: ${getErrorMessage(duckdbError)}. Falling back to warehouse`,
+                            );
+                            span.setAttribute(
+                                'lightdash.preAggregate.fallback',
+                                true,
+                            );
+                            span.setAttribute(
+                                'lightdash.executionSource',
+                                'warehouse_after_duckdb_fallback',
+                            );
+                            this.prometheusMetrics?.incrementPreAggregateFallback(
+                                'duckdb_execution_error',
                             );
                             await this.runAsyncWarehouseQuery(warehouseArgs);
                         }

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -23,6 +23,7 @@ import { type LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { type PreAggregateModel } from '../../models/PreAggregateModel';
 import { type ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import type PrometheusMetrics from '../../prometheus/PrometheusMetrics';
 import { wrapSentryTransaction } from '../../utils';
 import { PivotQueryBuilder } from '../../utils/QueryBuilder/PivotQueryBuilder';
 import {
@@ -37,6 +38,7 @@ type PreAggregationDuckDbClientArgs = {
     lightdashConfig: LightdashConfig;
     preAggregateModel: Pick<PreAggregateModel, 'getActiveMaterialization'>;
     projectModel: Pick<ProjectModel, 'getExploreFromCache'>;
+    prometheusMetrics?: PrometheusMetrics;
     createDuckdbWarehouseClient?: (args: {
         s3Config: DuckdbS3SessionConfig;
     }) => WarehouseClient;
@@ -81,10 +83,13 @@ export class PreAggregationDuckDbClient {
         s3Config: DuckdbS3SessionConfig;
     }) => WarehouseClient;
 
+    private readonly prometheusMetrics?: PrometheusMetrics;
+
     constructor(args: PreAggregationDuckDbClientArgs) {
         this.lightdashConfig = args.lightdashConfig;
         this.preAggregateModel = args.preAggregateModel;
         this.projectModel = args.projectModel;
+        this.prometheusMetrics = args.prometheusMetrics;
         this.createDuckdbWarehouseClient =
             args.createDuckdbWarehouseClient ??
             ((warehouseArgs) => new DuckdbWarehouseClient(warehouseArgs));
@@ -124,11 +129,19 @@ export class PreAggregationDuckDbClient {
     async resolve(
         args: ResolvePreAggregationDuckDbArgs,
     ): Promise<PreAggregationDuckDbResolution> {
+        const startTime = Date.now();
         try {
             const result = await wrapSentryTransaction(
                 'PreAggregationDuckDbClient.resolve',
                 {},
                 () => this._resolve(args),
+            );
+
+            const durationMs = Date.now() - startTime;
+            this.prometheusMetrics?.trackDuckdbResolution(
+                result.resolved,
+                result.resolved ? undefined : result.reason,
+                durationMs,
             );
 
             if (!result.resolved) {
@@ -137,6 +150,13 @@ export class PreAggregationDuckDbClient {
 
             return result;
         } catch (error) {
+            const durationMs = Date.now() - startTime;
+            this.prometheusMetrics?.trackDuckdbResolution(
+                false,
+                PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
+                durationMs,
+            );
+
             Logger.warn(
                 `DuckDB pre-agg resolve failed: ${getErrorMessage(error)}. Returning unresolved`,
             );

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -701,6 +701,7 @@ export class ServiceRepository
                         lightdashConfig: this.context.lightdashConfig,
                         preAggregateModel: this.models.getPreAggregateModel(),
                         projectModel: this.models.getProjectModel(),
+                        prometheusMetrics: this.prometheusMetrics,
                     }),
                     projectCompileLogModel:
                         this.models.getProjectCompileLogModel(),

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -312,6 +312,7 @@ export type SentryConfig = {
     release: string;
     environment: string;
     tracesSampleRate: number;
+    queryTracesSampleRate: number | null;
     profilesSampleRate: number;
     anr: {
         enabled: boolean;


### PR DESCRIPTION
### Description:

This PR enhances monitoring capabilities for query execution and pre-aggregation performance by adding comprehensive metrics tracking and configurable Sentry tracing.

**New Prometheus Metrics:**
- `assessment_query_execution_duration_ms` - Tracks query execution time by source (warehouse vs pre-aggregate DuckDB)
- `assessment_pre_aggregate_duckdb_resolution_duration_ms` - Measures DuckDB resolution performance
- `assessment_pre_aggregate_duckdb_resolution_total` - Counts resolution attempts and outcomes
- `assessment_pre_aggregate_fallback_total` - Tracks fallbacks from pre-aggregate to warehouse
- `assessment_s3_results_upload_duration_ms` - Monitors S3 upload performance
- `assessment_pre_aggregate_cache_hit_total` - Records query cache hit/miss rates

**Enhanced Sentry Tracing:**
- Added `SENTRY_QUERY_TRACES_SAMPLE_RATE` environment variable for targeted query trace sampling
- Improved span attributes with pre-aggregation context, execution source, and query metadata
- Selective tracing for async query execution and dashboard chart requests

**Configuration Options:**
- `LIGHTDASH_PROMETHEUS_ALL_QUERY_METRICS_ENABLED` - Controls whether to track metrics for all queries or just pre-aggregate DuckDB queries (defaults to false)
- Query-specific trace sampling allows higher sampling rates for performance analysis without overwhelming general traces

The metrics are scoped to pre-aggregate queries by default but can be expanded to all queries via configuration. All existing pre-aggregate metric names have been prefixed with `assessment_` for consistency.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches async query execution flow and observability wiring (Prometheus/Sentry), which can affect performance overhead and metric/trace cardinality if misconfigured, but does not alter core query results logic.
> 
> **Overview**
> Adds **new Prometheus instrumentation** around async query execution and pre-aggregate behavior (query execution duration by source/status, DuckDB resolution timing/outcome, cache hit/miss, S3 results upload duration, and fallback reasons), and wires `PrometheusMetrics` into `PreAggregationDuckDbClient` to record resolution metrics.
> 
> Introduces new config knobs: `LIGHTDASH_PROMETHEUS_ALL_QUERY_METRICS_ENABLED` (default off) to broaden metrics beyond pre-aggregate queries, and `SENTRY_QUERY_TRACES_SAMPLE_RATE` (nullable) to selectively increase tracing for async query execution and dashboard chart query requests; also renames existing pre-aggregate Prometheus metric names to be prefixed with `assessment_` for consistency.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1e83e6887adc7a75219ac2a1cafd5c1e77b6c4c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->