### PR TITLE
chore: downgrade only-throw-error to warn until eslint supports TS6

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -35,7 +35,7 @@ module.exports = {
         '@typescript-eslint/no-floating-promises': 'error',
         '@typescript-eslint/no-throw-literal': 'off',
         // no-throw-literal replaced with only-throw-error
-        '@typescript-eslint/only-throw-error': 'error',
+        '@typescript-eslint/only-throw-error': 'warn', // TODO: revert to 'error' when eslint supports TS6
     },
     overrides: [
         {


### PR DESCRIPTION
## Summary
- Downgrades `@typescript-eslint/only-throw-error` from `error` to `warn` in the backend ESLint config
- Prevents compilation failures until eslint typescript plugin supports TS6

## Test plan
- [ ] Verify ESLint still reports `only-throw-error` as a warning (not error)
- [ ] Verify backend builds successfully