### PR TITLE
fix: set transparent background for markdown images

### DIFF
--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -373,6 +373,9 @@ export const getMantineThemeOverride = (
             '.wmde-markdown, .wmde-markdown-var': {
                 fontFamily: theme.fontFamily,
             },
+            '.wmde-markdown img': {
+                backgroundColor: 'transparent',
+            },
             '@keyframes fadeIn': {
                 from: { opacity: 0 },
                 to: { opacity: 1 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Set transparent background for images in markdown content by adding `backgroundColor: 'transparent'` to the `.wmde-markdown img` CSS selector in the Mantine theme override.

<!-- Even better add a screenshot / gif / loom -->