### PR TITLE
feat: add more child spans to duckdb execution

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1492,12 +1492,19 @@ export class AsyncQueryService extends ProjectService {
                   await write?.(rows);
               };
 
-        const warehouseResults = await warehouseClient.executeAsyncQuery(
+        const warehouseResults = await Sentry.startSpan(
             {
-                sql: query,
-                tags: queryTags,
+                op: 'db.query',
+                name: 'warehouse.executeAsyncQuery',
             },
-            write ? writeAndTransformRowsIfPivot : undefined,
+            () =>
+                warehouseClient.executeAsyncQuery(
+                    {
+                        sql: query,
+                        tags: queryTags,
+                    },
+                    write ? writeAndTransformRowsIfPivot : undefined,
+                ),
         );
 
         const columns = pivotConfiguration?.groupByColumns?.length
@@ -1710,7 +1717,18 @@ export class AsyncQueryService extends ProjectService {
             if (stream) {
                 // Wait for the file to be written before marking the query as ready
                 const s3UploadStart = Date.now();
-                await stream.close();
+                await Sentry.startSpan(
+                    {
+                        op: 's3.upload',
+                        name: 's3.results.upload',
+                        attributes: {
+                            'lightdash.executionSource': executionSource,
+                            'lightdash.totalRows':
+                                pivotDetails?.totalRows ?? totalRows,
+                        },
+                    },
+                    () => stream?.close(),
+                );
                 if (
                     executionSource === 'pre_aggregate_duckdb' ||
                     this.lightdashConfig.prometheus.allQueryMetricsEnabled

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -19,6 +19,7 @@ import {
     DuckdbWarehouseClient,
     warehouseSqlBuilderFromType,
 } from '@lightdash/warehouses';
+import * as Sentry from '@sentry/node';
 import { type LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
 import { type PreAggregateModel } from '../../models/PreAggregateModel';
@@ -199,11 +200,21 @@ export class PreAggregationDuckDbClient {
             args.preAggregationRoute.preAggregateName,
         );
 
-        const activeMaterialization =
-            await this.preAggregateModel.getActiveMaterialization(
-                args.projectUuid,
-                preAggExploreName,
-            );
+        const activeMaterialization = await Sentry.startSpan(
+            {
+                op: 'db.query',
+                name: 'preagg.getActiveMaterialization',
+                attributes: {
+                    'lightdash.projectUuid': args.projectUuid,
+                    'lightdash.preAggExploreName': preAggExploreName,
+                },
+            },
+            () =>
+                this.preAggregateModel.getActiveMaterialization(
+                    args.projectUuid,
+                    preAggExploreName,
+                ),
+        );
 
         if (!activeMaterialization) {
             return {
@@ -221,9 +232,20 @@ export class PreAggregationDuckDbClient {
             activeMaterialization.columns,
         );
 
-        const preAggExplore = await this.projectModel.getExploreFromCache(
-            args.projectUuid,
-            preAggExploreName,
+        const preAggExplore = await Sentry.startSpan(
+            {
+                op: 'cache.read',
+                name: 'preagg.getExploreFromCache',
+                attributes: {
+                    'lightdash.projectUuid': args.projectUuid,
+                    'lightdash.preAggExploreName': preAggExploreName,
+                },
+            },
+            () =>
+                this.projectModel.getExploreFromCache(
+                    args.projectUuid,
+                    preAggExploreName,
+                ),
         );
 
         if (isExploreError(preAggExplore)) {
@@ -252,19 +274,27 @@ export class PreAggregationDuckDbClient {
             args.startOfWeek,
         );
 
-        const fullQuery = await ProjectService._compileQuery({
-            metricQuery: args.metricQuery,
-            explore: patchedPreAggExplore,
-            warehouseSqlBuilder,
-            intrinsicUserAttributes:
-                args.userAccessControls.intrinsicUserAttributes,
-            userAttributes: args.userAccessControls.userAttributes,
-            timezone: this.lightdashConfig.query.timezone || 'UTC',
-            dateZoom: args.dateZoom,
-            parameters: args.parameters,
-            availableParameterDefinitions: args.availableParameterDefinitions,
-            pivotConfiguration: args.pivotConfiguration,
-        });
+        const fullQuery = await Sentry.startSpan(
+            {
+                op: 'function',
+                name: 'preagg.compileQuery',
+            },
+            () =>
+                ProjectService._compileQuery({
+                    metricQuery: args.metricQuery,
+                    explore: patchedPreAggExplore,
+                    warehouseSqlBuilder,
+                    intrinsicUserAttributes:
+                        args.userAccessControls.intrinsicUserAttributes,
+                    userAttributes: args.userAccessControls.userAttributes,
+                    timezone: this.lightdashConfig.query.timezone || 'UTC',
+                    dateZoom: args.dateZoom,
+                    parameters: args.parameters,
+                    availableParameterDefinitions:
+                        args.availableParameterDefinitions,
+                    pivotConfiguration: args.pivotConfiguration,
+                }),
+        );
 
         let { query } = fullQuery;
         if (args.pivotConfiguration) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds Sentry performance monitoring spans to key operations in the AsyncQueryService and PreAggregationDuckDbClient.

**AsyncQueryService changes:**
- Wraps `warehouseClient.executeAsyncQuery` calls with a `db.query` span named `warehouse.executeAsyncQuery`
- Adds an `s3.upload` span around `stream.close()` operations with attributes for execution source and total rows

**PreAggregationDuckDbClient changes:**
- Adds `db.query` span for `getActiveMaterialization` calls with project UUID and explore name attributes
- Wraps `getExploreFromCache` calls with a `cache.read` span including project and explore identifiers
- Instruments `ProjectService._compileQuery` calls with a `function` span named `preagg.compileQuery`

These instrumentation changes will provide better visibility into query execution performance and help identify bottlenecks in the pre-aggregation pipeline.