### PR TITLE
fix: add express-session types to backend tsconfig

### DIFF
--- a/packages/backend/tsconfig.json
+++ b/packages/backend/tsconfig.json
@@ -20,8 +20,9 @@
         "moduleResolution": "node10",
         "resolveJsonModule": true,
         "skipLibCheck": true,
-        "types": ["node", "jest", "passport"]
+        "types": ["node", "jest", "passport", "express-session"]
     },
+    "files": ["src/@types/express-session.d.ts"],
     "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.json"],
     "exclude": ["dist", "node_modules", "src/ee/services/McpService/mcp-chart-app"],
     "references": [


### PR DESCRIPTION
### Description:
Added express-session type definitions to the backend TypeScript configuration. This includes adding "express-session" to the types array and referencing a custom type definition file at `src/@types/express-session.d.ts` to provide proper TypeScript support for express-session functionality.