### PR TITLE
fix: scale CLI e2e test timeouts dynamically based on model count

### DIFF
--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -1,6 +1,8 @@
 import { defineConfig } from 'cypress';
 import cypressSplit from 'cypress-split';
-import { readdirSync, unlinkSync } from 'fs';
+import { readdirSync, readFileSync, unlinkSync } from 'fs';
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const { load: loadYaml } = require('js-yaml');
 import { join } from 'path';
 
 // If running natively, we want to use environment variables from the host machine
@@ -33,11 +35,13 @@ export default defineConfig({
         trashAssetsBeforeRuns: true,
         experimentalMemoryManagement: true,
         setupNodeEvents(on, config) {
-            // Count dbt models so CLI tests can scale timeouts dynamically
-            const modelsDir = join(
+            // Count dbt models and read thread count so CLI tests can
+            // scale timeouts dynamically based on parallel execution.
+            const demoDir = join(
                 __dirname,
-                '../../examples/full-jaffle-shop-demo/dbt/models',
+                '../../examples/full-jaffle-shop-demo',
             );
+            const modelsDir = join(demoDir, 'dbt/models');
             const countSqlFiles = (dir: string): number =>
                 readdirSync(dir, { withFileTypes: true }).reduce(
                     (count, entry) =>
@@ -49,6 +53,18 @@ export default defineConfig({
                     0,
                 );
             config.env.MODEL_COUNT = countSqlFiles(modelsDir);
+
+            const DBT_DEFAULT_THREADS = 4;
+            const profilesPath = join(demoDir, 'profiles/profiles.yml');
+            const profiles = loadYaml(
+                readFileSync(profilesPath, 'utf8'),
+            ) as Record<string, any>;
+            const targetName =
+                profiles?.jaffle_shop?.target ?? 'jaffle';
+            const threads =
+                profiles?.jaffle_shop?.outputs?.[targetName]?.threads ??
+                DBT_DEFAULT_THREADS;
+            config.env.DBT_THREADS = threads;
 
             cypressSplit(on, config);
 

--- a/packages/e2e/cypress/cli/dbt/cli.cy.ts
+++ b/packages/e2e/cypress/cli/dbt/cli.cy.ts
@@ -3,14 +3,15 @@ describe('CLI', () => {
     const profilesDir = `../../examples/full-jaffle-shop-demo/profiles`;
     const cliCommand = `lightdash`;
 
-    // Scale timeout based on the number of models in the project (counted
-    // dynamically in cypress.config.ts). Allow 3s per model + 30s base overhead
-    // for dbt startup so the timeout grows automatically as models are added.
-    const TIMEOUT_PER_MODEL_MS = 3000;
+    // Scale timeout based on the number of models and thread count (both
+    // read dynamically in cypress.config.ts). dbt runs models in parallel,
+    // so we estimate batches rather than sequential model count.
+    const TIMEOUT_PER_BATCH_MS = 3000;
     const BASE_TIMEOUT_MS = 30000;
     const modelCount = Number(Cypress.env('MODEL_COUNT')) || 50;
-    const allModelsTimeout =
-        BASE_TIMEOUT_MS + modelCount * TIMEOUT_PER_MODEL_MS;
+    const dbtThreads = Number(Cypress.env('DBT_THREADS')) || 4;
+    const batches = Math.ceil(modelCount / dbtThreads);
+    const allModelsTimeout = BASE_TIMEOUT_MS + batches * TIMEOUT_PER_BATCH_MS;
 
     const databaseEnvVars = {
         PGHOST: Cypress.env('PGHOST') ?? 'localhost',


### PR DESCRIPTION
Closes: [PROD-5842](https://linear.app/lightdash/issue/PROD-5842/update-cypress-cli-test-timeouts-based-on-model-count)

### Description:
The CLI tests were using hardcoded 60s timeouts, and with the current number of dbt models in the jaffle-shop demo, we were consistently hitting ~58-59s at runtime which resulted in many failed tests in Github actions. 

Instead of a fixed timeout, tests now calculate one based on how many models actually need to run:

**`cypress.config.ts`** (setup)
- Counts `.sql` files in the jaffle-shop models directory
- Reads the thread count from `profiles.yml`
- Exposes both as env vars for the tests to use

**`cli.cy.ts`** (test execution)
- Calculates timeout as: `30s base + 3s × ceil(modelCount / dbtThreads)`
- Since dbt runs models in parallel (up to `threads` at a time), we scale by number of *batches*, not total models
- Replaces hardcoded timeouts on `dbt run`, `dbt compile`, and related CLI commands

We should no longer see CLI: dbt 1.10 and CLI: dbt 1.11 fail:
<img width="1375" height="621" alt="image" src="https://github.com/user-attachments/assets/e532d1fe-b7b1-465b-93a7-76315323d4a2" />
