### PR TITLE
fix: disable Sankey chart animation in minimal mode

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
@@ -17,8 +17,13 @@ import { useVisualizationContext } from '../../components/LightdashVisualization
 const stripStepSuffix = (name: string) => name.replace(/ - Step \d+$/, '');
 
 const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
-    const { visualizationConfig, colorPalette, parameters, isTouchDevice } =
-        useVisualizationContext();
+    const {
+        visualizationConfig,
+        colorPalette,
+        parameters,
+        isTouchDevice,
+        minimal,
+    } = useVisualizationContext();
 
     const theme = useMantineTheme();
 
@@ -144,12 +149,13 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
                 },
             },
             series: [sankeySeriesOption],
-            animation: !isInDashboard,
+            animation: !(isInDashboard || minimal),
         };
     }, [
         chartConfig,
         sankeySeriesOption,
         isInDashboard,
+        minimal,
         theme,
         isTouchDevice,
         visualizationConfig,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Disable animations in Sankey charts when in minimal mode. The chart animation is now disabled when either `isInDashboard` or `minimal` context flags are true, providing a cleaner experience in minimal visualization contexts.

<!-- Even better add a screenshot / gif / loom -->