### PR TITLE
fix: make the user impersonation flag env variable only

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -350,6 +350,6 @@ export const lightdashConfigMock: LightdashConfig = {
         },
     },
     userImpersonation: {
-        enabled: undefined,
+        enabled: false,
     },
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1103,7 +1103,7 @@ export type LightdashConfig = {
         s3?: Omit<S3Config, 'expirationTime'>;
     };
     userImpersonation: {
-        enabled: boolean | undefined;
+        enabled: boolean;
     };
 };
 
@@ -2003,9 +2003,7 @@ export const parseConfig = (): LightdashConfig => {
             s3: preAggregatesS3,
         },
         userImpersonation: {
-            enabled: process.env.USER_IMPERSONATION_ENABLED
-                ? process.env.USER_IMPERSONATION_ENABLED === 'true'
-                : undefined,
+            enabled: process.env.USER_IMPERSONATION_ENABLED === 'true',
         },
     };
 };

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -304,28 +304,11 @@ export class FeatureFlagModel {
     }
 
     private async getUserImpersonationEnabled({
-        user,
         featureFlagId,
     }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.userImpersonation.enabled ??
-            (user !== undefined
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.UserImpersonation,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
-
         return {
             id: featureFlagId,
-            enabled,
+            enabled: this.lightdashConfig.userImpersonation.enabled,
         };
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://github.com/lightdash/lightdash/pull/20075

### Description:

This change simplifies the user impersonation feature flag configuration by removing the fallback to posthog feature flag service when the environment variable is not set.

The flag was called on every request when an admin was impersonating