### PR TITLE
feat: improve memory limit temp directory on duckdb conversion

### DIFF
--- a/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -107,7 +107,10 @@ export class PreAggregateMaterializationService extends BaseService {
             );
         }
 
-        const duckdb = new DuckdbWarehouseClient({ s3Config });
+        const duckdb = new DuckdbWarehouseClient({
+            s3Config,
+            resourceLimits: { memoryLimit: '256MB', threads: 1 },
+        });
 
         const jsonlSqlTable = getDuckdbPreAggregateSqlTable(
             getPreAggregateDuckdbLocator({ uri: jsonlUri, format: 'jsonl' }),

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -11,6 +11,9 @@ import {
     WarehouseResults,
     WarehouseTypes,
 } from '@lightdash/common';
+import fs from 'fs/promises';
+import os from 'os';
+import path from 'path';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';
 
@@ -48,9 +51,15 @@ export type DuckdbS3SessionConfig = {
     useSsl: boolean;
 };
 
+export type DuckdbResourceLimits = {
+    memoryLimit: string; // e.g. '256MB'
+    threads: number; // e.g. 1
+};
+
 export type DuckdbWarehouseClientArgs = {
     databasePath?: string;
     s3Config?: DuckdbS3SessionConfig;
+    resourceLimits?: DuckdbResourceLimits;
 };
 
 const DUCKDB_INTERNAL_CREDENTIALS: CreatePostgresCredentials = {
@@ -126,10 +135,13 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
 
     private readonly s3Config?: DuckdbS3SessionConfig;
 
+    private readonly resourceLimits?: DuckdbResourceLimits;
+
     constructor(args: DuckdbWarehouseClientArgs = {}) {
         super(DUCKDB_INTERNAL_CREDENTIALS, new DuckdbSqlBuilder());
         this.databasePath = args.databasePath ?? ':memory:';
         this.s3Config = args.s3Config;
+        this.resourceLimits = args.resourceLimits;
     }
 
     private getSQLWithMetadata(sql: string, tags?: Record<string, string>) {
@@ -148,19 +160,40 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         )) as DuckdbInstance;
         const connection = await instance.connect();
 
+        // Only create a temp dir when resource limits are set (spill to disk).
+        const tempDir = this.resourceLimits
+            ? await fs.mkdtemp(path.join(os.tmpdir(), 'duckdb-temp-'))
+            : undefined;
+
         try {
-            await this.bootstrapSession(connection);
+            await this.bootstrapSession(connection, tempDir);
             return await callback(connection);
         } finally {
             connection.closeSync?.();
             connection.disconnectSync?.();
             instance.closeSync?.();
+            if (tempDir) {
+                await fs.rm(tempDir, { recursive: true, force: true }).catch(
+                    () => {}, // best-effort cleanup
+                );
+            }
         }
     }
 
-    private async bootstrapSession(db: DuckdbConnection): Promise<void> {
+    private async bootstrapSession(
+        db: DuckdbConnection,
+        tempDir: string | undefined,
+    ): Promise<void> {
         await db.run('INSTALL httpfs;');
         await db.run('LOAD httpfs;');
+
+        if (this.resourceLimits && tempDir) {
+            await db.run(
+                `SET memory_limit = '${this.resourceLimits.memoryLimit}';`,
+            );
+            await db.run(`SET temp_directory = '${tempDir}';`);
+            await db.run(`SET threads = ${this.resourceLimits.threads};`);
+        }
 
         if (!this.s3Config) {
             return;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Added resource limits configuration to DuckDB warehouse client to control memory usage and thread count. The client now accepts optional `resourceLimits` parameter with `memoryLimit` and `threads` settings.

When resource limits are configured, the client:
- Sets memory limit (e.g., '256MB') to prevent excessive memory usage
- Creates a temporary directory for disk spilling when memory is exceeded
- Configures thread count for query execution
- Automatically cleans up temporary directories after use

The PreAggregateMaterializationService now uses these limits with 256MB memory and single-threaded execution for better resource control during materialization operations.