### PR TITLE
feat: add pre_aggregates config to orders model

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -9,6 +9,27 @@ models:
     config:
       tags: ["core", "ai"]
       meta:
+        pre_aggregates:
+          - name: orders_daily_avg_demo
+            dimensions:
+              - status
+            metrics:
+              - average_order_size
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: orders_daily_avg_demo_2
+            dimensions:
+              - status
+              - order_source
+              - order_priority
+              - customers.first_name
+            metrics:
+              - average_order_size
+              - total_order_amount
+              - total_completed_order_amount
+            time_dimension: order_date
+            granularity: day
         primary_key: order_id
         spotlight:
           categories:
@@ -406,7 +427,7 @@ models:
                 type: string
                 label: Delivery Speed Tier
                 sql: |
-                  CASE 
+                  CASE
                     WHEN ${estimated_delivery_days} = 1 THEN 'Same/Next Day'
                     WHEN ${estimated_delivery_days} <= 3 THEN 'Fast (2-3 days)'
                     WHEN ${estimated_delivery_days} <= 5 THEN 'Standard (4-5 days)'
@@ -448,7 +469,7 @@ models:
                 type: string
                 label: Shipping Cost Tier
                 sql: |
-                  CASE 
+                  CASE
                   WHEN ${shipping_cost} < 10 THEN 'Low (<$10)'
                   WHEN ${shipping_cost} < 20 THEN 'Medium ($10-$20)'
                   WHEN ${shipping_cost} < 30 THEN 'High ($20-$30)'


### PR DESCRIPTION
This PR adds pre-aggregation configurations to the orders model in the jaffle shop demo. Two pre-aggregates are defined:

1. `orders_daily_avg_demo` - aggregates orders by status with average order size and total order amount metrics, grouped by day
2. `orders_daily_avg_demo_2` - extends the first pre-aggregate to include additional dimensions (order_source, order_priority, customers.first_name) and an additional metric (total_completed_order_amount)

Both pre-aggregates use `order_date` as the time dimension with daily granularity. The PR also includes minor formatting fixes to remove trailing whitespace in CASE statements for delivery speed and shipping cost tier calculations.