### PR TITLE
fix: prevent raw column aggregations from using nested aggregate CTE

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -337,3 +337,10 @@ models:
               group: "aggregates"
               description: "Product of two aggregate metrics - valid SQL, no nesting"
               sql: ${max_event_id} * ${unique_event_count}
+            # Reproduces customer bug: sum(bare_column) / ${aggregate_metric}
+            # Uses a bare column name (no ${} or ${TABLE}) like the customer's
+            # sql: sum(prediction_d60_total)/nullif(${total_cost}, 0)
+            raw_agg_with_metric_ref:
+              type: number
+              description: "Raw column aggregation divided by aggregate metric ref"
+              sql: sum(event_id) / NULLIF(${count}, 0)

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -2650,6 +2650,24 @@ export const EXPLORE_WITH_NESTED_AGG: Explore = {
                     tablesReferences: ['my_table'],
                     hidden: false,
                 },
+                // Raw column aggregation combined with metric reference
+                // sql: sum(raw_col) / ${count_records}
+                // The sum() wraps a raw column (not a ${ } ref), so this is
+                // NOT a nested aggregate — it compiles to SUM(col) / COUNT(col)
+                // which is valid SQL (sibling aggregates, not nested).
+                raw_agg_with_ref: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'raw_agg_with_ref',
+                    label: 'raw_agg_with_ref',
+                    sql: 'sum(${TABLE}.value) / NULLIF(${count_records}, 0)',
+                    compiledSql:
+                        'SUM("my_table".value) / NULLIF(COUNT("my_table".id), 0)',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
                 // Product of aggregates - NO outer aggregation, valid SQL without CTE
                 product_of_aggregates: {
                     type: MetricType.NUMBER,
@@ -2740,6 +2758,23 @@ export const METRIC_QUERY_NESTED_AGG_PRODUCT: CompiledMetricQuery = {
     metrics: ['my_table_product_of_aggregates'],
     filters: {},
     sorts: [{ fieldId: 'my_table_product_of_aggregates', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+// Raw column aggregation + metric reference: sum(raw_col) / ${aggregate_metric}
+// This is NOT a nested aggregate — both aggregations are at the same level.
+// The sum() wraps a raw column (not a metric ref), so it should NOT be
+// routed through the nested_agg CTE.
+export const METRIC_QUERY_NESTED_AGG_RAW_COL: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['my_table_category'],
+    metrics: ['my_table_raw_agg_with_ref', 'my_table_sum_of_max'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_raw_agg_with_ref', descending: true }],
     limit: 10,
     tableCalculations: [],
     compiledTableCalculations: [],

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -62,6 +62,7 @@ import {
     METRIC_QUERY_NESTED_AGG_MIXED,
     METRIC_QUERY_NESTED_AGG_NO_DIMS,
     METRIC_QUERY_NESTED_AGG_PRODUCT,
+    METRIC_QUERY_NESTED_AGG_RAW_COL,
     METRIC_QUERY_NESTED_AGG_WITH_DIMS,
     METRIC_QUERY_SQL,
     METRIC_QUERY_SQL_BIGQUERY,
@@ -4632,6 +4633,33 @@ describe('Nested aggregate metrics', () => {
         );
         expect(result.query).toContain(
             'nested_agg_results."my_table_sum_of_max"',
+        );
+    });
+
+    test('should NOT route raw column aggregation + metric ref through CTE (sum(raw_col) / ${metric})', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_RAW_COL,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // The raw_agg_with_ref metric (sum(raw_col) / ${count_records}) should NOT
+        // be in the nested_agg_results CTE because its sum() wraps a raw column,
+        // not a metric reference. It's valid SQL as-is: SUM(col) / COUNT(col).
+        // The sum_of_max metric should still use the CTE.
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).toContain('nested_agg_results AS (');
+        // sum_of_max should be in nested_agg_results
+        expect(result.query).toContain(
+            'nested_agg_results."my_table_sum_of_max"',
+        );
+        // raw_agg_with_ref should be compiled directly in na_base (not in nested_agg_results)
+        // It should produce valid SQL: SUM("my_table".value) / NULLIF(COUNT("my_table".id), 0)
+        expect(result.query).toContain('SUM("my_table".value)');
+        expect(result.query).not.toContain(
+            'nested_agg_results."my_table_raw_agg_with_ref"',
         );
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -51,6 +51,7 @@ import {
     renderTableCalculationFilterRuleSql,
     snakeCaseName,
     SortField,
+    sqlAggregationWrapsReferences,
     sqlContainsAggregation,
     SupportedDbtAdapter,
     TableCalculationFunctionCompiler,
@@ -2467,6 +2468,7 @@ export class MetricQueryBuilder {
                     fieldId: string;
                     metric: CompiledMetric;
                 }> = [];
+                const aggregateRefNames: string[] = [];
                 let hasAggregateRef = false;
                 for (const ref of refs) {
                     if (ref.refName !== 'TABLE') {
@@ -2482,12 +2484,34 @@ export class MetricQueryBuilder {
                             });
                             if (isAggregateMetricType(refMetric.type)) {
                                 hasAggregateRef = true;
+                                // Track the raw reference name for position checking
+                                aggregateRefNames.push(
+                                    ref.refTable === metric.table
+                                        ? ref.refName
+                                        : `${ref.refTable}.${ref.refName}`,
+                                );
                             }
                         } catch {
                             // Not a metric reference (could be a dimension), skip
                         }
                     }
                 }
+
+                // When the SQL has aggregation AND aggregate metric refs, verify
+                // that the aggregation actually WRAPS the metric refs.
+                // e.g. sum(${max_value}) → true (nested aggregate)
+                // e.g. sum(raw_col) / ${count_records} → false (same-level aggregates)
+                if (
+                    hasSqlAgg &&
+                    hasAggregateRef &&
+                    !sqlAggregationWrapsReferences(
+                        metric.sql,
+                        aggregateRefNames,
+                    )
+                ) {
+                    hasAggregateRef = false;
+                }
+
                 // Only treat as nested aggregate if at least one ref is an
                 // aggregate metric type (to avoid pulling in normal
                 // type:number → type:number chains)

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -4,6 +4,7 @@ import { DimensionType, FieldType, friendlyName } from '../types/field';
 import {
     ExploreCompiler,
     parseAllReferences,
+    sqlAggregationWrapsReferences,
     sqlContainsAggregation,
     type UncompiledExplore,
 } from './exploreCompiler';
@@ -1108,5 +1109,74 @@ describe('sqlContainsAggregation', () => {
         test('should return false for null', () => {
             expect(sqlContainsAggregation(null)).toBe(false);
         });
+    });
+});
+
+describe('sqlAggregationWrapsReferences', () => {
+    test('should return true when aggregation wraps a metric reference', () => {
+        expect(
+            sqlAggregationWrapsReferences('sum(${max_value})', ['max_value']),
+        ).toBe(true);
+    });
+
+    test('should return true for count(distinct ${metric})', () => {
+        expect(
+            sqlAggregationWrapsReferences('count(distinct ${max_value})', [
+                'max_value',
+            ]),
+        ).toBe(true);
+    });
+
+    test('should return true when one of multiple refs is inside aggregation', () => {
+        expect(
+            sqlAggregationWrapsReferences(
+                'sum(${max_value}) / NULLIF(${count_records}, 0)',
+                ['max_value'],
+            ),
+        ).toBe(true);
+    });
+
+    test('should return false when ref is outside aggregation (sibling aggregates)', () => {
+        expect(
+            sqlAggregationWrapsReferences(
+                'sum(${TABLE}.value) / NULLIF(${count_records}, 0)',
+                ['count_records'],
+            ),
+        ).toBe(false);
+    });
+
+    test('should return false when aggregation wraps raw column, not metric ref', () => {
+        expect(
+            sqlAggregationWrapsReferences('sum(raw_col) / ${count_records}', [
+                'count_records',
+            ]),
+        ).toBe(false);
+    });
+
+    test('should return false for empty refs', () => {
+        expect(sqlAggregationWrapsReferences('sum(${max_value})', [])).toBe(
+            false,
+        );
+    });
+
+    test('should return false for empty sql', () => {
+        expect(sqlAggregationWrapsReferences('', ['max_value'])).toBe(false);
+    });
+
+    test('should handle nested parentheses correctly', () => {
+        expect(
+            sqlAggregationWrapsReferences(
+                'sum(case when ${max_value} > 100 then ${max_value} else 0 end)',
+                ['max_value'],
+            ),
+        ).toBe(true);
+    });
+
+    test('should handle cross-table references', () => {
+        expect(
+            sqlAggregationWrapsReferences('sum(${other_table.max_value})', [
+                'other_table.max_value',
+            ]),
+        ).toBe(true);
     });
 });

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -86,6 +86,72 @@ export const sqlContainsAggregation = (
     return SQL_AGGREGATION_FUNCTIONS_PATTERN.test(sql);
 };
 
+/**
+ * Check if any of the given ${} references appear inside an SQL aggregation
+ * function call. This is used to distinguish:
+ * - `sum(${max_value})` — ref IS inside aggregation (nested aggregate)
+ * - `sum(raw_col) / ${count_records}` — ref is NOT inside aggregation
+ *
+ * Uses a simple parenthesis-depth approach: track aggregation function
+ * positions and check if references fall within their parentheses.
+ */
+export const sqlAggregationWrapsReferences = (
+    sql: string,
+    refNames: string[],
+): boolean => {
+    if (!sql || refNames.length === 0) return false;
+
+    // Build a pattern that matches aggregation functions with opening paren
+    const aggPattern = new RegExp(
+        SQL_AGGREGATION_FUNCTIONS_PATTERN.source,
+        'gi',
+    );
+
+    // Find all aggregation function positions and their matching close-paren
+    const aggRanges: Array<{ start: number; end: number }> = [];
+    let match: RegExpExecArray | null;
+    // eslint-disable-next-line no-cond-assign
+    while ((match = aggPattern.exec(sql)) !== null) {
+        const openParenPos = sql.indexOf('(', match.index + match[1].length);
+        if (openParenPos !== -1) {
+            // Find the matching close paren by tracking depth
+            let depth = 1;
+            let pos = openParenPos + 1;
+            while (pos < sql.length && depth > 0) {
+                if (sql[pos] === '(') depth += 1;
+                else if (sql[pos] === ')') depth -= 1;
+                pos += 1;
+            }
+            if (depth === 0) {
+                aggRanges.push({ start: openParenPos, end: pos - 1 });
+            }
+        }
+    }
+
+    if (aggRanges.length === 0) return false;
+
+    // Check if any of the references appear inside any aggregation range
+    return refNames.some((refName) => {
+        const refPattern = new RegExp(
+            `\\$\\{${refName.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}\\}`,
+            'g',
+        );
+        let refMatch: RegExpExecArray | null;
+        // eslint-disable-next-line no-cond-assign
+        while ((refMatch = refPattern.exec(sql)) !== null) {
+            const refPos = refMatch.index;
+            if (
+                aggRanges.some(
+                    (range) => refPos > range.start && refPos < range.end,
+                )
+            ) {
+                return true;
+            }
+        }
+        return false;
+    });
+};
+
 type FieldContext = {
     fieldType:
         | 'metric'


### PR DESCRIPTION
The fix loosens the detection — it removes false positives from the nested aggregate filter. 
  Before, metrics like sum(raw_col) / ${aggregate_metric} were incorrectly pulled into the CTE. Now     
  they're left alone and run as normal SQL, which is how they worked before PR #20912.                  
   
  The only metrics that still go through the CTE are ones where ${} refs are genuinely inside           
  aggregation parentheses (e.g., sum(${max_value})). Those are the true nested aggregates that need the
  CTE to avoid invalid SUM(MAX(...))

---

Before
<img width="1281" height="952" alt="Screenshot from 2026-03-10 13-24-52" src="https://github.com/user-attachments/assets/69541e7e-8b01-45b1-89ce-9a485730ca15" />


After

<img width="1263" height="652" alt="Screenshot from 2026-03-10 13-22-31" src="https://github.com/user-attachments/assets/4e44e7b3-edfc-4283-aaea-d210e170b0a3" />

compatible with other nested aggreates

<img width="1644" height="1015" alt="Screenshot from 2026-03-10 13-26-52" src="https://github.com/user-attachments/assets/2bf83ec8-aaf4-43d6-9421-1beaa11a1827" />
<img width="1644" height="1015" alt="image" src="https://github.com/user-attachments/assets/24d490c2-d28a-4b44-a267-b20f5736d429" />


### Description:

Fixed nested aggregate detection to properly handle raw column aggregations combined with metric references. Previously, expressions like `sum(raw_column) / ${aggregate_metric}` were incorrectly treated as nested aggregates and routed through the CTE, when they should be compiled directly as sibling aggregates.

Added a new `sqlAggregationWrapsReferences` function that uses parenthesis-depth tracking to determine if metric references appear inside aggregation function calls. This distinguishes between:
- `sum(${max_value})` - true nested aggregate (reference inside aggregation)  
- `sum(raw_col) / ${count_records}` - sibling aggregates (reference outside aggregation)

The fix ensures that only actual nested aggregates use the CTE approach, while valid same-level aggregations compile directly to proper SQL like `SUM(col) / COUNT(col)`.