### PR TITLE
chore: migration - add impersonation bool to org

### DIFF
--- a/packages/backend/src/database/entities/organizations.ts
+++ b/packages/backend/src/database/entities/organizations.ts
@@ -8,13 +8,17 @@ export type DbOrganization = {
     chart_colors?: string[];
     default_project_uuid: string | null;
     color_palette_uuid: string | null;
+    impersonation_enabled: boolean;
 };
 
 export type DbOrganizationIn = Pick<DbOrganization, 'organization_name'>;
 export type DbOrganizationUpdate = Partial<
     Pick<
         DbOrganization,
-        'organization_name' | 'default_project_uuid' | 'color_palette_uuid'
+        | 'organization_name'
+        | 'default_project_uuid'
+        | 'color_palette_uuid'
+        | 'impersonation_enabled'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260310133643_add_impersonation_organization_setting.ts
+++ b/packages/backend/src/database/migrations/20260310133643_add_impersonation_organization_setting.ts
@@ -1,0 +1,13 @@
+import { Knex } from 'knex';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.boolean('impersonation_enabled').notNullable().defaultTo(false);
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable('organizations', (table) => {
+        table.dropColumn('impersonation_enabled');
+    });
+}

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -112,6 +112,7 @@ export * from './types/errors';
 export * from './types/explore';
 export * from './types/favorites';
 export * from './types/featureFlags';
+export * from './types/impersonationOrganizationSettings';
 export * from './types/field';
 export * from './types/fieldMatch';
 export * from './types/filter';

--- a/packages/common/src/types/impersonationOrganizationSettings.ts
+++ b/packages/common/src/types/impersonationOrganizationSettings.ts
@@ -1,0 +1,13 @@
+import { type ApiSuccess } from './api/success';
+
+export type ImpersonationOrganizationSettings = {
+    organizationUuid: string;
+    impersonationEnabled: boolean;
+};
+
+export type UpdateImpersonationOrganizationSettings = {
+    impersonationEnabled: boolean;
+};
+
+export type ApiImpersonationOrganizationSettingsResponse =
+    ApiSuccess<ImpersonationOrganizationSettings>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: GLITCH-221

### Description:

Add `impersonation_enable` to org table. When enabled admin-impersonation will be possible in this org. 

This PR is just adding the column. Reading and setting will follow. 

