### PR TITLE
fix: allow enabling pre-aggregates w/o NATS

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -761,6 +761,9 @@ describe('AsyncQueryService', () => {
             const runAsyncWarehouseQuerySpy = jest
                 .spyOn(service, 'runAsyncWarehouseQuery')
                 .mockResolvedValue(undefined);
+            const runAsyncPreAggregateQuerySpy = jest
+                .spyOn(service, 'runAsyncPreAggregateQuery')
+                .mockResolvedValue(undefined);
 
             await service.executeAsyncQuery(
                 {
@@ -793,6 +796,7 @@ describe('AsyncQueryService', () => {
 
             expect(resolveSpy).not.toHaveBeenCalled();
             expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledTimes(1);
+            expect(runAsyncPreAggregateQuerySpy).not.toHaveBeenCalled();
         });
 
         test('required pre-aggregate routes error when resolution fails and NATS is enabled', async () => {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -403,12 +403,7 @@ export class AsyncQueryService extends ProjectService {
     }
 
     private isPreAggregationExecutionEnabled(): boolean {
-        // Pre-aggregate execution is currently a NATS-only path. Keep the
-        // metadata and execution planners aligned on the same feature gate.
-        return (
-            this.lightdashConfig.preAggregates.enabled &&
-            this.lightdashConfig.natsWorker.enabled
-        );
+        return this.lightdashConfig.preAggregates.enabled;
     }
 
     private getResultsStorageClientForContext(
@@ -2781,6 +2776,18 @@ export class AsyncQueryService extends ProjectService {
                         originalColumns,
                     };
 
+                    if (executionPlan.target === 'pre_aggregate') {
+                        await this.queryHistoryModel.update(
+                            queryHistoryUuid,
+                            projectUuid,
+                            {
+                                pre_aggregate_compiled_sql:
+                                    executionPlan.preAggregateQuery,
+                            },
+                            account,
+                        );
+                    }
+
                     if (this.lightdashConfig.natsWorker.enabled) {
                         this.logger.info(
                             `Enqueueing query ${queryHistoryUuid} on NATS JetStream (${executionPlan.target})`,
@@ -2790,19 +2797,6 @@ export class AsyncQueryService extends ProjectService {
                             const natsPayload = {
                                 queryUuid: queryHistoryUuid,
                             };
-
-                            // Store pre-aggregate SQL in query_history before dispatching
-                            if (executionPlan.target === 'pre_aggregate') {
-                                await this.queryHistoryModel.update(
-                                    queryHistoryUuid,
-                                    projectUuid,
-                                    {
-                                        pre_aggregate_compiled_sql:
-                                            executionPlan.preAggregateQuery,
-                                    },
-                                    account,
-                                );
-                            }
 
                             const { jobId } =
                                 executionPlan.target === 'pre_aggregate'
@@ -2851,14 +2845,25 @@ export class AsyncQueryService extends ProjectService {
                             `Executing query ${queryHistoryUuid} in the main loop`,
                         );
 
-                        void this.runAsyncWarehouseQuery(warehouseArgs).catch(
-                            (e) => {
-                                span.setStatus({
-                                    code: 2, // ERROR
-                                    message: getErrorMessage(e),
-                                });
-                            },
-                        );
+                        const { query: warehouseSql, ...sharedAsyncQueryArgs } =
+                            warehouseArgs;
+                        const runQueryPromise =
+                            executionPlan.target === 'pre_aggregate'
+                                ? this.runAsyncPreAggregateQuery({
+                                      ...sharedAsyncQueryArgs,
+                                      preAggregateQuery:
+                                          executionPlan.preAggregateQuery,
+                                      warehouseQuery:
+                                          executionPlan.warehouseQuery,
+                                  })
+                                : this.runAsyncWarehouseQuery(warehouseArgs);
+
+                        void runQueryPromise.catch((e) => {
+                            span.setStatus({
+                                code: 2, // ERROR
+                                message: getErrorMessage(e),
+                            });
+                        });
                     }
 
                     return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR enables pre-aggregate query execution in the main loop when NATS is disabled. Previously, pre-aggregate execution was only available when NATS was enabled, but now it can run directly in the main execution path.

Key changes:
- Removed the NATS dependency from `isPreAggregationExecutionEnabled()` - now only checks if pre-aggregates are enabled in config
- Moved pre-aggregate SQL storage to query history outside of the NATS-specific code block so it runs regardless of NATS status  
- Added conditional logic to execute `runAsyncPreAggregateQuery()` instead of `runAsyncWarehouseQuery()` when the execution plan targets pre-aggregates and NATS is disabled
- Updated test to verify that pre-aggregate queries are not called when warehouse queries are executed

This allows pre-aggregate functionality to work in environments where NATS is not available or desired.
