### PR TITLE
feat: admin setting for user impersonation

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -357,6 +357,6 @@ export const lightdashConfigMock: LightdashConfig = {
         },
     },
     userImpersonation: {
-        enabled: false,
+        enabled: undefined,
     },
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1110,7 +1110,7 @@ export type LightdashConfig = {
         s3?: Omit<S3Config, 'expirationTime'>;
     };
     userImpersonation: {
-        enabled: boolean;
+        enabled: boolean | undefined;
     };
 };
 
@@ -2039,7 +2039,10 @@ export const parseConfig = (): LightdashConfig => {
             s3: preAggregatesS3,
         },
         userImpersonation: {
-            enabled: process.env.USER_IMPERSONATION_ENABLED === 'true',
+            enabled:
+                process.env.USER_IMPERSONATION_ENABLED === 'true'
+                    ? true
+                    : undefined,
         },
     };
 };

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -304,11 +304,20 @@ export class FeatureFlagModel {
     }
 
     private async getUserImpersonationEnabled({
+        user,
         featureFlagId,
     }: FeatureFlagLogicArgs) {
+        const enabled =
+            this.lightdashConfig.userImpersonation.enabled ??
+            (user
+                ? await isFeatureFlagEnabled(FeatureFlags.UserImpersonation, {
+                      userUuid: user.userUuid,
+                      organizationUuid: user.organizationUuid,
+                  })
+                : false);
         return {
             id: featureFlagId,
-            enabled: this.lightdashConfig.userImpersonation.enabled,
+            enabled,
         };
     }
 }

--- a/packages/frontend/src/components/UserSettings/ImpersonationPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/ImpersonationPanel/index.tsx
@@ -1,0 +1,37 @@
+import { Group, Stack, Switch, Text } from '@mantine-8/core';
+import { type FC } from 'react';
+import {
+    useImpersonationSettings,
+    useUpdateImpersonationSettings,
+} from '../../../hooks/user/useImpersonation';
+
+const ImpersonationPanel: FC = () => {
+    const { data: settings, isLoading } = useImpersonationSettings();
+    const { mutate: updateSettings, isLoading: isUpdating } =
+        useUpdateImpersonationSettings();
+
+    return (
+        <Group justify="space-between" wrap="nowrap">
+            <Stack gap="xxs">
+                <Text fw={500} fz="sm">
+                    Enable user impersonation
+                </Text>
+                <Text fz="xs" c="ldGray.6">
+                    Allow organization admins to impersonate other users to see
+                    Lightdash from their perspective.
+                </Text>
+            </Stack>
+            <Switch
+                checked={settings?.impersonationEnabled ?? false}
+                disabled={isLoading || isUpdating}
+                onChange={(event) => {
+                    updateSettings({
+                        impersonationEnabled: event.currentTarget.checked,
+                    });
+                }}
+            />
+        </Group>
+    );
+};
+
+export default ImpersonationPanel;

--- a/packages/frontend/src/hooks/user/useImpersonation.ts
+++ b/packages/frontend/src/hooks/user/useImpersonation.ts
@@ -1,10 +1,12 @@
 import {
     type ApiError,
     type ApiImpersonationOrganizationSettingsResponse,
+    type UpdateImpersonationOrganizationSettings,
 } from '@lightdash/common';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../api';
 import useApp from '../../providers/App/useApp';
+import useToaster from '../toaster/useToaster';
 
 const startImpersonation = async (targetUserUuid: string) =>
     lightdashApi<null>({
@@ -34,6 +36,40 @@ export const useImpersonationSettings = () => {
     >({
         queryKey: ['impersonation_settings'],
         queryFn: getImpersonationSettings,
+    });
+};
+
+const updateImpersonationSettings = async (
+    data: UpdateImpersonationOrganizationSettings,
+) =>
+    lightdashApi<ApiImpersonationOrganizationSettingsResponse['results']>({
+        url: `/org/impersonation`,
+        method: 'PATCH',
+        body: JSON.stringify(data),
+    });
+
+export const useUpdateImpersonationSettings = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+
+    return useMutation<
+        ApiImpersonationOrganizationSettingsResponse['results'],
+        ApiError,
+        UpdateImpersonationOrganizationSettings
+    >(updateImpersonationSettings, {
+        mutationKey: ['impersonation_settings_update'],
+        onSuccess: async () => {
+            showToastSuccess({
+                title: 'Impersonation settings updated',
+            });
+            await queryClient.invalidateQueries(['impersonation_settings']);
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update impersonation settings',
+                apiError: error,
+            });
+        },
     });
 };
 

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -55,6 +55,7 @@ import DefaultProjectPanel from '../components/UserSettings/DefaultProjectPanel'
 import { DeleteOrganizationPanel } from '../components/UserSettings/DeleteOrganizationPanel';
 import GithubSettingsPanel from '../components/UserSettings/GithubSettingsPanel';
 import GitlabSettingsPanel from '../components/UserSettings/GitlabSettingsPanel';
+import ImpersonationPanel from '../components/UserSettings/ImpersonationPanel';
 import { MyWarehouseConnectionsPanel } from '../components/UserSettings/MyWarehouseConnectionsPanel';
 import OrganizationPanel from '../components/UserSettings/OrganizationPanel';
 import { OrganizationWarehouseCredentialsPanel } from '../components/UserSettings/OrganizationWarehouseCredentialsPanel';
@@ -114,6 +115,14 @@ const Settings: FC = () => {
         },
         user: { data: user, isInitialLoading: isUserLoading, error: userError },
     } = useApp();
+
+    const { data: isUserImpersonationEnabled } = useServerFeatureFlag(
+        FeatureFlags.UserImpersonation,
+    );
+
+    const showImpersonationPanel =
+        isUserImpersonationEnabled?.enabled &&
+        user?.ability?.can('update', 'Organization');
 
     const isCustomRolesEnabled = health?.isCustomRolesEnabled;
 
@@ -270,6 +279,13 @@ const Settings: FC = () => {
                             <DefaultProjectPanel />
                         </SettingsGridCard>
 
+                        {showImpersonationPanel && (
+                            <SettingsGridCard>
+                                <Title order={4}>User impersonation</Title>
+                                <ImpersonationPanel />
+                            </SettingsGridCard>
+                        )}
+
                         {user.ability?.can('delete', 'Organization') && (
                             <SettingsGridCard>
                                 <div>
@@ -425,15 +441,18 @@ const Settings: FC = () => {
 
         return allowedRoutes;
     }, [
-        isServiceAccountsEnabled,
-        isScimTokenManagementEnabled?.enabled,
         allowPasswordAuthentication,
-        hasSocialLogin,
-        user,
+        user?.ability,
         organization,
         project,
-        health,
+        isScimTokenManagementEnabled?.enabled,
+        isServiceAccountsEnabled,
         isCustomRolesEnabled,
+        hasSocialLogin,
+        showImpersonationPanel,
+        health?.hasSlack,
+        health?.hasGithub,
+        health?.hasGitlab,
     ]);
     const routeElements = useRoutes(routes);
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: GLITCH-221

### Description:

Adds a setting that allows org admins to turn user impersonation on or off in their instance. The ability to turn switch this is behind a feature flag. 

**BEFORE**:
- `USER_IMPERSONATION_ENABLED` controlled whether user impersonation was enabled. It was only and env var

**NOW**
- There is a database setting that controls whether impersonation is enabled
- The ability to change that setting is behind the feature flag (and only available to admins)
- Its also in posthog

<img width="925" height="758" alt="Screenshot 2026-03-10 at 18 40 39" src="https://github.com/user-attachments/assets/0b4c529d-dfa7-4204-8e45-a48b959de2cf" />


