### PR TITLE
fix: limit NATS consumer to single message per consume call

### DIFF
--- a/packages/backend/src/nats/NatsWorker.ts
+++ b/packages/backend/src/nats/NatsWorker.ts
@@ -47,6 +47,8 @@ type NatsWorkerArgs = {
     streams: NatsWorkerStream[];
 };
 
+const CONSUME_MAX_MESSAGES = 1;
+
 export class NatsWorker {
     private readonly asyncQueryService: AsyncQueryService;
 
@@ -300,7 +302,9 @@ export class NatsWorker {
             `Async query worker ${workerId} spawned (concurrency=${this.workerConcurrency})`,
         );
 
-        const messages = await consumer.consume();
+        const messages = await consumer.consume({
+            max_messages: CONSUME_MAX_MESSAGES,
+        });
         this.messageStreams.push(messages);
 
         await this.consumeLoop(messages, workerId).catch((error) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Limits NATS consumer message consumption to 1 message at a time by adding a `CONSUME_MAX_MESSAGES` constant and passing it as the `max_messages` option to the consumer's `consume()` method in the async query worker.

<!-- Even better add a screenshot / gif / loom -->
