### PR TITLE
fix: replace autoFocus prop with data-autofocus attribute in filter inputs

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/BooleanFilterInputs.tsx
@@ -34,7 +34,7 @@ const BooleanFilterInputs = <T extends BaseFilterRule>(
                     onDropdownOpen={popoverProps?.onOpen}
                     onDropdownClose={popoverProps?.onClose}
                     disabled={disabled}
-                    autoFocus={true}
+                    data-autofocus
                     initiallyOpened={currentValue === null && !disabled}
                     placeholder={placeholder}
                     data={[

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -72,7 +72,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 <FilterWeekPicker
                                     placeholder={placeholder}
                                     disabled={disabled}
-                                    autoFocus={true}
+                                    data-autofocus
                                     value={
                                         rule.values && rule.values[0]
                                             ? parseDate(
@@ -114,7 +114,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                                 // @ts-ignore
                                 placeholder={placeholder}
-                                autoFocus={true}
+                                data-autofocus
                                 popoverProps={popoverProps}
                                 value={
                                     rule.values && rule.values[0]
@@ -146,7 +146,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                             <FilterQuarterPicker
                                 disabled={disabled}
                                 placeholder={placeholder}
-                                autoFocus={true}
+                                data-autofocus
                                 popoverProps={popoverProps}
                                 value={parsedValue}
                                 onChange={(newDate: Date) => {
@@ -166,7 +166,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                                 // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                                 // @ts-ignore
                                 placeholder={placeholder}
-                                autoFocus={true}
+                                data-autofocus
                                 popoverProps={popoverProps}
                                 value={
                                     rule.values && rule.values[0]
@@ -211,7 +211,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         // FIXME: until mantine 7.4: https://github.com/mantinedev/mantine/issues/5401#issuecomment-1874906064
                         // @ts-ignore
                         placeholder={placeholder}
-                        autoFocus={true}
+                        data-autofocus
                         withSeconds
                         // FIXME: mantine v7
                         // mantine does not set the first day of the week based on the locale
@@ -239,7 +239,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     // so we need to do it manually and always pass it as a prop
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     popoverProps={popoverProps}
-                    autoFocus={true}
+                    data-autofocus
                     value={
                         rule.values
                             ? parseDate(
@@ -269,7 +269,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                         sx={{ flexShrink: 1, flexGrow: 1 }}
                         placeholder={placeholder}
                         disabled={disabled}
-                        autoFocus={true}
+                        data-autofocus
                         value={isNaN(parsedValue) ? undefined : parsedValue}
                         min={0}
                         onChange={(value) => {
@@ -321,7 +321,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                     }
                     showOptionsInPlural={false}
                     showCompletedOptions={false}
-                    autoFocus={!rule.settings?.unitOfTime}
+                    data-autofocus={!rule.settings?.unitOfTime || undefined}
                     completed={false}
                     withinPortal={popoverProps?.withinPortal}
                     onDropdownOpen={popoverProps?.onOpen}
@@ -342,7 +342,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 return (
                     <FilterDateTimeRangePicker
                         disabled={disabled}
-                        autoFocus={true}
+                        data-autofocus
                         firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                         value={
                             rule.values && rule.values[0] && rule.values[1]
@@ -371,7 +371,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
             return (
                 <FilterDateRangePicker
                     disabled={disabled}
-                    autoFocus={true}
+                    data-autofocus
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     value={
                         rule.values && rule.values[0] && rule.values[1]

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -61,7 +61,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             limit={FILTER_SELECT_LIMIT}
                             disabled={disabled}
                             placeholder={placeholder}
-                            autoFocus={true}
+                            data-autofocus
                             withinPortal={popoverProps?.withinPortal}
                             onDropdownOpen={popoverProps?.onOpen}
                             onDropdownClose={popoverProps?.onClose}
@@ -79,7 +79,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                             filterId={rule.id}
                             disabled={disabled}
                             field={field}
-                            autoFocus={true}
+                            data-autofocus
                             placeholder={placeholder}
                             suggestions={suggestions || []}
                             withinPortal={popoverProps?.withinPortal}
@@ -107,7 +107,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                         return (
                             <FilterNumberInput
                                 disabled={disabled}
-                                autoFocus={true}
+                                data-autofocus
                                 placeholder={placeholder}
                                 value={rule.values?.[0]}
                                 onChange={(newValue) => {
@@ -122,7 +122,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                     } else {
                         return (
                             <FilterMultiNumberInput
-                                autoFocus={true}
+                                autoFocus
                                 disabled={disabled}
                                 placeholder={placeholder}
                                 values={rule.values?.map(String) ?? []}
@@ -138,7 +138,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                         <TagInput
                             w="100%"
                             clearable
-                            autoFocus={true}
+                            data-autofocus
                             size="xs"
                             disabled={disabled}
                             placeholder={placeholder}
@@ -166,7 +166,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
             return (
                 <FilterNumberInput
                     disabled={disabled}
-                    autoFocus={true}
+                    data-autofocus
                     placeholder={placeholder}
                     value={rule.values?.[0]}
                     onChange={(newValue) => {
@@ -182,7 +182,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
             return (
                 <FilterNumberRangeInput
                     disabled={disabled}
-                    autoFocus={true}
+                    data-autofocus
                     placeholder={placeholder}
                     value={rule.values}
                     onChange={(value) => {

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiNumberInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterMultiNumberInput.tsx
@@ -141,7 +141,7 @@ const FilterMultiNumberInput: FC<Props> = ({
                     <TagInput
                         w="100%"
                         clearable
-                        autoFocus={autoFocus}
+                        data-autofocus={autoFocus || undefined}
                         size="xs"
                         disabled={disabled}
                         placeholder={placeholder}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberRangeInput.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterNumberRangeInput.tsx
@@ -48,7 +48,7 @@ const FilterNumberRangeInput: FC<Props> = ({
                 <FilterNumberInput
                     error={!!errorMessage}
                     disabled={disabled}
-                    autoFocus={true}
+                    data-autofocus={autoFocus || undefined}
                     placeholder="Min value"
                     {...rest}
                     value={value?.[0]}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterQuarterPicker.tsx
@@ -35,6 +35,7 @@ const FilterQuarterPicker: FC<Props> = ({
     placeholder = 'Select Quarter',
     disabled,
     popoverProps,
+    autoFocus,
 }) => {
     const [opened, { open, close }] = useDisclosure(false);
 
@@ -149,6 +150,7 @@ const FilterQuarterPicker: FC<Props> = ({
             <Popover.Target>
                 <TextInput
                     size="xs"
+                    data-autofocus={autoFocus || undefined}
                     onClick={disabled ? undefined : open}
                     placeholder={placeholder}
                     value={


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #20902

### Description:
Replace `autoFocus` prop with `data-autofocus` attribute across filter input components. This change affects boolean, date, and default filter inputs, converting from the React `autoFocus` boolean prop to a custom `data-autofocus` data attribute. For conditional cases, the attribute is set to `undefined` when the condition is false to prevent the attribute from being rendered.

Ref: https://mantine.dev/hooks/use-focus-trap/#initial-focus 

<!-- Even better add a screenshot / gif / loom -->