### PR TITLE
fix(cli): linting/formatting

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1583,9 +1583,10 @@ describe('AsyncQueryService', () => {
                             credentials: sshTunnelCredentials,
                         }),
                         query: 'SELECT * FROM test',
-                        queryTags: {
+                        queryTags: expect.objectContaining({
                             query_context: QueryExecutionContext.EXPLORE,
-                        },
+                            query_uuid: 'test-query-uuid',
+                        }),
                     }),
                 );
 
@@ -1660,7 +1661,10 @@ describe('AsyncQueryService', () => {
                     warehouseClient: expect.objectContaining({
                         credentials: expect.any(Object),
                     }),
-                    queryTags: { query_context: QueryExecutionContext.EXPLORE },
+                    queryTags: expect.objectContaining({
+                        query_context: QueryExecutionContext.EXPLORE,
+                        query_uuid: 'test-query-uuid',
+                    }),
                 }),
             );
 

--- a/packages/cli/src/handlers/oauthLogin.ts
+++ b/packages/cli/src/handlers/oauthLogin.ts
@@ -29,7 +29,7 @@ export const loginWithOauth = async (
     const envPort = envPortStr ? parseInt(envPortStr, 10) : undefined;
     if (
         envPort !== undefined &&
-        (isNaN(envPort) || envPort < 1 || envPort > 65535)
+        (Number.isNaN(envPort) || envPort < 1 || envPort > 65535)
     ) {
         throw new Error(
             'LIGHTDASH_OAUTH_PORT must be a number between 1 and 65535',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -229,7 +229,7 @@ ${styles.bold('Examples:')}
         'Port for the local OAuth callback server (default: random available port)',
         (value: string) => {
             const port = parseInt(value, 10);
-            if (isNaN(port) || port < 1 || port > 65535) {
+            if (Number.isNaN(port) || port < 1 || port > 65535) {
                 throw new Error('Port must be a number between 1 and 65535');
             }
             return port;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Replace `isNaN()` with `Number.isNaN()` for more precise NaN checking in OAuth port validation. This change ensures that only actual NaN values are detected, rather than values that would be coerced to NaN during type conversion, providing more reliable port number validation in the CLI OAuth login functionality.
