### PR TITLE
feat: unify bolt icon for pre-aggregates and disable settings for preview projects

### DIFF
--- a/packages/frontend/src/components/PreAggregateMaterializations/MaterializationDetailDrawer.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/MaterializationDetailDrawer.tsx
@@ -14,6 +14,7 @@ import {
 } from '@mantine-8/core';
 import { useDisclosure } from '@mantine-8/hooks';
 import {
+    IconBolt,
     IconCalendarClock,
     IconChevronDown,
     IconChevronRight,
@@ -21,7 +22,6 @@ import {
     IconDatabase,
     IconFile,
     IconHourglass,
-    IconLayersIntersect,
     IconRefresh,
     IconTableRow,
 } from '@tabler/icons-react';
@@ -131,7 +131,7 @@ const MaterializationDetailDrawer: FC<Props> = ({
             zIndex={getDefaultZIndex('max') + 1}
             title={
                 <Group gap="xs">
-                    <IconBox icon={IconLayersIntersect} color="ldDark.9" />
+                    <IconBox icon={IconBolt} color="ldDark.9" />
                     <Text fw={600} fz="sm">
                         Pre-aggregate details
                     </Text>

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -23,6 +23,7 @@ import {
     IconArrowDown,
     IconArrowsSort,
     IconArrowUp,
+    IconBolt,
     IconCalendarTime,
     IconClock,
     IconColumns,
@@ -30,7 +31,6 @@ import {
     IconFile,
     IconFilter,
     IconFilterOff,
-    IconLayersIntersect,
     IconRefresh,
     IconRowInsertBottom,
     IconSearch,
@@ -677,7 +677,7 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                 {!isLoading && materializations.length === 0 ? (
                     <Paper withBorder radius="md" p="xxl">
                         <SuboptimalState
-                            icon={IconLayersIntersect}
+                            icon={IconBolt}
                             title="No pre-aggregates defined yet"
                             description="Define pre-aggregates in your dbt YAML to serve queries from materialized results instead of hitting your warehouse."
                         />

--- a/packages/frontend/src/components/common/RouterNavLink.tsx
+++ b/packages/frontend/src/components/common/RouterNavLink.tsx
@@ -11,13 +11,26 @@ type RouterNavLinkProps = Omit<NavLinkProps, 'component' | 'active'> & {
     exact?: boolean;
 } & Omit<ReactRouterNavLinkProps, 'component' | 'end'>;
 
-const RouterNavLink: FC<RouterNavLinkProps> = ({ exact, ...props }) => {
+const RouterNavLink: FC<RouterNavLinkProps> = ({
+    exact,
+    disabled,
+    onClick,
+    ...props
+}) => {
     const location = useLocation();
     const exactMatch = useMatch(props.to.toString());
     const isPartialMatch = location.pathname.startsWith(props.to.toString());
     return (
         <NavLink
             {...props}
+            disabled={disabled}
+            onClick={(e) => {
+                if (disabled) {
+                    e.preventDefault();
+                    return;
+                }
+                onClick?.(e);
+            }}
             component={ReactRouterNavLink}
             active={exact ? !!exactMatch : isPartialMatch}
             // Pass 'end' to React Router's NavLink to sync its active state

--- a/packages/frontend/src/hooks/usePreAggregateRefresh.ts
+++ b/packages/frontend/src/hooks/usePreAggregateRefresh.ts
@@ -1,5 +1,5 @@
 import { type ApiError } from '@lightdash/common';
-import { IconLayersIntersect } from '@tabler/icons-react';
+import { IconBolt } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import useSchedulerJobsContext from '../providers/SchedulerJobs/useSchedulerJobsContext';
@@ -35,7 +35,7 @@ export const useRefreshAllPreAggregates = (
                     showToast,
                     toastKey: 'pre-aggregate-refresh',
                     toastTitle: 'Pre-aggregate refresh',
-                    toastIcon: IconLayersIntersect,
+                    toastIcon: IconBolt,
                     onComplete: () => {
                         void queryClient.invalidateQueries({
                             queryKey: [
@@ -90,7 +90,7 @@ export const useRefreshPreAggregateByDefinitionName = (
                     showToast,
                     toastKey: 'pre-aggregate-refresh',
                     toastTitle: 'Pre-aggregate refresh',
-                    toastIcon: IconLayersIntersect,
+                    toastIcon: IconBolt,
                     onComplete: () => {
                         void queryClient.invalidateQueries({
                             queryKey: [

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -1,7 +1,12 @@
 import { subject } from '@casl/ability';
-import { CommercialFeatureFlags, FeatureFlags } from '@lightdash/common';
+import {
+    CommercialFeatureFlags,
+    FeatureFlags,
+    ProjectType,
+} from '@lightdash/common';
 import { Box, ScrollArea, Stack, Text, Title } from '@mantine-8/core';
 import {
+    IconBolt,
     IconBrain,
     IconBrowser,
     IconBuildingSkyscraper,
@@ -14,7 +19,6 @@ import {
     IconHistory,
     IconIdBadge2,
     IconKey,
-    IconLayersIntersect,
     IconLock,
     IconPalette,
     IconPlug,
@@ -845,9 +849,11 @@ const Settings: FC = () => {
                                             exact
                                             to={`/generalSettings/projectManagement/${project.projectUuid}/preAggregates`}
                                             leftSection={
-                                                <MantineIcon
-                                                    icon={IconLayersIntersect}
-                                                />
+                                                <MantineIcon icon={IconBolt} />
+                                            }
+                                            disabled={
+                                                project.type ===
+                                                ProjectType.PREVIEW
                                             }
                                             defaultOpened={location.pathname.includes(
                                                 `/projectManagement/${project.projectUuid}/preAggregates`,


### PR DESCRIPTION
### Description:

This PR updates the pre-aggregate feature UI with the following changes:

- Replaces `IconLayersIntersect` with `IconBolt` across all pre-aggregate related components for better visual consistency
- Adds disabled state handling to `RouterNavLink` component, preventing navigation when the `disabled` prop is true
- Disables pre-aggregate navigation for preview projects in the settings page

The icon change affects the materialization detail drawer, main pre-aggregates page, and refresh toast notifications. The disabled state enhancement ensures preview projects cannot access pre-aggregate functionality through the navigation.