### PR TITLE
fix: include deleted items in permanentDelete methods

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -1274,7 +1274,9 @@ export class DashboardModel {
     }
 
     async permanentDelete(dashboardUuid: string): Promise<DashboardDAO> {
-        const dashboard = await this.getByIdOrSlug(dashboardUuid);
+        const dashboard = await this.getByIdOrSlug(dashboardUuid, {
+            deleted: true,
+        });
         await this.database(DashboardsTableName)
             .where('dashboard_uuid', dashboardUuid)
             .delete();

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -739,7 +739,9 @@ export class SavedChartModel {
     }
 
     async permanentDelete(savedChartUuid: string): Promise<SavedChartDAO> {
-        const savedChart = await this.get(savedChartUuid);
+        const savedChart = await this.get(savedChartUuid, undefined, {
+            deleted: true,
+        });
         await this.database(SavedChartsTableName)
             .delete()
             .where('saved_query_uuid', savedChartUuid);


### PR DESCRIPTION
### Description:
Fix permanent deletion methods to properly retrieve soft-deleted items before performing hard deletion. Updated `DashboardModel.permanentDelete()` and `SavedChartModel.permanentDelete()` to include the `deleted: true` option when fetching items, ensuring that previously soft-deleted dashboards and charts can be found and permanently removed from the database.