### PR TITLE
fix: skip default sort on query without dimension

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -1371,7 +1371,7 @@ export const METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TAB
                                                                                               FROM metrics
                                                                                               WHERE ((
                                                                                                   1=1
-                                                                                                  )) ORDER BY "table1_metric_that_references_dim_from_table2" DESC LIMIT 10`;
+                                                                                                  )) LIMIT 10`;
 
 export const METRIC_QUERY_WITH_METRIC_FILTER_AND_ONE_DISABLED_SQL = `SELECT "table1".dim1 AS "table1_dim1"
                                                                      FROM "db"."schema"."table1" AS "table1"
@@ -2145,7 +2145,7 @@ export const EXPECTED_SQL_WITH_CROSS_TABLE_METRICS = `WITH cte_keys_customers AS
       cte_unaffected."orders_total_order_amount" / cte_metrics_customers."customers_total_customers" AS "orders_revenue_per_customer"
     FROM cte_unaffected
     CROSS JOIN cte_metrics_customers
-    ORDER BY "orders_revenue_per_customer" DESC LIMIT 100`;
+    LIMIT 100`;
 
 // --- Date zoom + filter test data ---
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -4529,6 +4529,24 @@ describe('Default sort behavior', () => {
         // Should have no ORDER BY clause at all
         expect(result.query).not.toContain('ORDER BY');
     });
+
+    test('Should have no ORDER BY when no dimensions but metrics present (e.g. calculate total)', () => {
+        const result = buildQuery({
+            explore: EXPLORE,
+            compiledMetricQuery: {
+                ...METRIC_QUERY,
+                dimensions: [],
+                metrics: ['table1_metric1'],
+                sorts: [],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // No dimensions means single aggregated row, ORDER BY is meaningless
+        expect(result.query).not.toContain('ORDER BY');
+    });
 });
 
 describe('Nested aggregate metrics', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1242,7 +1242,10 @@ export class MetricQueryBuilder {
         const { compiledMetricQuery } = this.args;
         const { dimensions, metrics } = compiledMetricQuery;
 
-        if (dimensions.length === 0 && metrics.length === 0) {
+        if (dimensions.length === 0) {
+            // No dimensions means the query returns a single aggregated row,
+            // so sorting is meaningless. This also prevents ORDER BY errors
+            // on non-sortable types (e.g., BigQuery ARRAY<INT64>).
             return undefined;
         }
 


### PR DESCRIPTION
### Description:
When the default sort was introduced it broke some "total calculations" in the case when the metric that it chose is an unsortable metric, e.g. BigQuery can't sort ARRAY<INT64>.

If there are no dimensions (the sort query always hard-codes an empty array), there shouldn't be any reason to sort anyways so we should be able to skip the sorting altogether.

This doesn't really fix the underlying problem that the default sort might choose a metric that it can't sort by, but at least the totals calculations should work again.

Ref: https://lightdash.slack.com/archives/C03MCQ08UKS/p1773180266486599