### PR TITLE
feat: add Liquid field introspection support for _in_query and _is_filtered

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -111,6 +111,28 @@ models:
             dynamic_total:
               type: sum
               description: "When metric_type=count, counts events. When metric_type=revenue, sums event IDs."
+      - name: conditional_event_id
+        description: "Returns event_id only when the event_id dimension is selected in the query, NULL otherwise. Uses ld.query.fields contains syntax."
+        meta:
+          dimension:
+            type: number
+            sql: >
+              {% raw %}{% if ld.query.fields contains "events.event_id" %}
+                ${TABLE}.event_id
+              {% else %}
+                NULL
+              {% endif %}{% endraw %}
+      - name: filtered_status_label
+        description: "Returns a label indicating whether the event dimension has an active filter. Uses ld.query.filters contains syntax."
+        meta:
+          dimension:
+            type: string
+            sql: >
+              {% raw %}{% if ld.query.filters contains "events.event" %}
+                'Filtered: ' || ${TABLE}.event
+              {% else %}
+                'All Events'
+              {% endif %}{% endraw %}
       - name: event
         description: ""
         meta:

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -57,6 +57,7 @@ import {
     TableCalculationFunctionCompiler,
     TimeFrames,
     UserAttributeValueMap,
+    type FieldsContext,
     type ParameterDefinitions,
     type ParametersValuesMap,
     type WarehouseSqlBuilder,
@@ -3211,6 +3212,61 @@ export class MetricQueryBuilder {
      *
      * @return {CompiledQuery} The compiled query object containing the SQL string and meta information ready for execution.
      */
+    /**
+     * Build a fields context for Liquid SQL introspection.
+     * Produces a nested { tableName: { fieldName: { inQuery, isFiltered } } }
+     * structure that lets Liquid templates check whether a field is selected or filtered.
+     */
+    private buildFieldsContext(): FieldsContext {
+        const { explore, compiledMetricQuery } = this.args;
+        const { dimensions, metrics, filters } = compiledMetricQuery;
+
+        const selectedFieldIds = new Set<string>([...dimensions, ...metrics]);
+
+        const filteredFieldIds = new Set<string>();
+        for (const rule of getFilterRulesFromGroup(filters.dimensions)) {
+            if ('fieldId' in rule.target) {
+                filteredFieldIds.add(rule.target.fieldId);
+            }
+        }
+        for (const rule of getFilterRulesFromGroup(filters.metrics)) {
+            if ('fieldId' in rule.target) {
+                filteredFieldIds.add(rule.target.fieldId);
+            }
+        }
+
+        const fieldsContext: FieldsContext = {};
+
+        for (const [tableName, table] of Object.entries(explore.tables)) {
+            const tableFields: Record<
+                string,
+                { inQuery: boolean; isFiltered: boolean }
+            > = {};
+
+            for (const dim of Object.values(table.dimensions)) {
+                const fieldId = getItemId(dim);
+                tableFields[dim.name] = {
+                    inQuery: selectedFieldIds.has(fieldId),
+                    isFiltered: filteredFieldIds.has(fieldId),
+                };
+            }
+
+            for (const metric of Object.values(table.metrics)) {
+                const fieldId = getItemId(metric);
+                tableFields[metric.name] = {
+                    inQuery: selectedFieldIds.has(fieldId),
+                    isFiltered: filteredFieldIds.has(fieldId),
+                };
+            }
+
+            if (Object.keys(tableFields).length > 0) {
+                fieldsContext[tableName] = tableFields;
+            }
+        }
+
+        return fieldsContext;
+    }
+
     public compileQuery(): CompiledQuery {
         const { explore, compiledMetricQuery } = this.args;
         const fields = getFieldsFromMetricQuery(compiledMetricQuery, explore);
@@ -3681,6 +3737,7 @@ export class MetricQueryBuilder {
             parameterValuesMap: this.args.parameters ?? {},
             parameterDefinitions: this.args.parameterDefinitions,
             sqlBuilder: this.args.warehouseSqlBuilder,
+            fieldsContext: this.buildFieldsContext(),
         });
 
         // Also collect parameter references from fields (e.g., format strings)

--- a/packages/backend/src/utils/QueryBuilder/parameters.ts
+++ b/packages/backend/src/utils/QueryBuilder/parameters.ts
@@ -2,6 +2,7 @@ import {
     parameterRegex,
     renderLiquidSql,
     UnexpectedServerError,
+    type FieldsContext,
     type ParameterDefinitions,
     type ParametersValuesMap,
     type WarehouseSqlBuilder,
@@ -162,17 +163,23 @@ export const safeReplaceParametersWithTypes = ({
     parameterDefinitions,
     sqlBuilder,
     wrapChar,
+    fieldsContext,
 }: {
     sql: string;
     parameterValuesMap: ParametersValuesMap;
     parameterDefinitions?: ParameterDefinitions;
     sqlBuilder: WarehouseSqlBuilder;
     wrapChar?: string;
+    fieldsContext?: FieldsContext;
 }) => {
     // Render Liquid template blocks ({% if %}/{% elsif %}/{% else %}/{% endif %})
-    // before parameter substitution. This evaluates conditional SQL based on parameter values,
-    // e.g., {% if ld.parameters.grain == "day" %} ${snapshot_date} {% endif %}
-    const liquidRenderedSql = renderLiquidSql(sql, parameterValuesMap);
+    // before parameter substitution. This evaluates conditional SQL based on parameter values
+    // and query context (field introspection via ld.query.fields/filters).
+    const liquidRenderedSql = renderLiquidSql(
+        sql,
+        parameterValuesMap,
+        fieldsContext,
+    );
 
     // First, get all parameter references from the original SQL using the standard function
     // This ensures we capture ALL parameter references, not just the ones we have values for

--- a/packages/common/src/templating/liquidSql.test.ts
+++ b/packages/common/src/templating/liquidSql.test.ts
@@ -1,11 +1,21 @@
-import { buildLiquidContext, renderLiquidSql } from './liquidSql';
+import {
+    buildLiquidContext,
+    renderLiquidSql,
+    type FieldsContext,
+} from './liquidSql';
 
 describe('buildLiquidContext', () => {
     it('should nest parameters under ld.parameters and lightdash.parameters', () => {
         const context = buildLiquidContext({ grain: 'day' });
         expect(context).toEqual({
-            ld: { parameters: { grain: 'day' } },
-            lightdash: { parameters: { grain: 'day' } },
+            ld: {
+                parameters: { grain: 'day' },
+                query: { fields: [], filters: [] },
+            },
+            lightdash: {
+                parameters: { grain: 'day' },
+                query: { fields: [], filters: [] },
+            },
         });
     });
 
@@ -39,9 +49,34 @@ describe('buildLiquidContext', () => {
     it('should handle numeric parameter values', () => {
         const context = buildLiquidContext({ threshold: 42 });
         expect(context).toEqual({
-            ld: { parameters: { threshold: 42 } },
-            lightdash: { parameters: { threshold: 42 } },
+            ld: {
+                parameters: { threshold: 42 },
+                query: { fields: [], filters: [] },
+            },
+            lightdash: {
+                parameters: { threshold: 42 },
+                query: { fields: [], filters: [] },
+            },
         });
+    });
+
+    it('should derive query.fields and query.filters from fieldsContext', () => {
+        const fieldsContext: FieldsContext = {
+            events: {
+                event_id: { inQuery: true, isFiltered: false },
+                event: { inQuery: false, isFiltered: true },
+                date: { inQuery: true, isFiltered: true },
+            },
+        };
+        const context = buildLiquidContext({}, fieldsContext);
+        expect(context.ld.query.fields).toEqual(
+            expect.arrayContaining(['events.event_id', 'events.date']),
+        );
+        expect(context.ld.query.fields).toHaveLength(2);
+        expect(context.ld.query.filters).toEqual(
+            expect.arrayContaining(['events.event', 'events.date']),
+        );
+        expect(context.ld.query.filters).toHaveLength(2);
     });
 });
 
@@ -239,5 +274,115 @@ describe('renderLiquidSql', () => {
     it('should skip unrelated {% in SQL strings', () => {
         const sql = "SELECT '{%something%}' AS col";
         expect(renderLiquidSql(sql, { grain: 'day' })).toBe(sql);
+    });
+});
+
+describe('renderLiquidSql with ld.query contains syntax', () => {
+    it('should evaluate ld.query.fields contains (true)', () => {
+        const sql = [
+            '{% if ld.query.fields contains "events.event_id" %}',
+            '  ${TABLE}.event_id',
+            '{% else %}',
+            '  NULL',
+            '{% endif %}',
+        ].join('\n');
+
+        const fieldsContext: FieldsContext = {
+            events: {
+                event_id: { inQuery: true, isFiltered: false },
+            },
+        };
+
+        expect(renderLiquidSql(sql, {}, fieldsContext).trim()).toBe(
+            '${TABLE}.event_id',
+        );
+    });
+
+    it('should evaluate ld.query.fields contains (false)', () => {
+        const sql = [
+            '{% if ld.query.fields contains "events.event_id" %}',
+            '  ${TABLE}.event_id',
+            '{% else %}',
+            '  NULL',
+            '{% endif %}',
+        ].join('\n');
+
+        const fieldsContext: FieldsContext = {
+            events: {
+                event_id: { inQuery: false, isFiltered: false },
+            },
+        };
+
+        expect(renderLiquidSql(sql, {}, fieldsContext).trim()).toBe('NULL');
+    });
+
+    it('should evaluate ld.query.filters contains', () => {
+        const sql = [
+            '{% if ld.query.filters contains "events.event" %}',
+            "  'Filtered'",
+            '{% else %}',
+            "  'All'",
+            '{% endif %}',
+        ].join('\n');
+
+        const fieldsContext: FieldsContext = {
+            events: {
+                event: { inQuery: false, isFiltered: true },
+            },
+        };
+
+        expect(renderLiquidSql(sql, {}, fieldsContext).trim()).toBe(
+            "'Filtered'",
+        );
+    });
+
+    it('should support lightdash.query long syntax', () => {
+        const sql = [
+            '{% if lightdash.query.fields contains "events.event_id" %}',
+            '  ${TABLE}.event_id',
+            '{% else %}',
+            '  NULL',
+            '{% endif %}',
+        ].join('\n');
+
+        const fieldsContext: FieldsContext = {
+            events: {
+                event_id: { inQuery: true, isFiltered: false },
+            },
+        };
+
+        expect(renderLiquidSql(sql, {}, fieldsContext).trim()).toBe(
+            '${TABLE}.event_id',
+        );
+    });
+
+    it('should return false for empty fieldsContext', () => {
+        const sql =
+            '{% if ld.query.fields contains "events.event_id" %} col {% else %} NULL {% endif %}';
+        expect(renderLiquidSql(sql, {}, {}).trim()).toBe('NULL');
+    });
+
+    it('should combine query fields and parameters in same SQL', () => {
+        const sql = [
+            '{% if ld.query.fields contains "events.event_id" %}',
+            '  {% if ld.parameters.grain == "day" %}',
+            "    DATE_TRUNC('day', ${TABLE}.event_date)",
+            '  {% else %}',
+            '    ${TABLE}.event_date',
+            '  {% endif %}',
+            '{% else %}',
+            '  NULL',
+            '{% endif %}',
+        ].join('\n');
+
+        const fieldsContext: FieldsContext = {
+            events: {
+                event_id: { inQuery: true, isFiltered: false },
+            },
+        };
+
+        expect(
+            renderLiquidSql(sql, { grain: 'day' }, fieldsContext).trim(),
+        ).toBe("DATE_TRUNC('day', ${TABLE}.event_date)");
     });
 });

--- a/packages/common/src/templating/liquidSql.ts
+++ b/packages/common/src/templating/liquidSql.ts
@@ -19,11 +19,27 @@ const liquidSqlEngine = new Liquid({
 });
 
 // Only activate Liquid rendering when the SQL contains Lightdash parameter
-// references inside {% %} tags. A bare {%  without ld.parameters/lightdash.parameters
-// could be unrelated syntax and should not be processed.
-const LIGHTDASH_LIQUID_PATTERN = /\{%[^%]*(?:ld|lightdash)\.parameters\b/;
+// or query context references inside {% %} tags. A bare {% without
+// ld.parameters/lightdash.parameters/ld.query could be unrelated syntax.
+const LIGHTDASH_LIQUID_PATTERN =
+    /\{%[^%]*(?:ld|lightdash)\.(?:parameters|query)\b/;
 
 type ParameterValue = string | number | string[] | number[];
+
+/**
+ * Query-time field introspection for a single field.
+ * Used internally to derive the ld.query.fields/filters arrays.
+ */
+export type FieldIntrospection = {
+    inQuery: boolean;
+    isFiltered: boolean;
+};
+
+/**
+ * Nested table → field → introspection map.
+ * e.g., { events: { event_id: { inQuery: true, isFiltered: false } } }
+ */
+export type FieldsContext = Record<string, Record<string, FieldIntrospection>>;
 
 /**
  * Build a Liquid context from a parameter values map.
@@ -36,9 +52,16 @@ type ParameterValue = string | number | string[] | number[];
  */
 export const buildLiquidContext = (
     parameterValuesMap: Record<string, ParameterValue>,
+    fieldsContext?: FieldsContext,
 ): {
-    ld: { parameters: Record<string, ParameterValue> };
-    lightdash: { parameters: Record<string, ParameterValue> };
+    ld: {
+        parameters: Record<string, ParameterValue>;
+        query: { fields: string[]; filters: string[] };
+    };
+    lightdash: {
+        parameters: Record<string, ParameterValue>;
+        query: { fields: string[]; filters: string[] };
+    };
 } => {
     const parameters: Record<string, ParameterValue> = {};
 
@@ -53,9 +76,31 @@ export const buildLiquidContext = (
         }
     }
 
+    // Derive flat arrays from fieldsContext for the
+    // ld.query.fields/filters "contains" syntax:
+    //   {% if ld.query.fields contains "events.event_id" %}
+    const queryFields: string[] = [];
+    const queryFilters: string[] = [];
+
+    for (const [tableName, tableFields] of Object.entries(
+        fieldsContext ?? {},
+    )) {
+        for (const [fieldName, introspection] of Object.entries(tableFields)) {
+            const dottedId = `${tableName}.${fieldName}`;
+            if (introspection.inQuery) {
+                queryFields.push(dottedId);
+            }
+            if (introspection.isFiltered) {
+                queryFilters.push(dottedId);
+            }
+        }
+    }
+
+    const query = { fields: queryFields, filters: queryFilters };
+
     return {
-        ld: { parameters },
-        lightdash: { parameters }, // Support both {% if ld.parameters.x %} and {% if lightdash.parameters.x %}
+        ld: { parameters, query },
+        lightdash: { parameters, query },
     };
 };
 
@@ -83,15 +128,16 @@ export const buildLiquidContext = (
 export const renderLiquidSql = (
     sql: string,
     parameterValuesMap: Record<string, ParameterValue>,
+    fieldsContext?: FieldsContext,
 ): string => {
-    // Only process SQL that contains Lightdash parameter references in Liquid tags.
+    // Only process SQL that contains Lightdash parameter or field references in Liquid tags.
     // This avoids accidentally processing unrelated {% %} syntax.
     if (!LIGHTDASH_LIQUID_PATTERN.test(sql)) {
         return sql;
     }
 
     try {
-        const context = buildLiquidContext(parameterValuesMap);
+        const context = buildLiquidContext(parameterValuesMap, fieldsContext);
         return liquidSqlEngine.parseAndRenderSync(sql, context);
     } catch {
         // If Liquid parsing fails (e.g., malformed syntax or unrelated {% in SQL),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-5778/unsupported-liquidjs-looker-runtime-query-introspection

```
      - name: conditional_event_id
        description: "Returns event_id only when the event_id dimension is selected in the query, NULL otherwise. Uses ld.query.fields contains syntax."
        meta:
          dimension:
            type: number
            sql: >
              {% raw %}{% if ld.query.fields contains "events.event_id" %}
                ${TABLE}.event_id
              {% else %}
                NULL
              {% endif %}{% endraw %}
      - name: filtered_status_label
        description: "Returns a label indicating whether the event dimension has an active filter. Uses ld.query.filters contains syntax."
        meta:
          dimension:
            type: string
            sql: >
              {% raw %}{% if ld.query.filters contains "events.event" %}
                'Filtered: ' || ${TABLE}.event
              {% else %}
                'All Events'
              {% endif %}{% endraw %}

```


### In query

<img width="1439" height="756" alt="Screenshot from 2026-03-11 10-18-15" src="https://github.com/user-attachments/assets/4272419e-74cd-4115-be43-9eb1e473a8e9" />

###Filters

<img width="1439" height="756" alt="Screenshot from 2026-03-11 10-16-53" src="https://github.com/user-attachments/assets/d4c2be4f-e883-431f-a011-2af85e2f9e83" />
<img width="1439" height="756" alt="Screenshot from 2026-03-11 10-17-11" src="https://github.com/user-attachments/assets/391cf4bc-e8fc-44a7-ae18-bacc6a51185e" />



### Description:

Adds field introspection support to Liquid SQL templating, enabling  patterns like `_in_query` and `_is_filtered`. This allows dimensions and metrics to conditionally render SQL based on whether fields are selected in the query or have active filters.

The implementation introduces a `FieldsContext` type that tracks field states and extends the Liquid template engine to support syntax like:

The feature includes comprehensive test coverage and example usage in the jaffle shop demo showing conditional event ID display and filtered status labels.