### PR TITLE
fix: configure NATS consumer ack timeout and max delivery attempts

### DIFF
--- a/packages/backend/src/nats/NatsWorker.ts
+++ b/packages/backend/src/nats/NatsWorker.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/node';
 import {
     AckPolicy,
     connect,
+    nanos,
     RetentionPolicy,
     StorageType,
     StringCodec,
@@ -49,6 +50,7 @@ type NatsWorkerArgs = {
 
 const CONSUME_MAX_MESSAGES = 1;
 const ACK_PROGRESS_INTERVAL_MS = 5 * 1000;
+const ACK_WAIT_MS = 30 * 1000;
 
 export class NatsWorker {
     private readonly asyncQueryService: AsyncQueryService;
@@ -129,6 +131,8 @@ export class NatsWorker {
                             durable_name: config.durableName,
                             filter_subjects: Object.values(config.subjects),
                             ack_policy: AckPolicy.Explicit,
+                            ack_wait: nanos(ACK_WAIT_MS),
+                            max_deliver: 1,
                         });
                     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Configure NATS consumer with explicit acknowledgment timeout and delivery limits. Sets `ack_wait` to 30 seconds using the `nanos` utility and limits `max_deliver` to 1 attempt to prevent message redelivery after processing failures.

<!-- Even better add a screenshot / gif / loom -->
