### PR TITLE
feat: cache shared duckdb connection

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -89,6 +89,8 @@ export class PreAggregationDuckDbClient {
 
     private readonly prometheusMetrics?: PrometheusMetrics;
 
+    private cachedWarehouseClient: WarehouseClient | null = null;
+
     constructor(args: PreAggregationDuckDbClientArgs) {
         this.lightdashConfig = args.lightdashConfig;
         this.preAggregateModel = args.preAggregateModel;
@@ -101,6 +103,25 @@ export class PreAggregationDuckDbClient {
                     ...warehouseArgs,
                     logger: Logger,
                 }));
+    }
+
+    private getOrCreateWarehouseClient(): WarehouseClient {
+        if (!this.cachedWarehouseClient) {
+            const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
+                this.lightdashConfig.preAggregates.s3,
+            );
+
+            if (!duckdbRuntimeConfig) {
+                throw new Error('Missing DuckDB runtime config');
+            }
+
+            this.cachedWarehouseClient = this.createDuckdbWarehouseClient({
+                s3Config: duckdbRuntimeConfig,
+            });
+
+            Logger.info('DuckDB warehouse client created and cached for reuse');
+        }
+        return this.cachedWarehouseClient;
     }
 
     static getPreAggregationResolutionErrorMessage({
@@ -135,17 +156,7 @@ export class PreAggregationDuckDbClient {
     }
 
     createExecutionWarehouseClient(): WarehouseClient {
-        const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
-            this.lightdashConfig.preAggregates.s3,
-        );
-
-        if (!duckdbRuntimeConfig) {
-            throw new Error('Missing DuckDB runtime config');
-        }
-
-        return this.createDuckdbWarehouseClient({
-            s3Config: duckdbRuntimeConfig,
-        });
+        return this.getOrCreateWarehouseClient();
     }
 
     async resolve(
@@ -350,9 +361,7 @@ export class PreAggregationDuckDbClient {
             });
         }
 
-        const warehouseClient = this.createDuckdbWarehouseClient({
-            s3Config: duckdbRuntimeConfig,
-        });
+        const warehouseClient = this.getOrCreateWarehouseClient();
 
         return {
             resolved: true,

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -3,6 +3,7 @@ import fs from 'fs/promises';
 import {
     DuckdbWarehouseClient,
     mapFieldTypeFromTypeId,
+    resetSharedDuckdbStateForTesting,
 } from './DuckdbWarehouseClient';
 
 const createInstanceMock = jest.fn();
@@ -165,6 +166,7 @@ describe('mapFieldTypeFromTypeId', () => {
 describe('DuckdbWarehouseClient', () => {
     beforeEach(() => {
         jest.clearAllMocks();
+        resetSharedDuckdbStateForTesting();
     });
 
     it('should return query rows and mapped fields', async () => {
@@ -274,7 +276,11 @@ describe('DuckdbWarehouseClient', () => {
         await client.runQuery('SELECT 1 AS val', undefined, 'UTC');
 
         const runCalls = runMock.mock.calls.map((call: unknown[]) => call[0]);
+        expect(runCalls).toContain('INSTALL httpfs;');
         expect(runCalls).toContain('LOAD httpfs;');
+        expect(runCalls).toContain('SET enable_http_metadata_cache = true;');
+        expect(runCalls).toContain('SET enable_external_file_cache = true;');
+        expect(runCalls).toContain('SET parquet_metadata_cache = true;');
         expect(runCalls).toContain("SET s3_endpoint = 'localhost:9000';");
         expect(runCalls).toContain("SET s3_region = 'us-east-1';");
         expect(runCalls).toContain("SET TimeZone = 'UTC';");

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -64,6 +64,7 @@ export type DuckdbWarehouseClientArgs = {
     databasePath?: string;
     s3Config?: DuckdbS3SessionConfig;
     resourceLimits?: DuckdbResourceLimits;
+    bufferPoolSize?: string; // e.g. '256MB' — controls DuckDB's buffer_pool_size for parquet/HTTP caching
     logger?: DuckdbLogger;
 };
 
@@ -135,12 +136,63 @@ export class DuckdbSqlBuilder extends WarehouseBaseSqlBuilder {
     }
 }
 
+/**
+ * Shared DuckDB instance — one per worker process.
+ * All DuckdbWarehouseClient instances share the same underlying DuckDB instance
+ * to maximize cache hits (parquet metadata, HTTP metadata, buffer pool).
+ */
+let sharedInstance: DuckdbInstance | null = null;
+let httpfsInstalled = false;
+let cachesConfigured = false;
+
+async function getOrCreateSharedInstance(
+    databasePath: string,
+    logger?: DuckdbLogger,
+): Promise<DuckdbInstance> {
+    if (!sharedInstance) {
+        const t0 = performance.now();
+        sharedInstance = (await DuckDBInstance.create(
+            databasePath,
+        )) as DuckdbInstance;
+        const createMs = performance.now() - t0;
+        httpfsInstalled = false;
+        cachesConfigured = false;
+        logger?.info(
+            `DuckDB shared instance created: path=${databasePath} createMs=${Math.round(createMs)}ms`,
+        );
+    }
+    return sharedInstance;
+}
+
+function clearSharedInstance(logger?: DuckdbLogger): void {
+    if (sharedInstance) {
+        try {
+            sharedInstance.closeSync?.();
+        } catch {
+            // best-effort cleanup
+        }
+        sharedInstance = null;
+        httpfsInstalled = false;
+        cachesConfigured = false;
+        logger?.info('DuckDB shared instance cleared');
+    }
+}
+
+/** Reset shared state without closing — for use in tests with mocked instances. */
+export function resetSharedDuckdbStateForTesting(): void {
+    sharedInstance = null;
+    httpfsInstalled = false;
+    cachesConfigured = false;
+}
+
 export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCredentials> {
     private readonly databasePath: string;
 
     private readonly s3Config?: DuckdbS3SessionConfig;
 
     private readonly resourceLimits?: DuckdbResourceLimits;
+
+    private readonly bufferPoolSize?: string;
 
     private readonly logger?: DuckdbLogger;
 
@@ -149,7 +201,12 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         this.databasePath = args.databasePath ?? ':memory:';
         this.s3Config = args.s3Config;
         this.resourceLimits = args.resourceLimits;
+        this.bufferPoolSize = args.bufferPoolSize;
         this.logger = args.logger;
+    }
+
+    async close(): Promise<void> {
+        clearSharedInstance(this.logger);
     }
 
     private getSQLWithMetadata(sql: string, tags?: Record<string, string>) {
@@ -160,15 +217,32 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         return `${sql}\n-- ${JSON.stringify(tags)}`;
     }
 
+    private async connectWithRetry(): Promise<DuckdbConnection> {
+        const instance = await getOrCreateSharedInstance(
+            this.databasePath,
+            this.logger,
+        );
+        try {
+            return await instance.connect();
+        } catch (firstError) {
+            this.logger?.info(
+                `DuckDB connect failed, retrying with fresh instance: ${firstError}`,
+            );
+            clearSharedInstance(this.logger);
+            const freshInstance = await getOrCreateSharedInstance(
+                this.databasePath,
+                this.logger,
+            );
+            return freshInstance.connect();
+        }
+    }
+
     private async withSession<T>(
         callback: (db: DuckdbConnection) => Promise<T>,
     ): Promise<T> {
         const sessionStart = performance.now();
 
-        const instance = (await DuckDBInstance.create(
-            this.databasePath,
-        )) as DuckdbInstance;
-        const connection = await instance.connect();
+        const connection = await this.connectWithRetry();
         const connectMs = performance.now() - sessionStart;
 
         // Only create a temp dir when resource limits are set (spill to disk).
@@ -194,7 +268,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         } finally {
             connection.closeSync?.();
             connection.disconnectSync?.();
-            instance.closeSync?.();
+            // Note: we do NOT close the instance — it's shared across queries
             if (tempDir) {
                 await fs.rm(tempDir, { recursive: true, force: true }).catch(
                     () => {}, // best-effort cleanup
@@ -207,13 +281,39 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         db: DuckdbConnection,
         tempDir: string | undefined,
     ): Promise<void> {
-        const t0 = performance.now();
-        await db.run('INSTALL httpfs;');
-        const installMs = performance.now() - t0;
+        let installMs = 0;
+        if (!httpfsInstalled) {
+            const t0 = performance.now();
+            await db.run('INSTALL httpfs;');
+            installMs = performance.now() - t0;
+            httpfsInstalled = true;
+            this.logger?.info(
+                `DuckDB httpfs installed (first use): ${Math.round(installMs)}ms`,
+            );
+        }
 
         const t1 = performance.now();
         await db.run('LOAD httpfs;');
         const loadMs = performance.now() - t1;
+
+        // Enable built-in caches — these are GLOBAL settings (instance-level, not
+        // connection-level), so they only need to be set once per shared instance.
+        if (!cachesConfigured) {
+            await db.run('SET enable_http_metadata_cache = true;');
+            await db.run('SET enable_external_file_cache = true;');
+            await db.run('SET parquet_metadata_cache = true;');
+            cachesConfigured = true;
+
+            if (this.bufferPoolSize) {
+                await db.run(
+                    `SET buffer_pool_size = '${this.bufferPoolSize}';`,
+                );
+            }
+
+            this.logger?.info(
+                `DuckDB caches enabled: http_metadata=true external_file=true parquet_metadata=true buffer_pool_size=${this.bufferPoolSize ?? 'default'}`,
+            );
+        }
 
         if (this.resourceLimits && tempDir) {
             await db.run(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR implements connection pooling and caching optimizations for the DuckDB warehouse client to improve performance when executing multiple queries.

**Key Changes:**

- **Shared DuckDB Instance**: Introduced a shared DuckDB instance across all `DuckdbWarehouseClient` instances within the same worker process, replacing the previous approach of creating new instances for each query
- **Connection Caching**: Added `cachedWarehouseClient` property to `PreAggregationDuckDbClient` with a `getOrCreateWarehouseClient()` method that reuses the same warehouse client instance
- **Performance Optimizations**: Enabled DuckDB's built-in caching mechanisms:
  - HTTP metadata cache (`enable_http_metadata_cache = true`)
  - External file cache (`enable_external_file_cache = true`) 
  - Parquet metadata cache (`parquet_metadata_cache = true`)
- **Resource Management**: Added configurable `bufferPoolSize` parameter to control DuckDB's buffer pool size for improved parquet/HTTP caching
- **Connection Retry Logic**: Implemented `connectWithRetry()` method that attempts to recover from connection failures by creating a fresh shared instance
- **Lifecycle Management**: Added proper cleanup methods including `close()` for clearing shared instances and `resetSharedDuckdbStateForTesting()` for test isolation

The shared instance approach maximizes cache hits across queries while the one-time installation of httpfs extension and cache configuration reduces bootstrap overhead for subsequent queries.



| Setting | Default | What it caches |
|---|---|---|
| `enable_http_metadata_cache` | `false` | HTTP response metadata (avoids re-fetching S3 headers) |
| `enable_external_file_cache` | `true` | External files (parquet) in the buffer pool |
| `parquet_metadata_cache` | `false` | Parquet file metadata (schema, row groups, statistics) |

Note: `enable_object_cache` is a legacy no-op — do not use.