### PR TITLE
chore: set only-throw-error eslint rule to warn in common package

### DIFF
--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -22,6 +22,7 @@ module.exports = {
                 fixStyle: 'inline-type-imports',
             },
         ],
+        '@typescript-eslint/only-throw-error': 'warn',
         '@typescript-eslint/no-unused-vars': [
             'error',
             {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Sets `only-throw-error` rule to `warn` until eslint supports TS6

**Before**
<img width="844" height="178" alt="CleanShot 2026-03-11 at 12 03 42" src="https://github.com/user-attachments/assets/adf0e2be-d690-4d4e-9199-934b05c7901d" />


**After**
<img width="422" height="32" alt="CleanShot 2026-03-11 at 12 04 33" src="https://github.com/user-attachments/assets/a27606d4-fda6-4ecb-9908-6f56a7d62782" />


