### PR TITLE
feat: add second, minute, and hour date granularities

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -42,7 +42,6 @@ import {
     DashboardFilters,
     DatabricksAuthenticationType,
     DatabricksTokenError,
-    DateGranularity,
     DateZoom,
     DbtExposure,
     DbtExposureType,
@@ -91,6 +90,7 @@ import {
     isJwtUser,
     isNotNull,
     isStandardDateGranularity,
+    isSubDayGranularity,
     isUserWithOrg,
     ItemsMap,
     Job,
@@ -2870,6 +2870,15 @@ export class ProjectService extends BaseService {
                     dimToOverride.timeInterval && baseDimensionId
                         ? timeDimensionsMap[baseDimensionId]
                         : dimToOverride;
+
+                // Skip sub-day zoom for DATE-only dimensions (no time component)
+                if (
+                    baseTimeDimension.type === DimensionType.DATE &&
+                    isStandardDateGranularity(dateZoom.granularity) &&
+                    isSubDayGranularity(dateZoom.granularity)
+                ) {
+                    return explore;
+                }
 
                 if (!isStandardDateGranularity(dateZoom.granularity)) {
                     // Custom granularity: find the pre-compiled dimension

--- a/packages/common/src/types/timeFrames.ts
+++ b/packages/common/src/types/timeFrames.ts
@@ -27,6 +27,9 @@ export enum TimeFrames {
 }
 
 export enum DateGranularity {
+    SECOND = 'Second',
+    MINUTE = 'Minute',
+    HOUR = 'Hour',
     DAY = 'Day',
     WEEK = 'Week',
     MONTH = 'Month',
@@ -43,6 +46,9 @@ export const dateGranularityToTimeFrameMap: Record<
     DateGranularity,
     TimeFrames
 > = {
+    [DateGranularity.SECOND]: TimeFrames.SECOND,
+    [DateGranularity.MINUTE]: TimeFrames.MINUTE,
+    [DateGranularity.HOUR]: TimeFrames.HOUR,
     [DateGranularity.DAY]: TimeFrames.DAY,
     [DateGranularity.WEEK]: TimeFrames.WEEK,
     [DateGranularity.MONTH]: TimeFrames.MONTH,
@@ -53,6 +59,9 @@ export const dateGranularityToTimeFrameMap: Record<
 export const timeFrameToDateGranularityMap: Partial<
     Record<TimeFrames, DateGranularity>
 > = {
+    [TimeFrames.SECOND]: DateGranularity.SECOND,
+    [TimeFrames.MINUTE]: DateGranularity.MINUTE,
+    [TimeFrames.HOUR]: DateGranularity.HOUR,
     [TimeFrames.DAY]: DateGranularity.DAY,
     [TimeFrames.WEEK]: DateGranularity.WEEK,
     [TimeFrames.MONTH]: DateGranularity.MONTH,

--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -1,7 +1,13 @@
 import { SupportedDbtAdapter } from '../types/dbt';
 import { DimensionType } from '../types/field';
-import { TimeFrames } from '../types/timeFrames';
-import { getDateDimension, timeFrameConfigs, WeekDay } from './timeFrames';
+import { DateGranularity, TimeFrames } from '../types/timeFrames';
+import {
+    getDateDimension,
+    isSubDayGranularity,
+    SUB_DAY_GRANULARITIES,
+    timeFrameConfigs,
+    WeekDay,
+} from './timeFrames';
 
 describe('TimeFrames', () => {
     describe('getSqlForTruncatedDate', () => {
@@ -270,15 +276,87 @@ describe('TimeFrames', () => {
         });
     });
 
+    describe('isSubDayGranularity', () => {
+        test('SUB_DAY_GRANULARITIES matches timeFrameConfigs that produce TIMESTAMP', () => {
+            // Map from DateGranularity to TimeFrames for the sub-day ones
+            const subDayTimeFrames: Record<string, TimeFrames> = {
+                [DateGranularity.SECOND]: TimeFrames.SECOND,
+                [DateGranularity.MINUTE]: TimeFrames.MINUTE,
+                [DateGranularity.HOUR]: TimeFrames.HOUR,
+            };
+            for (const g of SUB_DAY_GRANULARITIES) {
+                const tf = subDayTimeFrames[g];
+                const dimType = timeFrameConfigs[tf].getDimensionType(
+                    DimensionType.DATE,
+                );
+                expect(dimType).toBe(DimensionType.TIMESTAMP);
+            }
+        });
+
+        test('standard granularities not in SUB_DAY produce DATE', () => {
+            const dayAndAbove: Array<{
+                granularity: DateGranularity;
+                timeFrame: TimeFrames;
+            }> = [
+                {
+                    granularity: DateGranularity.DAY,
+                    timeFrame: TimeFrames.DAY,
+                },
+                {
+                    granularity: DateGranularity.WEEK,
+                    timeFrame: TimeFrames.WEEK,
+                },
+                {
+                    granularity: DateGranularity.MONTH,
+                    timeFrame: TimeFrames.MONTH,
+                },
+                {
+                    granularity: DateGranularity.QUARTER,
+                    timeFrame: TimeFrames.QUARTER,
+                },
+                {
+                    granularity: DateGranularity.YEAR,
+                    timeFrame: TimeFrames.YEAR,
+                },
+            ];
+            for (const { granularity, timeFrame } of dayAndAbove) {
+                expect(isSubDayGranularity(granularity)).toBe(false);
+                const dimType = timeFrameConfigs[timeFrame].getDimensionType(
+                    DimensionType.DATE,
+                );
+                expect(dimType).toBe(DimensionType.DATE);
+            }
+        });
+
+        test('identifies sub-day granularities correctly', () => {
+            expect(isSubDayGranularity(DateGranularity.SECOND)).toBe(true);
+            expect(isSubDayGranularity(DateGranularity.MINUTE)).toBe(true);
+            expect(isSubDayGranularity(DateGranularity.HOUR)).toBe(true);
+            expect(isSubDayGranularity(DateGranularity.DAY)).toBe(false);
+            expect(isSubDayGranularity(DateGranularity.YEAR)).toBe(false);
+        });
+    });
+
     describe('getDateDimension', () => {
         test('should parse dates', async () => {
             // Invalid date granularities
-            expect(getDateDimension('dimension_hour')).toEqual({});
             expect(getDateDimension('dimension')).toEqual({});
             expect(getDateDimension('dimension_date')).toEqual({});
             expect(getDateDimension('dimension_raw')).toEqual({});
 
             // Valid date granularities
+            expect(getDateDimension('dimension_second')).toEqual({
+                baseDimensionId: `dimension`,
+                newTimeFrame: TimeFrames.SECOND,
+            });
+            expect(getDateDimension('dimension_minute')).toEqual({
+                baseDimensionId: `dimension`,
+                newTimeFrame: TimeFrames.MINUTE,
+            });
+            expect(getDateDimension('dimension_hour')).toEqual({
+                baseDimensionId: `dimension`,
+                newTimeFrame: TimeFrames.HOUR,
+            });
             expect(getDateDimension('dimension_day')).toEqual({
                 baseDimensionId: `dimension`,
                 newTimeFrame: TimeFrames.DAY,

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -722,6 +722,15 @@ export const timeFrameOrder = [
 export const sortTimeFrames = (a: TimeFrames, b: TimeFrames) =>
     timeFrameOrder.indexOf(a) - timeFrameOrder.indexOf(b);
 
+export const SUB_DAY_GRANULARITIES: ReadonlySet<string> = new Set<string>([
+    DateGranularity.SECOND,
+    DateGranularity.MINUTE,
+    DateGranularity.HOUR,
+]);
+
+export const isSubDayGranularity = (g: string): boolean =>
+    SUB_DAY_GRANULARITIES.has(g);
+
 export const getDateDimension = (dimensionId: string) => {
     const timeFrames = Object.values(DateGranularity).map((tf) =>
         tf.toLowerCase(),

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -1,4 +1,8 @@
-import { DateGranularity, isStandardDateGranularity } from '@lightdash/common';
+import {
+    DateGranularity,
+    isStandardDateGranularity,
+    isSubDayGranularity,
+} from '@lightdash/common';
 import {
     ActionIcon,
     Button,
@@ -141,16 +145,42 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
     const availableCustomGranularities = useDashboardContext(
         (c) => c.availableCustomGranularities,
     );
+    const dashboardHasTimestampDimension = useDashboardContext(
+        (c) => c.dashboardHasTimestampDimension,
+    );
     const { track } = useTracking();
 
     useEffect(() => {
         if (isEditMode) setDateZoomGranularity(undefined);
     }, [isEditMode, setDateZoomGranularity]);
 
+    // Reset active sub-day granularity when no TIMESTAMP dimensions exist
+    // (e.g., saved config or URL param on DATE-only dashboard)
+    useEffect(() => {
+        if (
+            !dashboardHasTimestampDimension &&
+            dateZoomGranularity &&
+            isStandardDateGranularity(dateZoomGranularity) &&
+            isSubDayGranularity(dateZoomGranularity)
+        ) {
+            setDateZoomGranularity(undefined);
+        }
+    }, [
+        dashboardHasTimestampDimension,
+        dateZoomGranularity,
+        setDateZoomGranularity,
+    ]);
+
     // Split available granularities into standard and custom for rendering with a divider.
+    // Exclude sub-day granularities when no TIMESTAMP dimensions exist on the dashboard.
     const standardGranularities = useMemo(
-        () => Object.values(DateGranularity),
-        [],
+        () =>
+            dashboardHasTimestampDimension
+                ? Object.values(DateGranularity)
+                : Object.values(DateGranularity).filter(
+                      (g) => !isSubDayGranularity(g),
+                  ),
+        [dashboardHasTimestampDimension],
     );
 
     const customGranularities = useMemo(

--- a/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
+++ b/packages/frontend/src/hooks/dashboard/useDashboardChartReadyQuery.ts
@@ -1,9 +1,12 @@
 import {
+    DimensionType,
     FeatureFlags,
     getAvailableParametersFromTables,
     getDimensions,
     getItemId,
     isDateItem,
+    isStandardDateGranularity,
+    isSubDayGranularity,
     QueryExecutionContext,
     type ApiError,
     type ApiExecuteAsyncDashboardChartQueryResults,
@@ -109,6 +112,9 @@ export const useDashboardChartReadyQuery = (
     const addAvailableCustomGranularities = useDashboardContext(
         (c) => c.addAvailableCustomGranularities,
     );
+    const setTileHasTimestampDimension = useDashboardContext(
+        (c) => c.setTileHasTimestampDimension,
+    );
 
     useEffect(() => {
         if (explore) {
@@ -137,22 +143,40 @@ export const useDashboardChartReadyQuery = (
     const timezoneFixFilters =
         dashboardFilters && convertDateDashboardFilters(dashboardFilters);
 
-    const hasADateDimension = useMemo(() => {
+    const { hasADateDimension, hasTimestampDimension } = useMemo(() => {
         const metricQueryDimensions = [
             ...(chartQuery.data?.metricQuery?.dimensions ?? []),
             ...(chartQuery.data?.metricQuery?.customDimensions ?? []),
         ];
 
-        if (!explore) return false;
-        return getDimensions(explore).find(
+        if (!explore)
+            return {
+                hasADateDimension: false,
+                hasTimestampDimension: false,
+            };
+
+        const dateDims = getDimensions(explore).filter(
             (c) =>
                 metricQueryDimensions.includes(getItemId(c)) && isDateItem(c),
         );
+
+        return {
+            hasADateDimension: dateDims.length > 0,
+            hasTimestampDimension: dateDims.some(
+                (d) => d.type === DimensionType.TIMESTAMP,
+            ),
+        };
     }, [
         chartQuery.data?.metricQuery?.customDimensions,
         chartQuery.data?.metricQuery?.dimensions,
         explore,
     ]);
+
+    // Report TIMESTAMP dimension presence to dashboard context per tile
+    useEffect(() => {
+        setTileHasTimestampDimension(tileUuid, hasTimestampDimension);
+        return () => setTileHasTimestampDimension(tileUuid, false);
+    }, [tileUuid, hasTimestampDimension, setTileHasTimestampDimension]);
 
     const chartParameterValues = useMemo(() => {
         if (!tileParameterReferences || !tileParameterReferences[tileUuid])
@@ -164,13 +188,27 @@ export const useDashboardChartReadyQuery = (
         );
     }, [parameterValues, tileParameterReferences, tileUuid]);
 
+    // Determine if the zoom is effectively applied to this chart.
+    // Sub-day zoom on DATE-only charts is skipped by the backend, so don't mark them.
+    const isZoomEffectivelyApplied = useMemo(() => {
+        if (!hasADateDimension || !granularity) return false;
+        if (
+            !hasTimestampDimension &&
+            isStandardDateGranularity(granularity) &&
+            isSubDayGranularity(granularity)
+        ) {
+            return false;
+        }
+        return true;
+    }, [hasADateDimension, hasTimestampDimension, granularity]);
+
     useEffect(() => {
         if (!chartUuid) return;
 
         setChartsWithDateZoomApplied((prev) => {
             if (hasADateDimension) {
                 const nextSet = new Set(prev ?? []);
-                if (granularity) {
+                if (isZoomEffectivelyApplied) {
                     nextSet.add(chartUuid);
                 } else {
                     nextSet.delete(chartUuid);
@@ -181,7 +219,7 @@ export const useDashboardChartReadyQuery = (
         });
     }, [
         hasADateDimension,
-        granularity,
+        isZoomEffectivelyApplied,
         chartUuid,
         setChartsWithDateZoomApplied,
     ]);

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -10,6 +10,7 @@ import {
     isDashboardChartTileType,
     isDashboardSqlChartTile,
     isStandardDateGranularity,
+    isSubDayGranularity,
     type CacheMetadata,
     type Dashboard,
     type DashboardFilterRule,
@@ -247,6 +248,27 @@ const DashboardProvider: React.FC<
     // Date zoom granularities state
     const allStandardGranularities = useMemo(
         () => Object.values(DateGranularity),
+        [],
+    );
+
+    // Track which tiles have TIMESTAMP dimensions; derive boolean from set size
+    const [tilesWithTimestampDimension, setTilesWithTimestampDimension] =
+        useState<Set<string>>(new Set());
+    const dashboardHasTimestampDimension = tilesWithTimestampDimension.size > 0;
+
+    const setTileHasTimestampDimension = useCallback(
+        (tileUuid: string, hasTimestamp: boolean) => {
+            setTilesWithTimestampDimension((prev) => {
+                const next = new Set(prev);
+                if (hasTimestamp) {
+                    next.add(tileUuid);
+                } else {
+                    next.delete(tileUuid);
+                }
+                if (next.size === prev.size) return prev;
+                return next;
+            });
+        },
         [],
     );
 
@@ -502,17 +524,25 @@ const DashboardProvider: React.FC<
         return chartTileUuids.every((tileUuid) => loadedTiles.has(tileUuid));
     }, [dashboardTiles, loadedTiles, activeTab, dashboardTabs]);
 
-    // Once all charts have loaded, clean up stale custom granularities that
-    // are no longer provided by any explore on the dashboard.
+    // Once all charts have loaded, clean up stale granularities:
+    // - Custom granularities no longer provided by any explore
+    // - Sub-day granularities when no TIMESTAMP dimensions exist
     useEffect(() => {
         if (!areAllChartsLoaded) return;
 
         const availableCustomGranularityKeys = new Set(
             Object.keys(availableCustomGranularities),
         );
-        const isAvailable = (g: string) =>
-            isStandardDateGranularity(g) ||
-            availableCustomGranularityKeys.has(g);
+        const isAvailable = (g: string) => {
+            if (!isStandardDateGranularity(g)) {
+                return availableCustomGranularityKeys.has(g);
+            }
+            // Strip sub-day standard granularities when no timestamp dims
+            if (!dashboardHasTimestampDimension && isSubDayGranularity(g)) {
+                return false;
+            }
+            return true;
+        };
 
         setDateZoomGranularitiesState((prev) => {
             const filtered = prev.filter(isAvailable);
@@ -532,7 +562,11 @@ const DashboardProvider: React.FC<
             }
             return prev;
         });
-    }, [areAllChartsLoaded, availableCustomGranularities]);
+    }, [
+        areAllChartsLoaded,
+        availableCustomGranularities,
+        dashboardHasTimestampDimension,
+    ]);
 
     const [screenshotReadyTiles, setScreenshotReadyTiles] = useState<
         Set<string>
@@ -1468,6 +1502,8 @@ const DashboardProvider: React.FC<
         hasDefaultDateZoomGranularityChanged,
         setHasDefaultDateZoomGranularityChanged,
         addParameterDefinitions,
+        dashboardHasTimestampDimension,
+        setTileHasTimestampDimension,
         availableCustomGranularities,
         addAvailableCustomGranularities,
         tileNamesById,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -135,6 +135,11 @@ export type DashboardContextType = {
     toggleParameterPin: (parameterKey: string) => void;
     havePinnedParametersChanged: boolean;
     setHavePinnedParametersChanged: Dispatch<SetStateAction<boolean>>;
+    dashboardHasTimestampDimension: boolean;
+    setTileHasTimestampDimension: (
+        tileUuid: string,
+        hasTimestamp: boolean,
+    ) => void;
     dateZoomGranularities: (DateGranularity | string)[];
     setDateZoomGranularities: (
         granularities: (DateGranularity | string)[],


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-191/i-want-more-granular-date-zoom-options-hour-minute-second

## Summary
- Adds Second, Minute, and Hour to the date zoom granularity picker
- Backend skips sub-day zoom for DATE-only dimensions (no time component) — returns the explore unchanged
- Frontend hides sub-day options from the picker and resets stale selections when no dashboard tile has a TIMESTAMP dimension
- Each tile reports TIMESTAMP dimension presence to the dashboard context; `isZoomEffectivelyApplied` guards the zoom badge accordingly


https://github.com/user-attachments/assets/8d5b1d61-8ad1-4c86-8362-d0192496fca4

