### PR TITLE
fix: prevent frozen DEFAULT_FORMAT from crashing format modal

### DIFF
--- a/packages/frontend/src/components/Explorer/FormatModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatModal/index.tsx
@@ -43,6 +43,11 @@ const DEFAULT_FORMAT: CustomFormat = {
     suffix: undefined,
 };
 
+// Returns a fresh copy to avoid the module-level constant being frozen by Immer
+// when passed through Redux. klona (used by Mantine form) preserves frozen
+// property descriptors, causing "Cannot assign to read only property" errors.
+const getDefaultFormat = (): CustomFormat => ({ ...DEFAULT_FORMAT });
+
 export const FormatModal = memo(() => {
     const dispatch = useExplorerDispatch();
     const { isOpen, item } = useExplorerSelector(selectFormatModal);
@@ -90,7 +95,7 @@ export const FormatModal = memo(() => {
     const form = useForm<{ format: CustomFormat }>({
         validateInputOnChange: true,
         initialValues: {
-            format: DEFAULT_FORMAT,
+            format: getDefaultFormat(),
         },
     });
 
@@ -177,7 +182,7 @@ export const FormatModal = memo(() => {
                         leftSection={<MantineIcon icon={IconEraser} />}
                         onClick={() =>
                             form.setValues({
-                                format: DEFAULT_FORMAT,
+                                format: getDefaultFormat(),
                             })
                         }
                     >


### PR DESCRIPTION
### Description:
- Fix TypeError: Cannot assign to read only property 'type' when editing column format after resetting another column's format to default
  (https://lightdash.sentry.io/issues/7326686420/)
- Replace direct usage of the DEFAULT_FORMAT module constant with a factory function that returns a fresh copy

### Reproduction steps:
1. Open a saved table chart in edit mode
2. Click a numeric column header -> "Edit format" -> change to any non-default type -> click "Reset" -> click "Save changes"
3. Click a different numeric column/metric header (with no existing format override) -> "Edit format"
4. Change the "Format type" dropdown -> crash


### Before:

https://github.com/user-attachments/assets/f0b96e46-75ff-4593-becd-b69237a1a309



### After:


https://github.com/user-attachments/assets/fb411989-70bc-4c91-be5b-08318ee47f0d

