### PR TITLE
fix: account for duplicate paths in space inheritance

### DIFF
--- a/packages/backend/src/models/SpacePermissionModel.test.ts
+++ b/packages/backend/src/models/SpacePermissionModel.test.ts
@@ -1,0 +1,34 @@
+import { Knex } from 'knex';
+import { SpacePermissionModel } from './SpacePermissionModel';
+
+describe('SpacePermissionModel', () => {
+    describe('getInheritanceChains', () => {
+        // Regression guard: the inheritance chain query MUST use a recursive CTE
+        // that walks parent_space_uuid FK pointers, NOT ltree path @> joins.
+        //
+        // Why: getLtreePathFromSlug() is lossy (dashes become underscores), so
+        // distinct slugs like "expert-unit" and "expert_unit" produce identical
+        // ltree paths. An @> join matches both spaces, causing one space's
+        // inherit_parent_permissions=false to incorrectly break another space's
+        // chain — hiding 100+ users from "Who has access".
+        //
+        // If this test fails, someone has reintroduced ltree @> joins. Use the
+        // parent_space_uuid recursive CTE instead.
+        it('should use recursive CTE on parent_space_uuid, not ltree @> joins', async () => {
+            let capturedSql = '';
+            const mockRaw = jest.fn(async (sql: string) => {
+                capturedSql = sql;
+                return { rows: [] };
+            });
+            const mockDatabase = { raw: mockRaw } as unknown as Knex;
+            const model = new SpacePermissionModel(mockDatabase);
+
+            await model.getInheritanceChains(['some-space-uuid']);
+
+            expect(mockRaw).toHaveBeenCalledTimes(1);
+            expect(capturedSql).toContain('WITH RECURSIVE');
+            expect(capturedSql).toContain('parent_space_uuid');
+            expect(capturedSql).not.toContain('@>');
+        });
+    });
+});

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -428,27 +428,44 @@ export class SpacePermissionModel {
             async () => {
                 if (spaceUuids.length === 0) return {};
 
+                // NOTE: use a CTE instead of ltree path @> joins to walk the space
+                // hierarchy via parent_space_uuid FK. We have duplicate paths in the
+                // database due to legacy spaces and content as code and an ltree path
+                // @> join matches unrelated spaces due to those duplicates,
+                // breaking the inheritance chain and hiding users from "Who has access".
                 const ancestorRows: {
                     requested_space_uuid: string;
                     space_uuid: string;
                     name: string;
                     inherit_parent_permissions: boolean;
                     parent_space_uuid: string | null;
-                }[] = await this.database(`${SpaceTableName} as leaf`)
-                    .select({
-                        requested_space_uuid: 'leaf.space_uuid',
-                        space_uuid: 'ancestor.space_uuid',
-                        name: 'ancestor.name',
-                        inherit_parent_permissions:
-                            'ancestor.inherit_parent_permissions',
-                        parent_space_uuid: 'ancestor.parent_space_uuid',
-                    })
-                    .joinRaw(
-                        `JOIN ${SpaceTableName} ancestor ON ancestor.path @> leaf.path AND ancestor.project_id = leaf.project_id`,
+                }[] = await this.database
+                    .raw(
+                        `
+                    WITH RECURSIVE chain AS (
+                        SELECT space_uuid AS requested_space_uuid,
+                               space_uuid, name, inherit_parent_permissions, parent_space_uuid,
+                               1 AS depth
+                        FROM ${SpaceTableName}
+                        WHERE space_uuid = ANY(?)
+                          AND deleted_at IS NULL
+
+                        UNION ALL
+
+                        SELECT c.requested_space_uuid,
+                               s.space_uuid, s.name, s.inherit_parent_permissions, s.parent_space_uuid,
+                               c.depth + 1
+                        FROM ${SpaceTableName} s
+                        JOIN chain c ON s.space_uuid = c.parent_space_uuid
+                        WHERE s.deleted_at IS NULL
                     )
-                    .whereIn('leaf.space_uuid', spaceUuids)
-                    .orderBy('leaf.space_uuid')
-                    .orderByRaw('nlevel(ancestor.path) DESC');
+                    SELECT requested_space_uuid, space_uuid, name, inherit_parent_permissions, parent_space_uuid
+                    FROM chain
+                    ORDER BY requested_space_uuid, depth ASC
+                    `,
+                        [spaceUuids],
+                    )
+                    .then((res: { rows: typeof ancestorRows }) => res.rows);
 
                 // Group ancestor rows by requested space (order is preserved)
                 const ancestorsBySpace = new Map<string, typeof ancestorRows>();


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #21023

### Description:

A root-level space was showing only 3 users in "Who has access" instead of the expected 100+. The root cause is in how getInheritanceChains() determines whether a space inherits permissions from the org/project level. It uses an ltree @> (ancestor-of) join to walk from a space up to its root. The problem is that ltree paths are generated getLtreePathFromSlug(), which is lossy (dashes become underscores, so two distinct slugs like expert-unit and expert_unit), but also produces duplicate paths for duplicate slugs, which can come up in a few ways. 

When two root-level spaces in the same project share a path, the @> join matches both. If the unrelated space has inherit_parent_permissions: false and gets processed first (due to nlevel DESC ordering), the chain walker breaks early and incorrectly concludes the space doesn't inherit from org/project — making it appear private and hiding most users.

**Fix**
Replace the ltree @> join with a recursive CTE that walks the parent_space_uuid foreign key. This follows the actual space hierarchy rather than relying on the denormalized (and potentially duplicate) ltree path.

Performance is bounded by tree depth (~4-5 levels max), not width, and each recursion step is an indexed PK lookup — so this is effectively the same cost as the original query.

The output shape is identical (same columns, same leaf-to-root ordering), so no changes are needed in the downstream chain-walking logic or callers.

