### PR TITLE
fix: big number label showing zoom granularity for DATE-only dimensions

### DIFF
--- a/packages/frontend/src/components/LightdashVisualization/VisualizationBigNumberConfig.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationBigNumberConfig.tsx
@@ -11,7 +11,6 @@ const VisualizationBigNumberConfig: FC<VisualizationBigNumberConfigProps> = ({
     children,
     tableCalculationsMetadata,
     parameters,
-    dateZoom,
 }) => {
     const bigNumberConfig = useBigNumberConfig(
         initialChartConfig,
@@ -19,7 +18,6 @@ const VisualizationBigNumberConfig: FC<VisualizationBigNumberConfigProps> = ({
         itemsMap,
         tableCalculationsMetadata,
         parameters,
-        dateZoom,
     );
 
     useEffect(() => {

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -441,7 +441,6 @@ const VisualizationProvider: FC<
                     onChartConfigChange={handleChartConfigChange}
                     tableCalculationsMetadata={tableCalculationsMetadata}
                     parameters={parameters}
-                    dateZoom={dateZoom}
                 >
                     {({ visualizationConfig }) => (
                         <Context.Provider

--- a/packages/frontend/src/components/LightdashVisualization/types.ts
+++ b/packages/frontend/src/components/LightdashVisualization/types.ts
@@ -58,7 +58,6 @@ export type VisualizationBigNumberConfigProps =
     VisualizationConfigCommon<VisualizationConfigBigNumber> & {
         itemsMap: ItemsMap | undefined;
         tableCalculationsMetadata?: TableCalculationMetadata[];
-        dateZoom?: DateZoom;
     };
 
 // Cartesian

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -24,7 +24,6 @@ import {
     type BigNumber,
     type CompactOrAlias,
     type ConditionalFormattingConfig,
-    type DateZoom,
     type GranularityMap,
     type ItemsMap,
     type ParametersValuesMap,
@@ -130,7 +129,6 @@ const useBigNumberConfig = (
     itemsMap: ItemsMap | undefined,
     tableCalculationsMetadata?: TableCalculationMetadata[],
     parameters?: ParametersValuesMap,
-    dateZoom?: DateZoom,
 ) => {
     const availableFieldsIds = useMemo(() => {
         const itemsSortedByType = Object.values(itemsMap || {}).sort((a, b) => {
@@ -427,19 +425,6 @@ const useBigNumberConfig = (
     const granularityMap = useMemo((): GranularityMap => {
         if (!itemsMap) return {};
 
-        // When date zoom is active with a custom granularity, resolve its label
-        // from the explore dimensions so interpolation shows e.g. "fiscal quarter"
-        // instead of the raw key "fiscal_quarter".
-        let dateZoomGranularityLabel: string | undefined;
-        if (dateZoom?.granularity) {
-            const matchingDim = Object.values(itemsMap)
-                .filter(isDimension)
-                .find((f) => f.customTimeInterval === dateZoom.granularity);
-            dateZoomGranularityLabel = matchingDim
-                ? matchingDim.label
-                : dateZoom.granularity;
-        }
-
         const map: GranularityMap = {};
         for (const field of Object.values(itemsMap)) {
             if (
@@ -449,10 +434,7 @@ const useBigNumberConfig = (
             ) {
                 const baseId = `${field.table}_${field.timeIntervalBaseDimensionName}`;
 
-                if (dateZoom?.granularity) {
-                    map[baseId] =
-                        dateZoomGranularityLabel ?? dateZoom.granularity;
-                } else if (field.customTimeInterval) {
+                if (field.customTimeInterval) {
                     map[baseId] = field.label;
                 } else if (field.timeInterval) {
                     const granularity =
@@ -464,7 +446,7 @@ const useBigNumberConfig = (
             }
         }
         return map;
-    }, [dateZoom?.granularity, itemsMap]);
+    }, [itemsMap]);
 
     const resolvedBigNumberLabel = useMemo(
         () => resolveGranularityInLabel(bigNumberLabel, granularityMap),


### PR DESCRIPTION
## Summary
- Removes the `dateZoom.granularity` override from the big number `granularityMap`
- Label interpolation (e.g. `${orders_created_at.granularity}`) now reads from the field's actual `timeInterval`/`customTimeInterval` in the query response instead of the dashboard-level zoom prop
- The backend already returns correct field metadata (zoomed for TIMESTAMP, original for DATE), so the frontend no longer needs to override

Big number tiles with date dimensions would show sub-day granularities in their labels even though they weren't applied

**Before**
<img width="910" height="675" alt="CleanShot 2026-03-11 at 15 06 19" src="https://github.com/user-attachments/assets/11ebb34a-6e88-420f-ab14-27a09b639160" />

**After**
<img width="921" height="643" alt="CleanShot 2026-03-11 at 15 05 11" src="https://github.com/user-attachments/assets/3147ff88-e49f-43f3-a2d4-6403528c75bb" />
