### PR TITLE
feat: stream pre-aggregate results directly to Parquet via local temp files

### DIFF
--- a/packages/backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.ts
@@ -1,0 +1,115 @@
+import { getErrorMessage } from '@lightdash/common';
+import {
+    DuckdbWarehouseClient,
+    type DuckdbS3SessionConfig,
+} from '@lightdash/warehouses';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import type Logger from '../../logging/logger';
+import { writeWithBackpressure } from '../../utils/streamUtils';
+
+type LocalParquetUploadStreamArgs = {
+    parquetS3Uri: string;
+    s3Config: DuckdbS3SessionConfig;
+    logger: typeof Logger;
+};
+
+const cleanupDir = (dir: string) => {
+    try {
+        fs.rmSync(dir, { recursive: true, force: true });
+    } catch {
+        // best-effort cleanup
+    }
+};
+
+/**
+ * Streams rows as JSONL to a local temp file, then on close() converts
+ * to Parquet and uploads directly to S3 via DuckDB.
+ *
+ * This avoids the S3 round-trip of: upload JSONL to S3 → DuckDB reads
+ * from S3 → DuckDB writes Parquet to S3.
+ *
+ * Rows should arrive pre-sorted by dimensions from the warehouse query
+ * for optimal Parquet compression.
+ */
+export const createLocalParquetUploadStream = ({
+    parquetS3Uri,
+    s3Config,
+    logger,
+}: LocalParquetUploadStreamArgs) => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lightdash-parquet-'));
+    const localJsonlPath = path.join(tmpDir, 'data.jsonl');
+    const fileWriteStream = fs.createWriteStream(localJsonlPath, {
+        highWaterMark: 16 * 1024 * 1024,
+    });
+
+    let totalBytesWritten = 0;
+    let totalRowsWritten = 0;
+    let writeCalls = 0;
+    let firstWriteTime: number | null = null;
+    let closed = false;
+
+    const write = async (rows: Record<string, unknown>[]): Promise<void> => {
+        if (firstWriteTime === null) firstWriteTime = Date.now();
+        writeCalls += 1;
+
+        for (const row of rows) {
+            const data = `${JSON.stringify(row)}\n`;
+            totalBytesWritten += data.length;
+            totalRowsWritten += 1;
+            // eslint-disable-next-line no-await-in-loop
+            await writeWithBackpressure(fileWriteStream, data);
+        }
+    };
+
+    const close = async (): Promise<void> => {
+        if (closed) return;
+        closed = true;
+
+        await new Promise<void>((resolve, reject) => {
+            fileWriteStream.end(() => resolve());
+            fileWriteStream.on('error', reject);
+        });
+
+        if (totalRowsWritten === 0) {
+            cleanupDir(tmpDir);
+            return;
+        }
+
+        try {
+            const duckdb = new DuckdbWarehouseClient({
+                s3Config,
+                resourceLimits: { memoryLimit: '256MB', threads: 1 },
+                logger,
+            });
+
+            const escapedPath = localJsonlPath.replace(/'/g, "''");
+            const localJsonlSqlTable = `read_json_auto('${escapedPath}', format='newline_delimited')`;
+            const copySql = `COPY (SELECT * FROM ${localJsonlSqlTable}) TO '${parquetS3Uri}' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE 100000)`;
+
+            const metrics = await duckdb.runSqlWithMetrics(copySql);
+            const localFileSize = fs.statSync(localJsonlPath).size;
+
+            logger.info(
+                `Parquet conversion complete: rows=${totalRowsWritten} jsonlBytes=${localFileSize} duckdbMs=${metrics.totalMs} target=${parquetS3Uri}`,
+            );
+        } catch (error) {
+            logger.error(
+                `Failed to convert local JSONL to Parquet: ${getErrorMessage(error)}`,
+            );
+            throw error;
+        } finally {
+            cleanupDir(tmpDir);
+        }
+    };
+
+    const getStreamMetrics = () => ({
+        totalBytesWritten,
+        totalRowsWritten,
+        writeCalls,
+        elapsedMs: firstWriteTime ? Date.now() - firstWriteTime : 0,
+    });
+
+    return { write, close, getStreamMetrics };
+};

--- a/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/S3ResultsFileStorageClient.ts
@@ -108,15 +108,21 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
             }
         };
 
-        // Create a function that can be used as a streamQuery callback
-        // This function handles backpressure by waiting for drain when buffer is full.
+        let totalBytesWritten = 0;
+        let totalRowsWritten = 0;
+        let writeCalls = 0;
+        let firstWriteTime: number | null = null;
+
         const write = async (rows: WarehouseResults['rows']): Promise<void> => {
             try {
+                if (firstWriteTime === null) firstWriteTime = Date.now();
+                writeCalls += 1;
+
                 for await (const row of rows) {
-                    await writeWithBackpressure(
-                        passThrough,
-                        `${JSON.stringify(row)}\n`,
-                    );
+                    const data = `${JSON.stringify(row)}\n`;
+                    totalBytesWritten += data.length;
+                    totalRowsWritten += 1;
+                    await writeWithBackpressure(passThrough, data);
                 }
             } catch (error) {
                 Logger.error(
@@ -128,7 +134,14 @@ export class S3ResultsFileStorageClient extends S3CacheClient {
             }
         };
 
-        return { write, close, writeStream: passThrough };
+        const getStreamMetrics = () => ({
+            totalBytesWritten,
+            totalRowsWritten,
+            writeCalls,
+            elapsedMs: firstWriteTime ? Date.now() - firstWriteTime : 0,
+        });
+
+        return { write, close, writeStream: passThrough, getStreamMetrics };
     }
 
     async getFileSize(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -104,6 +104,7 @@ import { DownloadCsv } from '../../analytics/LightdashAnalytics';
 import { transformAndExportResults } from '../../clients/Aws/transformAndExportResults';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import type { INatsJobClient } from '../../clients/NatsJobClient';
+import { createLocalParquetUploadStream } from '../../clients/ResultsFileStorageClients/LocalParquetUploadStream';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { measureTime } from '../../logging/measureTime';
 import { DownloadAuditModel } from '../../models/DownloadAuditModel';
@@ -145,6 +146,7 @@ import {
     getNextAndPreviousPage,
     validatePagination,
 } from '../ProjectService/resultsPagination';
+import { getDuckdbRuntimeConfig } from './getDuckdbRuntimeConfig';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {
@@ -1793,10 +1795,18 @@ export class AsyncQueryService extends ProjectService {
         warehouseClientOverride?: WarehouseClient;
         warehouseCredentialsTypeOverride?: CreateWarehouseCredentials['type'];
     }) {
+        type StreamMetrics = {
+            totalBytesWritten: number;
+            totalRowsWritten: number;
+            writeCalls: number;
+            elapsedMs: number;
+        };
+
         let stream:
             | {
                   write: (rows: Record<string, unknown>[]) => void;
                   close: () => Promise<void>;
+                  getStreamMetrics?: () => StreamMetrics;
               }
             | undefined;
 
@@ -1862,17 +1872,39 @@ export class AsyncQueryService extends ProjectService {
             );
 
             // Create upload stream for storing results
-            // If S3 is not configured, we don't write to S3
-            stream = resultsStorageClient.isEnabled
-                ? resultsStorageClient.createUploadStream(
-                      S3ResultsFileStorageClient.sanitizeFileExtension(
-                          fileName,
-                      ),
-                      {
-                          contentType: 'application/jsonl',
-                      },
-                  )
-                : undefined;
+            const isParquetMaterialization =
+                this.lightdashConfig.preAggregates.parquetEnabled &&
+                queryTags.query_context ===
+                    QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION;
+
+            if (isParquetMaterialization) {
+                const s3Config = getDuckdbRuntimeConfig(
+                    this.lightdashConfig.preAggregates.s3,
+                );
+                const bucket = this.lightdashConfig.preAggregates.s3?.bucket;
+                if (!s3Config || !bucket) {
+                    throw new Error(
+                        'Missing S3 configuration for stream-to-parquet',
+                    );
+                }
+                const parquetS3Uri = `s3://${bucket}/${fileName}.parquet`;
+                this.logger.debug(
+                    `Creating LocalParquetUploadStream for query ${queryUuid}: target=${parquetS3Uri}`,
+                );
+                stream = createLocalParquetUploadStream({
+                    parquetS3Uri,
+                    s3Config,
+                    logger: this.logger,
+                });
+            } else if (resultsStorageClient.isEnabled) {
+                // Default: stream JSONL to S3
+                stream = resultsStorageClient.createUploadStream(
+                    S3ResultsFileStorageClient.sanitizeFileExtension(fileName),
+                    {
+                        contentType: 'application/jsonl',
+                    },
+                );
+            }
 
             const s3StreamCreatedMs = Date.now() - t0;
 
@@ -2036,8 +2068,12 @@ export class AsyncQueryService extends ProjectService {
                       totalMs - queryExecMs - s3StreamCreatedMs - dbUpdateMs,
                   )
                 : 0;
+            const streamMetrics = stream?.getStreamMetrics?.();
+            const streamMetricsStr = streamMetrics
+                ? ` stream_bytes=${streamMetrics.totalBytesWritten} stream_rows=${streamMetrics.totalRowsWritten} write_calls=${streamMetrics.writeCalls}`
+                : '';
             this.logger.info(
-                `Query ${queryUuid} completed: source=${executionSource} s3_stream_create=${s3StreamCreatedMs}ms query_exec=${queryExecMs}ms s3_upload_close=${s3UploadCloseMs}ms db_update=${dbUpdateMs}ms total=${totalMs}ms rows=${pivotDetails?.totalRows ?? totalRows}`,
+                `Query ${queryUuid} completed: source=${executionSource} s3_stream_create=${s3StreamCreatedMs}ms query_exec=${queryExecMs}ms s3_upload_close=${s3UploadCloseMs}ms db_update=${dbUpdateMs}ms total=${totalMs}ms rows=${pivotDetails?.totalRows ?? totalRows}${streamMetricsStr}`,
             );
 
             // Track successful query in Prometheus
@@ -2047,6 +2083,10 @@ export class AsyncQueryService extends ProjectService {
                 queryTags.query_context,
             );
         } catch (e) {
+            this.logger.error(
+                `Query ${queryUuid} execution error: ${getErrorMessage(e)}`,
+            );
+
             if (
                 executionSource === 'pre_aggregate_duckdb' ||
                 this.lightdashConfig.prometheus.allQueryMetricsEnabled
@@ -2888,6 +2928,9 @@ export class AsyncQueryService extends ProjectService {
                                 : this.runAsyncWarehouseQuery(warehouseArgs);
 
                         void runQueryPromise.catch((e) => {
+                            this.logger.error(
+                                `Async query ${queryHistoryUuid} failed: ${getErrorMessage(e)}`,
+                            );
                             span.setStatus({
                                 code: 2, // ERROR
                                 message: getErrorMessage(e),

--- a/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -9,9 +9,7 @@ import {
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type PreAggregateMaterializationTrigger,
-    type ResultColumns,
 } from '@lightdash/common';
-import { DuckdbWarehouseClient } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
 import { type S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type LightdashConfig } from '../../config/parseConfig';
@@ -19,13 +17,7 @@ import { PreAggregateModel } from '../../models/PreAggregateModel';
 import { type QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
 import type PrometheusMetrics from '../../prometheus/PrometheusMetrics';
 import { type AsyncQueryService } from '../AsyncQueryService/AsyncQueryService';
-import { getDuckdbRuntimeConfig } from '../AsyncQueryService/getDuckdbRuntimeConfig';
 import { BaseService } from '../BaseService';
-import {
-    getDuckdbPreAggregateSqlTable,
-    getPreAggregateDuckdbLocator,
-    quoteDuckdbIdentifier,
-} from './getDuckdbPreAggregateSqlTable';
 
 const QUERY_POLL_INTERVAL_MS = 1000;
 const QUERY_POLL_TIMEOUT_MS = 30 * 60 * 1000;
@@ -65,18 +57,6 @@ export class PreAggregateMaterializationService extends BaseService {
         return this.lightdashConfig.preAggregates.parquetEnabled;
     }
 
-    private getJsonlUri(resultsFileName: string): string {
-        const bucket = this.lightdashConfig.preAggregates.s3?.bucket;
-
-        if (!bucket) {
-            throw new Error(
-                'Missing pre-aggregate S3 bucket configuration for materializations',
-            );
-        }
-
-        return `s3://${bucket}/${resultsFileName}.jsonl`;
-    }
-
     private getMaterializationUri(resultsFileName: string): string {
         const bucket = this.lightdashConfig.preAggregates.s3?.bucket;
 
@@ -92,83 +72,6 @@ export class PreAggregateMaterializationService extends BaseService {
 
     private getMaterializationFormat(): 'jsonl' | 'parquet' {
         return this.parquetEnabled ? 'parquet' : 'jsonl';
-    }
-
-    private async convertJsonlToParquet(
-        jsonlUri: string,
-        parquetUri: string,
-        columns: ResultColumns | null,
-        dimensionFieldIds: string[],
-    ): Promise<void> {
-        const s3Config = getDuckdbRuntimeConfig(
-            this.lightdashConfig.preAggregates.s3,
-        );
-
-        if (!s3Config) {
-            throw new Error(
-                'Missing DuckDB runtime S3 configuration for Parquet conversion',
-            );
-        }
-
-        const duckdb = new DuckdbWarehouseClient({
-            s3Config,
-            resourceLimits: { memoryLimit: '256MB', threads: 1 },
-            logger: this.logger,
-        });
-
-        const jsonlSqlTable = getDuckdbPreAggregateSqlTable(
-            getPreAggregateDuckdbLocator({ uri: jsonlUri, format: 'jsonl' }),
-            columns,
-        );
-
-        const orderByClause =
-            dimensionFieldIds.length > 0
-                ? ` ORDER BY ${dimensionFieldIds.map(quoteDuckdbIdentifier).join(', ')}`
-                : '';
-
-        const copySql = `COPY (SELECT * FROM ${jsonlSqlTable}${orderByClause}) TO '${parquetUri}' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE 1000000)`;
-        const metrics = await duckdb.runSqlWithMetrics(copySql);
-
-        this.logger.info(
-            `DuckDB JSONL→Parquet conversion metrics: bootstrap=${metrics.bootstrapMs}ms, query=${metrics.queryMs}ms, total=${metrics.totalMs}ms`,
-        );
-
-        Sentry.getActiveSpan()?.setAttributes({
-            'duckdb.bootstrapMs': metrics.bootstrapMs,
-            'duckdb.queryMs': metrics.queryMs,
-            'duckdb.totalMs': metrics.totalMs,
-        });
-    }
-
-    private async recordFileSizes(resultsFileName: string): Promise<void> {
-        const [jsonlSize, parquetSize] = await Promise.all([
-            this.preAggregateResultsStorageClient.getFileSize(
-                resultsFileName,
-                'jsonl',
-            ),
-            this.preAggregateResultsStorageClient.getFileSize(
-                resultsFileName,
-                'parquet',
-            ),
-        ]);
-
-        if (jsonlSize != null) {
-            this.prometheusMetrics?.preAggregateMaterializationFileSizeGauge?.set(
-                { format: 'jsonl' },
-                jsonlSize,
-            );
-        }
-
-        if (parquetSize != null) {
-            this.prometheusMetrics?.preAggregateMaterializationFileSizeGauge?.set(
-                { format: 'parquet' },
-                parquetSize,
-            );
-        }
-
-        this.logger.info(
-            `Pre-aggregate file sizes - JSONL: ${jsonlSize ?? 'unknown'} bytes, Parquet: ${parquetSize ?? 'unknown'} bytes`,
-        );
     }
 
     async materializePreAggregate(args: {
@@ -249,7 +152,19 @@ export class PreAggregateMaterializationService extends BaseService {
                         projectUuid: args.projectUuid,
                         context:
                             QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
-                        metricQuery: materializationMetricQuery.metricQuery,
+                        metricQuery: {
+                            ...materializationMetricQuery.metricQuery,
+                            sorts:
+                                materializationMetricQuery.metricQuery
+                                    .dimensions.length > 0
+                                    ? materializationMetricQuery.metricQuery.dimensions.map(
+                                          (fieldId) => ({
+                                              fieldId,
+                                              descending: false,
+                                          }),
+                                      )
+                                    : [],
+                        },
                         invalidateCache: true,
                     }),
             );
@@ -368,96 +283,9 @@ export class PreAggregateMaterializationService extends BaseService {
                 };
             }
 
-            // Convert JSONL to Parquet if enabled
-            if (this.parquetEnabled) {
-                const jsonlUri = this.getJsonlUri(queryHistory.resultsFileName);
-                const parquetUri = this.getMaterializationUri(
-                    queryHistory.resultsFileName,
-                );
-
-                this.logger.info(
-                    `Starting conversion of JSONL to Parquet for pre-aggregate materialization for definition ${args.preAggregateDefinitionUuid}`,
-                    {
-                        materializationUuid,
-                        queryUuid,
-                        jsonlUri,
-                        parquetUri,
-                    },
-                );
-
-                const conversionStartTime = Date.now();
-                try {
-                    await Sentry.startSpan(
-                        {
-                            op: 'preaggregate',
-                            name: 'convertJsonlToParquet',
-                            attributes: {
-                                projectUuid: args.projectUuid,
-                                materializationUuid,
-                                queryUuid,
-                                rowCount: queryHistory.totalRowCount ?? 0,
-                            },
-                        },
-                        () =>
-                            this.convertJsonlToParquet(
-                                jsonlUri,
-                                parquetUri,
-                                queryHistory.columns,
-                                materializationMetricQuery.metricQuery
-                                    .dimensions,
-                            ),
-                    );
-
-                    this.logger.info(
-                        `Conversion of JSONL to Parquet completed for pre-aggregate materialization for definition ${args.preAggregateDefinitionUuid}`,
-                        {
-                            materializationUuid,
-                            queryUuid,
-                        },
-                    );
-
-                    const conversionDurationMs =
-                        Date.now() - conversionStartTime;
-                    this.prometheusMetrics?.preAggregateParquetConversionDurationHistogram?.observe(
-                        { status: 'success' },
-                        conversionDurationMs,
-                    );
-
-                    this.logger.info(
-                        `Converted pre-aggregate JSONL to Parquet in ${conversionDurationMs}ms`,
-                    );
-                } catch (error) {
-                    const conversionDurationMs =
-                        Date.now() - conversionStartTime;
-                    this.prometheusMetrics?.preAggregateParquetConversionDurationHistogram?.observe(
-                        { status: 'failed' },
-                        conversionDurationMs,
-                    );
-
-                    throw new Error(
-                        `Failed to convert JSONL to Parquet: ${getErrorMessage(error)}`,
-                    );
-                }
-
-                // Record file sizes for both formats (keeping JSONL for comparison)
-                await Sentry.startSpan(
-                    {
-                        op: 'preaggregate',
-                        name: 'recordFileSizes',
-                        attributes: {
-                            materializationUuid,
-                        },
-                    },
-                    () =>
-                        this.recordFileSizes(
-                            queryHistory.resultsFileName!,
-                        ).catch((e) =>
-                            this.logger.warn(
-                                `Failed to record file sizes: ${getErrorMessage(e)}`,
-                            ),
-                        ),
-                );
-            }
+            // When parquetEnabled, the Parquet file is already on S3
+            // (written directly via LocalParquetUploadStream in
+            // AsyncQueryService), so no JSONL→Parquet conversion needed.
 
             const columnCount = queryHistory.columns
                 ? Object.keys(queryHistory.columns).length


### PR DESCRIPTION
### Description:
Stream pre-aggregate materializations instead of previous pipeline of uploading jsonl to s3 to then copy to parquet. 