### PR TITLE
feat: add processing_started_at to query history tracking

### DIFF
--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -156,6 +156,9 @@ export default class NatsWorkerApp {
                     : this.lightdashConfig.mode,
             integrations: [],
             ignoreErrors: IGNORE_ERRORS,
+            tracesSampleRate:
+                this.lightdashConfig.sentry.queryTracesSampleRate ??
+                this.lightdashConfig.sentry.tracesSampleRate,
         });
     }
 

--- a/packages/backend/src/database/entities/queryHistory.ts
+++ b/packages/backend/src/database/entities/queryHistory.ts
@@ -43,6 +43,7 @@ export type DbQueryHistory = {
     columns: ResultColumns | null; // result columns with or without pivoting
     original_columns: ResultColumns | null; // columns from original SQL, before pivoting
     pre_aggregate_compiled_sql: string | null; // DuckDB SQL for pre-aggregate execution path
+    processing_started_at: Date | null; // when the NATS worker picked up the job
 };
 
 export type DbQueryHistoryIn = Omit<
@@ -72,6 +73,7 @@ export type DbQueryHistoryUpdate = Partial<
         | 'columns'
         | 'original_columns'
         | 'pre_aggregate_compiled_sql'
+        | 'processing_started_at'
     >
 >;
 

--- a/packages/backend/src/database/migrations/20260311135356_add_processing_started_at_to_query_history.ts
+++ b/packages/backend/src/database/migrations/20260311135356_add_processing_started_at_to_query_history.ts
@@ -1,0 +1,18 @@
+import { Knex } from 'knex';
+
+const QUERY_HISTORY_TABLE = 'query_history';
+const PROCESSING_STARTED_AT_COLUMN = 'processing_started_at';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table
+            .timestamp(PROCESSING_STARTED_AT_COLUMN, { useTz: false })
+            .nullable();
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(QUERY_HISTORY_TABLE, (table) => {
+        table.dropColumn(PROCESSING_STARTED_AT_COLUMN);
+    });
+}

--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -53,6 +53,7 @@ function convertDbQueryHistoryToQueryHistory(
         columns: queryHistory.columns,
         originalColumns: queryHistory.original_columns,
         preAggregateCompiledSql: queryHistory.pre_aggregate_compiled_sql,
+        processingStartedAt: queryHistory.processing_started_at,
     };
 }
 
@@ -115,6 +116,7 @@ export class QueryHistoryModel {
             | 'columns'
             | 'originalColumns'
             | 'preAggregateCompiledSql'
+            | 'processingStartedAt'
             | 'createdByAccount'
             | 'createdByUserUuid'
             | 'createdByActorType'
@@ -155,6 +157,7 @@ export class QueryHistoryModel {
                 columns: null,
                 original_columns: null,
                 pre_aggregate_compiled_sql: null,
+                processing_started_at: null,
             })
             .returning('query_uuid');
 
@@ -242,6 +245,12 @@ export class QueryHistoryModel {
             columns: result.columns,
             originalColumns: result.original_columns,
         };
+    }
+
+    async updateProcessingStartedAt(queryUuid: string): Promise<void> {
+        await this.database(QueryHistoryTableName)
+            .where('query_uuid', queryUuid)
+            .update({ processing_started_at: new Date() });
     }
 
     async getByQueryUuid(queryUuid: string): Promise<QueryHistory | undefined> {

--- a/packages/backend/src/nats/NatsWorker.ts
+++ b/packages/backend/src/nats/NatsWorker.ts
@@ -225,8 +225,22 @@ export class NatsWorker {
                         baggage: parsed.trace.baggageHeader,
                     },
                     () =>
-                        this.asyncQueryService.runAsyncWarehouseQueryFromHistory(
-                            parsed.payload.queryUuid,
+                        Sentry.startSpan(
+                            {
+                                op: 'queue.process',
+                                name: 'queue_consumer',
+                                attributes: {
+                                    'messaging.message.id': parsed.jobId ?? '',
+                                    'messaging.destination.name':
+                                        message.subject,
+                                    'lightdash.queryUuid':
+                                        parsed.payload.queryUuid,
+                                },
+                            },
+                            () =>
+                                this.asyncQueryService.runAsyncWarehouseQueryFromHistory(
+                                    parsed.payload.queryUuid,
+                                ),
                         ),
                 ),
             );
@@ -272,11 +286,24 @@ export class NatsWorker {
                         sentryTrace: parsed.trace.traceHeader,
                         baggage: parsed.trace.baggageHeader,
                     },
-                    async () => {
-                        await this.asyncQueryService.runAsyncPreAggregateQueryFromHistory(
-                            parsed.payload.queryUuid,
-                        );
-                    },
+                    () =>
+                        Sentry.startSpan(
+                            {
+                                op: 'queue.process',
+                                name: 'queue_consumer',
+                                attributes: {
+                                    'messaging.message.id': parsed.jobId ?? '',
+                                    'messaging.destination.name':
+                                        message.subject,
+                                    'lightdash.queryUuid':
+                                        parsed.payload.queryUuid,
+                                },
+                            },
+                            () =>
+                                this.asyncQueryService.runAsyncPreAggregateQueryFromHistory(
+                                    parsed.payload.queryUuid,
+                                ),
+                        ),
                 ),
             );
             message.ack();

--- a/packages/backend/src/sentry.ts
+++ b/packages/backend/src/sentry.ts
@@ -86,7 +86,7 @@ Sentry.init({
         }
 
         // Boost sampling for async query execution when queryTracesSampleRate is set
-        // This captures more pre-aggregate vs warehouse traces for comparison
+        // Set SENTRY_QUERY_TRACES_SAMPLE_RATE=1.0 for 100% attribution on query traces
         const { queryTracesSampleRate } = lightdashConfig.sentry;
         if (queryTracesSampleRate !== null) {
             // Match by span/transaction name (e.g. scheduler-triggered queries)
@@ -95,8 +95,7 @@ Sentry.init({
                 return queryTracesSampleRate;
             }
 
-            // Match by URL for HTTP-rooted dashboard chart query requests
-            // Targets POST /api/v2/projects/{uuid}/query/dashboard-chart
+            // Match query endpoints (metric-query/dashboard-chart)
             if (request?.url) {
                 try {
                     const url = new URL(
@@ -104,7 +103,7 @@ Sentry.init({
                         `http://${request.headers?.host || 'localhost'}`,
                     );
                     if (
-                        /\/api\/v2\/projects\/[^/]+\/query\/dashboard-chart/.test(
+                        /\/api\/v2\/projects\/[^/]+\/query\/(?:metric-query|dashboard-chart)$/.test(
                             url.pathname,
                         )
                     ) {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1167,6 +1167,7 @@ describe('AsyncQueryService', () => {
                 columns: null,
                 originalColumns: null,
                 preAggregateCompiledSql: null,
+                processingStartedAt: null,
             });
 
             serviceWithCache.getExplore = jest
@@ -1339,6 +1340,7 @@ describe('AsyncQueryService', () => {
                 columns: expectedColumns,
                 originalColumns: mockOriginalColumns,
                 preAggregateCompiledSql: null,
+                processingStartedAt: null,
             };
 
             serviceWithCache.queryHistoryModel.get = jest

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1760,6 +1760,7 @@ export class AsyncQueryService extends ProjectService {
     public async runAsyncWarehouseQueryFromHistory(
         queryUuid: string,
     ): Promise<void> {
+        await this.queryHistoryModel.updateProcessingStartedAt(queryUuid);
         const args = await this.buildWarehouseQueryArgs(queryUuid);
         await this.runAsyncWarehouseQuery(args);
     }
@@ -1767,6 +1768,7 @@ export class AsyncQueryService extends ProjectService {
     public async runAsyncPreAggregateQueryFromHistory(
         queryUuid: string,
     ): Promise<void> {
+        await this.queryHistoryModel.updateProcessingStartedAt(queryUuid);
         const args = await this.buildPreAggregateQueryArgs(queryUuid);
         await this.runAsyncPreAggregateQuery(args);
     }

--- a/packages/common/src/types/queryHistory.ts
+++ b/packages/common/src/types/queryHistory.ts
@@ -57,4 +57,5 @@ export type QueryHistory = {
     columns: ResultColumns | null; // result columns with or without pivoting
     originalColumns: ResultColumns | null; // columns from original SQL, before pivoting
     preAggregateCompiledSql: string | null; // DuckDB SQL for pre-aggregate execution path
+    processingStartedAt: Date | null; // when the NATS worker picked up the job
 };


### PR DESCRIPTION
### Description:

This PR adds tracking for when NATS workers begin processing query jobs and improves observability for async query execution.