### PR TITLE
feat: add config field to dashboard-as-code schema and types

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -381,6 +381,7 @@ export class CoderService extends BaseService {
             filters: CoderService.getFiltersWithTileSlugs(dashboard),
             tabs: dashboard.tabs,
             slug: dashboard.slug,
+            config: dashboard.config,
 
             spaceSlug,
             version: currentVersion,

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -428,6 +428,35 @@
                     }
                 }
             }
+        },
+        "config": {
+            "type": "object",
+            "description": "Dashboard configuration settings such as date zoom behavior",
+            "additionalProperties": false,
+            "properties": {
+                "isDateZoomDisabled": {
+                    "type": "boolean",
+                    "description": "Whether the date zoom feature is disabled for this dashboard"
+                },
+                "pinnedParameters": {
+                    "type": "array",
+                    "description": "List of pinned parameter names",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "dateZoomGranularities": {
+                    "type": "array",
+                    "description": "Available date zoom granularity options (e.g., Day, Week, Month, Quarter, Year)",
+                    "items": {
+                        "type": "string"
+                    }
+                },
+                "defaultDateZoomGranularity": {
+                    "type": "string",
+                    "description": "The default date zoom granularity when the dashboard loads"
+                }
+            }
         }
     }
 }

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -142,7 +142,7 @@ export type DashboardTileWithSlug = DashboardTile & {
 
 export type DashboardAsCode = Pick<
     Dashboard,
-    'name' | 'description' | 'tabs' | 'slug'
+    'name' | 'description' | 'tabs' | 'slug' | 'config'
 > & {
     /** Not modifiable by user, but useful to know if it has been updated. Defaults to now if omitted. */
     updatedAt?: Date;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-224

### Description:

This PR adds support for dashboard configuration settings in the dashboard-as-code functionality. The changes include:

- Added `config` field to the `DashboardAsCode` type to include dashboard configuration alongside existing fields like name, description, tabs, and slug
- Updated the CoderService to pass through the dashboard config when processing dashboard-as-code operations
- Extended the JSON schema to define the structure of dashboard configuration options, including:
  - `isDateZoomDisabled`: Boolean flag to control date zoom functionality
  - `pinnedParameters`: Array of pinned parameter names
  - `dateZoomGranularities`: Available date zoom granularity options (Day, Week, Month, etc.)
  - `defaultDateZoomGranularity`: Default granularity setting when dashboard loads

This enables dashboard configurations to be version controlled and managed through the dashboard-as-code workflow, allowing teams to maintain consistent dashboard behavior across environments.