### PR TITLE
fix: permanentDelete fails with 404 when soft delete is disabled

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -710,7 +710,7 @@ export class DashboardModel {
 
     async getByIdOrSlug(
         dashboardUuidOrSlug: string,
-        options?: { deleted?: boolean },
+        options?: { deleted?: boolean | 'any' },
     ): Promise<DashboardDAO> {
         const query = this.database(DashboardsTableName)
             .leftJoin(
@@ -792,8 +792,10 @@ export class DashboardModel {
             .orderBy(`${DashboardVersionsTableName}.created_at`, 'desc')
             .limit(1);
 
-        // Filter by deleted status
-        if (options?.deleted) {
+        // Filter by deleted status: deleted=true gets deleted items, deleted='any' skips filter, default gets non-deleted
+        if (options?.deleted === 'any') {
+            // No filter — find regardless of deleted status
+        } else if (options?.deleted) {
             void query.whereNotNull(`${DashboardsTableName}.deleted_at`);
         } else {
             void query.whereNull(`${DashboardsTableName}.deleted_at`);
@@ -1275,7 +1277,7 @@ export class DashboardModel {
 
     async permanentDelete(dashboardUuid: string): Promise<DashboardDAO> {
         const dashboard = await this.getByIdOrSlug(dashboardUuid, {
-            deleted: true,
+            deleted: 'any',
         });
         await this.database(DashboardsTableName)
             .where('dashboard_uuid', dashboardUuid)

--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -740,7 +740,7 @@ export class SavedChartModel {
 
     async permanentDelete(savedChartUuid: string): Promise<SavedChartDAO> {
         const savedChart = await this.get(savedChartUuid, undefined, {
-            deleted: true,
+            deleted: 'any',
         });
         await this.database(SavedChartsTableName)
             .delete()
@@ -850,7 +850,7 @@ export class SavedChartModel {
     async get(
         savedChartUuidOrSlug: string,
         versionUuid?: string,
-        options?: { deleted?: boolean },
+        options?: { deleted?: boolean | 'any' },
     ): Promise<SavedChartDAO> {
         return Sentry.startSpan(
             {
@@ -969,8 +969,10 @@ export class SavedChartModel {
                     .orderBy('saved_queries_versions.created_at', 'desc')
                     .limit(1);
 
-                // Filter by deleted status: deleted=true gets deleted charts, deleted=false (default) gets non-deleted
-                if (options?.deleted) {
+                // Filter by deleted status: deleted=true gets deleted charts, deleted='any' skips filter, default gets non-deleted
+                if (options?.deleted === 'any') {
+                    // No filter — find regardless of deleted status
+                } else if (options?.deleted) {
                     void chartQuery.whereNotNull(
                         `${SavedChartsTableName}.deleted_at`,
                     );


### PR DESCRIPTION
## Summary

Fixes a regression introduced in #21029 where `DELETE /api/v1/dashboards/{uuid}` and `DELETE /api/v1/saved/{uuid}` return 404 "not found" even though the item exists.

### Root cause

PR #21029 changed `DashboardModel.permanentDelete()` and `SavedChartModel.permanentDelete()` to call `get()` with `{ deleted: true }`, which adds `WHERE deleted_at IS NOT NULL` — only finding **already soft-deleted** items.

When `SOFT_DELETE_ENABLED=false` (the default), `service.delete()` calls `permanentDelete()` on items that have **not** been soft-deleted (`deleted_at IS NULL`). The query finds no rows and throws `NotFoundError`.

**Before**
<img width="2065" height="641" alt="CleanShot 2026-03-11 at 16 33 50" src="https://github.com/user-attachments/assets/ce7c04d7-5e0f-43f9-922e-36c658302016" />


**After**
<img width="900" height="217" alt="CleanShot 2026-03-11 at 16 33 05" src="https://github.com/user-attachments/assets/39538ab9-9bab-4583-90ce-19c2deb71662" />
