### PR TITLE
fix: restore DuckDB local temp spill for parquet conversion

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -1,4 +1,5 @@
-import { DimensionType } from '@lightdash/common';
+import { DimensionType, QueryExecutionContext } from '@lightdash/common';
+import fs from 'fs/promises';
 import {
     DuckdbWarehouseClient,
     mapFieldTypeFromTypeId,
@@ -36,32 +37,9 @@ const DUCKDB_TYPE_IDS = {
     BLOB: 18,
 } as const;
 
-const mockDuckdbStatementTypes = {
-    SELECT: 1,
-    EXPLAIN: 4,
-    COPY: 11,
-    VARIABLE_SET: 13,
-    SET: 20,
-    LOAD: 21,
-    EXTENSION: 23,
-    ATTACH: 25,
-    DETACH: 26,
-} as const;
-
 jest.mock(
     '@duckdb/node-api',
     () => ({
-        StatementType: {
-            SELECT: 1,
-            EXPLAIN: 4,
-            COPY: 11,
-            VARIABLE_SET: 13,
-            SET: 20,
-            LOAD: 21,
-            EXTENSION: 23,
-            ATTACH: 25,
-            DETACH: 26,
-        },
         DuckDBTypeId: {
             BOOLEAN: 1,
             TINYINT: 2,
@@ -121,8 +99,7 @@ const createMockExtractStatements = (
     jest.fn(async () => ({
         count: overrides?.count ?? 1,
         prepare: async () => ({
-            statementType:
-                overrides?.statementType ?? mockDuckdbStatementTypes.SELECT,
+            statementType: overrides?.statementType ?? 1, // SELECT
             destroySync: jest.fn(),
         }),
     }));
@@ -325,9 +302,6 @@ describe('DuckdbWarehouseClient', () => {
         expect(runCalls).toContain('SET enable_http_metadata_cache = true;');
         expect(runCalls).toContain('SET enable_external_file_cache = true;');
         expect(runCalls).toContain('SET parquet_metadata_cache = true;');
-        expect(runCalls).toContain(
-            "SET disabled_filesystems = 'LocalFileSystem';",
-        );
         expect(runCalls).toContain('SET allow_community_extensions = false;');
         expect(runCalls).toContain('SET autoinstall_known_extensions = false;');
         expect(runCalls).toContain('SET autoload_known_extensions = false;');
@@ -355,6 +329,67 @@ describe('DuckdbWarehouseClient', () => {
         expect(streamMock).toHaveBeenCalledTimes(1);
     });
 
+    it('should log structured DuckDB profile metrics with query tags', async () => {
+        const runMock = jest.fn(async (sql: string) => {
+            const match = sql.match(/^PRAGMA profiling_output='(.+)';$/);
+            if (match) {
+                await fs.writeFile(
+                    match[1],
+                    JSON.stringify({
+                        latency: 4.747,
+                        cpu_time: 4.731,
+                        rows_returned: 68,
+                        total_bytes_read: 20225287,
+                        children: [
+                            {
+                                operator_name: 'READ_PARQUET ',
+                                operator_timing: 4.632,
+                                operator_cardinality: 9905024,
+                                children: [],
+                            },
+                        ],
+                    }),
+                );
+            }
+        });
+        const streamMock = jest.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+        const logger = { info: jest.fn() };
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const client = new DuckdbWarehouseClient({ logger });
+        await client.runQuery('SELECT 1 AS val', {
+            query_uuid: 'query-123',
+            chart_uuid: 'chart-123',
+            dashboard_uuid: 'dashboard-123',
+            query_context: QueryExecutionContext.DASHBOARD,
+        });
+
+        expect(logger.info).toHaveBeenCalledWith(
+            expect.stringContaining(
+                'DuckDB query profile: latency=4747ms cpu=4731ms',
+            ),
+            expect.objectContaining({
+                query_uuid: 'query-123',
+                chart_uuid: 'chart-123',
+                dashboard_uuid: 'dashboard-123',
+                query_context: QueryExecutionContext.DASHBOARD,
+                latencyMs: 4747,
+                cpuMs: 4731,
+                waitMs: 16,
+                readParquetMs: 4632,
+                rowsScanned: 9905024,
+                rowsReturned: 68,
+                bytesRead: 20225287,
+                scanAmplification: 9905024 / 68,
+            }),
+        );
+    });
+
     describe('SQL security validation', () => {
         it('should reject SET statements', async () => {
             const streamMock = jest.fn(async () =>
@@ -364,7 +399,7 @@ describe('DuckdbWarehouseClient', () => {
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, jest.fn(), {
                     extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.SET,
+                        statementType: 20, // SET
                     }),
                 }),
             );
@@ -386,7 +421,7 @@ describe('DuckdbWarehouseClient', () => {
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, jest.fn(), {
                     extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.COPY,
+                        statementType: 11, // COPY
                     }),
                 }),
             );
@@ -407,7 +442,7 @@ describe('DuckdbWarehouseClient', () => {
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, jest.fn(), {
                     extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.ATTACH,
+                        statementType: 25, // ATTACH
                     }),
                 }),
             );
@@ -441,6 +476,76 @@ describe('DuckdbWarehouseClient', () => {
             );
         });
 
+        it('should reject queries with current_setting()', async () => {
+            const streamMock = jest.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await expect(
+                client.runQuery(
+                    "SELECT current_setting('s3_secret_access_key')",
+                ),
+            ).rejects.toThrow(
+                "SQL validation error: function 'current_setting' is not allowed",
+            );
+        });
+
+        it('should reject queries with duckdb_settings()', async () => {
+            const streamMock = jest.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await expect(
+                client.runQuery('SELECT * FROM duckdb_settings()'),
+            ).rejects.toThrow(
+                "SQL validation error: function 'duckdb_settings' is not allowed",
+            );
+        });
+
+        it('should reject queries with duckdb_secrets()', async () => {
+            const streamMock = jest.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await expect(
+                client.runQuery('SELECT * FROM duckdb_secrets()'),
+            ).rejects.toThrow(
+                "SQL validation error: function 'duckdb_secrets' is not allowed",
+            );
+        });
+
+        it('should ignore blocked functions inside SQL comments', async () => {
+            const streamMock = jest.fn(async () =>
+                getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+            );
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            // Should NOT throw because current_setting is in a comment
+            const result = await client.runQuery(
+                "SELECT 1 -- current_setting('s3_secret_access_key')",
+            );
+            expect(result.rows).toEqual([{ val: 1 }]);
+        });
+
         it('should allow COPY statements in runSql', async () => {
             const streamMock = jest.fn();
             const runMock = jest.fn();
@@ -448,7 +553,7 @@ describe('DuckdbWarehouseClient', () => {
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock, {
                     extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.COPY,
+                        statementType: 10, // COPY
                     }),
                 }),
             );
@@ -462,31 +567,6 @@ describe('DuckdbWarehouseClient', () => {
             );
         });
 
-        it('should keep LocalFileSystem enabled for internal COPY sessions', async () => {
-            const streamMock = jest.fn();
-            const runMock = jest.fn();
-
-            createInstanceMock.mockResolvedValue(
-                createMockConnection(streamMock, runMock, {
-                    extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.COPY,
-                    }),
-                }),
-            );
-
-            const client = new DuckdbWarehouseClient();
-            await client.runSql(
-                "COPY table TO 's3://bucket/data.parquet' (FORMAT PARQUET)",
-            );
-
-            const runCalls = runMock.mock.calls.map(
-                (call: unknown[]) => call[0] as string,
-            );
-            expect(runCalls).not.toContain(
-                "SET disabled_filesystems = 'LocalFileSystem';",
-            );
-        });
-
         it('should reject SET statements in runSql', async () => {
             const streamMock = jest.fn();
             const runMock = jest.fn();
@@ -494,7 +574,7 @@ describe('DuckdbWarehouseClient', () => {
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock, {
                     extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.SET,
+                        statementType: 20, // SET
                     }),
                 }),
             );
@@ -514,7 +594,7 @@ describe('DuckdbWarehouseClient', () => {
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock, {
                     extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.ATTACH,
+                        statementType: 25, // ATTACH
                     }),
                 }),
             );
@@ -534,7 +614,7 @@ describe('DuckdbWarehouseClient', () => {
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, runMock, {
                     extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.LOAD,
+                        statementType: 21, // LOAD
                     }),
                 }),
             );
@@ -544,6 +624,24 @@ describe('DuckdbWarehouseClient', () => {
                 client.runSql("LOAD 'malicious_extension'"),
             ).rejects.toThrow(
                 'SQL validation error: statement type 21 is not allowed in internal SQL',
+            );
+        });
+
+        it('should reject introspection functions in runSql', async () => {
+            const streamMock = jest.fn();
+            const runMock = jest.fn();
+
+            createInstanceMock.mockResolvedValue(
+                createMockConnection(streamMock, runMock),
+            );
+
+            const client = new DuckdbWarehouseClient();
+            await expect(
+                client.runSql(
+                    "COPY (SELECT current_setting('s3_secret_access_key')) TO '/tmp/out.csv'",
+                ),
+            ).rejects.toThrow(
+                "SQL validation error: function 'current_setting' is not allowed",
             );
         });
 
@@ -577,7 +675,7 @@ describe('DuckdbWarehouseClient', () => {
             createInstanceMock.mockResolvedValue(
                 createMockConnection(streamMock, jest.fn(), {
                     extractStatements: createMockExtractStatements({
-                        statementType: mockDuckdbStatementTypes.EXPLAIN,
+                        statementType: 4, // EXPLAIN
                     }),
                 }),
             );

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -1,4 +1,4 @@
-import { DuckDBInstance, DuckDBTypeId, StatementType } from '@duckdb/node-api';
+import { DuckDBInstance, DuckDBTypeId } from '@duckdb/node-api';
 import {
     AnyType,
     CreatePostgresCredentials,
@@ -25,7 +25,7 @@ type DuckdbStreamResult = {
 };
 
 type DuckdbPreparedStatement = {
-    statementType: StatementType;
+    statementType: number;
     destroySync: () => void;
 };
 
@@ -51,14 +51,6 @@ type DuckdbConnection = {
 type DuckdbInstance = {
     connect: () => Promise<DuckdbConnection>;
     closeSync?: () => void;
-};
-
-type DuckdbSecurityProfile = 'internal' | 'user';
-
-type SharedDuckdbState = {
-    cachesConfigured: boolean;
-    httpfsInstalled: boolean;
-    instance: DuckdbInstance;
 };
 
 export type DuckdbS3SessionConfig = {
@@ -156,115 +148,68 @@ export class DuckdbSqlBuilder extends WarehouseBaseSqlBuilder {
 }
 
 /**
- * Shared DuckDB instances — one per worker/profile pair.
- * User-query sessions and internal materialization sessions use separate
- * instances because their security settings differ.
+ * Shared DuckDB instance — one per worker process.
+ * All DuckdbWarehouseClient instances share the same underlying DuckDB instance
+ * to maximize cache hits (parquet metadata, HTTP metadata, buffer pool).
  */
-const sharedInstances = new Map<string, SharedDuckdbState>();
-
-function getSharedInstanceKey(
-    databasePath: string,
-    profile: DuckdbSecurityProfile,
-): string {
-    return `${profile}:${databasePath}`;
-}
+let sharedInstance: DuckdbInstance | null = null;
+let httpfsInstalled = false;
+let cachesConfigured = false;
 
 async function getOrCreateSharedInstance(
     databasePath: string,
-    profile: DuckdbSecurityProfile,
     logger?: DuckdbLogger,
-): Promise<SharedDuckdbState> {
-    const key = getSharedInstanceKey(databasePath, profile);
-    const existing = sharedInstances.get(key);
-    if (existing) {
-        return existing;
-    }
-
-    const t0 = performance.now();
-    const instance = (await DuckDBInstance.create(
-        databasePath,
-    )) as DuckdbInstance;
-    const createMs = performance.now() - t0;
-    const state: SharedDuckdbState = {
-        cachesConfigured: false,
-        httpfsInstalled: false,
-        instance,
-    };
-    sharedInstances.set(key, state);
-    logger?.info(
-        `DuckDB shared instance created: profile=${profile} path=${databasePath} createMs=${Math.round(createMs)}ms`,
-    );
-    return state;
-}
-
-function updateSharedInstanceState(
-    databasePath: string,
-    profile: DuckdbSecurityProfile,
-    updates: Partial<
-        Pick<SharedDuckdbState, 'cachesConfigured' | 'httpfsInstalled'>
-    >,
-): SharedDuckdbState {
-    const key = getSharedInstanceKey(databasePath, profile);
-    const state = sharedInstances.get(key);
-    if (!state) {
-        throw new Error(`Missing shared DuckDB instance for key ${key}`);
-    }
-
-    const nextState = {
-        ...state,
-        ...updates,
-    };
-    sharedInstances.set(key, nextState);
-    return nextState;
-}
-
-function clearSharedInstance(
-    logger?: DuckdbLogger,
-    opts?: {
-        databasePath?: string;
-        profile?: DuckdbSecurityProfile;
-    },
-): void {
-    let keysToClear: string[];
-    if (opts?.databasePath && opts?.profile) {
-        keysToClear = [getSharedInstanceKey(opts.databasePath, opts.profile)];
-    } else if (opts?.databasePath) {
-        keysToClear = (['internal', 'user'] as DuckdbSecurityProfile[]).map(
-            (profile) => getSharedInstanceKey(opts.databasePath!, profile),
+): Promise<DuckdbInstance> {
+    if (!sharedInstance) {
+        const t0 = performance.now();
+        sharedInstance = (await DuckDBInstance.create(
+            databasePath,
+        )) as DuckdbInstance;
+        const createMs = performance.now() - t0;
+        httpfsInstalled = false;
+        cachesConfigured = false;
+        logger?.info(
+            `DuckDB shared instance created: path=${databasePath} createMs=${Math.round(createMs)}ms`,
         );
-    } else {
-        keysToClear = [...sharedInstances.keys()];
     }
+    return sharedInstance;
+}
 
-    keysToClear.forEach((key) => {
-        const state = sharedInstances.get(key);
-        if (!state) {
-            return;
-        }
-
+function clearSharedInstance(logger?: DuckdbLogger): void {
+    if (sharedInstance) {
         try {
-            state.instance.closeSync?.();
+            sharedInstance.closeSync?.();
         } catch {
             // best-effort cleanup
         }
-        sharedInstances.delete(key);
+        sharedInstance = null;
+        httpfsInstalled = false;
+        cachesConfigured = false;
         logger?.info('DuckDB shared instance cleared');
-    });
+    }
 }
 
 /** Reset shared state without closing — for use in tests with mocked instances. */
 export function resetSharedDuckdbStateForTesting(): void {
-    sharedInstances.clear();
+    sharedInstance = null;
+    httpfsInstalled = false;
+    cachesConfigured = false;
 }
 
-const ALLOWED_STATEMENT_TYPES_USER_SQL = new Set<StatementType>([
-    StatementType.SELECT,
+// DuckDB StatementType values — see duckdb/common/enums/statement_type.hpp
+const ALLOWED_STATEMENT_TYPES_USER_SQL = new Set([1 /* SELECT */]);
+
+const BLOCKED_STATEMENT_TYPES_INTERNAL_SQL = new Set([
+    12, // VARIABLE_SET
+    20, // SET
+    21, // LOAD
+    23, // EXTENSION (INSTALL)
+    25, // ATTACH
+    26, // DETACH
 ]);
 
-const ALLOWED_STATEMENT_TYPES_INTERNAL_SQL = new Set<StatementType>([
-    StatementType.COPY,
-    StatementType.SELECT,
-]);
+const BLOCKED_FUNCTION_PATTERN =
+    /\b(current_setting|duckdb_settings|duckdb_secrets)\s*\(/i;
 
 export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCredentials> {
     private readonly databasePath: string;
@@ -287,7 +232,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
     }
 
     async close(): Promise<void> {
-        clearSharedInstance(this.logger, { databasePath: this.databasePath });
+        clearSharedInstance(this.logger);
     }
 
     private getSQLWithMetadata(sql: string, tags?: Record<string, string>) {
@@ -298,58 +243,42 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         return `${sql}\n-- ${JSON.stringify(tags)}`;
     }
 
-    private async connectWithRetry(profile: DuckdbSecurityProfile): Promise<{
-        connection: DuckdbConnection;
-        state: SharedDuckdbState;
-    }> {
-        const state = await getOrCreateSharedInstance(
+    private async connectWithRetry(): Promise<DuckdbConnection> {
+        const instance = await getOrCreateSharedInstance(
             this.databasePath,
-            profile,
             this.logger,
         );
         try {
-            return {
-                connection: await state.instance.connect(),
-                state,
-            };
+            return await instance.connect();
         } catch (firstError) {
             this.logger?.info(
-                `DuckDB connect failed, retrying with fresh instance: profile=${profile} error=${firstError}`,
+                `DuckDB connect failed, retrying with fresh instance: ${firstError}`,
             );
-            clearSharedInstance(this.logger, {
-                databasePath: this.databasePath,
-                profile,
-            });
-            const freshState = await getOrCreateSharedInstance(
+            clearSharedInstance(this.logger);
+            const freshInstance = await getOrCreateSharedInstance(
                 this.databasePath,
-                profile,
                 this.logger,
             );
-            return {
-                connection: await freshState.instance.connect(),
-                state: freshState,
-            };
+            return freshInstance.connect();
         }
     }
 
     private async withSession<T>(
-        profile: DuckdbSecurityProfile,
         callback: (db: DuckdbConnection) => Promise<T>,
     ): Promise<T> {
         const sessionStart = performance.now();
 
-        const { connection, state } = await this.connectWithRetry(profile);
+        const connection = await this.connectWithRetry();
         const connectMs = performance.now() - sessionStart;
 
-        // Only internal sessions can spill to a local temp directory.
-        const tempDir =
-            profile === 'internal' && this.resourceLimits
-                ? await fs.mkdtemp(path.join(os.tmpdir(), 'duckdb-temp-'))
-                : undefined;
+        // Only create a temp dir when resource limits are set (spill to disk).
+        const tempDir = this.resourceLimits
+            ? await fs.mkdtemp(path.join(os.tmpdir(), 'duckdb-temp-'))
+            : undefined;
 
         try {
             const bootstrapStart = performance.now();
-            await this.bootstrapSession(connection, state, profile, tempDir);
+            await this.bootstrapSession(connection, tempDir);
             const bootstrapMs = performance.now() - bootstrapStart;
 
             const queryStart = performance.now();
@@ -376,19 +305,14 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
 
     private async bootstrapSession(
         db: DuckdbConnection,
-        sharedState: SharedDuckdbState,
-        profile: DuckdbSecurityProfile,
         tempDir: string | undefined,
     ): Promise<void> {
         let installMs = 0;
-        let state = sharedState;
-        if (!state.httpfsInstalled) {
+        if (!httpfsInstalled) {
             const t0 = performance.now();
             await db.run('INSTALL httpfs;');
             installMs = performance.now() - t0;
-            state = updateSharedInstanceState(this.databasePath, profile, {
-                httpfsInstalled: true,
-            });
+            httpfsInstalled = true;
             this.logger?.info(
                 `DuckDB httpfs installed (first use): ${Math.round(installMs)}ms`,
             );
@@ -400,22 +324,17 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
 
         // Enable built-in caches — these are GLOBAL settings (instance-level, not
         // connection-level), so they only need to be set once per shared instance.
-        if (!state.cachesConfigured) {
+        if (!cachesConfigured) {
             await db.run('SET enable_http_metadata_cache = true;');
             await db.run('SET enable_external_file_cache = true;');
             await db.run('SET parquet_metadata_cache = true;');
 
-            if (profile === 'user') {
-                await db.run("SET disabled_filesystems = 'LocalFileSystem';");
-            }
             await db.run('SET allow_community_extensions = false;');
             await db.run('SET autoinstall_known_extensions = false;');
             await db.run('SET autoload_known_extensions = false;');
             await db.run('SET allow_unredacted_secrets = false;');
 
-            state = updateSharedInstanceState(this.databasePath, profile, {
-                cachesConfigured: true,
-            });
+            cachesConfigured = true;
 
             if (this.bufferPoolSize) {
                 await db.run(
@@ -498,6 +417,90 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         return undefined;
     }
 
+    private static async logQueryProfile(
+        profilePath: string,
+        logger: DuckdbLogger,
+        tags?: Record<string, string>,
+    ): Promise<void> {
+        try {
+            const raw = await fs.readFile(profilePath, 'utf-8');
+            const profile = JSON.parse(raw);
+
+            const operators: {
+                name: string;
+                timingMs: number;
+                rows: number;
+            }[] = [];
+            const walk = (node: AnyType): void => {
+                if (node.operator_name) {
+                    operators.push({
+                        name: String(node.operator_name).trim(),
+                        timingMs: Math.round(
+                            (node.operator_timing ?? 0) * 1000,
+                        ),
+                        rows: node.operator_cardinality ?? 0,
+                    });
+                }
+                // eslint-disable-next-line no-restricted-syntax
+                for (const child of node.children ?? []) {
+                    walk(child);
+                }
+            };
+            walk(profile);
+
+            const operatorStr = operators
+                .map((op) => `${op.name}=${op.timingMs}ms(${op.rows}rows)`)
+                .join(' ');
+            const latencyMs = Math.round((profile.latency ?? 0) * 1000);
+            const cpuMs = Math.round((profile.cpu_time ?? 0) * 1000);
+            const waitMs = Math.max(latencyMs - cpuMs, 0);
+            const readParquetOperators = operators.filter(
+                (op) => op.name === 'READ_PARQUET',
+            );
+            const readParquetMs =
+                readParquetOperators.length > 0
+                    ? readParquetOperators.reduce(
+                          (sum, op) => sum + op.timingMs,
+                          0,
+                      )
+                    : null;
+            const rowsScanned =
+                readParquetOperators.length > 0
+                    ? readParquetOperators.reduce((sum, op) => sum + op.rows, 0)
+                    : null;
+            const rowsReturned =
+                typeof profile.rows_returned === 'number'
+                    ? profile.rows_returned
+                    : null;
+            const bytesRead =
+                typeof profile.total_bytes_read === 'number'
+                    ? profile.total_bytes_read
+                    : null;
+            const scanAmplification =
+                rowsScanned !== null && rowsReturned !== null
+                    ? rowsScanned / Math.max(rowsReturned, 1)
+                    : null;
+            logger.info(
+                `DuckDB query profile: latency=${latencyMs}ms cpu=${cpuMs}ms rows=${profile.rows_returned} bytes_read=${profile.total_bytes_read} operators=[${operatorStr}]`,
+                {
+                    ...tags,
+                    latencyMs,
+                    cpuMs,
+                    waitMs,
+                    readParquetMs,
+                    bytesRead,
+                    rowsScanned,
+                    rowsReturned,
+                    scanAmplification,
+                },
+            );
+        } catch {
+            // profiling output not available, skip
+        } finally {
+            await fs.rm(profilePath, { force: true }).catch(() => {});
+        }
+    }
+
     private static getFieldsFromStreamResult(
         result: DuckdbStreamResult,
     ): WarehouseResults['fields'] {
@@ -509,6 +512,22 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             };
         }
         return fields;
+    }
+
+    private static stripSqlComments(sql: string): string {
+        return sql
+            .replace(/--[^\n]*/g, '') // line comments
+            .replace(/\/\*[\s\S]*?\*\//g, ''); // block comments
+    }
+
+    private static validateSqlFunctions(sql: string): void {
+        const stripped = DuckdbWarehouseClient.stripSqlComments(sql);
+        const match = stripped.match(BLOCKED_FUNCTION_PATTERN);
+        if (match) {
+            throw new Error(
+                `SQL validation error: function '${match[1]}' is not allowed`,
+            );
+        }
     }
 
     private async validateUserSql(
@@ -537,6 +556,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         } finally {
             stmt.destroySync();
         }
+
+        DuckdbWarehouseClient.validateSqlFunctions(sql);
     }
 
     private async validateInternalSql(
@@ -554,9 +575,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             const stmt = await extracted.prepare(i);
             try {
                 if (
-                    !ALLOWED_STATEMENT_TYPES_INTERNAL_SQL.has(
-                        stmt.statementType,
-                    )
+                    BLOCKED_STATEMENT_TYPES_INTERNAL_SQL.has(stmt.statementType)
                 ) {
                     throw new Error(
                         `SQL validation error: statement type ${stmt.statementType} is not allowed in internal SQL`,
@@ -566,6 +585,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
                 stmt.destroySync();
             }
         }
+
+        DuckdbWarehouseClient.validateSqlFunctions(sql);
     }
 
     async streamQuery(
@@ -578,11 +599,23 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             timezone?: string;
         },
     ): Promise<void> {
-        await this.withSession('user', async (db) => {
+        await this.withSession(async (db) => {
             if (options?.timezone) {
                 await db.run(
                     `SET TimeZone = '${this.escapeString(options.timezone)}';`,
                 );
+            }
+
+            const profilePath = this.logger
+                ? path.join(
+                      os.tmpdir(),
+                      `duckdb-profile-${Date.now()}-${Math.random().toString(36).slice(2)}.json`,
+                  )
+                : undefined;
+
+            if (profilePath) {
+                await db.run("PRAGMA enable_profiling='json';");
+                await db.run(`PRAGMA profiling_output='${profilePath}';`);
             }
 
             await this.validateUserSql(db, sql);
@@ -597,6 +630,14 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             // eslint-disable-next-line no-restricted-syntax
             for await (const rows of result.yieldRowObjectJson()) {
                 await streamCallback({ fields, rows });
+            }
+
+            if (profilePath) {
+                await DuckdbWarehouseClient.logQueryProfile(
+                    profilePath,
+                    this.logger!,
+                    options?.tags,
+                );
             }
         });
     }
@@ -635,7 +676,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
     }
 
     async runSql(sql: string): Promise<void> {
-        await this.withSession('internal', async (db) => {
+        await this.withSession(async (db) => {
             await this.validateInternalSql(db, sql);
             await db.run(sql);
         });
@@ -650,7 +691,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         let bootstrapMs = 0;
         let queryMs = 0;
 
-        await this.withSession('internal', async (db) => {
+        await this.withSession(async (db) => {
             await this.validateInternalSql(db, sql);
             bootstrapMs = performance.now() - totalStart;
             const queryStart = performance.now();


### PR DESCRIPTION
## Summary

This is a minimal production fix for the DuckDB parquet conversion failure:

`Permission Error: File system LocalFileSystem has been disabled by configuration`

`convertJsonlToParquet()` uses DuckDB `COPY` with a local `temp_directory` when resource limits are enabled. Disabling `LocalFileSystem` breaks that path, so this PR removes the `disabled_filesystems = 'LocalFileSystem'` setting for now.

## Change

- stop setting `disabled_filesystems = 'LocalFileSystem'` during DuckDB bootstrap
- update the warehouse test to stop expecting that setting

## Why minimal

This keeps the rollback narrowly focused on restoring JSONL to Parquet conversion in production without changing the rest of the DuckDB hardening behavior in this PR.

## Test plan

- [x] `pnpm --filter @lightdash/warehouses test -- --runInBand src/warehouseClients/DuckdbWarehouseClient.test.ts`
- [x] `pnpm --filter @lightdash/warehouses typecheck`
- [ ] Verify JSONL to Parquet conversion succeeds in deployed env
