### PR TITLE
fix: uppercase Snowflake identifiers from dbt Cloud Metadata API

### DIFF
--- a/packages/backend/src/dbt/DbtMetadataApiClient.test.ts
+++ b/packages/backend/src/dbt/DbtMetadataApiClient.test.ts
@@ -1,0 +1,162 @@
+import { DbtModelNode } from '@lightdash/common';
+import { GraphQLClient } from 'graphql-request';
+import { DbtMetadataApiClient } from './DbtMetadataApiClient';
+
+jest.mock('graphql-request');
+
+const makeNode = (overrides: Record<string, unknown> = {}) => ({
+    resourceType: 'model',
+    accountId: '1',
+    projectId: '1',
+    environmentId: '1',
+    uniqueId: 'model.project.pull_requests',
+    name: 'pull_requests',
+    description: '',
+    meta: {},
+    tags: [],
+    filePath: 'models/pull_requests.sql',
+    database: 'dbt_semantic_layer',
+    schema: 'prod',
+    alias: 'pull_requests',
+    packageName: 'project',
+    rawCode: 'SELECT 1',
+    compiledCode: 'SELECT 1',
+    materializedType: 'table',
+    language: 'sql',
+    packages: [],
+    dbtVersion: '1.8.0',
+    group: '',
+    access: 'public',
+    deprecationDate: '',
+    version: '',
+    latestVersion: '',
+    releaseVersion: '',
+    contractEnforced: false,
+    patchPath: '',
+    config: {},
+    catalog: { columns: [] },
+    ...overrides,
+});
+
+const makeApiResponse = (adapterType: string, nodes: unknown[]) => ({
+    environment: {
+        adapterType,
+        applied: {
+            lastUpdatedAt: '2026-01-01T00:00:00Z',
+            models: {
+                totalCount: nodes.length,
+                pageInfo: {
+                    startCursor: '0',
+                    hasNextPage: false,
+                    endCursor: '0',
+                },
+                edges: nodes.map((node) => ({ node })),
+            },
+        },
+    },
+});
+
+const createClient = () =>
+    new DbtMetadataApiClient({
+        environmentId: '123',
+        bearerToken: 'test-token',
+        discoveryApiEndpoint: undefined,
+        tags: undefined,
+    });
+
+describe('DbtMetadataApiClient', () => {
+    beforeEach(() => {
+        jest.resetAllMocks();
+    });
+
+    describe('Snowflake identifier casing', () => {
+        it('should uppercase database, schema, alias, and relation_name for Snowflake', async () => {
+            const mockRequest = jest
+                .fn()
+                .mockResolvedValue(makeApiResponse('snowflake', [makeNode()]));
+            (GraphQLClient as jest.Mock).mockImplementation(() => ({
+                request: mockRequest,
+            }));
+
+            const client = createClient();
+            const result = await client.getDbtManifest();
+            const model = result.manifest.nodes[
+                'model.project.pull_requests'
+            ] as DbtModelNode;
+
+            expect(model.database).toBe('DBT_SEMANTIC_LAYER');
+            expect(model.schema).toBe('PROD');
+            expect(model.alias).toBe('PULL_REQUESTS');
+            expect(model.relation_name).toBe(
+                '"DBT_SEMANTIC_LAYER"."PROD"."PULL_REQUESTS"',
+            );
+        });
+
+        it('should use model name when alias is empty for Snowflake', async () => {
+            const mockRequest = jest
+                .fn()
+                .mockResolvedValue(
+                    makeApiResponse('snowflake', [
+                        makeNode({ alias: '', name: 'my_model' }),
+                    ]),
+                );
+            (GraphQLClient as jest.Mock).mockImplementation(() => ({
+                request: mockRequest,
+            }));
+
+            const client = createClient();
+            const result = await client.getDbtManifest();
+            const model = result.manifest.nodes[
+                'model.project.pull_requests'
+            ] as DbtModelNode;
+
+            expect(model.alias).toBe('MY_MODEL');
+            expect(model.relation_name).toBe(
+                '"DBT_SEMANTIC_LAYER"."PROD"."MY_MODEL"',
+            );
+        });
+    });
+
+    describe('non-Snowflake identifier casing', () => {
+        it('should preserve original casing for Postgres', async () => {
+            const mockRequest = jest
+                .fn()
+                .mockResolvedValue(makeApiResponse('postgres', [makeNode()]));
+            (GraphQLClient as jest.Mock).mockImplementation(() => ({
+                request: mockRequest,
+            }));
+
+            const client = createClient();
+            const result = await client.getDbtManifest();
+            const model = result.manifest.nodes[
+                'model.project.pull_requests'
+            ] as DbtModelNode;
+
+            expect(model.database).toBe('dbt_semantic_layer');
+            expect(model.schema).toBe('prod');
+            expect(model.alias).toBe('pull_requests');
+            expect(model.relation_name).toBe(
+                '"dbt_semantic_layer"."prod"."pull_requests"',
+            );
+        });
+
+        it('should preserve original casing for BigQuery', async () => {
+            const mockRequest = jest
+                .fn()
+                .mockResolvedValue(makeApiResponse('bigquery', [makeNode()]));
+            (GraphQLClient as jest.Mock).mockImplementation(() => ({
+                request: mockRequest,
+            }));
+
+            const client = createClient();
+            const result = await client.getDbtManifest();
+            const model = result.manifest.nodes[
+                'model.project.pull_requests'
+            ] as DbtModelNode;
+
+            expect(model.relation_name).toBe(
+                '`dbt_semantic_layer`.`prod`.`pull_requests`',
+            );
+        });
+    });
+});

--- a/packages/backend/src/dbt/DbtMetadataApiClient.ts
+++ b/packages/backend/src/dbt/DbtMetadataApiClient.ts
@@ -274,57 +274,69 @@ export class DbtMetadataApiClient implements DbtClient {
                 );
             }
 
+            // Snowflake defaults to uppercase identifiers, but the dbt Cloud
+            // Metadata API returns lowercase. Since we wrap identifiers in
+            // double quotes (which makes them case-sensitive in Snowflake),
+            // we must uppercase them to match the actual object names.
+            const normalizeIdentifier =
+                adapterType === 'snowflake'
+                    ? (id: string) => id.toUpperCase()
+                    : (id: string) => id;
+
             const dbtModelNodes: Record<string, DbtModelNode> =
                 Object.fromEntries(
-                    results.environment.applied.models.edges.map(({ node }) => [
-                        node.uniqueId,
-                        <DbtModelNode>{
-                            checksum: {
-                                name: '',
-                                checksum: '',
-                            },
-                            columns: Object.values(
-                                node.catalog?.columns || [],
-                            ).reduce<DbtModelNode['columns']>(
-                                (acc, column: AnyType) => {
-                                    acc[column.name] = {
-                                        name: column.name,
-                                        description: column.description,
-                                        meta: column.meta,
-                                        type: column.type,
-                                        data_type: column.type?.toLowerCase(),
-                                    };
-                                    return acc;
+                    results.environment.applied.models.edges.map(({ node }) => {
+                        const database = normalizeIdentifier(node.database);
+                        const schema = normalizeIdentifier(node.schema);
+                        const alias = normalizeIdentifier(
+                            node.alias || node.name,
+                        );
+
+                        return [
+                            node.uniqueId,
+                            <DbtModelNode>{
+                                checksum: {
+                                    name: '',
+                                    checksum: '',
                                 },
-                                {},
-                            ),
-                            compiled: true,
-                            fqn: [],
-                            language: node.language,
-                            path: node.filePath,
-                            resource_type: 'model',
-                            unique_id: node.uniqueId,
-                            name: node.name,
-                            description: node.description,
-                            meta: node.meta,
-                            tags: node.tags,
-                            original_file_path: node.filePath,
-                            database: node.database,
-                            schema: node.schema,
-                            alias: node.alias,
-                            package_name: node.packageName,
-                            raw_code: node.rawCode,
-                            compiled_code: node.compiledCode,
-                            relation_name: `${fieldQuoteChar}${
-                                node.database
-                            }${fieldQuoteChar}.${fieldQuoteChar}${
-                                node.schema
-                            }${fieldQuoteChar}.${fieldQuoteChar}${
-                                node.alias || node.name
-                            }${fieldQuoteChar}`,
-                            config: node.config,
-                        },
-                    ]),
+                                columns: Object.values(
+                                    node.catalog?.columns || [],
+                                ).reduce<DbtModelNode['columns']>(
+                                    (acc, column: AnyType) => {
+                                        acc[column.name] = {
+                                            name: column.name,
+                                            description: column.description,
+                                            meta: column.meta,
+                                            type: column.type,
+                                            data_type:
+                                                column.type?.toLowerCase(),
+                                        };
+                                        return acc;
+                                    },
+                                    {},
+                                ),
+                                compiled: true,
+                                fqn: [],
+                                language: node.language,
+                                path: node.filePath,
+                                resource_type: 'model',
+                                unique_id: node.uniqueId,
+                                name: node.name,
+                                description: node.description,
+                                meta: node.meta,
+                                tags: node.tags,
+                                original_file_path: node.filePath,
+                                database,
+                                schema,
+                                alias,
+                                package_name: node.packageName,
+                                raw_code: node.rawCode,
+                                compiled_code: node.compiledCode,
+                                relation_name: `${fieldQuoteChar}${database}${fieldQuoteChar}.${fieldQuoteChar}${schema}${fieldQuoteChar}.${fieldQuoteChar}${alias}${fieldQuoteChar}`,
+                                config: node.config,
+                            },
+                        ];
+                    }),
                 );
             return <DbtRpcGetManifestResults>{
                 manifest: {


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-5893/snowflake-dbt-cloud-metadata-api-returns-lowercase-identifiers-causing

### Description:
The dbt Cloud Metadata API returns lowercase database/schema/table names.
When wrapped in double quotes for Snowflake (which treats quoted identifiers as case-sensitive), these fail with "Schema does not exist" errors since Snowflake stores objects as uppercase by default.


### Before:
<img width="2654" height="1644" alt="Before" src="https://github.com/user-attachments/assets/cdf07dbe-e750-4e32-983b-fb5c8cafeab4" />


### After:
<img width="2654" height="1644" alt="After" src="https://github.com/user-attachments/assets/3e379ae2-9489-450c-9673-254da9a2ca17" />


