### PR TITLE
feat: lazy warehouse client for dbt ls

### DIFF
--- a/packages/backend/src/dbt/profiles.test.ts
+++ b/packages/backend/src/dbt/profiles.test.ts
@@ -1,0 +1,349 @@
+import {
+    AthenaAuthenticationType,
+    BigqueryAuthenticationType,
+    CreateWarehouseCredentials,
+    WarehouseTypes,
+} from '@lightdash/common';
+import * as yaml from 'js-yaml';
+import { minimalProfileFromCredentials } from './profiles';
+
+const DUMMY_SECRET = 'LIGHTDASH_DUMMY';
+
+type DbtProfileYaml = {
+    lightdash_profile: {
+        target: string;
+        outputs: Record<string, Record<string, unknown>>;
+    };
+};
+
+const assertNoSecrets = (
+    target: Record<string, unknown>,
+    secrets: string[],
+) => {
+    const targetStr = JSON.stringify(target);
+    for (const secret of secrets) {
+        expect(targetStr).not.toContain(secret);
+    }
+};
+
+const assertValidProfileYaml = (profileStr: string) => {
+    const parsed = yaml.load(profileStr) as DbtProfileYaml;
+    expect(parsed).toHaveProperty('lightdash_profile');
+    expect(parsed.lightdash_profile).toHaveProperty('target');
+    expect(parsed.lightdash_profile).toHaveProperty('outputs');
+};
+
+describe('minimalProfileFromCredentials', () => {
+    describe('BigQuery', () => {
+        it('produces minimal profile with dummy keyfile values for private key auth', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.BIGQUERY,
+                project: 'my-project',
+                dataset: 'my_dataset',
+                timeoutSeconds: 300,
+                priority: 'interactive',
+                retries: 3,
+                maximumBytesBilled: 1000000,
+                executionProject: 'exec-project',
+                location: 'US',
+                authenticationType: BigqueryAuthenticationType.PRIVATE_KEY,
+                keyfileContents: {
+                    type: 'service_account',
+                    project_id: 'my-project',
+                    private_key_id: 'key-id-123',
+                    private_key:
+                        '-----BEGIN RSA PRIVATE KEY-----\nSECRET\n-----END RSA PRIVATE KEY-----',
+                    client_email: 'sa@project.iam.gserviceaccount.com',
+                },
+            };
+
+            const { profile, environment } =
+                minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+            expect(environment).toEqual({});
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.project).toBe('my-project');
+            expect(target.dataset).toBe('my_dataset');
+            expect(target.method).toBe('service-account-json');
+            expect(target.keyfile_json).toBeDefined();
+            // All keyfile values should be dummy
+            for (const value of Object.values(
+                target.keyfile_json as Record<string, string>,
+            )) {
+                expect(value).toBe(DUMMY_SECRET);
+            }
+            // Key structure preserved
+            expect(
+                Object.keys(target.keyfile_json as Record<string, unknown>),
+            ).toEqual([
+                'type',
+                'project_id',
+                'private_key_id',
+                'private_key',
+                'client_email',
+            ]);
+            assertNoSecrets(target, ['-----BEGIN RSA', 'key-id-123']);
+        });
+
+        it('produces minimal profile for ADC auth', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.BIGQUERY,
+                project: 'my-project',
+                dataset: 'my_dataset',
+                timeoutSeconds: 300,
+                priority: 'interactive',
+                retries: 3,
+                maximumBytesBilled: 0,
+                location: 'US',
+                authenticationType: BigqueryAuthenticationType.ADC,
+                keyfileContents: {},
+            };
+
+            const { profile } = minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+            expect(target.method).toBe('oauth');
+        });
+    });
+
+    describe('Postgres', () => {
+        it('keeps user but dummies password', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                user: 'admin',
+                password: 'super_secret_password',
+                port: 5432,
+                dbname: 'mydb',
+                schema: 'public',
+                keepalivesIdle: 0,
+                searchPath: '',
+                role: undefined,
+                sslmode: undefined,
+            };
+
+            const { profile, environment } =
+                minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+            expect(environment).toEqual({});
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.user).toBe('admin');
+            expect(target.password).toBe(DUMMY_SECRET);
+            expect(target.host).toBe('localhost');
+            assertNoSecrets(target, ['super_secret_password']);
+        });
+    });
+
+    describe('Redshift', () => {
+        it('keeps user but dummies password', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.REDSHIFT,
+                host: 'cluster.redshift.amazonaws.com',
+                user: 'redshift_user',
+                password: 'redshift_secret',
+                port: 5439,
+                dbname: 'warehouse',
+                schema: 'analytics',
+                keepalivesIdle: 0,
+                sslmode: 'require',
+                ra3Node: true,
+            };
+
+            const { profile } = minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.user).toBe('redshift_user');
+            expect(target.password).toBe(DUMMY_SECRET);
+            assertNoSecrets(target, ['redshift_secret']);
+        });
+    });
+
+    describe('Snowflake', () => {
+        it('dummies password for all auth types', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.SNOWFLAKE,
+                account: 'myaccount',
+                user: 'snowflake_user',
+                password: 'snowflake_secret',
+                role: 'analyst',
+                database: 'ANALYTICS',
+                warehouse: 'COMPUTE_WH',
+                schema: 'PUBLIC',
+                clientSessionKeepAlive: true,
+                queryTag: 'lightdash',
+            };
+
+            const { profile } = minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.user).toBe('snowflake_user');
+            expect(target.password).toBe(DUMMY_SECRET);
+            expect(target.account).toBe('myaccount');
+            expect(target.role).toBe('analyst');
+            assertNoSecrets(target, ['snowflake_secret']);
+        });
+    });
+
+    describe('Databricks', () => {
+        it('dummies token', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.DATABRICKS,
+                catalog: 'main',
+                database: 'analytics',
+                serverHostName: 'adb-123.azuredatabricks.net',
+                httpPath: '/sql/1.0/warehouses/abc',
+                personalAccessToken: 'dapi_secret_token_123',
+            };
+
+            const { profile } = minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.token).toBe(DUMMY_SECRET);
+            expect(target.host).toBe('adb-123.azuredatabricks.net');
+            assertNoSecrets(target, ['dapi_secret_token_123']);
+        });
+    });
+
+    describe('Trino', () => {
+        it('keeps user but dummies password', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.TRINO,
+                host: 'trino.example.com',
+                user: 'trino_user',
+                password: 'trino_secret',
+                port: 8443,
+                dbname: 'hive',
+                schema: 'default',
+                http_scheme: 'https',
+            };
+
+            const { profile } = minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.user).toBe('trino_user');
+            expect(target.password).toBe(DUMMY_SECRET);
+            assertNoSecrets(target, ['trino_secret']);
+        });
+    });
+
+    describe('ClickHouse', () => {
+        it('keeps user but dummies password', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.CLICKHOUSE,
+                host: 'clickhouse.example.com',
+                user: 'ch_user',
+                password: 'ch_secret',
+                port: 8443,
+                schema: 'default',
+                secure: true,
+            };
+
+            const { profile } = minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.user).toBe('ch_user');
+            expect(target.password).toBe(DUMMY_SECRET);
+            assertNoSecrets(target, ['ch_secret']);
+        });
+    });
+
+    describe('Athena', () => {
+        it('dummies access keys for access key auth', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.ATHENA,
+                region: 'us-east-1',
+                database: 'mydb',
+                schema: 'default',
+                s3StagingDir: 's3://bucket/staging',
+                authenticationType: AthenaAuthenticationType.ACCESS_KEY,
+                accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+                secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+            };
+
+            const { profile } = minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.aws_access_key_id).toBe(DUMMY_SECRET);
+            expect(target.aws_secret_access_key).toBe(DUMMY_SECRET);
+            expect(target.region_name).toBe('us-east-1');
+            assertNoSecrets(target, ['AKIAIOSFODNN7EXAMPLE', 'wJalrXUtnFEMI']);
+        });
+
+        it('omits access keys for IAM auth', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.ATHENA,
+                region: 'us-east-1',
+                database: 'mydb',
+                schema: 'default',
+                s3StagingDir: 's3://bucket/staging',
+                authenticationType: AthenaAuthenticationType.IAM_ROLE,
+                accessKeyId: undefined,
+                secretAccessKey: undefined,
+            };
+
+            const { profile } = minimalProfileFromCredentials(credentials);
+            assertValidProfileYaml(profile);
+
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+            const target = parsed.lightdash_profile.outputs.prod;
+
+            expect(target.aws_access_key_id).toBeUndefined();
+            expect(target.aws_secret_access_key).toBeUndefined();
+        });
+    });
+
+    describe('custom target name', () => {
+        it('uses custom target name when provided', () => {
+            const credentials: CreateWarehouseCredentials = {
+                type: WarehouseTypes.POSTGRES,
+                host: 'localhost',
+                user: 'admin',
+                password: 'pass',
+                port: 5432,
+                dbname: 'mydb',
+                schema: 'public',
+                keepalivesIdle: 0,
+                searchPath: '',
+                role: undefined,
+                sslmode: undefined,
+            };
+
+            const { profile } = minimalProfileFromCredentials(
+                credentials,
+                'custom_target',
+            );
+            const parsed = yaml.load(profile) as DbtProfileYaml;
+
+            expect(parsed.lightdash_profile.target).toBe('custom_target');
+            expect(
+                parsed.lightdash_profile.outputs.custom_target,
+            ).toBeDefined();
+        });
+    });
+});

--- a/packages/backend/src/dbt/profiles.ts
+++ b/packages/backend/src/dbt/profiles.ts
@@ -300,6 +300,200 @@ const credentialsTarget = (
             );
     }
 };
+const DUMMY_SECRET = 'LIGHTDASH_DUMMY';
+
+const minimalCredentialsTarget = (
+    credentials: CreateWarehouseCredentials,
+): { target: Record<string, AnyType> } => {
+    switch (credentials.type) {
+        case WarehouseTypes.BIGQUERY: {
+            const target: Record<string, AnyType> = {
+                type: credentials.type,
+                project: credentials.project,
+                dataset: credentials.dataset,
+                threads: DEFAULT_THREADS,
+                timeout_seconds: credentials.timeoutSeconds,
+                priority: credentials.priority,
+                retries: credentials.retries,
+                maximum_bytes_billed:
+                    credentials.maximumBytesBilled || undefined,
+                execution_project: credentials.executionProject,
+            };
+            switch (credentials.authenticationType) {
+                case BigqueryAuthenticationType.PRIVATE_KEY:
+                case BigqueryAuthenticationType.SSO:
+                case undefined:
+                    target.method = 'service-account-json';
+                    target.keyfile_json = credentials.keyfileContents
+                        ? Object.fromEntries(
+                              Object.keys(credentials.keyfileContents).map(
+                                  (key) => [key, DUMMY_SECRET],
+                              ),
+                          )
+                        : {};
+                    return { target };
+                case BigqueryAuthenticationType.ADC:
+                    target.method = 'oauth';
+                    return { target };
+                default: {
+                    const { authenticationType } = credentials;
+                    return assertUnreachable(
+                        credentials,
+                        `Incorrect BigQuery profile. Received authenticationType: ${authenticationType}`,
+                    );
+                }
+            }
+        }
+        case WarehouseTypes.REDSHIFT:
+            return {
+                target: {
+                    type: credentials.type,
+                    host: credentials.host,
+                    user: credentials.user,
+                    password: DUMMY_SECRET,
+                    port: credentials.port,
+                    dbname: credentials.dbname,
+                    schema: credentials.schema,
+                    threads: DEFAULT_THREADS,
+                    keepalives_idle: credentials.keepalivesIdle,
+                    sslmode: credentials.sslmode,
+                    sslrootcert:
+                        require.resolve('@lightdash/warehouses/dist/warehouseClients/ca-bundle-aws-redshift.crt'),
+                    ra3_node: credentials.ra3Node || true,
+                },
+            };
+        case WarehouseTypes.POSTGRES:
+            return {
+                target: {
+                    type: credentials.type,
+                    host: credentials.host,
+                    user: credentials.user,
+                    password: DUMMY_SECRET,
+                    port: credentials.port,
+                    dbname: credentials.dbname,
+                    schema: credentials.schema,
+                    threads: DEFAULT_THREADS,
+                    keepalives_idle: credentials.keepalivesIdle,
+                    search_path: credentials.searchPath,
+                    role: credentials.role,
+                    sslmode: credentials.sslmode,
+                    ...(credentials.host.endsWith('.rds.amazonaws.com')
+                        ? {
+                              sslrootcert:
+                                  require.resolve('@lightdash/warehouses/dist/warehouseClients/ca-bundle-aws-rds-global.pem'),
+                          }
+                        : {}),
+                },
+            };
+        case WarehouseTypes.TRINO:
+            return {
+                target: {
+                    type: credentials.type,
+                    host: credentials.host,
+                    method: 'ldap',
+                    user: credentials.user,
+                    password: DUMMY_SECRET,
+                    port: credentials.port,
+                    database: credentials.dbname,
+                    schema: credentials.schema,
+                    http_scheme: credentials.http_scheme,
+                },
+            };
+        case WarehouseTypes.SNOWFLAKE:
+            return {
+                target: {
+                    type: credentials.type,
+                    account: credentials.account,
+                    user: credentials.user,
+                    password: DUMMY_SECRET,
+                    role: credentials.role,
+                    database: credentials.database,
+                    warehouse: credentials.warehouse,
+                    schema: credentials.schema,
+                    threads: DEFAULT_THREADS,
+                    client_session_keep_alive:
+                        credentials.clientSessionKeepAlive,
+                    query_tag: credentials.queryTag,
+                },
+            };
+        case WarehouseTypes.DATABRICKS:
+            return {
+                target: {
+                    type: WarehouseTypes.DATABRICKS,
+                    catalog: credentials.catalog,
+                    schema: credentials.database,
+                    host: credentials.serverHostName,
+                    token: DUMMY_SECRET,
+                    http_path: credentials.httpPath,
+                },
+            };
+        case WarehouseTypes.CLICKHOUSE:
+            return {
+                target: {
+                    type: WarehouseTypes.CLICKHOUSE,
+                    host: credentials.host,
+                    port: credentials.port,
+                    user: credentials.user,
+                    password: DUMMY_SECRET,
+                    schema: credentials.schema,
+                    secure: credentials.secure,
+                },
+            };
+        case WarehouseTypes.ATHENA: {
+            const athenaAuthenticationType =
+                credentials.authenticationType ??
+                AthenaAuthenticationType.ACCESS_KEY;
+            return {
+                target: {
+                    type: WarehouseTypes.ATHENA,
+                    region_name: credentials.region,
+                    database: credentials.database,
+                    schema: credentials.schema,
+                    s3_staging_dir: credentials.s3StagingDir,
+                    s3_data_dir: credentials.s3DataDir || undefined,
+                    work_group: credentials.workGroup || undefined,
+                    threads: credentials.threads || DEFAULT_THREADS,
+                    num_retries: credentials.numRetries || undefined,
+                    aws_assume_role_arn: credentials.assumeRoleArn || undefined,
+                    aws_assume_role_external_id:
+                        credentials.assumeRoleExternalId || undefined,
+                    ...(athenaAuthenticationType ===
+                    AthenaAuthenticationType.ACCESS_KEY
+                        ? {
+                              aws_access_key_id: DUMMY_SECRET,
+                              aws_secret_access_key: DUMMY_SECRET,
+                          }
+                        : {}),
+                },
+            };
+        }
+        default: {
+            const { type } = credentials;
+            return assertUnreachable(
+                credentials,
+                `No profile implemented for warehouse type: ${type}`,
+            );
+        }
+    }
+};
+
+export const minimalProfileFromCredentials = (
+    credentials: CreateWarehouseCredentials,
+    customTargetName?: string,
+) => {
+    const targetName = customTargetName || LIGHTDASH_TARGET_NAME;
+    const { target } = minimalCredentialsTarget(credentials);
+    return {
+        profile: yaml.dump({
+            [LIGHTDASH_PROFILE_NAME]: {
+                target: targetName,
+                outputs: { [targetName]: target },
+            },
+        }),
+        environment: {} as Record<string, string>,
+    };
+};
+
 export const profileFromCredentials = (
     credentials: CreateWarehouseCredentials,
     profilesDir: string,

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -41,10 +41,19 @@ import {
     type TrackingParams,
 } from '../types';
 
+export type WarehouseClientFactory = () => Promise<{
+    warehouseClient: WarehouseClient;
+    cleanup: () => Promise<void>;
+}>;
+
 export class DbtBaseProjectAdapter implements ProjectAdapter {
     dbtClient: DbtClient;
 
     warehouseClient: WarehouseClient;
+
+    warehouseClientFactory: WarehouseClientFactory | undefined;
+
+    private warehouseClientCleanup: (() => Promise<void>) | undefined;
 
     cachedWarehouse: CachedWarehouse;
 
@@ -70,16 +79,34 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
         this.analytics = analytics;
     }
 
+    private async resolveWarehouseClient(): Promise<WarehouseClient> {
+        if (this.warehouseClientFactory) {
+            Logger.info(
+                'Resolving full warehouse client from factory (cache miss)',
+            );
+            const { warehouseClient, cleanup } =
+                await this.warehouseClientFactory();
+            this.warehouseClient = warehouseClient;
+            this.warehouseClientCleanup = cleanup;
+            this.warehouseClientFactory = undefined; // only resolve once
+        }
+        return this.warehouseClient;
+    }
+
     // eslint-disable-next-line class-methods-use-this
     async destroy(): Promise<void> {
         Logger.debug(`Destroy base project adapter`);
+        if (this.warehouseClientCleanup) {
+            await this.warehouseClientCleanup();
+        }
     }
 
     public async test(): Promise<void> {
         Logger.debug('Test dbt client');
         await this.dbtClient.test();
         Logger.debug('Test warehouse client');
-        await this.warehouseClient.test();
+        const warehouseClient = await this.resolveWarehouseClient();
+        await warehouseClient.test();
     }
 
     public async getDbtPackages(): Promise<DbtPackages | undefined> {
@@ -272,8 +299,11 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     `Fetching table metadata for ${modelCatalog.length} tables`,
                 );
 
+                // Resolve full warehouse client (OAuth + SSH tunnel) only when needed
+                const fullWarehouseClient = await this.resolveWarehouseClient();
+
                 const warehouseCatalog =
-                    await this.warehouseClient.getCatalog(modelCatalog);
+                    await fullWarehouseClient.getCatalog(modelCatalog);
                 await this.cachedWarehouse?.onWarehouseCatalogChange(
                     warehouseCatalog,
                 );
@@ -290,8 +320,8 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 );
                 Logger.info('Convert explores after missing catalog error');
                 const disableTimestampConversion =
-                    this.warehouseClient.credentials.type === 'snowflake' &&
-                    this.warehouseClient.credentials
+                    fullWarehouseClient.credentials.type === 'snowflake' &&
+                    fullWarehouseClient.credentials
                         .disableTimestampConversion === true;
 
                 const explores = await convertExplores(
@@ -299,7 +329,7 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     loadSources,
                     adapterType,
                     metrics,
-                    this.warehouseClient,
+                    fullWarehouseClient,
                     lightdashProjectConfig,
                     disableTimestampConversion,
                     allowPartialCompilation,

--- a/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtLocalCredentialsProjectAdapter.ts
@@ -11,7 +11,7 @@ import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import {
     LIGHTDASH_PROFILE_NAME,
     LIGHTDASH_TARGET_NAME,
-    profileFromCredentials,
+    minimalProfileFromCredentials,
 } from '../dbt/profiles';
 import Logger from '../logging/logger';
 import { CachedWarehouse } from '../types';
@@ -46,20 +46,8 @@ export class DbtLocalCredentialsProjectAdapter extends DbtLocalProjectAdapter {
         const profilesDir = fs.mkdtempSync('/tmp/local_');
         const profilesFilename = path.join(profilesDir, 'profiles.yml');
 
-        const {
-            profile,
-            environment: injectedEnvironment,
-            files,
-        } = profileFromCredentials(
-            warehouseCredentials,
-            profilesDir,
-            targetName,
-        );
-        if (files) {
-            Object.entries(files).forEach(([filePath, content]) => {
-                writeFileSync(filePath, content);
-            });
-        }
+        const { profile, environment: injectedEnvironment } =
+            minimalProfileFromCredentials(warehouseCredentials, targetName);
         writeFileSync(profilesFilename, profile);
         const e = (environment || []).reduce<Record<string, string>>(
             (previousValue, { key, value }) => ({

--- a/packages/backend/src/projectAdapters/projectAdapter.ts
+++ b/packages/backend/src/projectAdapters/projectAdapter.ts
@@ -14,6 +14,10 @@ import { getInstallationToken } from '../clients/github/Github';
 import Logger from '../logging/logger';
 import { CachedWarehouse, ProjectAdapter } from '../types';
 import { DbtAzureDevOpsProjectAdapter } from './dbtAzureDevOpsProjectAdapter';
+import {
+    DbtBaseProjectAdapter,
+    type WarehouseClientFactory,
+} from './dbtBaseProjectAdapter';
 import { DbtBitBucketProjectAdapter } from './dbtBitBucketProjectAdapter';
 import { DbtCloudIdeProjectAdapter } from './dbtCloudIdeProjectAdapter';
 import { DbtGithubProjectAdapter } from './dbtGithubProjectAdapter';
@@ -28,6 +32,7 @@ export const projectAdapterFromConfig = async (
     cachedWarehouse: CachedWarehouse,
     dbtVersionOption: DbtVersionOption,
     analytics?: LightdashAnalytics,
+    warehouseClientFactory?: WarehouseClientFactory,
 ): Promise<ProjectAdapter> => {
     Logger.debug(
         `Initialize warehouse client of type ${warehouseCredentials.type}`,
@@ -42,9 +47,10 @@ export const projectAdapterFromConfig = async (
             ? getLatestSupportDbtVersion()
             : dbtVersionOption;
 
+    let adapter: ProjectAdapter;
     switch (config.type) {
         case DbtProjectType.DBT:
-            return new DbtLocalCredentialsProjectAdapter({
+            adapter = new DbtLocalCredentialsProjectAdapter({
                 analytics,
                 warehouseClient,
                 projectDir: config.project_dir || '/usr/app/dbt',
@@ -56,22 +62,23 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
             });
+            break;
         case DbtProjectType.NONE:
-            return new DbtNoneCredentialsProjectAdapter({
+            adapter = new DbtNoneCredentialsProjectAdapter({
                 warehouseClient,
             });
-
+            break;
         case DbtProjectType.MANIFEST:
-            return new DbtManifestProjectAdapter({
+            adapter = new DbtManifestProjectAdapter({
                 warehouseClient,
                 cachedWarehouse,
                 dbtVersion,
                 analytics,
                 manifest: config.manifest,
             });
-
+            break;
         case DbtProjectType.DBT_CLOUD_IDE:
-            return new DbtCloudIdeProjectAdapter({
+            adapter = new DbtCloudIdeProjectAdapter({
                 analytics,
                 warehouseClient,
                 environmentId: `${config.environment_id}`,
@@ -82,6 +89,7 @@ export const projectAdapterFromConfig = async (
                 dbtVersion,
                 // TODO add selector to dbt cloud
             });
+            break;
         case DbtProjectType.GITHUB:
             const githubToken =
                 config.installation_id &&
@@ -100,7 +108,7 @@ export const projectAdapterFromConfig = async (
                     `Missing repository for GitHub project`,
                 );
             }
-            return new DbtGithubProjectAdapter({
+            adapter = new DbtGithubProjectAdapter({
                 analytics,
                 warehouseClient,
                 githubPersonalAccessToken: githubToken!,
@@ -116,8 +124,9 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
             });
+            break;
         case DbtProjectType.GITLAB:
-            return new DbtGitlabProjectAdapter({
+            adapter = new DbtGitlabProjectAdapter({
                 analytics,
                 warehouseClient,
                 gitlabPersonalAccessToken: config.personal_access_token,
@@ -133,8 +142,9 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
             });
+            break;
         case DbtProjectType.BITBUCKET:
-            return new DbtBitBucketProjectAdapter({
+            adapter = new DbtBitBucketProjectAdapter({
                 analytics,
                 warehouseClient,
                 username: config.username,
@@ -151,8 +161,9 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
             });
+            break;
         case DbtProjectType.AZURE_DEVOPS:
-            return new DbtAzureDevOpsProjectAdapter({
+            adapter = new DbtAzureDevOpsProjectAdapter({
                 analytics,
                 warehouseClient,
                 personalAccessToken: config.personal_access_token,
@@ -169,8 +180,14 @@ export const projectAdapterFromConfig = async (
 
                 selector: config.selector,
             });
+            break;
         default:
             const never: never = config;
             throw new Error(`Adapter not implemented for type: ${configType}`);
     }
+
+    if (warehouseClientFactory && adapter instanceof DbtBaseProjectAdapter) {
+        adapter.warehouseClientFactory = warehouseClientFactory;
+    }
+    return adapter;
 };

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -175,6 +175,7 @@ import {
     exchangeDatabricksOAuthCredentials,
     refreshDatabricksOAuthToken,
     SshTunnel,
+    warehouseClientFromCredentials,
     warehouseSqlBuilderFromType,
 } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
@@ -2651,73 +2652,68 @@ export class ProjectService extends BaseService {
         });
     }
 
-    private async buildAdapter(
+    /**
+     * Resolves OAuth tokens and sets up SSH tunnel for warehouse connection.
+     * Extracted so it can be called lazily (only when warehouse access is needed).
+     */
+    private async resolveWarehouseCredentials(
         projectUuid: string,
         user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+        rawWarehouseConnection: CreateWarehouseCredentials,
     ): Promise<{
+        credentials: CreateWarehouseCredentials;
         sshTunnel: SshTunnel<CreateWarehouseCredentials>;
-        adapter: ProjectAdapter;
     }> {
-        const project =
-            await this.projectModel.getWithSensitiveFields(projectUuid);
-        if (!project.warehouseConnection) {
-            throw new MissingWarehouseCredentialsError(
-                'Warehouse credentials must be provided to connect to your dbt project',
-            );
-        }
-        const cachedWarehouseCatalog =
-            await this.projectModel.getWarehouseFromCache(projectUuid);
-
+        const warehouseConnection = { ...rawWarehouseConnection };
         if (
-            project.warehouseConnection.type === WarehouseTypes.SNOWFLAKE &&
-            project.warehouseConnection.authenticationType === 'sso' &&
-            project.warehouseConnection.refreshToken
+            warehouseConnection.type === WarehouseTypes.SNOWFLAKE &&
+            warehouseConnection.authenticationType === 'sso' &&
+            warehouseConnection.refreshToken
         ) {
             this.logger.debug(
                 `Refreshing snowflake warehouse credentials from refresh token on buildAdapter`,
             );
             const accessToken = await UserService.generateSnowflakeAccessToken(
-                project.warehouseConnection.refreshToken,
+                warehouseConnection.refreshToken,
             );
-            project.warehouseConnection.token = accessToken;
+            warehouseConnection.token = accessToken;
         }
 
         if (
-            project.warehouseConnection.type === WarehouseTypes.DATABRICKS &&
-            project.warehouseConnection.authenticationType ===
+            warehouseConnection.type === WarehouseTypes.DATABRICKS &&
+            warehouseConnection.authenticationType ===
                 DatabricksAuthenticationType.OAUTH_M2M
         ) {
             // If we have OAuth credentials but no refresh token, exchange them for tokens
             if (
-                project.warehouseConnection.oauthClientId &&
-                project.warehouseConnection.oauthClientSecret &&
-                !project.warehouseConnection.refreshToken
+                warehouseConnection.oauthClientId &&
+                warehouseConnection.oauthClientSecret &&
+                !warehouseConnection.refreshToken
             ) {
                 this.logger.debug(
                     `Exchanging Databricks OAuth credentials for access token on buildAdapter`,
                 );
                 const { accessToken, refreshToken } =
                     await exchangeDatabricksOAuthCredentials(
-                        project.warehouseConnection.serverHostName,
-                        project.warehouseConnection.oauthClientId,
-                        project.warehouseConnection.oauthClientSecret,
+                        warehouseConnection.serverHostName,
+                        warehouseConnection.oauthClientId,
+                        warehouseConnection.oauthClientSecret,
                     );
-                project.warehouseConnection.token = accessToken;
+                warehouseConnection.token = accessToken;
                 if (refreshToken) {
-                    project.warehouseConnection.refreshToken = refreshToken;
+                    warehouseConnection.refreshToken = refreshToken;
                     // Note: refresh token will be persisted when project credentials are next saved
                 }
-            } else if (project.warehouseConnection.refreshToken) {
+            } else if (warehouseConnection.refreshToken) {
                 // If we have a refresh token, use it to get a fresh access token
                 this.logger.debug(
                     `Refreshing databricks warehouse credentials from refresh token on buildAdapter`,
                 );
                 let clientId: string;
                 let clientSecret: string | undefined;
-                if (project.warehouseConnection.oauthClientId) {
-                    clientId = project.warehouseConnection.oauthClientId;
-                    clientSecret =
-                        project.warehouseConnection.oauthClientSecret;
+                if (warehouseConnection.oauthClientId) {
+                    clientId = warehouseConnection.oauthClientId;
+                    clientSecret = warehouseConnection.oauthClientSecret;
                 } else if (this.lightdashConfig.auth.databricks.clientId) {
                     clientId = this.lightdashConfig.auth.databricks.clientId;
                     clientSecret =
@@ -2728,24 +2724,23 @@ export class ProjectService extends BaseService {
                 }
                 const { accessToken, refreshToken } =
                     await refreshDatabricksOAuthToken(
-                        project.warehouseConnection.serverHostName,
+                        warehouseConnection.serverHostName,
                         clientId,
-                        project.warehouseConnection.refreshToken,
+                        warehouseConnection.refreshToken,
                         clientSecret,
                     );
-                project.warehouseConnection.token = accessToken;
-                project.warehouseConnection.refreshToken = refreshToken;
+                warehouseConnection.token = accessToken;
+                warehouseConnection.refreshToken = refreshToken;
             }
         }
 
         if (
-            project.warehouseConnection.type === WarehouseTypes.DATABRICKS &&
-            project.warehouseConnection.authenticationType ===
+            warehouseConnection.type === WarehouseTypes.DATABRICKS &&
+            warehouseConnection.authenticationType ===
                 DatabricksAuthenticationType.OAUTH_U2M
         ) {
             // For U2M OAuth, resolve refresh token from user credentials if not on project
-            let u2mRefreshToken =
-                project.warehouseConnection.refreshToken ?? undefined;
+            let u2mRefreshToken = warehouseConnection.refreshToken ?? undefined;
 
             let userCredOauthClientId: string | undefined;
             if (!u2mRefreshToken) {
@@ -2774,8 +2769,7 @@ export class ProjectService extends BaseService {
                 let clientId: string;
                 let clientSecret: string | undefined;
                 const storedClientId =
-                    userCredOauthClientId ||
-                    project.warehouseConnection.oauthClientId;
+                    userCredOauthClientId || warehouseConnection.oauthClientId;
                 if (storedClientId) {
                     clientId = storedClientId;
                 } else if (this.lightdashConfig.auth.databricks.clientId) {
@@ -2793,22 +2787,57 @@ export class ProjectService extends BaseService {
 
                 const { accessToken, refreshToken } =
                     await refreshDatabricksOAuthToken(
-                        project.warehouseConnection.serverHostName,
+                        warehouseConnection.serverHostName,
                         clientId,
                         u2mRefreshToken,
                         clientSecret,
                     );
-                project.warehouseConnection.token = accessToken;
-                project.warehouseConnection.refreshToken = refreshToken;
+                warehouseConnection.token = accessToken;
+                warehouseConnection.refreshToken = refreshToken;
             }
         }
 
-        const sshTunnel = new SshTunnel(project.warehouseConnection);
+        const sshTunnel = new SshTunnel(warehouseConnection);
         await sshTunnel.connect();
+
+        return { credentials: sshTunnel.overrideCredentials, sshTunnel };
+    }
+
+    private async buildAdapter(
+        projectUuid: string,
+        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
+    ): Promise<{
+        adapter: ProjectAdapter;
+    }> {
+        const project =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+        if (!project.warehouseConnection) {
+            throw new MissingWarehouseCredentialsError(
+                'Warehouse credentials must be provided to connect to your dbt project',
+            );
+        }
+        const cachedWarehouseCatalog =
+            await this.projectModel.getWarehouseFromCache(projectUuid);
+
+        // Lazy factory: OAuth refresh + SSH tunnel + warehouse client
+        // Only invoked if cached catalog is missing and we need to query the warehouse
+        const warehouseClientFactory = async () => {
+            const { credentials, sshTunnel } =
+                await this.resolveWarehouseCredentials(
+                    projectUuid,
+                    user,
+                    project.warehouseConnection!,
+                );
+            const warehouseClient = warehouseClientFromCredentials(credentials);
+            return {
+                warehouseClient,
+                cleanup: () => sshTunnel.disconnect(),
+            };
+        };
 
         const adapter = await projectAdapterFromConfig(
             project.dbtConnection,
-            sshTunnel.overrideCredentials,
+            project.warehouseConnection,
             {
                 warehouseCatalog: cachedWarehouseCatalog,
                 onWarehouseCatalogChange: async (warehouseCatalog) => {
@@ -2820,8 +2849,9 @@ export class ProjectService extends BaseService {
             },
             project.dbtVersion || DefaultSupportedDbtVersion,
             this.analytics,
+            warehouseClientFactory,
         );
-        return { adapter, sshTunnel };
+        return { adapter };
     }
 
     static updateExploreWithDateZoom(
@@ -4568,10 +4598,7 @@ export class ProjectService extends BaseService {
 
         // Force refresh adapter (refetch git repos, check for changed credentials, etc.)
         // Might want to cache parts of this in future if slow
-        const { adapter, sshTunnel } = await this.buildAdapter(
-            projectUuid,
-            user,
-        );
+        const { adapter } = await this.buildAdapter(projectUuid, user);
         const packages = await adapter.getDbtPackages();
         try {
             const trackingParams = {
@@ -4746,7 +4773,6 @@ export class ProjectService extends BaseService {
             throw errorResponse;
         } finally {
             await adapter.destroy();
-            await sshTunnel.disconnect();
         }
     }
 


### PR DESCRIPTION
## Summary
- **Minimal dbt profile**: `minimalProfileFromCredentials()` generates `profiles.yml` with dummy secrets — `dbt ls` never connects to the warehouse so real credentials aren't needed
- **Lazy warehouse client**: OAuth token refresh, SSH tunnel setup, and warehouse client creation are deferred into a factory that's only invoked on catalog cache miss
- **When cache is warm** (common case): no OAuth calls, no SSH tunnel, no warehouse connection — just dbt ls with a dummy profile

## Test plan
- [x] Unit tests for `minimalProfileFromCredentials` covering all 8 warehouse types
- [x] `pnpm -F backend typecheck` passes
- [x] `pnpm -F backend lint` passes
- [ ] Manual test: trigger project compile with warm cache, verify dbt ls succeeds without warehouse connection
- [ ] Manual test: trigger project compile with cold cache, verify warehouse catalog fetch still works