### PR TITLE
fix: exclude null config from dashboard download response

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -381,7 +381,7 @@ export class CoderService extends BaseService {
             filters: CoderService.getFiltersWithTileSlugs(dashboard),
             tabs: dashboard.tabs,
             slug: dashboard.slug,
-            config: dashboard.config,
+            ...(dashboard.config ? { config: dashboard.config } : {}),
 
             spaceSlug,
             version: currentVersion,


### PR DESCRIPTION
## Summary
- When a dashboard has no config, the download serialized it as `config: null` in YAML
- On upload, TSOA rejected `null` because the type expects `DashboardConfig | undefined`, not `null`
- Fix: only include `config` in the download response when it has a value

Introduced by #21048

**Before**
<img width="661" height="1077" alt="CleanShot 2026-03-12 at 12 53 04" src="https://github.com/user-attachments/assets/d197a4b8-ba5d-4435-a848-3f16922f2c45" />

**After**
<img width="661" height="1020" alt="CleanShot 2026-03-12 at 12 51 54" src="https://github.com/user-attachments/assets/9d00b133-ae65-4b8c-a3b6-40f9b49eb2cf" />

test-all