### PR TITLE
fix: ignore non-uuid-jobs when considered stuck

### DIFF
--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -87,6 +87,15 @@ type SchedulerServiceArguments = {
     spacePermissionService: SpacePermissionService;
 };
 
+const getLightdashJobUuid = (
+    payload: Record<string, unknown>,
+): string | undefined => {
+    const { jobUuid } = payload;
+    return typeof jobUuid === 'string' && jobUuid.length > 0
+        ? jobUuid
+        : undefined;
+};
+
 export class SchedulerService extends BaseService {
     lightdashConfig: LightdashConfig;
 
@@ -1623,10 +1632,27 @@ export class SchedulerService extends BaseService {
             ),
         );
 
-        // Update Lightdash job status to ERROR for compile project jobs
+        const lightdashJobUuids = jobsToLog.flatMap(({ job }) => {
+            const jobUuid = getLightdashJobUuid(job.payload);
+            return jobUuid ? [jobUuid] : [];
+        });
+
+        if (lightdashJobUuids.length !== jobsToLog.length) {
+            this.logger.info(
+                'Skipping Lightdash job status update for stuck jobs without jobUuid',
+                {
+                    jobIds: jobsToLog.map(({ job }) => job.id),
+                    taskIdentifiers: jobsToLog.map(
+                        ({ job }) => job.taskIdentifier,
+                    ),
+                },
+            );
+        }
+
+        // Update Lightdash job status to ERROR for tasks that track a Lightdash job row
         await Promise.all(
-            jobsToLog.map(({ job }) =>
-                this.jobModel.update(job.payload.jobUuid as string, {
+            lightdashJobUuids.map((jobUuid) =>
+                this.jobModel.update(jobUuid, {
                     jobStatus: JobStatusType.ERROR,
                 }),
             ),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Added validation for job payloads before updating Lightdash job status to prevent errors when processing stuck jobs. The changes include:

- Added `getLightdashJobUuid` helper function to safely extract and validate `jobUuid` from job payloads
- Added filtering to only process jobs that have valid `jobUuid` values when updating job status to ERROR
- Added logging to track when jobs are skipped due to missing `jobUuid` in their payload

This prevents the scheduler from attempting to update job status with invalid or missing job UUIDs, which could cause runtime errors when cleaning up stuck jobs.