### PR TITLE
chore: remove enable-table-column-customization feature flag

### DIFF
--- a/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
+++ b/packages/backend/src/clients/EmailClient/EmailClient.mock.ts
@@ -23,7 +23,7 @@ export const lightdashConfigWithNoSMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableTableColumnCustomization: undefined,
+
         retryQueryOnTransientErrors: false,
     },
 };
@@ -61,7 +61,7 @@ export const lightdashConfigWithBasicSMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableTableColumnCustomization: undefined,
+
         retryQueryOnTransientErrors: false,
     },
 };
@@ -87,7 +87,7 @@ export const lightdashConfigWithOauth2SMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableTableColumnCustomization: undefined,
+
         retryQueryOnTransientErrors: false,
     },
 };
@@ -109,7 +109,7 @@ export const lightdashConfigWithSecurePortSMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableTableColumnCustomization: undefined,
+
         retryQueryOnTransientErrors: false,
     },
 };

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -219,7 +219,6 @@ export const lightdashConfigMock: LightdashConfig = {
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableTableColumnCustomization: undefined,
         retryQueryOnTransientErrors: true,
     },
     ai: {

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -879,7 +879,6 @@ export type LightdashConfig = {
         maxPageSize: number;
         useSqlPivotResults: boolean | undefined;
         showExecutionTime: boolean | undefined;
-        enableTableColumnCustomization: boolean | undefined;
         retryQueryOnTransientErrors: boolean;
     };
     pivotTable: {
@@ -1710,10 +1709,6 @@ export const parseConfig = (): LightdashConfig => {
                 : undefined,
             showExecutionTime: process.env.SHOW_EXECUTION_TIME
                 ? process.env.SHOW_EXECUTION_TIME === 'true'
-                : undefined,
-            enableTableColumnCustomization: process.env
-                .ENABLE_TABLE_COLUMN_CUSTOMIZATION
-                ? process.env.ENABLE_TABLE_COLUMN_CUSTOMIZATION === 'true'
                 : undefined,
             retryQueryOnTransientErrors: process.env
                 .LIGHTDASH_QUERY_RETRY_ON_TRANSIENT_ERRORS

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -46,8 +46,6 @@ export class FeatureFlagModel {
                 this.getSavedMetricsTreeEnabled.bind(this),
             [FeatureFlags.DefaultUserSpaces]:
                 this.getDefaultUserSpacesEnabled.bind(this),
-            [FeatureFlags.EnableTableColumnCustomization]:
-                this.getTableColumnCustomizationEnabled.bind(this),
             [FeatureFlags.GoogleChatEnabled]:
                 this.getGoogleChatEnabled.bind(this),
             [FeatureFlags.UserImpersonation]:
@@ -271,32 +269,6 @@ export class FeatureFlagModel {
                       },
                   )
                 : false);
-        return {
-            id: featureFlagId,
-            enabled,
-        };
-    }
-
-    private async getTableColumnCustomizationEnabled({
-        user,
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        const enabled =
-            this.lightdashConfig.query.enableTableColumnCustomization ??
-            (user !== undefined
-                ? await isFeatureFlagEnabled(
-                      FeatureFlags.EnableTableColumnCustomization,
-                      {
-                          userUuid: user.userUuid,
-                          organizationUuid: user.organizationUuid,
-                      },
-                      {
-                          throwOnTimeout: false,
-                          timeoutMilliseconds: 500,
-                      },
-                  )
-                : false);
-
         return {
             id: featureFlagId,
             enabled,

--- a/packages/backend/src/services/ProjectService/ProjectService.mock.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.mock.ts
@@ -478,7 +478,6 @@ export const lightdashConfigWithNoSMTP: Pick<
         timezone: undefined,
         useSqlPivotResults: false,
         showExecutionTime: false,
-        enableTableColumnCustomization: undefined,
         retryQueryOnTransientErrors: false,
     },
 };

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -79,11 +79,6 @@ export enum FeatureFlags {
     DefaultUserSpaces = 'default-user-spaces',
 
     /**
-     * Enable table column customization (resize, header wrap, tooltips)
-     */
-    EnableTableColumnCustomization = 'enable-table-column-customization',
-
-    /**
      * Enable Google Chat as a scheduled delivery destination
      */
     GoogleChatEnabled = 'google-chat-enabled',

--- a/packages/frontend/src/components/SimpleTable/index.tsx
+++ b/packages/frontend/src/components/SimpleTable/index.tsx
@@ -6,7 +6,6 @@ import {
     isChunkLoadError,
     triggerChunkErrorReload,
 } from '../../features/chunkErrorHandler';
-import { useIsTableColumnCustomizationEnabled } from '../../hooks/useIsTableColumnCustomizationEnabled';
 import LoadingChart from '../common/LoadingChart';
 import PivotTable from '../common/PivotTable';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
@@ -51,8 +50,6 @@ const SimpleTable: FC<SimpleTableProps> = ({
         isLoading,
         isEditMode,
     } = useVisualizationContext();
-
-    const isColumnCustomizationEnabled = useIsTableColumnCustomizationEnabled();
 
     const hasSignaledScreenshotReady = useRef(false);
 
@@ -208,7 +205,7 @@ const SimpleTable: FC<SimpleTableProps> = ({
     } = visualizationConfig.chartConfig;
 
     const onColumnWidthChange =
-        isColumnCustomizationEnabled && !isDashboard && isEditMode !== false
+        !isDashboard && isEditMode !== false
             ? (fieldId: string, width: number) => {
                   updateColumnProperty(fieldId, { width });
               }

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -26,7 +26,6 @@ import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
 import { useCalculateSubtotals } from '../useCalculateSubtotals';
 import { useCalculateTotal } from '../useCalculateTotal';
-import { useIsTableColumnCustomizationEnabled } from '../useIsTableColumnCustomizationEnabled';
 import { type InfiniteQueryResults } from '../useQueryResults';
 import getDataAndColumns from './getDataAndColumns';
 
@@ -53,7 +52,6 @@ const useTableConfig = (
     dateZoom?: DateZoom,
 ) => {
     const { embedToken } = useEmbed();
-    const isColumnCustomizationEnabled = useIsTableColumnCustomizationEnabled();
 
     const [showColumnCalculation, setShowColumnCalculation] = useState<boolean>(
         !!tableChartConfig?.showColumnCalculation,
@@ -175,11 +173,8 @@ const useTableConfig = (
     );
 
     const getColumnWidth = useCallback(
-        (fieldId: string) =>
-            isColumnCustomizationEnabled
-                ? columnProperties[fieldId]?.width
-                : undefined,
-        [columnProperties, isColumnCustomizationEnabled],
+        (fieldId: string) => columnProperties[fieldId]?.width,
+        [columnProperties],
     );
 
     const isPivotTableEnabled =
@@ -612,20 +607,7 @@ const useTableConfig = (
         resultsData,
     ]);
 
-    // Strip `width` from column properties when the feature flag is off.
-    // Column customization was previously released but reverted due to side
-    // effects. Some users set manual widths to work around those issues. Without
-    // this filter, users with the flag disabled would suddenly get those saved
-    // widths back, causing unexpected layout changes.
-    const exposedColumnProperties: Record<string, ColumnProperties> =
-        useMemo(() => {
-            if (isColumnCustomizationEnabled) return columnProperties;
-            return Object.fromEntries(
-                Object.entries(columnProperties).map(
-                    ([key, { width, ...rest }]) => [key, rest],
-                ),
-            );
-        }, [columnProperties, isColumnCustomizationEnabled]);
+    const exposedColumnProperties = columnProperties;
 
     const validConfig: TableChart = useMemo(
         () => ({
@@ -669,7 +651,7 @@ const useTableConfig = (
             setShowResultsTotal,
             showSubtotals,
             setShowSubtotals,
-            isColumnCustomizationEnabled,
+
             columnProperties: exposedColumnProperties,
             setColumnProperties,
             updateColumnProperty,
@@ -706,7 +688,7 @@ const useTableConfig = (
             setShowResultsTotal,
             showSubtotals,
             setShowSubtotals,
-            isColumnCustomizationEnabled,
+
             exposedColumnProperties,
             setColumnProperties,
             updateColumnProperty,

--- a/packages/frontend/src/hooks/useIsTableColumnCustomizationEnabled.ts
+++ b/packages/frontend/src/hooks/useIsTableColumnCustomizationEnabled.ts
@@ -1,9 +1,0 @@
-import { FeatureFlags } from '@lightdash/common';
-import { useServerFeatureFlag } from './useServerOrClientFeatureFlag';
-
-export const useIsTableColumnCustomizationEnabled = () => {
-    const { data } = useServerFeatureFlag(
-        FeatureFlags.EnableTableColumnCustomization,
-    );
-    return data?.enabled ?? false;
-};


### PR DESCRIPTION
## Summary
- Removes the `enable-table-column-customization` feature flag, making table column customization (resize, header wrap, tooltips) permanently enabled for all users
- Removes the enum value, backend config/handler, environment variable parsing, and all mock references
- Simplifies frontend code by removing flag checks — column widths are now always respected and column resize is always available in edit mode

## Test plan
- [ ] Verify table column resizing works in the Explore view (edit mode)
- [ ] Verify saved column widths are applied when loading a chart
- [ ] Verify column resize is disabled on dashboards and in non-edit mode
- [ ] Verify no TypeScript errors introduced (`pnpm -F common typecheck && pnpm -F frontend typecheck`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)