### PR TITLE
feat: add BigQuery pre-aggregate batching and parquet guardrails

### DIFF
--- a/packages/backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.test.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.test.ts
@@ -1,0 +1,62 @@
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
+import { writeWithBackpressure } from '../../utils/streamUtils';
+import { createLocalParquetUploadStream } from './LocalParquetUploadStream';
+
+jest.mock('@lightdash/warehouses', () => ({
+    DuckdbWarehouseClient: jest.fn(),
+}));
+
+jest.mock('../../utils/streamUtils', () => ({
+    writeWithBackpressure: jest.fn(() => Promise.resolve()),
+}));
+
+describe('LocalParquetUploadStream', () => {
+    const duckdbWarehouseClientMock =
+        DuckdbWarehouseClient as unknown as jest.Mock;
+    const logger = {
+        info: jest.fn(),
+        error: jest.fn(),
+    };
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        duckdbWarehouseClientMock.mockImplementation(() => ({
+            runSqlWithMetrics: jest.fn().mockResolvedValue({ totalMs: 123 }),
+        }));
+    });
+
+    it('writes each row batch as a single backpressure call', async () => {
+        const stream = createLocalParquetUploadStream({
+            parquetS3Uri: 's3://bucket/results.parquet',
+            s3Config: {} as never,
+            logger: logger as never,
+        });
+
+        await stream.write([{ a: 1 }, { a: 2 }]);
+        await stream.close();
+
+        expect(writeWithBackpressure).toHaveBeenCalledTimes(1);
+        expect(writeWithBackpressure).toHaveBeenCalledWith(
+            expect.anything(),
+            '{"a":1}\n{"a":2}\n',
+        );
+    });
+
+    it('times out parquet conversion if close takes too long', async () => {
+        duckdbWarehouseClientMock.mockImplementation(() => ({
+            runSqlWithMetrics: jest.fn(() => new Promise(() => {})),
+        }));
+
+        const stream = createLocalParquetUploadStream({
+            parquetS3Uri: 's3://bucket/results.parquet',
+            s3Config: {} as never,
+            logger: logger as never,
+            closeTimeoutMs: 100,
+        });
+
+        await stream.write([{ a: 1 }]);
+        await expect(stream.close()).rejects.toThrow(
+            'Parquet conversion timed out after 100ms',
+        );
+    }, 1000);
+});

--- a/packages/backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.ts
+++ b/packages/backend/src/clients/ResultsFileStorageClients/LocalParquetUploadStream.ts
@@ -14,13 +14,35 @@ type LocalParquetUploadStreamArgs = {
     parquetS3Uri: string;
     s3Config: DuckdbS3SessionConfig;
     logger: typeof Logger;
+    closeTimeoutMs?: number;
 };
+
+const DEFAULT_PARQUET_CLOSE_TIMEOUT_MS = 10 * 60 * 1000;
 
 const cleanupDir = (dir: string) => {
     try {
         fs.rmSync(dir, { recursive: true, force: true });
     } catch {
         // best-effort cleanup
+    }
+};
+
+const withTimeout = async <T>(
+    promise: Promise<T>,
+    timeoutMs: number,
+    message: string,
+): Promise<T> => {
+    let timer: NodeJS.Timeout | undefined;
+
+    try {
+        return await Promise.race([
+            promise,
+            new Promise<T>((_, reject) => {
+                timer = setTimeout(() => reject(new Error(message)), timeoutMs);
+            }),
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
     }
 };
 
@@ -38,6 +60,7 @@ export const createLocalParquetUploadStream = ({
     parquetS3Uri,
     s3Config,
     logger,
+    closeTimeoutMs = DEFAULT_PARQUET_CLOSE_TIMEOUT_MS,
 }: LocalParquetUploadStreamArgs) => {
     const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'lightdash-parquet-'));
     const localJsonlPath = path.join(tmpDir, 'data.jsonl');
@@ -59,16 +82,14 @@ export const createLocalParquetUploadStream = ({
     };
 
     const write = async (rows: Record<string, unknown>[]): Promise<void> => {
+        if (rows.length === 0) return;
         if (firstWriteTime === null) firstWriteTime = Date.now();
         writeCalls += 1;
 
-        for (const row of rows) {
-            const data = `${JSON.stringify(row)}\n`;
-            totalBytesWritten += data.length;
-            totalRowsWritten += 1;
-            // eslint-disable-next-line no-await-in-loop
-            await writeWithBackpressure(fileWriteStream, data);
-        }
+        const data = `${rows.map((row) => JSON.stringify(row)).join('\n')}\n`;
+        totalBytesWritten += Buffer.byteLength(data);
+        totalRowsWritten += rows.length;
+        await writeWithBackpressure(fileWriteStream, data);
 
         const now = Date.now();
         if (now - lastProgressLog >= PROGRESS_LOG_INTERVAL_MS) {
@@ -95,7 +116,12 @@ export const createLocalParquetUploadStream = ({
             return;
         }
 
+        logger.info(
+            `Completed local JSONL write: rows=${totalRowsWritten} bytes=${Math.round(totalBytesWritten / 1024 / 1024)}MB target=${parquetS3Uri}`,
+        );
+
         try {
+            const closeStartedAt = Date.now();
             const duckdb = new DuckdbWarehouseClient({
                 s3Config,
                 resourceLimits: { memoryLimit: '256MB', threads: 1 },
@@ -108,11 +134,19 @@ export const createLocalParquetUploadStream = ({
             );
             const copySql = `COPY (SELECT * FROM ${localJsonlSqlTable}) TO '${parquetS3Uri}' (FORMAT PARQUET, COMPRESSION zstd, ROW_GROUP_SIZE 100000)`;
 
-            const metrics = await duckdb.runSqlWithMetrics(copySql);
+            logger.info(
+                `Starting Parquet conversion: rows=${totalRowsWritten} bytes=${Math.round(totalBytesWritten / 1024 / 1024)}MB timeoutMs=${closeTimeoutMs} target=${parquetS3Uri}`,
+            );
+
+            const metrics = await withTimeout(
+                duckdb.runSqlWithMetrics(copySql),
+                closeTimeoutMs,
+                `Parquet conversion timed out after ${closeTimeoutMs}ms`,
+            );
             const localFileSize = fs.statSync(localJsonlPath).size;
 
             logger.info(
-                `Parquet conversion complete: rows=${totalRowsWritten} jsonlBytes=${localFileSize} duckdbMs=${metrics.totalMs} target=${parquetS3Uri}`,
+                `Parquet conversion complete: rows=${totalRowsWritten} jsonlBytes=${localFileSize} duckdbMs=${metrics.totalMs} totalCloseMs=${Date.now() - closeStartedAt} target=${parquetS3Uri}`,
             );
         } catch (error) {
             logger.error(

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -350,6 +350,7 @@ export const lightdashConfigMock: LightdashConfig = {
     preAggregates: {
         enabled: false,
         parquetEnabled: false,
+        bigqueryResultsBatchSize: 1000,
         s3: {
             endpoint: 'mock_endpoint',
             bucket: 'mock_preagg_bucket',

--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -119,6 +119,14 @@ test('Should use explicit pre-aggregate S3 credentials when set', () => {
     });
 });
 
+test('Should parse pre-aggregate BigQuery results batch size from env', () => {
+    process.env.PRE_AGGREGATES_BIGQUERY_RESULTS_BATCH_SIZE = '2500';
+
+    const config = parseConfig();
+
+    expect(config.preAggregates.bigqueryResultsBatchSize).toBe(2500);
+});
+
 test('Should parse rudder config from env', () => {
     const expected = {
         dataPlaneUrl: 'customurl',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1107,6 +1107,7 @@ export type LightdashConfig = {
     preAggregates: {
         enabled: boolean;
         parquetEnabled: boolean;
+        bigqueryResultsBatchSize: number;
         s3?: Omit<S3Config, 'expirationTime'>;
     };
     userImpersonation: {
@@ -1383,6 +1384,10 @@ export const parseConfig = (): LightdashConfig => {
     const preAggregatesEnabled =
         licenseKey !== null && process.env.PRE_AGGREGATES_ENABLED === 'true';
     const preAggregatesS3 = parsePreAggregateResultsS3Config();
+    const preAggregatesBigqueryResultsBatchSize =
+        getIntegerFromEnvironmentVariable(
+            'PRE_AGGREGATES_BIGQUERY_RESULTS_BATCH_SIZE',
+        ) ?? 1000;
     const natsWorkerEnabled = process.env.NATS_ENABLED === 'true';
     const natsWorkerUrl = process.env.NATS_URL;
     const natsWorkerConcurrency =
@@ -1392,6 +1397,12 @@ export const parseConfig = (): LightdashConfig => {
 
     if (preAggregatesEnabled && !preAggregatesS3) {
         throw new ParseError('Pre-aggregates require S3 configuration', {});
+    }
+    if (preAggregatesBigqueryResultsBatchSize <= 0) {
+        throw new ParseError(
+            'PRE_AGGREGATES_BIGQUERY_RESULTS_BATCH_SIZE must be greater than 0',
+            {},
+        );
     }
     if (natsWorkerEnabled && !natsWorkerUrl) {
         throw new ParseError('NATS_URL is required when NATS_ENABLED=true', {});
@@ -2036,6 +2047,7 @@ export const parseConfig = (): LightdashConfig => {
             enabled: preAggregatesEnabled,
             parquetEnabled:
                 process.env.PRE_AGGREGATES_PARQUET_ENABLED === 'true',
+            bigqueryResultsBatchSize: preAggregatesBigqueryResultsBatchSize,
             s3: preAggregatesS3,
         },
         userImpersonation: {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -773,6 +773,7 @@ describe('AsyncQueryService', () => {
                 preAggregates: {
                     enabled: false,
                     parquetEnabled: false,
+                    bigqueryResultsBatchSize: 1000,
                 },
             });
             (service as AnyType).preAggregationDuckDbClient = {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -68,6 +68,7 @@ import {
     UnexpectedServerError,
     UserAccessControls,
     WarehouseClient,
+    WarehouseTypes,
     type ApiDownloadAsyncQueryResults,
     type ApiDownloadAsyncQueryResultsAsCsv,
     type ApiDownloadAsyncQueryResultsAsXlsx,
@@ -1377,6 +1378,7 @@ export class AsyncQueryService extends ProjectService {
         write,
         pivotConfiguration,
         itemsMap,
+        resultsBatchSize,
     }: {
         warehouseClient: WarehouseClient;
         query: string;
@@ -1384,6 +1386,7 @@ export class AsyncQueryService extends ProjectService {
         write?: (rows: Record<string, unknown>[]) => void | Promise<void>;
         pivotConfiguration?: PivotConfiguration;
         itemsMap: ItemsMap;
+        resultsBatchSize?: number;
     }): Promise<{
         columns: ResultColumns;
         warehouseResults: WarehouseExecuteAsyncQuery;
@@ -1555,6 +1558,7 @@ export class AsyncQueryService extends ProjectService {
                     {
                         sql: query,
                         tags: queryTags,
+                        resultsBatchSize,
                     },
                     write ? writeAndTransformRowsIfPivot : undefined,
                 ),
@@ -1987,12 +1991,30 @@ export class AsyncQueryService extends ProjectService {
                     s3Config,
                     logger: this.logger,
                 });
+                this.logger.info(
+                    `Configured parquet materialization stream for query ${queryUuid}`,
+                    {
+                        queryUuid,
+                        executionSource,
+                        queryContext: queryTags.query_context,
+                        target: parquetS3Uri,
+                    },
+                );
             } else if (resultsStorageClient.isEnabled) {
                 // Default: stream JSONL to S3
                 stream = resultsStorageClient.createUploadStream(
                     S3ResultsFileStorageClient.sanitizeFileExtension(fileName),
                     {
                         contentType: 'application/jsonl',
+                    },
+                );
+                this.logger.info(
+                    `Configured JSONL results stream for query ${queryUuid}`,
+                    {
+                        queryUuid,
+                        executionSource,
+                        queryContext: queryTags.query_context,
+                        fileName,
                     },
                 );
             }
@@ -2016,6 +2038,25 @@ export class AsyncQueryService extends ProjectService {
                 },
             });
             queryStartTime = Date.now();
+            const resultsBatchSize =
+                queryTags.query_context ===
+                    QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION &&
+                warehouseClient.credentials.type === WarehouseTypes.BIGQUERY
+                    ? this.lightdashConfig.preAggregates
+                          .bigqueryResultsBatchSize
+                    : undefined;
+
+            if (resultsBatchSize) {
+                this.logger.info(
+                    `Using BigQuery result batching for query ${queryUuid}: batchSize=${resultsBatchSize}`,
+                    {
+                        queryUuid,
+                        queryContext: queryTags.query_context,
+                        warehouseType: warehouseClient.credentials.type,
+                        batchSize: resultsBatchSize,
+                    },
+                );
+            }
             const {
                 warehouseResults: {
                     durationMs,
@@ -2045,6 +2086,7 @@ export class AsyncQueryService extends ProjectService {
                         write: stream?.write,
                         pivotConfiguration,
                         itemsMap: fieldsMap,
+                        resultsBatchSize,
                     }),
             );
 
@@ -2086,6 +2128,15 @@ export class AsyncQueryService extends ProjectService {
             if (stream) {
                 // Wait for the file to be written before marking the query as ready
                 const s3UploadStart = Date.now();
+                this.logger.info(
+                    `Closing results stream for query ${queryUuid}`,
+                    {
+                        queryUuid,
+                        executionSource,
+                        queryContext: queryTags.query_context,
+                        totalRows: pivotDetails?.totalRows ?? totalRows,
+                    },
+                );
                 await Sentry.startSpan(
                     {
                         op: 's3.upload',
@@ -2110,6 +2161,15 @@ export class AsyncQueryService extends ProjectService {
                         executionSource,
                     );
                 }
+                this.logger.info(
+                    `Closed results stream for query ${queryUuid}`,
+                    {
+                        queryUuid,
+                        executionSource,
+                        queryContext: queryTags.query_context,
+                        closeMs: Date.now() - s3UploadStart,
+                    },
+                );
 
                 this.analytics.track({
                     ...analyticsIdentity,
@@ -2129,6 +2189,14 @@ export class AsyncQueryService extends ProjectService {
             }
 
             const dbUpdateStart = Date.now();
+            this.logger.info(
+                `Updating query history to READY for query ${queryUuid}`,
+                {
+                    queryUuid,
+                    executionSource,
+                    queryContext: queryTags.query_context,
+                },
+            );
             await this.queryHistoryModel.update(
                 queryUuid,
                 projectUuid,
@@ -2155,6 +2223,15 @@ export class AsyncQueryService extends ProjectService {
                 queryHistoryAccount,
             );
             const dbUpdateMs = Date.now() - dbUpdateStart;
+            this.logger.info(
+                `Updated query history to READY for query ${queryUuid}`,
+                {
+                    queryUuid,
+                    executionSource,
+                    queryContext: queryTags.query_context,
+                    dbUpdateMs,
+                },
+            );
 
             const totalMs = Date.now() - t0;
             const s3UploadCloseMs = stream

--- a/packages/common/src/types/warehouse.ts
+++ b/packages/common/src/types/warehouse.ts
@@ -59,6 +59,7 @@ export type WarehouseExecuteAsyncQueryArgs = {
     values?: AnyType[]; // same as queryParams but in array form
     queryParams?: Record<string, AnyType>; // same as values but in object form
     sql: string;
+    resultsBatchSize?: number;
 };
 
 export type WarehouseExecuteAsyncQuery = {

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.test.ts
@@ -7,6 +7,7 @@ import {
     createJobResponse,
     credentials,
     getTableResponse,
+    rows,
 } from './BigqueryWarehouseClient.mock';
 import {
     config,
@@ -42,6 +43,68 @@ describe('BigqueryWarehouseClient', () => {
         );
         expect(getTableMock).toHaveBeenCalledTimes(1);
         expect(getTableResponse.getMetadata).toHaveBeenCalledTimes(1);
+    });
+
+    it('batches async query result callbacks', async () => {
+        const warehouse = new BigqueryWarehouseClient(credentials);
+        type MockJob = {
+            id: string;
+            location: string;
+            metadata: {
+                statistics: {
+                    startTime: number;
+                    endTime: number;
+                };
+            };
+            getQueryResults: jest.Mock;
+            getQueryResultsStream: jest.Mock;
+            on: jest.Mock;
+        };
+
+        const job = {} as MockJob;
+        Object.assign(job, {
+            id: 'job-1',
+            location: 'US',
+            metadata: {
+                statistics: {
+                    startTime: 1,
+                    endTime: 11,
+                },
+            },
+            getQueryResults: jest.fn(() => [
+                rows,
+                undefined,
+                createJobResponse[0].getQueryResults()[2],
+            ]),
+            getQueryResultsStream: createJobResponse[0].getQueryResultsStream,
+            on: jest.fn((event, callback) => {
+                if (event === 'complete') callback();
+                return job;
+            }),
+        });
+
+        (warehouse.client.createQueryJob as jest.Mock) = jest.fn(() => [job]);
+
+        const callback = jest.fn();
+        const result = await warehouse.executeAsyncQuery(
+            {
+                sql: 'fake sql',
+                tags: {},
+            },
+            callback,
+        );
+
+        expect(callback).toHaveBeenCalledTimes(1);
+        expect(callback).toHaveBeenCalledWith([expectedRow], expectedFields);
+        expect(result).toEqual({
+            queryId: 'job-1',
+            queryMetadata: {
+                type: 'bigquery',
+                jobLocation: 'US',
+            },
+            totalRows: 1,
+            durationMs: 10,
+        });
     });
 });
 

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -338,27 +338,51 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
     private async streamResults(
         job: Job,
         streamCallback: (
-            data: WarehouseResults['rows'][number],
+            data: WarehouseResults['rows'],
         ) => void | Promise<void>,
-        options: QueryResultsOptions = {},
+        options: QueryResultsOptions & { batchSize?: number } = {},
     ) {
         return new Promise<void>((resolve, reject) => {
+            let batch: WarehouseResults['rows'] = [];
+            const batchSize = options.batchSize ?? 1;
+
+            const flushBatch = async () => {
+                if (batch.length === 0) return;
+                const rows = batch;
+                batch = [];
+                await streamCallback(rows);
+            };
+
             pipeline(
                 job.getQueryResultsStream(options),
                 new Transform({
                     objectMode: true,
-                    async transform(chunk, _encoding, callback) {
-                        try {
-                            const chunkParsed = parseRow(chunk);
-                            await streamCallback(chunkParsed);
-                            callback();
-                        } catch (err) {
-                            if (err instanceof Error) {
-                                callback(err);
-                            } else {
-                                callback(new Error(String(err)));
+                    transform(chunk, _encoding, callback) {
+                        void (async () => {
+                            batch.push(parseRow(chunk));
+                            if (batch.length >= batchSize) {
+                                await flushBatch();
                             }
-                        }
+                        })()
+                            .then(() => callback())
+                            .catch((err) => {
+                                if (err instanceof Error) {
+                                    callback(err);
+                                } else {
+                                    callback(new Error(String(err)));
+                                }
+                            });
+                    },
+                    flush(callback) {
+                        void flushBatch()
+                            .then(() => callback())
+                            .catch((err) => {
+                                if (err instanceof Error) {
+                                    callback(err);
+                                } else {
+                                    callback(new Error(String(err)));
+                                }
+                            });
                     },
                 }),
                 (err: NodeJS.ErrnoException | null) => {
@@ -389,7 +413,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                 BigqueryWarehouseClient.getFieldsFromResponse(resultsMetadata);
 
             await this.streamResults(job, (chunk) =>
-                streamCallback({ fields, rows: [chunk] }),
+                streamCallback({ fields, rows: chunk }),
             );
         } catch (e: unknown) {
             if (BigqueryWarehouseClient.isBigqueryError(e)) {
@@ -652,7 +676,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
     }
 
     async executeAsyncQuery(
-        { sql, tags }: WarehouseExecuteAsyncQueryArgs,
+        { sql, tags, resultsBatchSize }: WarehouseExecuteAsyncQueryArgs,
         resultsStreamCallback?: (
             rows: WarehouseResults['rows'],
             fields: WarehouseResults['fields'],
@@ -688,8 +712,10 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
 
             // If a callback is provided, stream the results to the callback
             if (resultsStreamCallback) {
-                await this.streamResults(job, (row) =>
-                    resultsStreamCallback([row], fields),
+                await this.streamResults(
+                    job,
+                    (rows) => resultsStreamCallback(rows, fields),
+                    { batchSize: resultsBatchSize },
                 );
             }
 


### PR DESCRIPTION
## Summary
- add guardrails and clearer stage logging around local parquet materialization close/upload work
- add a configurable BigQuery pre-aggregate results batch size and scope batching to pre-aggregate materializations only
- add focused tests for parquet close timeout/write batching, BigQuery batching, and config parsing

## Testing
- pnpm --filter @lightdash/warehouses test -- BigqueryWarehouseClient.test.ts
- pnpm --filter backend test-sequential -- parseConfig.test.ts LocalParquetUploadStream.test.ts SchedulerService/SchedulerService.test.ts PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
- pnpm --filter @lightdash/warehouses typecheck
- pnpm --filter backend typecheck
