### PR TITLE
fix: make NATS stream creation opt-in for worker apps

### DIFF
--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -13,7 +13,7 @@ import { type NatsClient } from './clients/NatsClient';
 import { LightdashConfig } from './config/parseConfig';
 import Logger from './logging/logger';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
-import { type NatsWorkerStream } from './nats/natsConfig';
+import { STREAM_CONFIGS, type NatsWorkerStream } from './nats/natsConfig';
 import { NatsWorker } from './nats/NatsWorker';
 import { IGNORE_ERRORS } from './sentry';
 import {
@@ -173,6 +173,9 @@ export default class NatsWorkerApp {
     }> {
         const natsClient = this.clients.getNatsClient();
         await natsClient.connect();
+        await natsClient.ensureStreams(
+            this.streams.map((stream) => STREAM_CONFIGS[stream]),
+        );
 
         const worker = this.natsWorkerFactory({
             lightdashConfig: this.lightdashConfig,

--- a/packages/backend/src/clients/NatsClient.ts
+++ b/packages/backend/src/clients/NatsClient.ts
@@ -45,6 +45,8 @@ export class NatsClient implements INatsClient {
 
     private readonly codec = StringCodec();
 
+    private managedStreams: StreamConfig[] = [];
+
     /**
      * Lazy-init with retry-on-error: caches the connection promise so
      * concurrent callers share one connection. On failure the cache is
@@ -65,7 +67,7 @@ export class NatsClient implements INatsClient {
 
     // ── Connection ──────────────────────────────────────────────
 
-    /** Eagerly connect and ensure streams. Use from worker app startup. */
+    /** Eagerly connect. Worker startup can separately opt into stream setup. */
     async connect(): Promise<void> {
         await this.getOrCreateConnection();
     }
@@ -106,12 +108,15 @@ export class NatsClient implements INatsClient {
 
     // ── Stream infrastructure ───────────────────────────────────
 
-    /** Idempotently create all streams + consumers from STREAM_CONFIGS. */
-    async ensureStreams(): Promise<void> {
-        const conn = this.getConnection();
+    /** Idempotently create the selected streams + consumers for worker startup. */
+    async ensureStreams(streams: StreamConfig[]): Promise<void> {
+        this.managedStreams = streams;
+        if (this.managedStreams.length === 0) return;
+
+        const conn = await this.getOrCreateConnection();
         const jsm = await conn.jetstreamManager();
         await Promise.all(
-            Object.values(STREAM_CONFIGS).map(
+            this.managedStreams.map(
                 async (config: StreamConfig): Promise<void> => {
                     await jsm.streams.add({
                         name: config.streamName,
@@ -185,7 +190,6 @@ export class NatsClient implements INatsClient {
         this.connection = conn;
         Logger.info(`NATS #${this.connectionId} connected to ${url}`);
 
-        await this.ensureStreams();
         this.monitorStatus();
 
         return conn;
@@ -208,7 +212,7 @@ export class NatsClient implements INatsClient {
                 return;
             case Events.Reconnect:
                 Logger.info(`${tag} reconnected to ${status.data}`);
-                this.ensureStreams().catch((error) => {
+                this.reensureManagedStreams().catch((error) => {
                     Logger.error(
                         `${tag} failed to re-ensure streams after reconnect: ${getErrorMessage(error)}`,
                     );
@@ -216,7 +220,9 @@ export class NatsClient implements INatsClient {
                 });
                 return;
             case Events.Update:
-                Logger.info(`${tag} cluster update: ${status.data}`);
+                Logger.info(
+                    `${tag} cluster update: ${JSON.stringify(status.data)}`,
+                );
                 return;
             case Events.LDM:
                 Logger.info(`${tag} server entering lame duck mode`);
@@ -305,5 +311,10 @@ export class NatsClient implements INatsClient {
                 }
             },
         );
+    }
+
+    private async reensureManagedStreams(): Promise<void> {
+        if (this.managedStreams.length === 0) return;
+        await this.ensureStreams(this.managedStreams);
     }
 }

--- a/packages/backend/src/nats/NatsWorker.ts
+++ b/packages/backend/src/nats/NatsWorker.ts
@@ -71,7 +71,7 @@ export class NatsWorker {
     }
 
     public async run(): Promise<void> {
-        // Streams and consumers are already ensured by NatsClient.connect()
+        // Streams and consumers are ensured during NatsWorkerApp startup.
         const jetStream = this.natsClient.jetstream();
         this.messageStreams = [];
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR refactors NATS stream management to give workers explicit control over which streams they need. Previously, the NatsClient would automatically ensure all streams from STREAM_CONFIGS during connection. Now, workers must explicitly specify which streams to create by calling `ensureStreams()` with their required stream configurations.

The NatsWorkerApp now calls `ensureStreams()` after connecting, passing only the stream configurations that correspond to its configured worker streams. The NatsClient tracks these "managed streams" and will re-ensure them automatically after reconnection events.

This change provides better separation of concerns and allows different worker instances to only create the NATS infrastructure they actually need.
