### PR TITLE
fix: serialize DuckDB S3 secret bootstrap

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -329,6 +329,62 @@ describe('DuckdbWarehouseClient', () => {
         expect(streamMock).toHaveBeenCalledTimes(1);
     });
 
+    it('should serialize shared S3 secret bootstrap across concurrent sessions', async () => {
+        let releaseSecretCreation: (() => void) | undefined;
+        const secretCreationBlocked = new Promise<void>((resolve) => {
+            releaseSecretCreation = resolve;
+        });
+        const runMock = jest.fn(async (sql: string) => {
+            if (sql.includes('CREATE OR REPLACE SECRET __lightdash_s3')) {
+                await secretCreationBlocked;
+            }
+        });
+        const streamMock = jest.fn(async () =>
+            getMockStreamResult([[{ val: 1 }]], [DUCKDB_TYPE_IDS.INTEGER]),
+        );
+
+        createInstanceMock.mockResolvedValue(
+            createMockConnection(streamMock, runMock),
+        );
+
+        const client = new DuckdbWarehouseClient({
+            s3Config: {
+                endpoint: 'localhost:9000',
+                region: 'us-east-1',
+                accessKey: 'key',
+                secretKey: 'secret',
+                forcePathStyle: true,
+                useSsl: false,
+            },
+        });
+
+        const firstQuery = client.runQuery('SELECT 1 AS val');
+        const secondQuery = client.runQuery('SELECT 1 AS val');
+
+        await new Promise((resolve) => setImmediate(resolve));
+
+        expect(
+            runMock.mock.calls.filter(([sql]) =>
+                (sql as string).includes(
+                    'CREATE OR REPLACE SECRET __lightdash_s3',
+                ),
+            ),
+        ).toHaveLength(1);
+
+        releaseSecretCreation?.();
+
+        await Promise.all([firstQuery, secondQuery]);
+
+        expect(
+            runMock.mock.calls.filter(([sql]) =>
+                (sql as string).includes(
+                    'CREATE OR REPLACE SECRET __lightdash_s3',
+                ),
+            ),
+        ).toHaveLength(1);
+        expect(streamMock).toHaveBeenCalledTimes(2);
+    });
+
     it('should log structured DuckDB profile metrics with query tags', async () => {
         const runMock = jest.fn(async (sql: string) => {
             const match = sql.match(/^PRAGMA profiling_output='(.+)';$/);

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -155,6 +155,8 @@ export class DuckdbSqlBuilder extends WarehouseBaseSqlBuilder {
 let sharedInstance: DuckdbInstance | null = null;
 let httpfsInstalled = false;
 let cachesConfigured = false;
+let configuredS3SecretFingerprint: string | null = null;
+let sharedBootstrapQueue: Promise<void> = Promise.resolve();
 
 async function getOrCreateSharedInstance(
     databasePath: string,
@@ -185,6 +187,8 @@ function clearSharedInstance(logger?: DuckdbLogger): void {
         sharedInstance = null;
         httpfsInstalled = false;
         cachesConfigured = false;
+        configuredS3SecretFingerprint = null;
+        sharedBootstrapQueue = Promise.resolve();
         logger?.info('DuckDB shared instance cleared');
     }
 }
@@ -194,6 +198,30 @@ export function resetSharedDuckdbStateForTesting(): void {
     sharedInstance = null;
     httpfsInstalled = false;
     cachesConfigured = false;
+    configuredS3SecretFingerprint = null;
+    sharedBootstrapQueue = Promise.resolve();
+}
+
+async function withSharedBootstrapLock<T>(
+    callback: () => Promise<T>,
+): Promise<T> {
+    const run = sharedBootstrapQueue.then(callback, callback);
+    sharedBootstrapQueue = run.then(
+        () => undefined,
+        () => undefined,
+    );
+    return run;
+}
+
+function getS3SecretFingerprint(config: DuckdbS3SessionConfig): string {
+    return JSON.stringify({
+        endpoint: config.endpoint,
+        region: config.region,
+        accessKey: config.accessKey,
+        secretKey: config.secretKey,
+        forcePathStyle: config.forcePathStyle,
+        useSsl: config.useSsl,
+    });
 }
 
 // DuckDB StatementType values — see duckdb/common/enums/statement_type.hpp
@@ -307,44 +335,100 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         db: DuckdbConnection,
         tempDir: string | undefined,
     ): Promise<void> {
-        let installMs = 0;
-        if (!httpfsInstalled) {
-            const t0 = performance.now();
-            await db.run('INSTALL httpfs;');
-            installMs = performance.now() - t0;
-            httpfsInstalled = true;
-            this.logger?.info(
-                `DuckDB httpfs installed (first use): ${Math.round(installMs)}ms`,
-            );
-        }
+        const {
+            installMs,
+            s3ConfigMs,
+            loadedHttpfsDuringSharedBootstrap,
+        } = await withSharedBootstrapLock(async () => {
+            let nextInstallMs = 0;
+            let nextS3ConfigMs = 0;
+            let loadedDuringSharedBootstrap = false;
 
-        const t1 = performance.now();
-        await db.run('LOAD httpfs;');
-        const loadMs = performance.now() - t1;
-
-        // Enable built-in caches — these are GLOBAL settings (instance-level, not
-        // connection-level), so they only need to be set once per shared instance.
-        if (!cachesConfigured) {
-            await db.run('SET enable_http_metadata_cache = true;');
-            await db.run('SET enable_external_file_cache = true;');
-            await db.run('SET parquet_metadata_cache = true;');
-
-            await db.run('SET allow_community_extensions = false;');
-            await db.run('SET autoinstall_known_extensions = false;');
-            await db.run('SET autoload_known_extensions = false;');
-            await db.run('SET allow_unredacted_secrets = false;');
-
-            cachesConfigured = true;
-
-            if (this.bufferPoolSize) {
-                await db.run(
-                    `SET buffer_pool_size = '${this.bufferPoolSize}';`,
+            if (!httpfsInstalled) {
+                const t0 = performance.now();
+                await db.run('INSTALL httpfs;');
+                nextInstallMs = performance.now() - t0;
+                httpfsInstalled = true;
+                this.logger?.info(
+                    `DuckDB httpfs installed (first use): ${Math.round(nextInstallMs)}ms`,
                 );
             }
 
-            this.logger?.info(
-                `DuckDB caches enabled: http_metadata=true external_file=true parquet_metadata=true buffer_pool_size=${this.bufferPoolSize ?? 'default'}`,
-            );
+            // Enable built-in caches. These are global settings and should not
+            // be mutated concurrently on the shared instance.
+            if (!cachesConfigured) {
+                await db.run('SET enable_http_metadata_cache = true;');
+                await db.run('SET enable_external_file_cache = true;');
+                await db.run('SET parquet_metadata_cache = true;');
+
+                await db.run('SET allow_community_extensions = false;');
+                await db.run('SET autoinstall_known_extensions = false;');
+                await db.run('SET autoload_known_extensions = false;');
+                await db.run('SET allow_unredacted_secrets = false;');
+
+                cachesConfigured = true;
+
+                if (this.bufferPoolSize) {
+                    await db.run(
+                        `SET buffer_pool_size = '${this.bufferPoolSize}';`,
+                    );
+                }
+
+                this.logger?.info(
+                    `DuckDB caches enabled: http_metadata=true external_file=true parquet_metadata=true buffer_pool_size=${this.bufferPoolSize ?? 'default'}`,
+                );
+            }
+
+            if (this.s3Config) {
+                const nextFingerprint = getS3SecretFingerprint(this.s3Config);
+                if (configuredS3SecretFingerprint !== nextFingerprint) {
+                    const loadStart = performance.now();
+                    await db.run('LOAD httpfs;');
+                    loadedDuringSharedBootstrap = true;
+                    const loadMs = performance.now() - loadStart;
+
+                    const regionClause = this.s3Config.region
+                        ? `REGION '${this.escapeString(this.s3Config.region)}',`
+                        : '';
+                    const keyIdClause = this.s3Config.accessKey
+                        ? `KEY_ID '${this.escapeString(this.s3Config.accessKey)}',`
+                        : '';
+                    const secretClause = this.s3Config.secretKey
+                        ? `SECRET '${this.escapeString(this.s3Config.secretKey)}',`
+                        : '';
+
+                    const t2 = performance.now();
+                    await db.run(`CREATE OR REPLACE SECRET __lightdash_s3 (
+                        TYPE s3,
+                        ${keyIdClause}
+                        ${secretClause}
+                        ENDPOINT '${this.escapeString(this.s3Config.endpoint)}',
+                        ${regionClause}
+                        URL_STYLE '${this.s3Config.forcePathStyle ? 'path' : 'vhost'}',
+                        USE_SSL ${this.s3Config.useSsl}
+                    );`);
+                    nextS3ConfigMs = performance.now() - t2;
+                    configuredS3SecretFingerprint = nextFingerprint;
+
+                    this.logger?.info(
+                        `DuckDB S3 secret configured: load_httpfs=${Math.round(loadMs)}ms s3_config=${Math.round(nextS3ConfigMs)}ms`,
+                    );
+                }
+            }
+
+            return {
+                installMs: nextInstallMs,
+                s3ConfigMs: nextS3ConfigMs,
+                loadedHttpfsDuringSharedBootstrap:
+                    loadedDuringSharedBootstrap,
+            };
+        });
+
+        let loadMs = 0;
+        if (!loadedHttpfsDuringSharedBootstrap) {
+            const t1 = performance.now();
+            await db.run('LOAD httpfs;');
+            loadMs = performance.now() - t1;
         }
 
         if (this.resourceLimits && tempDir) {
@@ -361,30 +445,6 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             );
             return;
         }
-
-        const t2 = performance.now();
-
-        const regionClause = this.s3Config.region
-            ? `REGION '${this.escapeString(this.s3Config.region)}',`
-            : '';
-        const keyIdClause = this.s3Config.accessKey
-            ? `KEY_ID '${this.escapeString(this.s3Config.accessKey)}',`
-            : '';
-        const secretClause = this.s3Config.secretKey
-            ? `SECRET '${this.escapeString(this.s3Config.secretKey)}',`
-            : '';
-
-        await db.run(`CREATE OR REPLACE SECRET __lightdash_s3 (
-            TYPE s3,
-            ${keyIdClause}
-            ${secretClause}
-            ENDPOINT '${this.escapeString(this.s3Config.endpoint)}',
-            ${regionClause}
-            URL_STYLE '${this.s3Config.forcePathStyle ? 'path' : 'vhost'}',
-            USE_SSL ${this.s3Config.useSsl}
-        );`);
-
-        const s3ConfigMs = performance.now() - t2;
 
         this.logger?.info(
             `DuckDB bootstrap timing: install_httpfs=${Math.round(installMs)}ms load_httpfs=${Math.round(loadMs)}ms s3_config=${Math.round(s3ConfigMs)}ms`,


### PR DESCRIPTION
## Summary
- serialize shared DuckDB bootstrap work so concurrent sessions do not race on catalog writes
- only recreate ... when the S3 config changes
- add a regression test covering concurrent session bootstrap against the shared instance

## Why
This fixes transient pre-aggregate query failures caused by concurrent `CREATE OR REPLACE SECRET __lightdash_s3 (...)` calls on the shared DuckDB instance, which surfaced as `Catalog write-write conflict on alter with ....

## Testing
- `pnpm -F warehouses test -- DuckdbWarehouseClient.test.ts`