### PR TITLE
fix: skip queued/executing lifecycle statuses when NATS is disabled

### DIFF
--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -184,9 +184,12 @@ export class QueryHistoryModel {
             : 'created_by_account';
         void query.andWhere(createdByColumn, account.user.id);
 
-        // Only allow READY once the query has actually started executing.
+        // Only allow READY from PENDING (non-NATS) or EXECUTING (NATS).
         if (update.status === QueryHistoryStatus.READY) {
-            void query.andWhere('status', QueryHistoryStatus.EXECUTING);
+            void query.whereIn('status', [
+                QueryHistoryStatus.PENDING,
+                QueryHistoryStatus.EXECUTING,
+            ]);
         }
         return query;
     }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -394,9 +394,10 @@ describe('AsyncQueryService', () => {
                 sessionAccount,
             );
 
+            // NATS is disabled, so lifecycle statuses are skipped
             expect(
                 serviceWithCache.queryHistoryModel.updateStatusToExecuting,
-            ).toHaveBeenCalledWith('test-query-uuid');
+            ).not.toHaveBeenCalled();
             expect(
                 serviceWithCache.queryHistoryModel.updateStatusToQueued,
             ).not.toHaveBeenCalled();
@@ -487,9 +488,10 @@ describe('AsyncQueryService', () => {
                 } satisfies Partial<RunAsyncWarehouseQueryArgs>),
             );
 
+            // NATS is disabled, so lifecycle statuses are skipped
             expect(
                 serviceWithCache.queryHistoryModel.updateStatusToExecuting,
-            ).toHaveBeenCalledWith('test-query-uuid');
+            ).not.toHaveBeenCalled();
             expect(
                 serviceWithCache.queryHistoryModel.updateStatusToQueued,
             ).not.toHaveBeenCalled();

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2845,9 +2845,11 @@ export class AsyncQueryService extends ProjectService {
                     );
 
                     if (resultsCache.cacheHit) {
-                        await this.queryHistoryModel.updateStatusToExecuting(
-                            queryHistoryUuid,
-                        );
+                        if (this.lightdashConfig.natsWorker.enabled) {
+                            await this.queryHistoryModel.updateStatusToExecuting(
+                                queryHistoryUuid,
+                            );
+                        }
                         await this.queryHistoryModel.update(
                             queryHistoryUuid,
                             projectUuid,
@@ -3057,10 +3059,6 @@ export class AsyncQueryService extends ProjectService {
                     } else {
                         this.logger.info(
                             `Executing query ${queryHistoryUuid} in the main loop`,
-                        );
-
-                        await this.queryHistoryModel.updateStatusToExecuting(
-                            queryHistoryUuid,
                         );
 
                         const { query: warehouseSql, ...sharedAsyncQueryArgs } =


### PR DESCRIPTION
## Problem

Commit e4786001 (`feat: add async query queue lifecycle statuses`) introduced `QUEUED` and `EXECUTING` intermediate statuses for the async query lifecycle. For non-NATS instances (where queries execute in the main loop), this caused intermittent dashboard failures:

- The `QueryHistoryModel.update` guard was changed to only allow `EXECUTING → READY` transitions, but non-NATS queries were also forced through `PENDING → EXECUTING → READY`
- Users in India (higher latency) saw dashboards load fine because polling intervals were longer and queries resolved before the next poll
- US users (lower latency) hit the race condition more frequently, seeing intermittent failures where queries wouldn't complete

## Solution

When NATS is disabled, skip the `QUEUED` and `EXECUTING` lifecycle statuses entirely, restoring the simpler `PENDING → READY` flow:

1. **QueryHistoryModel**: Allow `READY` from both `PENDING` (non-NATS) and `EXECUTING` (NATS)
2. **AsyncQueryService cache hit path**: Only call `updateStatusToExecuting` when NATS is enabled
3. **AsyncQueryService main loop path**: Remove `updateStatusToExecuting` call — queries go directly from `PENDING` to execution, then to `READY`

## Test plan

- [x] Cache Hit test passes (NATS disabled — no lifecycle status calls)
- [x] Cache Miss test passes (NATS disabled — no lifecycle status calls)
- [x] Backend lint passes
- [x] Backend typecheck passes (only pre-existing errors from commit remain)


🤖 Generated with [Claude Code](https://claude.com/claude-code)