### PR TITLE
fix: memoize ReactQuery client creation with useState

### DIFF
--- a/packages/frontend/src/providers/ReactQuery/ReactQueryProvider.tsx
+++ b/packages/frontend/src/providers/ReactQuery/ReactQueryProvider.tsx
@@ -1,10 +1,10 @@
 import { QueryClientProvider } from '@tanstack/react-query';
 import { ReactQueryDevtools } from '@tanstack/react-query-devtools';
-import { type FC, type PropsWithChildren } from 'react';
+import { useState, type FC, type PropsWithChildren } from 'react';
 import { createQueryClient } from './createQueryClient';
 
 const ReactQueryProvider: FC<PropsWithChildren> = ({ children }) => {
-    const queryClient = createQueryClient();
+    const [queryClient] = useState(() => createQueryClient());
 
     return (
         <QueryClientProvider client={queryClient}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Memoizes the React Query client instance using `useState` with a lazy initializer to prevent recreating the client on every render. This ensures the QueryClient maintains its cache and state across component re-renders, improving performance and preventing unnecessary query refetches.

<!-- Even better add a screenshot / gif / loom -->
