### PR TITLE
fix: improve dashboard tile error message handling

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -79,7 +79,16 @@ type ClientSideError = {
     };
 };
 
-type DashboardTileError = ApiError | ClientSideError;
+type DashboardTileError = ApiError | ClientSideError | Error;
+
+const getDashboardTileErrorMessage = (
+    error: DashboardTileError,
+): string | undefined => {
+    if (error instanceof Error) {
+        return error.message;
+    }
+    return error.error?.message;
+};
 
 import { DashboardTileComments } from '../../features/comments';
 import { FilterDashboardTo } from '../../features/dashboardFilters/FilterDashboardTo';
@@ -1955,7 +1964,10 @@ export const GenericDashboardChartTile: FC<
                     adaptive
                     icon={IconAlertCircle}
                     title={tileTitle}
-                    description={error?.error?.message || 'No data available'}
+                    description={
+                        getDashboardTileErrorMessage(error) ||
+                        'No data available'
+                    }
                 />
             </TileBase>
         );


### PR DESCRIPTION
### Description:

Added support for generic `Error` objects in dashboard chart tile error handling. Previously, the error handling only supported `ApiError` and `ClientSideError` types. Now the `DashboardTileError` type includes the base `Error` class, and a new `getDashboardTileErrorMessage` function properly extracts error messages from all supported error types, including standard JavaScript errors.