### PR TITLE
fix(test): add materialized config to manifest test fixture

### DIFF
--- a/packages/api-tests/tests/createPreviewWithManifest.test.ts
+++ b/packages/api-tests/tests/createPreviewWithManifest.test.ts
@@ -29,7 +29,7 @@ const minimalManifest = {
             resource_type: 'model',
             alias: 'test_model',
             checksum: { name: 'sha256', checksum: 'abc123' },
-            config: {},
+            config: { materialized: 'table' },
             tags: [],
             refs: [],
             sources: [],


### PR DESCRIPTION
## Summary

The `createPreviewWithManifest` test was failing because the test manifest had `config: {}`. After #21064 unified compile paths, all models go through `getModelsFromManifest` which requires `config.materialized` to be set. Adds `materialized: 'table'` to the fixture.