### PR TITLE
chore: improve chart color all UX

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/BasicSeriesConfiguration.tsx
@@ -7,18 +7,9 @@ import {
     type Series,
     type TableCalculation,
 } from '@lightdash/common';
-import {
-    ActionIcon,
-    Box,
-    Group,
-    ColorPicker as MantineColorPicker,
-    Popover,
-    Stack,
-    TextInput,
-    Tooltip,
-} from '@mantine/core';
+import { Box, Group } from '@mantine/core';
 import { useDebouncedState } from '@mantine/hooks';
-import { IconHash, IconPalette } from '@tabler/icons-react';
+import { IconPalette } from '@tabler/icons-react';
 import { type FC } from 'react';
 import type useCartesianChartConfig from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
 import MantineIcon from '../../../common/MantineIcon';
@@ -70,54 +61,7 @@ const BasicSeriesConfiguration: FC<BasicSeriesConfigurationProps> = ({
                     />
 
                     {showColorPickerIcon ? (
-                        <Popover withinPortal shadow="md" withArrow>
-                            <Popover.Target>
-                                <Tooltip
-                                    label="Color all categories"
-                                    withinPortal
-                                >
-                                    <ActionIcon size="sm">
-                                        <MantineIcon
-                                            icon={IconPalette}
-                                            color="gray.6"
-                                        />
-                                    </ActionIcon>
-                                </Tooltip>
-                            </Popover.Target>
-                            <Popover.Dropdown p="xs">
-                                <Stack spacing="xs">
-                                    <MantineColorPicker
-                                        size="sm"
-                                        format="hex"
-                                        swatches={colorPalette}
-                                        swatchesPerRow={8}
-                                        value={colorPalette[0]}
-                                        onChange={(color) => {
-                                            updateSingleSeries({
-                                                ...series,
-                                                color,
-                                            });
-                                        }}
-                                    />
-                                    <TextInput
-                                        size="xs"
-                                        icon={<MantineIcon icon={IconHash} />}
-                                        placeholder="Type a custom HEX color"
-                                        onChange={(event) => {
-                                            const val =
-                                                event.currentTarget.value;
-                                            updateSingleSeries({
-                                                ...series,
-                                                color:
-                                                    val === ''
-                                                        ? val
-                                                        : `#${val}`,
-                                            });
-                                        }}
-                                    />
-                                </Stack>
-                            </Popover.Dropdown>
-                        </Popover>
+                        <MantineIcon size="sm" icon={IconPalette} />
                     ) : (
                         <ColorSelector
                             color={getSeriesColor(series)}

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/index.tsx
@@ -25,7 +25,13 @@ import {
     Text,
 } from '@mantine/core';
 import { produce } from 'immer';
-import React, { Fragment, useCallback, useMemo, type FC } from 'react';
+import React, {
+    Fragment,
+    useCallback,
+    useMemo,
+    useState,
+    type FC,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { getSeriesGroupedByField } from '../../../../hooks/cartesianChartConfig/utils';
 import { isCartesianVisualizationConfig } from '../../../LightdashVisualization/types';
@@ -169,10 +175,13 @@ export const Series: FC<Props> = ({ items }) => {
         resultsData?.rows,
     ]);
 
+    const [setAllColor, setSetAllColor] = useState<string | undefined>();
+
     // When colorByCategory is on, the top-level series color picker sets all categories
     const handleSetAllCategoryColors = useCallback(
         (color: string) => {
             if (!isCartesianChart) return;
+            setSetAllColor(color);
             const overrides: Record<string, string> = {};
             for (const rawKey of allRawKeys) {
                 overrides[rawKey] = color;
@@ -232,17 +241,6 @@ export const Series: FC<Props> = ({ items }) => {
 
     const colorByCategory = dirtyLayout?.colorByCategory ?? false;
     const categoryColorOverrides = dirtyLayout?.categoryColorOverrides ?? {};
-
-    // Wraps updateSingleSeries: when colorByCategory is on and a color is set,
-    // also apply that color to all category overrides
-    const colorByCategoryUpdateSingleSeries: typeof updateSingleSeries = (
-        updatedSeries,
-    ) => {
-        updateSingleSeries(updatedSeries);
-        if (colorByCategory && updatedSeries.color) {
-            handleSetAllCategoryColors(updatedSeries.color);
-        }
-    };
 
     return (
         <Stack spacing="md">
@@ -350,7 +348,7 @@ export const Series: FC<Props> = ({ items }) => {
                                                                 getSingleSeries
                                                             }
                                                             updateSingleSeries={
-                                                                colorByCategoryUpdateSingleSeries
+                                                                updateSingleSeries
                                                             }
                                                             dragHandleProps={
                                                                 dragHandleProps
@@ -385,91 +383,121 @@ export const Series: FC<Props> = ({ items }) => {
                                                             {colorByCategory &&
                                                                 uniqueCategories.length >
                                                                     0 && (
-                                                                    <Box
-                                                                        bg="ldGray.1"
-                                                                        p="xxs"
-                                                                        py="xs"
-                                                                        sx={(
-                                                                            theme,
-                                                                        ) => ({
-                                                                            borderRadius:
-                                                                                theme
-                                                                                    .radius
-                                                                                    .sm,
-                                                                        })}
-                                                                    >
-                                                                        <ScrollArea.Autosize
-                                                                            mah={
-                                                                                300
-                                                                            }
+                                                                    <>
+                                                                        <Divider />
+                                                                        <Group
+                                                                            spacing="xs"
+                                                                            noWrap
                                                                         >
-                                                                            <Stack spacing="xs">
-                                                                                {uniqueCategories.map(
-                                                                                    (
-                                                                                        [
-                                                                                            rawKey,
-                                                                                            label,
-                                                                                        ],
-                                                                                        idx,
-                                                                                    ) => (
-                                                                                        <Group
-                                                                                            key={
-                                                                                                rawKey
-                                                                                            }
-                                                                                            spacing="xs"
-                                                                                            noWrap
-                                                                                        >
-                                                                                            <ColorSelector
-                                                                                                color={
-                                                                                                    categoryColorOverrides[
-                                                                                                        rawKey
-                                                                                                    ] ??
-                                                                                                    colorPalette[
-                                                                                                        idx %
-                                                                                                            colorPalette.length
-                                                                                                    ]
+                                                                            <ColorSelector
+                                                                                color={
+                                                                                    setAllColor ??
+                                                                                    colorPalette[0]
+                                                                                }
+                                                                                swatches={
+                                                                                    colorPalette
+                                                                                }
+                                                                                onColorChange={
+                                                                                    handleSetAllCategoryColors
+                                                                                }
+                                                                            />
+                                                                            <Text
+                                                                                fz="xs"
+                                                                                fw={
+                                                                                    600
+                                                                                }
+                                                                                c="dimmed"
+                                                                            >
+                                                                                Set
+                                                                                all
+                                                                            </Text>
+                                                                        </Group>
+                                                                        <Box
+                                                                            bg="ldGray.1"
+                                                                            p="xxs"
+                                                                            py="xs"
+                                                                            sx={(
+                                                                                theme,
+                                                                            ) => ({
+                                                                                borderRadius:
+                                                                                    theme
+                                                                                        .radius
+                                                                                        .sm,
+                                                                            })}
+                                                                        >
+                                                                            <ScrollArea.Autosize
+                                                                                mah={
+                                                                                    300
+                                                                                }
+                                                                            >
+                                                                                <Stack spacing="xs">
+                                                                                    {uniqueCategories.map(
+                                                                                        (
+                                                                                            [
+                                                                                                rawKey,
+                                                                                                label,
+                                                                                            ],
+                                                                                            idx,
+                                                                                        ) => (
+                                                                                            <Group
+                                                                                                key={
+                                                                                                    rawKey
                                                                                                 }
-                                                                                                swatches={
-                                                                                                    colorPalette
-                                                                                                }
-                                                                                                onColorChange={(
-                                                                                                    c,
-                                                                                                ) =>
-                                                                                                    setCategoryColorOverride(
-                                                                                                        rawKey,
-                                                                                                        c,
-                                                                                                    )
-                                                                                                }
-                                                                                            />
-                                                                                            <Text
-                                                                                                fz="xs"
-                                                                                                truncate
+                                                                                                spacing="xs"
+                                                                                                noWrap
                                                                                             >
-                                                                                                {
-                                                                                                    label
-                                                                                                }
-                                                                                            </Text>
-                                                                                        </Group>
-                                                                                    ),
-                                                                                )}
-                                                                                {remainingCount >
-                                                                                    0 && (
-                                                                                    <Text
-                                                                                        fz="xs"
-                                                                                        c="dimmed"
-                                                                                        fs="italic"
-                                                                                    >
-                                                                                        {
-                                                                                            remainingCount
-                                                                                        }{' '}
-                                                                                        more
-                                                                                        colored
-                                                                                        automatically
-                                                                                    </Text>
-                                                                                )}
-                                                                            </Stack>
-                                                                        </ScrollArea.Autosize>
-                                                                    </Box>
+                                                                                                <ColorSelector
+                                                                                                    color={
+                                                                                                        categoryColorOverrides[
+                                                                                                            rawKey
+                                                                                                        ] ??
+                                                                                                        colorPalette[
+                                                                                                            idx %
+                                                                                                                colorPalette.length
+                                                                                                        ]
+                                                                                                    }
+                                                                                                    swatches={
+                                                                                                        colorPalette
+                                                                                                    }
+                                                                                                    onColorChange={(
+                                                                                                        c,
+                                                                                                    ) =>
+                                                                                                        setCategoryColorOverride(
+                                                                                                            rawKey,
+                                                                                                            c,
+                                                                                                        )
+                                                                                                    }
+                                                                                                />
+                                                                                                <Text
+                                                                                                    fz="xs"
+                                                                                                    truncate
+                                                                                                >
+                                                                                                    {
+                                                                                                        label
+                                                                                                    }
+                                                                                                </Text>
+                                                                                            </Group>
+                                                                                        ),
+                                                                                    )}
+                                                                                    {remainingCount >
+                                                                                        0 && (
+                                                                                        <Text
+                                                                                            fz="xs"
+                                                                                            c="dimmed"
+                                                                                            fs="italic"
+                                                                                        >
+                                                                                            {
+                                                                                                remainingCount
+                                                                                            }{' '}
+                                                                                            more
+                                                                                            colored
+                                                                                            automatically
+                                                                                        </Text>
+                                                                                    )}
+                                                                                </Stack>
+                                                                            </ScrollArea.Autosize>
+                                                                        </Box>
+                                                                    </>
                                                                 )}
                                                         </Stack>
                                                     )}


### PR DESCRIPTION
### Description:

Move the color all setting closer to the other colors in chart config

<img width="384" height="283" alt="Screenshot 2026-03-13 at 14 05 57" src="https://github.com/user-attachments/assets/2631f656-5e81-4585-9d06-aeadcf7a1bdb" />


