### PR TITLE
fix: set processing_started_at when marking query as expired

### DIFF
--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -229,6 +229,7 @@ export class QueryHistoryModel {
             .update({
                 status: QueryHistoryStatus.EXPIRED,
                 error,
+                processing_started_at: new Date(),
             });
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Set `processing_started_at` timestamp when marking queries as expired in the QueryHistoryModel. This ensures that expired queries have a consistent processing start time recorded alongside their status and error information.
