### PR TITLE
fix(cli): poll for QUEUED and EXECUTING query statuses

### DIFF
--- a/packages/cli/src/handlers/asyncQuery.ts
+++ b/packages/cli/src/handlers/asyncQuery.ts
@@ -30,7 +30,11 @@ export async function pollForResults(
 
     GlobalState.debug(`> Query status: ${result.status}`);
 
-    if (result.status === QueryHistoryStatus.PENDING) {
+    if (
+        result.status === QueryHistoryStatus.PENDING ||
+        result.status === QueryHistoryStatus.QUEUED ||
+        result.status === QueryHistoryStatus.EXECUTING
+    ) {
         await sleep(backoffMs);
         return pollForResults(projectUuid, queryUuid, {
             pageSize,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Enhanced the async query polling logic to continue polling for queries in `QUEUED` and `EXECUTING` states in addition to `PENDING` state. This ensures the CLI properly waits for query completion across all intermediate query states before returning results.

<!-- Even better add a screenshot / gif / loom -->
