### PR TITLE
feat: add nested object parameter access for Liquid templates

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -4,6 +4,15 @@ models:
     config:
       tags: ["core", "ai"]
     meta:
+      parameters:
+        event_status:
+          label: "Event Status"
+          description: "Filter events by status type. Tests model-scoped ld.parameters.events.event_status Liquid syntax."
+          default: "all"
+          options:
+            - "all"
+            - "song_played"
+            - "add_to_cart"
       primary_key: event_id
       group_details:
         events:
@@ -132,6 +141,17 @@ models:
                 'Filtered: ' || ${TABLE}.event
               {% else %}
                 'All Events'
+              {% endif %}{% endraw %}
+      - name: filtered_event
+        description: "Filters events by the model-scoped event_status parameter using ld.parameters.events.event_status Liquid syntax."
+        meta:
+          dimension:
+            type: string
+            sql: >
+              {% raw %}{% if ld.parameters.events.event_status == 'all' %}
+                ${TABLE}.event
+              {% else %}
+                CASE WHEN ${TABLE}.event = '{{ ld.parameters.events.event_status }}' THEN ${TABLE}.event ELSE NULL END
               {% endif %}{% endraw %}
       - name: event
         description: ""

--- a/packages/common/src/templating/liquidSql.test.ts
+++ b/packages/common/src/templating/liquidSql.test.ts
@@ -19,15 +19,31 @@ describe('buildLiquidContext', () => {
         });
     });
 
-    it('should expose dotted names via both full and short keys', () => {
+    it('should expose dotted names via full key, short key, and nested object', () => {
         const context = buildLiquidContext({ 'events.grain': 'week' });
         expect(context.ld.parameters).toEqual({
             'events.grain': 'week',
             grain: 'week',
+            events: { grain: 'week' },
         });
         expect(context.lightdash.parameters).toEqual({
             'events.grain': 'week',
             grain: 'week',
+            events: { grain: 'week' },
+        });
+    });
+
+    it('should group multiple dotted params under the same model', () => {
+        const context = buildLiquidContext({
+            'mymodel.grain': 'day',
+            'mymodel.currency': 'usd',
+        });
+        expect(context.ld.parameters).toEqual({
+            'mymodel.grain': 'day',
+            'mymodel.currency': 'usd',
+            grain: 'day',
+            currency: 'usd',
+            mymodel: { grain: 'day', currency: 'usd' },
         });
     });
 
@@ -168,7 +184,7 @@ describe('renderLiquidSql', () => {
         );
     });
 
-    it('should handle dotted parameter names from Lightdash format', () => {
+    it('should handle dotted parameter names via short name', () => {
         const sql = [
             '{% if ld.parameters.grain == "day" %}',
             '  "events".snapshot_date',
@@ -181,6 +197,34 @@ describe('renderLiquidSql', () => {
         expect(renderLiquidSql(sql, { 'events.grain': 'day' }).trim()).toBe(
             '"events".snapshot_date',
         );
+    });
+
+    it('should handle dotted parameter names via nested model.param access', () => {
+        const sql = [
+            '{% if ld.parameters.lookup_paid_search.date_granularity == "Day" %}',
+            '  ${cvr_same_day}',
+            '{% elsif ld.parameters.lookup_paid_search.date_granularity == "Week" %}',
+            '  ${cvr_same_7days}',
+            '{% else %}',
+            '  ${cvr_default}',
+            '{% endif %}',
+        ].join('\n');
+
+        expect(
+            renderLiquidSql(sql, {
+                'lookup_paid_search.date_granularity': 'Day',
+            }).trim(),
+        ).toBe('${cvr_same_day}');
+        expect(
+            renderLiquidSql(sql, {
+                'lookup_paid_search.date_granularity': 'Week',
+            }).trim(),
+        ).toBe('${cvr_same_7days}');
+        expect(
+            renderLiquidSql(sql, {
+                'lookup_paid_search.date_granularity': 'Other',
+            }).trim(),
+        ).toBe('${cvr_default}');
     });
 
     it('should preserve ${ld.parameters.*} references for later substitution', () => {

--- a/packages/common/src/templating/liquidSql.ts
+++ b/packages/common/src/templating/liquidSql.ts
@@ -55,24 +55,48 @@ export const buildLiquidContext = (
     fieldsContext?: FieldsContext,
 ): {
     ld: {
-        parameters: Record<string, ParameterValue>;
+        parameters: Record<
+            string,
+            ParameterValue | Record<string, ParameterValue>
+        >;
         query: { fields: string[]; filters: string[] };
     };
     lightdash: {
-        parameters: Record<string, ParameterValue>;
+        parameters: Record<
+            string,
+            ParameterValue | Record<string, ParameterValue>
+        >;
         query: { fields: string[]; filters: string[] };
     };
 } => {
-    const parameters: Record<string, ParameterValue> = {};
+    const parameters: Record<
+        string,
+        ParameterValue | Record<string, ParameterValue>
+    > = {};
 
     for (const [key, value] of Object.entries(parameterValuesMap)) {
         parameters[key] = value;
 
-        // For dotted names like "model.grain", also expose as "grain"
+        // For dotted names like "model.grain":
+        // - expose as short name ("grain") for backwards compatibility
+        // - expose as nested object ({ model: { grain: value } }) so Liquid
+        //   dot access like ld.parameters.model.grain works
         const parts = key.split('.');
         const shortName = parts[parts.length - 1];
         if (shortName !== key) {
             parameters[shortName] = value;
+
+            const [tableName, paramName] = parts;
+            const existing = parameters[tableName];
+            if (
+                existing !== undefined &&
+                typeof existing === 'object' &&
+                !Array.isArray(existing)
+            ) {
+                existing[paramName] = value;
+            } else {
+                parameters[tableName] = { [paramName]: value };
+            }
         }
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds support for nested object access in Liquid templating for model-scoped parameters. Previously, dotted parameter names like `events.event_status` were only accessible via the full key or short name. Now they can also be accessed using nested object syntax like `ld.parameters.events.event_status`.

The implementation creates nested parameter objects in the Liquid context, so parameters with dotted names are grouped under their model namespace. For example, `mymodel.grain` and `mymodel.currency` are now accessible as `ld.parameters.mymodel.grain` and `ld.parameters.mymodel.currency`.

The jaffle shop demo has been updated to include an example of this new functionality with an `event_status` parameter that filters events by status type, demonstrating the nested object access pattern in both parameter definitions and dimension SQL.