### PR TITLE
chore: isolate api-tests better

### DIFF
--- a/packages/api-tests/helpers/test-isolation.ts
+++ b/packages/api-tests/helpers/test-isolation.ts
@@ -1,0 +1,62 @@
+import { SEED_PROJECT } from '@lightdash/common';
+import { randomUUID } from 'crypto';
+import { ApiClient } from './api-client';
+
+const apiUrl = '/api/v1';
+
+/**
+ * Generate a globally unique name for test resources to prevent
+ * collisions when test files run in parallel.
+ */
+export function uniqueName(base: string): string {
+    return `${base} [${randomUUID().slice(0, 8)}]`;
+}
+
+/**
+ * Tracks resources created during a test file and provides
+ * cleanup in dependency order (charts -> dashboards -> spaces).
+ */
+export class TestResourceTracker {
+    private charts: string[] = [];
+
+    private dashboards: string[] = [];
+
+    private spaces: string[] = [];
+
+    trackChart(uuid: string): void {
+        this.charts.push(uuid);
+    }
+
+    trackDashboard(uuid: string): void {
+        this.dashboards.push(uuid);
+    }
+
+    trackSpace(uuid: string): void {
+        this.spaces.push(uuid);
+    }
+
+    async cleanup(client: ApiClient): Promise<void> {
+        for (const uuid of this.charts) {
+            await client
+                .delete(`${apiUrl}/saved/${uuid}`, {
+                    failOnStatusCode: false,
+                })
+                .catch(() => {});
+        }
+        for (const uuid of this.dashboards) {
+            await client
+                .delete(`${apiUrl}/dashboards/${uuid}`, {
+                    failOnStatusCode: false,
+                })
+                .catch(() => {});
+        }
+        for (const uuid of this.spaces) {
+            await client
+                .delete(
+                    `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces/${uuid}`,
+                    { failOnStatusCode: false },
+                )
+                .catch(() => {});
+        }
+    }
+}

--- a/packages/api-tests/tests/api.test.ts
+++ b/packages/api-tests/tests/api.test.ts
@@ -68,7 +68,10 @@ describe('Lightdash API', () => {
         );
         expect(resp.status).toBe(200);
         expect(resp.body).toHaveProperty('status', 'ok');
-        expect(resp.body.results[0]).toHaveProperty('name', 'Jaffle dashboard');
+        const jaffleDashboard = resp.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(jaffleDashboard).toBeDefined();
     });
 
     it('Should get success response (200) from POST runQuery', async () => {
@@ -101,12 +104,16 @@ describe('Lightdash API', () => {
 
     it('Should get success response (200) from PATCH dashboard', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        const projectResponse = await admin.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/dashboards`,
-        );
+        const projectResponse = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const jaffleDashboard = projectResponse.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(jaffleDashboard).toBeDefined();
+        const dashboardUuid = jaffleDashboard!.uuid;
         const endpoint = `${apiUrl}/dashboards/${dashboardUuid}`;
 
         const dashboardResponse = await admin.get<
@@ -136,12 +143,16 @@ describe('Lightdash API', () => {
 
     it('Should get success response (200) from GET savedChartRouter endpoints', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        const projectResponse = await admin.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
-        );
+        const projectResponse = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
         expect(projectResponse.status).toBe(200);
 
-        const savedChartUuid = projectResponse.body.results[0].uuid;
+        const seedChart = projectResponse.body.results.find(
+            (c) => c.name === 'How many orders we have over time ?',
+        );
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoints = [
             `/saved/${savedChartUuid}`,
             `/saved/${savedChartUuid}/availableFilters`,
@@ -190,12 +201,16 @@ describe('Lightdash API', () => {
 
     it('Should get success response (200) from GET dashboardRouter endpoints', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        const projectResponse = await admin.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/dashboards`,
-        );
+        const projectResponse = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const jaffleDashboard = projectResponse.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(jaffleDashboard).toBeDefined();
+        const dashboardUuid = jaffleDashboard!.uuid;
         const endpoints = [`/dashboards/${dashboardUuid}`];
         for (const endpoint of endpoints) {
             const resp = await admin.get(`${apiUrl}${endpoint}`);
@@ -329,10 +344,14 @@ describe('Lightdash API forbidden tests', () => {
         const adminClient = await login();
         const projectUuid = SEED_PROJECT.project_uuid;
         const projectResponse = await adminClient.get<
-            Body<Array<{ uuid: string }>>
+            Body<Array<{ uuid: string; name: string }>>
         >(`${apiUrl}/projects/${projectUuid}/charts`);
         expect(projectResponse.status).toBe(200);
-        const savedChartUuid = projectResponse.body.results[0].uuid;
+        const seedChart = projectResponse.body.results.find(
+            (c) => c.name === 'How many orders we have over time ?',
+        );
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
 
         const endpoints = [
             `/saved/${savedChartUuid}`,
@@ -362,11 +381,15 @@ describe('Lightdash API forbidden tests', () => {
         const adminClient = await login();
         const projectUuid = SEED_PROJECT.project_uuid;
         const projectResponse = await adminClient.get<
-            Body<Array<{ uuid: string }>>
+            Body<Array<{ uuid: string; name: string }>>
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const jaffleDashboard = projectResponse.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(jaffleDashboard).toBeDefined();
+        const dashboardUuid = jaffleDashboard!.uuid;
         const endpoints = [`/dashboards/${dashboardUuid}`];
         for (const endpoint of endpoints) {
             const resp = await other.get(`${apiUrl}${endpoint}`, {
@@ -380,11 +403,15 @@ describe('Lightdash API forbidden tests', () => {
         const adminClient = await login();
         const projectUuid = SEED_PROJECT.project_uuid;
         const projectResponse = await adminClient.get<
-            Body<Array<{ uuid: string }>>
+            Body<Array<{ uuid: string; name: string }>>
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const jaffleDashboard = projectResponse.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(jaffleDashboard).toBeDefined();
+        const dashboardUuid = jaffleDashboard!.uuid;
         const endpoint = `${apiUrl}/dashboards/${dashboardUuid}`;
 
         const resp = await other.patch(

--- a/packages/api-tests/tests/content.test.ts
+++ b/packages/api-tests/tests/content.test.ts
@@ -2,6 +2,7 @@ import { AnyType, SEED_PROJECT } from '@lightdash/common';
 import type { Body } from '../helpers/api-client';
 import { login, loginAsEditor, loginAsViewer } from '../helpers/auth';
 import { chartMock } from '../helpers/mocks';
+import { TestResourceTracker, uniqueName } from '../helpers/test-isolation';
 
 type ContentResults = { data: AnyType[] };
 
@@ -10,9 +11,14 @@ const apiUrl = '/api/v2';
 describe('Lightdash catalog all tables and fields', () => {
     let admin: Awaited<ReturnType<typeof login>>;
     let content: AnyType[] = [];
+    const tracker = new TestResourceTracker();
 
     beforeAll(async () => {
         admin = await login();
+    });
+
+    afterAll(async () => {
+        await tracker.cleanup(admin);
     });
 
     it('Should list all content', async () => {
@@ -68,39 +74,44 @@ describe('Lightdash catalog all tables and fields', () => {
 
     describe('Filter by spaceUuids', () => {
         it('Filter by existing spaceUuid', async () => {
+            // Find a seed content item by known name to avoid relying on content[0] ordering
+            const seedItem = content.find(
+                (d: AnyType) => d.name === 'Jaffle dashboard',
+            );
+            expect(seedItem).toBeDefined();
             const resp = await admin.get<Body<ContentResults>>(
-                `${apiUrl}/content?spaceUuids=${content[0]?.space?.uuid}`,
+                `${apiUrl}/content?spaceUuids=${seedItem.space.uuid}`,
             );
             expect(resp.status).toBe(200);
             expect(resp.body.results.data.length).toBeGreaterThan(0);
             const uuids = resp.body.results.data.map((d: AnyType) => d.uuid);
-            expect(uuids).toContain(content[0].uuid);
+            expect(uuids).toContain(seedItem.uuid);
         });
 
         it('Filter by existing spaceUuid with new chart', async () => {
-            const now = Date.now();
-
             const spaceResp = await admin.post<Body<{ uuid: string }>>(
                 `/api/v1/projects/${SEED_PROJECT.project_uuid}/spaces/`,
                 {
-                    name: `Public space to promote ${now}`,
+                    name: uniqueName('Public space to promote'),
                     inheritParentPermissions: true,
                 },
             );
             expect(spaceResp.status).toBe(200);
             const spaceUuid = spaceResp.body.results.uuid;
+            tracker.trackSpace(spaceUuid);
 
             const chartResp = await admin.post<Body<{ uuid: string }>>(
                 `/api/v1/projects/${SEED_PROJECT.project_uuid}/saved`,
                 {
                     ...chartMock,
-                    name: `Chart to promote ${now}`,
+                    name: uniqueName('Chart to promote'),
                     spaceUuid,
                     dashboardUuid: null,
                 },
             );
             expect(chartResp.status).toBe(200);
             const chart = chartResp.body.results;
+            tracker.trackChart(chart.uuid);
 
             const resp = await admin.get<Body<ContentResults>>(
                 `${apiUrl}/content?spaceUuids=${spaceUuid}`,

--- a/packages/api-tests/tests/dashboard.test.ts
+++ b/packages/api-tests/tests/dashboard.test.ts
@@ -14,6 +14,7 @@ import {
 import { ApiClient } from '../helpers/api-client';
 import { login } from '../helpers/auth';
 import { chartMock, dashboardMock } from '../helpers/mocks';
+import { TestResourceTracker, uniqueName } from '../helpers/test-isolation';
 
 const apiUrl = '/api/v1';
 
@@ -82,40 +83,6 @@ export async function createChartAndUpdateDashboard(
     return { chart: newChart, dashboard: updatedDashboard };
 }
 
-async function deleteDashboardsByName(
-    client: ApiClient,
-    names: string[],
-): Promise<void> {
-    const resp = await client.get<{
-        results: Array<{ uuid: string; name: string }>;
-    }>(`${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`);
-    expect(resp.status).toBe(200);
-    for (const { uuid, name } of resp.body.results) {
-        if (names.includes(name)) {
-            const deleteResp = await client.delete(
-                `${apiUrl}/dashboards/${uuid}`,
-            );
-            expect(deleteResp.status).toBe(200);
-        }
-    }
-}
-
-async function deleteChartsByName(
-    client: ApiClient,
-    names: string[],
-): Promise<void> {
-    const resp = await client.get<ApiChartSummaryListResponse>(
-        `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/charts`,
-    );
-    expect(resp.status).toBe(200);
-    for (const { uuid, name } of resp.body.results) {
-        if (names.includes(name)) {
-            const deleteResp = await client.delete(`${apiUrl}/saved/${uuid}`);
-            expect(deleteResp.status).toBe(200);
-        }
-    }
-}
-
 async function createSpace(
     client: ApiClient,
     projectUuid: string,
@@ -133,14 +100,18 @@ async function createSpace(
 }
 
 describe('Lightdash dashboard', () => {
-    const dashboardName = 'Dashboard with charts that belong to dashboard';
     let admin: ApiClient;
+    const tracker = new TestResourceTracker();
+    let dashboardName: string;
+    let createdDashboardUuid: string;
 
     beforeAll(async () => {
         admin = await login();
-        // clean previous e2e dashboards and charts
-        await deleteDashboardsByName(admin, [dashboardMock.name]);
-        await deleteChartsByName(admin, [chartMock.name]);
+        dashboardName = uniqueName('Dashboard with charts');
+    });
+
+    afterAll(async () => {
+        await tracker.cleanup(admin);
     });
 
     it('Should create charts that belong to dashboard', async () => {
@@ -151,6 +122,8 @@ describe('Lightdash dashboard', () => {
             ...dashboardMock,
             name: dashboardName,
         });
+        tracker.trackDashboard(newDashboard.uuid);
+        createdDashboardUuid = newDashboard.uuid;
 
         // update dashboard with chart
         const { chart: newChart, dashboard: updatedDashboard } =
@@ -200,21 +173,10 @@ describe('Lightdash dashboard', () => {
 
     it('Should update chart that belongs to dashboard', async () => {
         const newDescription = 'updated chart description';
-        const response = await admin.get<{
-            results: Dashboard[];
-        }>(`${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`);
 
-        // Get the latest dashboard created via API
-        const dashboard = response.body.results
-            .sort(
-                (a: Dashboard, b: Dashboard) =>
-                    new Date(b.updatedAt).getTime() -
-                    new Date(a.updatedAt).getTime(),
-            )
-            .find((s: Dashboard) => s.name === dashboardName);
-
+        // Use the dashboard UUID from the previous test
         const dashboardResponse = await admin.get<{ results: Dashboard }>(
-            `${apiUrl}/dashboards/${dashboard!.uuid}`,
+            `${apiUrl}/dashboards/${createdDashboardUuid}`,
         );
 
         const tileWithChartInDashboard =
@@ -239,26 +201,16 @@ describe('Lightdash dashboard', () => {
         expect(chartResponse.status).toBe(200);
         expect(chartResponse.body.results.name).toBe(chartMock.name);
         expect(chartResponse.body.results.description).toBe(newDescription);
-        expect(chartResponse.body.results.dashboardUuid).toBe(dashboard!.uuid);
+        expect(chartResponse.body.results.dashboardUuid).toBe(
+            createdDashboardUuid,
+        );
         expect(chartResponse.body.results.dashboardName).toBe(dashboardName);
     });
 
     it('Should get chart summaries without charts that belongs to dashboard', async () => {
-        const response = await admin.get<{
-            results: Dashboard[];
-        }>(`${apiUrl}/projects/${SEED_PROJECT.project_uuid}/dashboards`);
-
-        // Get the latest dashboard created via API
-        const dashboard = response.body.results
-            .sort(
-                (a: Dashboard, b: Dashboard) =>
-                    new Date(b.updatedAt).getTime() -
-                    new Date(a.updatedAt).getTime(),
-            )
-            .find((s: Dashboard) => s.name === dashboardName);
-
+        // Use the dashboard UUID from the first test
         const dashboardResponse = await admin.get<{ results: Dashboard }>(
-            `${apiUrl}/dashboards/${dashboard!.uuid}`,
+            `${apiUrl}/dashboards/${createdDashboardUuid}`,
         );
 
         const tileWithChartInDashboard =
@@ -296,9 +248,10 @@ describe('Lightdash dashboard', () => {
             },
         };
 
+        const paramDashboardName = uniqueName('Dashboard with Parameters');
         const dashboardWithParameters: CreateDashboard = {
             ...dashboardMock,
-            name: `${dashboardName} with Parameters`,
+            name: paramDashboardName,
             parameters: testParameters,
         };
 
@@ -307,7 +260,8 @@ describe('Lightdash dashboard', () => {
             SEED_PROJECT.project_uuid,
             dashboardWithParameters,
         );
-        expect(createdDashboard.name).toBe(dashboardWithParameters.name);
+        tracker.trackDashboard(createdDashboard.uuid);
+        expect(createdDashboard.name).toBe(paramDashboardName);
 
         // Get the dashboard via API to verify parameters are stored and retrieved correctly
         const response = await admin.get<{ results: Dashboard }>(
@@ -400,12 +354,13 @@ describe('Lightdash dashboard', () => {
 
         it('Should create and access dashboard by slug', async () => {
             const projectUuid = SEED_PROJECT.project_uuid;
-            const testDashboardName = `Test Dashboard ${Date.now()}`;
+            const testDashboardName = uniqueName('Test Dashboard');
 
             const newDashboard = await createDashboard(admin, projectUuid, {
                 ...dashboardMock,
                 name: testDashboardName,
             });
+            tracker.trackDashboard(newDashboard.uuid);
             expect(newDashboard.slug).toBeDefined();
 
             // Access the dashboard by slug
@@ -415,20 +370,18 @@ describe('Lightdash dashboard', () => {
             expect(response.status).toBe(200);
             expect(response.body.results.uuid).toBe(newDashboard.uuid);
             expect(response.body.results.name).toBe(testDashboardName);
-
-            // Clean up
-            await deleteDashboardsByName(admin, [testDashboardName]);
         });
 
         it('Should update dashboard accessed by slug', async () => {
             const projectUuid = SEED_PROJECT.project_uuid;
-            const testDashboardName = `Test Dashboard ${Date.now()}`;
+            const testDashboardName = uniqueName('Test Dashboard');
             const updatedDescription = 'Updated via slug test';
 
             const newDashboard = await createDashboard(admin, projectUuid, {
                 ...dashboardMock,
                 name: testDashboardName,
             });
+            tracker.trackDashboard(newDashboard.uuid);
 
             // Update dashboard using slug
             const updateResponse = await admin.patch<{
@@ -449,32 +402,22 @@ describe('Lightdash dashboard', () => {
             expect(verifyResponse.body.results.description).toBe(
                 updatedDescription,
             );
-
-            // Clean up
-            await deleteDashboardsByName(admin, [testDashboardName]);
         });
     });
 
     describe('Dashboard space selection', () => {
-        const spaceSelectionDashboardName = 'Dashboard space selection test';
-
-        afterAll(async () => {
-            const cleanupClient = await login();
-            await deleteDashboardsByName(cleanupClient, [
-                spaceSelectionDashboardName,
-            ]);
-        });
-
         it('Should create a dashboard in the specified space', async () => {
             const projectUuid = SEED_PROJECT.project_uuid;
-            const spaceName = `test-space-${Date.now()}`;
+            const spaceName = uniqueName('test-space');
 
             const spaceUuid = await createSpace(admin, projectUuid, spaceName);
+            tracker.trackSpace(spaceUuid);
             const dashboard = await createDashboard(admin, projectUuid, {
                 ...dashboardMock,
-                name: spaceSelectionDashboardName,
+                name: uniqueName('Dashboard space selection'),
                 spaceUuid,
             });
+            tracker.trackDashboard(dashboard.uuid);
             expect(dashboard.spaceUuid).toBe(spaceUuid);
         });
 
@@ -483,8 +426,9 @@ describe('Lightdash dashboard', () => {
 
             const dashboard = await createDashboard(admin, projectUuid, {
                 ...dashboardMock,
-                name: spaceSelectionDashboardName,
+                name: uniqueName('Dashboard space selection'),
             });
+            tracker.trackDashboard(dashboard.uuid);
             expect(dashboard.spaceUuid).toBeDefined();
             expect(typeof dashboard.spaceUuid).toBe('string');
 

--- a/packages/api-tests/tests/embedChart.test.ts
+++ b/packages/api-tests/tests/embedChart.test.ts
@@ -95,33 +95,36 @@ describe('Embed Chart JWT API', () => {
         expect(configResp.status).toBe(200);
         const originalEmbedConfig = configResp.body.results;
 
-        // Fetch specific charts by their known slugs from seed data
-        const chartResp = await admin.get<Body<{ uuid: string }>>(
-            `/api/v1/saved/how-much-revenue-do-we-have-per-payment-method?projectUuid=${SEED_PROJECT.project_uuid}`,
-        );
-        expect(chartResp.status).toBe(200);
-        testChartUuid = chartResp.body.results.uuid;
-        expect(typeof testChartUuid).toBe('string');
+        // Fetch charts by listing and finding by name (avoids slug lookup 500s under load)
+        const chartsResp = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`/api/v1/projects/${SEED_PROJECT.project_uuid}/charts`);
+        expect(chartsResp.status).toBe(200);
+        const charts = chartsResp.body.results;
 
-        const anotherChartResp = await admin.get<Body<{ uuid: string }>>(
-            `/api/v1/saved/how-many-orders-we-have-over-time?projectUuid=${SEED_PROJECT.project_uuid}`,
+        const chart = charts.find(
+            (c) => c.name === 'How much revenue do we have per payment method?',
         );
-        expect(anotherChartResp.status).toBe(200);
-        testAnotherChartUuid = anotherChartResp.body.results.uuid;
-        expect(typeof testAnotherChartUuid).toBe('string');
+        expect(chart).toBeDefined();
+        testChartUuid = chart!.uuid;
 
-        const notEmbeddedChartResp = await admin.get<Body<{ uuid: string }>>(
-            `/api/v1/saved/what-s-our-total-revenue-to-date?projectUuid=${SEED_PROJECT.project_uuid}`,
+        const anotherChart = charts.find(
+            (c) => c.name === 'How many orders we have over time ?',
         );
-        expect(notEmbeddedChartResp.status).toBe(200);
-        testChartNotEmbeddedUuid = notEmbeddedChartResp.body.results.uuid;
-        expect(typeof testChartNotEmbeddedUuid).toBe('string');
+        expect(anotherChart).toBeDefined();
+        testAnotherChartUuid = anotherChart!.uuid;
 
-        // Update embed config to include the charts we're testing with
+        const notEmbeddedChart = charts.find(
+            (c) => c.name === "What's our total revenue to date?",
+        );
+        expect(notEmbeddedChart).toBeDefined();
+        testChartNotEmbeddedUuid = notEmbeddedChart!.uuid;
+
+        // Update embed config — use allowAllDashboards to avoid racing with embedDashboard tests
         const chartsToEmbed = [testChartUuid, testAnotherChartUuid];
         const updateResp = await updateEmbedConfig(admin, {
             dashboardUuids: originalEmbedConfig.dashboardUuids || [],
-            allowAllDashboards: originalEmbedConfig.allowAllDashboards || false,
+            allowAllDashboards: true,
             chartUuids: chartsToEmbed,
             allowAllCharts: false,
         });

--- a/packages/api-tests/tests/embedDashboard.test.ts
+++ b/packages/api-tests/tests/embedDashboard.test.ts
@@ -95,25 +95,23 @@ describe('Embed Dashboard JWT API', () => {
         expect(configResp.status).toBe(200);
         const originalEmbedConfig = configResp.body.results;
 
-        // Get all dashboards from the project
-        const dashboardsResp = await admin.get<Body<Array<{ uuid: string }>>>(
-            `/api/v1/projects/${SEED_PROJECT.project_uuid}/dashboards`,
-        );
+        // Get seed dashboard by name to avoid results[0] ordering issues
+        const dashboardsResp = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`/api/v1/projects/${SEED_PROJECT.project_uuid}/dashboards`);
         expect(dashboardsResp.status).toBe(200);
-        const dashboards = dashboardsResp.body.results;
-        expect(dashboards.length).toBeGreaterThan(0);
+        const seedDashboard = dashboardsResp.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        testDashboardUuid = seedDashboard!.uuid;
 
-        // Store first dashboard for testing
-        testDashboardUuid = dashboards[0].uuid;
-        expect(typeof testDashboardUuid).toBe('string');
-        expect(testDashboardUuid.length).toBeGreaterThan(0);
-
-        // Update embed config to include the dashboard we're testing with
+        // Update embed config — use allowAllCharts to avoid racing with embedChart tests
         const updateResp = await updateEmbedConfig(admin, {
             dashboardUuids: [testDashboardUuid],
             allowAllDashboards: false,
             chartUuids: originalEmbedConfig.chartUuids || [],
-            allowAllCharts: originalEmbedConfig.allowAllCharts || false,
+            allowAllCharts: true,
         });
         expect(updateResp.status).toBe(200);
 
@@ -173,7 +171,7 @@ describe('Embed Dashboard JWT API', () => {
                     dashboardUuids: [testDashboardUuid],
                     allowAllDashboards: false,
                     chartUuids: config.chartUuids || [],
-                    allowAllCharts: config.allowAllCharts || false,
+                    allowAllCharts: true,
                 });
             }
 

--- a/packages/api-tests/tests/nestedSpaces.test.ts
+++ b/packages/api-tests/tests/nestedSpaces.test.ts
@@ -1,45 +1,55 @@
 import { SEED_PROJECT } from '@lightdash/common';
 import { type Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
+import { TestResourceTracker, uniqueName } from '../helpers/test-isolation';
 
 const apiUrl = '/api/v1';
 
 describe('Lightdash API tests for my own private spaces as admin', () => {
     let admin: Awaited<ReturnType<typeof login>>;
+    const tracker = new TestResourceTracker();
 
     beforeAll(async () => {
         admin = await login();
     });
 
+    afterAll(async () => {
+        await tracker.cleanup(admin);
+    });
+
     it('Should not create duplicate slugs in the same project', async () => {
-        const spaceName = `📈 Space Namè ${Date.now()}`;
+        const spaceName = uniqueName('📈 Space Namè');
         const res1 = await admin.post<Body<{ slug: string; uuid: string }>>(
             `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
             { name: spaceName },
         );
         expect(res1.status).toBe(200);
+        tracker.trackSpace(res1.body.results.uuid);
 
         const res2 = await admin.post<Body<{ slug: string; uuid: string }>>(
             `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
             { name: spaceName },
         );
         expect(res2.status).toBe(200);
+        tracker.trackSpace(res2.body.results.uuid);
         expect(res2.body.results.slug).not.toBe(res1.body.results.slug);
     });
 
     it('Should not create duplicate slugs in the same project for nested spaces', async () => {
-        const spaceName = `📈 Space Namè ${Date.now()}`;
+        const spaceName = uniqueName('📈 Space Namè');
         const res1 = await admin.post<Body<{ slug: string; uuid: string }>>(
             `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
             { name: spaceName },
         );
         expect(res1.status).toBe(200);
+        tracker.trackSpace(res1.body.results.uuid);
 
         const res2 = await admin.post<Body<{ slug: string; uuid: string }>>(
             `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
             { name: spaceName, parentSpaceUuid: res1.body.results.uuid },
         );
         expect(res2.status).toBe(200);
+        tracker.trackSpace(res2.body.results.uuid);
         expect(res2.body.results.slug).not.toBe(res1.body.results.slug);
     });
 });

--- a/packages/api-tests/tests/organizationPermissions.test.ts
+++ b/packages/api-tests/tests/organizationPermissions.test.ts
@@ -122,11 +122,15 @@ describe('Lightdash API organization permission tests', () => {
     it('Should get forbidden error (403) from GET savedChart endpoints from another organization', async () => {
         const admin = await login();
         const projectUuid = SEED_PROJECT.project_uuid;
-        const projectResponse = await admin.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
-        );
+        const projectResponse = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
         expect(projectResponse.status).toBe(200);
-        const savedChartUuid = projectResponse.body.results[0].uuid;
+        const seedChart = projectResponse.body.results.find(
+            (c) => c.name === 'How many orders we have over time ?',
+        );
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
 
         const endpoints = [
             `/saved/${savedChartUuid}`,
@@ -157,12 +161,16 @@ describe('Lightdash API organization permission tests', () => {
     it('Should get forbidden error (403) from GET dashboardRouter endpoints', async () => {
         const admin = await login();
         const projectUuid = SEED_PROJECT.project_uuid;
-        const projectResponse = await admin.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/dashboards`,
-        );
+        const projectResponse = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoints = [`/dashboards/${dashboardUuid}`];
         // eslint-disable-next-line no-restricted-syntax
         for (const endpoint of endpoints) {
@@ -177,12 +185,16 @@ describe('Lightdash API organization permission tests', () => {
     it('Should get forbidden error (403) from PATCH dashboard', async () => {
         const admin = await login();
         const projectUuid = SEED_PROJECT.project_uuid;
-        const projectResponse = await admin.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/dashboards`,
-        );
+        const projectResponse = await admin.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoint = `${apiUrl}/dashboards/${dashboardUuid}`;
 
         const resp = await other.patch(

--- a/packages/api-tests/tests/pinning.test.ts
+++ b/packages/api-tests/tests/pinning.test.ts
@@ -1,6 +1,8 @@
 import { SEED_PROJECT } from '@lightdash/common';
 import { Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
+import { chartMock, dashboardMock } from '../helpers/mocks';
+import { TestResourceTracker, uniqueName } from '../helpers/test-isolation';
 
 const apiUrl = '/api/v1';
 
@@ -12,69 +14,113 @@ function findByUuid(results: PinnableItem[], uuid: string) {
 
 describe('Lightdash pinning endpoints', () => {
     let admin: Awaited<ReturnType<typeof login>>;
+    const tracker = new TestResourceTracker();
+    let testChartUuid: string;
+    let testDashboardUuid: string;
 
     beforeAll(async () => {
         admin = await login();
+        const projectUuid = SEED_PROJECT.project_uuid;
+
+        // Create a dedicated space for this test file
+        const spaceResp = await admin.post<Body<{ uuid: string }>>(
+            `${apiUrl}/projects/${projectUuid}/spaces`,
+            { name: uniqueName('pinning-test-space'), isPrivate: false },
+        );
+        const spaceUuid = spaceResp.body.results.uuid;
+        tracker.trackSpace(spaceUuid);
+
+        // Create a dedicated chart
+        const chartResp = await admin.post<Body<{ uuid: string }>>(
+            `${apiUrl}/projects/${projectUuid}/saved`,
+            {
+                ...chartMock,
+                name: uniqueName('pinning-test-chart'),
+                spaceUuid,
+                dashboardUuid: null,
+            },
+        );
+        testChartUuid = chartResp.body.results.uuid;
+        tracker.trackChart(testChartUuid);
+
+        // Create a dedicated dashboard
+        const dashResp = await admin.post<Body<{ uuid: string }>>(
+            `${apiUrl}/projects/${projectUuid}/dashboards`,
+            {
+                ...dashboardMock,
+                name: uniqueName('pinning-test-dashboard'),
+                spaceUuid,
+            },
+        );
+        testDashboardUuid = dashResp.body.results.uuid;
+        tracker.trackDashboard(testDashboardUuid);
+    });
+
+    afterAll(async () => {
+        await tracker.cleanup(admin);
     });
 
     it('Should pin/unpin chart', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        const projectResponse = await admin.get<Body<PinnableItem[]>>(
+
+        // Verify chart starts unpinned
+        const res0 = await admin.get<Body<PinnableItem[]>>(
             `${apiUrl}/projects/${projectUuid}/charts`,
         );
-        // Find a chart that is not currently pinned
-        const savedChart = projectResponse.body.results.find(
-            (c) => c.pinnedListUuid === null,
-        );
-        expect(savedChart).toBeDefined();
-        expect(savedChart!.pinnedListUuid).toBe(null);
+        const initialChart = findByUuid(res0.body.results, testChartUuid);
+        expect(initialChart).toBeDefined();
+        expect(initialChart!.pinnedListUuid).toBe(null);
 
-        // Pin Chart
+        // Pin chart
         const pinResp = await admin.patch<Body<PinnableItem>>(
-            `${apiUrl}/saved/${savedChart!.uuid}/pinning`,
+            `${apiUrl}/saved/${testChartUuid}/pinning`,
         );
         const res1 = await admin.get<Body<PinnableItem[]>>(
             `${apiUrl}/projects/${projectUuid}/charts`,
         );
-        const pinnedChart = findByUuid(res1.body.results, savedChart!.uuid);
+        const pinnedChart = findByUuid(res1.body.results, testChartUuid);
         expect(pinnedChart?.pinnedListUuid).toBe(
             pinResp.body.results.pinnedListUuid,
         );
 
         // Unpin chart
-        await admin.patch(`${apiUrl}/saved/${savedChart!.uuid}/pinning`);
+        await admin.patch(`${apiUrl}/saved/${testChartUuid}/pinning`);
         const res2 = await admin.get<Body<PinnableItem[]>>(
             `${apiUrl}/projects/${projectUuid}/charts`,
         );
-        const unpinnedChart = findByUuid(res2.body.results, savedChart!.uuid);
+        const unpinnedChart = findByUuid(res2.body.results, testChartUuid);
         expect(unpinnedChart?.pinnedListUuid).toBe(null);
     });
 
     it('Should pin/unpin dashboard', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
-        const projectResponse = await admin.get<Body<PinnableItem[]>>(
+
+        // Verify dashboard starts unpinned
+        const res0 = await admin.get<Body<PinnableItem[]>>(
             `${apiUrl}/projects/${projectUuid}/dashboards`,
         );
-        const dashboard = projectResponse.body.results[0];
+        const initialDash = findByUuid(res0.body.results, testDashboardUuid);
+        expect(initialDash).toBeDefined();
+        expect(initialDash!.pinnedListUuid).toBe(null);
 
         // Pin dashboard
         const pinResp = await admin.patch<Body<PinnableItem>>(
-            `${apiUrl}/dashboards/${dashboard.uuid}/pinning`,
+            `${apiUrl}/dashboards/${testDashboardUuid}/pinning`,
         );
         const res1 = await admin.get<Body<PinnableItem[]>>(
             `${apiUrl}/projects/${projectUuid}/dashboards`,
         );
-        const pinnedDash = findByUuid(res1.body.results, dashboard.uuid);
+        const pinnedDash = findByUuid(res1.body.results, testDashboardUuid);
         expect(pinnedDash?.pinnedListUuid).toBe(
             pinResp.body.results.pinnedListUuid,
         );
 
         // Unpin dashboard
-        await admin.patch(`${apiUrl}/dashboards/${dashboard.uuid}/pinning`);
+        await admin.patch(`${apiUrl}/dashboards/${testDashboardUuid}/pinning`);
         const res2 = await admin.get<Body<PinnableItem[]>>(
             `${apiUrl}/projects/${projectUuid}/dashboards`,
         );
-        const unpinnedDash = findByUuid(res2.body.results, dashboard.uuid);
+        const unpinnedDash = findByUuid(res2.body.results, testDashboardUuid);
         expect(unpinnedDash?.pinnedListUuid).toBe(null);
     });
 });

--- a/packages/api-tests/tests/projectPermissions.test.ts
+++ b/packages/api-tests/tests/projectPermissions.test.ts
@@ -98,7 +98,10 @@ describe('Lightdash API tests for member user with admin project permissions', (
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(resp.status).toBe(200);
         expect(resp.body).toHaveProperty('status', 'ok');
-        expect(resp.body.results[0]).toHaveProperty('name', 'Jaffle dashboard');
+        const jaffleDashboard = resp.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(jaffleDashboard).toBeDefined();
     });
 
     it('Should get success response (200) from POST runQuery', async () => {
@@ -142,10 +145,15 @@ describe('Lightdash API tests for member user with admin project permissions', (
     it('Should get success response (200) from POST chart results', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const spacesResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
+        const spacesResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
+        const seedChart = spacesResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
         );
-        const savedChartUuid = spacesResponse.body.results[0].uuid;
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoint = `/saved/${savedChartUuid}/results`;
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.post(`${apiUrl}${endpoint}`, undefined);
@@ -156,10 +164,15 @@ describe('Lightdash API tests for member user with admin project permissions', (
     it('Should get success response (200) from POST chart-and-results with filters', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const spacesResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
+        const spacesResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
+        const seedChart = spacesResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
         );
-        const savedChartUuid = spacesResponse.body.results[0].uuid;
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.post(`${apiUrl}${endpoint}`, {
@@ -217,7 +230,11 @@ describe('Lightdash API tests for member user with admin project permissions', (
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoint = `${apiUrl}/dashboards/${dashboardUuid}`;
         // eslint-disable-next-line no-await-in-loop
         const dashboardResponse = await client.get<
@@ -249,12 +266,17 @@ describe('Lightdash API tests for member user with admin project permissions', (
     it('Should get success response (200) from GET savedChartRouter endpoints', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const projectResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
-        );
+        const projectResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
         expect(projectResponse.status).toBe(200);
 
-        const savedChartUuid = projectResponse.body.results[0].uuid;
+        const seedChart = projectResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
+        );
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoints = [
             `/saved/${savedChartUuid}`,
             `/saved/${savedChartUuid}/availableFilters`,
@@ -300,7 +322,11 @@ describe('Lightdash API tests for member user with admin project permissions', (
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoints = [`/dashboards/${dashboardUuid}`];
         for (const endpoint of endpoints) {
             // eslint-disable-next-line no-await-in-loop
@@ -379,12 +405,17 @@ describe('Lightdash API tests for member user with editor project permissions', 
     it('Should get success response (200) from GET savedChartRouter endpoints', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const projectResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
-        );
+        const projectResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
         expect(projectResponse.status).toBe(200);
 
-        const savedChartUuid = projectResponse.body.results[0].uuid;
+        const seedChart = projectResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
+        );
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoints = [
             `/saved/${savedChartUuid}`,
             `/saved/${savedChartUuid}/availableFilters`,
@@ -424,7 +455,10 @@ describe('Lightdash API tests for member user with editor project permissions', 
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(resp.status).toBe(200);
         expect(resp.body).toHaveProperty('status', 'ok');
-        expect(resp.body.results[0]).toHaveProperty('name', 'Jaffle dashboard');
+        const jaffleDashboard = resp.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(jaffleDashboard).toBeDefined();
     });
 
     it('Should get success response (200) from POST downloadCsv', async () => {
@@ -499,7 +533,11 @@ describe('Lightdash API tests for member user with editor project permissions', 
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoint = `${apiUrl}/dashboards/${dashboardUuid}`;
         // eslint-disable-next-line no-await-in-loop
         const dashboardResponse = await client.get<
@@ -561,7 +599,11 @@ describe('Lightdash API tests for member user with editor project permissions', 
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoints = [`/dashboards/${dashboardUuid}`];
         for (const endpoint of endpoints) {
             // eslint-disable-next-line no-await-in-loop
@@ -705,10 +747,15 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
     it('Should get success response (200) from POST chart results', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const spacesResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
+        const spacesResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
+        const seedChart = spacesResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
         );
-        const savedChartUuid = spacesResponse.body.results[0].uuid;
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoint = `/saved/${savedChartUuid}/results`;
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.post(`${apiUrl}${endpoint}`, undefined);
@@ -719,10 +766,15 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
     it('Should get success response (200) from POST chart-and-results with filters', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const spacesResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
+        const spacesResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
+        const seedChart = spacesResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
         );
-        const savedChartUuid = spacesResponse.body.results[0].uuid;
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.post(`${apiUrl}${endpoint}`, {
@@ -772,7 +824,11 @@ describe('Lightdash API tests for member user with interactive_viewer project pe
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoint = `${apiUrl}/dashboards/${dashboardUuid}`;
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.patch(
@@ -866,7 +922,10 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(resp.status).toBe(200);
         expect(resp.body).toHaveProperty('status', 'ok');
-        expect(resp.body.results[0]).toHaveProperty('name', 'Jaffle dashboard');
+        const jaffleDashboard = resp.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(jaffleDashboard).toBeDefined();
     });
 
     it('Should get forbidden (403) from PUT explores', async () => {
@@ -919,10 +978,15 @@ describe('Lightdash API tests for member user with viewer project permissions', 
     it('Should get success response (200) from POST chart results', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const spacesResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
+        const spacesResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
+        const seedChart = spacesResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
         );
-        const savedChartUuid = spacesResponse.body.results[0].uuid;
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoint = `/saved/${savedChartUuid}/results`;
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.post(`${apiUrl}${endpoint}`, undefined);
@@ -933,10 +997,15 @@ describe('Lightdash API tests for member user with viewer project permissions', 
     it('Should get success response (200) from POST chart-and-results with filters', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const spacesResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
+        const spacesResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
+        const seedChart = spacesResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
         );
-        const savedChartUuid = spacesResponse.body.results[0].uuid;
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoint = `/saved/${savedChartUuid}/chart-and-results`;
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.post(`${apiUrl}${endpoint}`, {
@@ -986,7 +1055,11 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoint = `${apiUrl}/dashboards/${dashboardUuid}`;
         // eslint-disable-next-line no-await-in-loop
         const resp = await client.patch(
@@ -1009,12 +1082,17 @@ describe('Lightdash API tests for member user with viewer project permissions', 
     it('Should get success response (200) from GET savedChartRouter endpoints', async () => {
         const projectUuid = SEED_PROJECT.project_uuid;
         // eslint-disable-next-line no-await-in-loop
-        const projectResponse = await client.get<Body<Array<{ uuid: string }>>>(
-            `${apiUrl}/projects/${projectUuid}/charts`,
-        );
+        const projectResponse = await client.get<
+            Body<Array<{ uuid: string; name: string }>>
+        >(`${apiUrl}/projects/${projectUuid}/charts`);
         expect(projectResponse.status).toBe(200);
 
-        const savedChartUuid = projectResponse.body.results[0].uuid;
+        const seedChart = projectResponse.body.results.find(
+            (c: { name: string }) =>
+                c.name === 'How many orders we have over time ?',
+        );
+        expect(seedChart).toBeDefined();
+        const savedChartUuid = seedChart!.uuid;
         const endpoints = [
             `/saved/${savedChartUuid}`,
             `/saved/${savedChartUuid}/availableFilters`,
@@ -1060,7 +1138,11 @@ describe('Lightdash API tests for member user with viewer project permissions', 
         >(`${apiUrl}/projects/${projectUuid}/dashboards`);
         expect(projectResponse.status).toBe(200);
 
-        const dashboardUuid = projectResponse.body.results[0].uuid;
+        const seedDashboard = projectResponse.body.results.find(
+            (d: { name: string }) => d.name === 'Jaffle dashboard',
+        );
+        expect(seedDashboard).toBeDefined();
+        const dashboardUuid = seedDashboard!.uuid;
         const endpoints = [`/dashboards/${dashboardUuid}`];
         for (const endpoint of endpoints) {
             // eslint-disable-next-line no-await-in-loop

--- a/packages/api-tests/tests/promotion.test.ts
+++ b/packages/api-tests/tests/promotion.test.ts
@@ -8,6 +8,7 @@ import {
 import { ApiClient, Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
 import { chartMock } from '../helpers/mocks';
+import { TestResourceTracker, uniqueName } from '../helpers/test-isolation';
 
 const apiUrl = '/api/v1';
 
@@ -233,9 +234,10 @@ function checkPromotedDashboard(
 // --- Tests ---
 
 describe('Promotion charts and dashboards', () => {
-    const upstreamProjectName = `Upstream project ${Date.now()}`;
+    const upstreamProjectName = uniqueName('Upstream project');
     let upstreamProjectUuid: string;
     let admin: ApiClient;
+    const tracker = new TestResourceTracker();
 
     beforeAll(async () => {
         admin = await login();
@@ -249,6 +251,8 @@ describe('Promotion charts and dashboards', () => {
     });
 
     afterAll(async () => {
+        // Clean up spaces/charts/dashboards created in seed project
+        await tracker.cleanup(admin);
         // Delete upstream project
         await deleteProjectsByName(admin, [upstreamProjectName]);
     });
@@ -287,23 +291,24 @@ describe('Promotion charts and dashboards', () => {
     });
 
     it('Promote new chart in new space', async () => {
-        const now = Date.now();
         const spaceUuid = await createSpace(
             admin,
             SEED_PROJECT.project_uuid,
-            `Public space to promote ${now}`,
+            uniqueName('Public space to promote'),
         );
+        tracker.trackSpace(spaceUuid);
 
         const chart = await createChartInSpace(
             admin,
             SEED_PROJECT.project_uuid,
             {
                 ...chartMock,
-                name: `Chart to promote ${now}`,
+                name: uniqueName('Chart to promote'),
                 spaceUuid,
                 dashboardUuid: null,
             },
         );
+        tracker.trackChart(chart.uuid);
 
         const promoteResp = await admin.post<Body<Record<string, any>>>(
             `${apiUrl}/saved/${chart.uuid}/promote`,
@@ -358,24 +363,25 @@ describe('Promotion charts and dashboards', () => {
         // 3. Create a new dashboard with the chart
         // 4. Create chart within dashboard
         // 5. Promote the dashboard
-        const now = Date.now();
         const projectUuid = SEED_PROJECT.project_uuid;
 
         const spaceUuid = await createSpace(
             admin,
             projectUuid,
-            `Public space to promote ${now}`,
+            uniqueName('Public space to promote'),
         );
+        tracker.trackSpace(spaceUuid);
 
         const chart = await createChartInSpace(admin, projectUuid, {
             ...chartMock,
-            name: `Chart to promote ${now}`,
+            name: uniqueName('Chart to promote'),
             spaceUuid,
             dashboardUuid: null,
         });
+        tracker.trackChart(chart.uuid);
 
         const newDashboard = await createDashboard(admin, projectUuid, {
-            name: `Dashboard to promote ${now}`,
+            name: uniqueName('Dashboard to promote'),
             tiles: [
                 {
                     tabUuid: undefined,
@@ -391,15 +397,16 @@ describe('Promotion charts and dashboards', () => {
             ],
             tabs: [],
         });
+        tracker.trackDashboard(newDashboard.uuid);
         expect(newDashboard.tiles.length).toBe(1);
 
-        const { dashboard: updatedDashboard } =
+        const { chart: chartInDashboard, dashboard: updatedDashboard } =
             await createChartAndUpdateDashboard(
                 admin,
                 projectUuid,
                 {
                     ...chartMock,
-                    name: `Chart in dashboard to promote ${now}`,
+                    name: uniqueName('Chart in dashboard to promote'),
                     dashboardUuid: newDashboard.uuid,
                     spaceUuid: null,
                 },

--- a/packages/api-tests/tests/rename.test.ts
+++ b/packages/api-tests/tests/rename.test.ts
@@ -2,43 +2,51 @@ import { RenameType, SEED_PROJECT } from '@lightdash/common';
 import { type Body } from '../helpers/api-client';
 import { login } from '../helpers/auth';
 import { chartMock } from '../helpers/mocks';
+import { TestResourceTracker, uniqueName } from '../helpers/test-isolation';
 
 const apiUrl = '/api/v1';
 
 describe('Rename Chart API', () => {
     let admin: Awaited<ReturnType<typeof login>>;
+    const tracker = new TestResourceTracker();
 
     beforeAll(async () => {
         admin = await login();
+    });
+
+    afterAll(async () => {
+        await tracker.cleanup(admin);
     });
 
     async function createSpaceAndChart(
         suffix: string,
         metricQuery: typeof chartMock.metricQuery,
     ) {
-        const now = Date.now();
         const spaceResp = await admin.post<Body<{ uuid: string }>>(
             `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces/`,
             {
-                name: `Public space to promote ${now}`,
+                name: uniqueName('rename-test-space'),
                 inheritParentPermissions: true,
             },
         );
         expect(spaceResp.status).toBe(200);
         const spaceUuid = spaceResp.body.results.uuid;
+        tracker.trackSpace(spaceUuid);
 
         const chartResp = await admin.post<Body<{ uuid: string }>>(
             `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/saved`,
             {
                 ...chartMock,
-                name: `Chart to rename ${now} ${suffix}`,
+                name: uniqueName(`Chart to rename ${suffix}`),
                 metricQuery,
                 spaceUuid,
                 dashboardUuid: null,
             },
         );
         expect(chartResp.status).toBe(200);
-        return chartResp.body.results.uuid;
+        const chartUuid = chartResp.body.results.uuid;
+        tracker.trackChart(chartUuid);
+        return chartUuid;
     }
 
     it('Should rename a chart field and check the response', async () => {
@@ -78,9 +86,6 @@ describe('Rename Chart API', () => {
         expect(updatedChart.metricQuery.exploreName).toBe('orders');
         expect(updatedChart.metricQuery.dimensions).toContain('orders_status');
         expect(updatedChart.metricQuery.sorts[0].fieldId).toBe('orders_status');
-
-        const delResp = await admin.delete(`${apiUrl}/saved/${chartUuid}`);
-        expect(delResp.status).toBe(200);
     });
 
     it('Should rename a chart model and check the response', async () => {
@@ -116,8 +121,5 @@ describe('Rename Chart API', () => {
         expect(updatedChart.metricQuery.exploreName).toBe('orders');
         expect(updatedChart.metricQuery.dimensions).toContain('orders_type');
         expect(updatedChart.metricQuery.sorts[0].fieldId).toBe('orders_type');
-
-        const delResp = await admin.delete(`${apiUrl}/saved/${chartUuid}`);
-        expect(delResp.status).toBe(200);
     });
 });

--- a/packages/api-tests/tests/savedChart.test.ts
+++ b/packages/api-tests/tests/savedChart.test.ts
@@ -9,12 +9,13 @@ import {
 } from '@lightdash/common';
 import { login, loginAsEditor } from '../helpers/auth';
 import { chartMock, dashboardMock } from '../helpers/mocks';
+import { uniqueName } from '../helpers/test-isolation';
 
 const apiUrl = '/api/v1';
 
 describe('Saved chart space selection', () => {
-    const chartName = 'Chart space selection test';
-    const dashboardName = 'Dashboard for chart space selection test';
+    const chartName = uniqueName('Chart space selection');
+    const dashboardName = uniqueName('Dashboard for chart space');
 
     let admin: Awaited<ReturnType<typeof login>>;
     const createdChartUuids: string[] = [];

--- a/packages/api-tests/tests/spacePermissions.test.ts
+++ b/packages/api-tests/tests/spacePermissions.test.ts
@@ -1,8 +1,14 @@
 import { Dashboard, SavedChart, SEED_PROJECT, Space } from '@lightdash/common';
 import { ApiClient, Body } from '../helpers/api-client';
 import { login, loginWithEmail, loginWithPermissions } from '../helpers/auth';
+import { uniqueName } from '../helpers/test-isolation';
 
 const apiUrl = '/api/v1';
+
+// Generate unique names once per test file to avoid cross-file collisions
+const privateSpaceName = uniqueName('private space');
+const privateChartName = uniqueName('private chart');
+const privateDashboardName = uniqueName('private dashboard');
 
 const chartBody = {
     tableName: 'customers',
@@ -25,11 +31,11 @@ const chartBody = {
         type: 'cartesian',
         config: { layout: {}, eChartsConfig: {} },
     },
-    name: 'private chart',
+    name: privateChartName,
 };
 
 const dashboardBody = {
-    name: 'private dashboard',
+    name: privateDashboardName,
     description: '',
     tiles: [],
     tabs: [],
@@ -40,7 +46,7 @@ async function createPrivateChart(
 ): Promise<{ space: Space; chart: SavedChart }> {
     const spaceResp = await client.post<{ results: Space }>(
         `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
-        { name: 'private space' },
+        { name: privateSpaceName },
     );
     expect(spaceResp.status).toBe(200);
 
@@ -65,7 +71,7 @@ async function createPrivateDashboard(
 ): Promise<{ space: Space; dashboard: Dashboard }> {
     const spaceResp = await client.post<{ results: Space }>(
         `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`,
-        { name: 'private space' },
+        { name: privateSpaceName },
     );
     expect(spaceResp.status).toBe(200);
 
@@ -103,14 +109,14 @@ describe('Lightdash API tests for my own private spaces as admin', () => {
                 uuid: string;
             }>
         >(`${apiUrl}/projects/${SEED_PROJECT.project_uuid}/spaces`, {
-            name: 'private space',
+            name: privateSpaceName,
         });
         expect(resp.status).toBe(200);
         expect(resp.body.results).toHaveProperty(
             'inheritParentPermissions',
             false,
         );
-        expect(resp.body.results).toHaveProperty('name', 'private space');
+        expect(resp.body.results).toHaveProperty('name', privateSpaceName);
         expect(resp.body.results).toHaveProperty(
             'projectUuid',
             SEED_PROJECT.project_uuid,
@@ -123,8 +129,8 @@ describe('Lightdash API tests for my own private spaces as admin', () => {
         const { space, chart } = await createPrivateChart(admin);
 
         expect(space).toHaveProperty('inheritParentPermissions', false);
-        expect(space).toHaveProperty('name', 'private space');
-        expect(chart).toHaveProperty('spaceName', 'private space');
+        expect(space).toHaveProperty('name', privateSpaceName);
+        expect(chart).toHaveProperty('spaceName', privateSpaceName);
         expect(chart).toHaveProperty('spaceUuid', space.uuid);
 
         await deleteSpace(admin, space.uuid);
@@ -134,8 +140,8 @@ describe('Lightdash API tests for my own private spaces as admin', () => {
         const { space, dashboard } = await createPrivateDashboard(admin);
 
         expect(space).toHaveProperty('inheritParentPermissions', false);
-        expect(space).toHaveProperty('name', 'private space');
-        expect(dashboard).toHaveProperty('spaceName', 'private space');
+        expect(space).toHaveProperty('name', privateSpaceName);
+        expect(dashboard).toHaveProperty('spaceName', privateSpaceName);
         expect(dashboard).toHaveProperty('spaceUuid', space.uuid);
 
         await deleteSpace(admin, space.uuid);
@@ -288,7 +294,7 @@ describe('Lightdash API tests for a project admin accessing other private spaces
         });
         expect(resp.status).toBe(200);
         const privateSpace = resp.body.results.find(
-            (space: any) => space.name === 'private space',
+            (space: any) => space.name === privateSpaceName,
         );
         expect(privateSpace).toBeDefined();
     });
@@ -306,17 +312,17 @@ describe('Lightdash API tests for a project admin accessing other private spaces
         expect(resp.status).toBe(200);
         expect(
             resp.body.results.spaces.find(
-                (space: any) => space.name === 'private space',
+                (space: any) => space.name === privateSpaceName,
             ),
         ).toBeDefined();
         expect(
             resp.body.results.savedCharts.find(
-                (chart: any) => chart.name === 'private chart',
+                (chart: any) => chart.name === privateChartName,
             ),
         ).toBeDefined();
         expect(
             resp.body.results.dashboards.find(
-                (dashboard: any) => dashboard.name === 'private dashboard',
+                (dashboard: any) => dashboard.name === privateDashboardName,
             ),
         ).toBeDefined();
     });
@@ -331,7 +337,7 @@ describe('Lightdash API tests for a project admin accessing other private spaces
         expect(resp.status).toBe(200);
         expect(
             resp.body.results.find(
-                (dashboard: any) => dashboard.name === 'private dashboard',
+                (dashboard: any) => dashboard.name === privateDashboardName,
             ),
         ).toBeUndefined();
     });

--- a/packages/api-tests/vitest.config.ts
+++ b/packages/api-tests/vitest.config.ts
@@ -9,6 +9,6 @@ export default defineConfig({
         globals: true,
         setupFiles: ['vitest.setup.ts'],
         pool: 'forks',
-        fileParallelism: false, // tests share DB state; parallel execution causes space/chart deletion race conditions
+        fileParallelism: true,
     },
 });


### PR DESCRIPTION
### Description:
After migrating the API tests to Vitest we still couldn't enjoy the full performance due to data races between different test files.
This PR aims for tests to be much more isolated by creating (and cleaning up properly) their resources (spaces/dashboards/charts). This way `fileParallelism` can be enabled.

If you run the api tests locally on your default Jaffle Shop set-up, the "All Spaces" view will look exactly the same after the run, as every test cleaned up after itself.