### PR TITLE
feat: add run_sql tool to MCP server

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -365,6 +365,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     asyncQueryService: repository.getAsyncQueryService(),
                     catalogService: repository.getCatalogService(),
                     projectService: repository.getProjectService(),
+                    savedSqlService: repository.getSavedSqlService(),
+                    schedulerService: repository.getSchedulerService(),
                     shareService: repository.getShareService(),
                     userAttributesModel: models.getUserAttributesModel(),
                     searchModel: models.getSearchModel(),

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -21,8 +21,10 @@ import {
     OauthAccount,
     ParameterError,
     QueryExecutionContext,
+    SchedulerJobStatus,
     ServiceAcctAccount,
     SessionUser,
+    sleep,
     ToolFindContentArgs,
     toolFindContentArgsSchema,
     toolFindExploresArgsSchemaV3,
@@ -31,6 +33,7 @@ import {
     toolFindFieldsArgsSchema,
     toolRunQueryArgsSchema,
     toolRunQueryArgsSchemaTransformed,
+    toolRunSqlArgsSchema,
     ToolSearchFieldValuesArgs,
     toolSearchFieldValuesArgsSchema,
     UserAttributeValueMap,
@@ -46,6 +49,7 @@ import * as Sentry from '@sentry/node';
 import { stringify } from 'csv-stringify/sync';
 import fs from 'fs/promises';
 import path from 'path';
+import { Readable } from 'stream';
 import { z, ZodRawShape } from 'zod';
 import {
     LightdashAnalytics,
@@ -63,6 +67,8 @@ import { CatalogService } from '../../../services/CatalogService/CatalogService'
 import { CsvService } from '../../../services/CsvService/CsvService';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
+import { SavedSqlService } from '../../../services/SavedSqlService/SavedSqlService';
+import { SchedulerService } from '../../../services/SchedulerService/SchedulerService';
 import { ShareService } from '../../../services/ShareService/ShareService';
 import { SpaceService } from '../../../services/SpaceService/SpaceService';
 import {
@@ -72,6 +78,7 @@ import {
     validateUserAttributeOverrides,
 } from '../../../services/UserAttributesService/UserAttributeUtils';
 import { wrapSentryTransaction } from '../../../utils';
+import { streamJsonlData } from '../../../utils/FileDownloadUtils/FileDownloadUtils';
 import { VERSION } from '../../../version';
 import { NO_RESULTS_RETRY_PROMPT } from '../ai/prompts/noResultsRetry';
 import { getFindContent } from '../ai/tools/findContent';
@@ -110,6 +117,7 @@ export enum McpToolName {
     SET_PROJECT = 'set_project',
     GET_CURRENT_PROJECT = 'get_current_project',
     RUN_METRIC_QUERY = 'run_metric_query',
+    RUN_SQL = 'run_sql',
     SEARCH_FIELD_VALUES = 'search_field_values',
 }
 
@@ -120,6 +128,8 @@ type McpServiceArguments = {
     catalogService: CatalogService;
     projectModel: ProjectModel;
     projectService: ProjectService;
+    savedSqlService: SavedSqlService;
+    schedulerService: SchedulerService;
     shareService: ShareService;
     userAttributesModel: UserAttributesModel;
     searchModel: SearchModel;
@@ -152,6 +162,10 @@ export class McpService extends BaseService {
 
     private projectService: ProjectService;
 
+    private savedSqlService: SavedSqlService;
+
+    private schedulerService: SchedulerService;
+
     private projectModel: ProjectModel;
 
     private userAttributesModel: UserAttributesModel;
@@ -178,6 +192,8 @@ export class McpService extends BaseService {
         asyncQueryService,
         catalogService,
         projectService,
+        savedSqlService,
+        schedulerService,
         shareService,
         userAttributesModel,
         searchModel,
@@ -193,6 +209,8 @@ export class McpService extends BaseService {
         this.asyncQueryService = asyncQueryService;
         this.catalogService = catalogService;
         this.projectService = projectService;
+        this.savedSqlService = savedSqlService;
+        this.schedulerService = schedulerService;
         this.shareService = shareService;
         this.userAttributesModel = userAttributesModel;
         this.searchModel = searchModel;
@@ -1034,6 +1052,170 @@ export class McpService extends BaseService {
                 };
             },
         );
+
+        this.mcpServer.registerTool(
+            McpToolName.RUN_SQL,
+            {
+                description: toolRunSqlArgsSchema.description,
+                inputSchema: this.getMcpCompatibleSchema(toolRunSqlArgsSchema),
+            },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
+                const args = _args as { sql: string; limit?: number };
+                const { user, account } = this.getAccount(
+                    extra as McpProtocolContext,
+                );
+                const projectUuid = await this.resolveProjectUuid(
+                    extra as McpProtocolContext,
+                );
+
+                this.trackToolCall(
+                    extra as McpProtocolContext,
+                    McpToolName.RUN_SQL,
+                    projectUuid,
+                );
+
+                try {
+                    const { jobId } =
+                        await this.savedSqlService.getResultJobFromSql(
+                            user,
+                            projectUuid,
+                            args.sql,
+                            args.limit ?? 500,
+                        );
+
+                    const jobResult = await this.pollSqlJobToCompletion(
+                        account,
+                        jobId,
+                    );
+
+                    const rows = await this.downloadSqlResults(
+                        user,
+                        projectUuid,
+                        jobResult.fileUrl,
+                    );
+
+                    const columns = jobResult.columns.map((c) => c.reference);
+
+                    if (rows.length === 0) {
+                        const header =
+                            columns.length > 0
+                                ? `Columns: ${columns.join(', ')}`
+                                : '';
+                        return {
+                            content: [
+                                {
+                                    type: 'text' as const,
+                                    text: `Query returned 0 rows.${header ? ` ${header}` : ''}`,
+                                },
+                            ],
+                        };
+                    }
+
+                    const csv = stringify(rows, {
+                        header: true,
+                        columns,
+                    });
+
+                    return {
+                        content: [
+                            {
+                                type: 'text' as const,
+                                text: csv,
+                            },
+                        ],
+                    };
+                } catch (e) {
+                    const errorMessage =
+                        e instanceof Error ? e.message : String(e);
+                    return {
+                        content: [
+                            {
+                                type: 'text' as const,
+                                text: `Error running SQL query: ${errorMessage}`,
+                            },
+                        ],
+                        isError: true,
+                    };
+                }
+            },
+        );
+    }
+
+    private async pollSqlJobToCompletion(
+        account: Account,
+        jobId: string,
+    ): Promise<{ fileUrl: string; columns: Array<{ reference: string }> }> {
+        const maxWaitMs = 5 * 60 * 1000;
+        const startTime = Date.now();
+        let delayMs = 500;
+
+        // eslint-disable-next-line no-constant-condition
+        while (true) {
+            if (Date.now() - startTime > maxWaitMs) {
+                throw new Error('SQL query timed out after 5 minutes');
+            }
+
+            // eslint-disable-next-line no-await-in-loop
+            const job = await this.schedulerService.getJobStatus(
+                account,
+                jobId,
+            );
+
+            if (job.status === SchedulerJobStatus.COMPLETED) {
+                const details = job.details as {
+                    fileUrl?: string;
+                    columns?: Array<{ reference: string }>;
+                } | null;
+                if (!details?.fileUrl) {
+                    throw new Error(
+                        'SQL query completed but no results file was produced',
+                    );
+                }
+                return {
+                    fileUrl: details.fileUrl,
+                    columns: details.columns ?? [],
+                };
+            }
+
+            if (job.status === SchedulerJobStatus.ERROR) {
+                const errorDetail =
+                    (job.details as { error?: string } | null)?.error ??
+                    'Unknown error';
+                throw new Error(`SQL query failed: ${errorDetail}`);
+            }
+
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(delayMs);
+            delayMs = Math.min(delayMs * 2, 2000);
+        }
+    }
+
+    private async downloadSqlResults(
+        user: SessionUser,
+        projectUuid: string,
+        fileUrl: string,
+    ): Promise<Record<string, unknown>[]> {
+        const fileId = fileUrl.split('/').pop();
+        if (!fileId) {
+            throw new Error(`Could not extract file ID from URL: ${fileUrl}`);
+        }
+
+        const readStream: Readable = await this.projectService.getFileStream(
+            user,
+            projectUuid,
+            fileId,
+        );
+
+        const { results } = await streamJsonlData<Record<string, unknown>>({
+            readStream,
+            onRow: (row) => row,
+        });
+
+        return results;
     }
 
     async getProjectUuidFromContext(

--- a/packages/common/src/ee/AiAgent/schemas/tools/index.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/index.ts
@@ -11,6 +11,7 @@ export * from './toolImproveContextArgs';
 export * from './toolProposeChangeArgs';
 export * from './toolRunMetricQueryArgs';
 export * from './toolRunQueryArgs';
+export * from './toolRunSqlArgs';
 export * from './toolSearchFieldValuesArgs';
 export * from './toolTableVizArgs';
 export * from './toolTimeSeriesArgs';

--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunSqlArgs.ts
@@ -1,0 +1,38 @@
+import { z } from 'zod';
+import { createToolSchema } from '../toolSchemaBuilder';
+
+const TOOL_RUN_SQL_DESCRIPTION = `Tool: run_sql
+
+Purpose:
+Execute an arbitrary SQL query against the project's data warehouse and return the results.
+
+Use this tool when the user wants to run a custom SQL query that doesn't fit the explore-based metric query model.
+This is useful for ad-hoc analysis, data exploration, or queries that join across tables not modeled in explores.
+
+The query is executed directly against the warehouse, so use the SQL dialect appropriate for the connected warehouse (e.g., PostgreSQL, BigQuery, Snowflake, etc.).
+
+Parameters:
+- sql: The SQL query to execute. Must be a valid SELECT statement.
+- limit: Maximum number of rows to return (default 500, max 5000).
+`;
+
+export const toolRunSqlArgsSchema = createToolSchema({
+    description: TOOL_RUN_SQL_DESCRIPTION,
+})
+    .extend({
+        sql: z
+            .string()
+            .describe('The SQL query to execute against the data warehouse.'),
+        limit: z
+            .number()
+            .int()
+            .positive()
+            .max(5000)
+            .default(500)
+            .describe(
+                'Maximum number of rows to return. Defaults to 500, max 5000.',
+            ),
+    })
+    .build();
+
+export type ToolRunSqlArgs = z.infer<typeof toolRunSqlArgsSchema>;


### PR DESCRIPTION
## Summary
- Adds a `run_sql` MCP tool that lets AI agents execute arbitrary SQL queries against the project's data warehouse
- Reuses existing SQL runner infrastructure: `SavedSqlService.getResultJobFromSql()` → scheduler job → JSONL file download
- Returns results as CSV text, with clear messaging for empty results and errors
- Zod schema enforces a configurable row limit (default 500, max 5000)

## Implementation
- **New schema**: `toolRunSqlArgs.ts` in common package (sql + limit fields)
- **McpService changes**: `RUN_SQL` enum value, `savedSqlService`/`schedulerService` dependencies, tool handler with `pollSqlJobToCompletion()` and `downloadSqlResults()` helpers
- **DI wiring**: Pass new services through `ee/index.ts`

## Permissions enforced
1. Project access via `resolveProjectUuid` (checks `view Project`)
2. SQL Runner access via `getResultJobFromSql` (checks `manage SqlRunner` + `create Job`)
3. Job status access via `getJobStatus` (checks `view JobStatus`)
4. File download access via `getFileStream` (checks `view Project`)

## Test plan
- [x] Typecheck passes (common + backend)
- [x] Lint passes (common + backend)
- [x] Unit tests pass (common + backend)
- [x] Manual MCP test: simple query (`SELECT 1 AS test`) returns correct CSV
- [x] Manual MCP test: real data query (aggregation on jaffle.orders) returns correct results
- [x] Manual MCP test: CTE + complex SQL works
- [x] Manual MCP test: subquery + JOIN works
- [x] Manual MCP test: limit parameter enforced (limit=2 returns 2 rows)
- [x] Manual MCP test: empty result set returns clear message
- [x] Manual MCP test: invalid SQL returns error with `isError: true`
- [x] Manual MCP test: limit > 5000 rejected by Zod validation
- [x] Manual MCP test: NULLs and mixed types handled correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)