### PR TITLE
fix: handle transitive nested aggregate metrics in CTE generation

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/events.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/events.yml
@@ -389,6 +389,22 @@ models:
               type: number
               description: "Window sum of max event IDs partitioned by event type"
               sql: SUM(${max_event_id}) OVER (PARTITION BY ${TABLE}.event)
+            # --- Transitive nested aggregate test metrics ---
+            # Reproduces customer bug: type:number → type:number (with agg) → type:max
+            # count_if_of_max wraps max_event_id in COUNT_IF, then
+            # ratio_of_count_if references count_if_of_max without any outer aggregation.
+            # The compiled SQL ends up as COUNT_IF(MAX(...)) / NULLIF(COUNT(...), 0)
+            # which is invalid (nested aggregates) but the detection misses it because
+            # ratio_of_count_if's raw SQL has no aggregation — only transitive inlining
+            # introduces the nesting.
+            sum_case_of_max:
+              type: number
+              description: "Count of groups where max event ID is above threshold"
+              sql: SUM(CASE WHEN ${max_event_id} > 100 THEN 1 ELSE 0 END)
+            ratio_of_sum_case:
+              type: number
+              description: "Ratio of sum_case_of_max to total count - transitive nested aggregate"
+              sql: ${sum_case_of_max} / NULLIF(${count}, 0)
             raw_agg_with_metric_ref:
               type: number
               description: "Raw column aggregation divided by aggregate metric ref"

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -2684,6 +2684,39 @@ export const EXPLORE_WITH_NESTED_AGG: Explore = {
                     tablesReferences: ['my_table'],
                     hidden: false,
                 },
+                // Transitive nested aggregate: type:number referencing another type:number
+                // which itself wraps an aggregate metric.
+                // sum_case_of_max.sql = SUM(CASE WHEN ${max_value} > 100 THEN 1 ELSE 0 END)
+                //   → compiles to SUM(CASE WHEN MAX("my_table".value) > 100 THEN 1 ELSE 0 END)
+                // Then ratio_of_sum_case.sql = ${sum_case_of_max} / NULLIF(${count_records}, 0)
+                //   → compiles to SUM(CASE WHEN MAX(...) > 100 ...) / NULLIF(COUNT(...), 0)
+                // The nesting is two levels deep: ratio → sum_case → max
+                sum_case_of_max: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'sum_case_of_max',
+                    label: 'sum_case_of_max',
+                    sql: 'SUM(CASE WHEN ${max_value} > 100 THEN 1 ELSE 0 END)',
+                    compiledSql:
+                        'SUM(CASE WHEN MAX("my_table".value) > 100 THEN 1 ELSE 0 END)',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
+                ratio_of_sum_case: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'ratio_of_sum_case',
+                    label: 'ratio_of_sum_case',
+                    sql: '${sum_case_of_max} / NULLIF(${count_records}, 0)',
+                    compiledSql:
+                        'SUM(CASE WHEN MAX("my_table".value) > 100 THEN 1 ELSE 0 END) / NULLIF(COUNT("my_table".id), 0)',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
                 // Product of aggregates - NO outer aggregation, valid SQL without CTE
                 product_of_aggregates: {
                     type: MetricType.NUMBER,
@@ -2820,6 +2853,39 @@ export const METRIC_QUERY_NESTED_AGG_WINDOW_TABLE_REF: CompiledMetricQuery = {
     metrics: ['my_table_window_sum_of_max'],
     filters: {},
     sorts: [{ fieldId: 'my_table_window_sum_of_max', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+// Transitive nested aggregate: type:number → type:number (with agg) → type:max
+// The outer metric (ratio_of_sum_case) has no SQL aggregation itself,
+// but its compiledSql contains SUM(CASE WHEN MAX(...)) via transitive inlining.
+// Only ratio_of_sum_case is selected — sum_case_of_max is NOT directly selected.
+export const METRIC_QUERY_NESTED_AGG_TRANSITIVE: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['my_table_category'],
+    metrics: ['my_table_ratio_of_sum_case'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_ratio_of_sum_case', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+// Transitive nested aggregate mixed with other nested metrics.
+// Reproduces bug where ratio_of_sum_case fails when combined with
+// other nested metrics like conditional_sum_of_max.
+export const METRIC_QUERY_NESTED_AGG_TRANSITIVE_MIXED: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: [],
+    metrics: ['my_table_ratio_of_sum_case', 'my_table_conditional_sum_of_max'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_ratio_of_sum_case', descending: true }],
     limit: 10,
     tableCalculations: [],
     compiledTableCalculations: [],

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -63,6 +63,8 @@ import {
     METRIC_QUERY_NESTED_AGG_NO_DIMS,
     METRIC_QUERY_NESTED_AGG_PRODUCT,
     METRIC_QUERY_NESTED_AGG_RAW_COL,
+    METRIC_QUERY_NESTED_AGG_TRANSITIVE,
+    METRIC_QUERY_NESTED_AGG_TRANSITIVE_MIXED,
     METRIC_QUERY_NESTED_AGG_WINDOW_TABLE_REF,
     METRIC_QUERY_NESTED_AGG_WITH_DIMS,
     METRIC_QUERY_SQL,
@@ -4747,5 +4749,52 @@ describe('Nested aggregate metrics', () => {
         expect(result.query).toContain(
             'PARTITION BY nested_agg."my_table_category"',
         );
+    });
+
+    test('should handle transitive nested aggregates (type:number → type:number with agg → type:max)', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_TRANSITIVE,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should use nested CTE to break apart the transitive nesting
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).toContain('nested_agg_results AS (');
+
+        // CTE 1 should pre-compute the inner aggregate metric (max_value)
+        expect(result.query).toContain(
+            'MAX("my_table".value) AS "my_table_max_value"',
+        );
+
+        // Final SQL should NOT contain nested aggregates like SUM(CASE WHEN MAX(...))
+        expect(result.query).not.toContain('SUM(CASE WHEN MAX(');
+    });
+
+    test('should handle transitive nested aggregates mixed with other nested metrics', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_TRANSITIVE_MIXED,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should use nested CTE
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).toContain('nested_agg_results AS (');
+
+        // CTE 1 should pre-compute leaf aggregates only
+        expect(result.query).toContain(
+            'MAX("my_table".value) AS "my_table_max_value"',
+        );
+
+        // No nested aggregation in the query (no SUM wrapping MAX)
+        expect(result.query).not.toContain('SUM(CASE WHEN MAX(');
+
+        // ratio_of_sum_case should reference CTE columns, not base table
+        expect(result.query).toContain('nested_agg."my_table_max_value"');
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -833,6 +833,50 @@ export class MetricQueryBuilder {
             referencedMetricIds.add(metricId);
         });
 
+        // Recursively resolve non-aggregate (type:number) metric references.
+        // When a type:number metric references another type:number metric
+        // (e.g. ratio_metric → count_if_metric → max_metric), the
+        // intermediate metrics must be in the list so the nested aggregate
+        // detection can see and handle them.
+        const resolveNonAggregateRefs = (metricId: string): void => {
+            let metric: CompiledMetric;
+            try {
+                metric = this.getMetricFromId(metricId);
+            } catch {
+                return;
+            }
+            if (!isNonAggregateMetric(metric)) return;
+
+            const refs = parseAllReferences(metric.sql, metric.table);
+            for (const ref of refs) {
+                if (
+                    ref.refName !== 'TABLE' &&
+                    !referencedMetricIds.has(
+                        getItemId({ table: ref.refTable, name: ref.refName }),
+                    )
+                ) {
+                    const refMetricId = getItemId({
+                        table: ref.refTable,
+                        name: ref.refName,
+                    });
+                    try {
+                        const refMetric = this.getMetricFromId(refMetricId);
+                        // Only add metric references (not dimensions)
+                        if (refMetric.fieldType === FieldType.METRIC) {
+                            referencedMetricIds.add(refMetricId);
+                            resolveNonAggregateRefs(refMetricId);
+                        }
+                    } catch {
+                        // Not a metric reference, skip
+                    }
+                }
+            }
+        };
+
+        for (const metricId of Array.from(referencedMetricIds)) {
+            resolveNonAggregateRefs(metricId);
+        }
+
         // Exclude PostCalculation metrics
         return Array.from(referencedMetricIds).filter((metricId) => {
             const metric = this.getMetricFromId(metricId);
@@ -2663,11 +2707,20 @@ export class MetricQueryBuilder {
             };
         }
 
-        // Collect all unique inner dependencies
+        // Collect all unique inner dependencies, excluding deps that are
+        // themselves outer metrics (they'll be computed in CTE 2, not CTE 1).
+        // This handles transitive nesting where an intermediate metric is both
+        // an inner dep of one metric and an outer metric that wraps another.
+        const outerMetricIds = new Set(
+            nestedAggMetrics.map(({ outerMetricId }) => outerMetricId),
+        );
         const allInnerDeps = new Map<string, CompiledMetric>();
         for (const { innerDeps } of nestedAggMetrics) {
             for (const dep of innerDeps) {
-                if (!allInnerDeps.has(dep.fieldId)) {
+                if (
+                    !allInnerDeps.has(dep.fieldId) &&
+                    !outerMetricIds.has(dep.fieldId)
+                ) {
                     allInnerDeps.set(dep.fieldId, dep.metric);
                 }
             }
@@ -2711,16 +2764,92 @@ export class MetricQueryBuilder {
             },
         ];
 
-        const resultsMetricSelects: string[] = [];
+        // Topological sort: metrics that reference other outer metrics must
+        // come after their dependencies. This allows transitive nesting
+        // (e.g. ratio → sum_case → max) to be resolved correctly by inlining
+        // the already-processed SQL of dependencies.
+        const outerMetricRefMap = new Map<string, Set<string>>();
         for (const { outerMetricId, outerMetric } of nestedAggMetrics) {
-            // Replace all metric refs with CTE column refs and re-compile
-            // remaining dimension refs. For wrapping metrics this keeps outer
-            // aggregation (e.g., sum(nested_agg."col")). For non-wrapping
-            // metrics this produces e.g., nested_agg."col1" * nested_agg."col2".
+            const refs = parseAllReferences(outerMetric.sql, outerMetric.table);
+            const outerRefs = new Set<string>();
+            for (const ref of refs) {
+                if (ref.refName !== 'TABLE') {
+                    const refId = getItemId({
+                        table: ref.refTable,
+                        name: ref.refName,
+                    });
+                    if (outerMetricIds.has(refId)) {
+                        outerRefs.add(refId);
+                    }
+                }
+            }
+            outerMetricRefMap.set(outerMetricId, outerRefs);
+        }
+
+        const sortedOuterMetrics: typeof nestedAggMetrics = [];
+        const visited = new Set<string>();
+        const visit = (metricId: string): void => {
+            if (visited.has(metricId)) return;
+            visited.add(metricId);
+            const deps = outerMetricRefMap.get(metricId);
+            if (deps) {
+                for (const depId of deps) {
+                    visit(depId);
+                }
+            }
+            const metric = nestedAggMetrics.find(
+                (m) => m.outerMetricId === metricId,
+            );
+            if (metric) {
+                sortedOuterMetrics.push(metric);
+            }
+        };
+        for (const { outerMetricId } of nestedAggMetrics) {
+            visit(outerMetricId);
+        }
+
+        // Track processed SQL for outer metrics so that metrics referencing
+        // other outer metrics can inline their already-processed expressions.
+        const processedOuterMetricSql = new Map<string, string>();
+
+        const resultsMetricSelects: string[] = [];
+        for (const { outerMetricId, outerMetric } of sortedOuterMetrics) {
+            // Build a metric with ${} refs to other outer metrics pre-replaced
+            // with their already-processed CTE SQL expressions
+            let preSql = outerMetric.sql;
+            for (const [depId, depSql] of processedOuterMetricSql) {
+                const depMetric = this.getMetricFromId(depId);
+                const escapedName = depMetric.name.replace(
+                    /[.*+?^${}()|[\]\\]/g,
+                    '\\$&',
+                );
+                // Replace both short form ${name} and qualified form ${table.name}
+                const escapedTable = depMetric.table.replace(
+                    /[.*+?^${}()|[\]\\]/g,
+                    '\\$&',
+                );
+                preSql = preSql
+                    .replace(
+                        new RegExp(`\\$\\{${escapedName}\\}`, 'g'),
+                        `(${depSql})`,
+                    )
+                    .replace(
+                        new RegExp(
+                            `\\$\\{${escapedTable}\\.${escapedName}\\}`,
+                            'g',
+                        ),
+                        `(${depSql})`,
+                    );
+            }
+
+            // Replace remaining metric refs with CTE column refs
+            const metricWithPreSql = { ...outerMetric, sql: preSql };
             const processedSql = this.replaceMetricReferencesWithCteReferences(
-                outerMetric,
+                metricWithPreSql,
                 metricCteLookup,
             );
+
+            processedOuterMetricSql.set(outerMetricId, processedSql);
             resultsMetricSelects.push(
                 `  ${processedSql} AS ${fieldQuoteChar}${outerMetricId}${fieldQuoteChar}`,
             );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-5947/multiple-nested-aggregation-sql-issue

  Case 1: sum_of_max with dims — sql: sum(${max_value})
  - Recursive resolver: sum_of_max is non-aggregate, refs max_value (type:max). max_value is aggregate → recursion stops. max_value added to set.
  - outerMetricIds = {sum_of_max}. max_value is NOT outer → stays in allInnerDeps. ✅
  - Topo sort: 1 metric, no outer-to-outer refs. Trivial. ✅
  - Inlining: processedOuterMetricSql empty for first metric. No-op. ✅

  Case 2: sum_of_max no dims — Same as case 1 but CROSS JOIN. ✅

  Case 3: avg_of_max — sql: sum(${max_value}) / NULLIF(${count_records}, 0)
  - Both refs are aggregate types. Same flow as case 1 with two inner deps. ✅

  Case 4: count_distinct_of_max — sql: count(distinct ${max_value})
  - Same as case 1. ✅

  Case 5: conditional_sum_of_max — sql: sum(case when ${max_value} > 100 then ${max_value} else 0 end)
  - Same as case 1. ✅

  Case 6: product_of_aggregates — sql: ${max_value} * ${count_records} (no wrapping)
  - Pass 1: no SQL agg → skipped. Pass 2: only runs if wrapping metrics exist. When selected alone, no wrapping metrics → no CTE. ✅

  Case 7: mixed sum_of_max + product_of_aggregates
  - Pass 1 finds sum_of_max. Pass 2 includes product_of_aggregates.
  - outerMetricIds = {sum_of_max, product_of_aggregates}. Their inner deps (max_value, count_records) are NOT outer → stay in allInnerDeps. ✅
  - Topo sort: neither references the other. Order doesn't matter. ✅
  - Inlining: neither references an outer metric. No-op. ✅

  Case 8: raw_agg_with_ref + sum_of_max — sql: sum(${TABLE}.value) / NULLIF(${count_records}, 0)
  - raw_agg_with_ref has SQL agg but does NOT wrap an aggregate ref (wrapping check fails). Only sum_of_max is a wrapping metric.
  - Pass 2 includes raw_agg_with_ref. Both in outerMetricIds. Inner deps (max_value, count_records) are NOT outer → stay in allInnerDeps. ✅

  Case 9: window_sum_of_max — sql: SUM(${max_value}) OVER (PARTITION BY ${TABLE}.category)
  - Same as case 1 but with window function + TABLE ref. ✅

  NEW Case 10: ratio_of_sum_case alone — transitive: ratio → sum_case → max
  - Recursive resolver adds sum_case_of_max and max_value.
  - Pass 1 detects sum_case_of_max (wrapping). Pass 2 adds ratio_of_sum_case.
  - outerMetricIds = {sum_case_of_max, ratio_of_sum_case}. Inner deps: max_value and count_records (not outer → stay). sum_case_of_max excluded from CTE 1.
  - Topo sort: ratio refs sum_case → sum_case first.
  - Inlining: ratio's ${sum_case_of_max} replaced with sum_case's processed SQL. ✅

  NEW Case 11: ratio_of_sum_case + conditional_sum_of_max — mixed transitive + direct
  - Same as case 10 plus conditional_sum_of_max in both passes.
  - Topo sort: conditional has no outer-to-outer refs. sum_case before ratio. conditional can be anywhere. ✅

  All 11 cases are safe. The code is clean and ready.


---

### Description:

Fixes transitive nested aggregate detection in metric queries. Previously, when a type:number metric referenced another type:number metric that wrapped an aggregate (e.g., `ratio_metric → sum_case_metric → max_metric`), the nested aggregate detection would miss the invalid SQL pattern because the outer metric's raw SQL contained no aggregation functions.

The fix includes:

- **Enhanced dependency resolution**: Recursively resolves non-aggregate metric references to ensure all transitive dependencies are included in nested aggregate analysis
- **Topological sorting**: Orders outer metrics so that those referencing other outer metrics are processed after their dependencies  
- **Pre-inlining of outer metric references**: Replaces references between outer metrics with their already-processed SQL expressions before CTE column replacement
- **Improved CTE generation**: Excludes metrics that are themselves outer metrics from the inner dependency CTE to prevent duplicate computation

Added comprehensive test coverage including:
- `sum_case_of_max` and `ratio_of_sum_case` metrics to the demo model reproducing the customer bug
- Mock data structures for transitive nested aggregate scenarios
- Test cases for both isolated transitive nesting and mixed scenarios with other nested metrics

The compiled SQL now correctly uses nested CTEs to break apart transitive aggregation instead of generating invalid nested aggregate expressions like `SUM(CASE WHEN MAX(...))`.