### PR TITLE
chore: fix chart query formatting

### DIFF
--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -81,8 +81,8 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
                 language: getLanguage(project?.warehouseConnection?.type),
             });
         } catch (e) {
-            console.error(
-                'Error rendering SQL:',
+            console.warn(
+                'Error formatting SQL:',
                 e instanceof Error ? e.message : 'Unknown error occurred',
             );
             return selectedSql;


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21153

### Description:
Previously, copying SQL from the SQL card or opening it in the SQL Runner gave you one long unformatted line which was difficult to work with. 

### Changes
The SQL is now automatically formatted in the SQL card before it hits the `open in SQL runner` or `copy` button, using the correct syntax for your warehouse (BigQuery, Postgres, Snowflake, etc.). If formatting ever fails for any reason, it falls back to the raw SQL so nothing breaks but logs an error. 

<img width="1123" height="326" alt="buttons_for_copying_sql" src="https://github.com/user-attachments/assets/5a2fe28f-e670-4cb7-84f5-27e839381966" />

[Loom explainer](https://www.loom.com/share/0b6a8f8aa6c945938a4f2dcd89b89344)
