### PR TITLE
fix: enable pointer events on SQL Runner chart config dropdowns

### DIFF
--- a/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
+++ b/packages/frontend/src/components/DataViz/FieldReferenceSelect.tsx
@@ -19,6 +19,7 @@ export const FieldReferenceSelect: FC<Props> = ({ fieldType, ...props }) => {
                 option: styles.option,
             }}
             rightSectionWidth="min-content"
+            rightSectionPointerEvents="all"
         />
     );
 };


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/20831

## Summary
- Fixes unclickable sorting and aggregation dropdowns in the SQL Runner chart config sidebar
- Mantine v8 `Select` defaults `rightSectionPointerEvents` to `'none'`, which blocked clicks on controls rendered in `rightSection` of `FieldReferenceSelect` - https://mantine.dev/core/select/?t=props
- Adds `rightSectionPointerEvents="all"` to restore interactivity

**Before**

https://github.com/user-attachments/assets/b1fab3e1-de1f-4f11-bd06-0488d8c49abd

**After**

https://github.com/user-attachments/assets/f81bdd9a-ca75-4cb1-a141-25291a5d5d6c

## Test plan
- [ ] Open SQL Runner, run a query, switch to chart view
- [ ] Verify the sorting dropdown on the X-axis is clickable
- [ ] Verify the aggregation dropdown on the Y-axis is clickable