### PR TITLE
fix: add HTML sanitization to RichTextCell to block iframes

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -120,6 +120,7 @@
         "react-use-intercom": "^4.1.0",
         "react-vega": "^8.0.0",
         "rehype-external-links": "^3.0.0",
+        "rehype-sanitize": "^6.0.0",
         "reselect": "5.1.1",
         "rudder-sdk-js": "^2.8.0",
         "scheduler": "^0.23.0",

--- a/packages/frontend/src/components/common/Table/RichTextCell.tsx
+++ b/packages/frontend/src/components/common/Table/RichTextCell.tsx
@@ -3,12 +3,27 @@ import MarkdownPreview from '@uiw/react-markdown-preview';
 import type { Root } from 'hast';
 import React, { type FC } from 'react';
 import rehypeExternalLinks from 'rehype-external-links';
+import rehypeSanitize, { defaultSchema } from 'rehype-sanitize';
 import type { Plugin } from 'unified';
 import styles from './RichTextCell.module.css';
 
 interface RichTextCellProps {
     content: string;
 }
+
+// Custom sanitization schema that blocks iframes and other potentially dangerous elements
+const sanitizeSchema = {
+    ...defaultSchema,
+    tagNames: [
+        ...(defaultSchema.tagNames || []).filter((tag) => tag !== 'iframe'),
+        // Explicitly allow common tags but exclude iframe
+    ],
+    attributes: {
+        ...defaultSchema.attributes,
+        // Remove any iframe-specific attributes
+        iframe: undefined,
+    },
+};
 
 // Custom rehype plugin to trim leading/trailing newlines from text nodes
 // This helps with multi-line HTML in templates while preserving content structure
@@ -56,6 +71,7 @@ const RichTextCell: FC<RichTextCellProps> = ({ content }) => {
                 source={content}
                 rehypePlugins={[
                     rehypeRemoveLineBreaks,
+                    [rehypeSanitize, sanitizeSchema],
                     [rehypeExternalLinks, { target: '_blank' }],
                 ]}
             />

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1129,6 +1129,9 @@ importers:
       rehype-external-links:
         specifier: ^3.0.0
         version: 3.0.0
+      rehype-sanitize:
+        specifier: ^6.0.0
+        version: 6.0.0
       reselect:
         specifier: 5.1.1
         version: 5.1.1
@@ -7450,7 +7453,6 @@ packages:
 
   antlr4ng-cli@1.0.7:
     resolution: {integrity: sha512-qN2FsDBmLvsQcA5CWTrPz8I8gNXeS1fgXBBhI78VyxBSBV/EJgqy8ks6IDTC9jyugpl40csCQ4sL5K4i2YZ/2w==}
-    deprecated: 'This package is deprecated and will no longer be updated. Please use the new antlr-ng package instead: https://github.com/mike-lischke/antlr-ng'
     hasBin: true
 
   antlr4ng@2.0.11:
@@ -10303,6 +10305,9 @@ packages:
 
   hast-util-raw@9.1.0:
     resolution: {integrity: sha512-Y8/SBAHkZGoNkpzqqfCldijcuUKh7/su31kEBp67cFY09Wy0mTRgtsLYsiIxMJxlu0f6AA5SUTbDR8K0rxnbUw==}
+
+  hast-util-sanitize@5.0.2:
+    resolution: {integrity: sha512-3yTWghByc50aGS7JlGhk61SPenfE/p1oaFeNwkOOyrscaOkMGrcW9+Cy/QAIOBpZxP1yqDIzFMR0+Np0i0+usg==}
 
   hast-util-select@6.0.3:
     resolution: {integrity: sha512-OVRQlQ1XuuLP8aFVLYmC2atrfWHS5UD3shonxpnyrjcCkwtvmt/+N6kYJdcY4mkMJhxp4kj2EFIxQ9kvkkt/eQ==}
@@ -13759,6 +13764,9 @@ packages:
   rehype-rewrite@4.0.2:
     resolution: {integrity: sha512-rjLJ3z6fIV11phwCqHp/KRo8xuUCO8o9bFJCNw5o6O2wlLk6g8r323aRswdGBQwfXPFYeSuZdAjp4tzo6RGqEg==}
     engines: {node: '>=16.0.0'}
+
+  rehype-sanitize@6.0.0:
+    resolution: {integrity: sha512-CsnhKNsyI8Tub6L4sm5ZFsme4puGfc6pYylvXo1AeqaGbjOYyzNv3qZPwvs0oMJ39eryyeOdmxwUIo94IpEhqg==}
 
   rehype-slug@6.0.0:
     resolution: {integrity: sha512-lWyvf/jwu+oS5+hL5eClVd3hNdmwM1kAC0BUvEGD19pajQMIzcNUd/k9GsfQ+FfECvX+JE+e9/btsKH0EjJT6A==}
@@ -27532,6 +27540,12 @@ snapshots:
       web-namespaces: 2.0.1
       zwitch: 2.0.4
 
+  hast-util-sanitize@5.0.2:
+    dependencies:
+      '@types/hast': 3.0.4
+      '@ungap/structured-clone': 1.2.1
+      unist-util-position: 5.0.0
+
   hast-util-select@6.0.3:
     dependencies:
       '@types/hast': 3.0.4
@@ -31793,6 +31807,11 @@ snapshots:
       hast-util-select: 6.0.3
       unified: 11.0.5
       unist-util-visit: 5.0.0
+
+  rehype-sanitize@6.0.0:
+    dependencies:
+      '@types/hast': 3.0.4
+      hast-util-sanitize: 5.0.2
 
   rehype-slug@6.0.0:
     dependencies:


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Added HTML sanitization to the RichTextCell component to prevent potentially dangerous content from being rendered. This change introduces the `rehype-sanitize` plugin with a custom schema that specifically blocks iframe elements and other potentially harmful HTML tags while preserving safe formatting elements.

The sanitization is applied during markdown processing and uses a custom configuration that extends the default schema but explicitly removes iframe support to enhance security when displaying user-generated content in table cells.