### PR TITLE
fix: apply parameter defaults in compileQuery endpoint

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3068,6 +3068,13 @@ export class ProjectService extends BaseService {
             explore,
         );
 
+        // Combine default parameter values with request parameters
+        const combinedParameters = await this.combineParameters(
+            projectUuid,
+            explore,
+            parameters,
+        );
+
         const timezone = await this.getQueryTimezoneForProject(projectUuid);
 
         const compiledQuery = await ProjectService._compileQuery({
@@ -3077,7 +3084,7 @@ export class ProjectService extends BaseService {
             intrinsicUserAttributes,
             userAttributes,
             timezone,
-            parameters,
+            parameters: combinedParameters,
             availableParameterDefinitions,
             pivotConfiguration,
             pivotDimensions,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21050

## Summary

- The `compileQuery` endpoint was not applying default parameter values, causing compiled SQL to show unreplaced parameter placeholders when users hadn't explicitly set a value
- All other query execution paths (`AsyncQueryService`, field values, totals, subtotals) already called `combineParameters()` to merge defaults — this was the only path missing it

### Fix

Added a `combineParameters()` call before `_compileQuery()`, matching the pattern used by every other call site.

**Before**
<img width="1227" height="950" alt="CleanShot 2026-03-16 at 14 54 42" src="https://github.com/user-attachments/assets/9205dba6-7d92-445b-8b88-9e1ee9b73176" />

**After**
<img width="1238" height="571" alt="CleanShot 2026-03-16 at 14 54 06" src="https://github.com/user-attachments/assets/1feb26e7-0b2a-474c-8aa8-61929b9a5031" />

**Note:** Regarding the default parameter not allowing to input, this should be a non-issue since for a user to be able to input a value in a parameter, then the parameter needs to have `allow_custom_values` set - https://docs.lightdash.com/references/tables#parameters-configuration

If the user doesn't specify options and leaves `allow_custom_values` as false then it should fail compilation with:
<img width="388" height="164" alt="CleanShot 2026-03-16 at 15 02 14" src="https://github.com/user-attachments/assets/d150272b-6be3-4637-84c4-1aafa65b1420" />
<img width="818" height="112" alt="CleanShot 2026-03-16 at 15 02 32" src="https://github.com/user-attachments/assets/9004986f-debf-453b-9fed-897f90b28aa9" />

With `allow_custom_values` set to true, a user can add a set a value for the parameter:
<img width="1243" height="176" alt="CleanShot 2026-03-16 at 15 05 44" src="https://github.com/user-attachments/assets/d92545a9-82a6-4a87-b2b4-2572c262a08d" />



