### PR TITLE
chore: add platform linux/amd64 to jaffle shop example

### DIFF
--- a/examples/full-jaffle-shop-demo/docker-compose.yml
+++ b/examples/full-jaffle-shop-demo/docker-compose.yml
@@ -1,5 +1,6 @@
 services:
     lightdash:
+        platform: linux/amd64
         build:
             context: .
             dockerfile: dockerfile


### PR DESCRIPTION
### Description:
On Apple Silicon, `docker compose up` on the full-jaffle-shop-demo fails with:

> failed to solve: lightdash/lightdash:latest: failed to resolve source metadata for docker.io/lightdash/lightdash:latest: no match for platform in manifest: not found
  
Adding platform: linux/amd64 tells Docker Desktop to pull the amd64 image and run it under emulation (Rosetta/QEMU).

