### PR TITLE
fix: fetch projects when default project is not found

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -113,7 +113,8 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
         isLastProjectUuidFetched &&
         !lastProject &&
         !isLoadingOrg &&
-        !organization?.defaultProjectUuid;
+        (!organization?.defaultProjectUuid ||
+            (!isLoadingDefaultProject && !defaultProject));
 
     const { data: projects, isInitialLoading: isLoadingProjects } = useProjects(
         {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
Fix project creation logic by adding additional condition to check if default project is loaded. The condition now ensures that a new project is created when there's no default project UUID or when the default project has finished loading but doesn't exist.

<!-- Even better add a screenshot / gif / loom -->