### PR TITLE
fix: resolve custom granularity dimensions in date zoom

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -66,6 +66,7 @@ import {
     ForbiddenError,
     formatRawRows,
     formatRows,
+    getAllDimensionsMap,
     getAvailableParametersFromTables,
     getDashboardFilterRulesForTables,
     getDimensions,
@@ -130,6 +131,7 @@ import {
     replaceDimensionInExplore,
     RequestMethod,
     resolveBaseDimension,
+    resolveToBaseTimeDimension,
     ResultRow,
     SavedChartDAO,
     SavedChartsInfoForDashboardAvailableFilters,
@@ -2837,24 +2839,27 @@ export class ProjectService extends BaseService {
         dateZoom?: DateZoom,
     ): { explore: Explore; dateZoomApplied: boolean } {
         if (dateZoom?.granularity) {
+            const allDimensionsMap = getAllDimensionsMap(explore);
             const timeDimensionsMap = getTimeDimensionsMap(explore);
 
             let timeOrDateDimension = dateZoom?.xAxisFieldId;
 
             if (!timeOrDateDimension) {
-                const firstTimeDimensionIdInMetricQuery =
-                    metricQuery.dimensions.find(
-                        (dimension) => !!timeDimensionsMap[dimension],
-                    );
-
-                timeOrDateDimension = firstTimeDimensionIdInMetricQuery;
+                timeOrDateDimension = metricQuery.dimensions.find(
+                    (dimension) =>
+                        !!resolveToBaseTimeDimension(
+                            dimension,
+                            allDimensionsMap,
+                            timeDimensionsMap,
+                        ),
+                );
             }
 
             if (timeOrDateDimension) {
-                const dimToOverride = timeDimensionsMap[timeOrDateDimension];
-                const baseTimeDimension = resolveBaseDimension(
+                const dimToOverride = allDimensionsMap[timeOrDateDimension];
+                const baseTimeDimension = resolveToBaseTimeDimension(
                     timeOrDateDimension,
-                    dimToOverride,
+                    allDimensionsMap,
                     timeDimensionsMap,
                 );
 

--- a/packages/common/src/utils/dateZoom.test.ts
+++ b/packages/common/src/utils/dateZoom.test.ts
@@ -489,6 +489,125 @@ describe('getDateZoomCapabilities', () => {
         expect(result.hasTimestampDimension).toBe(false);
     });
 
+    it('collects custom granularities when the metric query uses a STRING-typed custom granularity dimension', () => {
+        const baseDim = makeDimension({
+            name: 'order_date',
+            table: 'orders',
+            type: DimensionType.DATE,
+            isIntervalBase: true,
+        });
+        const customFiscalQuarter = makeDimension({
+            name: 'order_date_fiscal_quarter',
+            table: 'orders',
+            type: DimensionType.STRING,
+            customTimeInterval: 'fiscal_quarter',
+            timeIntervalBaseDimensionName: 'order_date',
+            label: 'Fiscal Quarter',
+        });
+        const customFiscalYear = makeDimension({
+            name: 'order_date_fiscal_year',
+            table: 'orders',
+            type: DimensionType.STRING,
+            customTimeInterval: 'fiscal_year',
+            timeIntervalBaseDimensionName: 'order_date',
+            label: 'Fiscal Year',
+        });
+        const explore = makeExplore([
+            baseDim,
+            customFiscalQuarter,
+            customFiscalYear,
+        ]);
+        // The chart already uses fiscal_quarter — should still discover all custom granularities
+        const metricQuery = makeMetricQuery([
+            'orders_order_date_fiscal_quarter',
+        ]);
+
+        const result = getDateZoomCapabilities(explore, metricQuery);
+
+        expect(result.hasDateDimension).toBe(true);
+        expect(result.availableCustomGranularities).toEqual({
+            fiscal_quarter: 'Fiscal Quarter',
+            fiscal_year: 'Fiscal Year',
+        });
+    });
+
+    it('collects custom granularities when the metric query uses a DATE-typed custom granularity dimension', () => {
+        const baseDim = makeDimension({
+            name: 'order_date',
+            table: 'orders',
+            type: DimensionType.DATE,
+            isIntervalBase: true,
+        });
+        const customBiweekly = makeDimension({
+            name: 'order_date_biweekly',
+            table: 'orders',
+            type: DimensionType.DATE,
+            customTimeInterval: 'biweekly',
+            timeIntervalBaseDimensionName: 'order_date',
+            label: 'Bi-weekly',
+        });
+        const customFiscalQuarter = makeDimension({
+            name: 'order_date_fiscal_quarter',
+            table: 'orders',
+            type: DimensionType.STRING,
+            customTimeInterval: 'fiscal_quarter',
+            timeIntervalBaseDimensionName: 'order_date',
+            label: 'Fiscal Quarter',
+        });
+        const explore = makeExplore([
+            baseDim,
+            customBiweekly,
+            customFiscalQuarter,
+        ]);
+        // The chart uses a DATE-typed custom granularity
+        const metricQuery = makeMetricQuery(['orders_order_date_biweekly']);
+
+        const result = getDateZoomCapabilities(explore, metricQuery);
+
+        expect(result.hasDateDimension).toBe(true);
+        expect(result.availableCustomGranularities).toEqual({
+            biweekly: 'Bi-weekly',
+            fiscal_quarter: 'Fiscal Quarter',
+        });
+    });
+
+    it('resolves STRING-typed standard time-interval dimension (e.g. QUARTER_NAME) to its base', () => {
+        const baseDim = makeDimension({
+            name: 'order_date',
+            table: 'orders',
+            type: DimensionType.DATE,
+            isIntervalBase: true,
+        });
+        const quarterNameDim = makeDimension({
+            name: 'order_date_quarter_name',
+            table: 'orders',
+            type: DimensionType.STRING,
+            timeInterval: 'QUARTER_NAME' as CompiledDimension['timeInterval'],
+            timeIntervalBaseDimensionName: 'order_date',
+        });
+        const customFiscalQuarter = makeDimension({
+            name: 'order_date_fiscal_quarter',
+            table: 'orders',
+            type: DimensionType.STRING,
+            customTimeInterval: 'fiscal_quarter',
+            timeIntervalBaseDimensionName: 'order_date',
+            label: 'Fiscal Quarter',
+        });
+        const explore = makeExplore([
+            baseDim,
+            quarterNameDim,
+            customFiscalQuarter,
+        ]);
+        const metricQuery = makeMetricQuery(['orders_order_date_quarter_name']);
+
+        const result = getDateZoomCapabilities(explore, metricQuery);
+
+        expect(result.hasDateDimension).toBe(true);
+        expect(result.availableCustomGranularities).toEqual({
+            fiscal_quarter: 'Fiscal Quarter',
+        });
+    });
+
     it('does not include custom granularities from unrelated base dimensions', () => {
         const orderDate = makeDimension({
             name: 'order_date',

--- a/packages/common/src/utils/dateZoom.ts
+++ b/packages/common/src/utils/dateZoom.ts
@@ -50,6 +50,54 @@ export type DateZoomCapabilities = {
     hasDateDimension: boolean;
 };
 
+/**
+ * Collects all dimensions from an explore, keyed by item ID.
+ */
+export const getAllDimensionsMap = (
+    explore: Explore,
+): Record<string, CompiledDimension> => {
+    const map: Record<string, CompiledDimension> = {};
+    for (const table of Object.values(explore.tables)) {
+        for (const dim of Object.values(table.dimensions)) {
+            map[getItemId(dim)] = dim;
+        }
+    }
+    return map;
+};
+
+/**
+ * Resolves any dimension from the metric query to its base time dimension.
+ * Handles three cases:
+ * - Standard time-interval dims (e.g. order_date_month) → resolves via getDateDimension
+ * - Custom granularity dims (e.g. order_date_fiscal_quarter) → resolves via timeIntervalBaseDimensionName
+ * - Plain date/timestamp dims → returns the dimension itself
+ */
+export const resolveToBaseTimeDimension = (
+    dimId: string,
+    allDimensionsMap: Record<string, CompiledDimension>,
+    timeDimensionsMap: Record<string, CompiledDimension>,
+): CompiledDimension | undefined => {
+    const dim = allDimensionsMap[dimId];
+    if (!dim) return undefined;
+
+    // Custom granularity or non-date time-interval dimension (e.g. QUARTER_NAME
+    // is STRING-typed) — resolve via timeIntervalBaseDimensionName
+    if (dim.timeIntervalBaseDimensionName) {
+        return timeDimensionsMap[
+            getItemId({
+                table: dim.table,
+                name: dim.timeIntervalBaseDimensionName,
+            })
+        ];
+    }
+
+    // Only process DATE/TIMESTAMP dimensions from here
+    const timeDim = timeDimensionsMap[dimId];
+    if (!timeDim) return undefined;
+
+    return resolveBaseDimension(dimId, timeDim, timeDimensionsMap);
+};
+
 export const getDateZoomCapabilities = (
     explore: Explore,
     metricQuery: MetricQuery,
@@ -58,19 +106,19 @@ export const getDateZoomCapabilities = (
         Object.values(t.dimensions),
     );
 
+    const allDimensionsMap = getAllDimensionsMap(explore);
     const timeDimensionsMap = getTimeDimensionsMap(explore);
-
-    const dateDimensions = metricQuery.dimensions.filter(
-        (d) => !!timeDimensionsMap[d],
-    );
 
     let hasTimestampDimension = false;
     let hasDateDimension = false;
     const availableCustomGranularities: Record<string, string> = {};
 
-    for (const dimId of dateDimensions) {
-        const dim = timeDimensionsMap[dimId];
-        const baseDim = resolveBaseDimension(dimId, dim, timeDimensionsMap);
+    for (const dimId of metricQuery.dimensions) {
+        const baseDim = resolveToBaseTimeDimension(
+            dimId,
+            allDimensionsMap,
+            timeDimensionsMap,
+        );
 
         if (baseDim) {
             if (baseDim.type === DimensionType.TIMESTAMP) {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Fixes an issue where if a chart was using a custom granularity as it X axis field, the date zoom select wouldn't populate with the available custom dimensions
