### PR TITLE
fix: path to delete in the service was passing slug and adds tests

### DIFF
--- a/packages/api-tests/tests/v2/dashboards.test.ts
+++ b/packages/api-tests/tests/v2/dashboards.test.ts
@@ -1,0 +1,249 @@
+import {
+    CreateDashboard,
+    Dashboard,
+    SEED_PROJECT,
+    UpdateDashboard,
+} from '@lightdash/common';
+import { ApiClient } from '../../helpers/api-client';
+import { login } from '../../helpers/auth';
+import { dashboardMock } from '../../helpers/mocks';
+import { TestResourceTracker, uniqueName } from '../../helpers/test-isolation';
+
+const v1 = '/api/v1';
+const v2 = '/api/v2';
+
+async function createDashboardV1(
+    client: ApiClient,
+    projectUuid: string,
+    body: CreateDashboard,
+): Promise<Dashboard> {
+    const resp = await client.post<{ results: Dashboard }>(
+        `${v1}/projects/${projectUuid}/dashboards`,
+        body,
+    );
+    expect(resp.status).toBe(201);
+    return resp.body.results;
+}
+
+describe('V2 Project Dashboard endpoints', () => {
+    let admin: ApiClient;
+    const tracker = new TestResourceTracker();
+    const projectUuid = SEED_PROJECT.project_uuid;
+
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    afterAll(async () => {
+        await tracker.cleanup(admin);
+    });
+
+    describe('GET /api/v2/projects/:projectUuid/dashboards/:dashboardUuidOrSlug', () => {
+        it('should get a dashboard by UUID', async () => {
+            const created = await createDashboardV1(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('V2 get by uuid'),
+            });
+            tracker.trackDashboard(created.uuid);
+
+            const resp = await admin.get<{
+                status: string;
+                results: Dashboard;
+            }>(`${v2}/projects/${projectUuid}/dashboards/${created.uuid}`);
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.status).toBe('ok');
+            expect(resp.body.results.uuid).toBe(created.uuid);
+            expect(resp.body.results.name).toBe(created.name);
+            expect(resp.body.results.projectUuid).toBe(projectUuid);
+        });
+
+        it('should get a dashboard by slug', async () => {
+            const created = await createDashboardV1(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('V2 get by slug'),
+            });
+            tracker.trackDashboard(created.uuid);
+
+            const resp = await admin.get<{
+                status: string;
+                results: Dashboard;
+            }>(`${v2}/projects/${projectUuid}/dashboards/${created.slug}`);
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.results.uuid).toBe(created.uuid);
+            expect(resp.body.results.slug).toBe(created.slug);
+        });
+
+        it('should get the seed jaffle-dashboard by slug', async () => {
+            const resp = await admin.get<{
+                status: string;
+                results: Dashboard;
+            }>(`${v2}/projects/${projectUuid}/dashboards/jaffle-dashboard`);
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.results.name).toBe('Jaffle dashboard');
+            expect(resp.body.results.slug).toBe('jaffle-dashboard');
+        });
+
+        it('should return 404 for a non-existent dashboard', async () => {
+            const resp = await admin.get(
+                `${v2}/projects/${projectUuid}/dashboards/non-existent-uuid`,
+                { failOnStatusCode: false },
+            );
+
+            expect(resp.ok).toBe(false);
+        });
+    });
+
+    describe('PATCH /api/v2/projects/:projectUuid/dashboards/:dashboardUuidOrSlug', () => {
+        it('should update a dashboard name and description', async () => {
+            const created = await createDashboardV1(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('V2 update test'),
+            });
+            tracker.trackDashboard(created.uuid);
+
+            const updatedName = uniqueName('V2 updated name');
+            const update: UpdateDashboard = {
+                name: updatedName,
+                description: 'Updated via V2 API',
+            };
+
+            const resp = await admin.patch<{
+                status: string;
+                results: Dashboard;
+            }>(
+                `${v2}/projects/${projectUuid}/dashboards/${created.uuid}`,
+                update,
+            );
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.status).toBe('ok');
+            expect(resp.body.results.name).toBe(updatedName);
+            expect(resp.body.results.description).toBe('Updated via V2 API');
+        });
+
+        it('should update a dashboard by slug', async () => {
+            const created = await createDashboardV1(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('V2 update by slug'),
+            });
+            tracker.trackDashboard(created.uuid);
+
+            const updatedName = uniqueName('V2 slug updated');
+            const update: UpdateDashboard = {
+                name: updatedName,
+                description: 'Updated by slug via V2',
+            };
+
+            const resp = await admin.patch<{
+                status: string;
+                results: Dashboard;
+            }>(
+                `${v2}/projects/${projectUuid}/dashboards/${created.slug}`,
+                update,
+            );
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.results.description).toBe(
+                'Updated by slug via V2',
+            );
+            expect(resp.body.results.uuid).toBe(created.uuid);
+        });
+    });
+
+    describe('DELETE /api/v2/projects/:projectUuid/dashboards/:dashboardUuidOrSlug', () => {
+        it('should delete a dashboard by UUID', async () => {
+            const created = await createDashboardV1(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('V2 delete test'),
+            });
+
+            const resp = await admin.delete<{
+                status: string;
+                results: undefined;
+            }>(`${v2}/projects/${projectUuid}/dashboards/${created.uuid}`);
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.status).toBe('ok');
+
+            // Verify it's deleted
+            const getResp = await admin.get(
+                `${v2}/projects/${projectUuid}/dashboards/${created.uuid}`,
+                { failOnStatusCode: false },
+            );
+            expect(getResp.ok).toBe(false);
+        });
+
+        it('should delete a dashboard by slug', async () => {
+            const created = await createDashboardV1(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('V2 delete by slug'),
+            });
+
+            const resp = await admin.delete<{
+                status: string;
+                results: undefined;
+            }>(`${v2}/projects/${projectUuid}/dashboards/${created.slug}`);
+
+            expect(resp.status).toBe(200);
+
+            // Verify it's deleted
+            const getResp = await admin.get(
+                `${v2}/projects/${projectUuid}/dashboards/${created.uuid}`,
+                { failOnStatusCode: false },
+            );
+            expect(getResp.ok).toBe(false);
+        });
+    });
+
+    describe('GET /api/v2/projects/:projectUuid/dashboards/:dashboardUuidOrSlug/comments', () => {
+        it('should get comments for a dashboard (empty by default)', async () => {
+            const created = await createDashboardV1(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('V2 comments test'),
+            });
+            tracker.trackDashboard(created.uuid);
+
+            const resp = await admin.get<{
+                status: string;
+                results: Record<string, unknown[]>;
+            }>(
+                `${v2}/projects/${projectUuid}/dashboards/${created.uuid}/comments`,
+            );
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.status).toBe('ok');
+            expect(typeof resp.body.results).toBe('object');
+        });
+    });
+
+    describe('V1 and V2 parity', () => {
+        it('should return the same dashboard data from V1 and V2', async () => {
+            const created = await createDashboardV1(admin, projectUuid, {
+                ...dashboardMock,
+                name: uniqueName('V2 parity test'),
+            });
+            tracker.trackDashboard(created.uuid);
+
+            const v1Resp = await admin.get<{ results: Dashboard }>(
+                `${v1}/dashboards/${created.uuid}`,
+            );
+            const v2Resp = await admin.get<{ results: Dashboard }>(
+                `${v2}/projects/${projectUuid}/dashboards/${created.uuid}`,
+            );
+
+            expect(v1Resp.status).toBe(200);
+            expect(v2Resp.status).toBe(200);
+            expect(v1Resp.body.results.uuid).toBe(v2Resp.body.results.uuid);
+            expect(v1Resp.body.results.name).toBe(v2Resp.body.results.name);
+            expect(v1Resp.body.results.tiles).toEqual(
+                v2Resp.body.results.tiles,
+            );
+            expect(v1Resp.body.results.filters).toEqual(
+                v2Resp.body.results.filters,
+            );
+        });
+    });
+});

--- a/packages/api-tests/tests/v2/savedCharts.test.ts
+++ b/packages/api-tests/tests/v2/savedCharts.test.ts
@@ -1,0 +1,170 @@
+import {
+    CreateChartInSpace,
+    SavedChart,
+    SEED_PROJECT,
+} from '@lightdash/common';
+import { ApiClient } from '../../helpers/api-client';
+import { login } from '../../helpers/auth';
+import { chartMock } from '../../helpers/mocks';
+import { TestResourceTracker, uniqueName } from '../../helpers/test-isolation';
+
+const v1 = '/api/v1';
+const v2 = '/api/v2';
+
+async function createChartV1(
+    client: ApiClient,
+    projectUuid: string,
+    name: string,
+): Promise<SavedChart> {
+    const body: CreateChartInSpace = {
+        ...chartMock,
+        name,
+        spaceUuid: undefined,
+        dashboardUuid: null,
+    };
+    const resp = await client.post<{ results: SavedChart }>(
+        `${v1}/projects/${projectUuid}/saved`,
+        body,
+    );
+    expect(resp.status).toBe(200);
+    return resp.body.results;
+}
+
+describe('V2 Project Saved Chart endpoints', () => {
+    let admin: ApiClient;
+    const tracker = new TestResourceTracker();
+    const projectUuid = SEED_PROJECT.project_uuid;
+
+    beforeAll(async () => {
+        admin = await login();
+    });
+
+    afterAll(async () => {
+        await tracker.cleanup(admin);
+    });
+
+    describe('GET /api/v2/projects/:projectUuid/saved/:chartUuidOrSlug', () => {
+        it('should get a chart by UUID', async () => {
+            const created = await createChartV1(
+                admin,
+                projectUuid,
+                uniqueName('V2 get chart by uuid'),
+            );
+            tracker.trackChart(created.uuid);
+
+            const resp = await admin.get<{
+                status: string;
+                results: SavedChart;
+            }>(`${v2}/projects/${projectUuid}/saved/${created.uuid}`);
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.status).toBe('ok');
+            expect(resp.body.results.uuid).toBe(created.uuid);
+            expect(resp.body.results.name).toBe(created.name);
+            expect(resp.body.results.projectUuid).toBe(projectUuid);
+        });
+
+        it('should get a chart by slug', async () => {
+            const created = await createChartV1(
+                admin,
+                projectUuid,
+                uniqueName('V2 get chart by slug'),
+            );
+            tracker.trackChart(created.uuid);
+
+            const resp = await admin.get<{
+                status: string;
+                results: SavedChart;
+            }>(`${v2}/projects/${projectUuid}/saved/${created.slug}`);
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.results.uuid).toBe(created.uuid);
+            expect(resp.body.results.slug).toBe(created.slug);
+        });
+
+        it('should return 404 for a non-existent chart', async () => {
+            const resp = await admin.get(
+                `${v2}/projects/${projectUuid}/saved/non-existent-uuid`,
+                { failOnStatusCode: false },
+            );
+
+            expect(resp.ok).toBe(false);
+        });
+    });
+
+    describe('DELETE /api/v2/projects/:projectUuid/saved/:chartUuidOrSlug', () => {
+        it('should delete a chart by UUID', async () => {
+            const created = await createChartV1(
+                admin,
+                projectUuid,
+                uniqueName('V2 delete chart'),
+            );
+
+            const resp = await admin.delete<{
+                status: string;
+                results: undefined;
+            }>(`${v2}/projects/${projectUuid}/saved/${created.uuid}`);
+
+            expect(resp.status).toBe(200);
+            expect(resp.body.status).toBe('ok');
+
+            // Verify it's deleted
+            const getResp = await admin.get(
+                `${v2}/projects/${projectUuid}/saved/${created.uuid}`,
+                { failOnStatusCode: false },
+            );
+            expect(getResp.ok).toBe(false);
+        });
+
+        it('should delete a chart by slug', async () => {
+            const created = await createChartV1(
+                admin,
+                projectUuid,
+                uniqueName('V2 delete chart by slug'),
+            );
+
+            const resp = await admin.delete<{
+                status: string;
+                results: undefined;
+            }>(`${v2}/projects/${projectUuid}/saved/${created.slug}`);
+
+            expect(resp.status).toBe(200);
+
+            // Verify it's deleted
+            const getResp = await admin.get(
+                `${v2}/projects/${projectUuid}/saved/${created.uuid}`,
+                { failOnStatusCode: false },
+            );
+            expect(getResp.ok).toBe(false);
+        });
+    });
+
+    describe('V1 and V2 parity', () => {
+        it('should return the same chart data from V1 and V2', async () => {
+            const created = await createChartV1(
+                admin,
+                projectUuid,
+                uniqueName('V2 chart parity'),
+            );
+            tracker.trackChart(created.uuid);
+
+            const v1Resp = await admin.get<{ results: SavedChart }>(
+                `${v1}/saved/${created.uuid}`,
+            );
+            const v2Resp = await admin.get<{ results: SavedChart }>(
+                `${v2}/projects/${projectUuid}/saved/${created.uuid}`,
+            );
+
+            expect(v1Resp.status).toBe(200);
+            expect(v2Resp.status).toBe(200);
+            expect(v1Resp.body.results.uuid).toBe(v2Resp.body.results.uuid);
+            expect(v1Resp.body.results.name).toBe(v2Resp.body.results.name);
+            expect(v1Resp.body.results.metricQuery).toEqual(
+                v2Resp.body.results.metricQuery,
+            );
+            expect(v1Resp.body.results.chartConfig).toEqual(
+                v2Resp.body.results.chartConfig,
+            );
+        });
+    });
+});

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -1047,12 +1047,13 @@ export class DashboardService
             }
         }
 
+        const resolvedUuid = dashboardToDelete.uuid;
         if (this.lightdashConfig.softDelete.enabled) {
-            await this.softDelete(user, dashboardUuid, {
+            await this.softDelete(user, resolvedUuid, {
                 bypassPermissions: true, // perms checked above
             });
         } else {
-            await this.permanentDelete(user, dashboardUuid, {
+            await this.permanentDelete(user, resolvedUuid, {
                 bypassPermissions: true, // perms checked above
             });
         }

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -713,6 +713,7 @@ export class SavedChartService
         options?: SoftDeleteOptions & { projectUuid?: string },
     ): Promise<void> {
         const {
+            uuid: resolvedUuid,
             organizationUuid,
             projectUuid,
             spaceUuid,
@@ -744,11 +745,11 @@ export class SavedChartService
         }
 
         if (this.lightdashConfig.softDelete.enabled) {
-            await this.softDelete(user, savedChartUuid, {
+            await this.softDelete(user, resolvedUuid, {
                 bypassPermissions: true, // perms checked above
             });
         } else {
-            await this.permanentDelete(user, savedChartUuid, {
+            await this.permanentDelete(user, resolvedUuid, {
                 bypassPermissions: true, // perms checked above
             });
         }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: #21086

### Description:
`packages/backend/src/services/DashboardService/DashboardService.ts` and `packages/backend/src/services/SavedChartsService/SavedChartService.ts` were passing in the slug to the delete. This PR fixes this by passing in the resolved UUID.

Also adds tests for the new endpoints
