### PR TITLE
feat: add isNonAggregateMetricType helper and display metric type/SQL in CustomMetricModal

### DIFF
--- a/packages/common/src/types/field.ts
+++ b/packages/common/src/types/field.ts
@@ -858,6 +858,9 @@ export const AggregateMetricTypes = [
 export const isAggregateMetricType = (type: MetricType): boolean =>
     (AggregateMetricTypes as readonly MetricType[]).includes(type);
 
+export const isNonAggregateMetricType = (type: MetricType): boolean =>
+    NonAggregateMetricTypes.includes(type);
+
 export const isPostCalculationMetricType = (type: MetricType): boolean =>
     PostCalculationMetricTypes.includes(type);
 

--- a/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
+++ b/packages/frontend/src/components/Explorer/CustomMetricModal/index.tsx
@@ -8,6 +8,7 @@ import {
     isAdditionalMetric,
     isCustomDimension,
     isDimension,
+    isNonAggregateMetricType,
     MetricType,
     NumberSeparator,
     type AdditionalMetric,
@@ -327,6 +328,25 @@ export const CustomMetricModal = memo(() => {
                         placeholder="Enter custom metric label"
                         {...form.getInputProps('customMetricLabel')}
                     />
+                    {customMetricType && (
+                        <TextInput
+                            label="Type"
+                            value={friendlyName(customMetricType)}
+                            readOnly
+                            description="Metric type"
+                        />
+                    )}
+                    {isEditing &&
+                        isAdditionalMetric(item) &&
+                        item.sql &&
+                        isNonAggregateMetricType(item.type) && (
+                            <TextInput
+                                label="SQL"
+                                value={item.sql}
+                                readOnly
+                                description="SQL"
+                            />
+                        )}
                     {customMetricType === MetricType.PERCENTILE && (
                         <NumberInput
                             w={100}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-5952<!-- reference the related issue e.g. #150 -->

### Description:

Added a new utility function `isNonAggregateMetricType` to check if a metric type is non-aggregate. Enhanced the Custom Metric Modal to display additional read-only fields when editing metrics:

- Added a "Type" field that shows the friendly name of the metric type
- Added a "SQL" field that displays the SQL query for non-aggregate metrics when editing existing additional metrics

These fields provide better visibility into metric properties during the editing process.

<!-- Even better add a screenshot / gif / loom -->