### PR TITLE
fix: show export limit options in embedded view underlying data

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
@@ -362,6 +362,7 @@ const UnderlyingDataModalContent: FC = () => {
                                 showTableNames
                                 totalResults={resultsData?.rows.length}
                                 getDownloadQueryUuid={getDownloadQueryUuid}
+                                forceShowLimitSelection
                             />
                         )}
                     </Popover.Dropdown>


### PR DESCRIPTION
### Description:

Display limit configuration when exporting underlying data form embedding, following the work of displaying limits for exporting csv done in https://github.com/lightdash/lightdash/pull/20128

---

note: I think we should revisit the permission checks for csv export limits. The limit dropdown is gated by `manage:ChangeCsvResults` which is a separated permission from the export itself. The current `forceShowLimitSelection` is a workaround used by dashboard tiles. If this is the case, then I think we should make it consistent and use the export permission should also allow limit configuration