### PR TITLE
fix: conditional for showing Slack Agent settings

### DIFF
--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -31,6 +31,7 @@ import {
 import { useEffect, type FC } from 'react';
 import { Link } from 'react-router';
 import { z } from 'zod';
+import { useAiOrganizationSettings } from '../../../ee/features/aiCopilot/hooks/useAiOrganizationSettings';
 import {
     useDeleteSlack,
     useGetSlack,
@@ -72,6 +73,7 @@ const formSchema = z.object({
 
 const SlackSettingsPanel: FC = () => {
     const { activeProjectUuid } = useActiveProjectUuid();
+    const aiOrganizationSettingsQuery = useAiOrganizationSettings();
     const { data: aiCopilotFlag } = useServerFeatureFlag(
         CommercialFeatureFlags.AiCopilot,
     );
@@ -80,6 +82,10 @@ const SlackSettingsPanel: FC = () => {
     );
     const { data: slackInstallation, isInitialLoading } = useGetSlack();
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
+    const isAiCopilotEnabledOrTrial =
+        !!aiCopilotFlag?.enabled ||
+        !!aiOrganizationSettingsQuery.data?.isCopilotEnabled ||
+        !!aiOrganizationSettingsQuery.data?.isTrial;
 
     const isSlackMultiAgentChannelEnabled = !!multiAgentChannelFlag?.enabled;
 
@@ -235,7 +241,7 @@ const SlackSettingsPanel: FC = () => {
                                     }
                                 />
                             </Group>
-                            {aiCopilotFlag?.enabled && (
+                            {isAiCopilotEnabledOrTrial && (
                                 <Stack gap="sm">
                                     <Group gap="two">
                                         <Title order={6} fw={500}>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:
Updates the AI Copilot visibility logic in the Slack settings panel to show AI-related features when the organization has AI Copilot enabled, is in trial mode, or has the feature flag enabled. Previously, the AI Copilot section was only visible when the server feature flag was enabled.

The change introduces a new `isAiCopilotEnabledOrTrial` condition that checks three states:
- Server feature flag enabled
- Organization has AI Copilot enabled 
- Organization is in trial mode
