### PR TITLE
feat: add detailed Prometheus metrics for materialization and DuckDB profiling

### DIFF
--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -92,6 +92,27 @@ export default class PrometheusMetrics {
     public preAggregateParquetConversionDurationHistogram: prometheus.Histogram<string> | null =
         null;
 
+    // Materialization sub-step metrics
+    private materializationPollDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
+    private materializationWarehouseDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
+    private materializationPromoteDurationHistogram: prometheus.Histogram<string> | null =
+        null;
+
+    // DuckDB query profiling metrics
+    private duckdbQueryLatencyHistogram: prometheus.Histogram | null = null;
+
+    private duckdbParquetReadDurationHistogram: prometheus.Histogram | null =
+        null;
+
+    private duckdbBytesReadHistogram: prometheus.Histogram | null = null;
+
+    private duckdbScanAmplificationHistogram: prometheus.Histogram | null =
+        null;
+
     // Query history pipeline metrics
     private queryStateTransitionCounter: prometheus.Counter<
         'from' | 'to'
@@ -353,6 +374,81 @@ export default class PrometheusMetrics {
                         help: 'Duration of JSONL to Parquet conversion',
                         labelNames: ['status'],
                         buckets: [0.5, 1, 2, 5, 10, 30, 60, 120],
+                        ...rest,
+                    });
+
+                // Materialization sub-step histograms
+                const materializationSubStepBuckets = [
+                    1, 5, 10, 30, 60, 120, 300, 600, 900, 1800,
+                ];
+
+                this.materializationPollDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_pre_aggregate_materialization_poll_duration_seconds',
+                        help: 'Time spent polling for materialization query completion (seconds)',
+                        labelNames: ['status', 'trigger'],
+                        buckets: materializationSubStepBuckets,
+                        ...rest,
+                    });
+
+                this.materializationWarehouseDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_pre_aggregate_materialization_warehouse_duration_seconds',
+                        help: 'Warehouse execution time during materialization (seconds)',
+                        labelNames: ['status', 'trigger'],
+                        buckets: materializationSubStepBuckets,
+                        ...rest,
+                    });
+
+                this.materializationPromoteDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_pre_aggregate_materialization_promote_duration_seconds',
+                        help: 'Time to check file size and promote materialization to active (seconds)',
+                        labelNames: ['status', 'trigger'],
+                        buckets: materializationSubStepBuckets,
+                        ...rest,
+                    });
+
+                // DuckDB query profiling histograms
+                this.duckdbQueryLatencyHistogram = new prometheus.Histogram({
+                    name: 'lightdash_pre_aggregate_duckdb_query_latency_seconds',
+                    help: 'Total DuckDB query latency (seconds)',
+                    buckets: [0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30],
+                    ...rest,
+                });
+
+                this.duckdbParquetReadDurationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_pre_aggregate_duckdb_parquet_read_duration_seconds',
+                        help: 'Time spent in READ_PARQUET operators (seconds)',
+                        buckets: [
+                            0.01, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30,
+                        ],
+                        ...rest,
+                    });
+
+                this.duckdbBytesReadHistogram = new prometheus.Histogram({
+                    name: 'lightdash_pre_aggregate_duckdb_bytes_read',
+                    help: 'Bytes read from S3/parquet by DuckDB queries',
+                    buckets: [
+                        1024, // 1KB
+                        10240, // 10KB
+                        102400, // 100KB
+                        1048576, // 1MB
+                        10485760, // 10MB
+                        52428800, // 50MB
+                        104857600, // 100MB
+                        524288000, // 500MB
+                        1073741824, // 1GB
+                    ],
+                    ...rest,
+                });
+
+                this.duckdbScanAmplificationHistogram =
+                    new prometheus.Histogram({
+                        name: 'lightdash_pre_aggregate_duckdb_scan_amplification',
+                        help: 'Ratio of rows scanned to rows returned in DuckDB queries',
+                        buckets: [1, 1.5, 2, 5, 10, 25, 50, 100],
                         ...rest,
                     });
 
@@ -739,6 +835,61 @@ export default class PrometheusMetrics {
             { warehouse_type: warehouseType },
             durationMs / 1000,
         );
+    }
+
+    public observeMaterializationPollDuration(
+        durationMs: number,
+        status: string,
+        trigger: string,
+    ) {
+        this.materializationPollDurationHistogram?.observe(
+            { status, trigger },
+            durationMs / 1000,
+        );
+    }
+
+    public observeMaterializationWarehouseDuration(
+        durationMs: number,
+        status: string,
+        trigger: string,
+    ) {
+        this.materializationWarehouseDurationHistogram?.observe(
+            { status, trigger },
+            durationMs / 1000,
+        );
+    }
+
+    public observeMaterializationPromoteDuration(
+        durationMs: number,
+        status: string,
+        trigger: string,
+    ) {
+        this.materializationPromoteDurationHistogram?.observe(
+            { status, trigger },
+            durationMs / 1000,
+        );
+    }
+
+    public observeDuckdbQueryProfile(profile: {
+        latencyMs: number;
+        readParquetMs: number | null;
+        bytesRead: number | null;
+        scanAmplification: number | null;
+    }) {
+        this.duckdbQueryLatencyHistogram?.observe(profile.latencyMs / 1000);
+        if (profile.readParquetMs != null) {
+            this.duckdbParquetReadDurationHistogram?.observe(
+                profile.readParquetMs / 1000,
+            );
+        }
+        if (profile.bytesRead != null) {
+            this.duckdbBytesReadHistogram?.observe(profile.bytesRead);
+        }
+        if (profile.scanAmplification != null) {
+            this.duckdbScanAmplificationHistogram?.observe(
+                profile.scanAmplification,
+            );
+        }
     }
 
     public monitorEventMetrics(eventEmitter: EventEmitter) {

--- a/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -103,6 +103,11 @@ export class PreAggregationDuckDbClient {
                 new DuckdbWarehouseClient({
                     ...warehouseArgs,
                     logger: Logger,
+                    onQueryProfile: (profile) => {
+                        this.prometheusMetrics?.observeDuckdbQueryProfile(
+                            profile,
+                        );
+                    },
                 }));
     }
 

--- a/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -191,6 +191,7 @@ export class PreAggregateMaterializationService extends BaseService {
                 },
             );
 
+            const pollStart = Date.now();
             const queryHistory = await Sentry.startSpan(
                 {
                     op: 'preaggregate',
@@ -213,6 +214,7 @@ export class PreAggregateMaterializationService extends BaseService {
                         throwOnError: false,
                     }),
             );
+            const pollDurationMs = Date.now() - pollStart;
 
             this.logger.info(
                 `pollForQueryCompletion completed for pre-aggregate materialization for definition ${args.preAggregateDefinitionUuid}`,
@@ -288,7 +290,8 @@ export class PreAggregateMaterializationService extends BaseService {
                 ? Object.keys(queryHistory.columns).length
                 : null;
 
-            // Get file size from S3 for the active format
+            // Get file size from S3 and promote to active — timed together
+            const promoteStart = Date.now();
             const totalBytes = await Sentry.startSpan(
                 {
                     op: 'preaggregate',
@@ -345,6 +348,7 @@ export class PreAggregateMaterializationService extends BaseService {
                         totalBytes,
                     }),
             );
+            const promoteDurationMs = Date.now() - promoteStart;
 
             if (
                 queryHistory.totalRowCount != null &&
@@ -388,6 +392,25 @@ export class PreAggregateMaterializationService extends BaseService {
             this.prometheusMetrics?.preAggregateMaterializationDurationHistogram?.observe(
                 { status, trigger: args.trigger },
                 durationMs / 1000,
+            );
+
+            // Sub-step metrics
+            this.prometheusMetrics?.observeMaterializationPollDuration(
+                pollDurationMs,
+                status,
+                args.trigger,
+            );
+            if (queryHistory.warehouseExecutionTimeMs != null) {
+                this.prometheusMetrics?.observeMaterializationWarehouseDuration(
+                    queryHistory.warehouseExecutionTimeMs,
+                    status,
+                    args.trigger,
+                );
+            }
+            this.prometheusMetrics?.observeMaterializationPromoteDuration(
+                promoteDurationMs,
+                status,
+                args.trigger,
             );
 
             return {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -71,12 +71,24 @@ export type DuckdbLogger = {
     info: (message: string, metadata?: Record<string, unknown>) => void;
 };
 
+export type DuckdbQueryProfileMetrics = {
+    latencyMs: number;
+    cpuMs: number;
+    waitMs: number;
+    readParquetMs: number | null;
+    bytesRead: number | null;
+    rowsReturned: number | null;
+    rowsScanned: number | null;
+    scanAmplification: number | null;
+};
+
 export type DuckdbWarehouseClientArgs = {
     databasePath?: string;
     s3Config?: DuckdbS3SessionConfig;
     resourceLimits?: DuckdbResourceLimits;
     bufferPoolSize?: string; // e.g. '256MB' — controls DuckDB's buffer_pool_size for parquet/HTTP caching
     logger?: DuckdbLogger;
+    onQueryProfile?: (profile: DuckdbQueryProfileMetrics) => void;
 };
 
 const DUCKDB_INTERNAL_CREDENTIALS: CreatePostgresCredentials = {
@@ -236,6 +248,10 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
 
     private readonly logger?: DuckdbLogger;
 
+    private readonly onQueryProfile?: (
+        profile: DuckdbQueryProfileMetrics,
+    ) => void;
+
     constructor(args: DuckdbWarehouseClientArgs = {}) {
         super(DUCKDB_INTERNAL_CREDENTIALS, new DuckdbSqlBuilder());
         this.databasePath = args.databasePath ?? ':memory:';
@@ -243,6 +259,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         this.resourceLimits = args.resourceLimits;
         this.bufferPoolSize = args.bufferPoolSize;
         this.logger = args.logger;
+        this.onQueryProfile = args.onQueryProfile;
     }
 
     async close(): Promise<void> {
@@ -445,7 +462,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         return undefined;
     }
 
-    private static async logQueryProfile(
+    private async logQueryProfile(
         profilePath: string,
         logger: DuckdbLogger,
         tags?: Record<string, string>,
@@ -522,6 +539,17 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
                     scanAmplification,
                 },
             );
+
+            this.onQueryProfile?.({
+                latencyMs,
+                cpuMs,
+                waitMs,
+                readParquetMs,
+                bytesRead,
+                rowsReturned,
+                rowsScanned,
+                scanAmplification,
+            });
         } catch {
             // profiling output not available, skip
         } finally {
@@ -661,7 +689,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             }
 
             if (profilePath) {
-                await DuckdbWarehouseClient.logQueryProfile(
+                await this.logQueryProfile(
                     profilePath,
                     this.logger!,
                     options?.tags,


### PR DESCRIPTION
### Description:

This PR adds detailed Prometheus metrics for pre-aggregate materialization performance monitoring and DuckDB query profiling.

**New Materialization Sub-step Metrics:**
- `lightdash_pre_aggregate_materialization_poll_duration_seconds` - tracks time spent polling for query completion
- `lightdash_pre_aggregate_materialization_warehouse_duration_seconds` - measures warehouse execution time during materialization
- `lightdash_pre_aggregate_materialization_promote_duration_seconds` - tracks time to check file size and promote materialization to active

**New DuckDB Query Profiling Metrics:**
- `lightdash_pre_aggregate_duckdb_query_latency_seconds` - total DuckDB query latency
- `lightdash_pre_aggregate_duckdb_parquet_read_duration_seconds` - time spent in READ_PARQUET operations
- `lightdash_pre_aggregate_duckdb_bytes_read` - bytes read from S3/parquet by DuckDB queries
- `lightdash_pre_aggregate_duckdb_scan_amplification` - ratio of rows scanned to rows returned

The DuckDB warehouse client now accepts an `onQueryProfile` callback that gets invoked with query performance metrics, which are automatically forwarded to Prometheus when configured. The materialization service has been instrumented to track timing for polling, warehouse execution, and promotion phases separately.