### PR TITLE
fix: prevent dashboard placeholder creation race condition in chart downloads

### DIFF
--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -916,8 +916,9 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
         }
     } else {
         // Two-phase parallel path
-        // Phase 1: Seed spaces by uploading the first item per unique spaceSlug sequentially
-        // This avoids the backend race condition in getOrCreateSpace()
+        // Phase 1: Seed one item per unique spaceSlug (and dashboardSlug for charts)
+        // sequentially. This avoids backend race conditions in getOrCreateSpace()
+        // and in placeholder dashboard creation for charts within dashboards.
         type ItemWithUpdate = T & { needsUpdating: boolean };
         const grouped = groupBy(
             filteredItems,
@@ -943,7 +944,43 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
             }
         });
 
-        // Phase 1: Sequential space seeding
+        // For charts: also seed one item per unique dashboardSlug to avoid
+        // concurrent placeholder dashboard creation (duplicate slug bug)
+        if (type === 'charts') {
+            const chartsWithDashboard = remainingItems.filter(
+                (item) =>
+                    'dashboardSlug' in item &&
+                    (item as unknown as ChartAsCode).dashboardSlug,
+            );
+            const groupedByDashboard = groupBy(
+                chartsWithDashboard,
+                (item) => (item as unknown as ChartAsCode).dashboardSlug,
+            );
+            Object.values(groupedByDashboard).forEach((dashboardItems) => {
+                // If no item for this dashboardSlug was already picked as a
+                // space seed, pick the first one as a dashboard seed
+                const alreadySeeded = dashboardItems.some((item) =>
+                    seedItems.has(item),
+                );
+                if (!alreadySeeded) {
+                    const seedIndex = force
+                        ? 0
+                        : dashboardItems.findIndex((i) => i.needsUpdating);
+                    if (seedIndex >= 0) {
+                        seedItems.add(dashboardItems[seedIndex]);
+                        // Remove from remainingItems since it's now a seed
+                        const idx = remainingItems.indexOf(
+                            dashboardItems[seedIndex],
+                        );
+                        if (idx >= 0) {
+                            remainingItems.splice(idx, 1);
+                        }
+                    }
+                }
+            });
+        }
+
+        // Phase 1: Sequential seeding (spaces + dashboard placeholders)
         for (const item of seedItems) {
             // eslint-disable-next-line no-await-in-loop
             await upsertSingleItem(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-5984/fix-placeholder-dashboards-created-during-chart-upload
Closes: https://linear.app/lightdash/issue/PROD-5979/investigate-duplicate-slug-when-using-lightdash-upload-and-concurrency

### Description:

Fixed race condition in chart downloads that was causing duplicate dashboard slug errors. The download handler now performs sequential seeding for both spaces and dashboard placeholders to prevent concurrent creation conflicts.

When downloading charts that belong to dashboards, the system now identifies one chart per unique `dashboardSlug` and processes it sequentially during the seeding phase. This ensures placeholder dashboards are created one at a time, avoiding backend race conditions that previously resulted in duplicate slug errors.

The fix extends the existing two-phase parallel processing approach by adding dashboard-level seeding alongside the existing space-level seeding, while maintaining the performance benefits of parallel processing for the remaining items.