### PR TITLE
feat: add context and overhead metrics, remove redundant query metrics

### DIFF
--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -1,6 +1,7 @@
 import {
     AnyType,
     PreAggregateMissReason,
+    QueryExecutionContext,
     QueryHistoryStatus,
 } from '@lightdash/common';
 import { EventEmitter } from 'events';
@@ -36,6 +37,24 @@ const prometheusEventMetricsConfigSchema = z.object({
     ),
 });
 
+const SCHEDULED_CONTEXTS: ReadonlySet<string> = new Set<string>([
+    QueryExecutionContext.AUTOREFRESHED_DASHBOARD,
+    QueryExecutionContext.ALERT,
+    QueryExecutionContext.SCHEDULED_DELIVERY,
+    QueryExecutionContext.SCHEDULED_GSHEETS_CHART,
+    QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
+    QueryExecutionContext.SCHEDULED_CHART,
+    QueryExecutionContext.SCHEDULED_DASHBOARD,
+    QueryExecutionContext.CLI,
+    QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION,
+]);
+
+export function getQueryContextLabel(
+    context: string,
+): 'interactive' | 'scheduled' {
+    return SCHEDULED_CONTEXTS.has(context) ? 'scheduled' : 'interactive';
+}
+
 export default class PrometheusMetrics {
     private readonly config: LightdashConfig['prometheus'];
 
@@ -69,10 +88,6 @@ export default class PrometheusMetrics {
     public preAggregateActiveMaterializationsGauge: prometheus.Gauge | null =
         null;
 
-    // Pre-aggregate query execution metrics
-    public queryExecutionDurationHistogram: prometheus.Histogram<string> | null =
-        null;
-
     public duckdbResolutionCounter: prometheus.Counter<string> | null = null;
 
     public duckdbResolutionDurationHistogram: prometheus.Histogram<string> | null =
@@ -94,7 +109,7 @@ export default class PrometheusMetrics {
 
     // Query history pipeline metrics
     private queryStateTransitionCounter: prometheus.Counter<
-        'from' | 'to'
+        'from' | 'to' | 'context'
     > | null = null;
 
     private queueWaitHistogram: prometheus.Histogram | null = null;
@@ -102,6 +117,8 @@ export default class PrometheusMetrics {
     private totalDurationHistogram: prometheus.Histogram | null = null;
 
     private warehouseDurationHistogram: prometheus.Histogram | null = null;
+
+    private overheadDurationHistogram: prometheus.Histogram | null = null;
 
     constructor(config: LightdashConfig['prometheus']) {
         this.config = config;
@@ -130,7 +147,7 @@ export default class PrometheusMetrics {
                 this.queryStatusCounter = new prometheus.Counter({
                     name: 'lightdash_query_status_total',
                     help: 'Total number of queries by terminal status',
-                    labelNames: ['status'],
+                    labelNames: ['status', 'context'],
                     ...rest,
                 });
 
@@ -138,13 +155,14 @@ export default class PrometheusMetrics {
                 this.queryStateTransitionCounter = new prometheus.Counter({
                     name: 'lightdash_query_state_transitions_total',
                     help: 'Query state transitions (monotonic, safe across processes)',
-                    labelNames: ['from', 'to'],
+                    labelNames: ['from', 'to', 'context'],
                     ...rest,
                 });
 
                 this.queueWaitHistogram = new prometheus.Histogram({
                     name: 'lightdash_query_queue_wait_duration_seconds',
                     help: 'Time spent waiting in queue before execution',
+                    labelNames: ['context'],
                     buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300],
                     ...rest,
                 });
@@ -152,6 +170,7 @@ export default class PrometheusMetrics {
                 this.totalDurationHistogram = new prometheus.Histogram({
                     name: 'lightdash_query_total_duration_seconds',
                     help: 'Total query duration from creation to results ready',
+                    labelNames: ['context'],
                     buckets: [0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600],
                     ...rest,
                 });
@@ -159,8 +178,16 @@ export default class PrometheusMetrics {
                 this.warehouseDurationHistogram = new prometheus.Histogram({
                     name: 'lightdash_query_warehouse_duration_seconds',
                     help: 'Warehouse query execution duration',
-                    labelNames: ['warehouse_type'],
+                    labelNames: ['warehouse_type', 'context'],
                     buckets: [0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+                    ...rest,
+                });
+
+                this.overheadDurationHistogram = new prometheus.Histogram({
+                    name: 'lightdash_query_overhead_duration_seconds',
+                    help: 'Lightdash overhead: total duration minus warehouse execution time',
+                    labelNames: ['context'],
+                    buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
                     ...rest,
                 });
 
@@ -294,19 +321,6 @@ export default class PrometheusMetrics {
                         ...rest,
                     });
 
-                // Pre-aggregate query execution metrics
-                this.queryExecutionDurationHistogram = new prometheus.Histogram(
-                    {
-                        name: 'lightdash_query_execution_duration_seconds',
-                        help: 'Query execution duration by source',
-                        labelNames: ['source', 'context', 'status'],
-                        buckets: [
-                            0.1, 0.5, 1, 2.5, 5, 10, 30, 60, 120, 300, 600,
-                        ],
-                        ...rest,
-                    },
-                );
-
                 this.duckdbResolutionCounter = new prometheus.Counter({
                     name: 'lightdash_pre_aggregate_duckdb_resolution_total',
                     help: 'Total number of DuckDB pre-aggregate resolution attempts',
@@ -384,9 +398,12 @@ export default class PrometheusMetrics {
         }
     }
 
-    public incrementQueryStatus(status: QueryHistoryStatus) {
+    public incrementQueryStatus(status: QueryHistoryStatus, context: string) {
         if (this.queryStatusCounter) {
-            this.queryStatusCounter.inc({ status });
+            this.queryStatusCounter.inc({
+                status,
+                context: getQueryContextLabel(context),
+            });
         }
     }
 
@@ -621,18 +638,6 @@ export default class PrometheusMetrics {
         }
     }
 
-    public observeQueryExecutionDuration(
-        durationMs: number,
-        source: 'warehouse' | 'pre_aggregate_duckdb',
-        context: string,
-        status: 'success' | 'error',
-    ) {
-        this.queryExecutionDurationHistogram?.observe(
-            { source, context, status },
-            durationMs / 1000,
-        );
-    }
-
     public trackDuckdbResolution(
         resolved: boolean,
         reason: string | undefined,
@@ -722,21 +727,52 @@ export default class PrometheusMetrics {
             | QueryHistoryStatus.ERROR
             | QueryHistoryStatus.EXPIRED
             | QueryHistoryStatus.CANCELLED,
+        context: string,
     ) {
-        this.queryStateTransitionCounter?.inc({ from, to });
+        this.queryStateTransitionCounter?.inc({
+            from,
+            to,
+            context: getQueryContextLabel(context),
+        });
     }
 
-    public observeQueueWaitDuration(durationMs: number) {
-        this.queueWaitHistogram?.observe(durationMs / 1000);
+    public observeQueueWaitDuration(durationMs: number, context: string) {
+        this.queueWaitHistogram?.observe(
+            { context: getQueryContextLabel(context) },
+            durationMs / 1000,
+        );
     }
 
-    public observeQueryTotalDuration(durationMs: number) {
-        this.totalDurationHistogram?.observe(durationMs / 1000);
+    public observeQueryTotalDuration(durationMs: number, context: string) {
+        this.totalDurationHistogram?.observe(
+            { context: getQueryContextLabel(context) },
+            durationMs / 1000,
+        );
     }
 
-    public observeWarehouseDuration(durationMs: number, warehouseType: string) {
+    public observeWarehouseDuration(
+        durationMs: number,
+        warehouseType: string,
+        context: string,
+    ) {
         this.warehouseDurationHistogram?.observe(
-            { warehouse_type: warehouseType },
+            {
+                warehouse_type: warehouseType,
+                context: getQueryContextLabel(context),
+            },
+            durationMs / 1000,
+        );
+    }
+
+    public observeOverheadDuration(durationMs: number, context: string) {
+        if (durationMs < 0) {
+            Logger.warn(
+                `Negative query overhead detected: ${durationMs}ms (context=${context}). Warehouse reported longer than wall clock.`,
+            );
+            return;
+        }
+        this.overheadDurationHistogram?.observe(
+            { context: getQueryContextLabel(context) },
             durationMs / 1000,
         );
     }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -573,6 +573,7 @@ export class AsyncQueryService extends ProjectService {
         );
 
         // Track state transition to cancelled
+        const queryContext = queryHistory.context || 'unknown';
         if (
             previousStatus === QueryHistoryStatus.PENDING ||
             previousStatus === QueryHistoryStatus.QUEUED ||
@@ -581,6 +582,7 @@ export class AsyncQueryService extends ProjectService {
             this.prometheusMetrics?.trackQueryStateTransition(
                 previousStatus,
                 QueryHistoryStatus.CANCELLED,
+                queryContext,
             );
         }
 
@@ -588,6 +590,7 @@ export class AsyncQueryService extends ProjectService {
         this.trackQueryTerminalStatus(
             QueryHistoryStatus.CANCELLED,
             queryHistory.createdAt,
+            queryContext,
         );
     }
 
@@ -1879,11 +1882,16 @@ export class AsyncQueryService extends ProjectService {
             return false;
         }
 
+        const queryContext = queryHistory.context || 'unknown';
         this.prometheusMetrics?.trackQueryStateTransition(
             QueryHistoryStatus.QUEUED,
             QueryHistoryStatus.EXECUTING,
+            queryContext,
         );
-        this.prometheusMetrics?.observeQueueWaitDuration(timeInQueueMs);
+        this.prometheusMetrics?.observeQueueWaitDuration(
+            timeInQueueMs,
+            queryContext,
+        );
 
         return true;
     }
@@ -2074,23 +2082,10 @@ export class AsyncQueryService extends ProjectService {
                     }),
             );
 
-            // Track query execution duration — scoped to pre-aggregate DuckDB queries by default
-            // Set LIGHTDASH_PROMETHEUS_ALL_QUERY_METRICS_ENABLED=true to track all queries
-            if (
-                executionSource === 'pre_aggregate_duckdb' ||
-                this.lightdashConfig.prometheus.allQueryMetricsEnabled
-            ) {
-                this.prometheusMetrics?.observeQueryExecutionDuration(
-                    durationMs,
-                    executionSource,
-                    queryTags.query_context || 'unknown',
-                    'success',
-                );
-            }
-
             this.prometheusMetrics?.observeWarehouseDuration(
                 durationMs,
                 warehouseCredentialsType || 'unknown',
+                queryTags.query_context || 'unknown',
             );
 
             this.analytics.track({
@@ -2205,27 +2200,17 @@ export class AsyncQueryService extends ProjectService {
             this.prometheusMetrics?.trackQueryStateTransition(
                 QueryHistoryStatus.EXECUTING,
                 QueryHistoryStatus.READY,
+                queryTags.query_context || 'unknown',
             );
             this.trackQueryTerminalStatus(
                 QueryHistoryStatus.READY,
                 queryCreatedAt,
+                queryTags.query_context || 'unknown',
             );
         } catch (e) {
             this.logger.error(
                 `Query ${queryUuid} execution error: ${getErrorMessage(e)}`,
             );
-            if (
-                executionSource === 'pre_aggregate_duckdb' ||
-                this.lightdashConfig.prometheus.allQueryMetricsEnabled
-            ) {
-                this.prometheusMetrics?.observeQueryExecutionDuration(
-                    Date.now() - queryStartTime,
-                    executionSource,
-                    queryTags.query_context || 'unknown',
-                    'error',
-                );
-            }
-
             this.analytics.track({
                 ...analyticsIdentity,
                 event: 'query.error',
@@ -2252,10 +2237,12 @@ export class AsyncQueryService extends ProjectService {
             this.prometheusMetrics?.trackQueryStateTransition(
                 QueryHistoryStatus.EXECUTING,
                 QueryHistoryStatus.ERROR,
+                queryTags.query_context || 'unknown',
             );
             this.trackQueryTerminalStatus(
                 QueryHistoryStatus.ERROR,
                 queryCreatedAt,
+                queryTags.query_context || 'unknown',
             );
 
             // Re-throw when using an override client (e.g. DuckDB pre-agg)
@@ -2361,12 +2348,14 @@ export class AsyncQueryService extends ProjectService {
 
     private trackQueryTerminalStatus(
         status: QueryHistoryStatus,
-        queryCreatedAt?: Date | null,
+        queryCreatedAt: Date | null | undefined,
+        context: string,
     ) {
-        this.prometheusMetrics?.incrementQueryStatus(status);
+        this.prometheusMetrics?.incrementQueryStatus(status, context);
         if (queryCreatedAt) {
             this.prometheusMetrics?.observeQueryTotalDuration(
                 Date.now() - queryCreatedAt.getTime(),
+                context,
             );
         }
     }
@@ -2381,13 +2370,16 @@ export class AsyncQueryService extends ProjectService {
             QUEUED_QUERY_EXPIRED_MESSAGE,
         );
 
+        const queryContext = queryHistory.context || 'unknown';
         this.prometheusMetrics?.trackQueryStateTransition(
             QueryHistoryStatus.QUEUED,
             QueryHistoryStatus.EXPIRED,
+            queryContext,
         );
         this.trackQueryTerminalStatus(
             QueryHistoryStatus.EXPIRED,
             queryHistory.createdAt,
+            queryContext,
         );
 
         Sentry.withScope((scope) => {
@@ -2876,6 +2868,7 @@ export class AsyncQueryService extends ProjectService {
                     this.prometheusMetrics?.trackQueryStateTransition(
                         'new',
                         QueryHistoryStatus.PENDING,
+                        context,
                     );
 
                     this.analytics.trackAccount(account, {
@@ -2946,10 +2939,12 @@ export class AsyncQueryService extends ProjectService {
                         this.prometheusMetrics?.trackQueryStateTransition(
                             QueryHistoryStatus.PENDING,
                             QueryHistoryStatus.READY,
+                            context,
                         );
                         this.trackQueryTerminalStatus(
                             QueryHistoryStatus.READY,
                             queryCreatedAt,
+                            context,
                         );
 
                         return {
@@ -2977,10 +2972,12 @@ export class AsyncQueryService extends ProjectService {
                         this.prometheusMetrics?.trackQueryStateTransition(
                             QueryHistoryStatus.PENDING,
                             QueryHistoryStatus.ERROR,
+                            context,
                         );
                         this.trackQueryTerminalStatus(
                             QueryHistoryStatus.ERROR,
                             queryCreatedAt,
+                            context,
                         );
 
                         return {
@@ -3049,10 +3046,12 @@ export class AsyncQueryService extends ProjectService {
                         this.prometheusMetrics?.trackQueryStateTransition(
                             QueryHistoryStatus.PENDING,
                             QueryHistoryStatus.ERROR,
+                            context,
                         );
                         this.trackQueryTerminalStatus(
                             QueryHistoryStatus.ERROR,
                             queryCreatedAt,
+                            context,
                         );
 
                         return {
@@ -3120,6 +3119,7 @@ export class AsyncQueryService extends ProjectService {
                             this.prometheusMetrics?.trackQueryStateTransition(
                                 QueryHistoryStatus.PENDING,
                                 QueryHistoryStatus.QUEUED,
+                                context,
                             );
                         } catch (e) {
                             const errorMessage = getErrorMessage(e);
@@ -3141,10 +3141,12 @@ export class AsyncQueryService extends ProjectService {
                             this.prometheusMetrics?.trackQueryStateTransition(
                                 QueryHistoryStatus.PENDING,
                                 QueryHistoryStatus.ERROR,
+                                context,
                             );
                             this.trackQueryTerminalStatus(
                                 QueryHistoryStatus.ERROR,
                                 queryCreatedAt,
+                                context,
                             );
 
                             return {
@@ -3161,6 +3163,11 @@ export class AsyncQueryService extends ProjectService {
                         this.prometheusMetrics?.trackQueryStateTransition(
                             QueryHistoryStatus.PENDING,
                             QueryHistoryStatus.EXECUTING,
+                            context,
+                        );
+                        this.prometheusMetrics?.observeQueueWaitDuration(
+                            0,
+                            context,
                         );
 
                         const { query: warehouseSql, ...sharedAsyncQueryArgs } =


### PR DESCRIPTION
- add `interactive` / `scheduled` context label to all query prometheus metrics (collapsed from 26 raw context values)
- add `lightdash_query_overhead_duration_seconds` metric (total duration minus warehouse time)
- remove `lightdash_query_execution_duration_seconds` (duplicate of `warehouse_duration` which is strictly better)
- remove `lightdash_query_row_throughput` (indirect signal, not actionable)
- log warning on negative overhead instead of silently clamping to zero