### PR TITLE
fix: Scheduled Deliveries: Custom message body not saving or visible in UI

### DIFF
--- a/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormCustomizationTab.tsx
+++ b/packages/frontend/src/features/scheduler/components/SchedulerForm/SchedulerFormCustomizationTab.tsx
@@ -2,10 +2,10 @@ import { Group, Stack, Switch, Text, Tooltip } from '@mantine-8/core';
 import { IconInfoCircle } from '@tabler/icons-react';
 import MDEditor, { commands } from '@uiw/react-md-editor';
 import MantineIcon from '../../../../components/common/MantineIcon';
-import { useSchedulerForm } from './schedulerFormContext';
+import { useSchedulerFormContext } from './schedulerFormContext';
 
 export const SchedulerFormCustomizationTab = () => {
-    const form = useSchedulerForm();
+    const form = useSchedulerFormContext();
     return (
         <Stack p="md">
             <Group gap="two">


### PR DESCRIPTION
Closes: #21002

### Description:
Fixed UI not saving `Customization` settings from Scheduled Deliveries modal by using the correct context