### PR TITLE
fix: Japanese characters in Slack AI chart screenshots

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -32,6 +32,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     # Required by node-canvas prebuilt binaries for font rendering in chart images
     fontconfig \
+    # Required so headless chart screenshots can render CJK glyphs
+    fonts-noto-cjk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -338,6 +340,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     # Required by node-canvas prebuilt binaries for font rendering in chart images
     fontconfig \
+    # Required so headless chart screenshots can render CJK glyphs
+    fonts-noto-cjk \
     dumb-init \
     # Optional: jemalloc allocator reduces native memory fragmentation vs glibc malloc.
     # Dormant unless activated via LD_PRELOAD env var per customer.

--- a/dockerfile-prs
+++ b/dockerfile-prs
@@ -35,6 +35,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     git \
     # Required by node-canvas prebuilt binaries for font rendering in chart images
     fontconfig \
+    # Required so headless chart screenshots can render CJK glyphs
+    fonts-noto-cjk \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
@@ -342,6 +344,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
     # Required by node-canvas prebuilt binaries for font rendering in chart images
     fontconfig \
+    # Required so headless chart screenshots can render CJK glyphs
+    fonts-noto-cjk \
     dumb-init \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*

--- a/packages/common/src/ee/AiAgent/chartConfig/slack/shared/getCommonEChartsConfig.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/slack/shared/getCommonEChartsConfig.ts
@@ -16,7 +16,7 @@ type GetCommonEChartsConfigParams = {
     showTooltip?: boolean;
 };
 
-const FONT_FAMILY = 'Inter, sans-serif';
+const FONT_FAMILY = '"Inter", "Noto Sans JP", "Noto Sans CJK JP", sans-serif';
 
 /**
  * Generates common echarts config for all chart types


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21180


## Summary
- add CJK font support to backend runtime images by installing `fonts-noto-cjk`
- update the Slack AI chart font stack to fall back to `Noto Sans JP` and `Noto Sans CJK JP`
- ensure headless chart rendering can display Japanese glyphs instead of missing characters
