### PR TITLE
fix: virtual view edit modal cut off by navbar

### DIFF
--- a/packages/frontend/src/features/virtualView/components/EditVirtualViewModal.tsx
+++ b/packages/frontend/src/features/virtualView/components/EditVirtualViewModal.tsx
@@ -1,4 +1,4 @@
-import { type Explore } from '@lightdash/common';
+import { ProjectType, type Explore } from '@lightdash/common';
 import { Button, Center, Loader, Modal, Stack, Text } from '@mantine-8/core';
 import { IconAlertCircle } from '@tabler/icons-react';
 import {
@@ -14,11 +14,18 @@ import MantineModal, {
     type MantineModalProps,
 } from '../../../components/common/MantineModal';
 import {
+    BANNER_HEIGHT,
+    NAVBAR_HEIGHT,
+} from '../../../components/common/Page/constants';
+import {
     explorerActions,
     selectTableName,
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
+import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
+import { useProject } from '../../../hooks/useProject';
+import { useImpersonation } from '../../../hooks/user/useImpersonation';
 import useSearchParams from '../../../hooks/useSearchParams';
 import { defaultState } from '../../../providers/Explorer/defaultState';
 
@@ -41,6 +48,14 @@ export const EditVirtualViewModal: FC<Props> = ({
     const dispatch = useExplorerDispatch();
     const navigate = useNavigate();
     const tableName = useExplorerSelector(selectTableName);
+
+    const { activeProjectUuid } = useActiveProjectUuid();
+    const { data: project } = useProject(activeProjectUuid);
+    const isCurrentProjectPreview = project?.type === ProjectType.PREVIEW;
+    const { isImpersonating } = useImpersonation();
+    const navbarHeight =
+        NAVBAR_HEIGHT +
+        (isCurrentProjectPreview || isImpersonating ? BANNER_HEIGHT : 0);
 
     const [modalStep, setModalStep] = useState<
         'unsavedChanges' | 'editVirtualView' | undefined
@@ -96,7 +111,7 @@ export const EditVirtualViewModal: FC<Props> = ({
             onClose={handleClose}
             size="97vw"
             centered={false}
-            yOffset="3vh"
+            yOffset={navbarHeight + 10}
             xOffset="2vw"
             closeOnClickOutside={false}
         >


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/20856

### Description:

Virtual view editor was getting hidden by the navbar.
Added a `yOffset` that takes into account `NAVBAR_HEIGHT` and `BANNER_HEIGHT` (when in preview project or impersonating)

**Before**
<img width="1575" height="1011" alt="CleanShot 2026-03-17 at 14 16 45" src="https://github.com/user-attachments/assets/02802f78-ba3a-4f5c-a40c-90807fb30fd5" />

**After**
<img width="1576" height="801" alt="CleanShot 2026-03-17 at 14 29 50" src="https://github.com/user-attachments/assets/6b0f8952-2761-472b-a09a-83150614a086" />
<img width="1581" height="959" alt="CleanShot 2026-03-17 at 14 30 06" src="https://github.com/user-attachments/assets/5dc6a2fe-9662-4c35-8978-83c9b6b630d4" />

