### PR TITLE
fix: dashboard content doesn't update when navigating

### DIFF
--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -819,12 +819,16 @@ const Dashboard: FC = () => {
 };
 
 const DashboardPage: FC = () => {
-    const { projectUuid } = useParams<{ projectUuid: string }>();
+    const { projectUuid, dashboardUuid } = useParams<{
+        projectUuid: string;
+        dashboardUuid: string;
+    }>();
     const { user } = useApp();
     const dashboardCommentsCheck = useDashboardCommentsCheck(user?.data);
 
     return (
         <DashboardProvider
+            key={dashboardUuid}
             projectUuid={projectUuid}
             dashboardCommentsCheck={dashboardCommentsCheck}
         >


### PR DESCRIPTION

Closes: #21063

### Description:
Added `dashboardUuid` as key for `DashboardProvider` to update dashboard data when url changes