### PR TITLE
fix: surface http error codes in frontend api errors

### DIFF
--- a/packages/frontend/src/api.test.ts
+++ b/packages/frontend/src/api.test.ts
@@ -91,4 +91,36 @@ describe('api', () => {
 
         clearInMemoryStorage();
     });
+
+    it('surfaces http status from non-json error responses instead of masking them as network errors', async () => {
+        const scope = nock(BASE_API_URL)
+            .post('/api/v1/embed/test-project/dashboard')
+            .reply(
+                404,
+                '<!DOCTYPE html><html><body><pre>Cannot POST /embed/test-project</pre></body></html>',
+                {
+                    'Content-Type': 'text/html; charset=utf-8',
+                },
+            );
+
+        await expect(
+            lightdashApi({
+                method: 'POST',
+                url: '/embed/test-project/dashboard',
+                body: undefined,
+                headers: undefined,
+            }),
+        ).rejects.toEqual({
+            status: 'error',
+            error: {
+                name: 'Not Found',
+                statusCode: 404,
+                message: 'Not Found',
+                data: {},
+            },
+        });
+
+        scope.done();
+        expect(scope.isDone()).toBe(true);
+    });
 });

--- a/packages/frontend/src/api.ts
+++ b/packages/frontend/src/api.ts
@@ -95,6 +95,19 @@ const handleError = (err: any): ApiError => {
         }
         return err;
     }
+    if (typeof err?.status === 'number') {
+        return {
+            status: 'error',
+            error: {
+                name: err.statusText || 'HttpError',
+                statusCode: err.status,
+                message:
+                    err.statusText ||
+                    `Request failed with status ${err.status}`,
+                data: {},
+            },
+        };
+    }
     return {
         status: 'error',
         error: {
@@ -170,9 +183,7 @@ export const lightdashApi = async <T extends ApiResponse['results']>({
     })
         .then((r) => {
             if (!r.ok) {
-                return r.json().then((d) => {
-                    throw d;
-                });
+                throw r;
             }
             return r;
         })


### PR DESCRIPTION
## Summary
- preserve HTTP status and status text for non-OK API responses instead of masking them as generic network errors
- throw the raw `Response` for failed requests so `handleError` can map HTTP failures into structured `ApiError` values
- add coverage for non-JSON error responses to confirm a `404` is surfaced correctly

## Testing
- `pnpm -F frontend test -- api.test.ts`