### PR TITLE
fix: improve query timezone setting description text clarity

### DIFF
--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -107,9 +107,12 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
                 <Stack gap="xs">
                     <Title order={4}>Query time zone</Title>
                     <Text c="ldGray.6" fz="sm">
-                        Sets the default time zone for date/time filter
-                        boundaries and relative date calculations in queries.
-                        Individual queries can still override this.
+                        Controls what &quot;today&quot;, &quot;this week&quot;,
+                        and other &quot;in the current&quot; date filters mean.
+                        For example, if set to US/Eastern, &quot;today&quot;
+                        means midnight-to-midnight New York time instead of UTC.
+                        This does not change your database&apos;s session time
+                        zone.
                     </Text>
                     <Text c="ldGray.6" fz="xs">
                         Learn more in our{' '}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ --><!-- reference the related issue e.g. #150 -->

### Description:

Improved the help text for the Query time zone setting to make it more user-friendly and clear. The new description explains what "today", "this week", and other relative date filters mean in practical terms, using a concrete example with US/Eastern timezone. Also clarified that this setting doesn't affect the database's session time zone to avoid confusion.

<!-- Even better add a screenshot / gif / loom -->