### PR TITLE
fix: stop dropping models without config.materialized

### DIFF
--- a/packages/common/src/types/dbt.test.ts
+++ b/packages/common/src/types/dbt.test.ts
@@ -1,0 +1,167 @@
+import { getModelsFromManifest, type DbtManifest } from './dbt';
+
+const makeManifest = (nodes: Record<string, object>): DbtManifest =>
+    ({
+        metadata: {
+            dbt_schema_version:
+                'https://schemas.getdbt.com/dbt/manifest/v12.json',
+            generated_at: '2024-01-01T00:00:00Z',
+            adapter_type: 'postgres',
+        },
+        nodes,
+        sources: {},
+        macros: {},
+        docs: {},
+        exposures: {},
+        metrics: {},
+    }) as unknown as DbtManifest;
+
+const baseModel = {
+    package_name: 'test',
+    path: 'model.sql',
+    original_file_path: 'models/model.sql',
+    resource_type: 'model' as const,
+    alias: 'model',
+    checksum: { name: 'sha256', checksum: 'abc' },
+    tags: [],
+    refs: [],
+    sources: [],
+    depends_on: { macros: [], nodes: [] },
+    database: 'db',
+    schema: 'public',
+    fqn: ['test', 'model'],
+    raw_code: 'SELECT 1',
+    columns: {},
+    meta: {},
+    description: '',
+    created_at: 0,
+    language: 'sql',
+    relation_name: '"db"."public"."model"',
+};
+
+describe('getModelsFromManifest', () => {
+    it('should include models with config.materialized set to table', () => {
+        const manifest = makeManifest({
+            'model.test.table_model': {
+                ...baseModel,
+                unique_id: 'model.test.table_model',
+                name: 'table_model',
+                config: { materialized: 'table' },
+            },
+        });
+
+        const models = getModelsFromManifest(manifest);
+        expect(models).toHaveLength(1);
+        expect(models[0].unique_id).toBe('model.test.table_model');
+    });
+
+    it('should include models with config.materialized set to view', () => {
+        const manifest = makeManifest({
+            'model.test.view_model': {
+                ...baseModel,
+                unique_id: 'model.test.view_model',
+                name: 'view_model',
+                config: { materialized: 'view' },
+            },
+        });
+
+        const models = getModelsFromManifest(manifest);
+        expect(models).toHaveLength(1);
+        expect(models[0].unique_id).toBe('model.test.view_model');
+    });
+
+    it('should include models without config.materialized (default materialization)', () => {
+        const manifest = makeManifest({
+            'model.test.default_model': {
+                ...baseModel,
+                unique_id: 'model.test.default_model',
+                name: 'default_model',
+                config: {},
+            },
+        });
+
+        const models = getModelsFromManifest(manifest);
+        expect(models).toHaveLength(1);
+        expect(models[0].unique_id).toBe('model.test.default_model');
+    });
+
+    it('should filter out ephemeral models', () => {
+        const manifest = makeManifest({
+            'model.test.table_model': {
+                ...baseModel,
+                unique_id: 'model.test.table_model',
+                name: 'table_model',
+                config: { materialized: 'table' },
+            },
+            'model.test.ephemeral_model': {
+                ...baseModel,
+                unique_id: 'model.test.ephemeral_model',
+                name: 'ephemeral_model',
+                config: { materialized: 'ephemeral' },
+            },
+        });
+
+        const models = getModelsFromManifest(manifest);
+        expect(models).toHaveLength(1);
+        expect(models[0].unique_id).toBe('model.test.table_model');
+    });
+
+    it('should filter out non-model nodes', () => {
+        const manifest = makeManifest({
+            'model.test.real_model': {
+                ...baseModel,
+                unique_id: 'model.test.real_model',
+                name: 'real_model',
+                config: { materialized: 'table' },
+            },
+            'test.test.some_test': {
+                ...baseModel,
+                unique_id: 'test.test.some_test',
+                name: 'some_test',
+                resource_type: 'test',
+                config: { materialized: 'table' },
+            },
+        });
+
+        const models = getModelsFromManifest(manifest);
+        expect(models).toHaveLength(1);
+        expect(models[0].unique_id).toBe('model.test.real_model');
+    });
+
+    it('should include a mix of tables, views, and models without materialized while excluding ephemeral', () => {
+        const manifest = makeManifest({
+            'model.test.table_model': {
+                ...baseModel,
+                unique_id: 'model.test.table_model',
+                name: 'table_model',
+                config: { materialized: 'table' },
+            },
+            'model.test.view_model': {
+                ...baseModel,
+                unique_id: 'model.test.view_model',
+                name: 'view_model',
+                config: { materialized: 'view' },
+            },
+            'model.test.no_mat_model': {
+                ...baseModel,
+                unique_id: 'model.test.no_mat_model',
+                name: 'no_mat_model',
+                config: {},
+            },
+            'model.test.ephemeral_model': {
+                ...baseModel,
+                unique_id: 'model.test.ephemeral_model',
+                name: 'ephemeral_model',
+                config: { materialized: 'ephemeral' },
+            },
+        });
+
+        const models = getModelsFromManifest(manifest);
+        const ids = models.map((m) => m.unique_id).sort();
+        expect(ids).toEqual([
+            'model.test.no_mat_model',
+            'model.test.table_model',
+            'model.test.view_model',
+        ]);
+    });
+});

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -787,13 +787,7 @@ export const getModelsFromManifest = (
         );
     }
     const adapterType = manifest.metadata.adapter_type;
-    return models
-        .filter(
-            (model) =>
-                model.config?.materialized &&
-                model.config.materialized !== 'ephemeral',
-        )
-        .map((model) => normaliseModelDatabase(model, adapterType));
+    return models.map((model) => normaliseModelDatabase(model, adapterType));
 };
 
 export function getCompiledModels(


### PR DESCRIPTION
## Summary

- Remove redundant filter in `getModelsFromManifest` that required `config.materialized` to be truthy
- The first filter already excludes ephemeral models (`config?.materialized !== 'ephemeral'`), making the second filter unnecessary
- Models without `config.materialized` set (e.g. views using default materialization) were silently dropped after #21064 unified all code paths to go through `getModelsFromManifest`

## Test plan

- [x] Added unit tests for `getModelsFromManifest` covering: tables, views, missing materialized, ephemeral exclusion, non-model exclusion, and mixed scenarios
- [x] Verified tests fail without the fix and pass with it
- [x] `pnpm -F common typecheck` passes