### PR TITLE
chore: readd reset all filters button when isAddFilterDisabled

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
@@ -107,6 +107,30 @@ const AddFilterButton: FC<Props> = ({
                     Enable Add Filter
                 </Button>
             );
+        if (showResetFiltersButton)
+            return (
+                <Tooltip label="Reset all filters" withinPortal>
+                    <Button
+                        aria-label="Reset all filters"
+                        size="xs"
+                        variant="default"
+                        radius="md"
+                        color="gray"
+                        onClick={() => {
+                            setHaveFiltersChanged(false);
+                            onResetDashboardFilters();
+                        }}
+                        styles={{
+                            root: {
+                                borderRadius: '100px',
+                                borderStyle: 'dashed',
+                            },
+                        }}
+                    >
+                        <MantineIcon icon={IconRotate2} />
+                    </Button>
+                </Tooltip>
+            );
         return null;
     }
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-5999/keep-reset-all-filters-available-without-add-filter

### Description:
Ensured that the Reset dashboard filters button is visible even when the AddFilterButton is disabled. 
AddFilterButton.tsx. Added a condition so that if showResetFiltersButton is true (even when adding filters is disabled), it renders a "Reset all filters" button.

Users can now reset dashboard filters even when the "add filter" functionality is disabled.

[Loom](https://www.loom.com/share/799336dfddf74d8e836543a36f43d585)
