### PR TITLE
feat: add React SDK code snippets

### DIFF
--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -7,7 +7,7 @@ import {
     isDashboardUuidContent,
     type CreateEmbedJwt,
 } from '@lightdash/common';
-import { Tabs } from '@mantine-8/core';
+import { Anchor, Stack, Tabs, Text, Title } from '@mantine-8/core';
 import { Prism } from '@mantine/prism';
 import {
     IconBrandGolang,
@@ -18,10 +18,12 @@ import { useCallback, type FC } from 'react';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useToaster from '../../../../hooks/toaster/useToaster';
 
+export type EmbedMethod = 'iframe' | 'sdk';
+
 // Not sure why lint-staged is removing the value of this enum.
 // prettier-ignore
 // eslint-disable-next-line
-enum SnippetLanguage {
+export enum SnippetLanguage {
     NODE = 'node',
     PYTHON = 'python',
     GO = 'go',
@@ -113,7 +115,7 @@ const languageStringArray = (
     }
 };
 
-const chartCodeTemplates: Record<SnippetLanguage, string> = {
+const chartIframeCodeTemplates: Record<SnippetLanguage, string> = {
     [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
 const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
 const projectUuid = '{{projectUuid}}';
@@ -243,7 +245,7 @@ func main() {
 `,
 };
 
-const dashboardCodeTemplates: Record<SnippetLanguage, string> = {
+const dashboardIframeCodeTemplates: Record<SnippetLanguage, string> = {
     [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
 const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
 const projectUuid = '{{projectUuid}}';
@@ -428,7 +430,302 @@ func main() {
 `,
 };
 
-const getCodeSnippet = (
+const chartSdkCodeTemplates: Record<SnippetLanguage, string> = {
+    [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
+const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
+const projectUuid = '{{projectUuid}}';
+const data = {
+    content: {
+        type: 'chart',
+        projectUuid: projectUuid,
+        contentId: '{{chartUuid}}',
+        canExportCsv: {{canExportCsv}},
+        canExportImages: {{canExportImages}},
+        canViewUnderlyingData: {{canViewUnderlyingData}},
+    },
+    user: {
+        externalId: {{externalId}},
+        email: {{email}}
+    },
+    userAttributes: {{userAttributes}},
+};
+const embedJwt = jwt.sign(data, LIGHTDASH_EMBED_SECRET, { expiresIn: '{{expiresIn}}' });
+`,
+    [SnippetLanguage.PYTHON]: `import datetime
+import jwt # pip install pyjwt
+
+key = "secret" # replace with your secret
+projectUuid = '{{projectUuid}}'
+
+data = {
+    "exp": datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(hours=1), # replace with your expiration time,
+    "iat": datetime.datetime.now(tz=datetime.timezone.utc),
+    "content": {
+        "type": "chart",
+        "projectUuid": projectUuid,
+        "contentId": "{{chartUuid}}",
+        "canExportCsv": {{canExportCsv}},
+        "canExportImages": {{canExportImages}},
+        "canViewUnderlyingData": {{canViewUnderlyingData}},
+    },
+    "user": {
+        "externalId": {{externalId}},
+        "email": {{email}}
+    },
+    "userAttributes": {{userAttributes}},
+};
+embedJwt = jwt.encode(data, key, algorithm="HS256")
+`,
+    [SnippetLanguage.GO]: `
+package main
+
+import (
+    "fmt"
+    "time"
+
+    jwt "github.com/dgrijalva/jwt-go"
+)
+
+const LIGHTDASH_EMBED_SECRET = "secret" // replace with your secret
+const projectUuid = "{{projectUuid}}"
+
+func main() {
+    {{externalIdDef}}
+    {{emailDef}}
+
+    type CustomClaims struct {
+        Content struct {
+            Type                  string \`json:"type"\`
+            ProjectUuid           string \`json:"projectUuid"\`
+            ContentId             string \`json:"contentId"\`
+            CanExportCsv          bool \`json:"canExportCsv"\`
+            CanExportImages       bool \`json:"canExportImages"\`
+            CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
+        } \`json:"content"\`
+        UserAttributes map[string]string \`json:"userAttributes"\`
+        jwt.StandardClaims
+        User *struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        } \`json:"user,omitempty"\`
+    }
+
+    claims := CustomClaims{
+        Content: struct {
+            Type                  string \`json:"type"\`
+            ProjectUuid           string \`json:"projectUuid"\`
+            ContentId             string \`json:"contentId"\`
+            CanExportCsv          bool \`json:"canExportCsv"\`
+            CanExportImages       bool \`json:"canExportImages"\`
+            CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
+        }{
+            Type:                  "chart",
+            ProjectUuid:           projectUuid,
+            ContentId:             "{{chartUuid}}",
+            CanExportCsv:          {{canExportCsv}},
+            CanExportImages:       {{canExportImages}},
+            CanViewUnderlyingData: {{canViewUnderlyingData}},
+        },
+        User: &struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        }{
+            ExternalId: {{externalIdUsage}},
+            Email:      {{emailUsage}},
+        },
+        UserAttributes: map[string]string{{userAttributes}},
+        StandardClaims: jwt.StandardClaims{
+            ExpiresAt: time.Now().Add(time.Hour).Unix(), // replace with your expiration
+        },
+    }
+
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+    embedJwt, err := token.SignedString([]byte(LIGHTDASH_EMBED_SECRET))
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println("JWT:", embedJwt)
+}
+`,
+};
+
+const dashboardSdkCodeTemplates: Record<SnippetLanguage, string> = {
+    [SnippetLanguage.NODE]: `import jwt from 'jsonwebtoken';
+const LIGHTDASH_EMBED_SECRET = 'secret'; // replace with your secret
+const projectUuid = '{{projectUuid}}';
+const data = {
+    content: {
+        type: 'dashboard',
+        projectUuid: projectUuid,
+        dashboardUuid: '{{dashboardUuid}}',
+        dashboardFiltersInteractivity: {
+            enabled: "{{dashboardFiltersInteractivityEnabled}}",
+            allowedFilters: {{dashboardFiltersInteractivityAllowedFilters}},
+        },
+        parameterInteractivity: {
+            enabled: {{canChangeParameters}},
+        },
+        canExportCsv: {{canExportCsv}},
+        canExportImages: {{canExportImages}},
+        canExportPagePdf: {{canExportPagePdf}},
+        canDateZoom: {{canDateZoom}},
+        canExplore: {{canExplore}},
+        canViewUnderlyingData: {{canViewUnderlyingData}},
+    },
+    user: {
+        externalId: {{externalId}},
+        email: {{email}}
+    },
+    userAttributes: {{userAttributes}},
+};
+const embedJwt = jwt.sign(data, LIGHTDASH_EMBED_SECRET, { expiresIn: '{{expiresIn}}' });
+`,
+    [SnippetLanguage.PYTHON]: `import datetime
+import jwt # pip install pyjwt
+
+key = "secret" # replace with your secret
+projectUuid = '{{projectUuid}}'
+
+data = {
+    "exp": datetime.datetime.now(tz=datetime.timezone.utc) + datetime.timedelta(hours=1), # replace with your expiration time,
+    "iat": datetime.datetime.now(tz=datetime.timezone.utc),
+    "content": {
+        "type": "dashboard",
+        "projectUuid": projectUuid,
+        "dashboardUuid": "{{dashboardUuid}}",
+        "dashboardFiltersInteractivity": {
+            "enabled": "{{dashboardFiltersInteractivityEnabled}}",
+            "allowedFilters": {{dashboardFiltersInteractivityAllowedFilters}},
+        },
+        "parameterInteractivity": {
+            "enabled": {{canChangeParameters}},
+        },
+        "canExportCsv": {{canExportCsv}},
+        "canExportImages": {{canExportImages}},
+        "canExportPagePdf": {{canExportPagePdf}},
+        "canDateZoom": {{canDateZoom}},
+        "canExplore": {{canExplore}},
+        "canViewUnderlyingData": {{canViewUnderlyingData}},
+    },
+    "user": {
+        "externalId": {{externalId}},
+        "email": {{email}}
+    },
+    "userAttributes": {{userAttributes}},
+};
+embedJwt = jwt.encode(data, key, algorithm="HS256")
+`,
+    [SnippetLanguage.GO]: `
+package main
+
+import (
+    "fmt"
+    "time"
+
+    jwt "github.com/dgrijalva/jwt-go"
+)
+
+const LIGHTDASH_EMBED_SECRET = "secret" // replace with your secret
+const projectUuid = "{{projectUuid}}"
+
+func main() {
+    {{externalIdDef}}
+    {{emailDef}}
+
+    type CustomClaims struct {
+        Content struct {
+            Type                       string \`json:"type"\`
+            ProjectUuid                string \`json:"projectUuid"\`
+            DashboardUuid              string \`json:"dashboardUuid"\`
+            DashboardFiltersInteractivity struct {
+                Enabled string \`json:"enabled"\`
+                AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+            } \`json:"dashboardFiltersInteractivity"\`
+            ParameterInteractivity struct {
+                Enabled bool \`json:"enabled"\`
+            } \`json:"parameterInteractivity"\`
+            CanExportCsv bool \`json:"canExportCsv"\`
+            CanExportImages bool \`json:"canExportImages"\`
+            CanExportPagePdf bool \`json:"canExportPagePdf"\`
+            CanDateZoom bool \`json:"canDateZoom"\`
+            CanExplore bool \`json:"canExplore"\`
+            CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
+        } \`json:"content"\`
+        UserAttributes map[string]string \`json:"userAttributes"\`
+        jwt.StandardClaims
+        User *struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        } \`json:"user,omitempty"\`
+    }
+
+    claims := CustomClaims{
+        Content: struct {
+            Type                       string \`json:"type"\`
+            ProjectUuid                string \`json:"projectUuid"\`
+            DashboardUuid              string \`json:"dashboardUuid"\`
+            DashboardFiltersInteractivity struct {
+                Enabled string \`json:"enabled"\`
+                AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+            } \`json:"dashboardFiltersInteractivity"\`
+            ParameterInteractivity struct {
+                Enabled bool \`json:"enabled"\`
+            } \`json:"parameterInteractivity"\`
+            CanExportCsv bool \`json:"canExportCsv"\`
+            CanExportImages bool \`json:"canExportImages"\`
+            CanExportPagePdf bool \`json:"canExportPagePdf"\`
+            CanDateZoom bool \`json:"canDateZoom"\`
+            CanExplore bool \`json:"canExplore"\`
+            CanViewUnderlyingData bool \`json:"canViewUnderlyingData"\`
+        }{
+            Type:          "dashboard",
+            ProjectUuid:   projectUuid,
+            DashboardUuid: "{{dashboardUuid}}",
+            DashboardFiltersInteractivity: struct {
+                Enabled string \`json:"enabled"\`
+                AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+            }{
+                Enabled: "{{dashboardFiltersInteractivityEnabled}}",
+                AllowedFilters: []string{{{dashboardFiltersInteractivityAllowedFilters}}},
+            },
+            ParameterInteractivity: struct {
+                Enabled bool \`json:"enabled"\`
+            }{
+                Enabled: {{canChangeParameters}},
+            },
+            CanExportCsv: {{canExportCsv}},
+            CanExportImages: {{canExportImages}},
+            CanExportPagePdf: {{canExportPagePdf}},
+            CanDateZoom: {{canDateZoom}},
+            CanExplore: {{canExplore}},
+            CanViewUnderlyingData: {{canViewUnderlyingData}},
+        },
+        User: &struct {
+            ExternalId *string \`json:"externalId,omitempty"\`
+            Email      *string \`json:"email,omitempty"\`
+        }{
+            ExternalId: {{externalIdUsage}},
+            Email:      {{emailUsage}},
+        },
+        UserAttributes: map[string]string{{userAttributes}},
+        StandardClaims: jwt.StandardClaims{
+            ExpiresAt: time.Now().Add(time.Hour).Unix(), // replace with your expiration
+        },
+    }
+
+    token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
+    embedJwt, err := token.SignedString([]byte(LIGHTDASH_EMBED_SECRET))
+    if err != nil {
+        panic(err)
+    }
+
+    fmt.Println("JWT:", embedJwt)
+}
+`,
+};
+
+const getBackendCodeSnippet = (
     language: SnippetLanguage,
     {
         projectUuid,
@@ -439,10 +736,20 @@ const getCodeSnippet = (
         siteUrl: string;
         data: CreateEmbedJwt;
     },
+    mode: EmbedMethod,
 ): string => {
-    let codeTemplate = isDashboardContent(data.content)
-        ? dashboardCodeTemplates[language]
-        : chartCodeTemplates[language];
+    let codeTemplate;
+    if (isDashboardContent(data.content)) {
+        codeTemplate =
+            mode === 'iframe'
+                ? dashboardIframeCodeTemplates[language]
+                : dashboardSdkCodeTemplates[language];
+    } else {
+        codeTemplate =
+            mode === 'iframe'
+                ? chartIframeCodeTemplates[language]
+                : chartSdkCodeTemplates[language];
+    }
 
     // Handle Go-specific user field placeholders
     const externalIdForGo = languageOptionalStringForGo(
@@ -490,8 +797,8 @@ const getCodeSnippet = (
                 .replace(
                     '{{dashboardUuid}}',
                     isDashboardUuidContent(data.content)
-                        ? data.content.dashboardUuid
-                        : '{{your dashboard uuid}}',
+                        ? data.content.dashboardUuid || '<DASHBOARD_UUID>'
+                        : '<DASHBOARD_UUID>',
                 )
                 .replace(
                     '{{dashboardFiltersInteractivityEnabled}}',
@@ -535,7 +842,7 @@ const getCodeSnippet = (
             if (isChartContent(data.content)) {
                 codeTemplate = codeTemplate.replace(
                     '{{chartUuid}}',
-                    data.content.contentId,
+                    data.content.contentId || '<CHART_UUID>',
                 );
             }
             break;
@@ -549,17 +856,104 @@ const getCodeSnippet = (
     return codeTemplate;
 };
 
-const EmbedCodeSnippet: FC<{
+const getReactSdkFrontendSnippet = ({
+    data,
+    siteUrl,
+}: {
+    data: CreateEmbedJwt;
+    siteUrl: string;
+}): string => {
+    const contentType = data.content.type;
+    const dashboardCanUseFilters =
+        isDashboardContent(data.content) &&
+        data.content.dashboardFiltersInteractivity?.enabled ===
+            FilterInteractivityValues.all;
+
+    switch (contentType) {
+        case 'dashboard':
+            return `import '@lightdash/sdk/sdk.css';
+import Lightdash from '@lightdash/sdk';
+
+type EmbeddedDashboardProps = {
+    embedJwt: string;
+};
+
+export const EmbeddedDashboard = ({ embedJwt }: EmbeddedDashboardProps) => (
+    <Lightdash.Dashboard
+        instanceUrl="${siteUrl}"
+        token={embedJwt}${
+            data.content.canExplore
+                ? `
+        onExplore={() => {
+            // Optional: handle when users open a chart in explore
+        }}`
+                : ''
+        }
+        styles={{
+            // Optional: customize supported SDK styles here:
+            // backgroundColor: '#fff',
+            // fontFamily: 'Inter, sans-serif',
+        }}
+${
+    dashboardCanUseFilters
+        ? `        // Optional: apply SDK filters.
+        // To use this example, also import \`FilterOperator\` from \`@lightdash/sdk\`.
+        /*
+        filters={[
+            {
+                model: 'orders',
+                field: 'status',
+                operator: FilterOperator.EQUALS,
+                value: 'completed',
+            },
+            {
+                model: 'orders',
+                field: 'created_date',
+                operator: FilterOperator.IN_BETWEEN,
+                value: ['2024-01-01', '2024-12-31'],
+            },
+        ]} */`
+        : ''
+}
+    />
+);
+`;
+        case 'chart':
+            return `import '@lightdash/sdk/sdk.css';
+import Lightdash from '@lightdash/sdk';
+
+type EmbeddedChartProps = {
+    embedJwt: string;
+};
+
+export const EmbeddedChart = ({ embedJwt }: EmbeddedChartProps) => (
+    <Lightdash.Chart
+        instanceUrl="${siteUrl}"
+        token={embedJwt}
+        id="${data.content.contentId || '<CHART_UUID>'}"
+        styles={{
+            // Optional: customize supported SDK styles here:
+            // backgroundColor: '#fff',
+            // fontFamily: 'Inter, sans-serif',
+        }}
+    />
+);
+`;
+        default:
+            return assertUnreachable(
+                contentType,
+                `Unsupported embedded content type ${contentType} frontend snippet`,
+            );
+    }
+};
+
+const CodeSnippetTabs: FC<{
+    data: CreateEmbedJwt;
+    mode: EmbedMethod;
+    onCopySnippet: () => void;
     projectUuid: string;
     siteUrl: string;
-    data: CreateEmbedJwt;
-}> = ({ projectUuid, siteUrl, data }) => {
-    const { showToastSuccess } = useToaster();
-
-    const handleCopySnippet = useCallback(() => {
-        showToastSuccess({ title: 'Code snippet copied to clipboard!' });
-    }, [showToastSuccess]);
-
+}> = ({ data, mode, onCopySnippet, projectUuid, siteUrl }) => {
     return (
         <Tabs defaultValue="node">
             <Tabs.List>
@@ -589,35 +983,120 @@ const EmbedCodeSnippet: FC<{
                 </Tabs.Tab>
             </Tabs.List>
             <Tabs.Panel value="node" pt="xs">
-                <Prism language="javascript" onCopy={handleCopySnippet}>
-                    {getCodeSnippet(SnippetLanguage.NODE, {
-                        projectUuid,
-                        siteUrl,
-                        data,
-                    })}
+                <Prism language="javascript" onCopy={onCopySnippet}>
+                    {getBackendCodeSnippet(
+                        SnippetLanguage.NODE,
+                        {
+                            projectUuid,
+                            siteUrl,
+                            data,
+                        },
+                        mode,
+                    )}
                 </Prism>
             </Tabs.Panel>
 
             <Tabs.Panel value="python" pt="xs">
-                <Prism language="python" onCopy={handleCopySnippet}>
-                    {getCodeSnippet(SnippetLanguage.PYTHON, {
-                        projectUuid,
-                        siteUrl,
-                        data,
-                    })}
+                <Prism language="python" onCopy={onCopySnippet}>
+                    {getBackendCodeSnippet(
+                        SnippetLanguage.PYTHON,
+                        {
+                            projectUuid,
+                            siteUrl,
+                            data,
+                        },
+                        mode,
+                    )}
                 </Prism>
             </Tabs.Panel>
 
             <Tabs.Panel value="go" pt="xs">
-                <Prism language="go" onCopy={handleCopySnippet}>
-                    {getCodeSnippet(SnippetLanguage.GO, {
-                        projectUuid,
-                        siteUrl,
-                        data,
-                    })}
+                <Prism language="go" onCopy={onCopySnippet}>
+                    {getBackendCodeSnippet(
+                        SnippetLanguage.GO,
+                        {
+                            projectUuid,
+                            siteUrl,
+                            data,
+                        },
+                        mode,
+                    )}
                 </Prism>
             </Tabs.Panel>
         </Tabs>
+    );
+};
+
+const EmbedCodeSnippet: FC<{
+    mode: EmbedMethod;
+    projectUuid: string;
+    siteUrl: string;
+    data: CreateEmbedJwt;
+}> = ({ mode, projectUuid, siteUrl, data }) => {
+    const { showToastSuccess } = useToaster();
+
+    const handleCopySnippet = useCallback(() => {
+        showToastSuccess({ title: 'Code snippet copied to clipboard!' });
+    }, [showToastSuccess]);
+
+    return (
+        <Stack gap="md">
+            <Stack gap="xs">
+                <Title order={6}>
+                    {mode === 'iframe'
+                        ? 'Backend: generate JWT and embed URL'
+                        : 'Backend: generate JWT'}
+                </Title>
+                <Text c="dimmed" fz="sm">
+                    {mode === 'iframe'
+                        ? 'Use this for iframe or direct embedding with a full embed URL.'
+                        : 'Generate the embed JWT on your backend, then pass it to the React SDK from your frontend.'}
+                </Text>
+                <Text c="dimmed" fz="sm">
+                    See the{' '}
+                    <Anchor
+                        href={
+                            mode === 'iframe'
+                                ? 'https://docs.lightdash.com/references/iframe-embedding'
+                                : 'https://docs.lightdash.com/references/react-sdk#embedding-with-react-sdk'
+                        }
+                        target="_blank"
+                    >
+                        {mode === 'iframe'
+                            ? 'iframe embed docs'
+                            : 'React SDK docs'}
+                    </Anchor>
+                    .
+                </Text>
+            </Stack>
+
+            <CodeSnippetTabs
+                data={data}
+                mode={mode}
+                onCopySnippet={handleCopySnippet}
+                projectUuid={projectUuid}
+                siteUrl={siteUrl}
+            />
+
+            {mode === 'sdk' && (
+                <Stack gap="xs">
+                    <Stack gap="xs">
+                        <Title order={6}>Frontend: mount React SDK</Title>
+                        <Text c="dimmed" fz="sm">
+                            Use <code>instanceUrl</code> for your Lightdash
+                            domain and <code>token</code> for the JWT from your
+                            backend.
+                        </Text>
+                    </Stack>
+                    <Prism language="tsx" onCopy={handleCopySnippet}>
+                        {getReactSdkFrontendSnippet({
+                            data,
+                            siteUrl,
+                        })}
+                    </Prism>
+                </Stack>
+            )}
+        </Stack>
     );
 };
 

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewChartForm.tsx
@@ -24,14 +24,14 @@ import {
 import { useForm } from '@mantine/form';
 import { IconEye, IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
-import { useCallback, type FC } from 'react';
+import { useCallback, useState, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { lightdashApi } from '../../../../api';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useAsyncClipboard } from '../../../../hooks/useAsyncClipboard';
 import useUser from '../../../../hooks/user/useUser';
-import EmbedCodeSnippet from './EmbedCodeSnippet';
+import EmbedCodeSnippet, { type EmbedMethod } from './EmbedCodeSnippet';
 
 const useEmbedUrlCreateMutation = (projectUuid: string) => {
     const { showToastError } = useToaster();
@@ -77,6 +77,7 @@ const EmbedPreviewChartForm: FC<{
     const { mutateAsync: createEmbedUrl } =
         useEmbedUrlCreateMutation(projectUuid);
     const { data: user } = useUser(true);
+    const [embedMethod, setEmbedMethod] = useState<EmbedMethod>('iframe');
 
     const form = useForm<FormValues>({
         initialValues: {
@@ -321,7 +322,7 @@ const EmbedPreviewChartForm: FC<{
                         leftSection={<MantineIcon icon={IconEye} />}
                         onClick={handlePreview}
                     >
-                        Preview
+                        Preview content
                     </Button>
                     <Button
                         variant="default"
@@ -335,13 +336,34 @@ const EmbedPreviewChartForm: FC<{
 
             <Stack gap="md" mb="md">
                 <Stack gap="xs">
-                    <Title order={5}>Code snippet</Title>
+                    <Text size="sm" fw={500}>
+                        Embed method
+                    </Text>
+                    <SegmentedControl
+                        value={embedMethod}
+                        onChange={(value) =>
+                            setEmbedMethod(value as EmbedMethod)
+                        }
+                        data={[
+                            { label: 'Iframe', value: 'iframe' },
+                            { label: 'SDK', value: 'sdk' },
+                        ]}
+                    />
+                </Stack>
+                <Stack gap="xs">
+                    <Title order={5}>
+                        {embedMethod === 'iframe'
+                            ? 'Iframe embed code'
+                            : 'React SDK code'}
+                    </Title>
                     <Text c="dimmed" fz="sm">
-                        Copy and paste this code snippet into your application
-                        to generate embed URLs.
+                        {embedMethod === 'iframe'
+                            ? 'Use this for iframe or direct embedding with a full embed URL.'
+                            : 'Use this for React SDK embedding with a backend-generated JWT.'}
                     </Text>
                 </Stack>
                 <EmbedCodeSnippet
+                    mode={embedMethod}
                     projectUuid={projectUuid}
                     siteUrl={siteUrl}
                     data={convertFormValuesToCreateEmbedJwt(formValues)}

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -27,14 +27,14 @@ import {
 import { useForm } from '@mantine/form';
 import { IconEye, IconLink, IconPlus, IconTrash } from '@tabler/icons-react';
 import { useMutation } from '@tanstack/react-query';
-import { useCallback, type FC } from 'react';
+import { useCallback, useState, type FC } from 'react';
 import { v4 as uuidv4 } from 'uuid';
 import { lightdashApi } from '../../../../api';
 import MantineIcon from '../../../../components/common/MantineIcon';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { useAsyncClipboard } from '../../../../hooks/useAsyncClipboard';
 import useUser from '../../../../hooks/user/useUser';
-import EmbedCodeSnippet from './EmbedCodeSnippet';
+import EmbedCodeSnippet, { type EmbedMethod } from './EmbedCodeSnippet';
 import EmbedFiltersInteractivity from './EmbedFiltersInteractivity';
 
 const useEmbedUrlCreateMutation = (projectUuid: string) => {
@@ -85,6 +85,7 @@ const EmbedPreviewDashboardForm: FC<{
     const { mutateAsync: createEmbedUrl } =
         useEmbedUrlCreateMutation(projectUuid);
     const { data: user } = useUser(true);
+    const [embedMethod, setEmbedMethod] = useState<EmbedMethod>('iframe');
 
     const form = useForm<FormValues>({
         initialValues: {
@@ -415,13 +416,34 @@ const EmbedPreviewDashboardForm: FC<{
 
             <Stack gap="md" mb="md">
                 <Stack gap="xs">
-                    <Title order={5}>Code snippet</Title>
+                    <Text size="sm" fw={500}>
+                        Embed method
+                    </Text>
+                    <SegmentedControl
+                        value={embedMethod}
+                        onChange={(value) =>
+                            setEmbedMethod(value as EmbedMethod)
+                        }
+                        data={[
+                            { label: 'Iframe', value: 'iframe' },
+                            { label: 'SDK', value: 'sdk' },
+                        ]}
+                    />
+                </Stack>
+                <Stack gap="xs">
+                    <Title order={5}>
+                        {embedMethod === 'iframe'
+                            ? 'Iframe embed code'
+                            : 'React SDK code'}
+                    </Title>
                     <Text c="dimmed" fz="sm">
-                        Copy and paste this code snippet into your application
-                        to generate embed URLs.
+                        {embedMethod === 'iframe'
+                            ? 'Use this for iframe or direct embedding with a full embed URL.'
+                            : 'Use this for React SDK embedding with a backend-generated JWT.'}
                     </Text>
                 </Stack>
                 <EmbedCodeSnippet
+                    mode={embedMethod}
                     projectUuid={projectUuid}
                     siteUrl={siteUrl}
                     data={convertFormValuesToCreateEmbedJwt(formValues)}

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/index.tsx
@@ -250,9 +250,10 @@ const SettingsEmbed: FC<{ projectUuid: string }> = ({ projectUuid }) => {
             </SettingsCard>
             <SettingsCard>
                 <Stack gap="xs" mb="md">
-                    <Title order={4}>Preview & code snippet</Title>
+                    <Title order={4}>Preview & embed code</Title>
                     <Text c="dimmed" fz="sm">
-                        Preview your embed URL and copy it to your clipboard.
+                        Configure your content, preview it, and copy the right
+                        embed code for your integration method.
                     </Text>
                 </Stack>
                 <Tabs defaultValue="dashboards" keepMounted>


### PR DESCRIPTION
### Description:

This PR adds React SDK support to the embed code generation feature, allowing users to choose between iframe and SDK embedding methods.

**Key changes:**

- Added `EmbedMethod` type and exported `SnippetLanguage` enum for better type safety
- Introduced SDK-specific code templates for both charts and dashboards in Node.js, Python, and Go
- Created `getReactSdkFrontendSnippet()` function to generate React SDK frontend code with proper component structure and optional filter examples
- Refactored code generation logic to support both iframe and SDK modes through the `getBackendCodeSnippet()` function
- Added embed method selection via `SegmentedControl` in dashboard forms (iframe/SDK options)
- Updated chart forms to use SDK-only mode
- Enhanced UI with better descriptions and documentation links for each embedding method
- Improved placeholder handling with fallback values like `<CHART_UUID>` and `<DASHBOARD_UUID>`
- Restructured the code snippet display to show both backend JWT generation and frontend React component code for SDK mode
