### PR TITLE
fix: use alphanumeric-only nanoid to prevent SQL comment parsing issues

### DIFF
--- a/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
+++ b/packages/backend/src/models/QueryHistoryModel/QueryHistoryModel.ts
@@ -9,7 +9,7 @@ import {
 } from '@lightdash/common';
 import crypto from 'crypto';
 import { Knex } from 'knex';
-import { nanoid } from 'nanoid';
+import { customAlphabet, nanoid } from 'nanoid';
 import {
     DbQueryHistory,
     DbQueryHistoryUpdate,
@@ -61,6 +61,11 @@ function convertDbQueryHistoryToQueryHistory(
 export class QueryHistoryModel {
     readonly database: Knex;
 
+    // Alphanumeric-only nanoid to avoid '--' sequences that break SQL comment stripping in DuckDB
+    private static readonly sqlSafeNanoid = customAlphabet(
+        '0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz',
+    );
+
     constructor({ database }: { database: Knex }) {
         this.database = database;
     }
@@ -91,8 +96,11 @@ export class QueryHistoryModel {
         return crypto.createHash('sha256').update(queryHashKey).digest('hex');
     }
 
-    static createUniqueResultsFileName(cacheKey: string) {
-        return `${cacheKey}-${nanoid()}`;
+    static createUniqueResultsFileName(
+        cacheKey: string,
+        options?: { sqlSafe: boolean },
+    ) {
+        return `${cacheKey}-${options?.sqlSafe ? QueryHistoryModel.sqlSafeNanoid() : nanoid()}`;
     }
 
     async create(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1899,17 +1899,21 @@ export class AsyncQueryService extends ProjectService {
                 `Running query ${queryUuid} source=${executionSource}`,
             );
 
-            const fileName =
-                QueryHistoryModel.createUniqueResultsFileName(cacheKey);
-            const resultsStorageClient = this.getResultsStorageClientForContext(
-                queryTags.query_context,
-            );
-
             // Create upload stream for storing results
             const isParquetMaterialization =
                 this.lightdashConfig.preAggregates.parquetEnabled &&
                 queryTags.query_context ===
                     QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION;
+
+            const fileName = QueryHistoryModel.createUniqueResultsFileName(
+                cacheKey,
+                {
+                    sqlSafe: isParquetMaterialization,
+                },
+            );
+            const resultsStorageClient = this.getResultsStorageClientForContext(
+                queryTags.query_context,
+            );
 
             if (isParquetMaterialization) {
                 const s3Config = getDuckdbRuntimeConfig(


### PR DESCRIPTION
Closes ZAP-306

Modified nanoid generation to use only alphanumeric characters when creating unique results file names.

The alphanumeric-only constraint prevents '--' character sequences in generated IDs that would break SQL comment stripping functionality.