### PR TITLE
feat: improve explore search for nested field groups

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/TreeSingleNode.tsx
@@ -24,6 +24,7 @@ import {
 import {
     IconAlertTriangle,
     IconFilter,
+    IconHierarchyOff,
     IconInfoCircle,
 } from '@tabler/icons-react';
 import { memo, useCallback, useMemo, type FC } from 'react';
@@ -46,6 +47,7 @@ import {
 import FieldIcon from '../../../../common/Filters/FieldIcon';
 import MantineIcon from '../../../../common/MantineIcon';
 import { ItemDetailPreview } from '../ItemDetailPreview';
+import { MAX_GROUP_DEPTH } from './constants';
 import TreeSingleNodeActions from './TreeSingleNodeActions';
 import { type Node } from './types';
 import useTableTree from './useTableTree';
@@ -254,7 +256,7 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                     withinPortal
                     maw={300}
                     multiline
-                    label={messages.join('\n')}
+                    label={messages.map((m) => m.message).join('\n')}
                 >
                     <MantineIcon
                         icon={alertIcon}
@@ -265,6 +267,17 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
             );
         });
     }, [alerts]);
+
+    const isTruncated = useMemo(() => {
+        if (!isField(item)) return false;
+        const groups = item.groups ?? [];
+        return groups.length > MAX_GROUP_DEPTH;
+    }, [item]);
+
+    const truncatedActualDepth = useMemo(() => {
+        if (!isField(item)) return 0;
+        return (item.groups ?? []).length;
+    }, [item]);
 
     // Apply indentation for virtualized mode only
     // Non-virtualized mode uses NavLink's built-in nesting with childrenOffset
@@ -336,6 +349,20 @@ const TreeSingleNodeComponent: FC<Props> = ({ node }) => {
                         </HoverCard.Dropdown>
                     </HoverCard>
                     {renderAlerts}
+                    {isTruncated && (
+                        <Tooltip
+                            withinPortal
+                            maw={300}
+                            multiline
+                            label={`Located ${truncatedActualDepth} levels deep`}
+                        >
+                            <MantineIcon
+                                icon={IconHierarchyOff}
+                                color="ldGray.6"
+                                style={{ flexShrink: 0 }}
+                            />
+                        </Tooltip>
+                    )}
                     {showFilterAction && (
                         <Tooltip
                             withinPortal

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/constants.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Tree/constants.ts
@@ -1,1 +1,1 @@
-export const MAX_GROUP_DEPTH = 3;
+export const MAX_GROUP_DEPTH = 5;

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/flattenTree.ts
@@ -59,16 +59,14 @@ function flattenNodeRecursive(
     // If it's a group, check if any children are visible
     if (isGroup) {
         const groupNode = node;
-        const hasVisibleChildren = Object.values(groupNode.children).some(
-            (child) =>
-                !isSearching ||
-                searchResults.includes(child.key) ||
-                ('children' in child &&
-                    child.children &&
-                    Object.values(child.children).some((grandchild) =>
-                        searchResults.includes(grandchild.key),
-                    )),
-        );
+        const hasMatchInDescendants = (treeNode: TreeNode): boolean =>
+            searchResults.includes(treeNode.key) ||
+            (isGroupNode(treeNode) &&
+                Object.values(treeNode.children).some(hasMatchInDescendants));
+
+        const hasVisibleChildren =
+            !isSearching ||
+            Object.values(groupNode.children).some(hasMatchInDescendants);
 
         if (!hasVisibleChildren && isSearching) {
             return items;


### PR DESCRIPTION

Closes: #19635

### Description:
Fixed search not finding fields in deeply nested groups (was limited to 2 levels) by making the visibility check recursive, matching the non-virtualized tree.
I also bumped the `MAX_GROUP_DEPTH` from 3 to 5, to display in the UI the tree. I included an indicator that shows if the found field exceeded the UI max depth limit


![CleanShot 2026-03-18 at 13.12.42.png](https://app.graphite.com/user-attachments/assets/f896f843-84c5-4d37-bf65-9140ae6ce899.png)


![CleanShot 2026-03-18 at 13.12.50.png](https://app.graphite.com/user-attachments/assets/d823e4dd-152d-4840-96b0-8c692259726f.png)
