### PR TITLE
fix: field processing logic in GoogleDriveClient

### DIFF
--- a/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.test.ts
@@ -1,3 +1,4 @@
+import { DimensionType, FieldType } from '@lightdash/common';
 import { GoogleDriveClient } from './GoogleDriveClient';
 
 describe('GoogleDriveClient', () => {
@@ -87,6 +88,56 @@ describe('GoogleDriveClient', () => {
             const truncatedObject = GoogleDriveClient.formatCell(largeObject);
             expect(truncatedObject).toHaveLength(50000);
             expect(truncatedObject).toMatch(/\.\.\. \[TRUNCATED\]$/);
+        });
+    });
+
+    describe('appendToSheet', () => {
+        test('should only export selected fields from the results table', async () => {
+            const client = new GoogleDriveClient({
+                lightdashConfig: {
+                    auth: {
+                        google: {
+                            oauth2ClientId: 'client-id',
+                            oauth2ClientSecret: 'client-secret',
+                        },
+                    },
+                },
+            } as never);
+
+            const appendCsvToSheet = jest
+                .spyOn(client, 'appendCsvToSheet')
+                .mockResolvedValue(undefined);
+
+            await client.appendToSheet(
+                'refresh-token',
+                'file-id',
+                [
+                    {
+                        orders_total_revenue: 120,
+                        orders_normalized_charges: 150,
+                    },
+                ],
+                {
+                    orders_total_revenue: {
+                        name: 'total_revenue',
+                        label: 'Total revenue',
+                        type: DimensionType.NUMBER,
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        fieldType: FieldType.METRIC,
+                        sql: '${TABLE}.total_revenue',
+                        hidden: false,
+                    },
+                },
+                false,
+            );
+
+            expect(appendCsvToSheet).toHaveBeenCalledWith(
+                'refresh-token',
+                'file-id',
+                [['Total revenue'], [120]],
+                undefined,
+            );
         });
     });
 });

--- a/packages/backend/src/clients/Google/GoogleDriveClient.ts
+++ b/packages/backend/src/clients/Google/GoogleDriveClient.ts
@@ -6,8 +6,6 @@ import {
     ForbiddenError,
     formatDate,
     getErrorMessage,
-    getItemLabel,
-    getItemLabelWithoutTableName,
     GoogleSheetsQuotaError,
     GoogleSheetsScopeError,
     GoogleSheetsTransientError,
@@ -23,6 +21,7 @@ import {
 import { google, sheets_v4 } from 'googleapis';
 import { LightdashConfig } from '../../config/parseConfig';
 import Logger from '../../logging/logger';
+import { processFieldsForExport } from '../../utils/FileDownloadUtils/FileDownloadUtils';
 
 type GoogleDriveClientArguments = {
     lightdashConfig: LightdashConfig;
@@ -384,21 +383,15 @@ export class GoogleDriveClient {
             return;
         }
 
-        const sortedFieldIds = Object.keys(csvContent[0])
-            .sort((a, b) => columnOrder.indexOf(a) - columnOrder.indexOf(b))
-            .filter((id) => !hiddenFields.includes(id));
-
-        const csvHeader = sortedFieldIds.map((id) => {
-            if (customLabels[id]) {
-                return customLabels[id];
-            }
-            if (itemMap[id]) {
-                return showTableNames
-                    ? getItemLabel(itemMap[id])
-                    : getItemLabelWithoutTableName(itemMap[id]);
-            }
-            return id;
-        });
+        const { sortedFieldIds, headers: csvHeader } = processFieldsForExport(
+            itemMap,
+            {
+                showTableNames,
+                customLabels,
+                columnOrder,
+                hiddenFields,
+            },
+        );
 
         const values = csvContent.map((row) =>
             sortedFieldIds.map((fieldId) => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/21223

## Summary

Fix Google Sheets sync exporting underlying YAML metric dependencies as extra columns.

After the Google Sheets export path moved to async query results, non-pivot sheet exports started building columns from the raw result row keys. For metrics defined from other metrics in YAML, those raw rows can include dependency metrics that are not part of the visible Lightdash results table. As a result, Google Sheets syncs were writing extra columns that users did not select.

This change updates the Google Sheets export path to use the selected results-table fields, matching the existing CSV/XLSX export behavior.

## Changes

- update Google Sheets non-pivot export to derive columns from the selected field map instead of raw row keys
- preserve existing column ordering, custom labels, and hidden field handling
- add a regression test covering a derived metric row that contains underlying dependency metrics in the raw results

## Testing

- reproduced on `main`
- reproduced locally with a metric defined from other metrics in YAML
- verified that CSV/XLSX already behaved correctly
- verified that after this change Google Sheets only exports the visible results-table columns