### PR TITLE
chore: Keep Add Filter button accessible in dashboard edit mode via eye toggle

### DIFF
--- a/packages/frontend/src/features/dashboardFilters/AddFilterButton.module.css
+++ b/packages/frontend/src/features/dashboardFilters/AddFilterButton.module.css
@@ -1,6 +1,0 @@
-.closeButton {
-    position: absolute;
-    top: -6px;
-    right: -6px;
-    z-index: 1;
-}

--- a/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
+++ b/packages/frontend/src/features/dashboardFilters/AddFilterButton.tsx
@@ -1,6 +1,5 @@
 import { type DashboardFilterRule } from '@lightdash/common';
 import {
-    ActionIcon,
     Button,
     Divider,
     Group,
@@ -9,11 +8,10 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { useDisclosure, useId } from '@mantine-8/hooks';
-import { IconRotate2, IconX } from '@tabler/icons-react';
+import { IconEye, IconEyeOff, IconRotate2 } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import MantineIcon from '../../components/common/MantineIcon';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
-import styles from './AddFilterButton.module.css';
 import FilterConfiguration from './FilterConfiguration';
 
 type Props = {
@@ -95,18 +93,9 @@ const AddFilterButton: FC<Props> = ({
     );
 
     const showResetFiltersButton = !isEditMode && haveFiltersChanged;
+    const hasAttachedButton = showResetFiltersButton || isEditMode;
 
-    if (isAddFilterDisabled) {
-        if (isEditMode)
-            return (
-                <Button
-                    variant="light"
-                    size="xs"
-                    onClick={() => setIsAddFilterDisabled(false)}
-                >
-                    Enable Add Filter
-                </Button>
-            );
+    if (isAddFilterDisabled && !isEditMode) {
         if (showResetFiltersButton)
             return (
                 <Tooltip label="Reset all filters" withinPortal>
@@ -169,55 +158,35 @@ const AddFilterButton: FC<Props> = ({
                             </Text>
                         }
                     >
-                        <Group gap={0} pos="relative">
-                            {isEditMode && (
-                                <ActionIcon
-                                    size="xs"
-                                    variant="default"
-                                    onClick={() => setIsAddFilterDisabled(true)}
-                                    className={styles.closeButton}
-                                >
-                                    <MantineIcon icon={IconX} size={12} />
-                                </ActionIcon>
-                            )}
-                            <Button
-                                size="xs"
-                                variant="default"
-                                radius="md"
-                                disabled={disabled}
-                                loading={
-                                    isLoadingDashboardFilters ||
-                                    isFetchingDashboardFilters
-                                }
-                                styles={{
-                                    root: {
-                                        borderStyle: 'dashed',
-                                        borderRadius: '100px',
-                                        ...(showResetFiltersButton
-                                            ? {
-                                                  borderRightWidth: '0px',
-                                                  borderTopRightRadius: '0px',
-                                                  borderBottomRightRadius:
-                                                      '0px',
-                                              }
-                                            : {
-                                                  borderRightStyle: 'dashed',
-                                                  borderRightWidth: '1px',
-                                                  borderTopRightRadius: '100px',
-                                                  borderBottomRightRadius:
-                                                      '100px',
-                                              }),
-                                    },
-                                }}
-                                onClick={() =>
-                                    isPopoverOpen
-                                        ? handleClose()
-                                        : onPopoverOpen(popoverId)
-                                }
-                            >
-                                Add filter
-                            </Button>
-                        </Group>
+                        <Button
+                            size="xs"
+                            variant="default"
+                            radius={100}
+                            disabled={disabled}
+                            loading={
+                                isLoadingDashboardFilters ||
+                                isFetchingDashboardFilters
+                            }
+                            styles={{
+                                root: {
+                                    borderStyle: 'dashed',
+                                    ...(hasAttachedButton
+                                        ? {
+                                              borderRightWidth: '0px',
+                                              borderTopRightRadius: '0px',
+                                              borderBottomRightRadius: '0px',
+                                          }
+                                        : {}),
+                                },
+                            }}
+                            onClick={() =>
+                                isPopoverOpen
+                                    ? handleClose()
+                                    : onPopoverOpen(popoverId)
+                            }
+                        >
+                            Add filter
+                        </Button>
                     </Tooltip>
                 </Popover.Target>
 
@@ -242,6 +211,47 @@ const AddFilterButton: FC<Props> = ({
                     )}
                 </Popover.Dropdown>
             </Popover>
+
+            {isEditMode && (
+                <>
+                    <Divider orientation="vertical" />
+
+                    <Tooltip
+                        label={
+                            isAddFilterDisabled
+                                ? 'Hidden from viewers. Click to show.'
+                                : 'Visible to viewers. Click to hide.'
+                        }
+                        withinPortal
+                    >
+                        <Button
+                            aria-label="Toggle filter visibility for viewers"
+                            size="xs"
+                            variant="default"
+                            color="gray"
+                            onClick={() =>
+                                setIsAddFilterDisabled(!isAddFilterDisabled)
+                            }
+                            styles={{
+                                root: {
+                                    borderLeft: '0px',
+                                    borderStartStartRadius: '0px',
+                                    borderEndStartRadius: '0px',
+                                    borderStartEndRadius: '100px',
+                                    borderEndEndRadius: '100px',
+                                    borderStyle: 'dashed',
+                                },
+                            }}
+                        >
+                            <MantineIcon
+                                icon={
+                                    isAddFilterDisabled ? IconEyeOff : IconEye
+                                }
+                            />
+                        </Button>
+                    </Tooltip>
+                </>
+            )}
 
             {showResetFiltersButton && (
                 <>

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.module.css
@@ -2,13 +2,6 @@
     border-color: var(--mantine-color-blue-6);
 }
 
-.closeButton {
-    position: absolute;
-    top: -6px;
-    right: -6px;
-    z-index: 1;
-}
-
 .checkboxInput {
     cursor: pointer;
 }

--- a/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
+++ b/packages/frontend/src/features/dateZoom/components/DateZoom.tsx
@@ -7,6 +7,7 @@ import {
     ActionIcon,
     Button,
     Checkbox,
+    Divider,
     Group,
     Menu,
     Text,
@@ -16,9 +17,10 @@ import {
     IconCheck,
     IconChevronDown,
     IconChevronUp,
+    IconEye,
+    IconEyeOff,
     IconPin,
     IconPinFilled,
-    IconX,
 } from '@tabler/icons-react';
 import { useCallback, useEffect, useMemo, useState, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
@@ -270,49 +272,40 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
         [track, setDateZoomGranularity],
     );
 
-    if (isDateZoomDisabled) {
-        if (isEditMode)
-            return (
-                <Button
-                    variant="light"
-                    size="xs"
-                    onClick={() => setIsDateZoomDisabled(false)}
-                >
-                    Enable Date Zoom
-                </Button>
-            );
+    if (isDateZoomDisabled && !isEditMode) {
         return null;
     }
 
     return (
-        <Menu
-            withinPortal
-            withArrow
-            closeOnItemClick={!isEditMode}
-            closeOnClickOutside
-            offset={-1}
-            position="bottom-end"
-            onOpen={() => setShowOpenIcon(true)}
-            onClose={() => setShowOpenIcon(false)}
-        >
-            <Menu.Target>
-                <Group gap={0} pos="relative">
-                    {isEditMode && (
-                        <ActionIcon
-                            size="xs"
-                            variant="default"
-                            onClick={() => setIsDateZoomDisabled(true)}
-                            className={styles.closeButton}
-                        >
-                            <MantineIcon icon={IconX} size={12} />
-                        </ActionIcon>
-                    )}
+        <Group gap={0} wrap="nowrap">
+            <Menu
+                withinPortal
+                withArrow
+                closeOnItemClick={!isEditMode}
+                closeOnClickOutside
+                offset={-1}
+                position="bottom-end"
+                onOpen={() => setShowOpenIcon(true)}
+                onClose={() => setShowOpenIcon(false)}
+            >
+                <Menu.Target>
                     <Button
                         size="xs"
                         variant="default"
                         classNames={
                             !isEditMode && dateZoomGranularity
                                 ? { root: styles.activeDateZoomButton }
+                                : undefined
+                        }
+                        styles={
+                            isEditMode
+                                ? {
+                                      root: {
+                                          borderRightWidth: '0px',
+                                          borderTopRightRadius: '0px',
+                                          borderBottomRightRadius: '0px',
+                                      },
+                                  }
                                 : undefined
                         }
                         rightSection={
@@ -340,137 +333,177 @@ export const DateZoom: FC<Props> = ({ isEditMode }) => {
                             </>
                         ) : null}
                     </Button>
-                </Group>
-            </Menu.Target>
-            <Menu.Dropdown>
-                {isEditMode ? (
-                    <>
-                        <Menu.Label>Granularities</Menu.Label>
-                        {standardGranularities.map((granularity) => (
-                            <EditModeGranularityItem
-                                key={granularity}
-                                granularity={granularity}
-                                label={granularity}
-                                isEnabled={dateZoomGranularities.includes(
-                                    granularity,
-                                )}
-                                isDefault={
-                                    defaultDateZoomGranularity === granularity
-                                }
-                                isLastEnabled={
-                                    dateZoomGranularities.includes(
-                                        granularity,
-                                    ) && dateZoomGranularities.length <= 1
-                                }
-                                onToggle={handleToggleGranularity}
-                                onSetDefault={handleSetDefault}
-                            />
-                        ))}
-                        {customGranularities.length > 0 && (
-                            <>
-                                <Menu.Divider />
-                                <Menu.Label>Custom</Menu.Label>
-                                {customGranularities.map((granularity) => (
-                                    <EditModeGranularityItem
-                                        key={granularity}
-                                        granularity={granularity}
-                                        label={getGranularityLabel(
-                                            granularity,
-                                            availableCustomGranularities,
-                                        )}
-                                        isEnabled={dateZoomGranularities.includes(
-                                            granularity,
-                                        )}
-                                        isDefault={
-                                            defaultDateZoomGranularity ===
-                                            granularity
-                                        }
-                                        isLastEnabled={
-                                            dateZoomGranularities.includes(
-                                                granularity,
-                                            ) &&
-                                            dateZoomGranularities.length <= 1
-                                        }
-                                        onToggle={handleToggleGranularity}
-                                        onSetDefault={handleSetDefault}
-                                    />
-                                ))}
-                            </>
-                        )}
-                    </>
-                ) : (
-                    <>
-                        <Tooltip
-                            label="Charts will display dates using their original granularity settings."
-                            position="left"
-                            multiline
-                            maw={200}
-                        >
-                            <Menu.Item
-                                fz="xs"
-                                onClick={() => {
-                                    track({
-                                        name: EventName.DATE_ZOOM_CLICKED,
-                                        properties: {
-                                            granularity: 'default',
-                                        },
-                                    });
-
-                                    setDateZoomGranularity(undefined);
-                                }}
-                                disabled={dateZoomGranularity === undefined}
-                                rightSection={
-                                    dateZoomGranularity === undefined ? (
-                                        <MantineIcon
-                                            icon={IconCheck}
-                                            size={14}
-                                        />
-                                    ) : null
-                                }
-                            >
-                                None
-                            </Menu.Item>
-                        </Tooltip>
-
-                        {dateZoomGranularities
-                            .filter((g) => isStandardDateGranularity(g))
-                            .map((granularity) => (
-                                <ViewModeGranularityItem
+                </Menu.Target>
+                <Menu.Dropdown>
+                    {isEditMode ? (
+                        <>
+                            <Menu.Label>Granularities</Menu.Label>
+                            {standardGranularities.map((granularity) => (
+                                <EditModeGranularityItem
                                     key={granularity}
                                     granularity={granularity}
                                     label={granularity}
-                                    isActive={
-                                        dateZoomGranularity === granularity
+                                    isEnabled={dateZoomGranularities.includes(
+                                        granularity,
+                                    )}
+                                    isDefault={
+                                        defaultDateZoomGranularity ===
+                                        granularity
                                     }
-                                    onSelect={handleSelectGranularity}
+                                    isLastEnabled={
+                                        dateZoomGranularities.includes(
+                                            granularity,
+                                        ) && dateZoomGranularities.length <= 1
+                                    }
+                                    onToggle={handleToggleGranularity}
+                                    onSetDefault={handleSetDefault}
                                 />
                             ))}
-
-                        {enabledCustomGranularities.length > 0 && (
-                            <>
-                                <Menu.Divider />
-                                {enabledCustomGranularities.map(
-                                    (granularity) => (
-                                        <ViewModeGranularityItem
+                            {customGranularities.length > 0 && (
+                                <>
+                                    <Menu.Divider />
+                                    <Menu.Label>Custom</Menu.Label>
+                                    {customGranularities.map((granularity) => (
+                                        <EditModeGranularityItem
                                             key={granularity}
                                             granularity={granularity}
                                             label={getGranularityLabel(
                                                 granularity,
                                                 availableCustomGranularities,
                                             )}
-                                            isActive={
-                                                dateZoomGranularity ===
+                                            isEnabled={dateZoomGranularities.includes(
+                                                granularity,
+                                            )}
+                                            isDefault={
+                                                defaultDateZoomGranularity ===
                                                 granularity
                                             }
-                                            onSelect={handleSelectGranularity}
+                                            isLastEnabled={
+                                                dateZoomGranularities.includes(
+                                                    granularity,
+                                                ) &&
+                                                dateZoomGranularities.length <=
+                                                    1
+                                            }
+                                            onToggle={handleToggleGranularity}
+                                            onSetDefault={handleSetDefault}
                                         />
-                                    ),
-                                )}
-                            </>
-                        )}
-                    </>
-                )}
-            </Menu.Dropdown>
-        </Menu>
+                                    ))}
+                                </>
+                            )}
+                        </>
+                    ) : (
+                        <>
+                            <Tooltip
+                                label="Charts will display dates using their original granularity settings."
+                                position="left"
+                                multiline
+                                maw={200}
+                            >
+                                <Menu.Item
+                                    fz="xs"
+                                    onClick={() => {
+                                        track({
+                                            name: EventName.DATE_ZOOM_CLICKED,
+                                            properties: {
+                                                granularity: 'default',
+                                            },
+                                        });
+
+                                        setDateZoomGranularity(undefined);
+                                    }}
+                                    disabled={dateZoomGranularity === undefined}
+                                    rightSection={
+                                        dateZoomGranularity === undefined ? (
+                                            <MantineIcon
+                                                icon={IconCheck}
+                                                size={14}
+                                            />
+                                        ) : null
+                                    }
+                                >
+                                    None
+                                </Menu.Item>
+                            </Tooltip>
+
+                            {dateZoomGranularities
+                                .filter((g) => isStandardDateGranularity(g))
+                                .map((granularity) => (
+                                    <ViewModeGranularityItem
+                                        key={granularity}
+                                        granularity={granularity}
+                                        label={granularity}
+                                        isActive={
+                                            dateZoomGranularity === granularity
+                                        }
+                                        onSelect={handleSelectGranularity}
+                                    />
+                                ))}
+
+                            {enabledCustomGranularities.length > 0 && (
+                                <>
+                                    <Menu.Divider />
+                                    {enabledCustomGranularities.map(
+                                        (granularity) => (
+                                            <ViewModeGranularityItem
+                                                key={granularity}
+                                                granularity={granularity}
+                                                label={getGranularityLabel(
+                                                    granularity,
+                                                    availableCustomGranularities,
+                                                )}
+                                                isActive={
+                                                    dateZoomGranularity ===
+                                                    granularity
+                                                }
+                                                onSelect={
+                                                    handleSelectGranularity
+                                                }
+                                            />
+                                        ),
+                                    )}
+                                </>
+                            )}
+                        </>
+                    )}
+                </Menu.Dropdown>
+            </Menu>
+
+            {isEditMode && (
+                <>
+                    <Divider orientation="vertical" />
+
+                    <Tooltip
+                        label={
+                            isDateZoomDisabled
+                                ? 'Hidden from viewers. Click to show.'
+                                : 'Visible to viewers. Click to hide.'
+                        }
+                        withinPortal
+                    >
+                        <Button
+                            aria-label="Toggle date zoom visibility for viewers"
+                            size="xs"
+                            variant="default"
+                            color="gray"
+                            onClick={() =>
+                                setIsDateZoomDisabled(!isDateZoomDisabled)
+                            }
+                            styles={{
+                                root: {
+                                    borderLeftWidth: '0px',
+                                    borderStartStartRadius: '0px',
+                                    borderEndStartRadius: '0px',
+                                },
+                            }}
+                        >
+                            <MantineIcon
+                                icon={isDateZoomDisabled ? IconEyeOff : IconEye}
+                            />
+                        </Button>
+                    </Tooltip>
+                </>
+            )}
+        </Group>
     );
 };


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-5998/improve-adding-default-filters-when-add-filter-is-hidden

### Description:
Previously when you disabled the "Add filter" button in order to hide it from viewers, you disabled it both in edit mode and view mode. This meant you had to reenable it to add default filters and then disable it again. 

I have improved the UX so that instead of the `X` on top of the `Add filter` button, you can use the eye toggle to toggle visibility in Dashboard viewer mode. The toggle allows users to use the `Add filter` button in edit mode regardless of whether it is disabled or enabled in view mode. 
This has also been applied to `Date Zoom` for consistency but note that this means Date Zoom options are still accessible regardless of whether enabled or disabled. 

### Changes
- Removed the X action icon from `Add filter` and `Date Zoom`       
  - Added an inline eye toggle button (only visible in edit mode) that attaches to the right side of the main buttons                                                 
  - When disabled in edit mode, the full component still renders (so editors can still interact with the `Add filter` and `Date Zoom` buttons but can toggle visibility for view mode on and off)                        

#### Before
![CleanShot 2026-03-18 at 14 59 22.gif](https://github.com/user-attachments/assets/4163af16-ef7d-4604-8b14-1540eefd0e62)

#### After

![CleanShot 2026-03-18 at 14 31 34.gif](https://github.com/user-attachments/assets/e9afeafa-7d4b-4b09-b862-c13bbf47421f)

Questions: 
Do we want to 
- grey out Date Zoom when it is disabled in view mode?
- do we want to grey out the eye toggle when disabled? 