### PR TITLE
feat: add nested aggregate fanout reproduction metrics

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_accounts.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_accounts.yml
@@ -49,6 +49,33 @@ models:
           sql_on: ${fanouts_users.user_id} = ${fanouts_tracks.user_id}
           type: left
           fields: [ id, user_id, event_count, name, timestamp, days_since_user_created, event_count]
+      metrics:
+        nested_agg_fanout_repro:
+          type: number
+          label: "Repro: Nested agg + fanout"
+          description: "Reproduction metric for nested aggregate + fanout CTE compilation. Example repro: fanouts_accounts explored by fanouts_users.job_title, metric nested_agg_fanout_repro, sorted DESC by the same metric."
+          sql: |
+            CASE
+              WHEN ${total_estimated_annual_recurring_revenue} IS NULL THEN NULL
+              ELSE 1 + (
+                0.99 * COALESCE(
+                  100.0 * (
+                    MAX(${total_estimated_annual_recurring_revenue}) OVER () - ${total_estimated_annual_recurring_revenue}
+                  ) / NULLIF(
+                    MAX(${total_estimated_annual_recurring_revenue}) OVER () - MIN(${total_estimated_annual_recurring_revenue}) OVER (),
+                    0
+                  ),
+                  0
+                )
+              )
+            END
+        nested_agg_cross_table_fanout_repro:
+          type: number
+          label: "Repro: Cross-table nested agg + fanout"
+          description: "Reproduction metric for nested aggregate + fanout CTE duplication via a joined metric reference. Example repro: fanouts_accounts explored by fanouts_users.job_title, metric nested_agg_cross_table_fanout_repro, sorted DESC by the same metric."
+          sql: |
+            SUM(${total_estimated_annual_recurring_revenue})
+            / NULLIF(${fanouts_users.unique_user_count}, 0)
     columns:
       - name: account_id
         description: "The Account ID from our database"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->


### Description:

Added two reproduction metrics to the fanouts_accounts model to help debug nested aggregate and fanout CTE compilation issues:

- `nested_agg_fanout_repro`: A metric that uses window functions (MAX/MIN OVER) with conditional logic to reproduce nested aggregate + fanout CTE compilation problems
- `nested_agg_cross_table_fanout_repro`: A metric that references a joined table metric (`fanouts_users.unique_user_count`) to reproduce cross-table nested aggregate + fanout CTE duplication issues

Both metrics include detailed descriptions with example reproduction steps for testing purposes.