### PR TITLE
poc: add trellis (small multiples) chart configuration

### DIFF
--- a/packages/common/src/types/savedCharts.ts
+++ b/packages/common/src/types/savedCharts.ts
@@ -677,6 +677,8 @@ export type CompleteCartesianChartLayout = {
     colorByCategory?: boolean | undefined;
     /** Per-category color overrides (maps category value to hex color) */
     categoryColorOverrides?: Record<string, string> | undefined;
+    /** Trellis (small multiples) configuration — splits the chart into a grid by a dimension */
+    trellis?: { fieldId: string } | undefined;
 };
 
 export type CartesianChartLayout = Partial<CompleteCartesianChartLayout>;

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Layout/index.tsx
@@ -189,6 +189,7 @@ export const Layout: FC<Props> = ({ items }) => {
         setXField,
         setStacking,
         setFlipAxis,
+        setTrellis,
         updateYField,
         removeSingleSeries,
         addSingleSeries,
@@ -463,6 +464,54 @@ export const Layout: FC<Props> = ({ items }) => {
                             </Group>
                         </Tooltip>
                     )}
+                </Config.Section>
+            </Config>
+
+            <Config>
+                <Config.Section>
+                    <Config.Group>
+                        <Config.Heading>Trellis</Config.Heading>
+                        {dirtyLayout?.trellis && (
+                            <CloseButton
+                                size="sm"
+                                onClick={() => setTrellis(undefined)}
+                            />
+                        )}
+                    </Config.Group>
+                    {!dirtyLayout?.trellis &&
+                    availableGroupByDimensions.length > 0 ? (
+                        <FieldSelect
+                            placeholder="Split chart by dimension"
+                            item={undefined}
+                            items={availableGroupByDimensions}
+                            onChange={(newValue) => {
+                                if (newValue) {
+                                    setTrellis(getItemId(newValue));
+                                }
+                            }}
+                            hasGrouping
+                        />
+                    ) : dirtyLayout?.trellis ? (
+                        <FieldSelect
+                            item={availableDimensions.find(
+                                (item) =>
+                                    getItemId(item) ===
+                                    dirtyLayout.trellis?.fieldId,
+                            )}
+                            items={availableGroupByDimensions}
+                            onChange={(newValue) => {
+                                setTrellis(
+                                    newValue ? getItemId(newValue) : undefined,
+                                );
+                            }}
+                            rightSection={
+                                <CloseButton
+                                    onClick={() => setTrellis(undefined)}
+                                />
+                            }
+                            hasGrouping
+                        />
+                    ) : null}
                 </Config.Section>
             </Config>
         </Stack>

--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -606,6 +606,13 @@ const useCartesianChartConfig = ({
         }));
     }, []);
 
+    const setTrellis = useCallback((fieldId: string | undefined) => {
+        setDirtyLayout((prev) => ({
+            ...prev,
+            trellis: fieldId ? { fieldId } : undefined,
+        }));
+    }, []);
+
     const updateAllGroupedSeries = useCallback(
         (fieldKey: string, updateSeries: Partial<Series>) =>
             setDirtyEchartsConfig(
@@ -1183,6 +1190,7 @@ const useCartesianChartConfig = ({
         updateAllGroupedSeries,
         updateYField,
         setFlipAxis,
+        setTrellis,
         setYMinValue,
         setYMaxValue,
         setXMinValue,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -3219,6 +3219,136 @@ const useEchartsCartesianConfig = (
         validCartesianConfig,
     ]);
 
+    // Trellis (small multiples) transformation:
+    // Splits data by a dimension and creates a grid of sub-charts
+    const trellisOptions = useMemo(() => {
+        const trellisFieldId = validCartesianConfig?.layout?.trellis?.fieldId;
+        if (!trellisFieldId || !eChartsOptions || !dataToRender?.length) {
+            return null;
+        }
+
+        // Group rows by trellis dimension value
+        const groups = new Map<string, Record<string, unknown>[]>();
+        for (const row of dataToRender as Record<string, unknown>[]) {
+            const key = String(row[trellisFieldId] ?? 'Unknown');
+            const group = groups.get(key);
+            if (group) {
+                group.push(row);
+            } else {
+                groups.set(key, [row]);
+            }
+        }
+
+        const trellisValues = Array.from(groups.keys()).sort();
+        const count = trellisValues.length;
+        if (count === 0) return null;
+
+        // Calculate grid layout (aim for ~3 columns)
+        const cols = Math.min(count, 3);
+        const rowCount = Math.ceil(count / cols);
+        const cellWidth = 100 / cols;
+        const cellHeight = 100 / rowCount;
+        const padding = { top: 30, right: 15, bottom: 35, left: 50 };
+
+        const grids: Record<string, unknown>[] = [];
+        const xAxes: Record<string, unknown>[] = [];
+        const yAxes: Record<string, unknown>[] = [];
+        const allSeries: Record<string, unknown>[] = [];
+        const datasets: Record<string, unknown>[] = [];
+        const titles: Record<string, unknown>[] = [];
+
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const baseXAxis: any = Array.isArray(eChartsOptions.xAxis)
+            ? (eChartsOptions.xAxis[0] ?? {})
+            : (eChartsOptions.xAxis ?? {});
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const baseYAxis: any = Array.isArray(eChartsOptions.yAxis)
+            ? (eChartsOptions.yAxis[0] ?? {})
+            : (eChartsOptions.yAxis ?? {});
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const baseSeries: any[] = Array.isArray(eChartsOptions.series)
+            ? eChartsOptions.series
+            : [];
+
+        for (let i = 0; i < count; i++) {
+            const value = trellisValues[i];
+            const col = i % cols;
+            const row = Math.floor(i / cols);
+            const isBottomRow = row === rowCount - 1;
+            const isLeftCol = col === 0;
+
+            const datasetId = `trellis_${i}`;
+
+            datasets.push({
+                id: datasetId,
+                source: groups.get(value) ?? [],
+            });
+
+            grids.push({
+                left: `${col * cellWidth + padding.left / 10}%`,
+                top: `${row * cellHeight + padding.top / 10}%`,
+                width: `${cellWidth - (padding.left + padding.right) / 10}%`,
+                height: `${cellHeight - (padding.top + padding.bottom) / 10}%`,
+            });
+
+            titles.push({
+                text: value,
+                textStyle: { fontSize: 11, fontWeight: 'normal' },
+                left: `${col * cellWidth + cellWidth / 2}%`,
+                top: `${row * cellHeight}%`,
+                textAlign: 'center',
+            });
+
+            xAxes.push({
+                ...baseXAxis,
+                gridIndex: i,
+                axisLabel: {
+                    ...(typeof baseXAxis.axisLabel === 'object'
+                        ? baseXAxis.axisLabel
+                        : {}),
+                    show: isBottomRow,
+                },
+                name: undefined, // Only show axis name on the original, not per-cell
+            });
+
+            yAxes.push({
+                ...baseYAxis,
+                gridIndex: i,
+                axisLabel: {
+                    ...(typeof baseYAxis.axisLabel === 'object'
+                        ? baseYAxis.axisLabel
+                        : {}),
+                    show: isLeftCol,
+                },
+                name: undefined,
+            });
+
+            for (const s of baseSeries) {
+                allSeries.push({
+                    ...s,
+                    xAxisIndex: i,
+                    yAxisIndex: i,
+                    datasetId,
+                    // Only show in legend for the first grid cell to avoid duplicates
+                    ...(i > 0 && { legendHoverLink: false }),
+                });
+            }
+        }
+
+        return {
+            ...eChartsOptions,
+            grid: grids,
+            xAxis: xAxes,
+            yAxis: yAxes,
+            // POC: cast series to match expected type — trellis adds xAxisIndex/yAxisIndex/datasetId
+            series: allSeries as typeof eChartsOptions.series,
+            dataset: datasets,
+            title: titles,
+            // Disable dataZoom for trellis
+            dataZoom: undefined,
+        };
+    }, [eChartsOptions, dataToRender, validCartesianConfig?.layout?.trellis]);
+
     if (
         !itemsMap ||
         rows.length <= 0 ||
@@ -3228,7 +3358,7 @@ const useEchartsCartesianConfig = (
         return undefined;
     }
 
-    return eChartsOptions;
+    return trellisOptions ?? eChartsOptions;
 };
 
 export default useEchartsCartesianConfig;


### PR DESCRIPTION
### Description:

This PR adds trellis (small multiples) functionality to Cartesian charts, allowing users to split charts into a grid of sub-charts based on a selected dimension.

**Key changes:**

- Added `trellis` configuration option to `CompleteCartesianChartLayout` type with a `fieldId` property
- Implemented trellis UI controls in the chart configuration panel, including:
  - Field selector to choose the dimension for splitting
  - Close button to remove trellis configuration
  - Conditional rendering based on available group-by dimensions
- Added `setTrellis` function to the cartesian chart config hook for managing trellis state
- Implemented trellis transformation logic in the ECharts configuration:
  - Groups data by the selected dimension value
  - Calculates optimal grid layout (targeting ~3 columns)
  - Creates separate grids, axes, series, and datasets for each sub-chart
  - Adds titles for each sub-chart showing the dimension value
  - Optimizes axis labels (only show on bottom row and left column)
  - Prevents legend duplication across sub-charts
  - Disables dataZoom for trellis views

The feature enables users to compare patterns across different categories by creating multiple smaller charts arranged in a grid, making it easier to identify trends and differences between groups.