### PR TITLE
fix: allow sub-dimension selection on required filters

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -89,6 +89,20 @@ const FilterRuleForm: FC<Props> = memo(
             ? 'This is a required filter defined in the model configuration and cannot be removed.'
             : '';
 
+        const availableFields = useMemo(() => {
+            if (!isRequired) return fields;
+            // For required filters, restrict to same-type sub-dimensions
+            const baseFieldId = filterRule.target.fieldId;
+            return fields.filter(
+                (field) =>
+                    getItemId(field).startsWith(baseFieldId) &&
+                    getFilterTypeFromItem(field) === filterType,
+            );
+        }, [isRequired, fields, filterRule.target.fieldId, filterType]);
+
+        const isFieldSelectDisabled =
+            !isEditMode || (isRequired && availableFields.length <= 1);
+
         if (!activeField) {
             return null;
         }
@@ -102,7 +116,7 @@ const FilterRuleForm: FC<Props> = memo(
             >
                 <Tooltip
                     label={isRequiredLabel}
-                    disabled={!isRequired}
+                    disabled={!isFieldSelectDisabled}
                     withinPortal
                     variant="xs"
                     multiline
@@ -110,7 +124,7 @@ const FilterRuleForm: FC<Props> = memo(
                     <Box>
                         <FieldSelect
                             size="xs"
-                            disabled={!isEditMode || isRequired}
+                            disabled={isFieldSelectDisabled}
                             comboboxProps={{
                                 withinPortal: popoverProps?.withinPortal,
                             }}
@@ -118,7 +132,7 @@ const FilterRuleForm: FC<Props> = memo(
                             onDropdownClose={popoverProps?.onClose}
                             hasGrouping
                             item={activeField}
-                            items={fields}
+                            items={availableFields}
                             onChange={(field) => {
                                 if (!field) return;
                                 onFieldChange(getItemId(field));


### PR DESCRIPTION
Closes: #21028

### Description:
Fixing regression by enabling dropdown for required filters when same-type sub-dimension exists. 

Example:

```yml
      required_filters:
        - timestamp: "inThePast 5 years"
        - context_app_version: "0.1000.1"
          required: false
      default_filters:
        - event: "lightdash_server_saved_chart_created"
        - event_text: "lightdash_%"
          required: true
```

required timestamp can be updated to any other time sub-dimension:

![CleanShot 2026-03-18 at 16.45.39.png](https://app.graphite.com/user-attachments/assets/dae98125-485e-420c-b066-b91c7f52b0a9.png)

