### PR TITLE
feat: add dashboard tile title update guidance for chart editing workflow

### DIFF
--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -101,8 +101,21 @@ See [Metrics Reference](./resources/metrics-reference.md) and [Dimensions Refere
 
 1. **Download**: `lightdash download --charts chart-slug`
 2. **Edit** the YAML file in `lightdash/` directory
-3. **Lint**: `lightdash lint` to validate before uploading
-4. **Upload**: `lightdash upload --charts chart-slug`
+3. **Update dashboard tiles**: If you changed the chart's name or purpose, download any dashboards that reference it and update their tile `title` and `chartName` properties to match
+4. **Lint**: `lightdash lint` to validate before uploading
+5. **Upload**: `lightdash upload --charts chart-slug` (and any modified dashboards)
+
+**Dashboard tiles have their own titles.** A `saved_chart` tile's `title` and `chartName` properties are independent overrides — they do NOT auto-update when you rename the chart. If you change a chart from "Total Revenue" to "Gross Profit" but don't update the dashboard tile, the dashboard will still display "Total Revenue". Always download the dashboard, find tiles with matching `chartSlug`, and update their `title` and `chartName` to match.
+
+```yaml
+# Dashboard tile — title and chartName must be updated manually when chart changes
+tiles:
+  - type: saved_chart
+    properties:
+      chartSlug: total-revenue-kpi
+      title: "Gross Profit"        # ← Update this when chart name/purpose changes
+      chartName: "Gross Profit"    # ← Update this too
+```
 
 ### Editing Dashboards
 

--- a/skills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/skills/developing-in-lightdash/resources/dashboard-reference.md
@@ -35,9 +35,11 @@ tiles:
     h: 6              # Height in grid units
     properties:
       chartSlug: monthly-revenue
-      title: "Monthly Revenue"      # Optional override
+      title: "Monthly Revenue"      # Optional override — does NOT auto-update when chart is renamed
       hideTitle: false
 ```
+
+**WARNING:** The `title` property is independent of the chart's own name. When you rename or repurpose a chart, you MUST also update the `title` in every dashboard tile that references it via `chartSlug`. Forgetting this leaves stale titles on the dashboard.
 
 ### SQL Chart Tile
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Added documentation for managing dashboard tile titles when editing charts in Lightdash. The chart editing workflow now includes a step to update dashboard tiles that reference the modified chart, since tile titles and chartName properties don't automatically sync with chart name changes.

Added a warning section explaining that dashboard tiles maintain independent title overrides that must be manually updated when charts are renamed or repurposed. Included a YAML example showing the tile properties that need updating and emphasized this requirement in the dashboard reference documentation to prevent stale titles from appearing on dashboards.

<details>
<summary>Demo</summary>

<img width="1241" height="812" alt="Screenshot 2026-03-18 at 18 14 49" src="https://github.com/user-attachments/assets/c4e823de-d4f9-4607-9b6a-7fbdcabdca3a" />


</details>