### PR TITLE
fix: prevent row limit popover from closing on drag-select

### DIFF
--- a/packages/frontend/src/components/RunQuerySettings/index.tsx
+++ b/packages/frontend/src/components/RunQuerySettings/index.tsx
@@ -8,7 +8,7 @@ import {
 } from '@mantine-8/core';
 import { useClickOutside, useDisclosure } from '@mantine-8/hooks';
 import { IconChevronDown } from '@tabler/icons-react';
-import { memo, useEffect, useState, type FC } from 'react';
+import { memo, useCallback, useEffect, useRef, useState, type FC } from 'react';
 import MantineIcon from '../common/MantineIcon';
 import AutoFetchResultsSwitch from './AutoFetchResultsSwitch';
 import LimitInput from './LimitInput';
@@ -34,10 +34,18 @@ const RunQuerySettings: FC<Props> = memo(
         targetProps,
     }) => {
         const [opened, { open, close }] = useDisclosure(false);
-        const ref = useClickOutside(
-            () => setTimeout(() => close(), 0),
-            ['mouseup', 'touchend'],
-        );
+        const mouseDownInsideRef = useRef(false);
+        const handleClickOutside = useCallback(() => {
+            if (mouseDownInsideRef.current) {
+                mouseDownInsideRef.current = false;
+                return;
+            }
+            setTimeout(() => close(), 0);
+        }, [close]);
+        const ref = useClickOutside(handleClickOutside, [
+            'mouseup',
+            'touchend',
+        ]);
 
         const [tempLimit, setTempLimit] = useState(limit);
 
@@ -79,7 +87,12 @@ const RunQuerySettings: FC<Props> = memo(
                 </Popover.Target>
 
                 <Popover.Dropdown>
-                    <Stack ref={ref}>
+                    <Stack
+                        ref={ref}
+                        onMouseDown={() => {
+                            mouseDownInsideRef.current = true;
+                        }}
+                    >
                         {showAutoFetchSetting && (
                             <AutoFetchResultsSwitch size={size} />
                         )}
@@ -91,6 +104,12 @@ const RunQuerySettings: FC<Props> = memo(
                             size={size}
                             numberInputProps={{
                                 onBlur: handleLimitBlur,
+                                onKeyDown: (e) => {
+                                    if (e.key === 'Enter') {
+                                        handleLimitBlur();
+                                        close();
+                                    }
+                                },
                             }}
                         />
                     </Stack>


### PR DESCRIPTION
## Summary
- Fix the row limit popover in the explore view closing when drag-selecting text in the number input and releasing the mouse outside the popover. Anyone who has used Lightdash has been driven mad by this.
- Add Enter key support to submit the row limit value and close the popover, this is a natural user behaviour that is now supported.

The old way:

https://github.com/user-attachments/assets/f02edb03-b972-422c-9431-df9e24e68b12


The new way:

https://github.com/user-attachments/assets/877a4cd3-afc0-4866-ac63-a3664bb6415d


## Test plan
- [x] Open the Run Query settings popover in the explore view
- [x] Highlight the row limit number by clicking and dragging outside the popover — verify the popover stays open
- [x] Click outside the popover normally — verify it still closes
- [x] Type a new row limit value and press Enter — verify the value is applied and the popover closes

🤖 Generated with [Claude Code](https://claude.com/claude-code)