### PR TITLE
chore: bump github action versions

### DIFF
--- a/.github/workflows/_setup_node_pnpm_cypress/action.yml
+++ b/.github/workflows/_setup_node_pnpm_cypress/action.yml
@@ -6,14 +6,14 @@ runs:
     using: 'composite'
     steps:
         - name: Checkout
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
 
         - name: Setup PNPM
-          uses: pnpm/action-setup@v4
+          uses: pnpm/action-setup@v5
         - name: Setup Node
-          uses: actions/setup-node@v4
+          uses: actions/setup-node@v6
           with:
-              node-version: '20'
+              node-version-file: '.nvmrc'
               cache: 'pnpm'
               cache-dependency-path: 'pnpm-lock.yaml'
 

--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -35,12 +35,12 @@ jobs:
                     - 5432:5432
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: '20'
+                  node-version-file: '.nvmrc'
                   cache: 'pnpm'
                   cache-dependency-path: 'pnpm-lock.yaml'
 
@@ -57,7 +57,7 @@ jobs:
               run: pnpm backend-build
 
             - name: Setup Python and dbt
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v6
               with:
                   python-version: '3.10.x'
 
@@ -98,7 +98,7 @@ jobs:
                   PGPASSWORD=password pg_dump -h localhost -U postgres -d lightdash_test -Fc -f lightdash_test_setup.dump
 
             - name: Cache build artifacts
-              uses: actions/cache/save@v4
+              uses: actions/cache/save@v5
               with:
                   path: |
                       node_modules
@@ -141,17 +141,17 @@ jobs:
                     - 5432:5432
 
         steps:
-            - uses: actions/checkout@v4
+            - uses: actions/checkout@v6
 
-            - uses: pnpm/action-setup@v4
-            - uses: actions/setup-node@v4
+            - uses: pnpm/action-setup@v5
+            - uses: actions/setup-node@v6
               with:
-                  node-version: '20'
+                  node-version-file: '.nvmrc'
                   cache: 'pnpm'
                   cache-dependency-path: 'pnpm-lock.yaml'
 
             - name: Restore build artifacts
-              uses: actions/cache/restore@v4
+              uses: actions/cache/restore@v5
               with:
                   path: |
                       node_modules
@@ -166,7 +166,7 @@ jobs:
                   fail-on-cache-miss: true
 
             - name: Setup Python and dbt
-              uses: actions/setup-python@v4
+              uses: actions/setup-python@v6
               with:
                   python-version: '3.10.x'
 
@@ -240,7 +240,7 @@ jobs:
                   AI_DEFAULT_EMBEDDING_PROVIDER: 'openai'
 
             - name: Upload test results
-              uses: actions/upload-artifact@v4
+              uses: actions/upload-artifact@v7
               if: always()
               with:
                   name: ai-agent-test-results-${{ matrix.ai_provider }}-${{ matrix.model_name }}

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -20,7 +20,7 @@ jobs:
     name: Build and Push Images
     runs-on: depot-ubuntu-24.04-4
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false
@@ -45,7 +45,7 @@ jobs:
       # ========================================
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY_IMAGE }}
           tags: |
@@ -62,7 +62,7 @@ jobs:
       # Login to Docker Hub
       # ========================================
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -71,12 +71,12 @@ jobs:
       # Login to GCP Artifact Registry (all regions)
       # ========================================
       - id: 'auth'
-        uses: 'google-github-actions/auth@v2'
+        uses: 'google-github-actions/auth@v3'
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS_IMAGE_DEPLOY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@v2'
+        uses: 'google-github-actions/setup-gcloud@v3'
         with:
           version: '>= 381.0.0'
 
@@ -128,7 +128,7 @@ jobs:
     outputs:
       should_build: ${{ steps.check.outputs.should_build }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ref: ${{ github.event.release.tag_name }}
@@ -175,21 +175,21 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           ref: ${{ github.event.release.tag_name }}
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Cache node_modules
         id: cache-node-modules
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             node_modules
@@ -204,7 +204,7 @@ jobs:
 
       - name: Cache common build
         id: cache-common
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/common/dist
           key: ${{ runner.os }}-common-build-${{ hashFiles('packages/common/src/**', 'packages/common/tsconfig*.json') }}
@@ -215,7 +215,7 @@ jobs:
 
       - name: Cache warehouses build
         id: cache-warehouses
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: packages/warehouses/dist
           key: ${{ runner.os }}-warehouses-build-${{ hashFiles('packages/warehouses/src/**', 'packages/warehouses/tsconfig*.json', 'packages/common/src/**') }}
@@ -309,7 +309,7 @@ jobs:
     runs-on: depot-ubuntu-24.04-4
     steps:
       - name: Checkout Homebrew tap
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           repository: lightdash/homebrew-lightdash
           token: ${{ secrets.CI_GITHUB_TOKEN }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -29,11 +29,11 @@ jobs:
       TURBO_API: https://cache.depot.dev
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version-file: ".nvmrc"
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
@@ -68,9 +68,9 @@ jobs:
       timezone: ${{ steps.changes.outputs.timezone == 'true' || contains(github.event.pull_request.body, 'test-timezone') || contains(github.event.pull_request.body, 'test-all') }}
       cli: ${{ steps.changes.outputs.cli == 'true' || contains(github.event.pull_request.body, 'test-cli') || contains(github.event.pull_request.body, 'test-all') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - name: Check for files changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@v4
         id: changes
         with:
           token: ${{ github.token }}
@@ -82,7 +82,7 @@ jobs:
     needs: files-changed
     steps:
       - name: Post comment with test selection info
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const marker = '<!-- test-selection-comment -->';
@@ -215,7 +215,7 @@ jobs:
           environment-url: https://lightdash-preview-pr-${{ github.event.number }}.lightdash.okteto.dev
 
       - name: Comment PR with preview info
-        uses: actions/github-script@v6
+        uses: actions/github-script@v8
         with:
           script: |
             const marker = '<!-- preview-environment-comment -->';
@@ -265,16 +265,16 @@ jobs:
     name: Build E2E Image
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
       - name: GitHub Registry Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@v7
         with:
           file: ./packages/e2e/dockerfile
           context: .
@@ -293,11 +293,11 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+        uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version-file: ".nvmrc"
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
@@ -306,7 +306,7 @@ jobs:
         run: pnpm common-build
       - name: Create BigQuery credentials file
         id: create-json
-        uses: jsdaniell/create-json@v1.2.2
+        uses: jsdaniell/create-json@v1.2.3
         with:
           name: "credentials.json"
           json: ${{ secrets.GCP_CREDENTIALS }}
@@ -346,20 +346,20 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
       - name: Build packages/common module
         run: pnpm common-build
       - name: create-json
         id: create-json
-        uses: jsdaniell/create-json@v1.2.2
+        uses: jsdaniell/create-json@v1.2.3
         with:
           name: "credentials.json"
           json: ${{ secrets.GCP_CREDENTIALS }}
           dir: "./packages/e2e/cypress/fixtures/"
       - name: Run Cypress
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           install: false
           browser: firefox
@@ -382,7 +382,7 @@ jobs:
           CYPRESS_TRINO_PASSWORD: ${{ secrets.TRINO_PASSWORD }}
           TZ: "UTC"
           CYPRESS_TZ: "UTC"
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: cypress-screenshots-and-videos-${{ strategy.job-index }}
@@ -408,20 +408,20 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
       - name: Build packages/common module
         run: pnpm common-build
       - name: create-json
         id: create-json
-        uses: jsdaniell/create-json@v1.2.2
+        uses: jsdaniell/create-json@v1.2.3
         with:
           name: "credentials.json"
           json: ${{ secrets.GCP_CREDENTIALS }}
           dir: "./packages/e2e/cypress/fixtures/"
       - name: Run Cypress
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           install: false
           browser: firefox
@@ -431,7 +431,7 @@ jobs:
         env:
           TZ: ${{ matrix.timezone }}
           CYPRESS_TZ: ${{ matrix.timezone }}
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         if: failure()
         with:
           name: cypress-screenshots-and-videos-timezone-${{ strategy.job-index }}
@@ -451,7 +451,7 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
       - name: Build packages/common module
@@ -466,7 +466,7 @@ jobs:
           package_version="$(pnpm m ls --depth=-1 | grep '@lightdash/cli@' | sed -E 's/.*@lightdash\/cli@([0-9.]+).*/\1/')"
           if [ $package_version = $lightdash_version ]; then exit 0 ; else echo "Version mismatch"; exit 1; fi
       - name: Run Cypress
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           install: false
           working-directory: packages/e2e
@@ -484,10 +484,10 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10.x"
       - run: pip install dbt-core~=1.9.0 dbt-postgres~=1.9.0
@@ -525,7 +525,7 @@ jobs:
           package_version="$(pnpm m ls --depth=-1 | grep '@lightdash/cli@' | sed -E 's/.*@lightdash\/cli@([0-9.]+).*/\1/')"
           if [ $package_version = $lightdash_version ]; then exit 0 ; else echo "Version mismatch"; exit 1; fi
       - name: Run Cypress
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           install: false
           working-directory: packages/e2e
@@ -551,10 +551,10 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Setup Node, PNPM, and Cypress
         uses: ./.github/workflows/_setup_node_pnpm_cypress
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.10.x"
       - run: |
@@ -597,7 +597,7 @@ jobs:
           package_version="$(pnpm m ls --depth=-1 | grep '@lightdash/cli@' | sed -E 's/.*@lightdash\/cli@([0-9.]+).*/\1/')"
           if [ $package_version = $lightdash_version ]; then exit 0 ; else echo "Version mismatch"; exit 1; fi
       - name: Run Cypress
-        uses: cypress-io/github-action@v6
+        uses: cypress-io/github-action@v7
         with:
           install: false
           working-directory: packages/e2e

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,11 +14,11 @@ jobs:
       TURBO_API: https://cache.depot.dev
       NODE_OPTIONS: '--max-old-space-size=8192'
     steps:
-      - uses: actions/checkout@v4
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: pnpm/action-setup@v5
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
       - name: Install packages
@@ -34,16 +34,16 @@ jobs:
       contents: read
       id-token: write  # Required for OIDC authentication with npm
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: '20'
+          node-version-file: '.nvmrc'
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
 

--- a/.github/workflows/test-easy-install.yml
+++ b/.github/workflows/test-easy-install.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
     - name: Run easy install
       env: 
         RUDDERSTACK_WRITE_KEY: '1vikeGadtB0Y0oRDFNL2Prdhkbp' # dev key

--- a/.github/workflows/validate-pr-title.yml
+++ b/.github/workflows/validate-pr-title.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Validate PR Title
-      uses: amannn/action-semantic-pull-request@v5
+      uses: amannn/action-semantic-pull-request@v6
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:


### PR DESCRIPTION
### Description:
> Node.js 20 actions are deprecated. The following actions are running on Node.js 20 and may not work as expected: actions/cache@v4, actions/checkout@v4, actions/setup-node@v4. Actions will be forced to run with Node.js 24 by default starting June 2nd, 2026. Please check if updated versions of these actions are available that support Node.js 24. To opt into Node.js 24 now, set the FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true environment variable on the runner or in your workflow file. Once Node.js 24 becomes the default, you can temporarily opt out by setting ACTIONS_ALLOW_USE_UNSECURE_NODE_VERSION=true. For more information see: https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/


Note: this is unrelated to our application version which is built with node 20. There I only changed from `node-version` -> `node-version-file` so we don't have the same version repeated all over the place.

test-all