### PR TITLE
feat: add SQL formatting to SQL Runner +refactor to shared SQLFormatting util

### DIFF
--- a/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
+++ b/packages/frontend/src/components/Explorer/SqlCard/SqlCard.tsx
@@ -18,7 +18,6 @@ import {
     useState,
     type FC,
 } from 'react';
-import { format } from 'sql-formatter';
 import {
     explorerActions,
     selectIsSqlExpanded,
@@ -26,12 +25,12 @@ import {
     useExplorerDispatch,
     useExplorerSelector,
 } from '../../../features/explorer/store';
-import { getLanguage } from '../../../features/sqlRunner/store/sqlRunnerSlice';
 import { useCompiledSql } from '../../../hooks/useCompiledSql';
 import { useProject } from '../../../hooks/useProject';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import { ExplorerSection } from '../../../providers/Explorer/types';
+import { formatSql } from '../../../utils/sqlFormatter';
 import CollapsableCard from '../../common/CollapsableCard/CollapsableCard';
 import MantineIcon from '../../common/MantineIcon';
 import { type SqlViewType } from '../../RenderedSql';
@@ -74,20 +73,13 @@ const SqlCard: FC<SqlCardProps> = memo(({ projectUuid }) => {
     const selectedSql =
         selectedView === 'pivotQuery' ? data?.pivotQuery : data?.query;
 
-    const formattedSql = useMemo(() => {
-        if (!selectedSql) return '';
-        try {
-            return format(selectedSql, {
-                language: getLanguage(project?.warehouseConnection?.type),
-            });
-        } catch (e) {
-            console.warn(
-                'Error formatting SQL:',
-                e instanceof Error ? e.message : 'Unknown error occurred',
-            );
-            return selectedSql;
-        }
-    }, [selectedSql, project?.warehouseConnection?.type]);
+    const formattedSql = useMemo(
+        () =>
+            selectedSql
+                ? formatSql(selectedSql, project?.warehouseConnection?.type)
+                : '',
+        [selectedSql, project?.warehouseConnection?.type],
+    );
 
     return (
         <CollapsableCard

--- a/packages/frontend/src/components/RenderedSql.tsx
+++ b/packages/frontend/src/components/RenderedSql.tsx
@@ -13,8 +13,6 @@ import Editor, {
 import { IconAlertCircle } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import { useParams } from 'react-router';
-import { format } from 'sql-formatter';
-import { getLanguage } from '../features/sqlRunner/store/sqlRunnerSlice';
 import {
     getLightdashMonacoTheme,
     getMonacoLanguage,
@@ -23,6 +21,7 @@ import {
 } from '../features/sqlRunner/utils/monaco';
 import { useCompiledSql } from '../hooks/useCompiledSql';
 import { useProject } from '../hooks/useProject';
+import { formatSql } from '../utils/sqlFormatter';
 
 const MONACO_READ_ONLY: EditorProps['options'] = {
     ...MONACO_DEFAULT_OPTIONS,
@@ -64,24 +63,6 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
         [language],
     );
 
-    const formatSql = useCallback(
-        (sql: string | undefined) => {
-            if (!sql) return '';
-            try {
-                return format(sql, {
-                    language: getLanguage(project?.warehouseConnection?.type),
-                });
-            } catch (e) {
-                console.error(
-                    'Error rendering SQL:',
-                    e instanceof Error ? e.message : 'Unknown error occurred',
-                );
-                return sql;
-            }
-        },
-        [project?.warehouseConnection?.type],
-    );
-
     // Fall back to 'query' if 'pivotQuery' is selected but no pivotQuery is available
     const effectiveView = useMemo(
         () =>
@@ -94,8 +75,14 @@ export const RenderedSql: FC<RenderedSqlProps> = ({
     const formattedSql = useMemo(() => {
         const sqlToFormat =
             effectiveView === 'pivotQuery' ? data?.pivotQuery : data?.query;
-        return formatSql(sqlToFormat);
-    }, [data?.query, data?.pivotQuery, effectiveView, formatSql]);
+        if (!sqlToFormat) return '';
+        return formatSql(sqlToFormat, project?.warehouseConnection?.type);
+    }, [
+        data?.query,
+        data?.pivotQuery,
+        effectiveView,
+        project?.warehouseConnection?.type,
+    ]);
 
     if (isInitialLoading) {
         return (

--- a/packages/frontend/src/components/SqlRunner/SqlEditorActions.tsx
+++ b/packages/frontend/src/components/SqlRunner/SqlEditorActions.tsx
@@ -2,6 +2,7 @@ import { ActionIcon, CopyButton, Group, Tooltip } from '@mantine-8/core';
 import {
     IconCheck,
     IconClipboard,
+    IconCode,
     IconTextWrap,
     IconTextWrapDisabled,
 } from '@tabler/icons-react';
@@ -12,9 +13,21 @@ export const SqlEditorActions: FC<{
     isSoftWrapEnabled: boolean;
     clipboardContent?: string | undefined;
     onToggleSoftWrap: () => void;
-}> = ({ isSoftWrapEnabled, onToggleSoftWrap, clipboardContent }) => {
+    onFormat?: () => void;
+}> = ({ isSoftWrapEnabled, onToggleSoftWrap, clipboardContent, onFormat }) => {
     return (
         <Group pos="absolute" bottom={5} right={12} gap="xxs">
+            {onFormat && (
+                <Tooltip label="Format SQL" withArrow position="left">
+                    <ActionIcon
+                        onClick={onFormat}
+                        color="ldLight"
+                        variant="outline"
+                    >
+                        <MantineIcon icon={IconCode} />
+                    </ActionIcon>
+                </Tooltip>
+            )}
             <Tooltip
                 label={
                     isSoftWrapEnabled

--- a/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/ContentPanel.tsx
@@ -8,6 +8,7 @@ import {
     type VizTableHeaderSortConfig,
 } from '@lightdash/common';
 import {
+    ActionIcon,
     Box,
     Group,
     Indicator,
@@ -24,6 +25,7 @@ import { notifications } from '@mantine/notifications';
 import {
     IconAlertCircle,
     IconChartHistogram,
+    IconCode,
     IconGripHorizontal,
 } from '@tabler/icons-react';
 import {
@@ -56,6 +58,7 @@ import RunSqlQueryButton from '../../../components/SqlRunner/RunSqlQueryButton';
 import { useOrganization } from '../../../hooks/organization/useOrganization';
 import useToaster from '../../../hooks/toaster/useToaster';
 import useApp from '../../../providers/App/useApp';
+import { formatSql } from '../../../utils/sqlFormatter';
 import { Parameters, useParameters } from '../../parameters';
 import { executeSqlQuery } from '../../queryRunner/executeQuery';
 import { DEFAULT_SQL_LIMIT } from '../constants';
@@ -77,6 +80,7 @@ import {
     selectSqlRunnerResultsRunner,
     setActiveEditorTab,
     setEditorHighlightError,
+    setSql,
     setSqlLimit,
     updateParameterValue,
 } from '../store/sqlRunnerSlice';
@@ -104,6 +108,9 @@ export const ContentPanel: FC = () => {
     const queryError = useAppSelector((state) => state.sqlRunner.queryError);
     const editorHighlightError = useAppSelector(
         (state) => state.sqlRunner.editorHighlightError,
+    );
+    const warehouseConnectionType = useAppSelector(
+        (state) => state.sqlRunner.warehouseConnectionType,
     );
     // So we can dispatch to redux
     const dispatch = useAppDispatch();
@@ -210,6 +217,11 @@ export const ContentPanel: FC = () => {
             notifications.clean();
         }
     }, [queryError, showToastError]);
+
+    const handleFormatSql = useCallback(() => {
+        if (!sql) return;
+        dispatch(setSql(formatSql(sql, warehouseConnectionType)));
+    }, [sql, warehouseConnectionType, dispatch]);
 
     // Run query on cmd + enter
     useHotkeys([
@@ -536,6 +548,22 @@ export const ContentPanel: FC = () => {
                                       }
                                     : {})}
                             />
+                            {activeEditorTab === EditorTabs.SQL && (
+                                <Tooltip
+                                    variant="xs"
+                                    label="Format SQL"
+                                    withArrow
+                                    position="bottom"
+                                >
+                                    <ActionIcon
+                                        onClick={handleFormatSql}
+                                        disabled={!sql}
+                                        variant="default"
+                                    >
+                                        <MantineIcon icon={IconCode} />
+                                    </ActionIcon>
+                                </Tooltip>
+                            )}
                             {activeEditorTab === EditorTabs.VISUALIZATION &&
                             !isVizTableConfig(currentVizConfig) &&
                             selectedChartType ? (

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerSlice.ts
@@ -1,6 +1,5 @@
 import {
     ChartKind,
-    WarehouseTypes,
     type ApiErrorDetail,
     type ParametersValuesMap,
     type ParameterValue,
@@ -10,11 +9,12 @@ import {
     type VizSortBy,
     type VizTableColumnsConfig,
     type VizTableConfig,
+    type WarehouseTypes,
 } from '@lightdash/common';
 import type { PayloadAction, SerializedError } from '@reduxjs/toolkit';
 import { createSlice } from '@reduxjs/toolkit';
 import { createSelector } from 'reselect';
-import { format, type FormatOptionsWithLanguage } from 'sql-formatter';
+import { formatSql } from '../../../utils/sqlFormatter';
 import { type MonacoHighlightChar } from '../components/SqlEditor';
 import { SqlRunnerResultsRunnerFrontend } from '../runners/SqlRunnerResultsRunnerFrontend';
 import { createHistoryReducer, withHistory, type WithHistory } from './history';
@@ -30,54 +30,14 @@ export enum SidebarTabs {
     VISUALIZATION = 'visualization',
 }
 
-export const getLanguage = (
-    warehouseConnectionType?: WarehouseTypes,
-): FormatOptionsWithLanguage['language'] => {
-    switch (warehouseConnectionType) {
-        case WarehouseTypes.BIGQUERY:
-            return 'bigquery';
-        case WarehouseTypes.SNOWFLAKE:
-            return 'snowflake';
-        case WarehouseTypes.TRINO:
-            return 'spark';
-        case WarehouseTypes.DATABRICKS:
-            return 'spark';
-        case WarehouseTypes.POSTGRES:
-            return 'postgresql';
-        case WarehouseTypes.REDSHIFT:
-            return 'redshift';
-        default:
-            return 'sql';
-    }
-};
-
-/**
- * Normalizes the SQL by removing all whitespace and formatting it consistently - helpful for comparing two SQL queries
- * @param sql
- * @returns formatted SQL
- */
-const normalizeSQL = (
-    sql: string,
-    warehouseConnectionType: WarehouseTypes | undefined,
-): string => {
-    try {
-        return format(sql, {
-            language: getLanguage(warehouseConnectionType),
-        });
-    } catch (error) {
-        // Return the original SQL or a placeholder if formatting fails
-        return sql;
-    }
-};
-
 export const compareSqlQueries = (
     previousSql: string,
     currentSql: string,
     warehouseConnectionType: WarehouseTypes | undefined,
 ): boolean => {
     return (
-        normalizeSQL(previousSql, warehouseConnectionType) !==
-        normalizeSQL(currentSql, warehouseConnectionType)
+        formatSql(previousSql, warehouseConnectionType) !==
+        formatSql(currentSql, warehouseConnectionType)
     );
 };
 
@@ -271,11 +231,11 @@ export const sqlRunnerSlice = createSlice({
         setSql: (state, action: PayloadAction<string>) => {
             state.sql = action.payload;
 
-            const normalizedNewSql = normalizeSQL(
+            const normalizedNewSql = formatSql(
                 action.payload,
                 state.warehouseConnectionType,
             );
-            const normalizedCurrentSql = normalizeSQL(
+            const normalizedCurrentSql = formatSql(
                 state.successfulSqlQueries.current || '',
                 state.warehouseConnectionType,
             );
@@ -413,11 +373,11 @@ export const sqlRunnerSlice = createSlice({
                         payload: {
                             value: state.sql,
                             compareFunc: (a, b) =>
-                                normalizeSQL(
+                                formatSql(
                                     a || '',
                                     state.warehouseConnectionType,
                                 ) !==
-                                normalizeSQL(
+                                formatSql(
                                     b || '',
                                     state.warehouseConnectionType,
                                 ),

--- a/packages/frontend/src/utils/sqlFormatter.ts
+++ b/packages/frontend/src/utils/sqlFormatter.ts
@@ -1,0 +1,44 @@
+import { type WarehouseTypes } from '@lightdash/common';
+import { format, type FormatOptionsWithLanguage } from 'sql-formatter';
+
+const getLanguage = (
+    warehouseConnectionType?: WarehouseTypes,
+): FormatOptionsWithLanguage['language'] => {
+    switch (warehouseConnectionType) {
+        case 'bigquery':
+            return 'bigquery';
+        case 'snowflake':
+            return 'snowflake';
+        case 'trino':
+            return 'spark';
+        case 'databricks':
+            return 'spark';
+        case 'postgres':
+            return 'postgresql';
+        case 'redshift':
+            return 'redshift';
+        default:
+            return 'sql';
+    }
+};
+
+/**
+ * Formats SQL using the appropriate dialect for the given warehouse type.
+ * Returns the original SQL on formatting failure.
+ */
+export const formatSql = (
+    sql: string,
+    warehouseConnectionType?: WarehouseTypes,
+): string => {
+    try {
+        return format(sql, {
+            language: getLanguage(warehouseConnectionType),
+        });
+    } catch (e) {
+        console.warn(
+            'Error formatting SQL:',
+            e instanceof Error ? e.message : 'Unknown error occurred',
+        );
+        return sql;
+    }
+};


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-5965/add-format-sql-button-to-sql-runner-editor

### Description:
I added a format button to the SQL Runner. As SQL formatting was implemented inline in multiple places, I decided to extract SQL formatting into a shared `sqlFormatter` utility and refactor so this is used wherever we were using inline SQL formatting. 

![CleanShot 2026-03-19 at 11 38 08.gif](https://github.com/user-attachments/assets/53e46354-7a21-4fc0-8206-3007442b1f20)


### Tested: 
New Button:
- format SQL button is visible in the SQL Runner
- format SQL button is greyed out when there is no text in the SQL runner 
- format SQL button formats the SQL code correctly (postgres)
- format SQL button doesn't crash when invalid SQL is entered 

Explorer SQL Card Refactor: 
- new chart and existing chart SQL is formatted
- base and chart query SQL is formatted correctly for pivot query charts 
- virtual view SQL is formatted in SQL Card

