### PR TITLE
feat: teach lightdash skill about 'chart (only) in dashboard'

### DIFF
--- a/skills/developing-in-lightdash/resources/charts-reference.md
+++ b/skills/developing-in-lightdash/resources/charts-reference.md
@@ -45,6 +45,7 @@ version: 1
 name: "Chart Name"
 slug: unique-chart-slug
 spaceSlug: target-space
+dashboardSlug: my-dashboard  # Optional: scopes chart to this dashboard (won't appear in space)
 tableName: my_explore
 updatedAt: "2024-01-01T00:00:00.000Z"
 
@@ -65,5 +66,14 @@ chartConfig:
 tableConfig:
   columnOrder: []
 ```
+
+### Chart Scoping
+
+| Property | Effect |
+|----------|--------|
+| `spaceSlug` only | Chart lives in the space, visible independently, can be added to multiple dashboards |
+| `spaceSlug` + `dashboardSlug` | Chart lives inside the dashboard, won't appear in the space |
+
+**Default to `dashboardSlug`** when creating a chart for a specific dashboard. Only omit it when the chart needs to be shared across multiple dashboards.
 
 See individual chart reference files for type-specific `chartConfig.config` options.

--- a/skills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/skills/developing-in-lightdash/resources/dashboard-reference.md
@@ -41,6 +41,8 @@ tiles:
 
 **WARNING:** The `title` property is independent of the chart's own name. When you rename or repurpose a chart, you MUST also update the `title` in every dashboard tile that references it via `chartSlug`. Forgetting this leaves stale titles on the dashboard.
 
+**Chart scoping:** Charts can be scoped to a dashboard (via `dashboardSlug` on the chart YAML) or live independently in a space. See [Charts Reference](./charts-reference.md#chart-scoping) for guidance.
+
 ### SQL Chart Tile
 
 Display a SQL-based chart:

--- a/skills/developing-in-lightdash/resources/map-chart-reference.md
+++ b/skills/developing-in-lightdash/resources/map-chart-reference.md
@@ -218,6 +218,6 @@ colorRange: ["#dc2626", "#f3f4f6", "#22c55e"]
 
 ## Related Resources
 
-- [Chart Types Reference](./chart-types-reference.md) - Other visualization types
+- [Charts Reference](./charts-reference.md) - Other visualization types
 - [Metrics Reference](./metrics-reference.md) - Creating metrics for maps
 - [Dimensions Reference](./dimensions-reference.md) - Location dimensions

--- a/skills/developing-in-lightdash/resources/pie-chart-reference.md
+++ b/skills/developing-in-lightdash/resources/pie-chart-reference.md
@@ -222,6 +222,6 @@ legendPosition: vertical
 
 ## Related Documentation
 
-- [Chart Types Reference](chart-types-reference.md)
+- [Charts Reference](./charts-reference.md)
 - [Metrics Reference](metrics-reference.md)
 - [Dimensions Reference](dimensions-reference.md)

--- a/skills/developing-in-lightdash/resources/treemap-chart-reference.md
+++ b/skills/developing-in-lightdash/resources/treemap-chart-reference.md
@@ -189,6 +189,6 @@ chartConfig:
 
 ## Related Documentation
 
-- [Chart Types Reference](./chart-types-reference.md) - Overview of all chart types
+- [Charts Reference](./charts-reference.md) - Overview of all chart types
 - [Dashboard Reference](./dashboard-reference.md) - Using treemaps in dashboards
 - [Workflows Reference](./workflows-reference.md) - Charts-as-code workflow


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-258/lightdash-skills-i-want-to-be-able-to-create-charts-directly-within

### Description:
Previously the lightdash skill wasn't aware of charts that only exist within a dashboard, so it would *always* create the chart in the space first and then referencing it in the dashboard. That bloats the spaces view very quickly!

Adding a few lines to the charts reference does the trick. Tested locally before/after with a simple prompt:

> I'm currently running Lightdash locally with the Jaffle Shop project.
I want you to create the most simple chart and add it to a new dashboard.


### Before:
- Chart saved in space
- Dashboard references chart

### After:
- Chart saved in dashboard

