### PR TITLE
feat(cli): make project selection optional during login

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -95,6 +95,18 @@ export const setProject = async (projectUuid: string, projectName: string) => {
     });
 };
 
+export const unsetProject = async () => {
+    const config = await getRawConfig();
+    await setConfig({
+        ...config,
+        context: {
+            ...(config.context || {}),
+            project: undefined,
+            projectName: undefined,
+        },
+    });
+};
+
 export const setPreviewProject = async (projectUuid: string, name: string) => {
     const config = await getRawConfig();
     await setConfig({

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -492,9 +492,12 @@ export const downloadHandler = async (
 
     const projectSelection = await selectProject(config, options.project);
     if (!projectSelection) {
-        throw new Error(
-            'No project selected. Run lightdash config set-project',
-        );
+        throw new LightdashError({
+            message: 'No project selected. Run lightdash config set-project',
+            name: 'Not Found',
+            statusCode: 404,
+            data: {},
+        });
     }
     const projectId = projectSelection.projectUuid;
 
@@ -1074,9 +1077,12 @@ export const uploadHandler = async (
 
     const projectSelection = await selectProject(config, options.project);
     if (!projectSelection) {
-        throw new Error(
-            'No project selected. Run lightdash config set-project',
-        );
+        throw new LightdashError({
+            message: 'No project selected. Run lightdash config set-project',
+            name: 'Not Found',
+            statusCode: 404,
+            data: {},
+        });
     }
     const projectId = projectSelection.projectUuid;
 

--- a/packages/cli/src/handlers/login.ts
+++ b/packages/cli/src/handlers/login.ts
@@ -315,14 +315,22 @@ export const login = async (
         } else if (GlobalState.isNonInteractive()) {
             await setFirstProject();
         } else {
-            const project = await setProjectCommand();
+            const result = await setProjectCommand();
 
-            if (project === undefined) {
+            if (result === 'empty') {
                 console.error(
                     'Now you can add your first project to lightdash by doing: ',
                 );
                 console.error(
                     `\n  ${styles.bold(`⚡️ lightdash deploy --create`)}\n`,
+                );
+            } else if (result === 'skipped') {
+                console.error(
+                    `\n  No project selected — use ${styles.bold(
+                        'lightdash config set-project',
+                    )} or ${styles.bold(
+                        '--project <uuid>',
+                    )} when running commands.\n`,
                 );
             }
         }

--- a/packages/cli/src/handlers/renameHandler.ts
+++ b/packages/cli/src/handlers/renameHandler.ts
@@ -2,6 +2,7 @@ import {
     ApiJobScheduledResponse,
     AuthorizationError,
     getErrorMessage,
+    LightdashError,
     RenameChange,
     RenameType,
     SchedulerJobStatus,
@@ -91,9 +92,12 @@ export const renameHandler = async (options: RenameHandlerOptions) => {
         config.context.previewProject ||
         config.context.project;
     if (!projectUuid) {
-        throw new Error(
-            'No project selected. Run lightdash config set-project',
-        );
+        throw new LightdashError({
+            message: 'No project selected. Run lightdash config set-project',
+            name: 'Not Found',
+            statusCode: 404,
+            data: {},
+        });
     }
 
     // Log current project info

--- a/packages/cli/src/handlers/setProject.ts
+++ b/packages/cli/src/handlers/setProject.ts
@@ -2,7 +2,7 @@ import { OrganizationProject } from '@lightdash/common';
 import inquirer from 'inquirer';
 import { URL } from 'url';
 import { LightdashAnalytics } from '../analytics/analytics';
-import { getConfig, setProject } from '../config';
+import { getConfig, setProject, unsetProject } from '../config';
 import GlobalState from '../globalState';
 import { lightdashApi } from './dbt/apiClient';
 
@@ -12,7 +12,10 @@ type SetProjectOptions = {
     uuid: string;
 };
 
-export const setProjectCommand = async (name?: string, uuid?: string) => {
+export const setProjectCommand = async (
+    name?: string,
+    uuid?: string,
+): Promise<'selected' | 'skipped' | 'empty'> => {
     const projects = await lightdashApi<OrganizationProject[]>({
         method: 'GET',
         url: `/api/v1/org/projects`,
@@ -23,7 +26,7 @@ export const setProjectCommand = async (name?: string, uuid?: string) => {
         `> Set project returned response: ${JSON.stringify(projects)}`,
     );
 
-    if (projects.length === 0) return;
+    if (projects.length === 0) return 'empty';
 
     let selectedProject: OrganizationProject | undefined;
 
@@ -36,16 +39,28 @@ export const setProjectCommand = async (name?: string, uuid?: string) => {
         GlobalState.debug('> Non-interactive mode: selecting first project');
         [selectedProject] = projects;
     } else {
+        const SKIP_VALUE = '__skip__';
         const answers = await inquirer.prompt([
             {
                 type: 'list',
                 name: 'project',
-                choices: projects.map((project) => ({
-                    name: project.name,
-                    value: project.projectUuid,
-                })),
+                choices: [
+                    {
+                        name: "Don't select a project",
+                        value: SKIP_VALUE,
+                    },
+                    ...projects.map((project) => ({
+                        name: project.name,
+                        value: project.projectUuid,
+                    })),
+                ],
             },
         ]);
+
+        if (answers.project === SKIP_VALUE) {
+            await unsetProject();
+            return 'skipped';
+        }
 
         selectedProject = projects.find(
             (project) => project.projectUuid === answers.project,
@@ -64,9 +79,9 @@ export const setProjectCommand = async (name?: string, uuid?: string) => {
         console.error(
             `\n  ✅️ Connected to Lightdash project: ${projectUrl || ''}\n`,
         );
-    } else {
-        throw new Error(`Project not found.`);
+        return 'selected';
     }
+    throw new Error(`Project not found.`);
 };
 
 export const setFirstProject = async () => {
@@ -95,7 +110,10 @@ export const setProjectHandler = async (options: SetProjectOptions) => {
     let success = true;
     GlobalState.setVerbose(options.verbose);
     try {
-        await setProjectCommand(options.name, options.uuid);
+        const result = await setProjectCommand(options.name, options.uuid);
+        if (result === 'skipped') {
+            console.error(`\n  Project unset.\n`);
+        }
     } catch (e) {
         success = false;
         throw e;
@@ -104,6 +122,32 @@ export const setProjectHandler = async (options: SetProjectOptions) => {
             event: 'command.executed',
             properties: {
                 command: 'set-project',
+                durationMs: Date.now() - startTime,
+                success,
+            },
+        });
+    }
+};
+
+export const unsetProjectCommand = async () => {
+    await unsetProject();
+    console.error(`\n  Project unset.\n`);
+};
+
+export const unsetProjectHandler = async (options: { verbose: boolean }) => {
+    const startTime = Date.now();
+    let success = true;
+    GlobalState.setVerbose(options.verbose);
+    try {
+        await unsetProjectCommand();
+    } catch (e) {
+        success = false;
+        throw e;
+    } finally {
+        await LightdashAnalytics.track({
+            event: 'command.executed',
+            properties: {
+                command: 'unset-project',
                 durationMs: Date.now() - startTime,
                 success,
             },

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -39,7 +39,7 @@ import {
 } from './handlers/preview';
 import { renameHandler } from './handlers/renameHandler';
 import { runChartHandler } from './handlers/runChart';
-import { setProjectHandler } from './handlers/setProject';
+import { setProjectHandler, unsetProjectHandler } from './handlers/setProject';
 import { sqlHandler } from './handlers/sql';
 import { validateHandler } from './handlers/validate';
 import * as styles from './styles';
@@ -219,11 +219,13 @@ ${styles.bold('Examples:')}
 `,
     )
     .option('--token <token>', 'Login with an API access token', undefined)
-    .option(
-        '--project <project uuid>',
-        'Select a project by UUID after login',
-        parseProjectArgument,
-        undefined,
+    .addOption(
+        new Option(
+            '--project <project uuid>',
+            'Select a project by UUID after login',
+        )
+            .argParser(parseProjectArgument)
+            .conflicts('skipProjectSelection'),
     )
     .option('--email <email>', 'Login with email and password', undefined)
     .option(
@@ -276,6 +278,11 @@ configProgram
     .description('Show the currently selected project')
     .option('--verbose', undefined, false)
     .action(getProjectHandler);
+configProgram
+    .command('unset-project')
+    .description('Clear the currently selected project')
+    .option('--verbose', undefined, false)
+    .action(unsetProjectHandler);
 
 const dbtProgram = program.command('dbt').description('Runs dbt commands');
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-252/improve-project-creation-flow-for-agents

### Description:
One slightly uncomfortable flow has been that the cli's login command forced you to select a project. However, when all your intention is to CREATE a new project, it feels wrong to select a project first and adds risk that we end up overwriting the selected project if we're not careful.

This PR introduces a few things to improve that situation:

### 1) At the project selection after logging in you now have an option to not select a project:
<img width="363" height="120" alt="image" src="https://github.com/user-attachments/assets/7f1eaa48-b4a6-41c9-9db4-de055e29b2bb" />

To test run `pnpm -F @lightdash/cli dev login http://localhost:3000`

### 2) Same thing when trying to set a project explicitly

To test run `pnpm -F @lightdash/cli dev config set-project`

### 3) Extra command to quickly unset the project

To test run `pnpm -F @lightdash/cli dev config unset-project`

### 4) User friendly error when trying to run a command that requires a project, but not project is being provided:

<img width="834" height="100" alt="image" src="https://github.com/user-attachments/assets/0150e7a0-2c58-4617-b8c4-02a18b27c61f" />



Note: to verify that these commands work as expected you can keep an eye on `cat ~/.config/lightdash/config.yaml` and verify that `project` and `projectName` update accordingly.