### PR TITLE
fix: add userAttributeOverrides support to async query execution

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1705,6 +1705,7 @@ export class McpService extends BaseService {
                     additionalMetrics: additionalMetrics ?? [],
                 },
                 context: QueryExecutionContext.MCP,
+                userAttributeOverrides,
             });
 
         return { agentContext, runAsyncQuery };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2613,9 +2613,15 @@ export class AsyncQueryService extends ProjectService {
         parameters,
         projectUuid,
         pivotConfiguration,
+        userAttributeOverrides,
     }: Pick<
         ExecuteAsyncMetricQueryArgs,
-        'account' | 'metricQuery' | 'dateZoom' | 'parameters' | 'projectUuid'
+        | 'account'
+        | 'metricQuery'
+        | 'dateZoom'
+        | 'parameters'
+        | 'projectUuid'
+        | 'userAttributeOverrides'
     > & {
         warehouseSqlBuilder: WarehouseSqlBuilder;
         explore: Explore;
@@ -2623,8 +2629,11 @@ export class AsyncQueryService extends ProjectService {
     }) {
         assertIsAccountWithOrg(account);
 
-        const { userAttributes, intrinsicUserAttributes } =
+        const { userAttributes: dbUserAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes({ account });
+        const userAttributes = userAttributeOverrides
+            ? { ...dbUserAttributes, ...userAttributeOverrides }
+            : dbUserAttributes;
 
         const availableParameterDefinitions = await this.getAvailableParameters(
             projectUuid,
@@ -3234,6 +3243,7 @@ export class AsyncQueryService extends ProjectService {
         invalidateCache,
         parameters,
         pivotConfiguration,
+        userAttributeOverrides,
     }: ExecuteAsyncMetricQueryArgs): Promise<ApiExecuteAsyncMetricQueryResults> {
         assertIsAccountWithOrg(account);
 
@@ -3326,6 +3336,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             pivotConfiguration,
+            userAttributeOverrides,
         });
         const prepareMs = Date.now() - prepareStart;
 

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -16,6 +16,7 @@ import {
     type ResultsPaginationArgs,
     type RunQueryTags,
     type SortField,
+    type UserAttributeValueMap,
 } from '@lightdash/common';
 
 export type CommonAsyncQueryArgs = {
@@ -24,6 +25,7 @@ export type CommonAsyncQueryArgs = {
     invalidateCache?: boolean;
     context: QueryExecutionContext;
     parameters?: ParametersValuesMap;
+    userAttributeOverrides?: UserAttributeValueMap;
 };
 
 export type GetAsyncQueryResultsArgs = Omit<


### PR DESCRIPTION
### Description:
The previously user attributes override using `x-lightdash-user-attributes` header was removed in a regression when the mcp query path was migrated to asyncQueryService in #19656.
This pr restores the behavior originally introduced in #18521
