### PR TITLE
feat: add configurable polling options for scheduler async query operations

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -135,6 +135,7 @@ import Logger from '../logging/logger';
 import type { PreAggregateModel } from '../models/PreAggregateModel';
 import { isFeatureFlagEnabled } from '../postHog';
 import { AsyncQueryService } from '../services/AsyncQueryService/AsyncQueryService';
+import { SCHEDULER_POLLING_OPTIONS } from '../services/AsyncQueryService/types';
 import type { CatalogService } from '../services/CatalogService/CatalogService';
 import {
     CsvService,
@@ -549,6 +550,7 @@ export default class SchedulerTask {
                                     columnOrder: chart.tableConfig.columnOrder,
                                     expirationSecondsOverride,
                                 },
+                                SCHEDULER_POLLING_OPTIONS,
                             );
                         csvUrl = {
                             filename: ExcelService.generateFileId(chart.name),
@@ -688,6 +690,7 @@ export default class SchedulerTask {
                                                 chart.tableConfig.columnOrder,
                                             expirationSecondsOverride,
                                         },
+                                        SCHEDULER_POLLING_OPTIONS,
                                     );
                                 return {
                                     chartName: chart.name,
@@ -764,6 +767,7 @@ export default class SchedulerTask {
                                                 ),
                                             expirationSecondsOverride,
                                         },
+                                        SCHEDULER_POLLING_OPTIONS,
                                     );
                                 return {
                                     chartName: chart.name,
@@ -2158,13 +2162,16 @@ export default class SchedulerTask {
                 rows,
                 fields: itemMap,
                 pivotDetails,
-            } = await this.asyncQueryService.executeMetricQueryAndGetResults({
-                account,
-                projectUuid: payload.projectUuid,
-                metricQuery,
-                context: QueryExecutionContext.GSHEETS,
-                pivotConfiguration,
-            });
+            } = await this.asyncQueryService.executeMetricQueryAndGetResults(
+                {
+                    account,
+                    projectUuid: payload.projectUuid,
+                    metricQuery,
+                    context: QueryExecutionContext.GSHEETS,
+                    pivotConfiguration,
+                },
+                SCHEDULER_POLLING_OPTIONS,
+            );
 
             const refreshToken = await this.userService.getRefreshToken(
                 payload.userUuid,
@@ -2745,6 +2752,7 @@ export default class SchedulerTask {
                             QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
                         pivotResults: shouldPivot,
                     },
+                    SCHEDULER_POLLING_OPTIONS,
                 );
 
                 if (thresholds !== undefined && thresholds.length > 0) {
@@ -2911,6 +2919,7 @@ export default class SchedulerTask {
                                 pivotResults: shouldPivotChart,
                                 parameters: dashboardParameters,
                             },
+                            SCHEDULER_POLLING_OPTIONS,
                         );
                         const showTableNames = isTableChartConfig(
                             chart.chartConfig.config,
@@ -3313,6 +3322,7 @@ export default class SchedulerTask {
                                 chartUuid: savedChartUuid,
                                 context: QueryExecutionContext.SCHEDULED_CHART,
                             },
+                            SCHEDULER_POLLING_OPTIONS,
                         );
 
                     if (
@@ -3957,19 +3967,22 @@ export default class SchedulerTask {
         const chart =
             await this.schedulerService.savedChartModel.get(chartUuid);
         const downloadResult =
-            await this.asyncQueryService.downloadSyncQueryResults({
-                account,
-                projectUuid,
-                queryUuid: query.queryUuid,
-                type: DownloadFileType.CSV,
-                onlyRaw: false,
-                customLabels: getCustomLabelsFromTableConfig(
-                    chart.chartConfig.config,
-                ),
-                hiddenFields: getHiddenTableFields(chart.chartConfig),
-                pivotConfig: getPivotConfig(chart),
-                columnOrder: chart.tableConfig.columnOrder,
-            });
+            await this.asyncQueryService.downloadSyncQueryResults(
+                {
+                    account,
+                    projectUuid,
+                    queryUuid: query.queryUuid,
+                    type: DownloadFileType.CSV,
+                    onlyRaw: false,
+                    customLabels: getCustomLabelsFromTableConfig(
+                        chart.chartConfig.config,
+                    ),
+                    hiddenFields: getHiddenTableFields(chart.chartConfig),
+                    pivotConfig: getPivotConfig(chart),
+                    columnOrder: chart.tableConfig.columnOrder,
+                },
+                SCHEDULER_POLLING_OPTIONS,
+            );
         return {
             chartName: chart.name,
             filename: chart.name,
@@ -4016,22 +4029,31 @@ export default class SchedulerTask {
             },
         );
         const downloadResult =
-            await this.asyncQueryService.downloadSyncQueryResults({
-                account,
-                projectUuid,
-                queryUuid: query.queryUuid,
-                type: DownloadFileType.CSV,
-                onlyRaw: false,
-                customLabels: getCustomLabelsFromVizTableConfig(
-                    isVizTableConfig(chart.config) ? chart.config : undefined,
-                ),
-                hiddenFields: getHiddenFieldsFromVizTableConfig(
-                    isVizTableConfig(chart.config) ? chart.config : undefined,
-                ),
-                columnOrder: getColumnOrderFromVizTableConfig(
-                    isVizTableConfig(chart.config) ? chart.config : undefined,
-                ),
-            });
+            await this.asyncQueryService.downloadSyncQueryResults(
+                {
+                    account,
+                    projectUuid,
+                    queryUuid: query.queryUuid,
+                    type: DownloadFileType.CSV,
+                    onlyRaw: false,
+                    customLabels: getCustomLabelsFromVizTableConfig(
+                        isVizTableConfig(chart.config)
+                            ? chart.config
+                            : undefined,
+                    ),
+                    hiddenFields: getHiddenFieldsFromVizTableConfig(
+                        isVizTableConfig(chart.config)
+                            ? chart.config
+                            : undefined,
+                    ),
+                    columnOrder: getColumnOrderFromVizTableConfig(
+                        isVizTableConfig(chart.config)
+                            ? chart.config
+                            : undefined,
+                    ),
+                },
+                SCHEDULER_POLLING_OPTIONS,
+            );
         return {
             chartName: chart.name,
             filename: chart.name,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -167,6 +167,7 @@ import {
     type ExecuteAsyncSqlChartArgs,
     type ExecuteAsyncUnderlyingDataQueryArgs,
     type GetAsyncQueryResultsArgs,
+    type PollingOptions,
     type PreAggregationRoute,
     type RunAsyncPreAggregateQueryArgs,
     type RunAsyncWarehouseQueryArgs,
@@ -910,9 +911,17 @@ export class AsyncQueryService extends ProjectService {
     }
 
     // Note: This method should only be used in scheduler worker. It may cause API timeouts.
-    async downloadSyncQueryResults(args: DownloadAsyncQueryResultsArgs) {
+    async downloadSyncQueryResults(
+        args: DownloadAsyncQueryResultsArgs,
+        pollingOptions?: PollingOptions,
+    ) {
         const { queryUuid, projectUuid, account } = args;
-        await this.pollForQueryCompletion({ account, projectUuid, queryUuid });
+        await this.pollForQueryCompletion({
+            account,
+            projectUuid,
+            queryUuid,
+            ...pollingOptions,
+        });
         return this.downloadAsyncQueryResults(args);
     }
 
@@ -4768,6 +4777,7 @@ export class AsyncQueryService extends ProjectService {
      */
     async executeMetricQueryAndGetResults(
         args: ExecuteAsyncMetricQueryArgs,
+        pollingOptions?: PollingOptions,
     ): Promise<{
         rows: Record<string, unknown>[];
         cacheMetadata: CacheMetadata;
@@ -4779,7 +4789,12 @@ export class AsyncQueryService extends ProjectService {
         const { queryUuid, cacheMetadata, fields } =
             await this.executeAsyncMetricQuery(args);
 
-        await this.pollForQueryCompletion({ account, projectUuid, queryUuid });
+        await this.pollForQueryCompletion({
+            account,
+            projectUuid,
+            queryUuid,
+            ...pollingOptions,
+        });
 
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
@@ -4814,6 +4829,7 @@ export class AsyncQueryService extends ProjectService {
      */
     async executeSavedChartQueryAndGetResults(
         args: ExecuteAsyncSavedChartQueryArgs,
+        pollingOptions?: PollingOptions,
     ): Promise<{
         rows: Record<string, unknown>[];
         cacheMetadata: CacheMetadata;
@@ -4825,7 +4841,12 @@ export class AsyncQueryService extends ProjectService {
         const { queryUuid, cacheMetadata, fields } =
             await this.executeAsyncSavedChartQuery(args);
 
-        await this.pollForQueryCompletion({ account, projectUuid, queryUuid });
+        await this.pollForQueryCompletion({
+            account,
+            projectUuid,
+            queryUuid,
+            ...pollingOptions,
+        });
 
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
@@ -4860,6 +4881,7 @@ export class AsyncQueryService extends ProjectService {
      */
     async executeDashboardChartQueryAndGetResults(
         args: ExecuteAsyncDashboardChartQueryArgs,
+        pollingOptions?: PollingOptions,
     ): Promise<{
         rows: Record<string, unknown>[];
         cacheMetadata: CacheMetadata;
@@ -4871,7 +4893,12 @@ export class AsyncQueryService extends ProjectService {
         const { queryUuid, cacheMetadata, fields } =
             await this.executeAsyncDashboardChartQuery(args);
 
-        await this.pollForQueryCompletion({ account, projectUuid, queryUuid });
+        await this.pollForQueryCompletion({
+            account,
+            projectUuid,
+            queryUuid,
+            ...pollingOptions,
+        });
 
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -155,6 +155,21 @@ export const isExecuteAsyncSqlChartByUuid = (
     args: ExecuteAsyncSqlChartArgs,
 ): args is ExecuteAsyncSqlChartByUuidArgs => 'savedSqlUuid' in args;
 
+export type PollingOptions = {
+    initialBackoffMs?: number;
+    maxBackoffMs?: number;
+    timeoutMs?: number;
+};
+
+/**
+ * Polling options tuned for scheduled/background tasks (e.g. GSheet syncs, email deliveries).
+ * Slower polling reduces DB round-trips through cloud-sql-proxy, preventing OOM under load.
+ */
+export const SCHEDULER_POLLING_OPTIONS: PollingOptions = {
+    initialBackoffMs: 2000,
+    maxBackoffMs: 5000,
+};
+
 export type RunAsyncWarehouseQueryArgs = {
     projectUuid: string;
     userUuid: string;


### PR DESCRIPTION
### Description:

This PR introduces configurable polling options for async query operations in scheduled tasks to improve performance under load.

**Key Changes:**

- Added `PollingOptions` type with configurable `initialBackoffMs`, `maxBackoffMs`, and `timeoutMs` parameters
- Introduced `SCHEDULER_POLLING_OPTIONS` constant with slower polling intervals (2s initial, 5s max) specifically tuned for background operations
- Updated `AsyncQueryService` methods to accept optional `pollingOptions` parameter:
  - `downloadSyncQueryResults`
  - `executeMetricQueryAndGetResults` 
  - `executeSavedChartQueryAndGetResults`
  - `executeDashboardChartQueryAndGetResults`
- Applied scheduler-specific polling options to all async query calls in `SchedulerTask` for GSheet syncs, email deliveries, and dashboard exports

The slower polling intervals reduce database round-trips through cloud-sql-proxy, preventing OOM issues during high-load scheduled operations while maintaining existing behavior for interactive queries.