### PR TITLE
fix: extract OAuth refresh strategies registration into shared function

### DIFF
--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -4,6 +4,7 @@ import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
+import { registerOAuthRefreshStrategies } from './auth/registerOAuthRefreshStrategies';
 import {
     ClientProviderMap,
     ClientRepository,
@@ -146,6 +147,7 @@ export default class NatsWorkerApp {
     }
 
     public async start() {
+        registerOAuthRefreshStrategies();
         this.prometheusMetrics.start();
         this.prometheusMetrics.monitorDatabase(this.database);
         // @ts-ignore

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -4,16 +4,13 @@ import { EventEmitter } from 'events';
 import express from 'express';
 import http from 'http';
 import knex, { Knex } from 'knex';
-import refresh from 'passport-oauth2-refresh';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
+import { registerOAuthRefreshStrategies } from './auth/registerOAuthRefreshStrategies';
 import {
     ClientProviderMap,
     ClientRepository,
 } from './clients/ClientRepository';
 import { LightdashConfig } from './config/parseConfig';
-import { googlePassportStrategy } from './controllers/authentication';
-import { databricksPassportStrategy } from './controllers/authentication/strategies/databricksStrategy';
-import { snowflakePassportStrategy } from './controllers/authentication/strategies/snowflakeStrategy';
 import Logger from './logging/logger';
 import { ModelProviderMap, ModelRepository } from './models/ModelRepository';
 import PrometheusMetrics from './prometheus/PrometheusMetrics';
@@ -172,16 +169,7 @@ export default class SchedulerApp {
     }
 
     public async start() {
-        // Load refresh strategies, required when running scheduler in production mode
-        if (googlePassportStrategy) {
-            refresh.use(googlePassportStrategy);
-        }
-        if (snowflakePassportStrategy) {
-            refresh.use('snowflake', snowflakePassportStrategy);
-        }
-        if (databricksPassportStrategy) {
-            refresh.use('databricks', databricksPassportStrategy);
-        }
+        registerOAuthRefreshStrategies();
 
         this.prometheusMetrics.start();
         this.prometheusMetrics.monitorDatabase(this.database);

--- a/packages/backend/src/auth/registerOAuthRefreshStrategies.ts
+++ b/packages/backend/src/auth/registerOAuthRefreshStrategies.ts
@@ -1,0 +1,18 @@
+import refresh from 'passport-oauth2-refresh';
+import { googlePassportStrategy } from '../controllers/authentication';
+import { databricksPassportStrategy } from '../controllers/authentication/strategies/databricksStrategy';
+import { snowflakePassportStrategy } from '../controllers/authentication/strategies/snowflakeStrategy';
+
+export const registerOAuthRefreshStrategies = (): void => {
+    if (googlePassportStrategy) {
+        refresh.use(googlePassportStrategy);
+    }
+
+    if (snowflakePassportStrategy) {
+        refresh.use('snowflake', snowflakePassportStrategy);
+    }
+
+    if (databricksPassportStrategy) {
+        refresh.use('databricks', databricksPassportStrategy);
+    }
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Extracted OAuth refresh strategy registration logic into a dedicated utility function. The new `registerOAuthRefreshStrategies` function handles the registration of Google, Snowflake, and Databricks passport strategies with the passport-oauth2-refresh library. This function is now called from both `NatsWorkerApp` and `SchedulerApp` during their startup process, ensuring OAuth refresh strategies are properly initialized across both applications.