### PR TITLE
feat: add saved_sql_uuid column to scheduler table

### DIFF
--- a/packages/backend/src/database/entities/scheduler.ts
+++ b/packages/backend/src/database/entities/scheduler.ts
@@ -33,6 +33,7 @@ export type SchedulerDb = {
     timezone: string | null;
     saved_chart_uuid: string | null;
     dashboard_uuid: string | null;
+    saved_sql_uuid: string | null;
     options: Record<string, AnyType>;
     filters: string | null;
     parameters: string | null;
@@ -49,10 +50,17 @@ export type SchedulerDb = {
 export type ChartSchedulerDb = SchedulerDb & {
     saved_chart_uuid: string;
     dashboard_uuid: null;
+    saved_sql_uuid: null;
 };
 export type DashboardSchedulerDB = SchedulerDb & {
     saved_chart_uuid: null;
     dashboard_uuid: string;
+    saved_sql_uuid: null;
+};
+export type SqlChartSchedulerDb = SchedulerDb & {
+    saved_chart_uuid: null;
+    dashboard_uuid: null;
+    saved_sql_uuid: string;
 };
 
 export type SchedulerSlackTargetDb = {
@@ -88,7 +96,7 @@ export type SchedulerEmailTargetDb = {
 export type SchedulerTable = Knex.CompositeTableType<
     SchedulerDb,
     Omit<
-        ChartSchedulerDb | DashboardSchedulerDB,
+        ChartSchedulerDb | DashboardSchedulerDB | SqlChartSchedulerDb,
         'scheduler_uuid' | 'created_at' | 'deleted_at' | 'deleted_by_user_uuid'
     >,
     | Pick<

--- a/packages/backend/src/database/migrations/20260320104849_add_saved_sql_uuid_to_scheduler.ts
+++ b/packages/backend/src/database/migrations/20260320104849_add_saved_sql_uuid_to_scheduler.ts
@@ -1,0 +1,45 @@
+import { Knex } from 'knex';
+
+const SCHEDULER_TABLE = 'scheduler';
+// This is the name Knex auto-generated when the original migration used table.check()
+// in 20230206192228_add_scheduler_tables.ts
+const CHECK_NAME = 'scheduler_check';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.alterTable(SCHEDULER_TABLE, (table) => {
+        table
+            .uuid('saved_sql_uuid')
+            .nullable()
+            .references('saved_sql_uuid')
+            .inTable('saved_sql')
+            .onDelete('CASCADE');
+
+        table.dropChecks(CHECK_NAME);
+        table.check(
+            `(saved_chart_uuid IS NOT NULL AND dashboard_uuid IS NULL AND saved_sql_uuid IS NULL)
+             OR (dashboard_uuid IS NOT NULL AND saved_chart_uuid IS NULL AND saved_sql_uuid IS NULL)
+             OR (saved_sql_uuid IS NOT NULL AND saved_chart_uuid IS NULL AND dashboard_uuid IS NULL)`,
+            {},
+            CHECK_NAME,
+        );
+    });
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex(SCHEDULER_TABLE).whereNotNull('saved_sql_uuid').delete();
+
+    // Drop the check first since it references saved_sql_uuid
+    await knex.schema.alterTable(SCHEDULER_TABLE, (table) => {
+        table.dropChecks(CHECK_NAME);
+    });
+
+    await knex.schema.alterTable(SCHEDULER_TABLE, (table) => {
+        table.dropColumn('saved_sql_uuid');
+        table.check(
+            `(saved_chart_uuid IS NULL AND dashboard_uuid IS NOT NULL)
+             OR (dashboard_uuid IS NULL AND saved_chart_uuid IS NOT NULL)`,
+            {},
+            CHECK_NAME,
+        );
+    });
+}

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -698,6 +698,8 @@ export class SchedulerModel {
                     timezone: newScheduler.timezone ?? null,
                     saved_chart_uuid: newScheduler.savedChartUuid,
                     dashboard_uuid: newScheduler.dashboardUuid,
+                    // Hardcoded to null until SavedSqlService.createScheduler passes savedSqlUuid
+                    saved_sql_uuid: null,
                     updated_at: new Date(),
                     options: newScheduler.options,
                     filters:


### PR DESCRIPTION
Relates to: https://github.com/lightdash/lightdash/issues/21267

## Summary

Extends the `scheduler` table to support SQL runner charts as a scheduler resource, alongside the existing `saved_chart_uuid` and `dashboard_uuid`.

Adds a nullable `saved_sql_uuid` FK column and updates the CHECK constraint so exactly one of the three resource columns must be non-null. Entity types are updated to include the new `SqlChartSchedulerDb` variant.

This is a prerequisite for enabling Google Sheets sync on SQL runner saved charts.