### PR TITLE
fix: embed setup config handling when environment variables are undefined

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -13,6 +13,7 @@ import {
     getIntegerFromEnvironmentVariable,
     getMaybeBase64EncodedFromEnvironmentVariable,
     getObjectFromEnvironmentVariable,
+    getUpdateSetupConfig,
     parseConfig,
     parseOrganizationMemberRoleArray,
 } from './parseConfig';
@@ -474,6 +475,34 @@ describe('process.env.LIGHTDASH_IFRAME_EMBEDDING_DOMAINS', () => {
             process.env.LD_SETUP_PROJECT_PAT = 'some_token';
             const config = parseConfig();
             expect(config.initialSetup).toBeUndefined();
+        });
+    });
+
+    describe('update setup embed configuration', () => {
+        test('should leave embed update config undefined when embed env vars are not set', () => {
+            const updateSetup = getUpdateSetupConfig();
+            expect(updateSetup?.embed).toBeUndefined();
+        });
+
+        test('should parse explicit false for allow all dashboards', () => {
+            process.env.LD_SETUP_EMBED_ALLOW_ALL_DASHBOARDS = 'false';
+            const updateSetup = getUpdateSetupConfig();
+            expect(updateSetup?.embed).toEqual({
+                allowAllDashboards: false,
+                secret: undefined,
+            });
+        });
+
+        test('should ignore empty embed secret for backwards compatibility', () => {
+            process.env.LD_SETUP_EMBED_SECRET = '';
+            const updateSetup = getUpdateSetupConfig();
+            expect(updateSetup?.embed).toBeUndefined();
+        });
+
+        test('should ignore empty allow all dashboards value for backwards compatibility', () => {
+            process.env.LD_SETUP_EMBED_ALLOW_ALL_DASHBOARDS = '';
+            const updateSetup = getUpdateSetupConfig();
+            expect(updateSetup?.embed).toBeUndefined();
         });
     });
 });

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -441,6 +441,13 @@ export const getUpdateSetupConfig = (): LightdashConfig['updateSetup'] => {
         );
     }
 
+    const embedAllowAllDashboards =
+        process.env.LD_SETUP_EMBED_ALLOW_ALL_DASHBOARDS;
+    const hasEmbedAllowAllDashboards =
+        embedAllowAllDashboards !== undefined && embedAllowAllDashboards !== '';
+    const embedSecret = process.env.LD_SETUP_EMBED_SECRET;
+    const hasEmbedSecret = embedSecret !== undefined && embedSecret !== '';
+
     return {
         organizationUuid: process.env.LD_SETUP_ORGANIZATION_UUID,
         projectUuid: process.env.LD_SETUP_PROJECT_UUID,
@@ -481,11 +488,15 @@ export const getUpdateSetupConfig = (): LightdashConfig['updateSetup'] => {
         dbt: {
             personal_access_token: process.env.LD_SETUP_GITHUB_PAT,
         },
-        embed: {
-            allowAllDashboards:
-                process.env.LD_SETUP_EMBED_ALLOW_ALL_DASHBOARDS === 'true',
-            secret: process.env.LD_SETUP_EMBED_SECRET,
-        },
+        embed:
+            hasEmbedAllowAllDashboards || hasEmbedSecret
+                ? {
+                      allowAllDashboards: hasEmbedAllowAllDashboards
+                          ? embedAllowAllDashboards === 'true'
+                          : undefined,
+                      secret: hasEmbedSecret ? embedSecret : undefined,
+                  }
+                : undefined,
     };
 };
 

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
@@ -94,6 +94,18 @@ const createMockService = (overrides: AnyType = {}) => {
         ...overrides.serviceAccountModel,
     };
 
+    const embedModel = {
+        get: jest.fn(),
+        save: jest.fn(),
+        updateDashboards: jest.fn(),
+        ...overrides.embedModel,
+    };
+
+    const encryptionUtil = {
+        encrypt: jest.fn(),
+        ...overrides.encryptionUtil,
+    };
+
     const lightdashConfig = {
         ...lightdashConfigMock,
         updateSetup: overrides.updateSetup || undefined,
@@ -110,8 +122,8 @@ const createMockService = (overrides: AnyType = {}) => {
         emailModel: {} as AnyType,
         projectService: {} as AnyType,
         serviceAccountModel: serviceAccountModel as AnyType,
-        embedModel: {} as AnyType,
-        encryptionUtil: { encrypt: jest.fn() } as AnyType,
+        embedModel: embedModel as AnyType,
+        encryptionUtil: encryptionUtil as AnyType,
     });
 };
 
@@ -124,6 +136,10 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
 
     describe('validation scenarios', () => {
         test('Do not throw error with default update setup config', async () => {
+            const getDefaultProjectUuids = jest
+                .fn()
+                .mockResolvedValue(['project-1', 'project-2']);
+
             service = createMockService({
                 organizationModel: {
                     getOrgUuids: jest
@@ -131,9 +147,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                         .mockResolvedValue(['org-1', 'org-2']),
                 },
                 projectModel: {
-                    getDefaultProjectUuids: jest
-                        .fn()
-                        .mockResolvedValue(['project-1', 'project-2']),
+                    getDefaultProjectUuids,
                 },
                 updateSetup: getUpdateSetupConfig(),
             });
@@ -141,6 +155,7 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
             await expect(
                 service.updateInstanceConfiguration(),
             ).resolves.not.toThrow();
+            expect(getDefaultProjectUuids).not.toHaveBeenCalled();
         });
 
         test('should throw ParameterError when there are multiple organizations and I am updating service account', async () => {
@@ -517,6 +532,78 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
             await expect(
                 service.updateInstanceConfiguration(),
             ).resolves.not.toThrow();
+        });
+
+        test('should ignore empty embed secret for backwards compatibility', async () => {
+            const encrypt = jest.fn().mockReturnValue(Buffer.from('encoded'));
+            const save = jest.fn().mockResolvedValue(undefined);
+            process.env.LD_SETUP_EMBED_SECRET = '';
+
+            service = createMockService({
+                organizationModel: {
+                    getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
+                },
+                projectModel: {
+                    getDefaultProjectUuids: jest
+                        .fn()
+                        .mockResolvedValue([mockProjectUuid]),
+                },
+                userModel: {
+                    findSessionUserByPrimaryEmail: jest
+                        .fn()
+                        .mockResolvedValue(mockSessionUser),
+                },
+                embedModel: {
+                    save,
+                },
+                encryptionUtil: {
+                    encrypt,
+                },
+                updateSetup: getUpdateSetupConfig(),
+            });
+
+            await service.updateInstanceConfiguration();
+            delete process.env.LD_SETUP_EMBED_SECRET;
+
+            expect(encrypt).not.toHaveBeenCalled();
+            expect(save).not.toHaveBeenCalled();
+        });
+
+        test('should preserve existing dashboard allowlist when disabling allow all dashboards', async () => {
+            const updateDashboards = jest.fn().mockResolvedValue(undefined);
+            const get = jest.fn().mockResolvedValue({
+                dashboardUuids: ['dashboard-1', 'dashboard-2'],
+            });
+
+            service = createMockService({
+                organizationModel: {
+                    getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
+                },
+                projectModel: {
+                    getDefaultProjectUuids: jest
+                        .fn()
+                        .mockResolvedValue([mockProjectUuid]),
+                },
+                embedModel: {
+                    get,
+                    updateDashboards,
+                },
+                updateSetup: {
+                    embed: {
+                        allowAllDashboards: false,
+                    },
+                },
+            });
+
+            await expect(
+                service.updateInstanceConfiguration(),
+            ).resolves.not.toThrow();
+
+            expect(get).toHaveBeenCalledWith(mockProjectUuid);
+            expect(updateDashboards).toHaveBeenCalledWith(mockProjectUuid, {
+                dashboardUuids: ['dashboard-1', 'dashboard-2'],
+                allowAllDashboards: false,
+            });
         });
 
         test('should allow non-git project to be updated with warehouse configuration only', async () => {

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -551,14 +551,14 @@ export class InstanceConfigurationService extends BaseService {
         if (!config.embed || !this.embedModel) return;
 
         const { allowAllDashboards, secret } = config.embed;
-        if (allowAllDashboards === undefined && !secret) return;
+        if (allowAllDashboards === undefined && secret === undefined) return;
 
         try {
             const projectUuid = await this.getSingleProject();
 
             // If config embed secret is provided, we need to call .save to upsert the embed record
             // This requires a user UUID, we get it from the admin email
-            if (secret) {
+            if (secret !== undefined) {
                 let userUuid: string | undefined;
                 const adminEmail = config.organization?.admin?.email;
                 if (adminEmail) {
@@ -589,12 +589,25 @@ export class InstanceConfigurationService extends BaseService {
                         allowAllDashboards ?? false
                     }`,
                 );
-            } else if (allowAllDashboards) {
+            } else if (allowAllDashboards !== undefined) {
+                let dashboardUuids: string[] = [];
+                if (!allowAllDashboards) {
+                    try {
+                        const existingEmbed =
+                            await this.embedModel.get(projectUuid);
+                        dashboardUuids = existingEmbed.dashboardUuids;
+                    } catch (error) {
+                        if (!(error instanceof NotFoundError)) {
+                            throw error;
+                        }
+                    }
+                }
+
                 this.logger.info(
-                    'No embed secret provided, enabling allowAllDashboards if configured',
+                    `No embed secret provided, setting allowAllDashboards=${allowAllDashboards}`,
                 );
                 await this.embedModel.updateDashboards(projectUuid, {
-                    dashboardUuids: [],
+                    dashboardUuids,
                     allowAllDashboards,
                 });
             }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR improves the handling of embed configuration during setup by making the embed configuration conditional and fixing the logic for the `allowAllDashboards` setting.

**Key changes:**

- The embed configuration object is now only created when embed-related environment variables (`LD_SETUP_EMBED_ALLOW_ALL_DASHBOARDS` or `LD_SETUP_EMBED_SECRET`) are explicitly set
- Fixed the `allowAllDashboards` logic to properly handle explicit `false` values instead of treating them as undefined
- Updated logging to be more accurate when no embed secret is provided but `allowAllDashboards` is configured
- Added test coverage for the new conditional embed configuration behavior
- Optimized the instance configuration service to avoid unnecessary database calls when embed configuration is not provided

This ensures that embed settings are only applied when intentionally configured, preventing unintended behavior during setup.