### PR TITLE
fix: scheduler search to use substring matching instead of regex tokens

### DIFF
--- a/packages/api-tests/tests/scheduler.test.ts
+++ b/packages/api-tests/tests/scheduler.test.ts
@@ -7,6 +7,7 @@ import {
     SEED_PROJECT,
     type ApiReassignSchedulerOwnerResponse,
     type ApiReassignUserSchedulersResponse,
+    type ApiSchedulersResponse,
     type ApiUserSchedulersSummaryResponse,
     type ChartScheduler,
     type CreateSchedulerAndTargetsWithoutIds,
@@ -57,6 +58,27 @@ async function createChartScheduler(client: ApiClient): Promise<string> {
     const createResp = await client.post<{ results: SchedulerAndTargets }>(
         `${apiUrl}/saved/${chart!.uuid}/schedulers`,
         createSchedulerBody,
+    );
+    return createResp.body.results.schedulerUuid;
+}
+
+async function createNamedChartScheduler(
+    client: ApiClient,
+    name: string,
+): Promise<string> {
+    const chartsResp = await client.get<{ results: SavedChart[] }>(
+        `${apiUrl}/projects/${SEED_PROJECT.project_uuid}/charts`,
+    );
+    const chart = chartsResp.body.results.find(
+        (s) => s.name === 'How much revenue do we have per payment method?',
+    );
+    const createResp = await client.post<{ results: SchedulerAndTargets }>(
+        `${apiUrl}/saved/${chart!.uuid}/schedulers`,
+        {
+            ...createSchedulerBody,
+            name,
+            targets: [{ recipient: 'search-fixture@getlightdash.com' }],
+        },
     );
     return createResp.body.results.schedulerUuid;
 }
@@ -270,6 +292,33 @@ describe('Lightdash scheduler endpoints', () => {
             { failOnStatusCode: false },
         );
         expect(deletedJobsResp.status).toBe(404);
+    });
+
+    it('Should search schedulers by full name substring instead of loose token matches', async () => {
+        const exactMatchName =
+            'CENTURY Smart IA Results: ACL Escalations Search Fixture';
+        const partialMatchName = 'CENTURY Leadership Summary Search Fixture';
+
+        const schedulerUuids = await Promise.all([
+            createNamedChartScheduler(admin, exactMatchName),
+            createNamedChartScheduler(admin, partialMatchName),
+        ]);
+
+        try {
+            const searchParams = new URLSearchParams({
+                searchQuery: `  ${exactMatchName}  `,
+                page: '1',
+                pageSize: '10',
+            });
+            const response = await admin.get<ApiSchedulersResponse>(
+                `${apiUrl}/schedulers/${SEED_PROJECT.project_uuid}/list?${searchParams.toString()}`,
+            );
+
+            expect(response.body.results.data).toHaveLength(1);
+            expect(response.body.results.data[0]?.name).toBe(exactMatchName);
+        } finally {
+            await deleteSchedulers(admin, schedulerUuids);
+        }
     });
 
     describe('Scheduler reassignment', () => {

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -60,7 +60,6 @@ import {
 import { SpaceTableName } from '../../database/entities/spaces';
 import { UserTableName } from '../../database/entities/users';
 import KnexPaginate from '../../database/pagination';
-import { getColumnMatchRegexQuery } from '../SearchModel/utils/search';
 
 type SelectScheduler = SchedulerDb & {
     created_by_name: string | null;
@@ -81,6 +80,17 @@ const statusOrder = [
     SchedulerJobStatus.STARTED,
     SchedulerJobStatus.SCHEDULED,
 ].map((s) => s.toString());
+
+const LIKE_ESCAPE_CHAR = '\\';
+
+const escapeLikeWildcards = (value: string): string =>
+    value
+        .split(LIKE_ESCAPE_CHAR)
+        .join(`${LIKE_ESCAPE_CHAR}${LIKE_ESCAPE_CHAR}`)
+        .split('%')
+        .join(`${LIKE_ESCAPE_CHAR}%`)
+        .split('_')
+        .join(`${LIKE_ESCAPE_CHAR}_`);
 
 export class SchedulerModel {
     private database: Knex;
@@ -323,10 +333,15 @@ export class SchedulerModel {
                 ).andOnNull(`${DashboardsTableName}.deleted_at`);
             });
         // Apply search query if present
-        if (searchQuery) {
-            baseQuery = getColumnMatchRegexQuery(baseQuery, searchQuery, [
-                `${SchedulerTableName}.name`,
-            ]);
+        const trimmedSearchQuery = searchQuery?.trim();
+        if (trimmedSearchQuery) {
+            baseQuery = baseQuery.whereRaw(
+                `:column: ILIKE :searchQuery ESCAPE '${LIKE_ESCAPE_CHAR}'`,
+                {
+                    column: `${SchedulerTableName}.name`,
+                    searchQuery: `%${escapeLikeWildcards(trimmedSearchQuery)}%`,
+                },
+            );
         }
 
         if (


### PR DESCRIPTION
### Description:

Closes: https://github.com/lightdash/lightdash/issues/21271

Changed scheduler search functionality to use exact substring matching instead of loose token-based regex matching. The search now uses SQL `ILIKE` with proper wildcard escaping to find schedulers by full name substrings, ensuring more precise search results.

Added a new test helper function `createNamedChartScheduler` to support testing with custom scheduler names, and included a test case that verifies the exact substring matching behavior by creating schedulers with similar but distinct names and confirming only the exact match is returned.