### PR TITLE
feat: improve query duration Prometheus metrics

### DIFF
--- a/packages/backend/src/prometheus/PrometheusMetrics.ts
+++ b/packages/backend/src/prometheus/PrometheusMetrics.ts
@@ -139,7 +139,9 @@ export default class PrometheusMetrics {
 
     private warehouseDurationHistogram: prometheus.Histogram | null = null;
 
-    private overheadDurationHistogram: prometheus.Histogram | null = null;
+    private processingDurationHistogram: prometheus.Histogram | null = null;
+
+    private prepDurationHistogram: prometheus.Histogram | null = null;
 
     constructor(config: LightdashConfig['prometheus']) {
         this.config = config;
@@ -204,9 +206,17 @@ export default class PrometheusMetrics {
                     ...rest,
                 });
 
-                this.overheadDurationHistogram = new prometheus.Histogram({
-                    name: 'lightdash_query_overhead_duration_seconds',
-                    help: 'Lightdash overhead: total duration minus warehouse execution time',
+                this.processingDurationHistogram = new prometheus.Histogram({
+                    name: 'lightdash_query_processing_duration_seconds',
+                    help: 'Time spent on S3 stream setup, upload finalization, and DB updates around the warehouse query',
+                    labelNames: ['context'],
+                    buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
+                    ...rest,
+                });
+
+                this.prepDurationHistogram = new prometheus.Histogram({
+                    name: 'lightdash_query_prep_duration_seconds',
+                    help: 'Time spent preparing a query before warehouse execution: explore fetch, SQL compilation, credential loading',
                     labelNames: ['context'],
                     buckets: [0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60, 120],
                     ...rest,
@@ -860,14 +870,21 @@ export default class PrometheusMetrics {
         );
     }
 
-    public observeOverheadDuration(durationMs: number, context: string) {
+    public observeProcessingDuration(durationMs: number, context: string) {
         if (durationMs < 0) {
             Logger.warn(
-                `Negative query overhead detected: ${durationMs}ms (context=${context}). Warehouse reported longer than wall clock.`,
+                `Negative query processing duration: ${durationMs}ms (context=${context}). Warehouse reported longer than wall clock.`,
             );
             return;
         }
-        this.overheadDurationHistogram?.observe(
+        this.processingDurationHistogram?.observe(
+            { context: getQueryContextLabel(context) },
+            durationMs / 1000,
+        );
+    }
+
+    public observePrepDuration(durationMs: number, context: string) {
+        this.prepDurationHistogram?.observe(
             { context: getQueryContextLabel(context) },
             durationMs / 1000,
         );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2207,6 +2207,10 @@ export class AsyncQueryService extends ProjectService {
                 queryCreatedAt,
                 queryTags.query_context || 'unknown',
             );
+            this.prometheusMetrics?.observeProcessingDuration(
+                totalMs - durationMs,
+                queryTags.query_context || 'unknown',
+            );
         } catch (e) {
             this.logger.error(
                 `Query ${queryUuid} execution error: ${getErrorMessage(e)}`,
@@ -3330,9 +3334,11 @@ export class AsyncQueryService extends ProjectService {
             context,
         });
 
+        const prepTotalMs = Date.now() - metricQueryStart;
         this.logger.info(
-            `Metric query prep for ${metricQuery.exploreName}: get_explore=${getExploreMs}ms get_wh_credentials=${getWarehouseCredentialsMs}ms prepare_query=${prepareMs}ms routing=${routingDecision.target} total=${Date.now() - metricQueryStart}ms`,
+            `Metric query prep for ${metricQuery.exploreName}: get_explore=${getExploreMs}ms get_wh_credentials=${getWarehouseCredentialsMs}ms prepare_query=${prepareMs}ms routing=${routingDecision.target} total=${prepTotalMs}ms`,
         );
+        this.prometheusMetrics?.observePrepDuration(prepTotalMs, context);
 
         if (routingDecision.preAggregateMetadata) {
             this.prometheusMetrics?.incrementPreAggregateMatch(

--- a/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/BigqueryWarehouseClient.ts
@@ -658,6 +658,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             fields: WarehouseResults['fields'],
         ) => void,
     ): Promise<WarehouseExecuteAsyncQuery> {
+        const startTime = performance.now();
         try {
             const [job] = await this.createJob(sql, {
                 tags,
@@ -678,8 +679,6 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
             await this.awaitJobCompletion(job);
 
             const resultsMetadata = await this.getJobResultsMetadata(job);
-            const startTime = job.metadata?.statistics?.startTime;
-            const endTime = job.metadata?.statistics?.endTime;
             const totalRows: number = resultsMetadata?.totalRows
                 ? parseInt(resultsMetadata.totalRows, 10)
                 : 1;
@@ -700,7 +699,7 @@ export class BigqueryWarehouseClient extends WarehouseBaseClient<CreateBigqueryC
                     jobLocation: job.location,
                 },
                 totalRows,
-                durationMs: startTime && endTime ? endTime - startTime : 0,
+                durationMs: performance.now() - startTime,
             };
         } catch (e: unknown) {
             if (BigqueryWarehouseClient.isBigqueryError(e)) {


### PR DESCRIPTION
## Summary
- Rename `overhead` metric to `processing` (measures S3/DB time around warehouse query)
- Add `query_prep_duration` metric (explore fetch, SQL compilation, credential loading)
- Use wall-clock timing for BigQuery warehouse duration instead of job metadata timestamps
- Wire up pre-aggregate file size histogram and parquet conversion duration metrics
- Change file size gauge to histogram for better percentile tracking

Combines changes from #21248 and #21249.

## Test plan
- [ ] Verify new Prometheus metrics appear at `/metrics` endpoint
- [ ] Confirm BigQuery queries report wall-clock duration
- [ ] Check pre-aggregate materialization records file size histogram