### PR TITLE
feat: add database-backed feature flags with env var override

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -358,4 +358,5 @@ export const lightdashConfigMock: LightdashConfig = {
     userImpersonation: {
         enabled: undefined,
     },
+    enabledFeatureFlags: new Set<string>(),
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1111,6 +1111,7 @@ export type LightdashConfig = {
     userImpersonation: {
         enabled: boolean | undefined;
     };
+    enabledFeatureFlags: Set<string>;
 };
 
 export type SlackConfig = {
@@ -2044,5 +2045,11 @@ export const parseConfig = (): LightdashConfig => {
                     ? true
                     : undefined,
         },
+        enabledFeatureFlags: new Set(
+            (process.env.LIGHTDASH_ENABLE_FEATURE_FLAGS ?? '')
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean),
+        ),
     };
 };

--- a/packages/backend/src/database/entities/featureFlags.ts
+++ b/packages/backend/src/database/entities/featureFlags.ts
@@ -1,0 +1,19 @@
+export const FeatureFlagsTableName = 'feature_flags';
+export const FeatureFlagOverridesTableName = 'feature_flag_overrides';
+
+export type DbFeatureFlag = {
+    flag_id: string;
+    default_enabled: boolean;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type DbFeatureFlagOverride = {
+    feature_flag_override_id: number;
+    flag_id: string;
+    user_uuid: string | null;
+    organization_uuid: string | null;
+    enabled: boolean;
+    created_at: Date;
+    updated_at: Date;
+};

--- a/packages/backend/src/database/migrations/20260320133611_add_feature_flags_tables.ts
+++ b/packages/backend/src/database/migrations/20260320133611_add_feature_flags_tables.ts
@@ -1,0 +1,52 @@
+import { Knex } from 'knex';
+
+const FEATURE_FLAGS_TABLE = 'feature_flags';
+const FEATURE_FLAG_OVERRIDES_TABLE = 'feature_flag_overrides';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.createTable(FEATURE_FLAGS_TABLE, (table) => {
+        table.string('flag_id').primary();
+        table.boolean('default_enabled').notNullable().defaultTo(false);
+        table.timestamps(true, true);
+    });
+
+    await knex.schema.createTable(FEATURE_FLAG_OVERRIDES_TABLE, (table) => {
+        table.increments('feature_flag_override_id').primary();
+        table
+            .string('flag_id')
+            .notNullable()
+            .references('flag_id')
+            .inTable(FEATURE_FLAGS_TABLE)
+            .onDelete('CASCADE');
+        table.uuid('user_uuid').nullable();
+        table.uuid('organization_uuid').nullable();
+        table.boolean('enabled').notNullable();
+        table.timestamps(true, true);
+    });
+
+    // Ensure at least one targeting field is set
+    await knex.raw(`
+        ALTER TABLE ${FEATURE_FLAG_OVERRIDES_TABLE}
+        ADD CONSTRAINT feature_flag_overrides_target_check
+        CHECK (user_uuid IS NOT NULL OR organization_uuid IS NOT NULL)
+    `);
+
+    // Unique constraint: one override per flag per user
+    await knex.raw(`
+        CREATE UNIQUE INDEX feature_flag_overrides_user_unique
+        ON ${FEATURE_FLAG_OVERRIDES_TABLE} (flag_id, user_uuid)
+        WHERE user_uuid IS NOT NULL
+    `);
+
+    // Unique constraint: one override per flag per org
+    await knex.raw(`
+        CREATE UNIQUE INDEX feature_flag_overrides_org_unique
+        ON ${FEATURE_FLAG_OVERRIDES_TABLE} (flag_id, organization_uuid)
+        WHERE organization_uuid IS NOT NULL AND user_uuid IS NULL
+    `);
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(FEATURE_FLAG_OVERRIDES_TABLE);
+    await knex.schema.dropTableIfExists(FEATURE_FLAGS_TABLE);
+}

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -7,6 +7,10 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
+import {
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../../database/entities/featureFlags';
 import { isFeatureFlagEnabled } from '../../postHog';
 
 export type FeatureFlagLogicArgs = {
@@ -54,11 +58,24 @@ export class FeatureFlagModel {
     }
 
     public async get(args: FeatureFlagLogicArgs): Promise<FeatureFlag> {
+        // 1. LIGHTDASH_ENABLE_FEATURE_FLAGS env var (highest priority, enable-only)
+        if (this.lightdashConfig.enabledFeatureFlags.has(args.featureFlagId)) {
+            return { id: args.featureFlagId, enabled: true };
+        }
+
+        // 2. Per-flag env var / config handlers
         const handler = this.featureFlagHandlers[args.featureFlagId];
         if (handler) {
             return handler(args);
         }
-        // Default to check Posthog feature flag
+
+        // 3. Check database
+        const dbResult = await this.getFromDatabase(args);
+        if (dbResult !== null) {
+            return dbResult;
+        }
+
+        // 4. Fall through to PostHog (being phased out)
         if (args.user && isFeatureFlags(args.featureFlagId)) {
             return FeatureFlagModel.getPosthogFeatureFlag(
                 args.user,
@@ -66,6 +83,63 @@ export class FeatureFlagModel {
             );
         }
         throw new NotFoundError(`Feature flag ${args.featureFlagId} not found`);
+    }
+
+    /**
+     * Check the database for a feature flag value.
+     * Returns null if the flag doesn't exist in the DB (caller should fall through to PostHog).
+     * Priority: user override > org override > flag default.
+     */
+    private async getFromDatabase(
+        args: FeatureFlagLogicArgs,
+    ): Promise<FeatureFlag | null> {
+        const flag = await this.database(FeatureFlagsTableName)
+            .where('flag_id', args.featureFlagId)
+            .first();
+
+        if (!flag) {
+            return null;
+        }
+
+        if (args.user) {
+            // Check user override first
+            if (args.user.userUuid) {
+                const userOverride = await this.database(
+                    FeatureFlagOverridesTableName,
+                )
+                    .where('flag_id', args.featureFlagId)
+                    .where('user_uuid', args.user.userUuid)
+                    .first();
+
+                if (userOverride) {
+                    return {
+                        id: args.featureFlagId,
+                        enabled: userOverride.enabled,
+                    };
+                }
+            }
+
+            // Check org override
+            if (args.user.organizationUuid) {
+                const orgOverride = await this.database(
+                    FeatureFlagOverridesTableName,
+                )
+                    .where('flag_id', args.featureFlagId)
+                    .where('organization_uuid', args.user.organizationUuid)
+                    .whereNull('user_uuid')
+                    .first();
+
+                if (orgOverride) {
+                    return {
+                        id: args.featureFlagId,
+                        enabled: orgOverride.enabled,
+                    };
+                }
+            }
+        }
+
+        // Return flag default
+        return { id: args.featureFlagId, enabled: flag.default_enabled };
     }
 
     static async getPosthogFeatureFlag(


### PR DESCRIPTION
## Summary

- Adds `feature_flags` and `feature_flag_overrides` PostgreSQL tables for managing feature flags without PostHog
- Adds `LIGHTDASH_ENABLE_FEATURE_FLAGS` env var for self-hosted users to enable flags by ID (comma-separated)
- Wires DB lookup into `FeatureFlagModel.get()` resolution chain: env var → config handlers → DB (user override > org override > default) → PostHog fallback

Tables are created empty — an external service will insert flag rows. Existing flags continue to resolve via env vars + PostHog until migrated.

## Test plan

- [x] Migration applies, rolls back, and re-applies cleanly
- [x] Lint passes
- [x] All 852 backend tests pass
- [ ] Manual: insert flag row via psql, verify it resolves via API
- [ ] Manual: verify user override > org override > default priority
- [ ] Manual: verify `LIGHTDASH_ENABLE_FEATURE_FLAGS=maps` enables the flag
- [ ] Manual: verify flags not in DB still fall through to PostHog