### PR TITLE
feat: add theme and background color support for embedded charts

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
@@ -1,4 +1,4 @@
-import { Box, MantineProvider, type MantineThemeOverride } from '@mantine/core';
+import { Box } from '@mantine/core';
 import { IconUnlink } from '@tabler/icons-react';
 import { memo, useMemo, type FC } from 'react';
 import SuboptimalState from '../../../../../components/common/SuboptimalState/SuboptimalState';
@@ -13,14 +13,6 @@ import { useProjectUuid } from '../../../../../hooks/useProjectUuid';
 import { useSavedQuery } from '../../../../../hooks/useSavedQuery';
 import MinimalSavedExplorer from '../../../../../pages/MinimalSavedExplorer';
 import useApp from '../../../../../providers/App/useApp';
-
-const themeOverride: MantineThemeOverride = {
-    globalStyles: () => ({
-        'html, body': {
-            backgroundColor: 'white',
-        },
-    }),
-};
 
 const MinimalChartContent = memo(() => {
     const { health } = useApp();
@@ -60,14 +52,12 @@ const MinimalChartContent = memo(() => {
             colorPalette={savedChart.colorPalette}
             parameters={query.data?.usedParametersValues}
         >
-            <MantineProvider inherit theme={themeOverride}>
-                <Box mih="inherit" h="100%">
-                    <LightdashVisualization
-                        className="sentry-block ph-no-capture"
-                        data-testid="visualization"
-                    />
-                </Box>
-            </MantineProvider>
+            <Box mih="inherit" h="100%">
+                <LightdashVisualization
+                    className="sentry-block ph-no-capture"
+                    data-testid="visualization"
+                />
+            </Box>
         </VisualizationProvider>
     );
 });

--- a/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedExplore/components/EmbedExplore.tsx
@@ -1,5 +1,4 @@
 import { ChartType, type SavedChart } from '@lightdash/common';
-import { MantineProvider, type MantineThemeOverride } from '@mantine/core';
 import { IconUnlink } from '@tabler/icons-react';
 import { useState, type FC } from 'react';
 import { Provider } from 'react-redux';
@@ -16,14 +15,6 @@ import { useExplorerQueryEffects } from '../../../../../hooks/useExplorerQueryEf
 import { ExplorerSection } from '../../../../../providers/Explorer/types';
 import useEmbed from '../../../../providers/Embed/useEmbed';
 
-const themeOverride: MantineThemeOverride = {
-    globalStyles: () => ({
-        'html, body': {
-            backgroundColor: 'white',
-        },
-    }),
-};
-
 const EmbedExploreView: FC<{ exploreId: string }> = ({ exploreId }) => {
     const { data } = useExplore(exploreId);
 
@@ -31,16 +22,14 @@ const EmbedExploreView: FC<{ exploreId: string }> = ({ exploreId }) => {
     useExplorerQueryEffects();
 
     return (
-        <MantineProvider inherit theme={themeOverride}>
-            <Page
-                title={data ? data?.label : 'Tables'}
-                sidebar={<ExploreSideBar />}
-                withFullHeight
-                withPaddedContent
-            >
-                <Explorer />
-            </Page>
-        </MantineProvider>
+        <Page
+            title={data ? data?.label : 'Tables'}
+            sidebar={<ExploreSideBar />}
+            withFullHeight
+            withPaddedContent
+        >
+            <Explorer />
+        </Page>
     );
 };
 

--- a/packages/frontend/src/ee/features/embed/EmbeddedApp.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbeddedApp.tsx
@@ -1,7 +1,35 @@
 import { type SavedChart } from '@lightdash/common';
-import { useState, type FC } from 'react';
+import { useMantineColorScheme } from '@mantine/core';
+import { useEffect, useState, type FC } from 'react';
 import { Outlet, useNavigate, useParams } from 'react-router';
 import EmbedProvider from '../../providers/Embed/EmbedProvider';
+import useEmbed from '../../providers/Embed/useEmbed';
+
+/**
+ * Syncs the embed theme URL params with the Mantine color scheme
+ * and applies a custom background color if provided.
+ */
+const EmbedThemeSync: FC<React.PropsWithChildren> = ({ children }) => {
+    const { theme, backgroundColor } = useEmbed();
+    const { toggleColorScheme } = useMantineColorScheme();
+
+    useEffect(() => {
+        toggleColorScheme(theme);
+    }, [theme, toggleColorScheme]);
+
+    useEffect(() => {
+        if (backgroundColor) {
+            document.documentElement.style.backgroundColor = backgroundColor;
+            document.body.style.backgroundColor = backgroundColor;
+        }
+        return () => {
+            document.documentElement.style.backgroundColor = '';
+            document.body.style.backgroundColor = '';
+        };
+    }, [backgroundColor]);
+
+    return <>{children}</>;
+};
 
 /**
  * A wrapping app around the Embed Context Provider. This allows better management of
@@ -30,7 +58,9 @@ const EmbeddedApp: FC = () => {
             onExplore={handleExplore}
             onBackToDashboard={handleBackToDashboard}
         >
-            <Outlet />
+            <EmbedThemeSync>
+                <Outlet />
+            </EmbedThemeSync>
         </EmbedProvider>
     );
 };

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -12,7 +12,29 @@ import { type SdkFilter } from '../../features/embed/EmbedDashboard/types';
 import { LightdashEventType } from '../../features/embed/events/types';
 import { useEmbedEventEmitter } from '../../features/embed/hooks/useEmbedEventEmitter';
 import EmbedProviderContext from './context';
-import { EMBED_KEY, type EmbedMode, type InMemoryEmbed } from './types';
+import {
+    EMBED_KEY,
+    type EmbedMode,
+    type EmbedTheme,
+    type InMemoryEmbed,
+} from './types';
+
+const HEX_COLOR_REGEX = /^[0-9a-fA-F]{3,8}$/;
+
+function parseEmbedThemeParams(): {
+    theme: EmbedTheme;
+    backgroundColor: string | null;
+} {
+    const params = new URLSearchParams(window.location.search);
+    const themeParam = params.get('theme');
+    const theme: EmbedTheme =
+        themeParam === 'light' || themeParam === 'dark' ? themeParam : 'light';
+    const bgParam = params.get('backgroundColor');
+    // Accept bare hex codes (e.g. "121212") and prepend "#"
+    const backgroundColor =
+        bgParam && HEX_COLOR_REGEX.test(bgParam) ? `#${bgParam}` : null;
+    return { theme, backgroundColor };
+}
 
 type Props = {
     embedToken?: string;
@@ -39,6 +61,9 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
 }) => {
     const embedToken = encodedToken || window.location.hash.replace('#', '');
     const [isInitialized, setIsInitialized] = useState(false);
+
+    // Parse theme params from URL once on mount (before hash is stripped)
+    const [embedThemeParams] = useState(parseEmbedThemeParams);
     const embed = getFromInMemoryStorage<InMemoryEmbed>(EMBED_KEY);
     const { data: account, isLoading } = useAccount();
     const ability = useAbilityContext();
@@ -103,6 +128,8 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             savedQueryUuid,
             onBackToDashboard,
             mode,
+            theme: embedThemeParams.theme,
+            backgroundColor: embedThemeParams.backgroundColor,
         };
     }, [
         embed?.projectUuid,
@@ -116,6 +143,8 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         savedQueryUuid,
         onBackToDashboard,
         mode,
+        embedThemeParams.theme,
+        embedThemeParams.backgroundColor,
     ]);
 
     return (

--- a/packages/frontend/src/ee/providers/Embed/context.ts
+++ b/packages/frontend/src/ee/providers/Embed/context.ts
@@ -12,6 +12,8 @@ const EmbedProviderContext = createContext<EmbedContext>({
     savedChart: undefined,
     onBackToDashboard: undefined,
     mode: 'direct',
+    theme: 'light',
+    backgroundColor: null,
 });
 
 export default EmbedProviderContext;

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -3,6 +3,8 @@ import { type SdkFilter } from '../../features/embed/EmbedDashboard/types';
 
 export const EMBED_KEY = 'lightdash-embed';
 
+export type EmbedTheme = 'light' | 'dark';
+
 export type InMemoryEmbed = {
     projectUuid?: string;
     token?: string;
@@ -31,4 +33,8 @@ export interface EmbedContext {
     savedQueryUuid?: string;
     // The mode of the embed: 'sdk' when embedded via SDK (no URL sync), 'direct' when navigating directly to /embed (sync URL)
     mode: EmbedMode;
+    // Theme color scheme for the embed, set via ?theme=light|dark URL param
+    theme: EmbedTheme;
+    // Custom background color for the embed, set via ?backgroundColor=<css-color> URL param
+    backgroundColor: string | null;
 }

--- a/packages/frontend/src/ee/providers/Embed/useEmbed.ts
+++ b/packages/frontend/src/ee/providers/Embed/useEmbed.ts
@@ -29,6 +29,8 @@ function useEmbed(): EmbedContext {
             onExplore: (_options: { chart: SavedChart }) => {},
             t: (_input: string) => undefined,
             mode: 'direct',
+            theme: 'light',
+            backgroundColor: null,
         };
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://github.com/lightdash/lightdash/issues/21277


> embed/3675b69e-8324-4110-bdca-059031aa8da3?theme=dark&backgroundColor=1c1c1c#embedToken

<img width="1912" height="596" alt="image" src="https://github.com/user-attachments/assets/5f0995bd-a70e-4cb7-bc75-a138b9a51c71" />

---
### Summary

Embed Theming URL Parameters                                                                             
                                                     
  Embedded charts and dashboards now support two new optional URL parameters:                              
                                                                                                           
  theme — Sets the color scheme for the embedded content.                                                  
  - Values: light or dark                                               
  - Default: light                                                                                         
  - Example: ?theme=dark                                                

  backgroundColor — Sets a custom background color on the embed.                                           
  - Accepts bare hex codes (without the # prefix): 121212, FFF, FF000080
  - The # is automatically prepended                                                                       
  - Other CSS color formats (named colors, rgb, etc.) are not supported 
  - Default: none (uses the theme's default background)                                                    
                                                                                                           
  URL format:                                                                                              
  /embed/<embedUuid>?theme=dark&backgroundColor=1c1c1c#<embedToken>                                        
                                                                                                           
  Both parameters are optional. Existing embed URLs without these parameters behave exactly as before      
  (light theme, default background).

---

### Description:

This PR adds theme support for embedded charts and dashboards by introducing URL parameter-based theming. 

**Key changes:**

- Added `theme` and `backgroundColor` URL parameters that can be passed to embedded content (e.g., `?theme=dark&backgroundColor=%23000000`)
- Implemented `EmbedThemeSync` component that automatically applies the theme to Mantine's color scheme and sets custom background colors on the document body
- Removed hardcoded white background theme overrides from `EmbedChart` and `EmbedExplore` components to allow dynamic theming
- Extended the embed context to include theme configuration that gets parsed from URL parameters on initialization

The theming system supports both `light` and `dark` themes (defaulting to `light`) and accepts any CSS-compatible color value for the background color parameter.