### PR TITLE
refactor: add generic explore post-processor to compiler

### DIFF
--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -24,6 +24,7 @@ import {
     normaliseModelDatabase,
     NotFoundError,
     ParseError,
+    preAggregatePostProcessor,
     SupportedDbtAdapter,
     SupportedDbtVersions,
     type LightdashProjectConfig,
@@ -40,6 +41,8 @@ import {
     ProjectAdapter,
     type TrackingParams,
 } from '../types';
+
+const postProcessors = [preAggregatePostProcessor];
 
 export class DbtBaseProjectAdapter implements ProjectAdapter {
     dbtClient: DbtClient;
@@ -256,8 +259,11 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 metrics,
                 this.warehouseClient,
                 lightdashProjectConfig,
-                disableTimestampConversion,
-                allowPartialCompilation,
+                {
+                    disableTimestampConversion,
+                    allowPartialCompilation,
+                    postProcessors,
+                },
             );
             Logger.info('Finished compiling explores');
             return [...lazyExplores, ...failedExplores];
@@ -301,8 +307,11 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     metrics,
                     this.warehouseClient,
                     lightdashProjectConfig,
-                    disableTimestampConversion,
-                    allowPartialCompilation,
+                    {
+                        disableTimestampConversion,
+                        allowPartialCompilation,
+                        postProcessors,
+                    },
                 );
                 Logger.info(
                     'Finished compiling explores after missing catalog error',

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -117,6 +117,7 @@ import {
     PivotChartData,
     PivotConfiguration,
     PivotValuesColumn,
+    preAggregatePostProcessor,
     Project,
     ProjectCatalog,
     ProjectDefaults,
@@ -7768,7 +7769,10 @@ export class ProjectService extends BaseService {
                 },
                 defaults: project.projectDefaults,
             },
-            disableTimestampConversion,
+            {
+                disableTimestampConversion,
+                postProcessors: [preAggregatePostProcessor],
+            },
         );
         Logger.info(`Explore count: ${convertedExplores.length}`);
         const previewName = `preview_${jobId}_${prId}`;

--- a/packages/cli/src/handlers/compile.ts
+++ b/packages/cli/src/handlers/compile.ts
@@ -97,8 +97,11 @@ const getExploresFromLightdashYmlProject = async (
         [],
         warehouseSqlBuilder,
         lightdashProjectConfig,
-        disableTimestampConversion,
-        process.env.PARTIAL_COMPILATION_ENABLED !== 'false',
+        {
+            disableTimestampConversion,
+            allowPartialCompilation:
+                process.env.PARTIAL_COMPILATION_ENABLED !== 'false',
+        },
     );
 
     return validExplores;
@@ -331,8 +334,11 @@ export const compile = async (options: CompileHandlerOptions) => {
                 : Object.values(manifest.metrics || {}),
             warehouseSqlBuilder,
             lightdashProjectConfig,
-            options.disableTimestampConversion,
-            process.env.PARTIAL_COMPILATION_ENABLED !== 'false',
+            {
+                disableTimestampConversion: options.disableTimestampConversion,
+                allowPartialCompilation:
+                    process.env.PARTIAL_COMPILATION_ENABLED !== 'false',
+            },
         );
         console.error('');
 

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1,4 +1,5 @@
 import { PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER } from '../preAggregates/buildPreAggregateExplore';
+import { preAggregatePostProcessor } from '../preAggregates/postProcessor';
 import { SupportedDbtAdapter, type DbtModelNode } from '../types/dbt';
 import { ExploreType, InlineErrorType, type Explore } from '../types/explore';
 import { DimensionType, FieldType } from '../types/field';
@@ -1248,6 +1249,7 @@ describe('pre-aggregates metadata parsing', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(1);
@@ -1273,6 +1275,7 @@ describe('pre-aggregates metadata parsing', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(1);
@@ -1314,6 +1317,7 @@ describe('pre-aggregates metadata parsing', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(1);
@@ -1349,6 +1353,7 @@ describe('pre-aggregates metadata parsing', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(1);
@@ -1390,6 +1395,7 @@ describe('pre-aggregate virtual explore generation', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(2);
@@ -1439,6 +1445,7 @@ describe('pre-aggregate virtual explore generation', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(2);
@@ -1501,6 +1508,7 @@ describe('pre-aggregate virtual explore generation', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(3);
@@ -1554,6 +1562,7 @@ describe('pre-aggregate virtual explore generation', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(1);
@@ -1590,6 +1599,7 @@ describe('pre-aggregate virtual explore generation', () => {
             {
                 spotlight: DEFAULT_SPOTLIGHT_CONFIG,
             },
+            { postProcessors: [preAggregatePostProcessor] },
         );
 
         expect(explores).toHaveLength(1);

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1,6 +1,5 @@
 import merge from 'lodash/merge';
-import { parseDbtPreAggregates } from '../preAggregates/definition';
-import { generatePreAggregateExplores } from '../preAggregates/generatePreAggregateExplores';
+import partition from 'lodash/partition';
 import {
     buildModelGraph,
     convertColumnMetric,
@@ -24,6 +23,7 @@ import {
 } from '../types/errors';
 import {
     InlineErrorType,
+    isExploreError,
     type Explore,
     type ExploreError,
     type InlineError,
@@ -48,7 +48,6 @@ import {
     type CustomGranularity,
     type LightdashProjectConfig,
 } from '../types/lightdashProjectConfig';
-import { type PreAggregateDef } from '../types/preAggregate';
 import { OrderFieldsByStrategy, type GroupType } from '../types/table';
 import { type TimeFrames } from '../types/timeFrames';
 import { type WarehouseSqlBuilder } from '../types/warehouse';
@@ -1057,6 +1056,20 @@ const modelCanUseMetric = (
     return false;
 };
 
+export type ExplorePostProcessor = (
+    compiledExplores: Explore[],
+    context: {
+        model: DbtModelNode;
+        meta: Record<string, unknown>;
+    },
+) => (Explore | ExploreError)[];
+
+export type ConvertExploresOptions = {
+    disableTimestampConversion?: boolean;
+    allowPartialCompilation?: boolean;
+    postProcessors?: ExplorePostProcessor[];
+};
+
 export const convertExplores = async (
     models: DbtModelNode[],
     loadSources: boolean,
@@ -1064,9 +1077,13 @@ export const convertExplores = async (
     metrics: DbtMetric[],
     warehouseSqlBuilder: WarehouseSqlBuilder,
     lightdashProjectConfig: LightdashProjectConfig,
-    disableTimestampConversion?: boolean,
-    allowPartialCompilation?: boolean,
+    options?: ConvertExploresOptions,
 ): Promise<(Explore | ExploreError)[]> => {
+    const {
+        disableTimestampConversion,
+        allowPartialCompilation,
+        postProcessors,
+    } = options ?? {};
     const tableLineage = translateDbtModelsToTableLineage(models);
     const [tables, exploreErrors] = models.reduce(
         ([accTables, accErrors], model) => {
@@ -1240,33 +1257,6 @@ export const convertExplores = async (
                 : []),
         ];
 
-        let parsedPreAggregates: PreAggregateDef[] = [];
-        try {
-            parsedPreAggregates = parseDbtPreAggregates(
-                meta.pre_aggregates,
-                model.name,
-            );
-        } catch (error) {
-            const preAggregateErrors = exploresToCreate.map(
-                (exploreToCreate) =>
-                    ({
-                        name: exploreToCreate.name,
-                        label: exploreToCreate.label,
-                        groupLabel: exploreToCreate.groupLabel,
-                        errors: [
-                            {
-                                type: InlineErrorType.METADATA_PARSE_ERROR,
-                                message:
-                                    error instanceof Error
-                                        ? error.message
-                                        : `Could not parse pre-aggregates for model "${model.name}"`,
-                            },
-                        ],
-                    }) as ExploreError,
-            );
-            return [...acc, ...preAggregateErrors];
-        }
-
         // Multiple explores can be created from a single model. The base explore + additional explores
         // Properties created from `model` are the same across all explores. e.g. all explores will have the same base table & warehouse
         // Properties created from `exploreToCreate` are specific to each explore. e.g. each explore can have a different name, label & joins
@@ -1300,9 +1290,6 @@ export const convertExplores = async (
                     spotlightConfig: lightdashProjectConfig.spotlight,
                     ...(meta.ai_hint
                         ? { aiHint: convertToAiHints(meta.ai_hint) }
-                        : {}),
-                    ...(parsedPreAggregates.length > 0
-                        ? { preAggregates: parsedPreAggregates }
                         : {}),
                     meta: {
                         ...meta,
@@ -1345,14 +1332,28 @@ export const convertExplores = async (
             }
         });
 
-        const exploresWithGeneratedPreAggregates = generatePreAggregateExplores(
-            {
-                compiledExplores,
-                parsedPreAggregates,
-            },
+        // Split compiled explores into successes and errors,
+        // then run post-processors over successful explores only
+        const [compileErrors, successfulExplores] = partition(
+            compiledExplores,
+            isExploreError,
         );
 
-        return [...acc, ...exploresWithGeneratedPreAggregates];
+        const postProcessorContext = {
+            model,
+            meta,
+        };
+        const postProcessedExplores = (postProcessors ?? []).reduce<
+            (Explore | ExploreError)[]
+        >((currentExplores, processor) => {
+            const [errors, successes] = partition(
+                currentExplores,
+                isExploreError,
+            );
+            return [...errors, ...processor(successes, postProcessorContext)];
+        }, successfulExplores);
+
+        return [...acc, ...compileErrors, ...postProcessedExplores];
     }, []);
 
     return [...explores, ...exploreErrors];

--- a/packages/common/src/preAggregates/index.ts
+++ b/packages/common/src/preAggregates/index.ts
@@ -5,4 +5,5 @@ export * from './generatePreAggregateExplores';
 export * from './matcher';
 export * from './metricRepresentation';
 export * from './naming';
+export * from './postProcessor';
 export * from './references';

--- a/packages/common/src/preAggregates/postProcessor.ts
+++ b/packages/common/src/preAggregates/postProcessor.ts
@@ -1,0 +1,49 @@
+import attempt from 'lodash/attempt';
+import isError from 'lodash/isError';
+import type { ExplorePostProcessor } from '../compiler/translator';
+import { InlineErrorType, type ExploreError } from '../types/explore';
+import { parseDbtPreAggregates } from './definition';
+import { generatePreAggregateExplores } from './generatePreAggregateExplores';
+
+export const preAggregatePostProcessor: ExplorePostProcessor = (
+    compiledExplores,
+    { model, meta },
+) => {
+    const parsedPreAggregates = attempt(
+        parseDbtPreAggregates,
+        meta.pre_aggregates,
+        model.name,
+    );
+
+    if (isError(parsedPreAggregates)) {
+        return compiledExplores.map(
+            (explore) =>
+                ({
+                    name: explore.name,
+                    label: explore.label,
+                    groupLabel: explore.groupLabel,
+                    errors: [
+                        {
+                            type: InlineErrorType.METADATA_PARSE_ERROR,
+                            message:
+                                parsedPreAggregates.message ||
+                                `Could not parse pre-aggregates for model "${model.name}"`,
+                        },
+                    ],
+                }) satisfies ExploreError,
+        );
+    }
+
+    // Attach parsed defs to explores
+    const exploresWithPreAggregates = compiledExplores.map((explore) =>
+        parsedPreAggregates.length > 0
+            ? { ...explore, preAggregates: parsedPreAggregates }
+            : explore,
+    );
+
+    // Generate virtual pre-aggregate explores
+    return generatePreAggregateExplores({
+        compiledExplores: exploresWithPreAggregates,
+        parsedPreAggregates,
+    });
+};


### PR DESCRIPTION
### Description:
Prepping the foundation to move pre-aggregates away from oss. Introduced post-processor workflow so we can hook processing after compilation is done