### PR TITLE
fix: add deterministic tiebreakers to dashboard tile ordering

### DIFF
--- a/packages/backend/src/models/DashboardModel/DashboardModel.ts
+++ b/packages/backend/src/models/DashboardModel/DashboardModel.ts
@@ -992,6 +992,10 @@ export class DashboardModel {
             .orderBy([
                 { column: `${DashboardTilesTableName}.y_offset` },
                 { column: `${DashboardTilesTableName}.x_offset` },
+                { column: `${DashboardTilesTableName}.tab_uuid` },
+                {
+                    column: `${DashboardTilesTableName}.dashboard_tile_uuid`,
+                },
             ]);
 
         const tabs = await this.database(DashboardTabsTableName)
@@ -1898,6 +1902,10 @@ export class DashboardModel {
             .orderBy([
                 { column: `${DashboardTilesTableName}.y_offset` },
                 { column: `${DashboardTilesTableName}.x_offset` },
+                { column: `${DashboardTilesTableName}.tab_uuid` },
+                {
+                    column: `${DashboardTilesTableName}.dashboard_tile_uuid`,
+                },
             ]);
 
         const tabs = await this.database(DashboardTabsTableName)


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-257/make-content-as-code-downloads-more-deterministic

### Description:
When dashboards are "downloaded as code" their ordering is not deterministic, because they are only sorted by y,x. As soon as you have more than 1 tab, there is a chance that you have the same coords more than once, creating in-consistent sorting.