### PR TITLE
feat(cli): add lightdash set-warehouse command

### DIFF
--- a/packages/cli/src/handlers/setWarehouse.ts
+++ b/packages/cli/src/handlers/setWarehouse.ts
@@ -1,0 +1,129 @@
+import {
+    AuthorizationError,
+    type ApiJobStartedResults,
+    type UpdateProject,
+} from '@lightdash/common';
+import inquirer from 'inquirer';
+import { getConfig } from '../config';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { loadWarehouseCredentialsFromProfiles } from './createProject';
+import { checkLightdashVersion, lightdashApi } from './dbt/apiClient';
+import { getFinalJobState, getProject } from './dbt/refresh';
+
+type SetWarehouseHandlerOptions = {
+    projectDir: string;
+    profilesDir: string;
+    target?: string;
+    profile?: string;
+    targetPath?: string;
+    project?: string;
+    startOfWeek?: number;
+    assumeYes: boolean;
+    verbose: boolean;
+};
+
+const resolveProjectUuid = async (projectOption?: string): Promise<string> => {
+    if (projectOption) {
+        return projectOption;
+    }
+    const config = await getConfig();
+    if (!config.context?.project) {
+        throw new AuthorizationError(
+            `No project selected. Run 'lightdash config set-project' first or pass '--project <uuid>'.`,
+        );
+    }
+    return config.context.project;
+};
+
+export const setWarehouseHandler = async (
+    options: SetWarehouseHandlerOptions,
+) => {
+    GlobalState.setVerbose(options.verbose);
+    await checkLightdashVersion();
+
+    const projectUuid = await resolveProjectUuid(options.project);
+
+    // Load credentials from profiles.yml
+    const loaded = await loadWarehouseCredentialsFromProfiles({
+        projectDir: options.projectDir,
+        profilesDir: options.profilesDir,
+        target: options.target,
+        profile: options.profile,
+        startOfWeek: options.startOfWeek,
+        assumeYes: options.assumeYes,
+        targetPath: options.targetPath,
+    });
+    if (!loaded) {
+        console.error(
+            styles.warning(
+                'User declined to store warehouse credentials. Use --assume-yes to bypass.',
+            ),
+        );
+        return;
+    }
+    const { credentials } = loaded;
+
+    // Fetch existing project to preserve its settings
+    const existingProject = await getProject(projectUuid);
+
+    // Confirmation prompt
+    if (!options.assumeYes && !GlobalState.isNonInteractive()) {
+        const spinner = GlobalState.getActiveSpinner();
+        spinner?.stop();
+        const answers = await inquirer.prompt([
+            {
+                type: 'confirm',
+                name: 'isConfirm',
+                message: `This will update the warehouse connection on project '${existingProject.name}' to ${credentials.type} and trigger a recompile. Continue?`,
+                default: false,
+            },
+        ]);
+        if (!answers.isConfirm) {
+            console.error(styles.warning('Aborted.'));
+            return;
+        }
+        spinner?.start();
+    }
+
+    const spinner = GlobalState.startSpinner(
+        '  Updating warehouse connection...',
+    );
+
+    try {
+        // Build UpdateProject body — preserve existing fields, override warehouseConnection.
+        // Note: dbtConnection from GET response may have stripped secrets, but the backend's
+        // mergeMissingProjectConfigSecrets fills them back in from the saved project before persisting.
+        const updateBody: UpdateProject = {
+            name: existingProject.name,
+            dbtConnection: existingProject.dbtConnection,
+            dbtVersion: existingProject.dbtVersion,
+            warehouseConnection: credentials,
+        };
+
+        // PATCH project — triggers adaptor test + recompile
+        const result = await lightdashApi<ApiJobStartedResults>({
+            method: 'PATCH',
+            url: `/api/v1/projects/${projectUuid}`,
+            body: JSON.stringify(updateBody),
+        });
+
+        // Poll until job completes (custom spinner prefix)
+        await getFinalJobState(result.jobUuid, 'Updating warehouse connection');
+
+        spinner.stop();
+    } catch (e) {
+        spinner.fail();
+        throw e;
+    }
+
+    const config = await getConfig();
+    const displayUrl = `${config.context?.serverUrl}/projects/${projectUuid}/home`;
+
+    console.error(
+        `${styles.bold('Successfully updated warehouse connection:')}`,
+    );
+    console.error('');
+    console.error(`      ${styles.bold(`⚡️ ${displayUrl}`)}`);
+    console.error('');
+};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -40,6 +40,7 @@ import {
 import { renameHandler } from './handlers/renameHandler';
 import { runChartHandler } from './handlers/runChart';
 import { setProjectHandler, unsetProjectHandler } from './handlers/setProject';
+import { setWarehouseHandler } from './handlers/setWarehouse';
 import { sqlHandler } from './handlers/sql';
 import { validateHandler } from './handlers/validate';
 import * as styles from './styles';
@@ -1244,6 +1245,46 @@ program
     )
     .option('--verbose', 'Show detailed output', false)
     .action(runChartHandler);
+
+program
+    .command('set-warehouse')
+    .description(
+        "Update a project's warehouse connection from dbt profiles.yml. Use --assume-yes for non-interactive/CI usage. For organization-managed credentials, use the Lightdash UI.",
+    )
+    .option(
+        '--project-dir <path>',
+        'The directory of the dbt project',
+        defaultProjectDir,
+    )
+    .option(
+        '--profiles-dir <path>',
+        'The directory of the dbt profiles',
+        defaultProfilesDir,
+    )
+    .option(
+        '--profile <name>',
+        'The name of the profile to use (defaults to profile name in dbt_project.yml)',
+        undefined,
+    )
+    .option('--target <name>', 'target to use in profiles.yml file', undefined)
+    .option(
+        '--target-path <path>',
+        'The target directory for dbt (overrides DBT_TARGET_PATH and dbt_project.yml)',
+        undefined,
+    )
+    .option(
+        '--project <uuid>',
+        'Lightdash project UUID to update (defaults to currently selected project)',
+        undefined,
+    )
+    .option(
+        '--start-of-week <number>',
+        'Specifies the first day of the week (used by week-related date functions). 0 (Monday) to 6 (Sunday)',
+        parseStartOfWeekArgument,
+    )
+    .option('-y, --assume-yes', 'assume yes to prompts', false)
+    .option('--verbose', 'Show detailed output', false)
+    .action(setWarehouseHandler);
 
 program
     .command('export-chart-image')


### PR DESCRIPTION
Related to: GLITCH-253

Adding `lightdash set-warehouse` command, re-using extracted handlers from [previous PR](https://github.com/lightdash/lightdash/pull/21293).