### PR TITLE
fix: only show .gitignore notice for metadata file once

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -29,6 +29,7 @@ export type Config = {
     };
     answers?: {
         permissionToStoreWarehouseCredentials?: boolean;
+        metadataFileGitignoreNoticeShown?: boolean;
     };
 };
 

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -25,7 +25,7 @@ import groupBy from 'lodash/groupBy';
 import pLimit from 'p-limit';
 import * as path from 'path';
 import { LightdashAnalytics } from '../analytics/analytics';
-import { getConfig } from '../config';
+import { getConfig, setAnswer } from '../config';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
 import {
@@ -721,11 +721,14 @@ export const downloadHandler = async (
         }
         const baseDir = getDownloadFolder(options.path);
         await writeMetadataFile(baseDir, metadataToWrite);
-        GlobalState.log(
-            styles.warning(
-                `\nNote: ${METADATA_FILENAME} was written to ${baseDir}. Consider adding it to your .gitignore.`,
-            ),
-        );
+        if (!config.answers?.metadataFileGitignoreNoticeShown) {
+            GlobalState.log(
+                styles.warning(
+                    `\nNote: ${METADATA_FILENAME} was written to ${baseDir}. Consider adding it to your .gitignore.`,
+                ),
+            );
+            await setAnswer({ metadataFileGitignoreNoticeShown: true });
+        }
 
         const end = Date.now();
 


### PR DESCRIPTION
### Description:
Last week I introduced the `.lightdash-metadata.json` to persist the `downloadedAt` metadata for change detection.
It will basically show this notice: `Note: .lightdash-metadata.json was written to /Users/lukas/Work/demo-f1/lightdash. Consider adding it to your .gitignore.`

Instead of showing it every time, not it will only show it the very first time.
