### PR TITLE
feat: add multi-project setup configuration via LD_SETUP_PROJECTS

### DIFF
--- a/packages/backend/src/config/parseConfig.test.ts
+++ b/packages/backend/src/config/parseConfig.test.ts
@@ -1,10 +1,12 @@
 import {
     ALL_TASK_NAMES,
+    DbtProjectType,
     LightdashMode,
     OrganizationMemberRole,
     ParameterError,
     ParseError,
     SentryConfig,
+    WarehouseTypes,
 } from '@lightdash/common';
 import { VERSION } from '../version';
 import {
@@ -12,6 +14,7 @@ import {
     getFloatFromEnvironmentVariable,
     getIntegerFromEnvironmentVariable,
     getMaybeBase64EncodedFromEnvironmentVariable,
+    getMultiProjectSetupConfig,
     getObjectFromEnvironmentVariable,
     parseConfig,
     parseOrganizationMemberRoleArray,
@@ -447,7 +450,9 @@ describe('process.env.LIGHTDASH_IFRAME_EMBEDDING_DOMAINS', () => {
         test('should parse personal access token', () => {
             process.env.LD_SETUP_PROJECT_PAT = 'project_personal_access_token';
             const config = parseConfig();
-            expect(config.initialSetup?.project?.personalAccessToken).toBe(
+            const warehouseConnection = config.initialSetup?.projects[0]
+                ?.warehouseConnection as { personalAccessToken?: string };
+            expect(warehouseConnection?.personalAccessToken).toBe(
                 'project_personal_access_token',
             );
         });
@@ -639,4 +644,147 @@ test('should set groups.enabled only when the environment variable is set', () =
     process.env.GROUPS_ENABLED = 'false';
     const falseConfig = parseConfig();
     expect(falseConfig.groups.enabled).toBe(false);
+});
+
+describe('getMultiProjectSetupConfig', () => {
+    beforeEach(() => {
+        delete process.env.LD_SETUP_PROJECTS;
+    });
+
+    test('should return undefined when LD_SETUP_PROJECTS is not set', () => {
+        expect(getMultiProjectSetupConfig()).toBeUndefined();
+    });
+
+    test('should return undefined for empty array', () => {
+        process.env.LD_SETUP_PROJECTS = '[]';
+        expect(getMultiProjectSetupConfig()).toBeUndefined();
+    });
+
+    test('should parse valid multi-project config', () => {
+        const projects = [
+            {
+                name: 'Project Alpha',
+                warehouseConnection: {
+                    type: WarehouseTypes.DATABRICKS,
+                    serverHostName: 'alpha.databricks.com',
+                    httpPath: '/sql/1.0/warehouses/alpha',
+                    database: 'alpha_db',
+                    personalAccessToken: 'alpha-token',
+                },
+                dbtConnection: {
+                    type: DbtProjectType.GITHUB,
+                    authorization_method: 'personal_access_token',
+                    personal_access_token: 'alpha-dbt-token',
+                    repository: 'org/alpha-repo',
+                    branch: 'main',
+                    project_sub_path: '/',
+                },
+            },
+        ];
+        process.env.LD_SETUP_PROJECTS = JSON.stringify(projects);
+        const result = getMultiProjectSetupConfig();
+        expect(result).toEqual(projects);
+    });
+
+    test('should throw ParseError for non-array JSON', () => {
+        process.env.LD_SETUP_PROJECTS = '{"name": "not an array"}';
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Invalid LD_SETUP_PROJECTS',
+        );
+    });
+
+    test('should throw ParseError for entry without name', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                warehouseConnection: { type: 'databricks' },
+                dbtConnection: { type: 'github' },
+            },
+        ]);
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Invalid LD_SETUP_PROJECTS',
+        );
+    });
+
+    test('should throw ParseError for entry without warehouseConnection', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Test',
+                dbtConnection: { type: 'github' },
+            },
+        ]);
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Invalid LD_SETUP_PROJECTS',
+        );
+    });
+
+    test('should throw ParseError for entry without dbtConnection', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Test',
+                warehouseConnection: { type: 'databricks' },
+            },
+        ]);
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Invalid LD_SETUP_PROJECTS',
+        );
+    });
+
+    test('should throw ParseError for invalid warehouse type', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Test',
+                warehouseConnection: { type: 'banana' },
+                dbtConnection: { type: 'github' },
+            },
+        ]);
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Invalid warehouse type',
+        );
+    });
+
+    test('should throw ParseError for invalid dbt connection type', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Test',
+                warehouseConnection: { type: 'databricks' },
+                dbtConnection: { type: 'invalid' },
+            },
+        ]);
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Invalid dbt connection type',
+        );
+    });
+
+    test('should throw ParseError for duplicate project names', () => {
+        process.env.LD_SETUP_PROJECTS = JSON.stringify([
+            {
+                name: 'Duplicate',
+                warehouseConnection: { type: 'databricks' },
+                dbtConnection: { type: 'github' },
+            },
+            {
+                name: 'Duplicate',
+                warehouseConnection: { type: 'databricks' },
+                dbtConnection: { type: 'github' },
+            },
+        ]);
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Duplicate project name "Duplicate"',
+        );
+    });
+
+    test('should throw ParseError for invalid JSON', () => {
+        process.env.LD_SETUP_PROJECTS = 'not valid json';
+        expect(() => getMultiProjectSetupConfig()).toThrow(ParseError);
+        expect(() => getMultiProjectSetupConfig()).toThrow(
+            'Failed to parse LD_SETUP_PROJECTS',
+        );
+    });
 });

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -7,7 +7,9 @@ import {
     AuthTokenPrefix,
     cleanColorArray,
     CreateDatabricksCredentials,
+    CreateWarehouseCredentials,
     DbtGithubProjectConfig,
+    DbtProjectConfig,
     DbtProjectType,
     DbtVersionOption,
     DbtVersionOptionLatest,
@@ -28,6 +30,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/core';
 import { type ClientAuthMethod } from 'openid-client';
+import { z } from 'zod';
 import { VERSION } from '../version';
 import {
     aiCopilotConfigSchema,
@@ -323,6 +326,120 @@ const parseEnum = <T>(
     return value as T;
 };
 
+const multiProjectSetupEntrySchema = z.object({
+    name: z.string().min(1, 'Project name cannot be empty'),
+    warehouseConnection: z
+        .object({
+            type: z.nativeEnum(WarehouseTypes, {
+                errorMap: () => ({
+                    message: `Invalid warehouse type. Must be one of: ${Object.values(WarehouseTypes).join(', ')}`,
+                }),
+            }),
+        })
+        .passthrough(),
+    dbtConnection: z
+        .object({
+            type: z.nativeEnum(DbtProjectType, {
+                errorMap: () => ({
+                    message: `Invalid dbt connection type. Must be one of: ${Object.values(DbtProjectType).join(', ')}`,
+                }),
+            }),
+        })
+        .passthrough(),
+    dbtVersion: z.nativeEnum(SupportedDbtVersions).optional(),
+    embed: z
+        .object({
+            secret: z.string().optional(),
+            allowAllDashboards: z.boolean().optional(),
+        })
+        .optional(),
+});
+
+const multiProjectSetupSchema = z.array(multiProjectSetupEntrySchema).refine(
+    (entries) => {
+        const names = entries.map((e) => e.name);
+        return new Set(names).size === names.length;
+    },
+    (entries) => {
+        const names = entries.map((e) => e.name);
+        const duplicate = names.find((name, i) => names.indexOf(name) !== i);
+        return {
+            message: `Duplicate project name "${duplicate}" in LD_SETUP_PROJECTS`,
+        };
+    },
+);
+
+export const getMultiProjectSetupConfig = ():
+    | MultiProjectSetupEntry[]
+    | undefined => {
+    const raw = process.env.LD_SETUP_PROJECTS;
+    if (!raw) return undefined;
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(raw);
+    } catch (e) {
+        throw new ParseError(
+            `Failed to parse LD_SETUP_PROJECTS: ${getErrorMessage(e)}`,
+        );
+    }
+
+    if (Array.isArray(parsed) && parsed.length === 0) {
+        return undefined;
+    }
+
+    const result = multiProjectSetupSchema.safeParse(parsed);
+    if (!result.success) {
+        const errorDetails = result.error.errors
+            .map((err) => {
+                const path =
+                    err.path.length > 0
+                        ? `  - ${err.path.join('.')}: ${err.message}`
+                        : `  - ${err.message}`;
+                return path;
+            })
+            .join('\n');
+
+        const exampleConfig = JSON.stringify(
+            [
+                {
+                    name: 'My Project',
+                    warehouseConnection: {
+                        type: 'postgres',
+                        host: 'db.example.com',
+                        port: 5432,
+                        user: 'user',
+                        password: 'password',
+                        dbname: 'mydb',
+                        schema: 'public',
+                    },
+                    dbtConnection: {
+                        type: 'github',
+                        authorization_method: 'personal_access_token',
+                        personal_access_token: 'ghp_...',
+                        repository: 'org/repo',
+                        branch: 'main',
+                        project_sub_path: '/',
+                    },
+                },
+            ],
+            null,
+            2,
+        );
+
+        throw new ParseError(
+            `Invalid LD_SETUP_PROJECTS:\n${errorDetails}\n\n` +
+                `Warehouse types: ${Object.values(WarehouseTypes).join(', ')}\n` +
+                `dbt connection types: ${Object.values(DbtProjectType).join(', ')}\n\n` +
+                `Example:\n${exampleConfig}\n\n` +
+                `See https://docs.lightdash.com/self-host/customize-deployment/environment-variables#initialize-instance for details.`,
+        );
+    }
+
+    // Zod validates structure; the full type comes from the original parsed JSON
+    return parsed as MultiProjectSetupEntry[];
+};
+
 const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
     const parseCompute = (): CreateDatabricksCredentials['compute'] => {
         // This is a stringified array of objects, in JSON format
@@ -335,12 +452,55 @@ const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
     try {
         if (!process.env.LD_SETUP_ADMIN_EMAIL) return undefined;
 
-        const projectPat = process.env.LD_SETUP_PROJECT_PAT;
-        if (!projectPat) {
-            throw new ParameterError(
-                `LD_SETUP_PROJECT_PAT is required for initial setup`,
-                { variant: 'ApiToken' },
-            );
+        // Build project list: either from LD_SETUP_PROJECTS or legacy single-project env vars
+        const multiProjectConfig = getMultiProjectSetupConfig();
+        let projects: MultiProjectSetupEntry[];
+
+        if (multiProjectConfig) {
+            projects = multiProjectConfig;
+        } else {
+            const projectPat = process.env.LD_SETUP_PROJECT_PAT;
+            if (!projectPat) {
+                throw new ParameterError(
+                    `LD_SETUP_PROJECT_PAT is required for initial setup. Set LD_SETUP_PROJECT_PAT for single-project setup, or use LD_SETUP_PROJECTS for multi-project setup.`,
+                    { variant: 'ApiToken' },
+                );
+            }
+
+            projects = [
+                {
+                    name: process.env.LD_SETUP_PROJECT_NAME!,
+                    warehouseConnection: {
+                        type: WarehouseTypes.DATABRICKS,
+                        catalog: process.env.LD_SETUP_PROJECT_CATALOG,
+                        database: process.env.LD_SETUP_PROJECT_SCHEMA!,
+                        serverHostName: process.env.LD_SETUP_PROJECT_HOST!,
+                        httpPath: process.env.LD_SETUP_PROJECT_HTTP_PATH!,
+                        personalAccessToken: projectPat,
+                        requireUserCredentials: undefined,
+                        startOfWeek: parseEnum<WeekDay>(
+                            process.env.LD_SETUP_START_OF_WEEK,
+                            WeekDay,
+                        ),
+                        compute: parseCompute(),
+                    },
+                    dbtConnection: {
+                        type: DbtProjectType.GITHUB,
+                        authorization_method: 'personal_access_token',
+                        personal_access_token: process.env.LD_SETUP_GITHUB_PAT!,
+                        repository: process.env.LD_SETUP_GITHUB_REPOSITORY!,
+                        branch: process.env.LD_SETUP_GITHUB_BRANCH!,
+                        project_sub_path:
+                            process.env.LD_SETUP_GITHUB_PATH || '/',
+                        host_domain: undefined,
+                    },
+                    dbtVersion:
+                        parseEnum<SupportedDbtVersions>(
+                            process.env.LD_SETUP_DBT_VERSION,
+                            SupportedDbtVersions,
+                        ) || DbtVersionOptionLatest.LATEST,
+                },
+            ];
         }
 
         return {
@@ -378,35 +538,7 @@ const getInitialSetupConfig = (): LightdashConfig['initialSetup'] => {
                       ),
                   }
                 : undefined,
-            project: {
-                name: process.env.LD_SETUP_PROJECT_NAME!,
-                type: WarehouseTypes.DATABRICKS,
-                catalog: process.env.LD_SETUP_PROJECT_CATALOG,
-                database: process.env.LD_SETUP_PROJECT_SCHEMA!,
-                serverHostName: process.env.LD_SETUP_PROJECT_HOST!,
-                httpPath: process.env.LD_SETUP_PROJECT_HTTP_PATH!,
-                personalAccessToken: projectPat,
-                requireUserCredentials: undefined,
-                startOfWeek: parseEnum<WeekDay>(
-                    process.env.LD_SETUP_START_OF_WEEK,
-                    WeekDay,
-                ),
-                compute: parseCompute(),
-                dbtVersion:
-                    parseEnum<SupportedDbtVersions>(
-                        process.env.LD_SETUP_DBT_VERSION,
-                        SupportedDbtVersions,
-                    ) || DbtVersionOptionLatest.LATEST,
-            },
-            dbt: {
-                type: DbtProjectType.GITHUB,
-                authorization_method: 'personal_access_token',
-                personal_access_token: process.env.LD_SETUP_GITHUB_PAT!,
-                repository: process.env.LD_SETUP_GITHUB_REPOSITORY!,
-                branch: process.env.LD_SETUP_GITHUB_BRANCH!,
-                project_sub_path: process.env.LD_SETUP_GITHUB_PATH || '/',
-                host_domain: undefined,
-            },
+            projects,
         };
     } catch (e) {
         // If a variable is not set, we will skip the initial setup
@@ -481,6 +613,7 @@ export const getUpdateSetupConfig = (): LightdashConfig['updateSetup'] => {
         dbt: {
             personal_access_token: process.env.LD_SETUP_GITHUB_PAT,
         },
+        projects: getMultiProjectSetupConfig(),
         embed: {
             allowAllDashboards:
                 process.env.LD_SETUP_EMBED_ALLOW_ALL_DASHBOARDS === 'true',
@@ -811,6 +944,17 @@ export type LoggingConfig = {
     filePath: string;
 };
 
+export type MultiProjectSetupEntry = {
+    name: string;
+    warehouseConnection: CreateWarehouseCredentials;
+    dbtConnection: DbtProjectConfig;
+    dbtVersion?: DbtVersionOption;
+    embed?: {
+        secret?: string;
+        allowAllDashboards?: boolean;
+    };
+};
+
 export type LightdashConfig = {
     lightdashSecret: string;
     secureCookies: boolean;
@@ -1025,11 +1169,7 @@ export type LightdashConfig = {
             token: string;
             expirationTime: Date | null;
         };
-        project: CreateDatabricksCredentials & {
-            name: string;
-            dbtVersion: DbtVersionOption;
-        };
-        dbt: DbtGithubProjectConfig;
+        projects: MultiProjectSetupEntry[];
     };
     updateSetup?: {
         organizationUuid?: string;
@@ -1053,6 +1193,7 @@ export type LightdashConfig = {
             dbtVersion?: DbtVersionOption;
             personalAccessToken?: CreateDatabricksCredentials['personalAccessToken'];
         };
+        projects?: MultiProjectSetupEntry[];
         serviceAccount?: {
             token: string;
             expirationTime: Date | null;

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -431,6 +431,14 @@ export class ProjectModel {
         return projects.map((project) => project.project_uuid);
     }
 
+    async getDefaultProjectUuidsByName(name: string): Promise<string[]> {
+        const projects = await this.database('projects')
+            .where('project_type', ProjectType.DEFAULT)
+            .where('name', name)
+            .select('project_uuid');
+        return projects.map((project) => project.project_uuid);
+    }
+
     async hasProjects(organizationUuid: string): Promise<boolean> {
         const orgs = await this.database('organizations')
             .where('organization_uuid', organizationUuid)

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.test.ts
@@ -73,6 +73,7 @@ const createMockService = (overrides: AnyType = {}) => {
 
     const projectModel = {
         getDefaultProjectUuids: jest.fn(),
+        getDefaultProjectUuidsByName: jest.fn(),
         getWithSensitiveFields: jest.fn(),
         update: jest.fn(),
         ...overrides.projectModel,
@@ -108,7 +109,10 @@ const createMockService = (overrides: AnyType = {}) => {
         organizationAllowedEmailDomainsModel: {} as AnyType,
         personalAccessTokenModel: personalAccessTokenModel as AnyType,
         emailModel: {} as AnyType,
-        projectService: {} as AnyType,
+        projectService: {
+            scheduleCompileProject: jest.fn(),
+            ...overrides.projectService,
+        } as AnyType,
         serviceAccountModel: serviceAccountModel as AnyType,
         embedModel: {} as AnyType,
         encryptionUtil: { encrypt: jest.fn() } as AnyType,
@@ -273,12 +277,13 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                 },
             });
 
-            await expect(service.updateInstanceConfiguration()).rejects.toThrow(
-                NotFoundError,
-            );
-            await expect(service.updateInstanceConfiguration()).rejects.toThrow(
-                `User ${mockAdminEmail} not found`,
-            );
+            await expect(
+                service.updateInstanceConfiguration(),
+            ).resolves.not.toThrow();
+
+            expect(
+                service['personalAccessTokenModel'].save,
+            ).not.toHaveBeenCalled();
         });
     });
 
@@ -685,6 +690,204 @@ describe('InstanceConfigurationService.updateInstanceConfiguration', () => {
                     },
                 },
             );
+        });
+    });
+
+    describe('multi-project configuration update scenarios', () => {
+        const multiProjectSetup = [
+            {
+                name: 'Project Alpha',
+                warehouseConnection: {
+                    type: WarehouseTypes.DATABRICKS,
+                    serverHostName: 'alpha.databricks.com',
+                    httpPath: '/sql/1.0/warehouses/alpha',
+                    catalog: 'alpha_catalog',
+                    database: 'alpha_db',
+                    personalAccessToken: 'alpha-token',
+                },
+                dbtConnection: {
+                    type: DbtProjectType.GITHUB,
+                    authorization_method: 'personal_access_token',
+                    personal_access_token: 'alpha-dbt-token',
+                    repository: 'org/alpha-repo',
+                    branch: 'main',
+                    project_sub_path: '/',
+                },
+            },
+            {
+                name: 'Project Beta',
+                warehouseConnection: {
+                    type: WarehouseTypes.DATABRICKS,
+                    serverHostName: 'beta.databricks.com',
+                    httpPath: '/sql/1.0/warehouses/beta',
+                    catalog: 'beta_catalog',
+                    database: 'beta_db',
+                    personalAccessToken: 'beta-token',
+                },
+                dbtConnection: {
+                    type: DbtProjectType.GITHUB,
+                    authorization_method: 'personal_access_token',
+                    personal_access_token: 'beta-dbt-token',
+                    repository: 'org/beta-repo',
+                    branch: 'main',
+                    project_sub_path: '/',
+                },
+            },
+        ];
+
+        test('should update multiple projects matched by name', async () => {
+            const mockAlphaProject = {
+                ...mockProject,
+                name: 'Project Alpha',
+                projectUuid: 'alpha-uuid',
+            };
+            const mockBetaProject = {
+                ...mockProject,
+                name: 'Project Beta',
+                projectUuid: 'beta-uuid',
+            };
+
+            service = createMockService({
+                organizationModel: {
+                    getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
+                },
+                projectModel: {
+                    getDefaultProjectUuids: jest
+                        .fn()
+                        .mockResolvedValue([mockProjectUuid]),
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockImplementation((name: string) => {
+                            if (name === 'Project Alpha')
+                                return Promise.resolve(['alpha-uuid']);
+                            if (name === 'Project Beta')
+                                return Promise.resolve(['beta-uuid']);
+                            return Promise.resolve([]);
+                        }),
+                    getWithSensitiveFields: jest
+                        .fn()
+                        .mockImplementation((uuid: string) => {
+                            if (uuid === 'alpha-uuid')
+                                return Promise.resolve(mockAlphaProject);
+                            if (uuid === 'beta-uuid')
+                                return Promise.resolve(mockBetaProject);
+                            return Promise.reject(
+                                new Error('Project not found'),
+                            );
+                        }),
+                    update: jest.fn().mockResolvedValue(undefined),
+                },
+                updateSetup: { projects: multiProjectSetup },
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(service['projectModel'].update).toHaveBeenCalledTimes(2);
+            expect(service['projectModel'].update).toHaveBeenCalledWith(
+                'alpha-uuid',
+                expect.objectContaining({
+                    warehouseConnection:
+                        multiProjectSetup[0].warehouseConnection,
+                    dbtConnection: multiProjectSetup[0].dbtConnection,
+                }),
+            );
+            expect(service['projectModel'].update).toHaveBeenCalledWith(
+                'beta-uuid',
+                expect.objectContaining({
+                    warehouseConnection:
+                        multiProjectSetup[1].warehouseConnection,
+                    dbtConnection: multiProjectSetup[1].dbtConnection,
+                }),
+            );
+        });
+
+        test('should throw ParameterError when multiple projects share the same name', async () => {
+            service = createMockService({
+                organizationModel: {
+                    getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
+                },
+                projectModel: {
+                    getDefaultProjectUuids: jest
+                        .fn()
+                        .mockResolvedValue([mockProjectUuid]),
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue([
+                            'duplicate-uuid-1',
+                            'duplicate-uuid-2',
+                        ]),
+                },
+                updateSetup: { projects: [multiProjectSetup[0]] },
+            });
+
+            await expect(service.updateInstanceConfiguration()).rejects.toThrow(
+                ParameterError,
+            );
+            await expect(service.updateInstanceConfiguration()).rejects.toThrow(
+                'Multiple projects found with name "Project Alpha"',
+            );
+        });
+
+        test('should create projects not found by name', async () => {
+            const newProjectUuid = 'new-project-uuid';
+            service = createMockService({
+                organizationModel: {
+                    getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
+                },
+                projectModel: {
+                    getDefaultProjectUuids: jest
+                        .fn()
+                        .mockResolvedValue([mockProjectUuid]),
+                    getDefaultProjectUuidsByName: jest
+                        .fn()
+                        .mockResolvedValue([]),
+                    create: jest.fn().mockResolvedValue(newProjectUuid),
+                },
+                userModel: {
+                    findSessionUserByPrimaryEmail: jest
+                        .fn()
+                        .mockResolvedValue(mockSessionUser),
+                },
+                updateSetup: {
+                    organization: {
+                        admin: { email: mockAdminEmail },
+                    },
+                    projects: [multiProjectSetup[0]],
+                },
+            });
+
+            await expect(
+                service.updateInstanceConfiguration(),
+            ).resolves.not.toThrow();
+
+            expect(service['projectModel'].update).not.toHaveBeenCalled();
+            expect(service['projectModel'].create).toHaveBeenCalledWith(
+                mockUserId,
+                mockOrgUuid,
+                expect.objectContaining({
+                    name: multiProjectSetup[0].name,
+                }),
+            );
+        });
+
+        test('should not update projects when projects is not configured', async () => {
+            service = createMockService({
+                organizationModel: {
+                    getOrgUuids: jest.fn().mockResolvedValue([mockOrgUuid]),
+                },
+                projectModel: {
+                    getDefaultProjectUuids: jest
+                        .fn()
+                        .mockResolvedValue([mockProjectUuid]),
+                },
+                updateSetup: {},
+            });
+
+            await service.updateInstanceConfiguration();
+
+            expect(
+                service['projectModel'].getDefaultProjectUuidsByName,
+            ).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
+++ b/packages/backend/src/services/InstanceConfigurationService/InstanceConfigurationService.ts
@@ -3,6 +3,7 @@ import {
     CreateProject,
     CreateWarehouseCredentials,
     DbtProjectConfig,
+    DbtVersionOptionLatest,
     isGitProjectType,
     NotFoundError,
     OrganizationMemberRole,
@@ -16,7 +17,10 @@ import {
     WarehouseTypes,
 } from '@lightdash/common';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
-import { LightdashConfig } from '../../config/parseConfig';
+import {
+    LightdashConfig,
+    MultiProjectSetupEntry,
+} from '../../config/parseConfig';
 import { EmbedModel } from '../../ee/models/EmbedModel';
 import { ServiceAccountModel } from '../../ee/models/ServiceAccountModel';
 import { PersonalAccessTokenModel } from '../../models/DashboardModel/PersonalAccessTokenModel';
@@ -163,38 +167,16 @@ export class InstanceConfigurationService extends BaseService {
 
             this.logger.info(`Initial setup: User ${user.userUuid} created`);
 
-            this.logger.debug(
-                `Initial setup: Creating project "${setup.project.name}"`,
-            );
-            const project: CreateProject = {
-                name: setup.project.name,
-                type: ProjectType.DEFAULT,
-                warehouseConnection: setup.project,
-                copyWarehouseConnectionFromUpstreamProject: undefined,
-                dbtConnection: setup.dbt,
-                upstreamProjectUuid: undefined,
-                dbtVersion: setup.project.dbtVersion,
-            };
-
-            const projectUuid = await this.projectModel.create(
-                user.userUuid,
-                organizationUuid,
-                project,
-            );
-            this.logger.info(`Initial setup: Project ${projectUuid} created`);
-
-            this.logger.info(`Initial setup: Compiling project ${projectUuid}`);
-
             const sessionUser =
                 await this.userModel.findSessionUserAndOrgByUuid(
                     user.userUuid,
                     organizationUuid,
                 );
-            await this.projectService.scheduleCompileProject(
-                sessionUser,
-                projectUuid,
-                RequestMethod.BACKEND,
-                true, // Skip permission check
+
+            await this.initializeMultipleProjects(
+                setup.projects,
+                user.userUuid,
+                organizationUuid,
             );
 
             // Optional steps are performed at the end
@@ -268,19 +250,191 @@ export class InstanceConfigurationService extends BaseService {
                     `Initial setup: No API key provided, skipping`,
                 );
             }
-
-            // Setup embed if configured
-            if (this.lightdashConfig.updateSetup?.embed) {
-                await this.updateEmbedSettingsForInstance(
-                    this.lightdashConfig.updateSetup,
-                );
-            }
         } catch (error) {
             this.logger.error(
                 `Initial setup: Error initializing project: ${error}`,
             );
             throw error;
         }
+    }
+
+    /**
+     * Initialize projects from the setup config.
+     * Each project is created with its own warehouse and dbt connections.
+     */
+    private async initializeMultipleProjects(
+        projects: MultiProjectSetupEntry[],
+        userUuid: string,
+        organizationUuid: string,
+    ) {
+        /* eslint-disable no-await-in-loop */
+        for (const entry of projects) {
+            this.logger.debug(
+                `Initial setup: Creating project "${entry.name}"`,
+            );
+
+            const createProject: CreateProject = {
+                name: entry.name,
+                type: ProjectType.DEFAULT,
+                warehouseConnection: entry.warehouseConnection,
+                copyWarehouseConnectionFromUpstreamProject: undefined,
+                dbtConnection: entry.dbtConnection,
+                upstreamProjectUuid: undefined,
+                dbtVersion: entry.dbtVersion ?? DbtVersionOptionLatest.LATEST,
+            };
+
+            const projectUuid = await this.projectModel.create(
+                userUuid,
+                organizationUuid,
+                createProject,
+            );
+            this.logger.info(
+                `Initial setup: Project "${entry.name}" created with UUID ${projectUuid}`,
+            );
+
+            const sessionUser =
+                await this.userModel.findSessionUserAndOrgByUuid(
+                    userUuid,
+                    organizationUuid,
+                );
+            await this.projectService.scheduleCompileProject(
+                sessionUser,
+                projectUuid,
+                RequestMethod.BACKEND,
+                true,
+            );
+
+            // Apply embed config if present for this project
+            if (entry.embed) {
+                const adminEmail =
+                    this.lightdashConfig.updateSetup?.organization?.admin
+                        ?.email;
+                await this.updateEmbedForProject(
+                    projectUuid,
+                    entry.embed,
+                    adminEmail,
+                );
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+    }
+
+    /**
+     * Update or create multiple projects from LD_SETUP_PROJECTS env var.
+     * Projects are matched by name. If a project doesn't exist, it is created.
+     * Throws if multiple projects share the same name.
+     */
+    private async updateMultipleProjectsConfiguration(
+        projects: MultiProjectSetupEntry[],
+    ) {
+        const adminEmail =
+            this.lightdashConfig.updateSetup?.organization?.admin?.email;
+
+        /* eslint-disable no-await-in-loop */
+        for (const entry of projects) {
+            const projectUuids =
+                await this.projectModel.getDefaultProjectUuidsByName(
+                    entry.name,
+                );
+
+            if (projectUuids.length > 1) {
+                throw new ParameterError(
+                    `Multiple projects found with name "${entry.name}". Project names must be unique when using LD_SETUP_PROJECTS.`,
+                );
+            }
+
+            let projectUuid: string;
+
+            if (projectUuids.length === 0) {
+                // Project doesn't exist yet — create it
+                projectUuid = await this.createProjectFromSetup(entry);
+            } else {
+                [projectUuid] = projectUuids;
+                this.logger.debug(
+                    `Update instance: Updating project "${entry.name}" (${projectUuid})`,
+                );
+
+                const project =
+                    await this.projectModel.getWithSensitiveFields(projectUuid);
+
+                const updatedProject: UpdateProject = {
+                    ...project,
+                    warehouseConnection: entry.warehouseConnection,
+                    dbtConnection: entry.dbtConnection,
+                    dbtVersion: entry.dbtVersion ?? project.dbtVersion,
+                };
+
+                await this.projectModel.update(projectUuid, updatedProject);
+
+                this.logger.info(
+                    `Update instance: Updated project "${entry.name}" (${projectUuid})`,
+                );
+            }
+
+            // Apply embed config if present for this project
+            if (entry.embed) {
+                await this.updateEmbedForProject(
+                    projectUuid,
+                    entry.embed,
+                    adminEmail,
+                );
+            }
+        }
+        /* eslint-enable no-await-in-loop */
+    }
+
+    /**
+     * Create a project from a multi-project setup entry.
+     * Finds the admin user from LD_SETUP_ADMIN_EMAIL and the org to create the project in.
+     */
+    private async createProjectFromSetup(
+        entry: MultiProjectSetupEntry,
+    ): Promise<string> {
+        const adminEmail =
+            this.lightdashConfig.updateSetup?.organization?.admin?.email;
+        if (!adminEmail) {
+            throw new ParameterError(
+                `LD_SETUP_ADMIN_EMAIL is required to create project "${entry.name}" from LD_SETUP_PROJECTS`,
+            );
+        }
+
+        const sessionUser =
+            await this.userModel.findSessionUserByPrimaryEmail(adminEmail);
+        if (!sessionUser) {
+            throw new NotFoundError(
+                `Admin user "${adminEmail}" not found. Cannot create project "${entry.name}".`,
+            );
+        }
+
+        const orgUuid = await this.getSingleOrg();
+
+        const createProject: CreateProject = {
+            name: entry.name,
+            type: ProjectType.DEFAULT,
+            warehouseConnection: entry.warehouseConnection,
+            copyWarehouseConnectionFromUpstreamProject: undefined,
+            dbtConnection: entry.dbtConnection,
+            upstreamProjectUuid: undefined,
+            dbtVersion: entry.dbtVersion ?? DbtVersionOptionLatest.LATEST,
+        };
+
+        const projectUuid = await this.projectModel.create(
+            sessionUser.userUuid,
+            orgUuid,
+            createProject,
+        );
+        this.logger.info(
+            `Update instance: Created project "${entry.name}" (${projectUuid})`,
+        );
+
+        await this.projectService.scheduleCompileProject(
+            sessionUser,
+            projectUuid,
+            RequestMethod.BACKEND,
+            true,
+        );
+
+        return projectUuid;
     }
 
     /**
@@ -299,7 +453,10 @@ export class InstanceConfigurationService extends BaseService {
             const sessionUser =
                 await this.userModel.findSessionUserByPrimaryEmail(adminEmail);
             if (!sessionUser) {
-                throw new NotFoundError(`User ${adminEmail} not found`);
+                this.logger.warn(
+                    `Update instance: User ${adminEmail} not found, skipping API key update`,
+                );
+                return;
             }
             // Revoke other existing PATs for the admin.
             await this.personalAccessTokenModel.deleteAllTokensForUser(
@@ -545,6 +702,57 @@ export class InstanceConfigurationService extends BaseService {
         );
     }
 
+    private async updateEmbedForProject(
+        projectUuid: string,
+        embedConfig: { secret?: string; allowAllDashboards?: boolean },
+        adminEmail?: string,
+    ) {
+        if (!this.embedModel) return;
+
+        const { secret, allowAllDashboards } = embedConfig;
+        if (allowAllDashboards === undefined && !secret) return;
+
+        if (secret) {
+            let userUuid: string | undefined;
+            if (adminEmail) {
+                const sessionUser =
+                    await this.userModel.findSessionUserByPrimaryEmail(
+                        adminEmail,
+                    );
+                userUuid = sessionUser?.userUuid;
+            }
+
+            if (!userUuid) {
+                throw new ParameterError(
+                    `Setting embed secret requires LD_SETUP_ADMIN_EMAIL`,
+                );
+            }
+
+            const encodedSecret = this.encryptionUtil.encrypt(secret);
+
+            await this.embedModel.save(
+                projectUuid,
+                encodedSecret,
+                userUuid,
+                [],
+                allowAllDashboards ?? false,
+            );
+            this.logger.info(
+                `Embed configured for project ${projectUuid} with allowAllDashboards=${
+                    allowAllDashboards ?? false
+                }`,
+            );
+        } else if (allowAllDashboards) {
+            await this.embedModel.updateDashboards(projectUuid, {
+                dashboardUuids: [],
+                allowAllDashboards,
+            });
+            this.logger.info(
+                `Embed allowAllDashboards enabled for project ${projectUuid}`,
+            );
+        }
+    }
+
     private async updateEmbedSettingsForInstance(
         config: NonNullable<LightdashConfig['updateSetup']>,
     ) {
@@ -555,49 +763,12 @@ export class InstanceConfigurationService extends BaseService {
 
         try {
             const projectUuid = await this.getSingleProject();
-
-            // If config embed secret is provided, we need to call .save to upsert the embed record
-            // This requires a user UUID, we get it from the admin email
-            if (secret) {
-                let userUuid: string | undefined;
-                const adminEmail = config.organization?.admin?.email;
-                if (adminEmail) {
-                    const sessionUser =
-                        await this.userModel.findSessionUserByPrimaryEmail(
-                            adminEmail,
-                        );
-                    userUuid = sessionUser?.userUuid;
-                }
-
-                if (!userUuid) {
-                    throw new ParameterError(
-                        `Setting embed secret LD_SETUP_EMBED_SECRET requires an admin email LD_SETUP_ADMIN_EMAIL`,
-                    );
-                }
-
-                const encodedSecret = this.encryptionUtil.encrypt(secret);
-
-                await this.embedModel.save(
-                    projectUuid,
-                    encodedSecret,
-                    userUuid,
-                    [],
-                    allowAllDashboards ?? false,
-                );
-                this.logger.info(
-                    `Embed created for project ${projectUuid} with allowAllDashboards=${
-                        allowAllDashboards ?? false
-                    }`,
-                );
-            } else if (allowAllDashboards) {
-                this.logger.info(
-                    'No embed secret provided, enabling allowAllDashboards if configured',
-                );
-                await this.embedModel.updateDashboards(projectUuid, {
-                    dashboardUuids: [],
-                    allowAllDashboards,
-                });
-            }
+            const adminEmail = config.organization?.admin?.email;
+            await this.updateEmbedForProject(
+                projectUuid,
+                { secret, allowAllDashboards },
+                adminEmail,
+            );
         } catch (error) {
             this.logger.error(`Error updating embed settings: ${error}`);
         }
@@ -616,10 +787,15 @@ export class InstanceConfigurationService extends BaseService {
 
         await this.updateServiceAccountForAdmin(config);
 
-        await this.updateProjectConfiguration(config);
+        if (config.projects) {
+            // LD_SETUP_PROJECTS: sync project configs by name (embed handled per-project)
+            await this.updateMultipleProjectsConfiguration(config.projects);
+        } else {
+            // Legacy single-project env vars (LD_SETUP_PROJECT_*)
+            await this.updateProjectConfiguration(config);
+            await this.updateEmbedSettingsForInstance(config);
+        }
 
         await this.updateOrganizationDefaultRole(config);
-
-        await this.updateEmbedSettingsForInstance(config);
     }
 }


### PR DESCRIPTION
### Closes: https://linear.app/lightdash/issue/SPK-336/support-multi-project-configuration-via-environment-variables-for-self  
  
Description:

This PR adds support for multi-project setup configuration through the `LD_SETUP_PROJECTS` environment variable. The feature allows administrators to define multiple projects with their warehouse and dbt connections in a single JSON configuration.

**Key changes:**

- Added `getMultiProjectSetupConfig()` function to parse and validate the `LD_SETUP_PROJECTS` environment variable
- Extended `LightdashConfig` type with `multiProjectSetup` field and `MultiProjectSetupEntry` type definition
- Added `getDefaultProjectUuidsByName()` method to `ProjectModel` for finding projects by name
- Enhanced `InstanceConfigurationService` with:
    - `initializeMultipleProjects()` method to create projects during initial setup
    - `updateMultipleProjectsConfiguration()` method to update existing projects by name
- Comprehensive test coverage for configuration parsing, validation, and project management scenarios

The configuration validates that each project has a unique name, required warehouse and dbt connections, and handles error cases like duplicate names, missing fields, and invalid JSON. During updates, projects are matched by name with proper error handling for ambiguous matches.