### PR TITLE
fix: strip tileTargets from filter rules to reduce API payload size

### DIFF
--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -4,6 +4,7 @@ import {
     isField,
     type AndFilterGroup,
     type ApiError,
+    type DashboardFilterRule,
     type FieldValueSearchResult,
     type FilterableItem,
     type ParametersValuesMap,
@@ -15,6 +16,27 @@ import { lightdashApi } from '../api';
 import useEmbed from '../ee/providers/Embed/useEmbed';
 
 export const MAX_AUTOCOMPLETE_RESULTS = 50;
+
+/**
+ * Strip tileTargets from filter rules before sending to the API.
+ * tileTargets are only used client-side to determine filter-tile relationships
+ * and can be very large (100+ entries per filter), bloating the request payload.
+ */
+const stripTileTargetsFromFilters = (
+    filters: AndFilterGroup | undefined,
+): AndFilterGroup | undefined => {
+    if (!filters) return undefined;
+    return {
+        ...filters,
+        and: filters.and.map((rule) => {
+            if ('tileTargets' in rule) {
+                const { tileTargets, ...rest } = rule as DashboardFilterRule;
+                return rest;
+            }
+            return rule;
+        }),
+    };
+};
 
 const getEmbedFilterValues = async (options: {
     embedToken: string;
@@ -32,7 +54,7 @@ const getEmbedFilterValues = async (options: {
         body: JSON.stringify({
             search: options.search,
             limit: MAX_AUTOCOMPLETE_RESULTS,
-            filters: options.filters,
+            filters: stripTileTargetsFromFilters(options.filters),
             forceRefresh: options.forceRefresh,
             tableName: options.tableName,
             fieldId: options.fieldId,
@@ -61,7 +83,7 @@ const getFieldValues = async (
             search,
             limit,
             table,
-            filters,
+            filters: stripTileTargetsFromFilters(filters),
             forceRefresh,
             parameters: parameterValues,
         }),


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

Related: https://linear.app/lightdash/issue/PROD-5913/dashboard-performance-timeouts-and-ui-lag-on-complex-dashboards-with

Fix on the customer side: 

 The key insight: our tileTargets fix would still help this customer because:
  1. Every keystroke sends 13.5KB → would become ~1.5KB (90% reduction per request)
  2. On their slower machines/connections, JSON.stringify of 13.5KB per keystroke adds up
  3. The debounce helps, but rapid typing still generates multiple requests

---

Request payload: 55,945 bytes → 1,623 bytes (97% / 34x reduction)                                        
                                                                                                           
  The tileTargets objects (100 entries per filter × 7 filters) were bloating each filter search request by 
  ~54KB of data the backend doesn't need. On a real customer connection (not localhost), this would add    
  significant serialization, transfer, and parsing overhead — likely accounting for a large portion of the 
  reported 5-second lag.                                                      

  The click INP (424ms) is identical with and without the fix because it's dominated by Mantine popover    
  rendering (345ms presentation delay). That's a separate issue related to browser layout reflow with many
  DOM elements on the page.

Before vs After Fix                                                                                      
                                                                                                           
  ┌────────────────────┬──────────────┬─────────────┬────────────────────────────────────┐                 
  │       Metric       │ Without Fix  │  With Fix   │            Improvement             │                 
  ├────────────────────┼──────────────┼─────────────┼────────────────────────────────────┤                 
  │ Request payload    │ 55,945 bytes │ 1,623 bytes │ 97% reduction                      │
  ├────────────────────┼──────────────┼─────────────┼────────────────────────────────────┤
  │ Click INP          │ 424ms        │ 424ms       │ Same (expected - client rendering) │                 
  ├────────────────────┼──────────────┼─────────────┼────────────────────────────────────┤                 
  │ Processing         │ 76ms         │ 76ms        │ Same                               │                 
  ├────────────────────┼──────────────┼─────────────┼────────────────────────────────────┤                 
  │ Presentation delay │ 342ms        │ 345ms       │ Same                               │
  ├────────────────────┼──────────────┼─────────────┼────────────────────────────────────┤                 
  │ Long task total    │ 2,216ms      │ ~1,100ms    │ ~50% reduction                     │
  └────────────────────┴──────────────┴─────────────┴────────────────────────────────────┘                 
                                                                              
  The payload goes from 55KB to 1.6KB — a 34x reduction. The INP is the same because it measures the       
  click-to-first-paint which is dominated by popover rendering. But the long task total dropped
  significantly (2.2s → 1.1s), meaning the overall response pipeline is faster.    

---

### Description:

This PR optimizes API request payloads by stripping `tileTargets` from dashboard filter rules before sending them to the backend. The `tileTargets` property is only used client-side to determine filter-tile relationships and can contain 100+ entries per filter, significantly bloating request sizes.

A new utility function `stripTileTargetsFromFilters` has been added to the `useFieldValues` hook that removes these properties from filter rules while preserving all other filter data. This optimization is applied to both embedded and standard field value requests.

<!-- Even better add a screenshot / gif / loom -->

test-frontend test-backend