### PR TITLE
fix: conditionally show soft delete message in DeleteSpaceModal

### DIFF
--- a/packages/frontend/src/components/common/SpaceActionModal/DeleteSpaceModal.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/DeleteSpaceModal.tsx
@@ -175,10 +175,12 @@ export const DeleteSpaceModal: FC<DeleteSpaceModalBody> = ({
                 data={data}
                 softDeleteEnabled={softDeleteEnabled}
             />
-            <Text fz="sm">
-                This space and its contents will be moved to Recently deleted
-                and permanently removed after {retentionDays} days.
-            </Text>
+            {softDeleteEnabled && (
+                <Text fz="sm">
+                    This space and its contents will be moved to Recently
+                    deleted and permanently removed after {retentionDays} days.
+                </Text>
+            )}
             <DeleteSpaceTextInputConfirmation
                 data={data}
                 setCanDelete={setCanDelete}


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Hide the retention period message in the delete space modal when soft delete is disabled. The text explaining that spaces will be moved to "Recently deleted" and permanently removed after a specified number of days now only appears when the `softDeleteEnabled` flag is true.

<!-- Even better add a screenshot / gif / loom -->