### PR TITLE
fix: pass projectUuid to useAiAgentPermission hook

### DIFF
--- a/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
+++ b/packages/frontend/src/ee/pages/AiAgents/AgentsWelcome.tsx
@@ -67,7 +67,10 @@ const AiPageLoading = () => (
 
 const AgentsWelcome = () => {
     const { projectUuid } = useParams();
-    const canCreateAgent = useAiAgentPermission({ action: 'manage' });
+    const canCreateAgent = useAiAgentPermission({
+        action: 'manage',
+        projectUuid,
+    });
     const aiOrganizationSettingsQuery = useAiOrganizationSettings();
 
     const isAiCopilotEnabledOrTrial =


### PR DESCRIPTION
Added missing `projectUuid` parameter to the `useAiAgentPermission` hook call in the AgentsWelcome component.