### PR TITLE
fix: disable cancel button during deletion operations

### DIFF
--- a/packages/frontend/src/components/common/SpaceActionModal/DeleteSpaceModal.tsx
+++ b/packages/frontend/src/components/common/SpaceActionModal/DeleteSpaceModal.tsx
@@ -151,6 +151,7 @@ export const DeleteSpaceModal: FC<DeleteSpaceModalBody> = ({
             onConfirm={form.onSubmit(handleSubmit)}
             confirmDisabled={!canDelete || isLoading}
             confirmLoading={isLoading}
+            cancelDisabled={isLoading}
         >
             <Text fz="sm">
                 {softDeleteEnabled ? (

--- a/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/ChartDeleteModal.tsx
@@ -70,6 +70,7 @@ const ChartDeleteModal: FC<ChartDeleteModalProps> = ({
             description={description}
             onConfirm={handleConfirm}
             confirmLoading={isDeleting}
+            cancelDisabled={isDeleting}
         >
             {relatedDashboards.length > 0 && (
                 <Callout

--- a/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/DashboardDeleteModal.tsx
@@ -73,6 +73,7 @@ const DashboardDeleteModal: FC<DashboardDeleteModalProps> = ({
             description={description}
             onConfirm={handleConfirm}
             confirmLoading={isDeleting}
+            cancelDisabled={isDeleting}
         >
             {hasChartsInDashboard(dashboard) && (
                 <Callout

--- a/packages/frontend/src/features/sqlRunner/components/DeleteSqlChartModal.tsx
+++ b/packages/frontend/src/features/sqlRunner/components/DeleteSqlChartModal.tsx
@@ -50,6 +50,7 @@ export const DeleteSqlChartModal: FC<Props> = ({
             description={description}
             onConfirm={mutate}
             confirmLoading={isLoading}
+            cancelDisabled={isLoading}
         />
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Disable cancel buttons during deletion operations to prevent users from interrupting the deletion process. This change affects the DeleteSpaceModal, ChartDeleteModal, DashboardDeleteModal, and DeleteSqlChartModal components by adding the `cancelDisabled={isLoading}` prop when deletion operations are in progress.

<!-- Even better add a screenshot / gif / loom -->