### PR TITLE
fix: optimize dashboard filter re-renders during tile drag/resize operations

### DIFF
--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -721,6 +721,23 @@ const DashboardProvider: React.FC<
         resetSavedFilterOverrides,
     } = useSavedDashboardFiltersOverrides();
 
+    // Stable key that only changes when the chart-tile mapping changes,
+    // not when tiles are repositioned/resized (x/y/w/h changes).
+    // This prevents unnecessary re-renders of the entire filter chain
+    // during drag/resize operations.
+    const savedChartUuidsAndTileUuidsKey = useMemo(
+        () =>
+            dashboardTiles
+                ?.filter(isDashboardChartTileType)
+                .map(
+                    (tile) =>
+                        `${tile.uuid}:${tile.properties.savedChartUuid ?? ''}`,
+                )
+                .sort()
+                .join(',') ?? '',
+        [dashboardTiles],
+    );
+
     const savedChartUuidsAndTileUuids = useMemo(
         () =>
             dashboardTiles
@@ -737,7 +754,8 @@ const DashboardProvider: React.FC<
                     },
                     [],
                 ),
-        [dashboardTiles],
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [savedChartUuidsAndTileUuidsKey],
     );
 
     /**
@@ -1048,12 +1066,12 @@ const DashboardProvider: React.FC<
         // If this is an embed dashboard, we skip the dashboard check
         if (
             (!dashboard && !embedToken) ||
-            !dashboardTiles ||
+            !savedChartUuidsAndTileUuids ||
             !dashboardAvailableFiltersData
         )
             return;
 
-        const filterFieldsMapping = savedChartUuidsAndTileUuids?.reduce<
+        const filterFieldsMapping = savedChartUuidsAndTileUuids.reduce<
             Record<string, FilterableDimension[]>
         >((acc, { tileUuid }) => {
             const filterFields =
@@ -1074,7 +1092,6 @@ const DashboardProvider: React.FC<
         return filterFieldsMapping;
     }, [
         dashboard,
-        dashboardTiles,
         dashboardAvailableFiltersData,
         savedChartUuidsAndTileUuids,
         embedToken,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->
Related:  https://linear.app/lightdash/issue/PROD-5913/dashboard-performance-timeouts-and-ui-lag-on-complex-dashboards-with


Performance Report: Dashboard Drag/Resize Optimization

  The Problem

  Every drag/resize operation on a dashboard tile triggered a full re-render cascade through the filter
  system:
  dashboardTiles changed → savedChartUuidsAndTileUuids recomputed → filterableFieldsByTileUuid recomputed →
   all filter components re-rendered

  This happened even though tile position/size changes don't affect the chart-tile mapping or filterable
  fields.


  The Fix

  Stabilized savedChartUuidsAndTileUuids with a string key that only changes when tiles are
  added/removed/swapped — not when they're repositioned. Also removed dashboardTiles from
  filterableFieldsByTileUuid deps since it only needs savedChartUuidsAndTileUuids.

  Results (10 tabs × 10 tiles, 7 filters with tileTargets)

Before

<img width="666" height="170" alt="Screenshot from 2026-03-23 13-01-37" src="https://github.com/user-attachments/assets/d72410a1-7406-462c-8cde-87da0f5e7dda" />

After

  ┌─────────────────────────┬─────────┬─────────┬───────────────┐
  │         Metric          │ BEFORE  │  AFTER  │  Improvement  │
  ├─────────────────────────┼─────────┼─────────┼───────────────┤
  │ Avg total blocking time │ 8,968ms │ 2,451ms │ 73% reduction │
  ├─────────────────────────┼─────────┼─────────┼───────────────┤
  │ Max single long task    │ 9,077ms │ 2,368ms │ 74% reduction │
  ├─────────────────────────┼─────────┼─────────┼───────────────┤
  │ Avg long task count     │ 8.7     │ 3.3     │ 62% fewer     │
  └─────────────────────────┴─────────┴─────────┴───────────────┘

  Change Size

  - +20 lines, -3 lines in a single file (DashboardProvider.tsx)
  - Zero API changes, fully backwards compatible


---



### Description:

Optimizes dashboard filter rendering performance by preventing unnecessary re-renders during tile drag and resize operations. 

Introduces a stable memoization key (`savedChartUuidsAndTileUuidsKey`) that only changes when the chart-tile mapping changes, not when tiles are repositioned or resized. This key is used as a dependency for the `savedChartUuidsAndTileUuids` memoization instead of the entire `dashboardTiles` array, which changes on every drag/resize operation.

Also improves the filter fields mapping logic by using `savedChartUuidsAndTileUuids` directly instead of `dashboardTiles` for the loading condition, making the dependency chain more explicit and removing the redundant `dashboardTiles` dependency.