### PR TITLE
fix: improve error handling in chart download and clipboard functionality

### DIFF
--- a/packages/frontend/src/components/common/ChartDownload/ChartDownloadOptions.tsx
+++ b/packages/frontend/src/components/common/ChartDownload/ChartDownloadOptions.tsx
@@ -180,7 +180,7 @@ const ChartDownloadOptions: React.FC<DownloadOptions> = ({
                 }
             }
         } catch (e) {
-            console.error(`Unable to download ${type} from chart ${e}`);
+            console.error(`Unable to download ${type} from chart`, e);
         } finally {
             // rollback workaround
             if (needsWorkaround) {

--- a/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
+++ b/packages/frontend/src/components/common/ChartDownload/chartDownloadUtils.ts
@@ -29,11 +29,14 @@ export const base64SvgToBase64Image = async (
 ): Promise<string> => {
     return new Promise((resolve, reject) => {
         const img = document.createElement('img');
+        img.onerror = () => {
+            reject(new Error('Unable to load chart SVG for rasterization'));
+        };
         img.onload = () => {
             document.body.appendChild(img);
-            const canvas = document.createElement('canvas');
             const ratio = img.clientWidth / img.clientHeight || 1;
             document.body.removeChild(img);
+            const canvas = document.createElement('canvas');
             canvas.width = width;
             canvas.height = width / ratio;
             const ctx = canvas.getContext('2d');
@@ -50,10 +53,10 @@ export const base64SvgToBase64Image = async (
                     const data = canvas.toDataURL(`image/${type}`);
                     resolve(data);
                 } catch (e: any) {
-                    reject();
+                    reject(e);
                 }
             } else {
-                reject();
+                reject(new Error('Could not get canvas context'));
             }
         };
         img.src = originalBase64;

--- a/packages/frontend/src/utils/copyImageToClipboard.test.ts
+++ b/packages/frontend/src/utils/copyImageToClipboard.test.ts
@@ -94,7 +94,10 @@ describe('copyImageToClipboard', () => {
             'Clipboard write failed',
         );
         expect(consoleErrorSpy).toHaveBeenCalledWith(
-            'Failed to copy image to clipboard: Clipboard write failed',
+            'Failed to copy image to clipboard',
+            expect.objectContaining({
+                message: 'Clipboard write failed',
+            }),
         );
 
         consoleErrorSpy.mockRestore();

--- a/packages/frontend/src/utils/copyImageToClipboard.ts
+++ b/packages/frontend/src/utils/copyImageToClipboard.ts
@@ -1,15 +1,17 @@
-import { getErrorMessage } from '@lightdash/common';
-
 export const copyImageToClipboard = async (
     base64Image: string,
 ): Promise<void> => {
     try {
         // Create a temporary canvas to convert base64 to blob
         const img = new Image();
-        img.src = base64Image;
-
-        await new Promise((resolve) => {
-            img.onload = resolve;
+        await new Promise<void>((resolve, reject) => {
+            img.onload = () => {
+                resolve();
+            };
+            img.onerror = () => {
+                reject(new Error('Unable to load rasterized chart image'));
+            };
+            img.src = base64Image;
         });
 
         const canvas = document.createElement('canvas');
@@ -22,9 +24,13 @@ export const copyImageToClipboard = async (
         ctx.drawImage(img, 0, 0);
 
         // Convert canvas to blob
-        const blob = await new Promise<Blob>((resolve) => {
+        const blob = await new Promise<Blob>((resolve, reject) => {
             canvas.toBlob((b) => {
-                if (b) resolve(b);
+                if (b) {
+                    resolve(b);
+                    return;
+                }
+                reject(new Error('Unable to convert chart image to blob'));
             }, 'image/png');
         });
 
@@ -32,9 +38,7 @@ export const copyImageToClipboard = async (
         const item = new ClipboardItem({ 'image/png': blob });
         await navigator.clipboard.write([item]);
     } catch (error) {
-        console.error(
-            `Failed to copy image to clipboard: ${getErrorMessage(error)}`,
-        );
+        console.error('Failed to copy image to clipboard', error);
         throw error;
     }
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Improved error handling in chart download and clipboard functionality by adding proper error callbacks and more descriptive error messages.

**Changes:**
- Added `onerror` handler to image loading in `base64SvgToBase64Image` function to catch SVG loading failures
- Enhanced error propagation by passing actual error objects instead of rejecting with undefined
- Added error handling for canvas blob conversion in `copyImageToClipboard` function
- Improved console error logging format by separating error messages from error objects for better debugging
- Added specific error messages for common failure scenarios like "Unable to load chart SVG for rasterization" and "Could not get canvas context"

These changes provide better debugging information and more graceful error handling when chart downloads or clipboard operations fail.