### PR TITLE
refactor: pre-aggregate strategy pattern

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -26,6 +26,7 @@ import { AiAgentAdminService } from './services/AiAgentAdminService';
 import { AiAgentService } from './services/AiAgentService/AiAgentService';
 import { AiOrganizationSettingsService } from './services/AiOrganizationSettingsService';
 import { AiService } from './services/AiService/AiService';
+import { PreAggregateStrategy } from './services/AsyncQueryService/PreAggregateStrategy';
 import { PreAggregationDuckDbClient } from './services/AsyncQueryService/PreAggregationDuckDbClient';
 import { CommercialCacheService } from './services/CommercialCacheService';
 import { CommercialSlackIntegrationService } from './services/CommercialSlackIntegrationService';
@@ -298,14 +299,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     encryptionUtil: utils.getEncryptionUtil(),
                     userModel: models.getUserModel(),
                     queryHistoryModel: models.getQueryHistoryModel(),
-                    preAggregateDailyStatsModel:
-                        models.getPreAggregateDailyStatsModel(),
                     downloadAuditModel: models.getDownloadAuditModel(),
                     cacheService: repository.getCacheService(),
                     savedSqlModel: models.getSavedSqlModel(),
                     resultsStorageClient: clients.getResultsFileStorageClient(),
-                    preAggregateResultsStorageClient:
-                        clients.getPreAggregateResultsFileStorageClient(),
                     featureFlagModel: models.getFeatureFlagModel(),
                     projectParametersModel: models.getProjectParametersModel(),
                     organizationWarehouseCredentialsModel:
@@ -315,11 +312,21 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     permissionsService: repository.getPermissionsService(),
                     persistentDownloadFileService:
                         repository.getPersistentDownloadFileService(),
-                    preAggregationDuckDbClient: new PreAggregationDuckDbClient({
-                        lightdashConfig: context.lightdashConfig,
-                        preAggregateModel: models.getPreAggregateModel(),
-                        projectModel: models.getProjectModel(),
-                        prometheusMetrics,
+                    preAggregateStrategy: new PreAggregateStrategy({
+                        preAggregationDuckDbClient:
+                            new PreAggregationDuckDbClient({
+                                lightdashConfig: context.lightdashConfig,
+                                preAggregateModel:
+                                    models.getPreAggregateModel(),
+                                projectModel: models.getProjectModel(),
+                                prometheusMetrics,
+                            }),
+                        preAggregateDailyStatsModel:
+                            models.getPreAggregateDailyStatsModel(),
+                        preAggregateResultsStorageClient:
+                            clients.getPreAggregateResultsFileStorageClient(),
+                        isEnabled: () =>
+                            context.lightdashConfig.preAggregates.enabled,
                     }),
                     projectCompileLogModel: models.getProjectCompileLogModel(),
                     adminNotificationService:

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -1,0 +1,255 @@
+import {
+    ApiPreAggregateStatsResults,
+    ExploreType,
+    QueryExecutionContext as QEC,
+    UnexpectedServerError,
+    type Explore,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+    type MetricQuery,
+    type QueryExecutionContext,
+    type WarehouseClient,
+} from '@lightdash/common';
+import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
+import Logger from '../../../logging/logger';
+import type {
+    PreAggregateStrategy as IPreAggregateStrategy,
+    PreAggregateExecutionResolution,
+    PreAggregateStatsFilters,
+    PreAggregationRoutingDecision,
+    ResolveExecutionArgs,
+} from '../../../services/AsyncQueryService/PreAggregateStrategy';
+import { type PreAggregationRoute } from '../../../services/AsyncQueryService/types';
+import { type PreAggregateDailyStatsModel } from '../../models/PreAggregateDailyStatsModel';
+import { findMatch } from '../../preAggregates/matcher';
+import {
+    PreAggregationDuckDbClient,
+    PreAggregationDuckDbResolveReason,
+} from './PreAggregationDuckDbClient';
+
+type EePreAggregateStrategyArgs = {
+    preAggregationDuckDbClient: PreAggregationDuckDbClient;
+    preAggregateDailyStatsModel: PreAggregateDailyStatsModel;
+    preAggregateResultsStorageClient: S3ResultsFileStorageClient;
+    isEnabled: () => boolean;
+};
+
+export class PreAggregateStrategy implements IPreAggregateStrategy {
+    private readonly duckDbClient: PreAggregationDuckDbClient;
+
+    private readonly statsModel: PreAggregateDailyStatsModel;
+
+    private readonly resultsStorageClient: S3ResultsFileStorageClient;
+
+    private readonly isEnabled: () => boolean;
+
+    constructor(args: EePreAggregateStrategyArgs) {
+        this.duckDbClient = args.preAggregationDuckDbClient;
+        this.statsModel = args.preAggregateDailyStatsModel;
+        this.resultsStorageClient = args.preAggregateResultsStorageClient;
+        this.isEnabled = args.isEnabled;
+    }
+
+    getRoutingDecision({
+        metricQuery,
+        explore,
+        context,
+    }: {
+        metricQuery: MetricQuery;
+        explore: Explore;
+        context: QueryExecutionContext;
+    }): PreAggregationRoutingDecision {
+        if (!this.isEnabled()) {
+            return { target: 'warehouse' };
+        }
+
+        if (explore.type === ExploreType.PRE_AGGREGATE) {
+            if (!explore.preAggregateSource) {
+                throw new UnexpectedServerError(
+                    `Pre-aggregate explore "${explore.name}" is missing source metadata`,
+                );
+            }
+
+            return {
+                target: 'pre_aggregate',
+                preAggregateMetadata: {
+                    hit: true,
+                    name: explore.preAggregateSource.preAggregateName,
+                },
+                route: {
+                    ...explore.preAggregateSource,
+                    mode: 'required',
+                },
+            };
+        }
+
+        if ((explore.preAggregates || []).length === 0) {
+            return { target: 'warehouse' };
+        }
+
+        const matchResult = findMatch(metricQuery, explore);
+        const preAggregateMetadata = {
+            hit: matchResult.hit,
+            name: matchResult.preAggregateName || undefined,
+            reason: matchResult.miss || undefined,
+        };
+
+        if (
+            matchResult.hit &&
+            matchResult.preAggregateName &&
+            context !== QEC.PRE_AGGREGATE_MATERIALIZATION
+        ) {
+            return {
+                target: 'pre_aggregate',
+                preAggregateMetadata,
+                route: {
+                    sourceExploreName: metricQuery.exploreName,
+                    preAggregateName: matchResult.preAggregateName,
+                    mode: 'opportunistic',
+                },
+            };
+        }
+
+        return { target: 'warehouse', preAggregateMetadata };
+    }
+
+    async resolveExecution({
+        projectUuid,
+        queryUuid,
+        warehouseQuery,
+        preAggregationRoute,
+        resolveArgs,
+    }: {
+        projectUuid: string;
+        queryUuid: string;
+        warehouseQuery: string;
+        preAggregationRoute: PreAggregationRoute;
+        resolveArgs: ResolveExecutionArgs;
+    }): Promise<PreAggregateExecutionResolution> {
+        const canResolve =
+            !!resolveArgs.userAccessControls &&
+            !!resolveArgs.availableParameterDefinitions;
+
+        if (!canResolve) {
+            const reason =
+                PreAggregationDuckDbClient.getPreAggregationResolutionErrorMessage(
+                    {
+                        route: preAggregationRoute,
+                        reason: PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
+                    },
+                );
+            return {
+                resolved: false,
+                reason,
+                isFatal: preAggregationRoute.mode === 'required',
+            };
+        }
+
+        const resolution = await this.duckDbClient.resolve({
+            projectUuid,
+            queryUuid,
+            metricQuery: resolveArgs.metricQuery,
+            timezone: resolveArgs.timezone,
+            dateZoom: resolveArgs.dateZoom,
+            parameters: resolveArgs.parameters,
+            preAggregationRoute,
+            fieldsMap: resolveArgs.fieldsMap,
+            pivotConfiguration: resolveArgs.pivotConfiguration,
+            startOfWeek: resolveArgs.startOfWeek,
+            userAccessControls: resolveArgs.userAccessControls!,
+            availableParameterDefinitions:
+                resolveArgs.availableParameterDefinitions!,
+        });
+
+        if (resolution.resolved) {
+            return { resolved: true, query: resolution.query };
+        }
+
+        const reason =
+            PreAggregationDuckDbClient.getPreAggregationResolutionErrorMessage({
+                route: preAggregationRoute,
+                reason: resolution.reason,
+            });
+
+        return {
+            resolved: false,
+            reason,
+            isFatal: preAggregationRoute.mode === 'required',
+        };
+    }
+
+    createExecutionWarehouseClient(): WarehouseClient {
+        return this.duckDbClient.createExecutionWarehouseClient();
+    }
+
+    recordStats(params: {
+        projectUuid: string;
+        exploreName: string;
+        routingDecision: PreAggregationRoutingDecision;
+        chartUuid: string | null;
+        dashboardUuid: string | null;
+        queryContext: string;
+    }): void {
+        const { preAggregateMetadata } = params.routingDecision;
+        if (!preAggregateMetadata) {
+            return;
+        }
+
+        void this.statsModel
+            .upsert({
+                projectUuid: params.projectUuid,
+                exploreName: params.exploreName,
+                chartUuid: params.chartUuid,
+                dashboardUuid: params.dashboardUuid,
+                queryContext: params.queryContext,
+                hit: preAggregateMetadata.hit,
+                missReason: preAggregateMetadata.reason?.reason ?? null,
+                preAggregateName: preAggregateMetadata.name ?? null,
+            })
+            .catch((e) =>
+                Logger.error('Failed to upsert pre-aggregate daily stats', e),
+            );
+    }
+
+    async cleanupStats(retentionDays: number): Promise<number> {
+        return this.statsModel.cleanup(retentionDays);
+    }
+
+    async getStats(
+        projectUuid: string,
+        days: number,
+        paginateArgs?: KnexPaginateArgs,
+        filters?: PreAggregateStatsFilters,
+    ): Promise<KnexPaginatedData<ApiPreAggregateStatsResults>> {
+        const result = await this.statsModel.getByProject(
+            projectUuid,
+            days,
+            paginateArgs,
+            filters,
+        );
+
+        return {
+            data: {
+                stats: result.data.map((row) => ({
+                    exploreName: row.exploreName,
+                    date: row.date.toISOString(),
+                    chartUuid: row.chartUuid,
+                    chartName: row.chartName,
+                    dashboardUuid: row.dashboardUuid,
+                    dashboardName: row.dashboardName,
+                    queryContext: row.queryContext,
+                    hitCount: row.hitCount,
+                    missCount: row.missCount,
+                    missReason: row.missReason,
+                    preAggregateName: row.preAggregateName,
+                    updatedAt: row.updatedAt.toISOString(),
+                })),
+            },
+            pagination: result.pagination,
+        };
+    }
+
+    getResultsStorageClient(): S3ResultsFileStorageClient {
+        return this.resultsStorageClient;
+    }
+}

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1,6 +1,7 @@
 import {
     AnyType,
     DimensionType,
+    ExploreType,
     ForbiddenError,
     NotFoundError,
     QueryExecutionContext,
@@ -25,10 +26,6 @@ import { type S3ResultsFileStorageClient } from '../../clients/ResultsFileStorag
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { LightdashConfig } from '../../config/parseConfig';
 import type { PreAggregateModel } from '../../ee/models/PreAggregateModel';
-import {
-    PreAggregationDuckDbResolveReason,
-    type PreAggregationDuckDbClient,
-} from '../../ee/services/AsyncQueryService/PreAggregationDuckDbClient';
 import type { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import type { ContentModel } from '../../models/ContentModel/ContentModel';
@@ -85,10 +82,31 @@ import {
     AsyncQueryService,
     QUEUED_QUERY_EXPIRED_MESSAGE,
 } from './AsyncQueryService';
+import {
+    NoOpPreAggregateStrategy,
+    type PreAggregateExecutionResolution,
+    type PreAggregateStrategy,
+} from './PreAggregateStrategy';
 import type {
     ExecuteAsyncQueryReturn,
     RunAsyncWarehouseQueryArgs,
 } from './types';
+
+const noOpStrategy = new NoOpPreAggregateStrategy();
+
+const makeMockStrategy = (
+    resolveResult: PreAggregateExecutionResolution,
+): PreAggregateStrategy => ({
+    getRoutingDecision: noOpStrategy.getRoutingDecision.bind(noOpStrategy),
+    resolveExecution: jest.fn(async () => resolveResult),
+    createExecutionWarehouseClient: jest.fn(
+        () => warehouseClientMock as unknown as WarehouseClient,
+    ),
+    recordStats: jest.fn(),
+    cleanupStats: jest.fn(async () => 0),
+    getStats: noOpStrategy.getStats.bind(noOpStrategy),
+    getResultsStorageClient: jest.fn(() => undefined),
+});
 
 // Import the mocked function
 const mockSshTunnel = {
@@ -223,26 +241,6 @@ const getMockedAsyncQueryService = (
                 close: jest.fn(),
             })),
         } as unknown as S3ResultsFileStorageClient,
-        preAggregateResultsStorageClient: {
-            isEnabled: true,
-            getDownloadStream: jest.fn(() => {
-                const readable = new Readable({
-                    read() {
-                        this.push('{}');
-                        this.push(null);
-                    },
-                });
-                return readable;
-            }),
-            getFirstLine: jest.fn(async () => '{}'),
-            getFileUrl: jest.fn(
-                async () => 'https://example.com/preagg-results.jsonl',
-            ),
-            createUploadStream: jest.fn(() => ({
-                write: jest.fn(),
-                close: jest.fn(),
-            })),
-        } as unknown as S3ResultsFileStorageClient,
         featureFlagModel: {} as FeatureFlagModel,
         projectParametersModel: {
             find: jest.fn(async () => []),
@@ -257,18 +255,10 @@ const getMockedAsyncQueryService = (
         }),
         permissionsService: {} as PermissionsService,
         persistentDownloadFileService: {} as PersistentDownloadFileService,
-        preAggregationDuckDbClient: {
-            resolve: jest.fn(async () => ({
-                resolved: false as const,
-                reason: PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
-            })),
-        } as unknown as PreAggregationDuckDbClient,
+        preAggregateStrategy: new NoOpPreAggregateStrategy(),
         projectCompileLogModel: {} as ProjectCompileLogModel,
         adminNotificationService: {} as AdminNotificationService,
         spacePermissionService: {} as SpacePermissionService,
-        preAggregateDailyStatsModel: {
-            upsert: jest.fn(),
-        } as unknown as import('../../ee/models/PreAggregateDailyStatsModel').PreAggregateDailyStatsModel,
         ...overrides,
     });
 
@@ -765,11 +755,12 @@ describe('AsyncQueryService', () => {
             expect(runAsyncWarehouseQuerySpy).not.toHaveBeenCalled();
         });
 
-        test('does not resolve pre-aggregates when flag is disabled', async () => {
-            const resolveSpy = jest.fn(async () => ({
-                resolved: false as const,
-                reason: PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
-            }));
+        test('does not resolve pre-aggregates when strategy returns not resolved', async () => {
+            const mockStrategy = makeMockStrategy({
+                resolved: false,
+                reason: 'not_available',
+                isFatal: false,
+            });
             const service = getMockedAsyncQueryService({
                 ...lightdashConfigMock,
                 preAggregates: {
@@ -777,9 +768,7 @@ describe('AsyncQueryService', () => {
                     parquetEnabled: false,
                 },
             });
-            (service as AnyType).preAggregationDuckDbClient = {
-                resolve: resolveSpy,
-            } as unknown as PreAggregationDuckDbClient;
+            (service as AnyType).preAggregateStrategy = mockStrategy;
 
             const runAsyncWarehouseQuerySpy = jest
                 .spyOn(service, 'runAsyncWarehouseQuery')
@@ -817,16 +806,18 @@ describe('AsyncQueryService', () => {
                 { query: metricQueryMock },
             );
 
-            expect(resolveSpy).not.toHaveBeenCalled();
+            // Strategy's resolveExecution is called but returns not-resolved,
+            // so execution falls back to warehouse
             expect(runAsyncWarehouseQuerySpy).toHaveBeenCalledTimes(1);
             expect(runAsyncPreAggregateQuerySpy).not.toHaveBeenCalled();
         });
 
         test('required pre-aggregate routes error when resolution fails and NATS is enabled', async () => {
-            const resolveSpy = jest.fn(async () => ({
-                resolved: false as const,
-                reason: PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION,
-            }));
+            const mockStrategy = makeMockStrategy({
+                resolved: false,
+                reason: 'No active materialization found for pre-aggregate explore "__preagg__valid_explore__rollup"',
+                isFatal: true,
+            });
             const service = getMockedAsyncQueryService({
                 ...lightdashConfigMock,
                 natsWorker: {
@@ -838,9 +829,7 @@ describe('AsyncQueryService', () => {
                     enabled: true,
                 },
             });
-            (service as AnyType).preAggregationDuckDbClient = {
-                resolve: resolveSpy,
-            } as unknown as PreAggregationDuckDbClient;
+            (service as AnyType).preAggregateStrategy = mockStrategy;
 
             (service.queryHistoryModel.create as jest.Mock).mockResolvedValue({
                 queryUuid: 'test-query-uuid',
@@ -891,7 +880,7 @@ describe('AsyncQueryService', () => {
                 },
             );
 
-            expect(resolveSpy).toHaveBeenCalledTimes(1);
+            expect(mockStrategy.resolveExecution).toHaveBeenCalledTimes(1);
             expect(runAsyncWarehouseSpy).not.toHaveBeenCalled();
             expect(runAsyncPreAggSpy).not.toHaveBeenCalled();
             expect(service.queryHistoryModel.update).toHaveBeenCalledWith(
@@ -906,6 +895,10 @@ describe('AsyncQueryService', () => {
         });
 
         test('resolved pre-aggregate routes enqueue a pre-aggregate job', async () => {
+            const mockStrategy = makeMockStrategy({
+                resolved: true,
+                query: 'SELECT * FROM duckdb_preagg',
+            });
             const service = getMockedAsyncQueryService({
                 ...lightdashConfigMock,
                 natsWorker: {
@@ -917,13 +910,7 @@ describe('AsyncQueryService', () => {
                     enabled: true,
                 },
             });
-            (service as AnyType).preAggregationDuckDbClient = {
-                resolve: jest.fn(async () => ({
-                    resolved: true as const,
-                    query: 'SELECT * FROM duckdb_preagg',
-                    warehouseClient: warehouseClientMock,
-                })),
-            } as unknown as PreAggregationDuckDbClient;
+            (service as AnyType).preAggregateStrategy = mockStrategy;
 
             (service.queryHistoryModel.create as jest.Mock).mockResolvedValue({
                 queryUuid: 'test-query-uuid',
@@ -989,10 +976,11 @@ describe('AsyncQueryService', () => {
         });
 
         test('opportunistic pre-aggregate routes enqueue a warehouse job when DuckDB cannot resolve', async () => {
-            const resolveSpy = jest.fn(async () => ({
-                resolved: false as const,
-                reason: PreAggregationDuckDbResolveReason.NO_ACTIVE_MATERIALIZATION,
-            }));
+            const mockStrategy = makeMockStrategy({
+                resolved: false,
+                reason: 'no_active_materialization',
+                isFatal: false,
+            });
             const service = getMockedAsyncQueryService({
                 ...lightdashConfigMock,
                 natsWorker: {
@@ -1004,9 +992,7 @@ describe('AsyncQueryService', () => {
                     enabled: true,
                 },
             });
-            (service as AnyType).preAggregationDuckDbClient = {
-                resolve: resolveSpy,
-            } as unknown as PreAggregationDuckDbClient;
+            (service as AnyType).preAggregateStrategy = mockStrategy;
 
             (service.queryHistoryModel.create as jest.Mock).mockResolvedValue({
                 queryUuid: 'test-query-uuid',
@@ -1049,7 +1035,7 @@ describe('AsyncQueryService', () => {
                 { query: metricQueryMock },
             );
 
-            expect(resolveSpy).toHaveBeenCalledTimes(1);
+            expect(mockStrategy.resolveExecution).toHaveBeenCalledTimes(1);
             expect(enqueueWarehouseSpy).toHaveBeenCalledTimes(1);
             expect(enqueueWarehouseSpy).toHaveBeenCalledWith({
                 queryUuid: 'test-query-uuid',
@@ -1060,6 +1046,32 @@ describe('AsyncQueryService', () => {
 
     describe('executeAsyncMetricQuery', () => {
         test('attaches required pre-aggregate routing metadata for direct pre-aggregate explores', async () => {
+            const mockStrategy: PreAggregateStrategy = {
+                ...makeMockStrategy({
+                    resolved: true,
+                    query: 'SELECT * FROM duckdb_preagg',
+                }),
+                getRoutingDecision: ({ explore }) => {
+                    if (
+                        explore.type === ExploreType.PRE_AGGREGATE &&
+                        explore.preAggregateSource
+                    ) {
+                        return {
+                            target: 'pre_aggregate',
+                            preAggregateMetadata: {
+                                hit: true,
+                                name: explore.preAggregateSource
+                                    .preAggregateName,
+                            },
+                            route: {
+                                ...explore.preAggregateSource,
+                                mode: 'required',
+                            },
+                        };
+                    }
+                    return { target: 'warehouse' };
+                },
+            };
             const service = getMockedAsyncQueryService({
                 ...lightdashConfigMock,
                 natsWorker: {
@@ -1071,6 +1083,7 @@ describe('AsyncQueryService', () => {
                     enabled: true,
                 },
             });
+            (service as AnyType).preAggregateStrategy = mockStrategy;
             service.getExplore = jest
                 .fn()
                 .mockResolvedValue(preAggregateExplore);

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -23,7 +23,6 @@ import {
     ExpiredQueryError,
     Explore,
     ExploreCompiler,
-    ExploreType,
     FieldType,
     ForbiddenError,
     formatItemValue,
@@ -106,12 +105,6 @@ import { type FileStorageClient } from '../../clients/FileStorage/FileStorageCli
 import type { INatsClient } from '../../clients/NatsClient';
 import { createLocalParquetUploadStream } from '../../clients/ResultsFileStorageClients/LocalParquetUploadStream';
 import { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
-import { PreAggregateDailyStatsModel } from '../../ee/models/PreAggregateDailyStatsModel';
-import { findMatch } from '../../ee/preAggregates/matcher';
-import {
-    PreAggregationDuckDbClient,
-    PreAggregationDuckDbResolveReason,
-} from '../../ee/services/AsyncQueryService/PreAggregationDuckDbClient';
 import { measureTime } from '../../logging/measureTime';
 import { DownloadAuditModel } from '../../models/DownloadAuditModel';
 import { QueryHistoryModel } from '../../models/QueryHistoryModel/QueryHistoryModel';
@@ -155,6 +148,12 @@ import { getDuckdbRuntimeConfig } from './getDuckdbRuntimeConfig';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {
+    NoOpPreAggregateStrategy,
+    type PreAggregateExecutionResolution,
+    type PreAggregateStrategy,
+    type PreAggregationRoutingDecision,
+} from './PreAggregateStrategy';
+import {
     ExecuteAsyncSqlQueryArgs,
     isExecuteAsyncDashboardSqlChartByUuid,
     isExecuteAsyncSqlChartByUuid,
@@ -178,23 +177,12 @@ const SQL_QUERY_MOCK_EXPLORER_NAME = 'sql_query_explorer';
 export const QUEUED_QUERY_EXPIRED_MESSAGE =
     'Your query expired while waiting in the queue. Please try again.';
 
-type PreAggregationRoutingDecision =
-    | {
-          target: 'warehouse';
-          preAggregateMetadata?: CacheMetadata['preAggregate'];
-      }
-    | {
-          target: 'pre_aggregate';
-          preAggregateMetadata: CacheMetadata['preAggregate'];
-          route: PreAggregationRoute;
-      };
-
 type AsyncQueryExecutionPlan =
     | {
           target: 'warehouse';
           warehouseQuery: string;
           preAggregateResolved?: false;
-          preAggregateResolveReason?: PreAggregationDuckDbResolveReason;
+          preAggregateResolveReason?: string;
       }
     | {
           target: 'pre_aggregate';
@@ -207,7 +195,7 @@ type AsyncQueryExecutionPlan =
           target: 'error';
           error: string;
           preAggregateResolved?: false;
-          preAggregateResolveReason?: PreAggregationDuckDbResolveReason;
+          preAggregateResolveReason?: string;
       };
 
 type AsyncQueryServiceArguments = ProjectServiceArguments & {
@@ -216,15 +204,13 @@ type AsyncQueryServiceArguments = ProjectServiceArguments & {
     cacheService?: ICacheService;
     savedSqlModel: SavedSqlModel;
     resultsStorageClient: S3ResultsFileStorageClient;
-    preAggregateResultsStorageClient?: S3ResultsFileStorageClient;
     pivotTableService: PivotTableService;
     prometheusMetrics?: PrometheusMetrics;
     schedulerClient: SchedulerClient;
     natsClient: INatsClient;
     permissionsService: PermissionsService;
     persistentDownloadFileService: PersistentDownloadFileService;
-    preAggregationDuckDbClient?: PreAggregationDuckDbClient;
-    preAggregateDailyStatsModel?: PreAggregateDailyStatsModel;
+    preAggregateStrategy?: PreAggregateStrategy;
 };
 
 export class AsyncQueryService extends ProjectService {
@@ -237,8 +223,6 @@ export class AsyncQueryService extends ProjectService {
     savedSqlModel: SavedSqlModel;
 
     resultsStorageClient: S3ResultsFileStorageClient;
-
-    preAggregateResultsStorageClient?: S3ResultsFileStorageClient;
 
     exportsStorageClient: FileStorageClient;
 
@@ -254,9 +238,7 @@ export class AsyncQueryService extends ProjectService {
 
     persistentDownloadFileService: PersistentDownloadFileService;
 
-    private readonly preAggregationDuckDbClient?: PreAggregationDuckDbClient;
-
-    private preAggregateDailyStatsModel?: PreAggregateDailyStatsModel;
+    protected readonly preAggregateStrategy: PreAggregateStrategy;
 
     constructor(args: AsyncQueryServiceArguments) {
         super(args);
@@ -265,8 +247,6 @@ export class AsyncQueryService extends ProjectService {
         this.cacheService = args.cacheService;
         this.savedSqlModel = args.savedSqlModel;
         this.resultsStorageClient = args.resultsStorageClient;
-        this.preAggregateResultsStorageClient =
-            args.preAggregateResultsStorageClient;
         this.exportsStorageClient = this.fileStorageClient;
         this.pivotTableService = args.pivotTableService;
         this.prometheusMetrics = args.prometheusMetrics;
@@ -274,8 +254,8 @@ export class AsyncQueryService extends ProjectService {
         this.natsClient = args.natsClient;
         this.permissionsService = args.permissionsService;
         this.persistentDownloadFileService = args.persistentDownloadFileService;
-        this.preAggregationDuckDbClient = args.preAggregationDuckDbClient;
-        this.preAggregateDailyStatsModel = args.preAggregateDailyStatsModel;
+        this.preAggregateStrategy =
+            args.preAggregateStrategy ?? new NoOpPreAggregateStrategy();
     }
 
     private recordPreAggregateStats(params: {
@@ -286,35 +266,13 @@ export class AsyncQueryService extends ProjectService {
         dashboardUuid: string | null;
         queryContext: string;
     }): void {
-        const { preAggregateMetadata } = params.routingDecision;
-        if (!preAggregateMetadata) {
-            return;
-        }
-
-        void this.preAggregateDailyStatsModel
-            ?.upsert({
-                projectUuid: params.projectUuid,
-                exploreName: params.exploreName,
-                chartUuid: params.chartUuid,
-                dashboardUuid: params.dashboardUuid,
-                queryContext: params.queryContext,
-                hit: preAggregateMetadata.hit,
-                missReason: preAggregateMetadata.reason?.reason ?? null,
-                preAggregateName: preAggregateMetadata.name ?? null,
-            })
-            .catch((e) =>
-                this.logger.error(
-                    'Failed to upsert pre-aggregate daily stats',
-                    e,
-                ),
-            );
+        this.preAggregateStrategy.recordStats(params);
     }
 
     async cleanupPreAggregateDailyStats(
         retentionDays: number,
     ): Promise<number> {
-        if (!this.preAggregateDailyStatsModel) return 0;
-        return this.preAggregateDailyStatsModel.cleanup(retentionDays);
+        return this.preAggregateStrategy.cleanupStats(retentionDays);
     }
 
     private async assertSavedChartAccess(
@@ -355,75 +313,21 @@ export class AsyncQueryService extends ProjectService {
         explore: Explore;
         context: QueryExecutionContext;
     }): PreAggregationRoutingDecision {
-        if (
-            !this.preAggregationDuckDbClient ||
-            !this.isPreAggregationExecutionEnabled()
-        ) {
-            return { target: 'warehouse' };
-        }
-
-        if (explore.type === ExploreType.PRE_AGGREGATE) {
-            if (!explore.preAggregateSource) {
-                throw new UnexpectedServerError(
-                    `Pre-aggregate explore "${explore.name}" is missing source metadata`,
-                );
-            }
-
-            return {
-                target: 'pre_aggregate',
-                preAggregateMetadata: {
-                    hit: true,
-                    name: explore.preAggregateSource.preAggregateName,
-                },
-                route: {
-                    ...explore.preAggregateSource,
-                    mode: 'required',
-                },
-            };
-        }
-
-        if ((explore.preAggregates || []).length === 0) {
-            return { target: 'warehouse' };
-        }
-
-        const matchResult = findMatch(metricQuery, explore);
-        const preAggregateMetadata: CacheMetadata['preAggregate'] = {
-            hit: matchResult.hit,
-            name: matchResult.preAggregateName || undefined,
-            reason: matchResult.miss || undefined,
-        };
-
-        if (
-            matchResult.hit &&
-            matchResult.preAggregateName &&
-            context !== QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
-        ) {
-            return {
-                target: 'pre_aggregate',
-                preAggregateMetadata,
-                route: {
-                    sourceExploreName: metricQuery.exploreName,
-                    preAggregateName: matchResult.preAggregateName,
-                    mode: 'opportunistic',
-                },
-            };
-        }
-
-        return { target: 'warehouse', preAggregateMetadata };
-    }
-
-    private isPreAggregationExecutionEnabled(): boolean {
-        return this.lightdashConfig.preAggregates.enabled;
+        return this.preAggregateStrategy.getRoutingDecision({
+            metricQuery,
+            explore,
+            context,
+        });
     }
 
     private getResultsStorageClientForContext(
         context?: QueryExecutionContext | null,
     ): S3ResultsFileStorageClient {
-        return context ===
-            QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION &&
-            this.preAggregateResultsStorageClient
-            ? this.preAggregateResultsStorageClient
-            : this.resultsStorageClient;
+        const strategyClient =
+            context === QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
+                ? this.preAggregateStrategy.getResultsStorageClient()
+                : undefined;
+        return strategyClient ?? this.resultsStorageClient;
     }
 
     public getCacheExpiresAt(baseDate: Date) {
@@ -1647,88 +1551,49 @@ export class AsyncQueryService extends ProjectService {
         availableParameterDefinitions?: ParameterDefinitions;
         queryUuid: string;
     }): Promise<AsyncQueryExecutionPlan> {
-        if (!preAggregationRoute || !this.isPreAggregationExecutionEnabled()) {
-            return {
-                target: 'warehouse',
-                warehouseQuery,
-            };
+        if (!preAggregationRoute) {
+            return { target: 'warehouse', warehouseQuery };
         }
 
-        const isRequiredPreAggregationRoute =
-            preAggregationRoute.mode === 'required';
-        const canResolvePreAggregation =
-            !!userAccessControls && !!availableParameterDefinitions;
+        const resolution = await this.preAggregateStrategy.resolveExecution({
+            projectUuid,
+            queryUuid,
+            warehouseQuery,
+            preAggregationRoute,
+            resolveArgs: {
+                metricQuery,
+                timezone,
+                dateZoom,
+                parameters,
+                fieldsMap,
+                pivotConfiguration,
+                startOfWeek,
+                userAccessControls,
+                availableParameterDefinitions,
+            },
+        });
 
-        if (isRequiredPreAggregationRoute && !canResolvePreAggregation) {
-            const error =
-                PreAggregationDuckDbClient.getPreAggregationResolutionErrorMessage(
-                    {
-                        route: preAggregationRoute,
-                        reason: PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
-                    },
-                );
-            this.logger.warn(
-                `Required pre-aggregate resolution failed for ${queryUuid}: ${error}`,
-            );
-            return {
-                target: 'error',
-                error,
-                preAggregateResolved: false,
-                preAggregateResolveReason:
-                    PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
-            };
-        }
-
-        const preAggResolution =
-            canResolvePreAggregation && this.preAggregationDuckDbClient
-                ? await this.preAggregationDuckDbClient.resolve({
-                      projectUuid,
-                      queryUuid,
-                      metricQuery,
-                      timezone,
-                      dateZoom,
-                      parameters,
-                      preAggregationRoute,
-                      fieldsMap,
-                      pivotConfiguration,
-                      startOfWeek,
-                      userAccessControls,
-                      availableParameterDefinitions,
-                  })
-                : undefined;
-
-        if (preAggResolution?.resolved) {
+        if (resolution.resolved) {
             this.logger.info(
-                `DuckDB pre-agg route selected for ${queryUuid}: ${preAggregationRoute!.sourceExploreName}/${preAggregationRoute!.preAggregateName}`,
+                `DuckDB pre-agg route selected for ${queryUuid}: ${preAggregationRoute.sourceExploreName}/${preAggregationRoute.preAggregateName}`,
             );
             return {
                 target: 'pre_aggregate',
-                preAggregateQuery: preAggResolution.query,
+                preAggregateQuery: resolution.query,
                 warehouseQuery,
                 preAggregateResolved: true,
             };
         }
 
-        if (
-            isRequiredPreAggregationRoute &&
-            preAggResolution &&
-            !preAggResolution.resolved
-        ) {
-            const error =
-                PreAggregationDuckDbClient.getPreAggregationResolutionErrorMessage(
-                    {
-                        route: preAggregationRoute,
-                        reason: preAggResolution.reason,
-                    },
-                );
+        if (resolution.isFatal) {
             this.logger.warn(
-                `Required pre-aggregate resolution failed for ${queryUuid}: ${error}`,
+                `Required pre-aggregate resolution failed for ${queryUuid}: ${resolution.reason}`,
             );
             return {
                 target: 'error',
-                error,
+                error: resolution.reason,
                 preAggregateResolved: false,
-                preAggregateResolveReason: preAggResolution.reason,
+                preAggregateResolveReason: resolution.reason,
             };
         }
 
@@ -1736,9 +1601,7 @@ export class AsyncQueryService extends ProjectService {
             target: 'warehouse',
             warehouseQuery,
             preAggregateResolved: false,
-            preAggregateResolveReason:
-                preAggResolution?.reason ??
-                PreAggregationDuckDbResolveReason.RESOLVE_ERROR,
+            preAggregateResolveReason: resolution.reason,
         };
     }
 
@@ -1759,13 +1622,8 @@ export class AsyncQueryService extends ProjectService {
         queryCreatedAt,
     }: RunAsyncPreAggregateQueryArgs) {
         try {
-            if (!this.preAggregationDuckDbClient) {
-                throw new UnexpectedServerError(
-                    'Pre-aggregate DuckDB client is not available',
-                );
-            }
             const duckDbWarehouseClient =
-                this.preAggregationDuckDbClient.createExecutionWarehouseClient();
+                this.preAggregateStrategy.createExecutionWarehouseClient();
 
             await this.runAsyncWarehouseQuery({
                 userUuid,
@@ -5017,43 +4875,11 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
-        if (!this.preAggregateDailyStatsModel) {
-            return {
-                data: { stats: [] },
-                pagination: {
-                    page: paginateArgs?.page ?? 1,
-                    pageSize: paginateArgs?.pageSize ?? 0,
-                    totalResults: 0,
-                    totalPageCount: 0,
-                },
-            };
-        }
-
-        const result = await this.preAggregateDailyStatsModel.getByProject(
+        return this.preAggregateStrategy.getStats(
             projectUuid,
             days,
             paginateArgs,
             filters,
         );
-
-        return {
-            data: {
-                stats: result.data.map((row) => ({
-                    exploreName: row.exploreName,
-                    date: row.date.toISOString(),
-                    chartUuid: row.chartUuid,
-                    chartName: row.chartName,
-                    dashboardUuid: row.dashboardUuid,
-                    dashboardName: row.dashboardName,
-                    queryContext: row.queryContext,
-                    hitCount: row.hitCount,
-                    missCount: row.missCount,
-                    missReason: row.missReason,
-                    preAggregateName: row.preAggregateName,
-                    updatedAt: row.updatedAt.toISOString(),
-                })),
-            },
-            pagination: result.pagination,
-        };
     }
 }

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -1,0 +1,131 @@
+import {
+    ApiPreAggregateStatsResults,
+    type CacheMetadata,
+    type Explore,
+    type KnexPaginateArgs,
+    type KnexPaginatedData,
+    type MetricQuery,
+    type QueryExecutionContext,
+} from '@lightdash/common';
+import { type S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
+import {
+    type PreAggregationRoute,
+    type RunAsyncPreAggregateQueryArgs,
+} from './types';
+
+export type PreAggregationRoutingDecision =
+    | {
+          target: 'warehouse';
+          preAggregateMetadata?: CacheMetadata['preAggregate'];
+      }
+    | {
+          target: 'pre_aggregate';
+          preAggregateMetadata: CacheMetadata['preAggregate'];
+          route: PreAggregationRoute;
+      };
+
+export type PreAggregateStatsFilters = {
+    exploreName?: string;
+    queryType?: 'chart' | 'dashboard' | 'explorer';
+};
+
+export interface PreAggregateStrategy {
+    getRoutingDecision(params: {
+        metricQuery: MetricQuery;
+        explore: Explore;
+        context: QueryExecutionContext;
+    }): PreAggregationRoutingDecision;
+
+    resolveExecution(params: {
+        projectUuid: string;
+        queryUuid: string;
+        warehouseQuery: string;
+        preAggregationRoute: PreAggregationRoute;
+        resolveArgs: ResolveExecutionArgs;
+    }): Promise<PreAggregateExecutionResolution>;
+
+    createExecutionWarehouseClient(): import('@lightdash/common').WarehouseClient;
+
+    recordStats(params: {
+        projectUuid: string;
+        exploreName: string;
+        routingDecision: PreAggregationRoutingDecision;
+        chartUuid: string | null;
+        dashboardUuid: string | null;
+        queryContext: string;
+    }): void;
+
+    cleanupStats(retentionDays: number): Promise<number>;
+
+    getStats(
+        projectUuid: string,
+        days: number,
+        paginateArgs?: KnexPaginateArgs,
+        filters?: PreAggregateStatsFilters,
+    ): Promise<KnexPaginatedData<ApiPreAggregateStatsResults>>;
+
+    getResultsStorageClient(): S3ResultsFileStorageClient | undefined;
+}
+
+export type ResolveExecutionArgs = {
+    metricQuery: MetricQuery;
+    timezone: string;
+    dateZoom: import('@lightdash/common').DateZoom | undefined;
+    parameters: import('@lightdash/common').ParametersValuesMap | undefined;
+    fieldsMap: import('@lightdash/common').ItemsMap;
+    pivotConfiguration:
+        | import('@lightdash/common').PivotConfiguration
+        | undefined;
+    startOfWeek: import('@lightdash/common').CreateWarehouseCredentials['startOfWeek'];
+    userAccessControls?: import('@lightdash/common').UserAccessControls;
+    availableParameterDefinitions?: import('@lightdash/common').ParameterDefinitions;
+};
+
+export type PreAggregateExecutionResolution =
+    | { resolved: true; query: string }
+    | { resolved: false; reason: string; isFatal: boolean };
+
+/* eslint-disable class-methods-use-this */
+export class NoOpPreAggregateStrategy implements PreAggregateStrategy {
+    getRoutingDecision(): PreAggregationRoutingDecision {
+        return { target: 'warehouse' };
+    }
+
+    async resolveExecution(): Promise<PreAggregateExecutionResolution> {
+        return { resolved: false, reason: 'not_available', isFatal: false };
+    }
+
+    createExecutionWarehouseClient(): never {
+        throw new Error(
+            'Pre-aggregate execution is not available in this edition',
+        );
+    }
+
+    recordStats(): void {
+        // no-op
+    }
+
+    async cleanupStats(): Promise<number> {
+        return 0;
+    }
+
+    async getStats(
+        _projectUuid: string,
+        _days: number,
+        paginateArgs?: KnexPaginateArgs,
+    ): Promise<KnexPaginatedData<ApiPreAggregateStatsResults>> {
+        return {
+            data: { stats: [] },
+            pagination: {
+                page: paginateArgs?.page ?? 1,
+                pageSize: paginateArgs?.pageSize ?? 0,
+                totalResults: 0,
+                totalPageCount: 0,
+            },
+        };
+    }
+
+    getResultsStorageClient(): undefined {
+        return undefined;
+    }
+}


### PR DESCRIPTION
### Description:

Introduced PreAggregatestrategy interface used in AsyncQueryService to separate pre-aggregate internals.
This way we can remove the three optional dependencies. OSS gets a no-op default that always returns to warehouse, and EE wires its own implementation that bundles duckdb client, stats, model, etc

