### PR TITLE
fix: Redshift interval syntax to use DATEADD instead of INTERVAL

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -20,6 +20,7 @@ import {
 import {
     BuildQueryProps,
     CompiledQuery,
+    getIntervalSyntax,
     MetricQueryBuilder,
 } from './MetricQueryBuilder';
 import {
@@ -584,6 +585,36 @@ const POP_TEST_FANOUT_METRIC_QUERY: CompiledMetricQuery = {
     ],
     compiledCustomDimensions: [],
 };
+
+describe('getIntervalSyntax', () => {
+    test('Should use DATEADD for Redshift month granularity', () => {
+        expect(
+            getIntervalSyntax(
+                SupportedDbtAdapter.REDSHIFT,
+                '"orders".order_date',
+                'pop.min_date',
+                '>=',
+                1,
+                'month',
+                false,
+            ),
+        ).toBe('"orders".order_date >= DATEADD(month, -1, pop.min_date)');
+    });
+
+    test('Should convert Redshift quarter granularity to months in DATEADD', () => {
+        expect(
+            getIntervalSyntax(
+                SupportedDbtAdapter.REDSHIFT,
+                '"orders".order_date',
+                'pop.max_date',
+                '<=',
+                1,
+                'quarter',
+                false,
+            ),
+        ).toBe('"orders".order_date <= DATEADD(MONTH, -3, pop.max_date)');
+    });
+});
 
 describe('Query builder', () => {
     test('Should build simple metric query', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -205,13 +205,12 @@ export function getIntervalSyntax(
             }, ${columnWithInterval})`;
             break;
         case SupportedDbtAdapter.REDSHIFT: {
-            // Redshift uses standard interval arithmetic
-            // Redshift doesn't support QUARTER interval, convert to months
+            // Redshift uses DATEADD and doesn't support QUARTER directly
             const [redshiftValue, redshiftGranularity] =
                 normalizeIntervalGranularity(value, granularity);
-            intervalExpression = `${columnWithInterval} ${
-                isAdd ? '+' : '-'
-            } INTERVAL '${redshiftValue} ${redshiftGranularity}'`;
+            intervalExpression = `DATEADD(${redshiftGranularity}, ${
+                isAdd ? redshiftValue : -redshiftValue
+            }, ${columnWithInterval})`;
             break;
         }
         case SupportedDbtAdapter.POSTGRES: {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/21104<!-- reference the related issue e.g. #150 -->

### Description:

<!-- Add a description of the changes proposed in the pull request. -->

Fixed Redshift interval syntax to use `DATEADD` function instead of standard interval arithmetic. The previous implementation used `INTERVAL` syntax which is not supported by Redshift. The new implementation properly converts quarter granularity to months (multiplying by 3) and handles both positive and negative intervals using the `DATEADD(unit, value, date)` format.

Added comprehensive tests to verify the correct `DATEADD` syntax generation for both month and quarter granularities, ensuring proper handling of comparison operators and interval calculations.

<!-- Even better add a screenshot / gif / loom -->