### PR TITLE
fix: update queued query loading message text

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/queryLoadingState.ts
+++ b/packages/frontend/src/components/Explorer/ResultsCard/queryLoadingState.ts
@@ -8,7 +8,7 @@ export const getQueryLoadingStateCopy = (
             return {
                 title: 'Your query is queued...',
                 description:
-                    'It will start automatically when a worker is available.',
+                    'We’ll start processing your query as soon as possible.',
             };
         case QueryHistoryStatus.EXECUTING:
             return {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Updated the queued query message to be more user-friendly by changing "It will start automatically when a worker is available" to "We'll start processing your query as soon as possible" in the Explorer results card.

<!-- Even better add a screenshot / gif / loom -->