### PR TITLE
fix: remove PRE_AGGREGATES_ENABLED environment variable check

### DIFF
--- a/packages/backend/src/ee/preAggregates/generatePreAggregateExplores.ts
+++ b/packages/backend/src/ee/preAggregates/generatePreAggregateExplores.ts
@@ -7,9 +7,6 @@ import {
 } from '@lightdash/common';
 import { buildPreAggregateExplore } from './buildPreAggregateExplore';
 
-const isPreAggregateVirtualExploreGenerationEnabled = (): boolean =>
-    process.env.PRE_AGGREGATES_ENABLED === 'true';
-
 const shouldGeneratePreAggregatesForExplore = (explore: Explore): boolean =>
     explore.name === explore.baseTable;
 
@@ -20,10 +17,7 @@ export const generatePreAggregateExplores = ({
     compiledExplores: Array<Explore | ExploreError>;
     parsedPreAggregates: PreAggregateDef[];
 }): Array<Explore | ExploreError> => {
-    if (
-        !isPreAggregateVirtualExploreGenerationEnabled() ||
-        parsedPreAggregates.length === 0
-    ) {
+    if (parsedPreAggregates.length === 0) {
         return compiledExplores;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Removed the environment variable check for `PRE_AGGREGATES_ENABLED` from the pre-aggregate explore generation logic. The function now only checks if parsed pre-aggregates exist before proceeding with generation, eliminating the need for the `isPreAggregateVirtualExploreGenerationEnabled` helper function.

<!-- Even better add a screenshot / gif / loom -->