### PR TITLE
fix: improve error handling for user activity CSV download

### DIFF
--- a/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
+++ b/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
@@ -5,6 +5,7 @@ import {
     ApiDownloadCsv,
     ForbiddenError,
     isUserWithOrg,
+    NotFoundError,
     SchedulerJobStatus,
     SessionUser,
     UnusedContent,
@@ -114,6 +115,10 @@ export class AnalyticsService extends BaseService {
         });
 
         const results = await this.analyticsModel.getViewsRawData(projectUuid);
+        if (results.length === 0) {
+            throw new NotFoundError('No user activity data found');
+        }
+
         const fileName = `lightdash raw usage analytics.csv`;
         const csvHeader = Object.keys(results[0]);
         const csvBody = stringify(results, {

--- a/packages/frontend/src/hooks/analytics/useUserActivity.tsx
+++ b/packages/frontend/src/hooks/analytics/useUserActivity.tsx
@@ -34,10 +34,12 @@ const downloadUserActivityCsv = async (projectUuid: string) =>
     });
 
 export const useDownloadUserActivityCsv = () => {
+    const setErrorResponse = useQueryError();
     return useMutation<ApiUserActivityDownloadCsv['results'], ApiError, string>(
         downloadUserActivityCsv,
         {
             mutationKey: ['download_user_activity_csv'],
+            onError: (result) => setErrorResponse(result),
         },
     );
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/21337<!-- reference the related issue e.g. #150 -->

### Description:

Added proper error handling for user activity CSV downloads when no data is available. The backend now throws a `NotFoundError` when attempting to download user activity data for projects with no analytics records, and the frontend properly displays this error to users through the error handling system.

<!-- Even better add a screenshot / gif / loom -->