### PR TITLE
fix: update job step status instead of throwing error when compilation lock fails

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3,7 +3,6 @@ import {
     Account,
     addDashboardFiltersToMetricQuery,
     AlreadyExistsError,
-    AlreadyProcessingError,
     AndFilterGroup,
     AnyType,
     ApiChartAndResults,
@@ -97,6 +96,7 @@ import {
     ItemsMap,
     Job,
     JobStatusType,
+    JobStepStatusType,
     JobStepType,
     JobType,
     LightdashError,
@@ -5035,7 +5035,12 @@ export class ProjectService extends BaseService {
         };
 
         const onLockFailed = async () => {
-            throw new AlreadyProcessingError('Project is already compiling');
+            await this.jobModel.updateJobStep(
+                job.jobUuid,
+                JobStepStatusType.ERROR,
+                JobStepType.COMPILING,
+                'Compilation is already in progress for this project',
+            );
         };
 
         const timings = {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Replace throwing `AlreadyProcessingError` with updating job step status to ERROR when project compilation lock fails. Instead of throwing an exception when a project is already compiling, the system now updates the job step with an error status and descriptive message indicating that compilation is already in progress.

<!-- Even better add a screenshot / gif / loom -->