### PR TITLE
fix: handle missing primary axis config in cartesian chart rendering

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1961,7 +1961,7 @@ const getEchartAxes = ({
                             hideOverlap: true,
                         },
                     }),
-                inverse: !!xAxisConfiguration?.[0].inverse,
+                inverse: !!xAxisConfiguration?.[0]?.inverse,
                 ...bottomAxisExtraConfig,
                 min: bottomAxisBounds.min,
                 max: maxXAxisValue,
@@ -2077,7 +2077,7 @@ const getEchartAxes = ({
                 axisTick: getAxisTickStyle(
                     validCartesianConfig?.eChartsConfig?.showAxisTicks,
                 ),
-                inverse: !!yAxisConfiguration?.[0].inverse,
+                inverse: !!yAxisConfiguration?.[0]?.inverse,
                 ...leftAxisExtraConfig,
             },
             {


### PR DESCRIPTION
## Summary
- guard primary `xAxis` and `yAxis` `inverse` reads with optional chaining in cartesian ECharts config generation
- prevent dashboards from crashing when uploaded chart configs contain empty axis arrays
- Closes: https://github.com/lightdash/lightdash/issues/21325

