### PR TITLE
fix: align embedded dashboard parameters

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardParameters.tsx
@@ -1,4 +1,4 @@
-import { Box } from '@mantine-8/core';
+import { Group } from '@mantine-8/core';
 import { useMemo, type FC } from 'react';
 import { Parameters } from '../../../../../features/parameters';
 import useDashboardContext from '../../../../../providers/Dashboard/useDashboardContext';
@@ -27,7 +27,7 @@ const EmbedDashboardParameters: FC = () => {
     }, [parameterDefinitions, parameterReferences]);
 
     return (
-        <Box style={{ flexShrink: 0 }}>
+        <Group gap="xs" wrap="wrap" style={{ flexShrink: 0 }}>
             <Parameters
                 isEditMode={false}
                 parameterValues={parameterValues}
@@ -37,7 +37,7 @@ const EmbedDashboardParameters: FC = () => {
                 isLoading={!areAllChartsLoaded}
                 missingRequiredParameters={missingRequiredParameters}
             />
-        </Box>
+        </Group>
     );
 };
 


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21347
## Summary
- fix embedded dashboard parameter chip spacing by rendering them in a wrapping `Group`
- update the SDK embed token generator to target the parameterized demo dashboard by name
- ensure embedding settings include the selected dashboard and enable both filter and parameter interactivity in the demo token

