### PR TITLE
chore: exclude generated files from Zed file scanning

### DIFF
--- a/.zed/settings.json
+++ b/.zed/settings.json
@@ -3,6 +3,9 @@
 // For a full list of overridable settings, and general information on folder-specific settings,
 // see the documentation: https://zed.dev/docs/configuring-zed#settings-files
 {
+  "file_scan_exclusions": [
+    "**/generated/**"
+  ],
   "lsp": {
     "oxfmt": {
       "initialization_options": {


### PR DESCRIPTION

### Description:

Added file scan exclusions to Zed editor settings to ignore all files and directories under `**/generated/**` paths. This prevents the editor from scanning generated code files, improving performance and reducing noise in search results.