### PR TITLE
fix: clear stale project reference from localStorage when project not found

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -84,8 +84,9 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
         useProject(shouldFetchLastProject ? lastProjectUuid : undefined, {
             onError: () => {
                 console.warn(
-                    `Couldn't find last project ${lastProjectUuid}. Will default to organization default or fallback project.`,
+                    `Couldn't find last project ${lastProjectUuid}. Clearing stale reference and falling back to organization default or fallback project.`,
                 );
+                localStorage.removeItem(LAST_PROJECT_KEY);
             },
         });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Clear stale project reference from localStorage when last project is not found. This prevents the application from repeatedly attempting to fetch an invalid project UUID by removing the stored reference and allowing it to properly fall back to the organization default or fallback project.

<!-- Even better add a screenshot / gif / loom -->