### PR TITLE
feat: add materialization query routing and NATS handling

### DIFF
--- a/packages/backend/src/clients/NatsClient.ts
+++ b/packages/backend/src/clients/NatsClient.ts
@@ -30,6 +30,7 @@ type EnqueueResult = Promise<{ jobId: string }>;
 export interface INatsClient {
     enqueueWarehouseQuery(payload: AsyncQueryJobPayload): EnqueueResult;
     enqueuePreAggregateQuery(payload: AsyncQueryJobPayload): EnqueueResult;
+    enqueueMaterializationQuery(payload: AsyncQueryJobPayload): EnqueueResult;
 }
 
 type NatsClientArgs = {
@@ -160,6 +161,15 @@ export class NatsClient implements INatsClient {
     ): Promise<{ jobId: string }> {
         return this.enqueue(
             STREAM_CONFIGS['pre-aggregate'].subjects.query,
+            payload,
+        );
+    }
+
+    async enqueueMaterializationQuery(
+        payload: AsyncQueryJobPayload,
+    ): Promise<{ jobId: string }> {
+        return this.enqueue(
+            STREAM_CONFIGS['pre-aggregate'].subjects.materialization,
             payload,
         );
     }

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -94,11 +94,11 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
             reason: matchResult.miss || undefined,
         };
 
-        if (
-            matchResult.hit &&
-            matchResult.preAggregateName &&
-            context !== QEC.PRE_AGGREGATE_MATERIALIZATION
-        ) {
+        if (context === QEC.PRE_AGGREGATE_MATERIALIZATION) {
+            return { target: 'materialization', preAggregateMetadata };
+        }
+
+        if (matchResult.hit && matchResult.preAggregateName) {
             return {
                 target: 'pre_aggregate',
                 preAggregateMetadata,

--- a/packages/backend/src/nats/NatsWorker.ts
+++ b/packages/backend/src/nats/NatsWorker.ts
@@ -150,6 +150,14 @@ export class NatsWorker {
                 );
         }
 
+        if (preAgg && subject === preAgg.subjects.materialization) {
+            return (queryUuid, worker) =>
+                this.asyncQueryService.runAsyncWarehouseQueryFromHistory(
+                    queryUuid,
+                    worker,
+                );
+        }
+
         return null;
     }
 

--- a/packages/backend/src/nats/natsConfig.ts
+++ b/packages/backend/src/nats/natsConfig.ts
@@ -46,6 +46,7 @@ const PRE_AGGREGATE_STREAM_CONFIG: StreamConfig = {
     streamName: 'PRE_AGGREGATE_QUERY_JOBS',
     subjects: {
         query: 'pre_aggregate.query.jobs',
+        materialization: 'pre_aggregate.materialization.jobs',
     },
     durableName: 'worker-pre-aggregate',
 };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -198,6 +198,9 @@ const getMockedAsyncQueryService = (
             enqueuePreAggregateQuery: jest.fn(async () => ({
                 jobId: 'test-nats-pre-agg-job-id',
             })),
+            enqueueMaterializationQuery: jest.fn(async () => ({
+                jobId: 'test-nats-materialization-job-id',
+            })),
         } as unknown as INatsClient,
         downloadFileModel: {} as unknown as DownloadFileModel,
         fileStorageClient: {} as FileStorageClient,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -192,6 +192,12 @@ type AsyncQueryExecutionPlan =
           preAggregateResolveReason?: undefined;
       }
     | {
+          target: 'materialization';
+          warehouseQuery: string;
+          preAggregateResolved?: false;
+          preAggregateResolveReason?: string;
+      }
+    | {
           target: 'error';
           error: string;
           preAggregateResolved?: false;
@@ -1529,6 +1535,7 @@ export class AsyncQueryService extends ProjectService {
         timezone,
         dateZoom,
         parameters,
+        routingTarget,
         preAggregationRoute,
         fieldsMap,
         pivotConfiguration,
@@ -1543,6 +1550,7 @@ export class AsyncQueryService extends ProjectService {
         timezone: string;
         dateZoom: ExecuteAsyncMetricQueryArgs['dateZoom'];
         parameters: ExecuteAsyncMetricQueryArgs['parameters'];
+        routingTarget: PreAggregationRoutingDecision['target'];
         preAggregationRoute?: PreAggregationRoute;
         fieldsMap: ItemsMap;
         pivotConfiguration?: PivotConfiguration;
@@ -1551,6 +1559,10 @@ export class AsyncQueryService extends ProjectService {
         availableParameterDefinitions?: ParameterDefinitions;
         queryUuid: string;
     }): Promise<AsyncQueryExecutionPlan> {
+        if (routingTarget === 'materialization') {
+            return { target: 'materialization', warehouseQuery };
+        }
+
         if (!preAggregationRoute) {
             return { target: 'warehouse', warehouseQuery };
         }
@@ -2591,6 +2603,7 @@ export class AsyncQueryService extends ProjectService {
             originalColumns?: ResultColumns;
             missingParameterReferences: string[];
             timezone?: string;
+            routingTarget?: PreAggregationRoutingDecision['target'];
             preAggregationRoute?: PreAggregationRoute;
             userAccessControls?: UserAccessControls;
             availableParameterDefinitions?: ParameterDefinitions;
@@ -2616,6 +2629,7 @@ export class AsyncQueryService extends ProjectService {
                     pivotConfiguration,
                     parameters,
                     timezone: resolvedTimezone,
+                    routingTarget,
                     preAggregationRoute,
                     userAccessControls,
                     availableParameterDefinitions,
@@ -2896,6 +2910,7 @@ export class AsyncQueryService extends ProjectService {
                             timezone: resolvedTimezone ?? 'UTC',
                             dateZoom,
                             parameters,
+                            routingTarget: routingTarget ?? 'warehouse',
                             preAggregationRoute,
                             fieldsMap,
                             pivotConfiguration,
@@ -2999,14 +3014,28 @@ export class AsyncQueryService extends ProjectService {
                                 queryUuid: queryHistoryUuid,
                             };
 
-                            const { jobId } =
-                                executionPlan.target === 'pre_aggregate'
-                                    ? await this.natsClient.enqueuePreAggregateQuery(
-                                          natsPayload,
-                                      )
-                                    : await this.natsClient.enqueueWarehouseQuery(
-                                          natsPayload,
-                                      );
+                            const enqueueQuery = () => {
+                                switch (executionPlan.target) {
+                                    case 'pre_aggregate':
+                                        return this.natsClient.enqueuePreAggregateQuery(
+                                            natsPayload,
+                                        );
+                                    case 'materialization':
+                                        return this.natsClient.enqueueMaterializationQuery(
+                                            natsPayload,
+                                        );
+                                    case 'warehouse':
+                                        return this.natsClient.enqueueWarehouseQuery(
+                                            natsPayload,
+                                        );
+                                    default:
+                                        return assertUnreachable(
+                                            executionPlan,
+                                            `Unknown execution target`,
+                                        );
+                                }
+                            };
+                            const { jobId } = await enqueueQuery();
 
                             this.logger.info(
                                 `Enqueued query ${queryHistoryUuid} on NATS with job ${jobId}`,
@@ -3071,16 +3100,29 @@ export class AsyncQueryService extends ProjectService {
 
                         const { query: warehouseSql, ...sharedAsyncQueryArgs } =
                             warehouseArgs;
-                        const runQueryPromise =
-                            executionPlan.target === 'pre_aggregate'
-                                ? this.runAsyncPreAggregateQuery({
-                                      ...sharedAsyncQueryArgs,
-                                      preAggregateQuery:
-                                          executionPlan.preAggregateQuery,
-                                      warehouseQuery:
-                                          executionPlan.warehouseQuery,
-                                  })
-                                : this.runAsyncWarehouseQuery(warehouseArgs);
+                        const getRunQueryPromise = () => {
+                            switch (executionPlan.target) {
+                                case 'pre_aggregate':
+                                    return this.runAsyncPreAggregateQuery({
+                                        ...sharedAsyncQueryArgs,
+                                        preAggregateQuery:
+                                            executionPlan.preAggregateQuery,
+                                        warehouseQuery:
+                                            executionPlan.warehouseQuery,
+                                    });
+                                case 'materialization':
+                                case 'warehouse':
+                                    return this.runAsyncWarehouseQuery(
+                                        warehouseArgs,
+                                    );
+                                default:
+                                    return assertUnreachable(
+                                        executionPlan,
+                                        `Unknown execution target`,
+                                    );
+                            }
+                        };
+                        const runQueryPromise = getRunQueryPromise();
 
                         void runQueryPromise.catch((e) => {
                             this.logger.error(
@@ -3259,6 +3301,7 @@ export class AsyncQueryService extends ProjectService {
                 missingParameterReferences,
                 timezone,
                 pivotConfiguration,
+                routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
                     userAccessControls,
@@ -3496,6 +3539,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns: undefined,
                 missingParameterReferences,
                 pivotConfiguration,
+                routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
                     userAccessControls,
@@ -3792,6 +3836,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns: undefined,
                 missingParameterReferences,
                 pivotConfiguration,
+                routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
                     userAccessControls,

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -22,6 +22,10 @@ export type PreAggregationRoutingDecision =
           target: 'pre_aggregate';
           preAggregateMetadata: CacheMetadata['preAggregate'];
           route: PreAggregationRoute;
+      }
+    | {
+          target: 'materialization';
+          preAggregateMetadata?: CacheMetadata['preAggregate'];
       };
 
 export type PreAggregateStatsFilters = {


### PR DESCRIPTION
### Description:

This PR adds support for materialization query routing in the async query system. 
Materializations now will run in the `preAggregate` nats queue
