### PR TITLE
fix: replace localStorage removal with deleteActiveProject mutation for stale references

### DIFF
--- a/packages/frontend/src/hooks/useActiveProject.ts
+++ b/packages/frontend/src/hooks/useActiveProject.ts
@@ -65,6 +65,7 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
     const { data: lastProjectUuid, isFetched: isLastProjectUuidFetched } =
         useActiveProject();
     const { mutate } = useUpdateActiveProjectMutation();
+    const { mutate: deleteActiveProject } = useDeleteActiveProjectMutation();
 
     // Get organization to access defaultProjectUuid (lightweight call, usually cached)
     const { data: organization, isInitialLoading: isLoadingOrg } =
@@ -86,7 +87,7 @@ export const useActiveProjectUuid = (useQueryFetchOptions?: {
                 console.warn(
                     `Couldn't find last project ${lastProjectUuid}. Clearing stale reference and falling back to organization default or fallback project.`,
                 );
-                localStorage.removeItem(LAST_PROJECT_KEY);
+                deleteActiveProject();
             },
         });
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Related to: PROD-6227

### Description:
Replace direct localStorage manipulation with proper mutation hook for clearing active project references. When a stale project UUID is detected, the code now uses `useDeleteActiveProjectMutation()` instead of directly calling `localStorage.removeItem(LAST_PROJECT_KEY)` to ensure consistent state management and proper cleanup of active project data.

<!-- Even better add a screenshot / gif / loom -->