### PR TITLE
fix: pre-aggregate status not updating immediately after rebuild

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -54,7 +54,7 @@ import {
     IconCopy,
     IconFilter,
     IconFolders,
-    IconRefresh,
+    IconRefreshDot,
     IconTableExport,
     IconTelescope,
     IconVariable,
@@ -1371,7 +1371,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                             <Menu.Item
                                                 leftSection={
                                                     <MantineIcon
-                                                        icon={IconRefresh}
+                                                        icon={IconRefreshDot}
                                                     />
                                                 }
                                                 disabled={
@@ -1384,7 +1384,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = (props) => {
                                                     )
                                                 }
                                             >
-                                                Refresh pre-aggregate
+                                                Rebuild pre-aggregate
                                             </Menu.Item>
                                         )}
                                 </Box>

--- a/packages/frontend/src/components/PreAggregateMaterializations/MaterializationDetailDrawer.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/MaterializationDetailDrawer.tsx
@@ -25,7 +25,7 @@ import {
     IconDatabase,
     IconFile,
     IconHourglass,
-    IconRefresh,
+    IconRefreshDot,
     IconTableRow,
 } from '@tabler/icons-react';
 import cronstrue from 'cronstrue';
@@ -256,7 +256,7 @@ const MaterializationDetailDrawer: FC<Props> = ({
                                         Last materialization
                                     </Text>
                                 </Group>
-                                <Tooltip label="Refresh this pre-aggregate">
+                                <Tooltip label="Rebuild this pre-aggregate">
                                     <ActionIcon
                                         variant="subtle"
                                         color="gray"
@@ -267,7 +267,7 @@ const MaterializationDetailDrawer: FC<Props> = ({
                                         }
                                     >
                                         <MantineIcon
-                                            icon={IconRefresh}
+                                            icon={IconRefreshDot}
                                             size="sm"
                                         />
                                     </ActionIcon>

--- a/packages/frontend/src/components/PreAggregateMaterializations/StatusBadge.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/StatusBadge.tsx
@@ -35,7 +35,7 @@ export const StatusBadge: FC<{
         case 'in_progress':
             return (
                 <Badge color="blue" variant="light" size="sm">
-                    In progress
+                    Building
                 </Badge>
             );
         case 'failed':

--- a/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/index.tsx
@@ -34,7 +34,7 @@ import {
     IconFilter,
     IconFilterOff,
     IconHourglass,
-    IconRefresh,
+    IconRefreshDot,
     IconRowInsertBottom,
     IconSearch,
     IconTable,
@@ -81,7 +81,7 @@ type StatusType = PreAggregateMaterializationStatus;
 
 const STATUS_LABELS: Record<StatusType, string> = {
     active: 'Active',
-    in_progress: 'In progress',
+    in_progress: 'Building',
     failed: 'Failed',
     superseded: 'Superseded',
 };
@@ -519,7 +519,7 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                         refreshingDefinitionName ===
                             row.original.preAggregateName;
                     return (
-                        <Tooltip label="Refresh this pre-aggregate">
+                        <Tooltip label="Rebuild this pre-aggregate">
                             <ActionIcon
                                 variant="subtle"
                                 color="gray"
@@ -532,7 +532,7 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                                     );
                                 }}
                             >
-                                <MantineIcon icon={IconRefresh} size="sm" />
+                                <MantineIcon icon={IconRefreshDot} size="sm" />
                             </ActionIcon>
                         </Tooltip>
                     );
@@ -714,12 +714,12 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
                         <Button
                             size="xs"
                             leftSection={
-                                <MantineIcon icon={IconRefresh} size="sm" />
+                                <MantineIcon icon={IconRefreshDot} size="sm" />
                             }
                             loading={isRefreshingAll || hasActiveJobs}
                             onClick={handleRefreshAllClick}
                         >
-                            Refresh all
+                            Rebuild all
                         </Button>
                     </Group>
                 </Group>
@@ -752,13 +752,13 @@ const PreAggregateMaterializations: FC<Props> = ({ projectUuid }) => {
             <MantineModal
                 opened={isRefreshModalOpen}
                 onClose={closeRefreshModal}
-                title="Refresh all pre-aggregates"
-                icon={IconRefresh}
+                title="Rebuild all pre-aggregates"
+                icon={IconRefreshDot}
                 size="lg"
                 onConfirm={handleRefreshAllConfirm}
-                confirmLabel="Refresh all"
+                confirmLabel="Rebuild all"
                 confirmLoading={isRefreshingAll}
-                description="This will refresh all pre-aggregate definitions in this project by re-running their warehouse queries to rebuild the cached data."
+                description="This will rebuild all pre-aggregate definitions in this project by re-running their warehouse queries to regenerate the cached data."
             >
                 <Stack gap="sm">
                     <Text fz="xs" c="ldGray.6">

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -37,7 +37,7 @@ import {
     IconPencil,
     IconPin,
     IconPinnedOff,
-    IconRefresh,
+    IconRefreshDot,
     IconSend,
     IconStar,
     IconStarFilled,
@@ -738,7 +738,7 @@ const DashboardHeader = ({
                                                                 leftSection={
                                                                     <MantineIcon
                                                                         icon={
-                                                                            IconRefresh
+                                                                            IconRefreshDot
                                                                         }
                                                                     />
                                                                 }
@@ -746,7 +746,7 @@ const DashboardHeader = ({
                                                                     preAggRefreshHandlers.open
                                                                 }
                                                             >
-                                                                Refresh
+                                                                Rebuild
                                                                 pre-aggregates
                                                             </Menu.Item>
                                                         )}

--- a/packages/frontend/src/components/common/Dashboard/DashboardPreAggRefreshModal.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardPreAggRefreshModal.tsx
@@ -1,5 +1,5 @@
 import { Code, List, Text } from '@mantine-8/core';
-import { IconRefresh } from '@tabler/icons-react';
+import { IconRefreshDot } from '@tabler/icons-react';
 import { type FC } from 'react';
 import { useRefreshPreAggregateByDefinitionName } from '../../../hooks/usePreAggregateRefresh';
 import MantineModal from '../MantineModal';
@@ -29,15 +29,15 @@ const DashboardPreAggRefreshModal: FC<DashboardPreAggRefreshModalProps> = ({
         <MantineModal
             opened={opened}
             onClose={onClose}
-            title="Refresh pre-aggregates"
-            icon={IconRefresh}
+            title="Rebuild pre-aggregates"
+            icon={IconRefreshDot}
             size="lg"
             onConfirm={handleConfirm}
-            confirmLabel="Refresh"
+            confirmLabel="Rebuild"
             confirmLoading={isLoading}
         >
             <Text fz="sm">
-                This will refresh {preAggregateNames.length} pre-aggregate
+                This will rebuild {preAggregateNames.length} pre-aggregate
                 {preAggregateNames.length === 1 ? '' : 's'} used by this
                 dashboard:
             </Text>

--- a/packages/frontend/src/hooks/usePreAggregateRefresh.ts
+++ b/packages/frontend/src/hooks/usePreAggregateRefresh.ts
@@ -1,5 +1,5 @@
 import { type ApiError } from '@lightdash/common';
-import { IconBolt } from '@tabler/icons-react';
+import { IconRefreshDot } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../api';
 import useSchedulerJobsContext from '../providers/SchedulerJobs/useSchedulerJobsContext';
@@ -30,12 +30,16 @@ export const useRefreshAllPreAggregates = (
         {
             mutationKey: ['refreshAllPreAggregates', projectUuid],
             onSuccess: (data) => {
+                // Immediately refetch so the table shows in_progress status
+                void queryClient.invalidateQueries({
+                    queryKey: ['preAggregateMaterializations', projectUuid],
+                });
                 registerJobs({
                     jobIds: data.jobIds,
                     showToast,
-                    toastKey: 'pre-aggregate-refresh',
-                    toastTitle: 'Pre-aggregate refresh',
-                    toastIcon: IconBolt,
+                    toastKey: 'pre-aggregate-rebuild',
+                    toastTitle: 'Rebuilding pre-aggregates',
+                    toastIcon: IconRefreshDot,
                     onComplete: () => {
                         void queryClient.invalidateQueries({
                             queryKey: [
@@ -48,7 +52,7 @@ export const useRefreshAllPreAggregates = (
             },
             onError: ({ error }) => {
                 showToastApiError({
-                    title: 'Failed to refresh pre-aggregates',
+                    title: 'Failed to rebuild pre-aggregates',
                     apiError: error,
                 });
             },
@@ -84,13 +88,17 @@ export const useRefreshPreAggregateByDefinitionName = (
         {
             mutationKey: ['refreshPreAggregateByDefinitionName', projectUuid],
             onSuccess: (data, preAggregateDefinitionName) => {
+                // Immediately refetch so the table shows in_progress status
+                void queryClient.invalidateQueries({
+                    queryKey: ['preAggregateMaterializations', projectUuid],
+                });
                 registerJobs({
                     jobIds: data.jobIds,
                     label: preAggregateDefinitionName,
                     showToast,
-                    toastKey: 'pre-aggregate-refresh',
-                    toastTitle: 'Pre-aggregate refresh',
-                    toastIcon: IconBolt,
+                    toastKey: 'pre-aggregate-rebuild',
+                    toastTitle: 'Rebuilding pre-aggregate',
+                    toastIcon: IconRefreshDot,
                     onComplete: () => {
                         void queryClient.invalidateQueries({
                             queryKey: [
@@ -103,7 +111,7 @@ export const useRefreshPreAggregateByDefinitionName = (
             },
             onError: ({ error }) => {
                 showToastApiError({
-                    title: 'Failed to refresh pre-aggregate',
+                    title: 'Failed to rebuild pre-aggregate',
                     apiError: error,
                 });
             },


### PR DESCRIPTION

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Fixed the pre-aggregate table not updating status immediately after triggering a rebuild by invalidating the query on trigger, not just on completion. Also renamed "Refresh" to "Rebuild" with a distinct icon to avoid confusion with generic refresh actions.