### PR TITLE
fix: accept verification in content-as-code lint schemas

### DIFF
--- a/packages/common/src/schemas/json/chart-as-code-1.0.json
+++ b/packages/common/src/schemas/json/chart-as-code-1.0.json
@@ -730,6 +730,31 @@
             "enum": ["chart"],
             "type": "string"
         },
+        "ContentVerificationInfo": {
+            "properties": {
+                "verifiedAt": {
+                    "format": "date-time",
+                    "type": "string"
+                },
+                "verifiedBy": {
+                    "properties": {
+                        "firstName": {
+                            "type": "string"
+                        },
+                        "lastName": {
+                            "type": "string"
+                        },
+                        "userUuid": {
+                            "type": "string"
+                        }
+                    },
+                    "required": ["lastName", "firstName", "userUuid"],
+                    "type": "object"
+                }
+            },
+            "required": ["verifiedAt", "verifiedBy"],
+            "type": "object"
+        },
         "CustomBinDimension": {
             "anyOf": [
                 {
@@ -3257,6 +3282,21 @@
             "description": "Not modifiable by user, but useful to know if it has been updated. Defaults to now if omitted.",
             "format": "date-time",
             "type": "string"
+        },
+        "verification": {
+            "anyOf": [
+                {
+                    "allOf": [
+                        {
+                            "$ref": "#/$defs/ContentVerificationInfo"
+                        }
+                    ],
+                    "description": "Verification status of this chart. Read-only; ignored on upload."
+                },
+                {
+                    "type": "null"
+                }
+            ]
         },
         "version": {
             "const": 1,

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -40,6 +40,39 @@
             "format": "date-time",
             "description": "Timestamp when the dashboard was last updated (readonly)"
         },
+        "verification": {
+            "description": "Verification status of this dashboard. Read-only; ignored on upload.",
+            "oneOf": [
+                {
+                    "type": "object",
+                    "required": ["verifiedAt", "verifiedBy"],
+                    "properties": {
+                        "verifiedAt": {
+                            "type": "string",
+                            "format": "date-time"
+                        },
+                        "verifiedBy": {
+                            "type": "object",
+                            "required": ["firstName", "lastName", "userUuid"],
+                            "properties": {
+                                "firstName": {
+                                    "type": "string"
+                                },
+                                "lastName": {
+                                    "type": "string"
+                                },
+                                "userUuid": {
+                                    "type": "string"
+                                }
+                            }
+                        }
+                    }
+                },
+                {
+                    "type": "null"
+                }
+            ]
+        },
         "downloadedAt": {
             "type": "string",
             "format": "date-time",


### PR DESCRIPTION
## Summary
- update the chart-as-code schema to allow the optional `verification` field
- update the dashboard-as-code schema to allow the optional `verification` field
- align `lightdash lint` validation with content exported from Lightdash

## Testing
- `pnpm -F cli dev lint --path /Users/giorgi/develop/lightdash-demo-data-gardening/lightdash/charts/aoispjdo.yml`
- `pnpm -F cli dev lint --path /Users/giorgi/develop/lightdash-demo-data-gardening/lightdash/dashboards/sales-example.yml`
- confirmed dashboard lint no longer fails on `verification`; remaining errors are unrelated existing markdown tile schema issues