### PR TITLE
fix(e2e): add table search step to userAttributes tests

### DIFF
--- a/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
+++ b/packages/e2e/cypress/e2e/app/userAttributes.cy.ts
@@ -25,6 +25,7 @@ describe('User attributes sql_filter', () => {
     it('Error on runquery if user attribute does not exist', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
+        cy.findByPlaceholderText('Search tables').type('Users');
         cy.findByText('Users').click();
         cy.findByText('First name').click();
 
@@ -55,6 +56,7 @@ describe('User attributes sql_filter', () => {
     it('Should return results with user attribute', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
+        cy.findByPlaceholderText('Search tables').type('Users');
         cy.findByText('Users').click();
         cy.findByText('First name').click();
 
@@ -75,6 +77,7 @@ describe('User attributes sql_filter', () => {
     it('Should return results with new user attribute', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
+        cy.findByPlaceholderText('Search tables').type('Users');
         cy.findByText('Users').click();
         cy.findByText('First name').click();
 
@@ -127,6 +130,7 @@ describe('User attributes dimension required_attribute', () => {
     it('Should not see last_name dimension', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
+        cy.findByPlaceholderText('Search tables').type('Users');
         cy.findByText('Users').click();
         cy.findByText('Last name').should('not.exist');
     });
@@ -147,6 +151,7 @@ describe('User attributes dimension required_attribute', () => {
     it('Should see last_name attribute', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
+        cy.findByPlaceholderText('Search tables').type('Users');
         cy.findByText('Users').click();
         cy.findByText('Last name').click();
 
@@ -167,6 +172,7 @@ describe('User attributes dimension required_attribute', () => {
     it('Should not see last_name dimension', () => {
         cy.visit(`/projects/${SEED_PROJECT.project_uuid}/tables`);
 
+        cy.findByPlaceholderText('Search tables').type('Users');
         cy.findByText('Users').click();
         cy.findByText('Last name').should('not.exist');
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Added search functionality to user attributes E2E tests by typing "Users" in the search tables input field before clicking on the Users table. This change improves test reliability by ensuring the Users table is visible and accessible in the table list before attempting to interact with it.

<!-- Even better add a screenshot / gif / loom -->

test-e2e