### PR TITLE
fix: optimize DuckDB S3 secret creation to run once per instance

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -329,7 +329,7 @@ describe('DuckdbWarehouseClient', () => {
         expect(streamMock).toHaveBeenCalledTimes(1);
     });
 
-    it('should serialize S3 secret creation across concurrent sessions without skipping', async () => {
+    it('should create S3 secret once and skip on subsequent connections', async () => {
         let releaseSecretCreation: (() => void) | undefined;
         const secretCreationBlocked = new Promise<void>((resolve) => {
             releaseSecretCreation = resolve;
@@ -338,7 +338,7 @@ describe('DuckdbWarehouseClient', () => {
         const runMock = jest.fn(async (sql: string) => {
             if (sql.includes('CREATE OR REPLACE SECRET __lightdash_s3')) {
                 secretCreateCount += 1;
-                // Only block the first CREATE SECRET call
+                // Block the first CREATE SECRET call
                 if (secretCreateCount === 1) {
                     await secretCreationBlocked;
                 }
@@ -370,22 +370,21 @@ describe('DuckdbWarehouseClient', () => {
             setImmediate(resolve);
         });
 
-        // First CREATE SECRET is blocked; second should not have started yet
-        // (serialized via the shared bootstrap lock)
+        // First CREATE SECRET is blocked; second waits behind the bootstrap lock
         expect(secretCreateCount).toBe(1);
 
         releaseSecretCreation?.();
 
         await Promise.all([firstQuery, secondQuery]);
 
-        // Both connections should create the secret (one each, serialized)
+        // Secret is instance-level — created once, skipped on second connection
         expect(
             runMock.mock.calls.filter(([sql]) =>
                 (sql as string).includes(
                     'CREATE OR REPLACE SECRET __lightdash_s3',
                 ),
             ),
-        ).toHaveLength(2);
+        ).toHaveLength(1);
         expect(streamMock).toHaveBeenCalledTimes(2);
     });
 

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -167,6 +167,7 @@ export class DuckdbSqlBuilder extends WarehouseBaseSqlBuilder {
 let sharedInstance: DuckdbInstance | null = null;
 let httpfsInstalled = false;
 let cachesConfigured = false;
+let s3SecretConfigured = false;
 let sharedBootstrapQueue: Promise<void> = Promise.resolve();
 
 /**
@@ -215,6 +216,7 @@ async function getOrCreateSharedInstance(
         const createMs = performance.now() - t0;
         httpfsInstalled = false;
         cachesConfigured = false;
+        s3SecretConfigured = false;
         logger?.info(
             `DuckDB shared instance created: path=${databasePath} createMs=${Math.round(createMs)}ms`,
         );
@@ -234,6 +236,7 @@ function clearSharedInstance(logger?: DuckdbLogger): void {
         sharedInstance = null;
         httpfsInstalled = false;
         cachesConfigured = false;
+        s3SecretConfigured = false;
         sharedBootstrapQueue = Promise.resolve();
         logger?.info('DuckDB shared instance cleared');
     }
@@ -244,6 +247,7 @@ export function resetSharedDuckdbStateForTesting(): void {
     sharedInstance = null;
     httpfsInstalled = false;
     cachesConfigured = false;
+    s3SecretConfigured = false;
     sharedBootstrapQueue = Promise.resolve();
 }
 
@@ -437,11 +441,12 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             return;
         }
 
-        // CREATE SECRET on every connection — DuckDB secrets may not reliably
-        // persist across connections on all DuckDB versions, so always set it.
-        // Serialize via the lock to avoid "Catalog write-write conflict on alter"
-        // when concurrent connections both run CREATE OR REPLACE SECRET.
+        // DuckDB secrets are instance-level — they persist across all
+        // connections on the same instance. Create once and skip on
+        // subsequent connections.
         const s3ConfigMs = await withSharedBootstrapLock(async () => {
+            if (s3SecretConfigured) return 0;
+
             const t2 = performance.now();
 
             const regionClause = this.s3Config!.region
@@ -463,6 +468,11 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
                 URL_STYLE '${this.s3Config!.forcePathStyle ? 'path' : 'vhost'}',
                 USE_SSL ${this.s3Config!.useSsl}
             );`);
+
+            s3SecretConfigured = true;
+            this.logger?.info(
+                `DuckDB S3 secret configured (first use): ${Math.round(performance.now() - t2)}ms`,
+            );
 
             return performance.now() - t2;
         });


### PR DESCRIPTION
### Description:
The S3 secret was being recreated on every DuckDB connection, forcing all concurrent pre-aggregate queries to serialize behind a lock. Since secrets are instance-level in DuckDB, they only need to be created once