### PR TITLE
feat: add space metadata to downloads

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -27,6 +27,7 @@ import {
     SavedChartDAO,
     SessionUser,
     Space,
+    SpaceAsCode,
     SpaceMemberRole,
     SqlChartAsCode,
     UpdatedByUser,
@@ -160,9 +161,19 @@ export class CoderService extends BaseService {
         this.contentVerificationModel = contentVerificationModel;
     }
 
+    private static transformSpaces(
+        spaces: Pick<SpaceSummaryBase, 'uuid' | 'name' | 'path'>[],
+    ): SpaceAsCode[] {
+        return spaces.map((space) => ({
+            contentType: ContentAsCodeType.SPACE,
+            spaceName: space.name,
+            slug: getContentAsCodePathFromLtreePath(space.path),
+        }));
+    }
+
     private static transformChart(
         chart: SavedChartDAO,
-        spaceSummary: Pick<SpaceSummaryBase, 'uuid' | 'path'>[],
+        spaceSummary: Pick<SpaceSummaryBase, 'uuid' | 'name' | 'path'>[],
         dashboardSlugs: Record<string, string>,
         verificationMap: Map<string, ContentVerificationInfo>,
     ): ChartAsCode {
@@ -345,7 +356,7 @@ export class CoderService extends BaseService {
 
     private static transformDashboard(
         dashboard: DashboardDAO,
-        spaceSummary: Pick<SpaceSummaryBase, 'uuid' | 'path'>[],
+        spaceSummary: Pick<SpaceSummaryBase, 'uuid' | 'name' | 'path'>[],
         verificationMap: Map<string, ContentVerificationInfo>,
     ): DashboardAsCode {
         const contentSpace = spaceSummary.find(
@@ -620,6 +631,7 @@ export class CoderService extends BaseService {
                 dashboards: [],
                 languageMap: undefined,
                 missingIds: dashboardIds || [],
+                spaces: [],
                 total: 0,
                 offset: 0,
             };
@@ -707,6 +719,7 @@ export class CoderService extends BaseService {
                   })
                 : undefined,
             missingIds,
+            spaces: CoderService.transformSpaces(spaces),
             total: dashboardSummariesWithAccess.length,
             offset: newOffset,
         };
@@ -748,6 +761,7 @@ export class CoderService extends BaseService {
                 charts: [],
                 languageMap: undefined,
                 missingIds: chartIds || [],
+                spaces: [],
                 total: 0,
                 offset: 0,
             };
@@ -832,6 +846,7 @@ export class CoderService extends BaseService {
                   })
                 : undefined,
             missingIds,
+            spaces: CoderService.transformSpaces(spaces),
             total: chartsSummariesWithAccess.length,
             offset: newOffset,
         };
@@ -845,6 +860,7 @@ export class CoderService extends BaseService {
     ): Promise<{
         sqlCharts: SqlChartAsCode[];
         missingIds: string[];
+        spaces: SpaceAsCode[];
         total: number;
         offset: number;
     }> {
@@ -875,6 +891,7 @@ export class CoderService extends BaseService {
             return {
                 sqlCharts: [],
                 missingIds: chartIds || [],
+                spaces: [],
                 total: 0,
                 offset: 0,
             };
@@ -948,6 +965,7 @@ export class CoderService extends BaseService {
         return {
             sqlCharts: transformedSqlCharts,
             missingIds,
+            spaces: CoderService.transformSpaces(sqlChartSpaces),
             total: accessibleSqlChartRows.length,
             offset: newOffset,
         };

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -19,6 +19,7 @@ import {
     PromotionAction,
     PromotionChanges,
     SqlChartAsCode,
+    type SpaceAsCode,
 } from '@lightdash/common';
 import { Dirent, promises as fs, type Stats } from 'fs';
 import * as yaml from 'js-yaml';
@@ -201,6 +202,48 @@ const writeContent = async (
         type: metadataType,
         downloadedAt: downloadedAtString,
     };
+};
+
+/**
+ * Writes space YAML files for each space in the download results.
+ * In flat mode, files go in the base download directory.
+ * In nested mode, files go in the root of each space's directory.
+ */
+const writeSpaceFiles = async (
+    spaces: SpaceAsCode[],
+    projectName: string,
+    customPath?: string,
+    folderScheme: FolderScheme = 'flat',
+): Promise<void> => {
+    if (spaces.length === 0) return;
+
+    const baseDir = getDownloadFolder(customPath);
+    const seen = new Set<string>();
+
+    for (const space of spaces) {
+        // Deduplicate across paginated API responses
+        if (!seen.has(space.slug)) {
+            seen.add(space.slug);
+
+            let outputDir: string;
+            if (folderScheme === 'nested') {
+                outputDir = path.join(baseDir, projectName, space.slug);
+            } else {
+                outputDir = baseDir;
+            }
+
+            await fs.mkdir(outputDir, { recursive: true });
+
+            const fileName = `${generateSlug(space.spaceName)}.space.yml`;
+            const filePath = path.join(outputDir, fileName);
+            const content = yaml.dump(space, {
+                quotingType: '"',
+                sortKeys: true,
+            });
+            await fs.writeFile(filePath, content);
+            GlobalState.debug(`Wrote space file: ${filePath}`);
+        }
+    }
 };
 
 const hasUnsortedKeys = (obj: unknown): boolean => {
@@ -408,6 +451,8 @@ const readLooseCodeFiles = async (
                                 metadata,
                             ),
                         );
+                    } else if (contentType === ContentAsCodeTypeEnum.SPACE) {
+                        // Space YAML files are metadata-only until the next PR
                     } else {
                         GlobalState.debug(
                             `Skipping ${file.name}: no recognized contentType`,
@@ -560,6 +605,7 @@ export const downloadContent = async (
     let total = 0;
     let chartSlugs: string[] = [];
     let allMetadataEntries: MetadataEntry[] = [];
+    let allSpaces: SpaceAsCode[] = [];
 
     do {
         GlobalState.debug(
@@ -656,9 +702,17 @@ export const downloadContent = async (
             }
         }
 
+        // Accumulate space metadata from each page
+        if ('spaces' in results && results.spaces) {
+            allSpaces = [...allSpaces, ...results.spaces];
+        }
+
         offset = results.offset;
         total = results.total;
     } while (offset < total);
+
+    // Write space YAML files
+    await writeSpaceFiles(allSpaces, projectName, customPath, folderScheme);
 
     return [total, [...new Set(chartSlugs)], allMetadataEntries];
 };

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -23,6 +23,7 @@ export enum ContentAsCodeType {
     CHART = 'chart',
     DASHBOARD = 'dashboard',
     SQL_CHART = 'sql_chart',
+    SPACE = 'space',
 }
 
 /**
@@ -110,6 +111,7 @@ export type ApiChartAsCodeListResponse = {
               >
             | undefined;
         missingIds: string[];
+        spaces: SpaceAsCode[];
         total: number;
         offset: number;
     };
@@ -130,6 +132,7 @@ export type ApiSqlChartAsCodeListResponse = {
     results: {
         sqlCharts: SqlChartAsCode[];
         missingIds: string[];
+        spaces: SpaceAsCode[];
         total: number;
         offset: number;
     };
@@ -172,6 +175,14 @@ export type DashboardAsCode = Pick<
     verification?: ContentVerificationInfo | null;
 };
 
+export type SpaceAsCode = {
+    contentType: ContentAsCodeType.SPACE;
+    /** The original human-readable space name (preserves emoji, casing, etc.) */
+    spaceName: string;
+    /** The space slug used for file naming and cross-referencing */
+    slug: string;
+};
+
 export type ApiDashboardAsCodeListResponse = {
     status: 'ok';
     results: {
@@ -186,6 +197,7 @@ export type ApiDashboardAsCodeListResponse = {
               >
             | undefined;
         missingIds: string[];
+        spaces: SpaceAsCode[];
         total: number;
         offset: number;
     };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: GLITCH-266

### Description:

This PR adds space metadata support to the code-as-code download functionality. When downloading we now create a space file for each space with the slug and the space name. 

Currently not used in upload. Thats next. 