### PR TITLE
fix: add stream and consumer updates to NATS client configuration

### DIFF
--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -182,7 +182,7 @@ export default class NatsWorkerApp {
     }> {
         const natsClient = this.clients.getNatsClient();
         await natsClient.connect();
-        await natsClient.ensureStreams(
+        await natsClient.ensureStreamsAndConsumers(
             this.streams.map((stream) => STREAM_CONFIGS[stream]),
         );
 

--- a/packages/backend/src/clients/NatsClient.ts
+++ b/packages/backend/src/clients/NatsClient.ts
@@ -6,10 +6,12 @@ import {
     DebugEvents,
     Events,
     nanos,
+    NatsError,
     RetentionPolicy,
     StorageType,
     StringCodec,
     type JetStreamClient,
+    type JetStreamManager,
     type NatsConnection,
     type Status,
 } from 'nats';
@@ -109,43 +111,84 @@ export class NatsClient implements INatsClient {
 
     // ── Stream infrastructure ───────────────────────────────────
 
-    /** Idempotently create the selected streams + consumers for worker startup. */
-    async ensureStreams(streams: StreamConfig[]): Promise<void> {
-        this.managedStreams = streams;
+    async ensureStreamsAndConsumers(
+        managedStreams: StreamConfig[],
+    ): Promise<void> {
+        this.managedStreams = managedStreams;
         if (this.managedStreams.length === 0) return;
 
         const conn = await this.getOrCreateConnection();
         const jsm = await conn.jetstreamManager();
         await Promise.all(
-            this.managedStreams.map(
-                async (config: StreamConfig): Promise<void> => {
-                    await jsm.streams.add({
-                        name: config.streamName,
-                        subjects: Object.values(config.subjects),
-                        retention: RetentionPolicy.Workqueue,
-                        storage: StorageType.Memory,
-                        num_replicas: 1,
-                    });
-
-                    // consumers.add with filter_subjects uses the old
-                    // DURABLE.CREATE API which is not idempotent — check first
-                    const consumerExists = await jsm.consumers
-                        .info(config.streamName, config.durableName)
-                        .then(() => true)
-                        .catch(() => false);
-
-                    if (!consumerExists) {
-                        await jsm.consumers.add(config.streamName, {
-                            durable_name: config.durableName,
-                            filter_subjects: Object.values(config.subjects),
-                            ack_policy: AckPolicy.Explicit,
-                            ack_wait: nanos(ACK_WAIT_MS),
-                            max_deliver: 1,
-                        });
-                    }
-                },
-            ),
+            this.managedStreams.map(async (streamConfig: StreamConfig) => {
+                await NatsClient.ensureStream(jsm, streamConfig);
+                await NatsClient.ensureConsumer(jsm, streamConfig);
+            }),
         );
+    }
+
+    private static async ensureStream(
+        jsm: JetStreamManager,
+        streamConfig: StreamConfig,
+    ): Promise<void> {
+        const subjects = Object.values(streamConfig.subjects);
+
+        const existing = await jsm.streams
+            .info(streamConfig.streamName)
+            .catch((e: unknown) => {
+                if (e instanceof NatsError && e.code === '404') return null;
+                throw e;
+            });
+
+        const jetStreamConfig = {
+            subjects,
+            retention: RetentionPolicy.Workqueue,
+            storage: StorageType.Memory,
+            num_replicas: 1,
+        };
+
+        if (existing) {
+            await jsm.streams.update(streamConfig.streamName, jetStreamConfig);
+        } else {
+            await jsm.streams.add({
+                name: streamConfig.streamName,
+                ...jetStreamConfig,
+            });
+        }
+    }
+
+    private static async ensureConsumer(
+        jsm: JetStreamManager,
+        streamConfig: StreamConfig,
+    ): Promise<void> {
+        const subjects = Object.values(streamConfig.subjects);
+
+        const existing = await jsm.consumers
+            .info(streamConfig.streamName, streamConfig.durableName)
+            .catch((e: unknown) => {
+                if (e instanceof NatsError && e.code === '404') return null;
+                throw e;
+            });
+
+        const jetStreamConsumerConfig = {
+            filter_subjects: subjects,
+            ack_policy: AckPolicy.Explicit,
+            ack_wait: nanos(ACK_WAIT_MS),
+            max_deliver: 1,
+        };
+
+        if (existing) {
+            await jsm.consumers.update(
+                streamConfig.streamName,
+                streamConfig.durableName,
+                jetStreamConsumerConfig,
+            );
+        } else {
+            await jsm.consumers.add(streamConfig.streamName, {
+                durable_name: streamConfig.durableName,
+                ...jetStreamConsumerConfig,
+            });
+        }
     }
 
     // ── Publishing (INatsClient) ─────────────────────────────
@@ -222,7 +265,7 @@ export class NatsClient implements INatsClient {
                 return;
             case Events.Reconnect:
                 Logger.info(`${tag} reconnected to ${status.data}`);
-                this.reensureManagedStreams().catch((error) => {
+                this.reconnectStreamsAndConsumers().catch((error) => {
                     Logger.error(
                         `${tag} failed to re-ensure streams after reconnect: ${getErrorMessage(error)}`,
                     );
@@ -323,8 +366,7 @@ export class NatsClient implements INatsClient {
         );
     }
 
-    private async reensureManagedStreams(): Promise<void> {
-        if (this.managedStreams.length === 0) return;
-        await this.ensureStreams(this.managedStreams);
+    private async reconnectStreamsAndConsumers(): Promise<void> {
+        await this.ensureStreamsAndConsumers(this.managedStreams);
     }
 }


### PR DESCRIPTION
The `ensureStreams` method now properly updates existing NATS streams and consumers with new configurations rather than just checking for their existence:

- Added `NatsError` import for proper error handling
- Replaced simple existence checks with proper error handling using NATS 404 error codes
- Implemented stream updates for existing streams using `jsm.streams.update()`
- Implemented consumer updates for existing consumers using `jsm.consumers.update()`
- Extracted stream and consumer configurations into reusable objects
- Improved error handling by catching and properly identifying 404 errors vs other exceptions
