### PR TITLE
fix: prevent derived explores from breaking validation field lookups

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -267,10 +267,7 @@ describe('validation', () => {
     it('Should validate only dashboards in project', async () => {
         (
             projectModel.findExploresFromCache as jest.Mock
-        ).mockImplementationOnce(async () => [
-            explore,
-            exploreWithoutDimension,
-        ]);
+        ).mockImplementationOnce(async () => [exploreWithoutDimension]);
 
         const errors = await validationService.generateValidation(
             'projectUuid',
@@ -447,6 +444,35 @@ describe('validation', () => {
 
         // Chart uses "additional_explore" as tableName but has same fields as base "table"
         // Should validate without errors because fields are indexed by both baseTable and explore name
+        expect(errors.length).toEqual(0);
+    });
+
+    it('Should not let derived explores overwrite base table validation fields', async () => {
+        const preAggregateLikeExplore = {
+            ...explore,
+            name: '__preagg__table__daily',
+            tables: {
+                table: {
+                    ...explore.tables.table!,
+                    dimensions: {},
+                    metrics: {},
+                },
+            },
+        };
+
+        (
+            projectModel.findExploresFromCache as jest.Mock
+        ).mockImplementationOnce(async () => [
+            explore,
+            preAggregateLikeExplore,
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.CHARTS]),
+        );
+
         expect(errors.length).toEqual(0);
     });
 });

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -79,7 +79,10 @@ export class ValidationService extends BaseService {
 
         compiledExplores.forEach((explore: Explore | ExploreError) => {
             if (!isExploreError(explore)) {
-                // For validation, index by both baseTable and explore name
+                // For validation, index by both baseTable and explore name.
+                // The base table key should always resolve to the canonical
+                // explore, not a derived explore (for example pre-aggregates)
+                // that only contains a subset of fields.
                 const dimensions = Object.values(explore.tables).flatMap(
                     (table) => Object.values(table.dimensions || {}),
                 );
@@ -90,8 +93,19 @@ export class ValidationService extends BaseService {
                     dimensionIds: dimensions.map(getItemId),
                     metricIds: metrics.map(getItemId),
                 };
-                // Index by baseTable
-                exploreFields[explore.baseTable] = fieldData;
+                const isCanonicalExploreForBaseTable =
+                    explore.name === explore.baseTable;
+
+                // Index by baseTable, but only for the canonical explore for
+                // that base table. Additional explores and pre-aggregates can
+                // share the same baseTable, but charts saved against the
+                // baseTable should validate against the canonical base explore.
+                if (
+                    isCanonicalExploreForBaseTable ||
+                    exploreFields[explore.baseTable] === undefined
+                ) {
+                    exploreFields[explore.baseTable] = fieldData;
+                }
                 // Also index by explore name if different
                 if (explore.name !== explore.baseTable) {
                     exploreFields[explore.name] = fieldData;


### PR DESCRIPTION
## Summary
- keep base-table validation field lookups pinned to the canonical explore instead of allowing derived explores to overwrite them
- add a regression test covering a derived explore with the same `baseTable` but a reduced field set
- clean up the dashboard validation test so it reflects the intended behavior instead of relying on the previous collision bug
- include the investigation notes in `bugreport.md`

## Testing
- `LIGHTDASH_SECRET=test-secret SECURE_COOKIES=false TRUST_PROXY=false NODE_ENV=test pnpm -F backend test-sequential -- ValidationService.test.ts`