### PR TITLE
refactor: isolate DuckDB sessions with resource limits

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -334,22 +334,23 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         }
     }
 
-    private async withSession<T>(
+    /** Ephemeral DuckDB instance with resource limits (e.g. parquet conversion). */
+    private async withIsolatedSession<T>(
         callback: (db: DuckdbConnection) => Promise<T>,
     ): Promise<T> {
         const sessionStart = performance.now();
 
-        const connection = await this.connectWithRetry();
+        const instance = await DuckDBInstance.create(this.databasePath);
+        const connection = await instance.connect();
         const connectMs = performance.now() - sessionStart;
 
-        // Only create a temp dir when resource limits are set (spill to disk).
-        const tempDir = this.resourceLimits
-            ? await fs.mkdtemp(path.join(os.tmpdir(), 'duckdb-temp-'))
-            : undefined;
+        const tempDir = await fs.mkdtemp(
+            path.join(os.tmpdir(), 'duckdb-temp-'),
+        );
 
         try {
             const bootstrapStart = performance.now();
-            await this.bootstrapSession(connection, tempDir);
+            await this.bootstrapIsolatedSession(connection, tempDir);
             const bootstrapMs = performance.now() - bootstrapStart;
 
             const queryStart = performance.now();
@@ -358,28 +359,84 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
 
             const totalMs = performance.now() - sessionStart;
             this.logger?.info(
-                `DuckDB session timing: connect=${Math.round(connectMs)}ms bootstrap=${Math.round(bootstrapMs)}ms query=${Math.round(queryMs)}ms total=${Math.round(totalMs)}ms`,
+                `DuckDB isolated session timing: connect=${Math.round(connectMs)}ms bootstrap=${Math.round(bootstrapMs)}ms query=${Math.round(queryMs)}ms total=${Math.round(totalMs)}ms`,
             );
 
             return result;
         } finally {
             connection.closeSync?.();
             connection.disconnectSync?.();
-            // Note: we do NOT close the instance — it's shared across queries
-            if (tempDir) {
-                await fs.rm(tempDir, { recursive: true, force: true }).catch(
-                    () => {}, // best-effort cleanup
-                );
-            }
+            instance.closeSync?.();
+            await fs.rm(tempDir, { recursive: true, force: true }).catch(
+                () => {}, // best-effort cleanup
+            );
         }
     }
 
-    private async bootstrapSession(
-        db: DuckdbConnection,
-        tempDir: string | undefined,
-    ): Promise<void> {
-        // INSTALL httpfs and global settings are instance-level — serialize and
-        // deduplicate them via the shared bootstrap lock.
+    private async withSession<T>(
+        callback: (db: DuckdbConnection) => Promise<T>,
+    ): Promise<T> {
+        if (this.resourceLimits) {
+            return this.withIsolatedSession(callback);
+        }
+
+        const sessionStart = performance.now();
+
+        const connection = await this.connectWithRetry();
+        const connectMs = performance.now() - sessionStart;
+
+        try {
+            const bootstrapStart = performance.now();
+            await this.bootstrapSession(connection);
+            const bootstrapMs = performance.now() - bootstrapStart;
+
+            const queryStart = performance.now();
+            const result = await callback(connection);
+            const queryMs = performance.now() - queryStart;
+
+            const totalMs = performance.now() - sessionStart;
+            this.logger?.info(
+                `DuckDB shared session (reusing instance): connect=${Math.round(connectMs)}ms bootstrap=${Math.round(bootstrapMs)}ms query=${Math.round(queryMs)}ms total=${Math.round(totalMs)}ms`,
+            );
+
+            return result;
+        } finally {
+            connection.closeSync?.();
+            connection.disconnectSync?.();
+        }
+    }
+
+    private buildS3SecretSql(s3Config: DuckdbS3SessionConfig): string {
+        const regionClause = s3Config.region
+            ? `REGION '${this.escapeString(s3Config.region)}',`
+            : '';
+        const keyIdClause = s3Config.accessKey
+            ? `KEY_ID '${this.escapeString(s3Config.accessKey)}',`
+            : '';
+        const secretClause = s3Config.secretKey
+            ? `SECRET '${this.escapeString(s3Config.secretKey)}',`
+            : '';
+
+        return `CREATE OR REPLACE SECRET __lightdash_s3 (
+            TYPE s3,
+            ${keyIdClause}
+            ${secretClause}
+            ENDPOINT '${this.escapeString(s3Config.endpoint)}',
+            ${regionClause}
+            URL_STYLE '${s3Config.forcePathStyle ? 'path' : 'vhost'}',
+            USE_SSL ${s3Config.useSsl}
+        );`;
+    }
+
+    private static async hardenInstance(db: DuckdbConnection): Promise<void> {
+        await db.run('SET allow_community_extensions = false;');
+        await db.run('SET autoinstall_known_extensions = false;');
+        await db.run('SET autoload_known_extensions = false;');
+        await db.run('SET allow_unredacted_secrets = false;');
+    }
+
+    /** Bootstrap for the shared query instance — deduplicates via shared locks. */
+    private async bootstrapSession(db: DuckdbConnection): Promise<void> {
         const installMs = await withSharedBootstrapLock(async () => {
             let nextInstallMs = 0;
 
@@ -393,17 +450,12 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
                 );
             }
 
-            // Enable built-in caches. These are global settings and should not
-            // be mutated concurrently on the shared instance.
             if (!cachesConfigured) {
                 await db.run('SET enable_http_metadata_cache = true;');
                 await db.run('SET enable_external_file_cache = true;');
                 await db.run('SET parquet_metadata_cache = true;');
 
-                await db.run('SET allow_community_extensions = false;');
-                await db.run('SET autoinstall_known_extensions = false;');
-                await db.run('SET autoload_known_extensions = false;');
-                await db.run('SET allow_unredacted_secrets = false;');
+                await DuckdbWarehouseClient.hardenInstance(db);
 
                 cachesConfigured = true;
 
@@ -421,18 +473,9 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             return nextInstallMs;
         });
 
-        // LOAD httpfs is per-connection — always run it.
         const t1 = performance.now();
         await db.run('LOAD httpfs;');
         const loadMs = performance.now() - t1;
-
-        if (this.resourceLimits && tempDir) {
-            await db.run(
-                `SET memory_limit = '${this.resourceLimits.memoryLimit}';`,
-            );
-            await db.run(`SET temp_directory = '${tempDir}';`);
-            await db.run(`SET threads = ${this.resourceLimits.threads};`);
-        }
 
         if (!this.s3Config) {
             this.logger?.info(
@@ -441,34 +484,11 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             return;
         }
 
-        // DuckDB secrets are instance-level — they persist across all
-        // connections on the same instance. Create once and skip on
-        // subsequent connections.
         const s3ConfigMs = await withSharedBootstrapLock(async () => {
             if (s3SecretConfigured) return 0;
 
             const t2 = performance.now();
-
-            const regionClause = this.s3Config!.region
-                ? `REGION '${this.escapeString(this.s3Config!.region)}',`
-                : '';
-            const keyIdClause = this.s3Config!.accessKey
-                ? `KEY_ID '${this.escapeString(this.s3Config!.accessKey)}',`
-                : '';
-            const secretClause = this.s3Config!.secretKey
-                ? `SECRET '${this.escapeString(this.s3Config!.secretKey)}',`
-                : '';
-
-            await db.run(`CREATE OR REPLACE SECRET __lightdash_s3 (
-                TYPE s3,
-                ${keyIdClause}
-                ${secretClause}
-                ENDPOINT '${this.escapeString(this.s3Config!.endpoint)}',
-                ${regionClause}
-                URL_STYLE '${this.s3Config!.forcePathStyle ? 'path' : 'vhost'}',
-                USE_SSL ${this.s3Config!.useSsl}
-            );`);
-
+            await db.run(this.buildS3SecretSql(this.s3Config!));
             s3SecretConfigured = true;
             this.logger?.info(
                 `DuckDB S3 secret configured (first use): ${Math.round(performance.now() - t2)}ms`,
@@ -479,6 +499,30 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
 
         this.logger?.info(
             `DuckDB bootstrap timing: install_httpfs=${Math.round(installMs)}ms load_httpfs=${Math.round(loadMs)}ms s3_config=${Math.round(s3ConfigMs)}ms`,
+        );
+    }
+
+    /** Bootstrap for isolated instances — no shared locks needed. */
+    private async bootstrapIsolatedSession(
+        db: DuckdbConnection,
+        tempDir: string,
+    ): Promise<void> {
+        await db.run('INSTALL httpfs;');
+        await db.run('LOAD httpfs;');
+        await DuckdbWarehouseClient.hardenInstance(db);
+
+        await db.run(
+            `SET memory_limit = '${this.resourceLimits!.memoryLimit}';`,
+        );
+        await db.run(`SET temp_directory = '${tempDir}';`);
+        await db.run(`SET threads = ${this.resourceLimits!.threads};`);
+
+        if (this.s3Config) {
+            await db.run(this.buildS3SecretSql(this.s3Config));
+        }
+
+        this.logger?.info(
+            `DuckDB isolated bootstrap: memory_limit=${this.resourceLimits!.memoryLimit} threads=${this.resourceLimits!.threads}`,
         );
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:  
  
#### Tests

  
**During materialization (2 concurrent materializations):**

```  
DuckDB isolated bootstrap: memory_limit=256MB threads=1
DuckDB isolated session timing: connect=19ms bootstrap=25ms query=24ms total=70ms
Parquet conversion complete: rows=148 jsonlBytes=48181 duckdbMs=75

DuckDB isolated bootstrap: memory_limit=256MB threads=1
DuckDB isolated session timing: connect=5ms bootstrap=12ms query=5ms total=23ms
Parquet conversion complete: rows=123 jsonlBytes=23022 duckdbMs=24

```  

**During pre-aggregate queries (5 concurrent curls):**

```  
DuckDB bootstrap timing: install_httpfs=0ms load_httpfs=1ms s3_config=0ms
DuckDB shared session (reusing instance): connect=4ms bootstrap=1ms query=5ms total=10ms

DuckDB bootstrap timing: install_httpfs=0ms load_httpfs=0ms s3_config=0ms
DuckDB shared session (reusing instance): connect=0ms bootstrap=0ms query=5ms total=6ms

DuckDB bootstrap timing: install_httpfs=0ms load_httpfs=0ms s3_config=0ms
DuckDB shared session (reusing instance): connect=0ms bootstrap=0ms query=4ms total=5ms

DuckDB bootstrap timing: install_httpfs=0ms load_httpfs=0ms s3_config=0ms
DuckDB shared session (reusing instance): connect=0ms bootstrap=0ms query=4ms total=4ms

DuckDB bootstrap timing: install_httpfs=0ms load_httpfs=0ms s3_config=0ms
DuckDB shared session (reusing instance): connect=0ms bootstrap=0ms query=5ms total=6ms  
```
