### PR TITLE
fix: prevent string-derived time filters from satisfying required date filters

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -1551,6 +1551,86 @@ describe('Query builder', () => {
         );
     });
 
+    it('Should not let string-derived time filters satisfy required date filters', () => {
+        const exploreWithStringDerivedTimeDimension: Explore = {
+            ...EXPLORE_WITH_DATE_DIMENSION,
+            tables: {
+                ...EXPLORE_WITH_DATE_DIMENSION.tables,
+                orders: {
+                    ...EXPLORE_WITH_DATE_DIMENSION.tables.orders,
+                    requiredFilters: [
+                        {
+                            id: 'required-created-at',
+                            target: {
+                                fieldRef: 'created_at',
+                            },
+                            operator: FilterOperator.IN_BETWEEN,
+                            values: ['2024-09-01', '2024-09-04'],
+                            required: true,
+                        },
+                    ],
+                    dimensions: {
+                        ...EXPLORE_WITH_DATE_DIMENSION.tables.orders.dimensions,
+                        created_at: {
+                            ...EXPLORE_WITH_DATE_DIMENSION.tables.orders
+                                .dimensions.created_at,
+                            isIntervalBase: true,
+                        },
+                        created_at_fiscal_quarter: {
+                            type: DimensionType.STRING,
+                            name: 'created_at_fiscal_quarter',
+                            label: 'created_at_fiscal_quarter',
+                            table: 'orders',
+                            tableLabel: 'orders',
+                            fieldType: FieldType.DIMENSION,
+                            sql: '${TABLE}.created_at_fiscal_quarter',
+                            compiledSql: '"orders".created_at_fiscal_quarter',
+                            tablesReferences: ['orders'],
+                            hidden: false,
+                            timeIntervalBaseDimensionName: 'created_at',
+                            customTimeInterval: 'fiscal_quarter',
+                        },
+                    },
+                },
+            },
+        };
+
+        const queryWithOnlyStringDerivedTimeFilter: CompiledMetricQuery = {
+            ...METRIC_QUERY_WITH_DATE_FILTER,
+            filters: {
+                dimensions: {
+                    id: 'root',
+                    and: [
+                        {
+                            id: 'string-derived-filter',
+                            target: {
+                                fieldId: 'orders_created_at_fiscal_quarter',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: ['FY2024-Q1'],
+                        },
+                    ],
+                },
+            },
+        };
+
+        const query = replaceWhitespace(
+            buildQuery({
+                explore: exploreWithStringDerivedTimeDimension,
+                compiledMetricQuery: queryWithOnlyStringDerivedTimeFilter,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            }).query,
+        );
+
+        expect(query).toContain(
+            replaceWhitespace(
+                '(("orders".created_at) >= (\'2024-09-01\') AND ("orders".created_at) <= (\'2024-09-04\'))',
+            ),
+        );
+    });
+
     it('Should build metric query with metric filters', () => {
         expect(
             replaceWhitespace(

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1108,6 +1108,7 @@ export class MetricQueryBuilder {
                         dimension,
                         filterRule,
                         dimensionsFilterGroup,
+                        explore,
                     )
                 )
                     return acc;

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -1,3 +1,4 @@
+import { DimensionType, FieldType } from '../types/field';
 import {
     FilterOperator,
     type AndFilterGroup,
@@ -8,6 +9,7 @@ import {
     type MetricFilterRule,
     type OrFilterGroup,
 } from '../types/filter';
+import { TimeFrames } from '../types/timeFrames';
 import {
     addDashboardFiltersToMetricQuery,
     addFilterRule,
@@ -181,6 +183,7 @@ describe('isFilterRuleInQuery', () => {
                 dimension('dim', 'table'),
                 filterRule,
                 filterGroupWithFilterRule,
+                mockExplore,
             ),
         ).toEqual(true);
         expect(
@@ -188,8 +191,271 @@ describe('isFilterRuleInQuery', () => {
                 dimension('dim', 'table'),
                 filterRule,
                 filterGroupWithoutFilterRule,
+                mockExplore,
             ),
         ).toEqual(false);
+    });
+
+    test('should not treat string-derived time dimensions as satisfying required date filters', () => {
+        const exploreWithStringDerivedTimeDimension = {
+            ...mockExplore,
+            tables: {
+                ...mockExplore.tables,
+                orders: {
+                    ...mockExplore.tables.orders,
+                    dimensions: {
+                        ...mockExplore.tables.orders.dimensions,
+                        order_date: {
+                            name: 'order_date',
+                            label: 'Order Date',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date',
+                            tablesReferences: [],
+                            sql: 'order_date',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.DATE,
+                            isIntervalBase: true,
+                        },
+                        order_date_fiscal_quarter: {
+                            name: 'order_date_fiscal_quarter',
+                            label: 'Order Date Fiscal Quarter',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date_fiscal_quarter',
+                            tablesReferences: [],
+                            sql: 'order_date_fiscal_quarter',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.STRING,
+                            timeIntervalBaseDimensionName: 'order_date',
+                            customTimeInterval: 'fiscal_quarter',
+                        },
+                    },
+                },
+            },
+        } as typeof mockExplore;
+        const requiredFilter = expectedRequiredResult('order_date', 'orders');
+        const filtersWithOnlyStringDerivedDimension: FilterGroup = {
+            id: 'mockGroupId',
+            and: [
+                {
+                    id: 'string-derived-filter',
+                    target: { fieldId: 'orders_order_date_fiscal_quarter' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['FY2024-Q1'],
+                },
+            ],
+        };
+
+        expect(
+            isFilterRuleInQuery(
+                exploreWithStringDerivedTimeDimension.tables.orders.dimensions
+                    .order_date,
+                requiredFilter,
+                filtersWithOnlyStringDerivedDimension,
+                exploreWithStringDerivedTimeDimension,
+            ),
+        ).toEqual(false);
+    });
+
+    test('should treat date-derived time dimensions as satisfying required date filters', () => {
+        const exploreWithDateDerivedTimeDimension = {
+            ...mockExplore,
+            tables: {
+                ...mockExplore.tables,
+                orders: {
+                    ...mockExplore.tables.orders,
+                    dimensions: {
+                        ...mockExplore.tables.orders.dimensions,
+                        order_date: {
+                            name: 'order_date',
+                            label: 'Order Date',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date',
+                            tablesReferences: [],
+                            sql: 'order_date',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.DATE,
+                            isIntervalBase: true,
+                        },
+                        order_date_biweekly: {
+                            name: 'order_date_biweekly',
+                            label: 'Order Date Biweekly',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date_biweekly',
+                            tablesReferences: [],
+                            sql: 'order_date_biweekly',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.DATE,
+                            timeIntervalBaseDimensionName: 'order_date',
+                            customTimeInterval: 'biweekly',
+                        },
+                    },
+                },
+            },
+        } as typeof mockExplore;
+        const requiredFilter = expectedRequiredResult('order_date', 'orders');
+        const filtersWithOnlyDateDerivedDimension: FilterGroup = {
+            id: 'mockGroupId',
+            and: [
+                {
+                    id: 'date-derived-filter',
+                    target: { fieldId: 'orders_order_date_biweekly' },
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [14],
+                    settings: {
+                        unitOfTime: 'days',
+                    },
+                },
+            ],
+        };
+
+        expect(
+            isFilterRuleInQuery(
+                exploreWithDateDerivedTimeDimension.tables.orders.dimensions
+                    .order_date,
+                requiredFilter,
+                filtersWithOnlyDateDerivedDimension,
+                exploreWithDateDerivedTimeDimension,
+            ),
+        ).toEqual(true);
+    });
+
+    test('should require an exact match when the required filter targets a custom derived time dimension', () => {
+        const exploreWithSiblingStringDerivedTimeDimensions = {
+            ...mockExplore,
+            tables: {
+                ...mockExplore.tables,
+                orders: {
+                    ...mockExplore.tables.orders,
+                    dimensions: {
+                        ...mockExplore.tables.orders.dimensions,
+                        order_date: {
+                            name: 'order_date',
+                            label: 'Order Date',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date',
+                            tablesReferences: [],
+                            sql: 'order_date',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.DATE,
+                            isIntervalBase: true,
+                        },
+                        order_date_fiscal_year: {
+                            name: 'order_date_fiscal_year',
+                            label: 'Order Date Fiscal Year',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date_fiscal_year',
+                            tablesReferences: [],
+                            sql: 'order_date_fiscal_year',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.STRING,
+                            timeIntervalBaseDimensionName: 'order_date',
+                            customTimeInterval: 'fiscal_year',
+                        },
+                        order_date_fiscal_quarter: {
+                            name: 'order_date_fiscal_quarter',
+                            label: 'Order Date Fiscal Quarter',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date_fiscal_quarter',
+                            tablesReferences: [],
+                            sql: 'order_date_fiscal_quarter',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.STRING,
+                            timeIntervalBaseDimensionName: 'order_date',
+                            customTimeInterval: 'fiscal_quarter',
+                        },
+                    },
+                },
+            },
+        } as typeof mockExplore;
+        const requiredFilter = expectedRequiredResult(
+            'order_date_fiscal_year',
+            'orders',
+        );
+        const filtersWithSiblingDerivedDimensionOnly: FilterGroup = {
+            id: 'mockGroupId',
+            and: [
+                {
+                    id: 'sibling-derived-filter',
+                    target: { fieldId: 'orders_order_date_fiscal_quarter' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['FY2024-Q1'],
+                },
+            ],
+        };
+
+        expect(
+            isFilterRuleInQuery(
+                exploreWithSiblingStringDerivedTimeDimensions.tables.orders
+                    .dimensions.order_date_fiscal_year,
+                requiredFilter,
+                filtersWithSiblingDerivedDimensionOnly,
+                exploreWithSiblingStringDerivedTimeDimensions,
+            ),
+        ).toEqual(false);
+    });
+
+    test('should allow sibling standard time dimensions when the required filter targets a standard derived time dimension', () => {
+        const exploreWithStandardDerivedTimeDimensions = {
+            ...mockExplore,
+            tables: {
+                ...mockExplore.tables,
+                orders: {
+                    ...mockExplore.tables.orders,
+                    dimensions: {
+                        ...mockExplore.tables.orders.dimensions,
+                        order_date_week: {
+                            ...mockExplore.tables.orders.dimensions
+                                .order_date_week,
+                            timeInterval: TimeFrames.WEEK,
+                        },
+                        order_date_month: {
+                            ...mockExplore.tables.orders.dimensions
+                                .order_date_month,
+                            timeInterval: TimeFrames.MONTH,
+                        },
+                    },
+                },
+            },
+        } as typeof mockExplore;
+        const requiredFilter = expectedRequiredResult(
+            'order_date_week',
+            'orders',
+        );
+        const filtersWithSiblingStandardDimension: FilterGroup = {
+            id: 'mockGroupId',
+            and: [
+                {
+                    id: 'sibling-standard-filter',
+                    target: { fieldId: 'orders_order_date_month' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2024-09-01'],
+                },
+            ],
+        };
+
+        expect(
+            isFilterRuleInQuery(
+                exploreWithStandardDerivedTimeDimensions.tables.orders
+                    .dimensions.order_date_week,
+                requiredFilter,
+                filtersWithSiblingStandardDimension,
+                exploreWithStandardDerivedTimeDimensions,
+            ),
+        ).toEqual(true);
     });
 });
 
@@ -220,6 +486,196 @@ describe('reduceRequiredDimensionFiltersToFilterRules', () => {
         ];
 
         expect(result).toEqual(expectedFilterRuleResult);
+    });
+
+    test('should keep required date filters when only string-derived time filters are present', () => {
+        const exploreWithStringDerivedTimeDimension = {
+            ...mockExplore,
+            tables: {
+                ...mockExplore.tables,
+                orders: {
+                    ...mockExplore.tables.orders,
+                    dimensions: {
+                        ...mockExplore.tables.orders.dimensions,
+                        order_date: {
+                            name: 'order_date',
+                            label: 'Order Date',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date',
+                            tablesReferences: [],
+                            sql: 'order_date',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.DATE,
+                            isIntervalBase: true,
+                        },
+                        order_date_fiscal_quarter: {
+                            name: 'order_date_fiscal_quarter',
+                            label: 'Order Date Fiscal Quarter',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date_fiscal_quarter',
+                            tablesReferences: [],
+                            sql: 'order_date_fiscal_quarter',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.STRING,
+                            timeIntervalBaseDimensionName: 'order_date',
+                            customTimeInterval: 'fiscal_quarter',
+                        },
+                    },
+                },
+            },
+        } as typeof mockExplore;
+        const filtersWithOnlyStringDerivedDimension: Filters = {
+            dimensions: {
+                id: 'mockGroupId',
+                and: [
+                    {
+                        id: 'string-derived-filter',
+                        target: { fieldId: 'orders_order_date_fiscal_quarter' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['FY2024-Q1'],
+                    },
+                ],
+            },
+        };
+
+        const result = reduceRequiredDimensionFiltersToFilterRules(
+            [modelRequiredFilterRule('order_date')],
+            filtersWithOnlyStringDerivedDimension.dimensions,
+            exploreWithStringDerivedTimeDimension,
+        );
+
+        expect(result).toEqual([
+            expectedRequiredResult('order_date', 'orders'),
+        ]);
+    });
+
+    test('should keep required derived time filters when only a sibling derived time filter is present', () => {
+        const exploreWithSiblingStringDerivedTimeDimensions = {
+            ...mockExplore,
+            tables: {
+                ...mockExplore.tables,
+                orders: {
+                    ...mockExplore.tables.orders,
+                    dimensions: {
+                        ...mockExplore.tables.orders.dimensions,
+                        order_date: {
+                            name: 'order_date',
+                            label: 'Order Date',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date',
+                            tablesReferences: [],
+                            sql: 'order_date',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.DATE,
+                            isIntervalBase: true,
+                        },
+                        order_date_fiscal_year: {
+                            name: 'order_date_fiscal_year',
+                            label: 'Order Date Fiscal Year',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date_fiscal_year',
+                            tablesReferences: [],
+                            sql: 'order_date_fiscal_year',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.STRING,
+                            timeIntervalBaseDimensionName: 'order_date',
+                            customTimeInterval: 'fiscal_year',
+                        },
+                        order_date_fiscal_quarter: {
+                            name: 'order_date_fiscal_quarter',
+                            label: 'Order Date Fiscal Quarter',
+                            table: 'orders',
+                            tableLabel: 'Orders',
+                            compiledSql: 'order_date_fiscal_quarter',
+                            tablesReferences: [],
+                            sql: 'order_date_fiscal_quarter',
+                            hidden: false,
+                            fieldType: FieldType.DIMENSION,
+                            type: DimensionType.STRING,
+                            timeIntervalBaseDimensionName: 'order_date',
+                            customTimeInterval: 'fiscal_quarter',
+                        },
+                    },
+                },
+            },
+        } as typeof mockExplore;
+        const filtersWithSiblingDerivedDimensionOnly: Filters = {
+            dimensions: {
+                id: 'mockGroupId',
+                and: [
+                    {
+                        id: 'sibling-derived-filter',
+                        target: { fieldId: 'orders_order_date_fiscal_quarter' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['FY2024-Q1'],
+                    },
+                ],
+            },
+        };
+
+        const result = reduceRequiredDimensionFiltersToFilterRules(
+            [modelRequiredFilterRule('order_date_fiscal_year')],
+            filtersWithSiblingDerivedDimensionOnly.dimensions,
+            exploreWithSiblingStringDerivedTimeDimensions,
+        );
+
+        expect(result).toEqual([
+            expectedRequiredResult('order_date_fiscal_year', 'orders'),
+        ]);
+    });
+
+    test('should not add a required standard derived time filter when a sibling standard time filter is present', () => {
+        const exploreWithStandardDerivedTimeDimensions = {
+            ...mockExplore,
+            tables: {
+                ...mockExplore.tables,
+                orders: {
+                    ...mockExplore.tables.orders,
+                    dimensions: {
+                        ...mockExplore.tables.orders.dimensions,
+                        order_date_week: {
+                            ...mockExplore.tables.orders.dimensions
+                                .order_date_week,
+                            timeInterval: TimeFrames.WEEK,
+                        },
+                        order_date_month: {
+                            ...mockExplore.tables.orders.dimensions
+                                .order_date_month,
+                            timeInterval: TimeFrames.MONTH,
+                        },
+                    },
+                },
+            },
+        } as typeof mockExplore;
+        const filtersWithSiblingStandardDimension: Filters = {
+            dimensions: {
+                id: 'mockGroupId',
+                and: [
+                    {
+                        id: 'sibling-standard-filter',
+                        target: { fieldId: 'orders_order_date_month' },
+                        operator: FilterOperator.EQUALS,
+                        values: ['2024-09-01'],
+                    },
+                ],
+            },
+        };
+
+        const result = reduceRequiredDimensionFiltersToFilterRules(
+            [modelRequiredFilterRule('order_date_week')],
+            filtersWithSiblingStandardDimension.dimensions,
+            exploreWithStandardDerivedTimeDimensions,
+        );
+
+        expect(result).toEqual([]);
     });
 });
 

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -30,7 +30,6 @@ import {
     isAndFilterGroup,
     isFilterGroup,
     isFilterRule,
-    isFilterRuleDefinedForFieldId,
     isJoinModelRequiredFilter,
     UnitOfTime,
     type AndFilterGroup,
@@ -1189,24 +1188,60 @@ export const isFilterRuleInQuery = (
     dimension: Dimension,
     filterRule: FilterRule,
     dimensionsFilterGroup: FilterGroup | undefined,
+    explore: Explore,
 ): undefined | boolean => {
-    let dimensionFieldId = filterRule.target.fieldId;
-    const timeDimension =
-        dimension.isIntervalBase || dimension.timeInterval !== undefined;
-    if (!dimension.isIntervalBase && dimension.timeInterval) {
-        dimensionFieldId = dimensionFieldId.replace(
-            `_${dimension.timeInterval.toLowerCase()}`,
-            '',
+    if (!dimensionsFilterGroup) return undefined;
+
+    const getBaseTimeDimensionName = (
+        timeDimension: Dimension,
+    ): string | undefined => {
+        if (timeDimension.isIntervalBase) return timeDimension.name;
+        return timeDimension.timeIntervalBaseDimensionName;
+    };
+
+    const getDimensionFromExplore = (fieldId: string): Dimension | undefined =>
+        Object.values(explore.tables)
+            .flatMap((table) => Object.values(table.dimensions))
+            .find(
+                (candidateDimension) =>
+                    getItemId(candidateDimension) === fieldId,
+            );
+
+    const isCompatibleDerivedTimeDimension = (
+        candidateDimension: Dimension,
+    ): boolean => {
+        const shouldAllowSiblingTimeDimensions =
+            dimension.isIntervalBase || dimension.timeInterval !== undefined;
+
+        if (!shouldAllowSiblingTimeDimensions) {
+            return false;
+        }
+
+        const requiredBaseDimensionName = getBaseTimeDimensionName(dimension);
+        const candidateBaseDimensionName =
+            getBaseTimeDimensionName(candidateDimension);
+
+        return (
+            requiredBaseDimensionName !== undefined &&
+            candidateBaseDimensionName === requiredBaseDimensionName &&
+            candidateDimension.table === dimension.table &&
+            getFilterTypeFromItem(candidateDimension) ===
+                getFilterTypeFromItem(dimension)
         );
-    }
-    return (
-        dimensionsFilterGroup &&
-        isFilterRuleDefinedForFieldId(
-            dimensionsFilterGroup,
-            dimensionFieldId,
-            timeDimension,
-        )
-    );
+    };
+
+    return getFilterRulesFromGroup(dimensionsFilterGroup).some((queryRule) => {
+        if (queryRule.target.fieldId === filterRule.target.fieldId) {
+            return true;
+        }
+
+        const queryDimension = getDimensionFromExplore(
+            queryRule.target.fieldId,
+        );
+        return queryDimension
+            ? isCompatibleDerivedTimeDimension(queryDimension)
+            : false;
+    });
 };
 
 export const reduceRequiredDimensionFiltersToFilterRules = (
@@ -1238,7 +1273,10 @@ export const reduceRequiredDimensionFiltersToFilterRules = (
             );
         }
 
-        if (dimension && !isFilterRuleInQuery(dimension, filterRule, filters)) {
+        if (
+            dimension &&
+            !isFilterRuleInQuery(dimension, filterRule, filters, explore)
+        ) {
             return [...acc, filterRule];
         }
         return acc;


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21391

### Description:

Fixed an issue where string-derived time dimensions were incorrectly satisfying required date filters. The system now properly distinguishes between string-type and date-type derived time dimensions when validating filter requirements.

Previously, any time dimension derived from a base time dimension would satisfy required filters for that base dimension, regardless of the derived dimension's data type. This caused problems when string-derived dimensions (like fiscal quarters) were used, as they would incorrectly fulfill date filter requirements.

The fix ensures that only derived time dimensions with compatible data types (date-type derived dimensions) can satisfy required date filters. String-derived time dimensions are now properly excluded from satisfying date filter requirements, forcing the system to apply the original required date filters as intended.

Added comprehensive test coverage for both scenarios - verifying that string-derived time dimensions don't satisfy date filter requirements while date-derived time dimensions continue to work correctly.