### PR TITLE
fix: handle mixed raw and aggregate dependencies in nested metric queries

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -5243,4 +5243,236 @@ describe('Nested aggregate metrics', () => {
             1,
         );
     });
+
+    test('should use valid inner dep aliases in nested_agg_results group by', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_WITH_DIMS,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(result.query).not.toContain('[object Object]');
+        expect(result.query).toContain(
+            'GROUP BY nested_agg."my_table_category", nested_agg."my_table_max_value"',
+        );
+    });
+
+    test('should handle max_by with mixed raw and aggregate refs without leaking helper metrics into na_base', () => {
+        const explore = JSON.parse(
+            JSON.stringify(EXPLORE_WITH_NESTED_AGG_AND_FANOUT),
+        ) as Explore;
+
+        explore.tables.my_table.metrics.raw_value_metric = {
+            type: MetricType.NUMBER,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'raw_value_metric',
+            label: 'raw_value_metric',
+            sql: '${TABLE}.value',
+            compiledSql: '"my_table".value',
+            tablesReferences: ['my_table'],
+            hidden: true,
+        };
+        explore.tables.my_table.metrics.max_date_metric = {
+            type: MetricType.MAX,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'max_date_metric',
+            label: 'max_date_metric',
+            sql: '${TABLE}.id',
+            compiledSql: 'MAX("my_table".id)',
+            tablesReferences: ['my_table'],
+            hidden: true,
+        };
+        explore.tables.my_table.metrics.max_by_raw_metric = {
+            type: MetricType.NUMBER,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'max_by_raw_metric',
+            label: 'max_by_raw_metric',
+            sql: 'MAX_BY(${raw_value_metric}, ${max_date_metric})',
+            compiledSql: 'MAX_BY("my_table".value, MAX("my_table".id))',
+            tablesReferences: ['my_table'],
+            hidden: false,
+        };
+
+        const result = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...METRIC_QUERY_NESTED_AGG_WITH_FANOUT,
+                metrics: ['my_table_max_by_raw_metric'],
+                sorts: [
+                    { fieldId: 'my_table_max_by_raw_metric', descending: true },
+                ],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(result.query).toContain('nested_agg AS (');
+        expect(
+            result.query.match(/AS "my_table_raw_value_metric"/g),
+        ).toHaveLength(1);
+        expect(result.query).toContain('GROUP BY 1, 2');
+        expect(result.query).toContain(
+            'GROUP BY nested_agg."fanout_users_title"',
+        );
+    });
+
+    test('should still group by non-wrapped aggregate helper deps when mixed with raw-helper max_by metric', () => {
+        const explore = JSON.parse(
+            JSON.stringify(EXPLORE_WITH_NESTED_AGG_AND_FANOUT),
+        ) as Explore;
+
+        explore.tables.my_table.metrics.raw_value_metric = {
+            type: MetricType.NUMBER,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'raw_value_metric',
+            label: 'raw_value_metric',
+            sql: '${TABLE}.value',
+            compiledSql: '"my_table".value',
+            tablesReferences: ['my_table'],
+            hidden: true,
+        };
+        explore.tables.my_table.metrics.max_date_metric = {
+            type: MetricType.MAX,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'max_date_metric',
+            label: 'max_date_metric',
+            sql: '${TABLE}.id',
+            compiledSql: 'MAX("my_table".id)',
+            tablesReferences: ['my_table'],
+            hidden: true,
+        };
+        explore.tables.my_table.metrics.max_by_raw_metric = {
+            type: MetricType.NUMBER,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'max_by_raw_metric',
+            label: 'max_by_raw_metric',
+            sql: 'MAX_BY(${raw_value_metric}, ${max_date_metric})',
+            compiledSql: 'MAX_BY("my_table".value, MAX("my_table".id))',
+            tablesReferences: ['my_table'],
+            hidden: false,
+        };
+
+        const result = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...METRIC_QUERY_NESTED_AGG_WITH_FANOUT,
+                metrics: [
+                    'my_table_max_by_raw_metric',
+                    'my_table_product_of_aggregates',
+                ],
+                sorts: [
+                    {
+                        fieldId: 'my_table_product_of_aggregates',
+                        descending: true,
+                    },
+                ],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(result.query).toContain(
+            'nested_agg."my_table_max_value" * nested_agg."my_table_count_records" AS "my_table_product_of_aggregates"',
+        );
+        expect(result.query).toContain(
+            'GROUP BY nested_agg."fanout_users_title", nested_agg."my_table_max_value", nested_agg."my_table_count_records"',
+        );
+    });
+
+    test('should compute mixed raw-helper max_by metric when used only in a metric filter', () => {
+        const explore = JSON.parse(
+            JSON.stringify(EXPLORE_WITH_NESTED_AGG_AND_FANOUT),
+        ) as Explore;
+
+        explore.tables.my_table.metrics.raw_value_metric = {
+            type: MetricType.NUMBER,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'raw_value_metric',
+            label: 'raw_value_metric',
+            sql: '${TABLE}.value',
+            compiledSql: '"my_table".value',
+            tablesReferences: ['my_table'],
+            hidden: true,
+        };
+        explore.tables.my_table.metrics.max_date_metric = {
+            type: MetricType.MAX,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'max_date_metric',
+            label: 'max_date_metric',
+            sql: '${TABLE}.id',
+            compiledSql: 'MAX("my_table".id)',
+            tablesReferences: ['my_table'],
+            hidden: true,
+        };
+        explore.tables.my_table.metrics.max_by_raw_metric = {
+            type: MetricType.NUMBER,
+            fieldType: FieldType.METRIC,
+            table: 'my_table',
+            tableLabel: 'my_table',
+            name: 'max_by_raw_metric',
+            label: 'max_by_raw_metric',
+            sql: 'MAX_BY(${raw_value_metric}, ${max_date_metric})',
+            compiledSql: 'MAX_BY("my_table".value, MAX("my_table".id))',
+            tablesReferences: ['my_table'],
+            hidden: false,
+        };
+
+        const result = buildQuery({
+            explore,
+            compiledMetricQuery: {
+                ...METRIC_QUERY_NESTED_AGG_WITH_FANOUT,
+                metrics: ['my_table_count_records'],
+                filters: {
+                    metrics: {
+                        id: 'root',
+                        and: [
+                            {
+                                id: '1',
+                                target: {
+                                    fieldId: 'my_table_max_by_raw_metric',
+                                },
+                                operator: FilterOperator.GREATER_THAN,
+                                values: [10],
+                            },
+                        ],
+                    },
+                },
+                sorts: [
+                    { fieldId: 'my_table_count_records', descending: true },
+                ],
+            },
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(result.query).toContain(
+            'nested_agg_results."my_table_max_by_raw_metric"',
+        );
+        expect(result.query).toContain('("my_table_max_by_raw_metric") > (10)');
+
+        expect(result.query).toContain(
+            'SELECT\n  "fanout_users_title",\n  "my_table_count_records"\nFROM metrics',
+        );
+    });
 });

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -883,6 +883,37 @@ export class MetricQueryBuilder {
         });
     }
 
+    private getMetricIdsRequiredInBaseSelects(): string[] {
+        const metricIds = new Set(this.getSelectedAndReferencedMetricIds());
+        const requiredMetricIds = new Set(
+            this.args.compiledMetricQuery.metrics.filter(
+                (metricId) => !this.isPopMetricId(metricId),
+            ),
+        );
+
+        getFilterRulesFromGroup(
+            this.args.compiledMetricQuery.filters.metrics,
+        ).forEach((filter) => {
+            requiredMetricIds.add(filter.target.fieldId);
+        });
+
+        this.getPostCalculationMetricReferences(
+            Array.from(requiredMetricIds),
+        ).forEach((metricId) => {
+            requiredMetricIds.add(metricId);
+        });
+
+        this.getMetricsWithNestedAggregates().forEach(({ innerDeps }) => {
+            innerDeps.forEach(({ fieldId }) => {
+                if (!requiredMetricIds.has(fieldId)) {
+                    metricIds.delete(fieldId);
+                }
+            });
+        });
+
+        return Array.from(metricIds);
+    }
+
     private getMetricsSQL(): {
         tables: string[];
         selects: string[];
@@ -894,7 +925,7 @@ export class MetricQueryBuilder {
             userAttributes = {},
         } = this.args;
         const { filters, additionalMetrics } = compiledMetricQuery;
-        const metrics = this.getSelectedAndReferencedMetricIds();
+        const metrics = this.getMetricIdsRequiredInBaseSelects();
         const adapterType: SupportedDbtAdapter =
             warehouseSqlBuilder.getAdapterType();
         const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
@@ -2748,20 +2779,38 @@ export class MetricQueryBuilder {
             (alias) => `${fieldQuoteChar}${alias}${fieldQuoteChar}`,
         );
 
-        const innerDepAliases = Array.from(allInnerDeps.keys()).map(
-            (depId) => `${fieldQuoteChar}${depId}${fieldQuoteChar}`,
+        const innerDepEntries = Array.from(allInnerDeps.entries());
+        const innerDepAliases = innerDepEntries.map(
+            ([depId]) => `${fieldQuoteChar}${depId}${fieldQuoteChar}`,
         );
+        const innerDepGroupByPositions = innerDepEntries.reduce<number[]>(
+            (acc, [, depMetric], index) => {
+                if (
+                    isNonAggregateMetric(depMetric) &&
+                    !sqlContainsAggregation(depMetric.sql)
+                ) {
+                    acc.push(dimensionAlias.length + index + 1);
+                }
+                return acc;
+            },
+            [],
+        );
+        const hasRawInnerDeps = innerDepGroupByPositions.length > 0;
 
         // --- CTE 1: nested_agg — pre-compute inner deps from base table ---
         const naCteName = 'nested_agg';
-        const innerMetricSelects = Array.from(allInnerDeps.entries()).map(
+        const innerMetricSelects = innerDepEntries.map(
             ([depId, depMetric]) =>
                 `  ${depMetric.compiledSql} AS ${fieldQuoteChar}${depId}${fieldQuoteChar}`,
         );
 
+        const naGroupByPositions = [
+            ...dimensionAlias.map((_, i) => i + 1),
+            ...innerDepGroupByPositions,
+        ];
         const naGroupBy =
-            dimensionAlias.length > 0
-                ? `GROUP BY ${dimensionAlias.map((_, i) => i + 1).join(',')}`
+            naGroupByPositions.length > 0
+                ? `GROUP BY ${naGroupByPositions.join(', ')}`
                 : undefined;
 
         const cte1Sql = MetricQueryBuilder.wrapAsCte(naCteName, [
@@ -2873,12 +2922,76 @@ export class MetricQueryBuilder {
             );
         }
 
-        // GROUP BY dims + inner deps so aggregate functions are valid
-        // Since CTE 1 has one row per dim group, this is effectively identity
-        const allGroupByCols = [
-            ...dimensionAlias.map((a) => `${naCteName}.${a}`),
-            ...innerDepAliases.map((a) => `${naCteName}.${a}`),
-        ];
+        const outerMetricsById = new Map(
+            nestedAggMetrics.map((metric) => [metric.outerMetricId, metric]),
+        );
+        const cachedResultsGroupByDeps = new Map<string, string[]>();
+        const getResultsGroupByDepIds = (metricId: string): string[] => {
+            const cachedDepIds = cachedResultsGroupByDeps.get(metricId);
+            if (cachedDepIds) {
+                return cachedDepIds;
+            }
+
+            const metricInfo = outerMetricsById.get(metricId);
+            if (!metricInfo || metricInfo.wrapsAggregation) {
+                cachedResultsGroupByDeps.set(metricId, []);
+                return [];
+            }
+
+            const depIds: string[] = [];
+            const addDepId = (depId: string) => {
+                if (!depIds.includes(depId)) {
+                    depIds.push(depId);
+                }
+            };
+
+            parseAllReferences(
+                metricInfo.outerMetric.sql,
+                metricInfo.outerMetric.table,
+            ).forEach((ref) => {
+                if (ref.refName === 'TABLE') {
+                    return;
+                }
+
+                const refId = getItemId({
+                    table: ref.refTable,
+                    name: ref.refName,
+                });
+
+                if (allInnerDeps.has(refId)) {
+                    addDepId(refId);
+                } else if (outerMetricsById.has(refId)) {
+                    getResultsGroupByDepIds(refId).forEach(addDepId);
+                }
+            });
+
+            cachedResultsGroupByDeps.set(metricId, depIds);
+            return depIds;
+        };
+
+        // GROUP BY dims + inner deps so aggregate functions are valid.
+        // When raw helper metrics are present, only preserve the helper deps
+        // needed by non-wrapping outer metrics; wrapped metrics collapse back
+        // to the dimension grain in CTE 2.
+        const allGroupByCols = hasRawInnerDeps
+            ? sortedOuterMetrics.reduce<string[]>(
+                  (acc, { outerMetricId }) => {
+                      getResultsGroupByDepIds(outerMetricId).forEach(
+                          (depId) => {
+                              const depRef = `${naCteName}.${fieldQuoteChar}${depId}${fieldQuoteChar}`;
+                              if (!acc.includes(depRef)) {
+                                  acc.push(depRef);
+                              }
+                          },
+                      );
+                      return acc;
+                  },
+                  dimensionAlias.map((a) => `${naCteName}.${a}`),
+              )
+            : [
+                  ...dimensionAlias.map((a) => `${naCteName}.${a}`),
+                  ...innerDepAliases.map((a) => `${naCteName}.${a}`),
+              ];
         const resultsGroupBy =
             allGroupByCols.length > 0
                 ? `GROUP BY ${allGroupByCols.join(', ')}`


### PR DESCRIPTION
### Description:

Fixed nested aggregate query generation to prevent object serialization errors and optimize GROUP BY clauses for mixed raw and aggregate metric dependencies.

**Key Changes:**
- Resolved `[object Object]` appearing in generated SQL by ensuring proper alias handling in nested aggregate GROUP BY clauses
- Implemented selective inclusion of helper metrics in base selects to prevent unnecessary metric leakage into `na_base` CTE
- Added intelligent GROUP BY optimization for mixed raw/aggregate dependencies that preserves only required helper dependencies for non-wrapping outer metrics
- Enhanced metric filtering support for `max_by` metrics with mixed raw and aggregate references

**Technical Details:**
- Added `getMetricIdsRequiredInBaseSelects()` method to filter out unreferenced helper metrics from base query selects
- Implemented dependency tracking for nested aggregate results GROUP BY clauses to handle raw helper metrics correctly
- Added position-based GROUP BY handling for raw inner dependencies in the `nested_agg` CTE
- Enhanced GROUP BY clause generation to collapse wrapped metrics back to dimension grain while preserving required dependencies

The changes ensure that complex nested aggregate queries with `MAX_BY` and other mixed-dependency metrics generate valid SQL while maintaining optimal performance through selective dependency inclusion.