### PR TITLE
fix: improve error handling for chart field usage during dashboard duplication

### DIFF
--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -382,12 +382,14 @@ export class DashboardService
             },
         );
 
-        // Update catalog field usage for the new chart
-        const cachedExplore = await this.projectModel.getExploreFromCache(
-            projectUuid,
-            duplicatedChart.tableName,
-        );
+        // Best effort: the chart has already been duplicated at this point, so
+        // missing explore metadata should not fail the parent dashboard copy.
+        let cachedExplore: Explore | ExploreError | undefined;
         try {
+            cachedExplore = await this.projectModel.getExploreFromCache(
+                projectUuid,
+                duplicatedChart.tableName,
+            );
             await this.updateChartFieldUsage(projectUuid, cachedExplore, {
                 oldChartFields: {
                     metrics: [],
@@ -399,9 +401,13 @@ export class DashboardService
                 },
             });
         } catch (error) {
-            this.logger.error(
-                `Error updating chart field usage for duplicated chart ${duplicatedChart.uuid}`,
-                error,
+            this.logger.warn(
+                `Skipping duplicated chart enrichment for chart ${duplicatedChart.uuid}`,
+                {
+                    error,
+                    projectUuid,
+                    tableName: duplicatedChart.tableName,
+                },
             );
         }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Improved error handling during chart duplication by wrapping the explore cache retrieval in a try-catch block and changing error logging from `error` to `warn` level. This ensures that missing explore metadata won't cause the entire dashboard copy operation to fail, since the chart has already been successfully duplicated at that point. Added additional context to the warning log including project UUID and table name for better debugging.