### PR TITLE
fix: load chart results after selecting version in version history page

### DIFF
--- a/packages/frontend/src/pages/ChartHistory.tsx
+++ b/packages/frontend/src/pages/ChartHistory.tsx
@@ -68,6 +68,7 @@ const ChartHistoryExplorer = memo<{ selectedVersionUuid: string | undefined }>(
                     parameterDefinitions: {},
                     expandedSections: [ExplorerSection.VISUALIZATION],
                     unsavedChartVersion: chartVersionQuery.data.chart,
+                    savedChart: chartVersionQuery.data.chart,
                     modals: {
                         format: { isOpen: false },
                         additionalMetric: { isOpen: false },
@@ -77,7 +78,6 @@ const ChartHistoryExplorer = memo<{ selectedVersionUuid: string | undefined }>(
                         periodOverPeriodComparison: { isOpen: false },
                     },
                 },
-                savedChart: chartVersionQuery.data.chart,
             });
 
             store.dispatch(explorerActions.reset(initialState));


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Move `savedChart` property inside the `explore` object in the ChartHistoryExplorer initial state configuration. This relocates the chart data to be properly nested within the explorer state structure rather than at the root level.

<!-- Even better add a screenshot / gif / loom -->