### PR TITLE
feat: add InMemoryCacheClient and factory function for cache client creation

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -32,7 +32,7 @@ import qs from 'qs';
 import reDoc from 'redoc-express';
 import { URL } from 'url';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
-import { RedisCacheClient } from './clients/CacheClient';
+import { createCacheClient } from './clients/CacheClient';
 import {
     ClientProviderMap,
     ClientRepository,
@@ -219,9 +219,9 @@ export default class App {
             utilProviders: args.utilProviders,
             lightdashConfig: this.lightdashConfig,
         });
-        const keyValueCacheClient = this.lightdashConfig.redis
-            ? new RedisCacheClient(this.lightdashConfig.redis)
-            : undefined;
+        const keyValueCacheClient = createCacheClient(
+            this.lightdashConfig.redis,
+        );
         this.models = new ModelRepository({
             modelProviders: args.modelProviders,
             lightdashConfig: this.lightdashConfig,

--- a/packages/backend/src/NatsWorkerApp.ts
+++ b/packages/backend/src/NatsWorkerApp.ts
@@ -5,7 +5,7 @@ import http from 'http';
 import knex, { Knex } from 'knex';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import { registerOAuthRefreshStrategies } from './auth/registerOAuthRefreshStrategies';
-import { RedisCacheClient } from './clients/CacheClient';
+import { createCacheClient } from './clients/CacheClient';
 import {
     ClientProviderMap,
     ClientRepository,
@@ -109,9 +109,9 @@ export default class NatsWorkerApp {
             utilProviders: args.utilProviders,
             lightdashConfig: this.lightdashConfig,
         });
-        const keyValueCacheClient = this.lightdashConfig.redis
-            ? new RedisCacheClient(this.lightdashConfig.redis)
-            : undefined;
+        const keyValueCacheClient = createCacheClient(
+            this.lightdashConfig.redis,
+        );
         const models = new ModelRepository({
             modelProviders: args.modelProviders,
             lightdashConfig: this.lightdashConfig,

--- a/packages/backend/src/SchedulerApp.ts
+++ b/packages/backend/src/SchedulerApp.ts
@@ -6,7 +6,7 @@ import http from 'http';
 import knex, { Knex } from 'knex';
 import { LightdashAnalytics } from './analytics/LightdashAnalytics';
 import { registerOAuthRefreshStrategies } from './auth/registerOAuthRefreshStrategies';
-import { RedisCacheClient } from './clients/CacheClient';
+import { createCacheClient } from './clients/CacheClient';
 import {
     ClientProviderMap,
     ClientRepository,
@@ -133,9 +133,9 @@ export default class SchedulerApp {
             utilProviders: args.utilProviders,
             lightdashConfig: this.lightdashConfig,
         });
-        const keyValueCacheClient = this.lightdashConfig.redis
-            ? new RedisCacheClient(this.lightdashConfig.redis)
-            : undefined;
+        const keyValueCacheClient = createCacheClient(
+            this.lightdashConfig.redis,
+        );
         this.models = new ModelRepository({
             modelProviders: args.modelProviders,
             lightdashConfig: this.lightdashConfig,

--- a/packages/backend/src/clients/CacheClient/InMemoryCacheClient.ts
+++ b/packages/backend/src/clients/CacheClient/InMemoryCacheClient.ts
@@ -1,0 +1,42 @@
+import NodeCache from 'node-cache';
+import Logger from '../../logging/logger';
+import { KeyValueCacheClient } from './ICacheClient';
+
+export class InMemoryCacheClient implements KeyValueCacheClient {
+    private readonly cache: NodeCache;
+
+    constructor(defaultTtlSeconds: number = 30) {
+        this.cache = new NodeCache({
+            stdTTL: defaultTtlSeconds,
+            checkperiod: 60,
+        });
+        Logger.debug('InMemoryCacheClient initialized');
+    }
+
+    async get<T>(key: string): Promise<T | undefined> {
+        const value = this.cache.get<T>(key);
+        if (value !== undefined) {
+            Logger.debug(`InMemory cache HIT for key "${key}"`);
+        }
+        return value;
+    }
+
+    async set<T>(key: string, value: T, ttlSeconds?: number): Promise<void> {
+        if (ttlSeconds !== undefined) {
+            this.cache.set(key, value, ttlSeconds);
+        } else {
+            this.cache.set(key, value);
+        }
+    }
+
+    async del(key: string): Promise<void> {
+        this.cache.del(key);
+    }
+
+    async delByPrefix(prefix: string): Promise<void> {
+        const keys = this.cache.keys().filter((k) => k.startsWith(prefix));
+        if (keys.length > 0) {
+            this.cache.del(keys);
+        }
+    }
+}

--- a/packages/backend/src/clients/CacheClient/index.ts
+++ b/packages/backend/src/clients/CacheClient/index.ts
@@ -1,2 +1,18 @@
+import { LightdashConfig } from '../../config/parseConfig';
+import type { KeyValueCacheClient } from './ICacheClient';
+import { InMemoryCacheClient } from './InMemoryCacheClient';
+import { RedisCacheClient } from './RedisCacheClient';
+
 export type { KeyValueCacheClient } from './ICacheClient';
-export { RedisCacheClient } from './RedisCacheClient';
+
+export function createCacheClient(
+    redisConfig: LightdashConfig['redis'],
+): KeyValueCacheClient | undefined {
+    if (redisConfig) {
+        return new RedisCacheClient(redisConfig);
+    }
+    if (process.env.EXPERIMENTAL_CACHE === 'true') {
+        return new InMemoryCacheClient();
+    }
+    return undefined;
+}

--- a/packages/backend/src/models/ProjectModel/ExploreCache.ts
+++ b/packages/backend/src/models/ProjectModel/ExploreCache.ts
@@ -1,23 +1,12 @@
 import { Explore, ExploreError } from '@lightdash/common';
-import NodeCache from 'node-cache';
 import { KeyValueCacheClient } from '../../clients/CacheClient';
 
 type CachedExplores = Record<string, Explore | ExploreError>;
 
 export class ExploreCache {
-    private readonly cache: NodeCache | undefined;
-
     private readonly keyValueCacheClient: KeyValueCacheClient | undefined;
 
     constructor(keyValueCacheClient?: KeyValueCacheClient) {
-        // Initialize in-memory cache with 30 seconds TTL
-        this.cache =
-            process.env.EXPERIMENTAL_CACHE === 'true'
-                ? new NodeCache({
-                      stdTTL: 30, // time to live in seconds
-                      checkperiod: 60, // cleanup interval in seconds
-                  })
-                : undefined;
         this.keyValueCacheClient = keyValueCacheClient;
     }
 
@@ -46,17 +35,7 @@ export class ExploreCache {
             changesetUpdatedAt,
         );
 
-        // Try key-value cache first (if available)
-        if (this.keyValueCacheClient) {
-            const kvCached =
-                await this.keyValueCacheClient.get<CachedExplores>(cacheKey);
-            if (kvCached) {
-                return kvCached;
-            }
-        }
-
-        // Fall back to in-memory NodeCache
-        return this.cache?.get<CachedExplores>(cacheKey);
+        return this.keyValueCacheClient?.get<CachedExplores>(cacheKey);
     }
 
     public async setExplores(
@@ -71,8 +50,6 @@ export class ExploreCache {
             changesetUpdatedAt,
         );
 
-        // Store in both caches
-        this.cache?.set(cacheKey, explore);
         await this.keyValueCacheClient?.set(cacheKey, explore, 30);
     }
 }

--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -51,7 +51,6 @@ import {
     warehouseClientFromCredentials,
 } from '@lightdash/warehouses';
 import { Knex } from 'knex';
-import NodeCache from 'node-cache';
 import { DatabaseError } from 'pg';
 import { v4 as uuidv4 } from 'uuid';
 import { KeyValueCacheClient } from '../../clients/CacheClient';
@@ -128,15 +127,6 @@ export type ProjectModelArguments = {
 };
 
 const CACHED_EXPLORES_PG_LOCK_NAMESPACE = 1;
-
-// Initialize cache for warehouse credentials with 30 seconds TTL
-const warehouseCredentialsCache =
-    process.env.EXPERIMENTAL_CACHE === 'true'
-        ? new NodeCache({
-              stdTTL: 30, // time to live in seconds
-              checkperiod: 60, // cleanup interval in seconds
-          })
-        : undefined;
 
 type RawSummaryRow = {
     name: Explore['name'];
@@ -560,8 +550,6 @@ export class ProjectModel {
     }
 
     async update(projectUuid: string, data: UpdateProject): Promise<void> {
-        // Invalidate warehouse credentials cache
-        warehouseCredentialsCache?.del(projectUuid);
         await this.keyValueCacheClient?.delByPrefix(`project:${projectUuid}:`);
 
         await this.database.transaction(async (trx) => {
@@ -600,8 +588,6 @@ export class ProjectModel {
     }
 
     async delete(projectUuid: string): Promise<void> {
-        // Invalidate all caches for this project
-        warehouseCredentialsCache?.del(projectUuid);
         await this.keyValueCacheClient?.delByPrefix(`project:${projectUuid}:`);
 
         await this.database.transaction(async (trx) => {
@@ -1793,22 +1779,12 @@ export class ProjectModel {
     ): Promise<CreateWarehouseCredentials> {
         const cacheKey = `project:${projectUuid}:warehouseCredentials`;
 
-        // Try key-value cache first (if available)
-        const kvCached =
+        const cached =
             await this.keyValueCacheClient?.get<CreateWarehouseCredentials>(
                 cacheKey,
             );
-        if (kvCached) {
-            return kvCached;
-        }
-
-        // Fall back to in-memory NodeCache
-        const cachedCredentials =
-            warehouseCredentialsCache?.get<CreateWarehouseCredentials>(
-                projectUuid,
-            );
-        if (cachedCredentials) {
-            return cachedCredentials;
+        if (cached) {
+            return cached;
         }
 
         const [row] = await this.database('warehouse_credentials')
@@ -1846,8 +1822,6 @@ export class ProjectModel {
                     row.organization_warehouse_credentials_uuid,
                     row.organization_uuid,
                 );
-            // Store in both caches
-            warehouseCredentialsCache?.set(projectUuid, orgCredentials);
             await this.keyValueCacheClient?.set(cacheKey, orgCredentials, 30);
             return orgCredentials;
         }
@@ -1856,8 +1830,6 @@ export class ProjectModel {
             const credentials = JSON.parse(
                 this.encryptionUtil.decrypt(row.encrypted_credentials),
             ) as CreateWarehouseCredentials;
-            // Store in both caches
-            warehouseCredentialsCache?.set(projectUuid, credentials);
             await this.keyValueCacheClient?.set(cacheKey, credentials, 30);
             return credentials;
         } catch (e) {

--- a/packages/backend/src/models/UserModel.ts
+++ b/packages/backend/src/models/UserModel.ts
@@ -29,7 +29,6 @@ import {
 } from '@lightdash/common';
 import bcrypt from 'bcrypt';
 import { Knex } from 'knex';
-import NodeCache from 'node-cache';
 import { KeyValueCacheClient } from '../clients/CacheClient';
 import { LightdashConfig } from '../config/parseConfig';
 import {
@@ -128,14 +127,6 @@ type UserModelArguments = {
     keyValueCacheClient?: KeyValueCacheClient;
 };
 
-const sessionUserCache =
-    process.env.EXPERIMENTAL_CACHE === 'true'
-        ? new NodeCache({
-              stdTTL: 30, // time to live in seconds
-              checkperiod: 60, // cleanup interval in seconds
-          })
-        : undefined;
-
 export class UserModel {
     private readonly lightdashConfig: LightdashConfig;
 
@@ -180,30 +171,20 @@ export class UserModel {
     ) {
         const cacheKey = `${userUuid}::${organizationUuid}`;
 
-        // Try key-value cache first (if available)
-        const kvCached =
+        const cached =
             await this.keyValueCacheClient?.get<SessionUser>(cacheKey);
-        if (kvCached) {
+        if (cached) {
             return {
-                sessionUser: UserModel.hydrateSessionUser(kvCached),
+                sessionUser: UserModel.hydrateSessionUser(cached),
                 cacheHit: true,
             };
         }
 
-        // Fall back to in-memory NodeCache
-        const cachedUser = sessionUserCache?.get<SessionUser>(cacheKey);
-        if (cachedUser) {
-            return { sessionUser: cachedUser, cacheHit: true };
-        }
-
-        // If not in any cache, get from database
         const sessionUser = await this.findSessionUserAndOrgByUuid(
             userUuid,
             organizationUuid,
         );
 
-        // Store in both caches
-        sessionUserCache?.set(cacheKey, sessionUser);
         await this.keyValueCacheClient?.set(cacheKey, sessionUser, 30);
 
         return { sessionUser, cacheHit: false };


### PR DESCRIPTION
### Description:

Refactored cache client initialization to use a factory function pattern. Replaced direct `RedisCacheClient` instantiation with `createCacheClient()` function that handles both Redis and in-memory cache creation based on configuration.

Removed duplicate in-memory `NodeCache` instances from `ExploreCache`, `ProjectModel`, and `UserModel` classes. The caching logic now relies solely on the injected `KeyValueCacheClient` interface, with the new `InMemoryCacheClient` implementation providing fallback caching when Redis is not available and `EXPERIMENTAL_CACHE=true`.

The `createCacheClient()` factory function returns:
- `RedisCacheClient` when Redis configuration is provided
- `InMemoryCacheClient` when `EXPERIMENTAL_CACHE=true` and no Redis config
- `undefined` when no caching is configured

This consolidates cache management into a single, consistent interface across all application entry points (App, NatsWorkerApp, SchedulerApp).