### PR TITLE
fix: use --isolated flag for Chrome DevTools MCP

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -264,8 +264,6 @@ pm2 restart ${LD_INSTANCE_ID}-frontend  # Restart only the frontend
 
 Use the \`/debug-local\` skill for comprehensive debugging combining PM2 logs, Spotlight traces, and browser automation.
 
-**Chrome DevTools:** Always use \`isolatedContext: "${LD_INSTANCE_ID}"\` when opening browser pages via \`mcp__chrome-devtools__new_page\`. This keeps each instance's browser session isolated from other instances and manual browsing.
-
 Spotlight UI: http://localhost:${SPOTLIGHT_PORT}
 
 ## Database Snapshots

--- a/.claude/skills/debug-local/SKILL.md
+++ b/.claude/skills/debug-local/SKILL.md
@@ -221,14 +221,12 @@ Returns application log entries.
 
 ### Browser Debugging (Chrome DevTools MCP)
 
-Use the Chrome DevTools MCP tools for browser automation.
-
-**Always use `isolatedContext`** to avoid polluting other browser sessions (e.g., other Claude instances or manual browsing). Use your instance ID or worktree name as the context name:
+Use the Chrome DevTools MCP tools for browser automation:
 
 #### Opening pages
 
 ```
-mcp__chrome-devtools__new_page with url: "http://localhost:3000/login", isolatedContext: "debug-session"
+mcp__chrome-devtools__new_page with url: "http://localhost:3000/login"
 mcp__chrome-devtools__navigate_page with url: "http://localhost:3000", type: "url"
 ```
 

--- a/.mcp.json
+++ b/.mcp.json
@@ -2,7 +2,7 @@
   "mcpServers": {
     "chrome-devtools": {
       "command": "pnpx",
-      "args": ["chrome-devtools-mcp@latest"]
+      "args": ["chrome-devtools-mcp@latest", "--isolated"]
     },
     "lightdash-docs": {
       "type": "http",


### PR DESCRIPTION
## Summary
- Adds `--isolated` flag to Chrome DevTools MCP server config in `.mcp.json`, which creates a temporary user-data-dir per MCP server instance — preventing "browser is already running" profile lock conflicts
- Reverts the `isolatedContext` tool-call approach from #21416, which only isolated browser contexts *within* a single Chrome instance and didn't fix the actual problem

## Test plan
- [ ] Start Chrome DevTools MCP from one Claude instance, verify it launches successfully
- [ ] Start a second Claude instance — verify it can also launch Chrome without "browser is already running" error
- [ ] Verify browser automation (new_page, take_snapshot, etc.) works normally with `--isolated`

🤖 Generated with [Claude Code](https://claude.com/claude-code)