### PR TITLE
fix: add min-width to number input in date filter

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DateFilterInputs.tsx
@@ -266,7 +266,11 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
                 <Flex gap="xs" w="100%">
                     <NumberInput
                         size="xs"
-                        sx={{ flexShrink: 1, flexGrow: 1 }}
+                        sx={{
+                            flexShrink: 1,
+                            flexGrow: 1,
+                            minWidth: 50,
+                        }}
                         placeholder={placeholder}
                         disabled={disabled}
                         data-autofocus
@@ -282,7 +286,7 @@ const DateFilterInputs = <T extends BaseFilterRule = DateFilterRule>(
 
                     <FilterUnitOfTimeAutoComplete
                         disabled={disabled}
-                        sx={{ flexShrink: 0, flexGrow: 3 }}
+                        sx={{ flexShrink: 1, flexGrow: 3 }}
                         isTimestamp={isTimestamp}
                         minUnitOfTime={
                             isDimension(field) && field.timeInterval


### PR DESCRIPTION
## Summary
- Adds `minWidth: 50` to the `NumberInput` in "in the last/next" date filters to prevent it from collapsing to near-zero width in constrained containers (e.g., custom metric modal)
- Changes `FilterUnitOfTimeAutoComplete` from `flexShrink: 0` to `flexShrink: 1` so the unit selector can shrink when space is tight, preventing the close button from being pushed/overlapped

Fixes [SPK-367](https://linear.app/lightdash/issue/SPK-367)

## Test plan
- [x] Verified in custom metric modal: number input is usable, "x" button has proper spacing
- [x] Verified in Explore page filter: number input displays correctly with adequate width
- [x] Lint, format, and unused-exports checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)