### PR TITLE
feat(experimental): jwt auth for app router

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -513,7 +513,10 @@ export default class App {
         if (this.lightdashConfig.appRuntime.enabled) {
             expressApp.use(
                 '/api/apps',
-                createAppPreviewRouter(this.lightdashConfig.appRuntime),
+                createAppPreviewRouter(
+                    this.lightdashConfig.appRuntime,
+                    this.lightdashConfig.lightdashSecret,
+                ),
             );
         }
 

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -1,6 +1,7 @@
 import { ApiErrorPayload } from '@lightdash/common';
 import {
     Body,
+    Get,
     Hidden,
     Middlewares,
     OperationId,
@@ -31,6 +32,13 @@ export type ApiGenerateAppResponse = {
     };
 };
 
+export type ApiPreviewTokenResponse = {
+    status: 'ok';
+    results: {
+        token: string;
+    };
+};
+
 @Route('/api/v1/ee/projects/{projectUuid}/apps')
 @Hidden()
 @Response<ApiErrorPayload>('default', 'Error')
@@ -53,6 +61,32 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    /**
+     * Mints a short-lived JWT for accessing an app version preview in an iframe.
+     * @summary Get preview token
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/{appUuid}/versions/{versionUuid}/preview-token')
+    @OperationId('getAppPreviewToken')
+    async getPreviewToken(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+        @Path() versionUuid: string,
+    ): Promise<ApiPreviewTokenResponse> {
+        const token = this.getAppGenerateService().getPreviewToken(
+            req.user!,
+            projectUuid,
+            appUuid,
+            versionUuid,
+        );
+        return {
+            status: 'ok',
+            results: { token },
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -7,14 +7,16 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     MissingConfigError,
+    ParameterError,
     type SessionUser,
 } from '@lightdash/common';
 import { Sandbox } from 'e2b';
 import { PassThrough } from 'node:stream';
 import { extract, type Headers } from 'tar-stream';
-import { v4 as uuidv4 } from 'uuid';
+import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
+import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
 
 type AppGenerateServiceDeps = {
@@ -256,6 +258,38 @@ export class AppGenerateService extends BaseService {
             passThrough.pipe(extractor);
             passThrough.end(tarBuffer);
         });
+    }
+
+    getPreviewToken(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+        versionUuid: string,
+    ): string {
+        this.assertDataAppsEnabled();
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('DataApp', {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access data apps',
+            );
+        }
+
+        if (!isValidUuid(appUuid) || !isValidUuid(versionUuid)) {
+            throw new ParameterError('Invalid UUID format');
+        }
+
+        return mintPreviewToken(
+            this.lightdashConfig.lightdashSecret,
+            appUuid,
+            versionUuid,
+        );
     }
 
     private static getContentType(filePath: string): string {

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -4,6 +4,11 @@ import path from 'path';
 import { validate as isValidUuid } from 'uuid';
 import { type AppRuntimeConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
+import {
+    PREVIEW_COOKIE_NAME,
+    PREVIEW_TOKEN_MAX_AGE_SECONDS,
+    verifyPreviewToken,
+} from './appPreviewToken';
 
 const CONTENT_TYPE_BY_EXT: Record<string, string> = {
     '.js': 'application/javascript',
@@ -50,7 +55,22 @@ const buildCspHeader = (config: AppRuntimeConfig): string => {
 const isSafeFilename = (filename: string): boolean =>
     /^[a-zA-Z0-9._-]+$/.test(filename) && !filename.includes('..');
 
-export const createAppPreviewRouter = (config: AppRuntimeConfig): Router => {
+/**
+ * Extracts a named cookie value from the Cookie header.
+ */
+const getCookieValue = (
+    cookieHeader: string | undefined,
+    name: string,
+): string | undefined => {
+    if (!cookieHeader) return undefined;
+    const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
+    return match ? match[1] : undefined;
+};
+
+export const createAppPreviewRouter = (
+    config: AppRuntimeConfig,
+    lightdashSecret: string,
+): Router => {
     const router = express.Router({ strict: true });
 
     // Host header validation — defense-in-depth for domain isolation.
@@ -148,18 +168,21 @@ export const createAppPreviewRouter = (config: AppRuntimeConfig): Router => {
         }
     };
 
-    // Serve index.html for an app version.
-    // Redirect to trailing slash so relative asset paths resolve correctly.
-    // e.g. "assets/foo.css" from "/api/apps/X/versions/Y" resolves to
-    //       "/api/apps/X/versions/assets/foo.css" (wrong, missing Y)
-    // but from "/api/apps/X/versions/Y/" resolves to
-    //       "/api/apps/X/versions/Y/assets/foo.css" (correct)
-    // No trailing slash → redirect to add one
-    router.get('/:appUuid/versions/:versionUuid', (req, res) => {
-        res.redirect(302, `${req.originalUrl}/`);
-    });
+    // -- Auth middleware ------------------------------------------------
+    // Two flavours: one accepts a JWT query param and promotes it to a
+    // cookie (used on index.html), the other only accepts the cookie
+    // (used on assets loaded by the page).
 
-    router.get('/:appUuid/versions/:versionUuid/', async (req, res) => {
+    /**
+     * Verifies a token and translates the result into an HTTP response.
+     * Shared by both middleware variants.
+     */
+    const handleTokenVerification = (
+        token: string | undefined,
+        req: express.Request,
+        res: express.Response,
+        next: express.NextFunction,
+    ): void => {
         const { appUuid, versionUuid } = req.params;
 
         if (!isValidUuid(appUuid) || !isValidUuid(versionUuid)) {
@@ -170,8 +193,12 @@ export const createAppPreviewRouter = (config: AppRuntimeConfig): Router => {
             return;
         }
 
-        const s3Key = `apps/${appUuid}/versions/${versionUuid}/index.html`;
-        const result = await fetchFromS3(s3Key);
+        const result = verifyPreviewToken(
+            token,
+            lightdashSecret,
+            appUuid,
+            versionUuid,
+        );
 
         if (!result.ok) {
             res.status(result.status).json({
@@ -181,25 +208,85 @@ export const createAppPreviewRouter = (config: AppRuntimeConfig): Router => {
             return;
         }
 
-        setSecurityHeaders(res);
-        res.setHeader('Content-Type', 'text/html; charset=utf-8');
-        res.setHeader('Cache-Control', 'no-store');
-        result.body.pipe(res);
+        next();
+    };
+
+    /**
+     * Accepts a JWT from the `?token` query param, verifies it, and
+     * promotes it to a path-scoped HttpOnly cookie so subsequent asset
+     * requests are authenticated automatically by the browser.
+     */
+    const requireTokenAndSetCookie: express.RequestHandler = (
+        req,
+        res,
+        next,
+    ) => {
+        const token =
+            typeof req.query.token === 'string' ? req.query.token : undefined;
+
+        handleTokenVerification(token, req, res, () => {
+            const { appUuid, versionUuid } = req.params;
+            const cookiePath = `/api/apps/${appUuid}/versions/${versionUuid}/`;
+            res.cookie(PREVIEW_COOKIE_NAME, token!, {
+                path: cookiePath,
+                httpOnly: true,
+                secure: true,
+                sameSite: 'strict',
+                maxAge: PREVIEW_TOKEN_MAX_AGE_SECONDS * 1000,
+            });
+            next();
+        });
+    };
+
+    /** Accepts a JWT only from the path-scoped cookie. */
+    const requireCookie: express.RequestHandler = (req, res, next) => {
+        const token = getCookieValue(req.headers.cookie, PREVIEW_COOKIE_NAME);
+        handleTokenVerification(token, req, res, next);
+    };
+
+    // -- Routes ---------------------------------------------------------
+
+    // Redirect to trailing slash so relative asset paths resolve correctly.
+    // e.g. "assets/foo.css" from "/api/apps/X/versions/Y" would resolve to
+    //       "/api/apps/X/versions/assets/foo.css" (wrong)
+    // but from "/api/apps/X/versions/Y/" resolves correctly.
+    router.get('/:appUuid/versions/:versionUuid', (req, res) => {
+        const queryString = req.originalUrl.includes('?')
+            ? req.originalUrl.slice(req.originalUrl.indexOf('?'))
+            : '';
+        res.redirect(302, `${req.baseUrl}${req.path}/${queryString}`);
     });
 
-    // Serve static assets (JS, CSS, fonts) for local dev without CDN
+    // Serve index.html for an app version.
     router.get(
-        '/:appUuid/versions/:versionUuid/assets/:filename',
+        '/:appUuid/versions/:versionUuid/',
+        requireTokenAndSetCookie,
         async (req, res) => {
-            const { appUuid, versionUuid, filename } = req.params;
+            const { appUuid, versionUuid } = req.params;
+            const s3Key = `apps/${appUuid}/versions/${versionUuid}/index.html`;
+            const result = await fetchFromS3(s3Key);
 
-            if (!isValidUuid(appUuid) || !isValidUuid(versionUuid)) {
-                res.status(400).json({
+            if (!result.ok) {
+                res.status(result.status).json({
                     status: 'error',
-                    error: { message: 'Invalid UUID format' },
+                    error: { message: result.message },
                 });
                 return;
             }
+
+            setSecurityHeaders(res);
+            res.setHeader('Content-Type', 'text/html; charset=utf-8');
+            res.setHeader('Cache-Control', 'no-store');
+            result.body.pipe(res);
+        },
+    );
+
+    // Serve static assets (JS, CSS, fonts) for local dev without CDN.
+    router.get(
+        '/:appUuid/versions/:versionUuid/assets/:filename',
+        requireCookie,
+        async (req, res) => {
+            const { filename } = req.params;
 
             if (!isSafeFilename(filename)) {
                 res.status(400).json({
@@ -209,6 +296,7 @@ export const createAppPreviewRouter = (config: AppRuntimeConfig): Router => {
                 return;
             }
 
+            const { appUuid, versionUuid } = req.params;
             const s3Key = `apps/${appUuid}/versions/${versionUuid}/assets/${filename}`;
             const result = await fetchFromS3(s3Key);
 

--- a/packages/backend/src/routers/appPreviewToken.ts
+++ b/packages/backend/src/routers/appPreviewToken.ts
@@ -1,0 +1,100 @@
+import { createHmac } from 'crypto';
+import jwt from 'jsonwebtoken';
+
+const PREVIEW_TOKEN_TYPE = 'app-preview';
+const PREVIEW_TOKEN_MAX_AGE_SECONDS = 3600; // 1 hour
+const PREVIEW_TOKEN_ISSUER = 'lightdash';
+const PREVIEW_TOKEN_AUDIENCE = 'app-preview';
+
+/** Cookie name used to carry the preview token on asset requests. */
+export const PREVIEW_COOKIE_NAME = '__preview_token';
+export { PREVIEW_TOKEN_MAX_AGE_SECONDS };
+
+type PreviewTokenPayload = {
+    type: typeof PREVIEW_TOKEN_TYPE;
+    appUuid: string;
+    versionUuid: string;
+};
+
+/**
+ * Derives a purpose-specific signing key from the global lightdash secret.
+ * This ensures preview tokens cannot be confused with session cookies or
+ * other HMAC uses of the same root secret.
+ */
+const deriveSigningKey = (lightdashSecret: string): Buffer =>
+    createHmac('sha256', lightdashSecret).update('app-preview-token').digest();
+
+/**
+ * Mints a short-lived JWT for accessing a specific app version's preview.
+ */
+export const mintPreviewToken = (
+    lightdashSecret: string,
+    appUuid: string,
+    versionUuid: string,
+): string =>
+    jwt.sign(
+        {
+            type: PREVIEW_TOKEN_TYPE,
+            appUuid,
+            versionUuid,
+        } satisfies PreviewTokenPayload,
+        deriveSigningKey(lightdashSecret),
+        {
+            expiresIn: PREVIEW_TOKEN_MAX_AGE_SECONDS,
+            issuer: PREVIEW_TOKEN_ISSUER,
+            audience: PREVIEW_TOKEN_AUDIENCE,
+            algorithm: 'HS256',
+        },
+    );
+
+type VerifySuccess = { ok: true; payload: PreviewTokenPayload };
+type VerifyFailure = { ok: false; status: 401 | 403; message: string };
+export type VerifyPreviewTokenResult = VerifySuccess | VerifyFailure;
+
+/**
+ * Verifies a preview JWT and checks that the appUuid and versionUuid match
+ * the expected values. Returns a discriminated union so callers can decide
+ * how to handle errors without coupling to HTTP.
+ */
+export const verifyPreviewToken = (
+    token: string | undefined,
+    lightdashSecret: string,
+    appUuid: string,
+    versionUuid: string,
+): VerifyPreviewTokenResult => {
+    if (!token) {
+        return { ok: false, status: 401, message: 'Missing preview token' };
+    }
+
+    try {
+        const decoded = jwt.verify(token, deriveSigningKey(lightdashSecret), {
+            algorithms: ['HS256'],
+            issuer: PREVIEW_TOKEN_ISSUER,
+            audience: PREVIEW_TOKEN_AUDIENCE,
+        });
+
+        if (
+            typeof decoded === 'string' ||
+            decoded.type !== PREVIEW_TOKEN_TYPE ||
+            decoded.appUuid !== appUuid ||
+            decoded.versionUuid !== versionUuid
+        ) {
+            return {
+                ok: false,
+                status: 403,
+                message: 'Invalid or expired preview token',
+            };
+        }
+
+        return {
+            ok: true,
+            payload: decoded as PreviewTokenPayload,
+        };
+    } catch {
+        return {
+            ok: false,
+            status: 403,
+            message: 'Invalid or expired preview token',
+        };
+    }
+};


### PR DESCRIPTION
To get the serving router on a new domain we can't use the existing auth

This uses a scoped JWT that the main app generates, passes into the serving router, which verifies it and serves content.

The jwt is passed in a query param on initial load of the index.html and then is used to create a short cookie. That's because the asset loading won't see the jwt, so we need the cookies.