### PR TITLE
feat: update support nav menu options

### DIFF
--- a/packages/frontend/src/components/NavBar/HelpMenu.tsx
+++ b/packages/frontend/src/components/NavBar/HelpMenu.tsx
@@ -2,10 +2,10 @@ import { LightdashMode } from '@lightdash/common';
 import { Button, getDefaultZIndex, Menu } from '@mantine-8/core';
 import { modals } from '@mantine/modals';
 import {
+    IconBook,
     IconHelp,
     IconMessages,
     IconSos,
-    IconSparkles,
     IconUsers,
 } from '@tabler/icons-react';
 import { type FC } from 'react';
@@ -64,7 +64,7 @@ const HelpMenu: FC = () => {
                     target="_blank"
                     title="Ask the docs"
                     description="Chat with the Lightdash docs AI assistant"
-                    icon={IconSparkles}
+                    icon={IconBook}
                 />
 
                 {isCloudCustomer && (
@@ -73,7 +73,7 @@ const HelpMenu: FC = () => {
                             // @ts-ignore
                             if (window.Pylon) {
                                 // @ts-ignore
-                                window.Pylon(‘show’);
+                                window.Pylon('show');
                             } else {
                                 showIntercom();
                             }
@@ -98,9 +98,9 @@ const HelpMenu: FC = () => {
                         component="a"
                         onClick={() => {
                             modals.open({
-                                id: ‘support-drawer’,
-                                title: ‘Share with Lightdash Support’,
-                                size: ‘lg’,
+                                id: 'support-drawer',
+                                title: 'Share with Lightdash Support',
+                                size: 'lg',
                                 children: <SupportDrawerContent />,
                                 yOffset: 100,
                                 zIndex: 1000,


### PR DESCRIPTION
## Summary
- Rename "View Docs" → "Ask the docs" with AI assistant description
- Rename "Contact support" → "Talk to support" with updated subtext
- Rename "Join Slack community" → "Join the Slack community"
- Rename "Report an issue to Lightdash Support" → "Report an issue" with updated subtext
- Remove "Feedback on Lightdash" (GitHub issues link)
- Reorder: docs first, then support

Closes AE-263

## Test plan
- [ ] Click the help (?) icon in the nav bar
- [ ] Verify "Ask the docs" appears first with book icon and links to docs.lightdash.com
- [ ] Verify "Talk to support" appears for cloud customers and opens Pylon/Intercom
- [ ] Verify "Join the Slack community" links to Slack invite
- [ ] Verify "Report an issue" appears for cloud/dev and opens the diagnostic modal
- [ ] Verify "Feedback on Lightdash" is no longer shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)