### PR TITLE
feat: write project model context to sandbox before generation

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -74,9 +74,10 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
-            appGenerateService: ({ context }) =>
+            appGenerateService: ({ context, models }) =>
                 new AppGenerateService({
                     lightdashConfig: context.lightdashConfig,
+                    catalogModel: models.getCatalogModel(),
                 }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -16,11 +16,13 @@ import { extract, type Headers } from 'tar-stream';
 import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../../../config/parseConfig';
 import Logger from '../../../logging/logger';
+import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
 
 type AppGenerateServiceDeps = {
     lightdashConfig: LightdashConfig;
+    catalogModel: CatalogModel;
 };
 
 type GenerateAppResult = {
@@ -31,9 +33,12 @@ type GenerateAppResult = {
 export class AppGenerateService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
-    constructor({ lightdashConfig }: AppGenerateServiceDeps) {
+    private readonly catalogModel: CatalogModel;
+
+    constructor({ lightdashConfig, catalogModel }: AppGenerateServiceDeps) {
         super();
         this.lightdashConfig = lightdashConfig;
+        this.catalogModel = catalogModel;
     }
 
     private getAnthropicApiKey(): string {
@@ -128,6 +133,17 @@ export class AppGenerateService extends BaseService {
         });
 
         try {
+            // Write the project's catalog to the sandbox so Claude knows
+            // which models, dimensions, and metrics are available.
+            this.logger.info(`App ${appUuid}: writing model context`);
+            const catalogItems =
+                await this.catalogModel.getCatalogItemsSummary(projectUuid);
+            const modelYaml = AppGenerateService.catalogToYaml(catalogItems);
+            await sandbox.files.write(
+                '/tmp/dbt-repo/models/schema.yml',
+                modelYaml,
+            );
+
             // Write the prompt to a file to avoid shell injection
             await sandbox.files.write('/tmp/prompt.txt', prompt);
 
@@ -290,6 +306,62 @@ export class AppGenerateService extends BaseService {
             appUuid,
             versionUuid,
         );
+    }
+
+    /**
+     * Convert catalog items into a dbt-style YAML that skill.md expects.
+     * Groups fields by table and separates dimensions from metrics.
+     */
+    private static catalogToYaml(
+        items: {
+            name: string;
+            type: string;
+            tableName: string;
+            fieldType: string | undefined;
+        }[],
+    ): string {
+        // Group fields by table
+        const tables = new Map<
+            string,
+            { dimensions: string[]; metrics: string[] }
+        >();
+
+        for (const item of items) {
+            if (item.type === 'field') {
+                if (!tables.has(item.tableName)) {
+                    tables.set(item.tableName, { dimensions: [], metrics: [] });
+                }
+                const table = tables.get(item.tableName)!;
+
+                if (item.fieldType === 'metric') {
+                    table.metrics.push(item.name);
+                } else {
+                    table.dimensions.push(item.name);
+                }
+            }
+        }
+
+        // Build YAML
+        const lines: string[] = ['models:'];
+        for (const [tableName, fields] of tables) {
+            lines.push(`  - name: ${tableName}`);
+            if (fields.metrics.length > 0) {
+                lines.push(`    meta:`);
+                lines.push(`      metrics:`);
+                for (const m of fields.metrics) {
+                    lines.push(`        ${m}:`);
+                    lines.push(`          type: metric`);
+                }
+            }
+            if (fields.dimensions.length > 0) {
+                lines.push(`    columns:`);
+                for (const d of fields.dimensions) {
+                    lines.push(`      - name: ${d}`);
+                }
+            }
+        }
+
+        return lines.join('\n');
     }
 
     private static getContentType(filePath: string): string {


### PR DESCRIPTION
## Summary

Gives Claude accurate field names when generating data apps by writing the project's catalog (dimensions and metrics) into the E2B sandbox as dbt-style YAML.

### Changes

- **`AppGenerateService`** — before running Claude, fetches catalog items from `catalog_search` table and writes them as YAML to `/tmp/dbt-repo/models/schema.yml` in the sandbox
- **`catalogToYaml()`** — serializes catalog items into the dbt YAML format that `skill.md` expects, grouping fields by table and separating dimensions from metrics
- **`CatalogModel` dependency** — added to `AppGenerateService` constructor (wired in EE index)

### Why

Previously the sandbox had no model context — Claude was guessing field names, resulting in `unknown field id` errors at runtime. The `skill.md` template tells Claude to read `/tmp/dbt-repo/models/` but nothing was writing there.

### Example output

```yaml
models:
  - name: orders
    meta:
      metrics:
        total_revenue:
          type: metric
        order_count:
          type: metric
    columns:
      - name: status
      - name: order_date
      - name: customer_id
```