### PR TITLE
feat: add configurable DuckDB memory limit for pre-aggregates

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -350,6 +350,7 @@ export const lightdashConfigMock: LightdashConfig = {
         enabled: false,
         parquetEnabled: false,
         materializationMaxRows: null,
+        duckdbQueryMemoryLimit: null,
         s3: {
             endpoint: 'mock_endpoint',
             bucket: 'mock_preagg_bucket',

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1248,6 +1248,8 @@ export type LightdashConfig = {
         enabled: boolean;
         parquetEnabled: boolean;
         materializationMaxRows: number | null;
+        /** Max memory DuckDB can use for caching parquet data and query intermediates on the shared query instance (e.g. '256MB', '1GB', '2GB'). Only affects pre-aggregate reads, not materializations which use isolated instances. */
+        duckdbQueryMemoryLimit: string | null;
         s3?: Omit<S3Config, 'expirationTime'>;
     };
     userImpersonation: {
@@ -2239,6 +2241,8 @@ export const parseConfig = (): LightdashConfig => {
             materializationMaxRows:
                 getIntegerFromEnvironmentVariable('PRE_AGGREGATES_MAX_ROWS') ??
                 null,
+            duckdbQueryMemoryLimit:
+                process.env.PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT ?? null,
             s3: preAggregatesS3,
         },
         userImpersonation: {

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -330,6 +330,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                                     models.getPreAggregateModel(),
                                 projectModel: models.getProjectModel(),
                                 prometheusMetrics,
+                                memoryLimit:
+                                    context.lightdashConfig.preAggregates
+                                        .duckdbQueryMemoryLimit ?? undefined,
                             }),
                         preAggregateDailyStatsModel:
                             models.getPreAggregateDailyStatsModel(),

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -42,6 +42,7 @@ type PreAggregationDuckDbClientArgs = {
     preAggregateModel: Pick<PreAggregateModel, 'getActiveMaterialization'>;
     projectModel: Pick<ProjectModel, 'getExploreFromCache'>;
     prometheusMetrics?: PrometheusMetrics;
+    memoryLimit?: string;
     createDuckdbWarehouseClient?: (args: {
         s3Config: DuckdbS3SessionConfig;
     }) => WarehouseClient;
@@ -104,6 +105,7 @@ export class PreAggregationDuckDbClient {
             ((warehouseArgs) =>
                 new DuckdbWarehouseClient({
                     ...warehouseArgs,
+                    memoryLimit: args.memoryLimit,
                     logger: Logger,
                 }));
     }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -770,6 +770,7 @@ describe('AsyncQueryService', () => {
                     enabled: false,
                     parquetEnabled: false,
                     materializationMaxRows: null,
+                    duckdbQueryMemoryLimit: null,
                 },
             });
             (service as AnyType).preAggregateStrategy = mockStrategy;

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -86,7 +86,7 @@ export type DuckdbWarehouseClientArgs = {
     databasePath?: string;
     s3Config?: DuckdbS3SessionConfig;
     resourceLimits?: DuckdbResourceLimits;
-    bufferPoolSize?: string; // e.g. '256MB' — controls DuckDB's buffer_pool_size for parquet/HTTP caching
+    memoryLimit?: string; // e.g. '256MB', '1GB' — sets DuckDB's memory_limit for the shared instance
     logger?: DuckdbLogger;
     onQueryProfile?: (profile: DuckdbQueryProfileMetrics) => void;
 };
@@ -245,10 +245,8 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
 
             await DuckdbWarehouseClient.hardenInstance(db);
 
-            if (client.bufferPoolSize) {
-                await db.run(
-                    `SET buffer_pool_size = '${client.bufferPoolSize}';`,
-                );
+            if (client.memoryLimit) {
+                await db.run(`SET memory_limit = '${client.memoryLimit}';`);
             }
 
             if (client.s3Config) {
@@ -258,7 +256,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
             }
 
             client.logger?.info(
-                `DuckDB shared instance bootstrapped: httpfs=${Math.round(httpfsMs)}ms buffer_pool_size=${client.bufferPoolSize ?? 'default'} s3=${client.s3Config ? 'configured' : 'none'}`,
+                `DuckDB shared instance bootstrapped: httpfs=${Math.round(httpfsMs)}ms memory_limit=${client.memoryLimit ?? 'default'} s3=${client.s3Config ? 'configured' : 'none'}`,
             );
         } finally {
             db.closeSync?.();
@@ -322,7 +320,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
 
     private readonly resourceLimits?: DuckdbResourceLimits;
 
-    private readonly bufferPoolSize?: string;
+    private readonly memoryLimit?: string;
 
     private readonly logger?: DuckdbLogger;
 
@@ -335,7 +333,7 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreatePostgresCre
         this.databasePath = args.databasePath ?? ':memory:';
         this.s3Config = args.s3Config;
         this.resourceLimits = args.resourceLimits;
-        this.bufferPoolSize = args.bufferPoolSize;
+        this.memoryLimit = args.memoryLimit;
         this.logger = args.logger;
         this.onQueryProfile = args.onQueryProfile;
     }


### PR DESCRIPTION
### Description:



The shared DuckDB instance used for pre-aggregate queries has no memory cap. Under concurrent load, multiple queries scanning parquet files can grow memory past the container limit, OOMKilling the pod and losing all inflight queries:skull:



This pr adds `PRE_AGGREGATE_DUCKDB_QUERY_MEMORY_LIMIT` env var to bound DuckDB's memory. When the limit is hit, individual queries error and fall back to the warehouse instead of crashing the entire pod. Only affects the pre-aggregate query path, materializations use isolated instances with their own limits for now

Sizing guide:

```
memory_limit >= (per_query_memory × max_concurrent_queries) + overhead
```

- `per_query_memory`: depends on the parquet size and query complexity (~120-140MB for a HASH_GROUP_BY over 4.3M rows)
- `max_concurrent_queries`: controlled by `NATS_WORKER_CONCURRENCY`
- `overhead`: bootstrap, parquet metadata cache, etc