### PR TITLE
fix: clear colorByCategory when grouping dimension added

### DIFF
--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -604,6 +604,21 @@ const useCartesianChartConfig = ({
         }
     }, [cartesianType, setType]);
 
+    // Color by category only works for single-series ungrouped charts;
+    // clear when a grouping dimension is added
+    useEffect(() => {
+        if (pivotKeys && pivotKeys.length > 0) {
+            setDirtyLayout((prev) => {
+                if (!prev?.colorByCategory) return prev;
+                return {
+                    ...prev,
+                    colorByCategory: undefined,
+                    categoryColorOverrides: undefined,
+                };
+            });
+        }
+    }, [pivotKeys]);
+
     const setFlipAxis = useCallback((flipAxes: boolean) => {
         setDirtyLayout((prev) => ({
             ...prev,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:
Automatically clear color by category settings when pivot keys are added to cartesian charts. This prevents invalid chart configurations since color by category only works for single-series ungrouped charts. When grouping dimensions are detected, both `colorByCategory` and `categoryColorOverrides` are reset to undefined.

<!-- Even better add a screenshot / gif / loom -->