### PR TITLE
fix: preserve colorByCategory setting when pivot dimensions are active

### DIFF
--- a/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
+++ b/packages/frontend/src/hooks/cartesianChartConfig/useCartesianChartConfig.ts
@@ -604,21 +604,6 @@ const useCartesianChartConfig = ({
         }
     }, [cartesianType, setType]);
 
-    // Color by category only works for single-series ungrouped charts;
-    // clear when a grouping dimension is added
-    useEffect(() => {
-        if (pivotKeys && pivotKeys.length > 0) {
-            setDirtyLayout((prev) => {
-                if (!prev?.colorByCategory) return prev;
-                return {
-                    ...prev,
-                    colorByCategory: undefined,
-                    categoryColorOverrides: undefined,
-                };
-            });
-        }
-    }, [pivotKeys]);
-
     const setFlipAxis = useCallback((flipAxes: boolean) => {
         setDirtyLayout((prev) => ({
             ...prev,

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2438,9 +2438,12 @@ const useEchartsCartesianConfig = (
         if (!itemsMap) return;
 
         const isHorizontal = Boolean(validCartesianConfig?.layout.flipAxes);
-        const isColorByCategory = Boolean(
-            validCartesianConfig?.layout?.colorByCategory,
-        );
+        // Color by category only applies to ungrouped single-series charts;
+        // ignore the setting when pivot dimensions are active so that the
+        // saved overrides survive and restore when the grouping is removed.
+        const isColorByCategory =
+            Boolean(validCartesianConfig?.layout?.colorByCategory) &&
+            !pivotDimensions?.length;
         const categoryColorOverrides =
             validCartesianConfig?.layout?.categoryColorOverrides;
         // xField is always the dimension (category) field regardless of flipAxes.
@@ -2598,6 +2601,7 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.colorByCategory,
         validCartesianConfig?.layout?.categoryColorOverrides,
         validCartesianConfig?.layout?.xField,
+        pivotDimensions,
         series,
         rows,
         validCartesianConfigLegend,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-6610

### Description:

Fixed color by category behavior for grouped charts by moving the logic from clearing the setting when pivot keys are present to instead ignoring the setting during chart rendering while preserving the saved configuration. This allows color overrides to persist and automatically restore when grouping dimensions are removed, providing a better user experience when toggling between grouped and ungrouped chart views.

<!-- Even better add a screenshot / gif / loom -->