### PR TITLE
fix: show actual value instead of n/a for non-numeric big number comparisons

### DIFF
--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -294,6 +294,15 @@ const useBigNumberConfig = (
         return resultsData.rows?.[1]?.[selectedField]?.value.raw;
     }, [selectedField, comparisonField, resultsData]);
 
+    const secondRowValueFormatted = useMemo(() => {
+        if (!resultsData) return;
+        if (comparisonField) {
+            return resultsData.rows?.[0]?.[comparisonField]?.value.formatted;
+        }
+        if (!selectedField) return;
+        return resultsData.rows?.[1]?.[selectedField]?.value.formatted;
+    }, [selectedField, comparisonField, resultsData]);
+
     const bigNumber = useMemo(() => {
         if (!isNumber(item, firstRowValueRaw)) {
             return (
@@ -387,7 +396,7 @@ const useBigNumberConfig = (
 
     const comparisonValue = useMemo(() => {
         return unformattedValue === NOT_APPLICABLE
-            ? NOT_APPLICABLE
+            ? (secondRowValueFormatted ?? NOT_APPLICABLE)
             : formatComparisonValue(
                   comparisonFormat,
                   comparisonDiff,
@@ -401,6 +410,7 @@ const useBigNumberConfig = (
         comparisonDiff,
         comparisonItem,
         unformattedValue,
+        secondRowValueFormatted,
         bigNumberComparisonStyle,
         parameters,
     ]);
@@ -414,9 +424,7 @@ const useBigNumberConfig = (
             case ComparisonDiffTypes.NONE:
                 return `No change compared to ${source}`;
             case ComparisonDiffTypes.NAN:
-                return comparisonField
-                    ? `The comparison field's value is not a number`
-                    : `The previous row's value is not a number`;
+                return `${comparisonValue} from ${source}`;
             case ComparisonDiffTypes.UNDEFINED:
                 return comparisonField
                     ? `Comparison field has no value`


### PR DESCRIPTION
Closes: PROD-6616

## Summary
- Big number charts with comparisons enabled on non-numeric fields (e.g. dates) previously showed `n/a` with a tooltip "The previous row's value is not a number"
- Now shows the actual formatted comparison value instead, consistent with how the main big number already handles non-numeric fields
- Updated tooltip from the unhelpful "not a number" message to show the value with its source context (e.g. "2026-03-15 from previous row")

## Test plan
- [ ] Create a big number chart with a date dimension and enable comparison
- [ ] Verify the comparison pill shows the formatted date value instead of `n/a`
- [ ] Verify the tooltip shows the value with source context
- [ ] Verify numeric comparisons still work as before (diff, percentage, arrows)
- [ ] Verify comparison with a comparison field (not just previous row) also shows the value

🤖 Generated with [Claude Code](https://claude.com/claude-code)