### PR TITLE
feat: apply space names on upload

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -1099,6 +1099,7 @@ export class ProjectController extends BaseController {
             skipSpaceCreate?: boolean;
             publicSpaceCreate?: boolean;
             force?: boolean;
+            spaceNames?: Record<string, string>;
             chartConfig: AnyType;
             description?: string | null; // Allow both undefined and null
         },
@@ -1118,6 +1119,7 @@ export class ProjectController extends BaseController {
                 chart.skipSpaceCreate,
                 chart.publicSpaceCreate,
                 chart.force,
+                chart.spaceNames,
             ),
         };
     }
@@ -1161,6 +1163,7 @@ export class ProjectController extends BaseController {
             skipSpaceCreate?: boolean;
             publicSpaceCreate?: boolean;
             force?: boolean;
+            spaceNames?: Record<string, string>;
             config: AnyType;
             description?: string | null;
         },
@@ -1180,6 +1183,7 @@ export class ProjectController extends BaseController {
                 sqlChart.skipSpaceCreate,
                 sqlChart.publicSpaceCreate,
                 sqlChart.force,
+                sqlChart.spaceNames,
             ),
         };
     }
@@ -1200,6 +1204,7 @@ export class ProjectController extends BaseController {
             skipSpaceCreate?: boolean;
             publicSpaceCreate?: boolean;
             force?: boolean;
+            spaceNames?: Record<string, string>;
             tiles: AnyType;
             description?: string | null; // Allow both undefined and null
         }, // Simplify filter type for tsoa
@@ -1219,6 +1224,7 @@ export class ProjectController extends BaseController {
                 dashboard.skipSpaceCreate,
                 dashboard.publicSpaceCreate,
                 dashboard.force,
+                dashboard.spaceNames,
             ),
         };
     }

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -979,6 +979,7 @@ export class CoderService extends BaseService {
         skipSpaceCreate?: boolean,
         publicSpaceCreate?: boolean,
         force?: boolean,
+        spaceNames?: Record<string, string>,
     ) {
         const project = await this.projectModel.get(projectUuid);
 
@@ -1022,6 +1023,7 @@ export class CoderService extends BaseService {
                     user,
                     skipSpaceCreate,
                     publicSpaceCreate,
+                    spaceNames,
                 );
 
             console.info(
@@ -1122,6 +1124,8 @@ export class CoderService extends BaseService {
             chartWithDefaults.spaceSlug,
             user,
             skipSpaceCreate,
+            undefined,
+            spaceNames,
         );
 
         const { promotedChart, upstreamChart } =
@@ -1178,6 +1182,7 @@ export class CoderService extends BaseService {
         skipSpaceCreate?: boolean,
         publicSpaceCreate?: boolean,
         force?: boolean,
+        spaceNames?: Record<string, string>,
     ): Promise<PromotionChanges> {
         const project = await this.projectModel.get(projectUuid);
 
@@ -1211,6 +1216,7 @@ export class CoderService extends BaseService {
             user,
             skipSpaceCreate,
             publicSpaceCreate,
+            spaceNames,
         );
 
         if (existingSqlChart === undefined) {
@@ -1311,6 +1317,7 @@ export class CoderService extends BaseService {
         user: SessionUser,
         skipSpaceCreate?: boolean,
         publicSpaceCreate?: boolean,
+        spaceNames?: Record<string, string>,
     ): Promise<{ space: SpaceSummaryBase; created: boolean }> {
         const [existingSpace] = await this.spaceModel.find({
             path: getLtreePathFromContentAsCodePath(spaceSlug),
@@ -1375,10 +1382,16 @@ export class CoderService extends BaseService {
                 parentPath = `${parentPath}.${currentPath}`;
             }
 
+            // Use the original space name from space definition files if available,
+            // otherwise fall back to deriving a name from the slug path segment
+            const spaceName =
+                spaceNames?.[getContentAsCodePathFromLtreePath(parentPath)] ??
+                friendlyName(currentPath);
+
             const newSpace = await this.spaceModel.createSpace(
                 {
                     inheritParentPermissions,
-                    name: friendlyName(currentPath),
+                    name: spaceName,
                     parentSpaceUuid,
                 },
                 {
@@ -1455,6 +1468,7 @@ export class CoderService extends BaseService {
         skipSpaceCreate?: boolean,
         publicSpaceCreate?: boolean,
         force?: boolean,
+        spaceNames?: Record<string, string>,
     ): Promise<PromotionChanges> {
         const project = await this.projectModel.get(projectUuid);
 
@@ -1505,6 +1519,7 @@ export class CoderService extends BaseService {
                     user,
                     skipSpaceCreate,
                     publicSpaceCreate,
+                    spaceNames,
                 );
 
             const newDashboard = await this.dashboardModel.create(
@@ -1578,6 +1593,8 @@ export class CoderService extends BaseService {
             dashboardWithDefaults.spaceSlug,
             user,
             skipSpaceCreate,
+            undefined,
+            spaceNames,
         );
 
         //  we force the new space on the upstreamDashboard

--- a/packages/cli/src/handlers/download.ts
+++ b/packages/cli/src/handlers/download.ts
@@ -247,6 +247,62 @@ const writeSpaceFiles = async (
     }
 };
 
+/**
+ * Reads all .space.yml files from the download directory and returns
+ * a map of space slug → original space name. Used during upload to
+ * preserve human-readable space names instead of deriving them from slugs.
+ */
+const readSpaceNames = async (
+    customPath?: string,
+): Promise<Record<string, string>> => {
+    const baseDir = getDownloadFolder(customPath);
+    const spaceNames: Record<string, string> = {};
+
+    try {
+        const allEntries = await fs.readdir(baseDir, {
+            recursive: true,
+            withFileTypes: true,
+        });
+
+        await Promise.all(
+            allEntries
+                .filter(
+                    (entry) =>
+                        entry.isFile() && entry.name.endsWith('.space.yml'),
+                )
+                .map(async (file) => {
+                    try {
+                        const filePath = path.join(file.parentPath, file.name);
+                        const fileContent = await fs.readFile(
+                            filePath,
+                            'utf-8',
+                        );
+                        const parsed = yaml.load(fileContent) as Record<
+                            string,
+                            unknown
+                        >;
+                        if (
+                            parsed?.contentType ===
+                                ContentAsCodeTypeEnum.SPACE &&
+                            typeof parsed.slug === 'string' &&
+                            typeof parsed.spaceName === 'string'
+                        ) {
+                            spaceNames[parsed.slug] = parsed.spaceName;
+                        }
+                    } catch (e) {
+                        GlobalState.debug(
+                            `Skipping space file ${file.name}: ${getErrorMessage(e)}`,
+                        );
+                    }
+                }),
+        );
+    } catch {
+        // Directory doesn't exist or can't be read — return empty map
+    }
+
+    return spaceNames;
+};
+
 const hasUnsortedKeys = (obj: unknown): boolean => {
     if (typeof obj !== 'object' || obj === null || Array.isArray(obj)) {
         if (Array.isArray(obj)) {
@@ -1041,6 +1097,7 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
     skipSpaceCreate?: boolean,
     publicSpaceCreate?: boolean,
     validate?: boolean,
+    spaceNames?: Record<string, string>,
 ): Promise<void> => {
     try {
         if (!force && !item.needsUpdating) {
@@ -1068,6 +1125,8 @@ const upsertSingleItem = async <T extends ChartAsCode | DashboardAsCode>(
                 skipSpaceCreate,
                 publicSpaceCreate,
                 force,
+                ...(spaceNames &&
+                    Object.keys(spaceNames).length > 0 && { spaceNames }),
             }),
         });
 
@@ -1203,6 +1262,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
     validate?: boolean,
     concurrency: number = 1,
     extraItems: (T & { needsUpdating: boolean })[] = [],
+    spaceNames?: Record<string, string>,
 ): Promise<{ changes: Record<string, number>; total: number }> => {
     const config = await getConfig();
 
@@ -1243,6 +1303,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 skipSpaceCreate,
                 publicSpaceCreate,
                 validate,
+                spaceNames,
             );
         }
     } else {
@@ -1324,6 +1385,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                 skipSpaceCreate,
                 publicSpaceCreate,
                 validate,
+                spaceNames,
             );
         }
 
@@ -1342,6 +1404,7 @@ const upsertResources = async <T extends ChartAsCode | DashboardAsCode>(
                         skipSpaceCreate,
                         publicSpaceCreate,
                         validate,
+                        spaceNames,
                     );
                 }),
             ),
@@ -1459,6 +1522,14 @@ export const uploadHandler = async (
             );
         }
 
+        // Read space definition files to preserve original space names during upload
+        const spaceNames = await readSpaceNames(options.path);
+        if (Object.keys(spaceNames).length > 0) {
+            GlobalState.log(
+                `Found ${Object.keys(spaceNames).length} space definition(s)`,
+            );
+        }
+
         // Discover loose YAML files (outside charts/ and dashboards/) classified by contentType
         const looseFiles = await readLooseCodeFiles(options.path);
         if (looseFiles.charts.length > 0) {
@@ -1490,6 +1561,7 @@ export const uploadHandler = async (
                     options.validate,
                     concurrency,
                     looseFiles.charts,
+                    spaceNames,
                 );
             changes = chartChanges;
             chartTotal = total;
@@ -1513,6 +1585,7 @@ export const uploadHandler = async (
                     options.validate,
                     concurrency,
                     looseFiles.dashboards,
+                    spaceNames,
                 );
             changes = dashboardChanges;
             dashboardTotal = total;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds support for preserving original space names during content upload operations. 

**Key Changes:**

- Added `spaceNames` parameter to project controller endpoints for charts, SQL charts, and dashboards
- Enhanced the `CoderService` to accept and utilize a `spaceNames` mapping when creating spaces
- Modified space creation logic to use original space names from `.space.yml` files instead of deriving names from slug paths
- Added `readSpaceNames()` function in the CLI to parse space definition files and extract original space names
- Updated upload handler to read space definitions and pass the name mappings through the entire upload pipeline

**How it works:**

1. During upload, the CLI scans for `.space.yml` files and builds a mapping of space slugs to their original names
2. This mapping is passed through the API to the backend services
3. When creating spaces, the service now prioritizes the original space name from the mapping over the auto-generated friendly name from the slug
4. Falls back to the existing slug-based naming when no original name is available

This ensures that spaces maintain their human-readable names even after being downloaded and re-uploaded, improving the content-as-code workflow.