### PR TITLE
fix: throw API errors before logging in useSavedSqlChartResults

### DIFF
--- a/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
+++ b/packages/frontend/src/features/sqlRunner/hooks/useSavedSqlChartResults.tsx
@@ -147,15 +147,13 @@ export const useSavedSqlChartResults = (
                     originalColumns,
                 };
             } catch (e) {
+                if (isApiError(e)) {
+                    throw e;
+                }
                 captureException(e, {
                     tags: { errorType: 'chartResultsProcessing' },
                     extra: { chartData: chartQuery.data },
                 });
-                // Re-throw API errors as-is; wrap client-side errors
-                // so the UI can display the message via .error.message
-                if (isApiError(e)) {
-                    throw e;
-                }
                 const message = e instanceof Error ? e.message : String(e);
                 const wrapped: ApiError = {
                     status: 'error',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: LIGHTDASH-FRONTEND-4QQ

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

Fixed error handling logic in `useSavedSqlChartResults` hook by moving the API error check before exception capture. This ensures that API errors are re-thrown immediately without being logged to error tracking, while client-side errors are still captured and wrapped appropriately for UI display.

<!-- Even better add a screenshot / gif / loom -->