### PR TITLE
fix: refetch chart config when rolling back version

### DIFF
--- a/packages/frontend/src/hooks/useSavedQuery.ts
+++ b/packages/frontend/src/hooks/useSavedQuery.ts
@@ -182,6 +182,7 @@ export const useChartVersionRollbackMutation = (
         'mutationFn'
     >,
 ) => {
+    const queryClient = useQueryClient();
     const { showToastSuccess, showToastApiError } = useToaster();
     return useMutation<null, ApiError, string>(
         (versionUuid: string) =>
@@ -192,6 +193,7 @@ export const useChartVersionRollbackMutation = (
             mutationKey: ['saved_query_rollback'],
             ...useMutationOptions,
             onSuccess: async (...args) => {
+                await queryClient.invalidateQueries(['saved_query']);
                 showToastSuccess({
                     title: `Success! Chart was reverted.`,
                 });


### PR DESCRIPTION
### Description:

**Bug**
When restoring a chart version, the old version was sticking around until reload.

**Fix**
Invalidate the chart query so we fetch the new version. 