### PR TITLE
fix: use dbt run_results to track compiled models for deferred preview builds

### DIFF
--- a/packages/cli/src/handlers/dbt/compile.ts
+++ b/packages/cli/src/handlers/dbt/compile.ts
@@ -7,7 +7,9 @@ import {
     SupportedDbtVersions,
 } from '@lightdash/common';
 import execa from 'execa';
+import { promises as fs } from 'fs';
 import { xor } from 'lodash';
+import * as path from 'path';
 import { loadManifest, LoadManifestArgs } from '../../dbt/manifest';
 import GlobalState from '../../globalState';
 import { getDbtVersion } from './getDbtVersion';
@@ -84,6 +86,39 @@ export const dbtCompile = async (options: DbtCompileOptions) => {
         throw new ParseError(`Failed to run dbt compile:\n  ${msg}`);
     }
 };
+
+/**
+ * Reads run_results.json written by dbt after each compile/run to get the
+ * unique_ids of models that were actually processed in THIS run.
+ * This is more reliable than manifest.compiled, which can contain stale flags
+ * from previous runs (e.g. when state:modified+ selects 0 models, all previously
+ * compiled models still have compiled=true in the manifest).
+ */
+async function getCompiledModelIdsFromRunResults(
+    targetDir: string,
+): Promise<string[] | undefined> {
+    const runResultsPath = path.join(targetDir, 'run_results.json');
+    try {
+        const content = await fs.readFile(runResultsPath, {
+            encoding: 'utf-8',
+        });
+        const runResults = JSON.parse(content) as {
+            results: Array<{ unique_id: string; status: string }>;
+        };
+        const modelIds = runResults.results
+            .map((r) => r.unique_id)
+            .filter((id) => id.startsWith('model.'));
+        GlobalState.debug(
+            `> Read ${modelIds.length} model(s) from run_results.json`,
+        );
+        return modelIds;
+    } catch (e) {
+        GlobalState.debug(
+            `> Warning: Could not read run_results.json from ${runResultsPath}: ${getErrorMessage(e)}`,
+        );
+        return undefined;
+    }
+}
 
 const getJoinedModelsRecursively = (
     modelNode: DbtModelNode,
@@ -214,6 +249,9 @@ export async function maybeCompileModelsAndJoins(
         compiledModelIds = await dbtList(options);
     } else {
         await dbtCompile(options);
+        compiledModelIds = await getCompiledModelIdsFromRunResults(
+            loadManifestOpts.targetDir,
+        );
     }
 
     // If no models are explicitly selected or excluded, we don't need to explicitly find joined models


### PR DESCRIPTION
## Summary

- read `run_results.json` after `dbt compile` when `--use-dbt-list=false`
- use the fresh `unique_id` list from the current invocation instead of relying on stale `manifest.compiled` flags
- avoid misclassifying deferred models as selected models during preview compilation, which can leave BigQuery queries pointing at missing PR tables
- fall back gracefully when `run_results.json` is unavailable

**How I validated the fix**

I reproduced the `--use-dbt-list=false` artifact issue using the local dbt example

The problem with the old behavior is that after `dbt compile`, Lightdash had no explicit `compiledModelIds`, so it fell back to `manifest.compiled`. Those flags can be stale from previous runs, which means a slim compile can incorrectly look like “many models were compiled in this run.”

To validate the fix, I checked both the “nothing modified” and “one model modified” cases using `run_results.json`, which is written fresh by dbt for each compile.

**Validation steps**

Create the state manifest:

```bash
cd examples/full-jaffle-shop-demo/dbt

dbt seed --profiles-dir ../profiles --target jaffle --target-path target-prod
dbt run --profiles-dir ../profiles --target jaffle --target-path target-prod
dbt compile --profiles-dir ../profiles --target jaffle --target-path target-prod
```

Verify the “nothing modified” case:

```bash
export SEED_SCHEMA=jaffle_pr

dbt compile \
  --profiles-dir ../profiles \
  --target jaffle \
  --target-path target-pr \
  --select 'state:modified+' \
  --defer \
  --state ./target-prod

jq '.results | map(.unique_id)' target-pr/run_results.json
```

Result:

- `run_results.json` returned `[]`
- this confirms dbt selected nothing in that invocation
- under the old behavior, Lightdash would still have fallen back to stale `manifest.compiled`

Verify the “one model modified” case:

```bash
printf '\n-- test change %s\n' "$(date +%s)" >> models/orders.sql

dbt compile \
  --profiles-dir ../profiles \
  --target jaffle \
  --target-path target-pr \
  --select 'state:modified+' \
  --defer \
  --state ./target-prod

jq '[.results[] | .unique_id | select(startswith("model."))]' target-pr/run_results.json
```

Result:

- dbt wrote a fresh `run_results.json`
- filtering to `model.` ids returned only:

```json
[
  "model.jaffle_shop.orders"
]
```

This is the expected behavior and demonstrates the fix:

- before: `useDbtList=false` meant `compiledModelIds` was `undefined`, so selection was inferred from stale `manifest.compiled`
- after: `useDbtList=false` reads `run_results.json`, so `compiledModelIds` reflects the models actually compiled in that invocation

That makes `originallySelectedModelIds` accurate again, which allows defer patching to correctly rewrite non-selected models to the state/prod relation.