### PR TITLE
fix: handle nested custom metrics when mixing raw and aggregate helper metrics

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_accounts.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/fanouts_examples/fanouts_accounts.yml
@@ -4,9 +4,11 @@ models:
     meta:
       primary_key: account_id
       # This filter means that unless you are an admin, you can't see Enterprise account
-      sql_filter: ${lightdash.attributes.is_admin_saas_demo} = 'true' or segment !=
+      sql_filter:
+        ${lightdash.attributes.is_admin_saas_demo} = 'true' or segment !=
         'Enterprise'
-      description: List of all customer and prospective customer fanouts_accounts pulled from
+      description:
+        List of all customer and prospective customer fanouts_accounts pulled from
         our CRM
       joins:
         - join: fanouts_deals
@@ -25,7 +27,7 @@ models:
               total_amount,
               total_deal_value,
               total_won_amount,
-              seats
+              seats,
             ]
         - join: fanouts_users
           relationship: many-to-many
@@ -42,13 +44,22 @@ models:
               created_at,
               first_logged_in_at,
               experience_in_years,
-              average_experience_in_years
+              average_experience_in_years,
             ]
         - join: fanouts_tracks
           relationship: one-to-many
           sql_on: ${fanouts_users.user_id} = ${fanouts_tracks.user_id}
           type: left
-          fields: [ id, user_id, event_count, name, timestamp, days_since_user_created, event_count]
+          fields:
+            [
+              id,
+              user_id,
+              event_count,
+              name,
+              timestamp,
+              days_since_user_created,
+              event_count,
+            ]
       metrics:
         nested_agg_fanout_repro:
           type: number
@@ -83,9 +94,25 @@ models:
           dimension:
             type: string
             urls:
-              - label: 'Open in CRM'
+              - label: "Open in CRM"
                 url: https://demo_saas.com/example/account/${ value.raw }
           metrics:
+            raw_arr_value:
+              hidden: true
+              type: number
+              label: "Raw ARR Value"
+              sql: ${TABLE}.estimated_annual_recurring_revenue
+
+            max_numeric_dim:
+              hidden: true
+              type: max
+              label: Max Numeric Dim"
+              sql: ${TABLE}.estimated_annual_recurring_revenue
+
+            mixed_raw_aggregate_repro:
+              type: number
+              label: "Mixed raw + aggregate"
+              sql: (ARRAY_AGG(${raw_arr_value} ORDER BY ${max_numeric_dim} DESC))[1]
             deals_seats_metric:
               type: sum
               description: "Sum of all deal seats for this account"
@@ -98,24 +125,27 @@ models:
             unique_smb_accounts:
               label: Unique SMB fanouts_accounts
               type: count_distinct
-              description: The unique number of fanouts_accounts based on distinct Account IDs for
+              description:
+                The unique number of fanouts_accounts based on distinct Account IDs for
                 fanouts_accounts in the SMB Segment
               filters:
-                - segment: 'SMB'
+                - segment: "SMB"
             unique_midmarket_accounts:
               label: Unique Midmarket fanouts_accounts
               type: count_distinct
-              description: The unique number of Midmarket fanouts_accounts based on distinct Account
+              description:
+                The unique number of Midmarket fanouts_accounts based on distinct Account
                 IDs for fanouts_accounts in the Midmarket Segment
               filters:
-                - segment: 'Midmarket'
+                - segment: "Midmarket"
             unique_enterprise_accounts:
               label: Unique Enterprise Accounts
               type: count_distinct
-              description: The unique number of accounts based on distinct Account IDs for
+              description:
+                The unique number of accounts based on distinct Account IDs for
                 accounts in the Enterprise Segment
               filters:
-                - segment: 'Enterprise'
+                - segment: "Enterprise"
       - name: account_name
         description: "Name of this company account"
         meta:
@@ -141,7 +171,7 @@ models:
               type: sum
               label: "Total Estimated Annual Recurring Revenue"
               description: "Sum of all estimated annual recurring revenue"
-              format: 'usd'
+              format: "usd"
       - name: numeric_dim
         description: "A numeric dimension for testing purposes"
         meta:

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -2732,6 +2732,37 @@ export const EXPLORE_WITH_NESTED_AGG: Explore = {
                     tablesReferences: ['my_table'],
                     hidden: false,
                 },
+                // Raw (non-aggregate) helper metric — just a column reference.
+                // Used by mixed_raw_agg_repro to test the mix of raw + aggregate deps.
+                raw_value: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'raw_value',
+                    label: 'raw_value',
+                    sql: '${TABLE}.value',
+                    compiledSql: '"my_table".value',
+                    tablesReferences: ['my_table'],
+                    hidden: true,
+                },
+                // Outer metric mixing raw + aggregate inner deps (GH-21501).
+                // Emulates MAX_BY: pick the raw value ordered by the max metric.
+                // Compiles to ARRAY_AGG(raw_col ORDER BY MAX(col)) which is a
+                // nested aggregate that needs CTE routing.
+                mixed_raw_agg_repro: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'mixed_raw_agg_repro',
+                    label: 'mixed_raw_agg_repro',
+                    sql: '(ARRAY_AGG(${raw_value} ORDER BY ${max_value} DESC))[1]',
+                    compiledSql:
+                        '(ARRAY_AGG("my_table".value ORDER BY MAX("my_table".value) DESC))[1]',
+                    tablesReferences: ['my_table'],
+                    hidden: false,
+                },
                 // Product of aggregates - NO outer aggregation, valid SQL without CTE
                 product_of_aggregates: {
                     type: MetricType.NUMBER,
@@ -2901,6 +2932,55 @@ export const METRIC_QUERY_NESTED_AGG_TRANSITIVE_MIXED: CompiledMetricQuery = {
     metrics: ['my_table_ratio_of_sum_case', 'my_table_conditional_sum_of_max'],
     filters: {},
     sorts: [{ fieldId: 'my_table_ratio_of_sum_case', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+// Mixed raw + aggregate inner deps (GH-21501):
+// Outer metric: ARRAY_AGG(${raw_value} ORDER BY ${max_value} DESC)[1]
+// raw_value is type:number (raw column), max_value is type:max (aggregate).
+// CTE 1 should only pre-compute aggregate deps; CTE 3 (nested_agg_mixed)
+// should join base table + CTE 1 so raw columns are accessible.
+export const METRIC_QUERY_NESTED_AGG_MIXED_RAW: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['my_table_category'],
+    metrics: ['my_table_mixed_raw_agg_repro'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_mixed_raw_agg_repro', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+// Mixed raw + aggregate alongside a pure aggregate metric in the same query.
+// Tests that CTE 2 (nested_agg_results) handles pure-agg metrics and
+// CTE 3 (nested_agg_mixed) handles mixed metrics without interfering.
+export const METRIC_QUERY_NESTED_AGG_MIXED_RAW_WITH_PURE: CompiledMetricQuery =
+    {
+        exploreName: 'my_table',
+        dimensions: ['my_table_category'],
+        metrics: ['my_table_mixed_raw_agg_repro', 'my_table_sum_of_max'],
+        filters: {},
+        sorts: [{ fieldId: 'my_table_mixed_raw_agg_repro', descending: true }],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+// Mixed raw + aggregate with no dimensions — tests CROSS JOIN path.
+export const METRIC_QUERY_NESTED_AGG_MIXED_RAW_NO_DIMS: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: [],
+    metrics: ['my_table_mixed_raw_agg_repro'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_mixed_raw_agg_repro', descending: true }],
     limit: 10,
     tableCalculations: [],
     compiledTableCalculations: [],

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -61,6 +61,9 @@ import {
     METRIC_QUERY_NESTED_AGG_CONDITIONAL,
     METRIC_QUERY_NESTED_AGG_COUNT_DISTINCT,
     METRIC_QUERY_NESTED_AGG_MIXED,
+    METRIC_QUERY_NESTED_AGG_MIXED_RAW,
+    METRIC_QUERY_NESTED_AGG_MIXED_RAW_NO_DIMS,
+    METRIC_QUERY_NESTED_AGG_MIXED_RAW_WITH_PURE,
     METRIC_QUERY_NESTED_AGG_NO_DIMS,
     METRIC_QUERY_NESTED_AGG_PRODUCT,
     METRIC_QUERY_NESTED_AGG_RAW_COL,
@@ -5300,6 +5303,88 @@ describe('Nested aggregate metrics', () => {
         expect(
             result.query.match(/AS "my_table_cross_table_sum_of_max"/g),
         ).toHaveLength(1);
+    });
+
+    test('should handle mixed raw + aggregate inner deps via nested_agg_mixed CTE', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_MIXED_RAW,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // CTE 1 should only pre-compute the aggregate dep (max_value),
+        // NOT the raw dep (raw_value) which would fail GROUP BY.
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).toContain(
+            'MAX("my_table".value) AS "my_table_max_value"',
+        );
+        // raw_value should NOT appear in CTE 1
+        expect(result.query).not.toMatch(
+            /nested_agg AS \([^)]*"my_table_raw_value"/,
+        );
+
+        // CTE 3 (nested_agg_mixed) should exist and join base table + CTE 1
+        expect(result.query).toContain('nested_agg_mixed AS (');
+        // The mixed metric should use base table raw column + CTE aggregate ref
+        expect(result.query).toContain('nested_agg."my_table_max_value"');
+        // Raw column should reference base table (inside ARRAY_AGG).
+        // compileMetricReference wraps the resolved SQL in parens.
+        expect(result.query).toContain('ARRAY_AGG(("my_table".value)');
+
+        // CTE 2 (nested_agg_results) should NOT be created since there
+        // are no pure-aggregate outer metrics
+        expect(result.query).not.toContain('nested_agg_results AS (');
+
+        // Final SELECT should reference nested_agg_mixed
+        expect(result.query).toContain(
+            'nested_agg_mixed."my_table_mixed_raw_agg_repro"',
+        );
+
+        // Should NOT contain nested aggregate (ARRAY_AGG wrapping MAX)
+        expect(result.query).not.toContain('ORDER BY MAX(');
+    });
+
+    test('should handle mixed raw + aggregate alongside pure aggregate metric', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_MIXED_RAW_WITH_PURE,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Both CTE 2 and CTE 3 should exist
+        expect(result.query).toContain('nested_agg AS (');
+        expect(result.query).toContain('nested_agg_results AS (');
+        expect(result.query).toContain('nested_agg_mixed AS (');
+
+        // Pure aggregate metric (sum_of_max) in CTE 2
+        expect(result.query).toContain(
+            'nested_agg_results."my_table_sum_of_max"',
+        );
+        // Mixed metric in CTE 3
+        expect(result.query).toContain(
+            'nested_agg_mixed."my_table_mixed_raw_agg_repro"',
+        );
+    });
+
+    test('should handle mixed raw + aggregate with no dimensions (CROSS JOIN path)', () => {
+        const result = buildQuery({
+            explore: EXPLORE_WITH_NESTED_AGG,
+            compiledMetricQuery: METRIC_QUERY_NESTED_AGG_MIXED_RAW_NO_DIMS,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        // Should use nested_agg_mixed CTE
+        expect(result.query).toContain('nested_agg_mixed AS (');
+        // With no dimensions, should use CROSS JOIN
+        expect(result.query).toContain('CROSS JOIN nested_agg');
+        // Should NOT contain nested aggregate
+        expect(result.query).not.toContain('ORDER BY MAX(');
     });
 
     test('should emit max_by nested aggregate metric only once when fanout CTEs are also generated', () => {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -929,11 +929,25 @@ export class MetricQueryBuilder {
 
         const selects = new Set<string>();
         const tables = new Set<string>();
+        const nestedAggMetrics = this.getMetricsWithNestedAggregates();
         const nestedAggOuterIds = new Set(
-            this.getMetricsWithNestedAggregates().map(
-                ({ outerMetricId }) => outerMetricId,
-            ),
+            nestedAggMetrics.map(({ outerMetricId }) => outerMetricId),
         );
+        // Also exclude raw (non-aggregate) inner deps from the regular SELECT.
+        // These are plain column references that can't appear in a SELECT with
+        // GROUP BY. They're accessed from the base table in CTE 3 instead.
+        const rawInnerDepIds = new Set<string>();
+        for (const { innerDeps } of nestedAggMetrics) {
+            for (const dep of innerDeps) {
+                if (
+                    !nestedAggOuterIds.has(dep.fieldId) &&
+                    !isAggregateMetricType(dep.metric.type) &&
+                    !sqlContainsAggregation(dep.metric.compiledSql)
+                ) {
+                    rawInnerDepIds.add(dep.fieldId);
+                }
+            }
+        }
         metrics.forEach((field) => {
             try {
                 const alias = field;
@@ -950,7 +964,7 @@ export class MetricQueryBuilder {
                     return;
                 }
                 // Metrics with nested aggregate dependencies are handled via CTE
-                if (nestedAggOuterIds.has(field)) {
+                if (nestedAggOuterIds.has(field) || rawInnerDepIds.has(field)) {
                     (metric.tablesReferences || [metric.table]).forEach(
                         (table) => tables.add(table),
                     );
@@ -2745,17 +2759,36 @@ export class MetricQueryBuilder {
             }
         }
 
+        // Partition inner deps into aggregate (can be pre-computed with
+        // GROUP BY) and raw/non-aggregate (plain column references that
+        // cannot appear in a SELECT with GROUP BY without aggregation).
+        const aggregateInnerDeps = new Map<string, CompiledMetric>();
+        const rawInnerDeps = new Map<string, CompiledMetric>();
+        for (const [depId, depMetric] of allInnerDeps) {
+            if (
+                isAggregateMetricType(depMetric.type) ||
+                sqlContainsAggregation(depMetric.compiledSql)
+            ) {
+                aggregateInnerDeps.set(depId, depMetric);
+            } else {
+                rawInnerDeps.set(depId, depMetric);
+            }
+        }
+
         const dimensionAlias = Object.keys(dimensionSelects).map(
             (alias) => `${fieldQuoteChar}${alias}${fieldQuoteChar}`,
         );
 
-        const innerDepAliases = Array.from(allInnerDeps.keys()).map(
+        const aggInnerDepAliases = Array.from(aggregateInnerDeps.keys()).map(
             (depId) => `${fieldQuoteChar}${depId}${fieldQuoteChar}`,
         );
 
-        // --- CTE 1: nested_agg — pre-compute inner deps from base table ---
+        // --- CTE 1: nested_agg — pre-compute AGGREGATE inner deps only ---
+        // Raw (non-aggregate) inner deps are excluded because they can't
+        // appear in a SELECT with GROUP BY. They'll be accessed from the
+        // base table in CTE 3 (nested_agg_mixed) instead.
         const naCteName = 'nested_agg';
-        const innerMetricSelects = Array.from(allInnerDeps.entries()).map(
+        const innerMetricSelects = Array.from(aggregateInnerDeps.entries()).map(
             ([depId, depMetric]) =>
                 `  ${depMetric.compiledSql} AS ${fieldQuoteChar}${depId}${fieldQuoteChar}`,
         );
@@ -2779,7 +2812,7 @@ export class MetricQueryBuilder {
         const metricCteLookup: Array<{ name: string; metrics: string[] }> = [
             {
                 name: naCteName,
-                metrics: Array.from(allInnerDeps.keys()),
+                metrics: Array.from(aggregateInnerDeps.keys()),
             },
         ];
 
@@ -2831,7 +2864,14 @@ export class MetricQueryBuilder {
         // other outer metrics can inline their already-processed expressions.
         const processedOuterMetricSql = new Map<string, string>();
 
-        const resultsMetricSelects: string[] = [];
+        // Partition outer metrics: "pure aggregate" (all inner deps are
+        // aggregate — handled in CTE 2 from CTE 1) vs "mixed" (has at least
+        // one raw/non-aggregate inner dep — needs base table access in CTE 3).
+        const pureAggResultsSelects: string[] = [];
+        const mixedResultsSelects: string[] = [];
+        const pureAggOuterMetricIds: string[] = [];
+        const mixedOuterMetricIds: string[] = [];
+
         for (const { outerMetricId, outerMetric } of sortedOuterMetrics) {
             // Build a metric with ${} refs to other outer metrics pre-replaced
             // with their already-processed CTE SQL expressions
@@ -2861,67 +2901,196 @@ export class MetricQueryBuilder {
                     );
             }
 
-            // Replace remaining metric refs with CTE column refs
-            const metricWithPreSql = { ...outerMetric, sql: preSql };
-            const processedSql = this.replaceMetricReferencesWithCteReferences(
-                metricWithPreSql,
-                metricCteLookup,
+            // Check if this outer metric has any raw (non-aggregate) inner deps
+            const metricEntry = nestedAggMetrics.find(
+                (m) => m.outerMetricId === outerMetricId,
             );
+            const hasRawDep =
+                metricEntry?.innerDeps.some((dep) =>
+                    rawInnerDeps.has(dep.fieldId),
+                ) ?? false;
 
-            processedOuterMetricSql.set(outerMetricId, processedSql);
-            resultsMetricSelects.push(
-                `  ${processedSql} AS ${fieldQuoteChar}${outerMetricId}${fieldQuoteChar}`,
-            );
+            if (hasRawDep) {
+                // Mixed metric: replace aggregate dep refs with CTE 1 column
+                // refs manually, then let compileMetricSql resolve raw refs
+                // and ${TABLE} refs against the base table (which is in scope
+                // in CTE 3).
+                let mixedSql = preSql;
+                for (const [depId, depMetric] of aggregateInnerDeps) {
+                    const escapedName = depMetric.name.replace(
+                        /[.*+?^${}()|[\]\\]/g,
+                        '\\$&',
+                    );
+                    const escapedTable = depMetric.table.replace(
+                        /[.*+?^${}()|[\]\\]/g,
+                        '\\$&',
+                    );
+                    const cteRef = `${naCteName}.${fieldQuoteChar}${depId}${fieldQuoteChar}`;
+                    mixedSql = mixedSql
+                        .replace(
+                            new RegExp(`\\$\\{${escapedName}\\}`, 'g'),
+                            cteRef,
+                        )
+                        .replace(
+                            new RegExp(
+                                `\\$\\{${escapedTable}\\.${escapedName}\\}`,
+                                'g',
+                            ),
+                            cteRef,
+                        );
+                }
+
+                // Compile remaining refs (raw metric refs, ${TABLE}, dimensions)
+                // against the explore tables — they resolve to base table columns.
+                const { explore, warehouseSqlBuilder: wsb } = this.args;
+                const exploreCompiler = new ExploreCompiler(wsb);
+                const compiled = exploreCompiler.compileMetricSql(
+                    { ...outerMetric, sql: mixedSql },
+                    explore.tables,
+                    Object.keys(this.args.parameterDefinitions),
+                );
+
+                processedOuterMetricSql.set(outerMetricId, compiled.sql);
+                mixedResultsSelects.push(
+                    `  ${compiled.sql} AS ${fieldQuoteChar}${outerMetricId}${fieldQuoteChar}`,
+                );
+                mixedOuterMetricIds.push(outerMetricId);
+            } else {
+                // Pure aggregate metric: all deps are in CTE 1 — use existing
+                // CTE column ref replacement.
+                const metricWithPreSql = { ...outerMetric, sql: preSql };
+                const processedSql =
+                    this.replaceMetricReferencesWithCteReferences(
+                        metricWithPreSql,
+                        metricCteLookup,
+                    );
+
+                processedOuterMetricSql.set(outerMetricId, processedSql);
+                pureAggResultsSelects.push(
+                    `  ${processedSql} AS ${fieldQuoteChar}${outerMetricId}${fieldQuoteChar}`,
+                );
+                pureAggOuterMetricIds.push(outerMetricId);
+            }
         }
 
-        // GROUP BY dims + inner deps so aggregate functions are valid
-        // Since CTE 1 has one row per dim group, this is effectively identity
-        const allGroupByCols = [
-            ...dimensionAlias.map((a) => `${naCteName}.${a}`),
-            ...innerDepAliases.map((a) => `${naCteName}.${a}`),
-        ];
-        const resultsGroupBy =
-            allGroupByCols.length > 0
-                ? `GROUP BY ${allGroupByCols.join(', ')}`
-                : undefined;
-
-        const resultsDimSelects = dimensionAlias.map(
-            (a) => `  ${naCteName}.${a}`,
-        );
-        const cte2Sql = MetricQueryBuilder.wrapAsCte(naResultsCteName, [
-            `SELECT\n${[...resultsDimSelects, ...resultsMetricSelects].join(',\n')}`,
-            `FROM ${naCteName}`,
-            resultsGroupBy,
-        ]);
-
-        // --- JOIN nested_agg_results to na_base ---
+        const ctes: string[] = [cte1Sql];
         const naJoins: string[] = [];
-        if (dimensionAlias.length === 0) {
-            naJoins.push(`CROSS JOIN ${naResultsCteName}`);
-        } else {
-            naJoins.push(
-                `INNER JOIN ${naResultsCteName} ON ${dimensionAlias
-                    .map(
-                        (alias) =>
-                            `( ${baseCteName}.${alias} = ${naResultsCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${naResultsCteName}.${alias} IS NULL ) )`,
-                    )
-                    .join(' AND ')}`,
+        const naMetricSelects: string[] = [];
+
+        // --- CTE 2: nested_agg_results — pure aggregate outer metrics ---
+        // These read FROM CTE 1 only (one row per dim group).
+        if (pureAggResultsSelects.length > 0) {
+            // GROUP BY dims + aggregate inner deps so aggregate functions are valid
+            // Since CTE 1 has one row per dim group, this is effectively identity
+            const allGroupByCols = [
+                ...dimensionAlias.map((a) => `${naCteName}.${a}`),
+                ...aggInnerDepAliases.map((a) => `${naCteName}.${a}`),
+            ];
+            const resultsGroupBy =
+                allGroupByCols.length > 0
+                    ? `GROUP BY ${allGroupByCols.join(', ')}`
+                    : undefined;
+
+            const resultsDimSelects = dimensionAlias.map(
+                (a) => `  ${naCteName}.${a}`,
             );
+            const cte2Sql = MetricQueryBuilder.wrapAsCte(naResultsCteName, [
+                `SELECT\n${[...resultsDimSelects, ...pureAggResultsSelects].join(',\n')}`,
+                `FROM ${naCteName}`,
+                resultsGroupBy,
+            ]);
+            ctes.push(cte2Sql);
+
+            if (dimensionAlias.length === 0) {
+                naJoins.push(`CROSS JOIN ${naResultsCteName}`);
+            } else {
+                naJoins.push(
+                    `INNER JOIN ${naResultsCteName} ON ${dimensionAlias
+                        .map(
+                            (alias) =>
+                                `( ${baseCteName}.${alias} = ${naResultsCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${naResultsCteName}.${alias} IS NULL ) )`,
+                        )
+                        .join(' AND ')}`,
+                );
+            }
+
+            for (const id of pureAggOuterMetricIds) {
+                naMetricSelects.push(
+                    `  ${naResultsCteName}.${fieldQuoteChar}${id}${fieldQuoteChar}`,
+                );
+            }
         }
 
-        // Outer SELECT just references nested_agg_results columns — no aggregates
-        const naMetricSelects = nestedAggMetrics.map(
-            ({ outerMetricId }) =>
-                `  ${naResultsCteName}.${fieldQuoteChar}${outerMetricId}${fieldQuoteChar}`,
-        );
+        // --- CTE 3: nested_agg_mixed — outer metrics with raw inner deps ---
+        // These need per-row access to the base table for raw column refs,
+        // JOINed with CTE 1 for pre-computed aggregate deps.
+        if (mixedResultsSelects.length > 0) {
+            const naMixedCteName = 'nested_agg_mixed';
+
+            // JOIN CTE 1 to the base table on dimensions.
+            // dimensionSelects values look like:
+            //   '  "table".col AS "alias"'
+            // Extract the expression before AS for join conditions.
+            const cteJoinConditions = Object.entries(dimensionSelects).map(
+                ([id]) => {
+                    const qId = `${fieldQuoteChar}${id}${fieldQuoteChar}`;
+                    const expr = dimensionSelects[id]
+                        .trim()
+                        .replace(/\s+AS\s+.*$/i, '')
+                        .trim();
+                    return `( ${expr} = ${naCteName}.${qId} OR ( ${expr} IS NULL AND ${naCteName}.${qId} IS NULL ) )`;
+                },
+            );
+            const cteJoinClause =
+                dimensionAlias.length > 0
+                    ? `INNER JOIN ${naCteName} ON ${cteJoinConditions.join(' AND ')}`
+                    : `CROSS JOIN ${naCteName}`;
+
+            const mixedDimSelects = Object.entries(dimensionSelects).map(
+                ([, selectExpr]) => selectExpr,
+            );
+
+            const mixedGroupBy =
+                mixedDimSelects.length > 0
+                    ? `GROUP BY ${mixedDimSelects.map((_, i) => i + 1).join(',')}`
+                    : undefined;
+
+            const cte3Sql = MetricQueryBuilder.wrapAsCte(naMixedCteName, [
+                `SELECT\n${[...mixedDimSelects, ...mixedResultsSelects].join(',\n')}`,
+                sqlFrom,
+                joinsSql,
+                ...dimensionJoins,
+                cteJoinClause,
+                dimensionFilters,
+                mixedGroupBy,
+            ]);
+            ctes.push(cte3Sql);
+
+            if (dimensionAlias.length === 0) {
+                naJoins.push(`CROSS JOIN ${naMixedCteName}`);
+            } else {
+                naJoins.push(
+                    `INNER JOIN ${naMixedCteName} ON ${dimensionAlias
+                        .map(
+                            (alias) =>
+                                `( ${baseCteName}.${alias} = ${naMixedCteName}.${alias} OR ( ${baseCteName}.${alias} IS NULL AND ${naMixedCteName}.${alias} IS NULL ) )`,
+                        )
+                        .join(' AND ')}`,
+                );
+            }
+
+            for (const id of mixedOuterMetricIds) {
+                naMetricSelects.push(
+                    `  ${naMixedCteName}.${fieldQuoteChar}${id}${fieldQuoteChar}`,
+                );
+            }
+        }
 
         return {
-            ctes: [cte1Sql, cte2Sql],
+            ctes,
             naJoins,
             naMetricSelects,
-            outerMetricIds: nestedAggMetrics.map(
-                ({ outerMetricId }) => outerMetricId,
-            ),
+            outerMetricIds: [...pureAggOuterMetricIds, ...mixedOuterMetricIds],
         };
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #21501

Root cause: The nested aggregate CTE system correctly detected these metrics needed CTE routing, but CTE 1 (nested_agg) tried to include ALL inner deps in its SELECT with GROUP BY. Raw column references (from non-aggregate helpers like `type: number` with sql: `${TABLE}.col) can't appear in a SELECT with GROUP BY` without aggregation.

Fix — 3 changes:

1. `buildNestedAggregateCtes` — Partitions inner deps into aggregate vs raw. CTE 1 now only pre-computes aggregate deps. A new CTE 3 (nested_agg_mixed) handles outer metrics with raw deps by joining the base table (for per-row raw column
access) with CTE 1 (for pre-computed aggregates). Pure-aggregate outer metrics stay in the existing CTE 2. RLS (dimension filters) is applied identically in CTE 3.
2. `getMetricsSQL` — Excludes raw inner deps from the regular metrics SELECT (they would also fail GROUP BY in the na_base CTE).
3. 3 new tests covering:
\- Mixed raw + aggregate with dimensions (the core GH-21501 fix)
\- Mixed + pure aggregate in the same query (both CTE 2 and CTE 3 active)
\- Mixed with no dimensions (CROSS JOIN path)



before

![Screenshot 2026-03-30 at 11.33.50.png](https://app.graphite.com/user-attachments/assets/9a741338-0c23-4588-b064-d062f82a5e7c.png)



after

![image.png](https://app.graphite.com/user-attachments/assets/18881439-fd1e-4522-bfbf-12bfbbaccd6a.png)

test-all