### PR TITLE
fix: replace unbounded resultsCacheTimes array with single oldest value

### DIFF
--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -192,7 +192,7 @@ const DashboardProvider: React.FC<
         useState<DashboardFilters>(emptyFilters);
     const [haveFiltersChanged, setHaveFiltersChanged] =
         useState<boolean>(false);
-    const [resultsCacheTimes, setResultsCacheTimes] = useState<Date[]>([]);
+    const [oldestCacheTime, setOldestCacheTime] = useState<Date | undefined>();
     const [preAggregateStatuses, setPreAggregateStatuses] = useState<
         Record<string, TilePreAggregateStatus>
     >({});
@@ -1461,16 +1461,15 @@ const DashboardProvider: React.FC<
             cacheMetadata.cacheHit &&
             cacheMetadata.cacheUpdatedTime
         ) {
-            setResultsCacheTimes((old) =>
-                cacheMetadata.cacheUpdatedTime
-                    ? [...old, cacheMetadata.cacheUpdatedTime]
-                    : [...old],
+            const newTime = cacheMetadata.cacheUpdatedTime;
+            setOldestCacheTime((prev) =>
+                prev === undefined ? newTime : min([prev, newTime])!,
             );
         }
     }, []);
 
     const clearCacheAndFetch = useCallback(() => {
-        setResultsCacheTimes([]);
+        setOldestCacheTime(undefined);
         setPreAggregateStatuses({});
         setLoadedTiles(new Set());
 
@@ -1510,11 +1509,6 @@ const DashboardProvider: React.FC<
         setDashboardTabs,
         setSavedParameters,
     ]);
-
-    const oldestCacheTime = useMemo(
-        () => min(resultsCacheTimes),
-        [resultsCacheTimes],
-    );
 
     // Filters that are required to have a value set
     const requiredDashboardFilters = useMemo(


### PR DESCRIPTION
## Summary

- **Fixes #21292** — Dashboard becomes laggy after a few minutes due to unbounded `resultsCacheTimes` array growth
- Replaced the growing `Date[]` array with a single `oldestCacheTime: Date | undefined` state value
- Removed the `useMemo` that recomputed `min()` over the entire array on every update

## Problem

On dashboards with N chart tiles, every query result appended to `resultsCacheTimes`. After filter changes and tab switches, the array grew to hundreds of entries, causing:
1. O(n) `min()` recomputation on every append
2. Context-wide re-render cascade (all N tiles re-render on each context update)
3. Progressive UI degradation that did not recover without a full page reload

## Fix

`addResultsCacheTime` now computes the minimum inline at O(1) per update instead of accumulating entries. `clearCacheAndFetch` resets to `undefined`.

## Test plan

- [ ] Open a dashboard with 10+ chart tiles
- [ ] Apply filters and switch tabs repeatedly for 3-5 minutes
- [ ] Verify UI remains responsive (no progressive lag)
- [ ] Verify the cache timestamp indicator still shows the correct oldest time
- [ ] Verify the manual refresh button still clears the cache time

🤖 Generated with [Claude Code](https://claude.com/claude-code)