### PR TITLE
feat: add Build App button to top nav bar

### DIFF
--- a/packages/frontend/src/components/NavBar/BuildAppButton.tsx
+++ b/packages/frontend/src/components/NavBar/BuildAppButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from '@mantine-8/core';
+import { IconAppWindow } from '@tabler/icons-react';
+import { useNavigate } from 'react-router';
+import { useActiveProject } from '../../hooks/useActiveProject';
+import useApp from '../../providers/App/useApp';
+import MantineIcon from '../common/MantineIcon';
+
+export const BuildAppButton = () => {
+    const navigate = useNavigate();
+    const { data: projectUuid } = useActiveProject();
+    const { health } = useApp();
+
+    if (!health.data?.dataApps.enabled) {
+        return null;
+    }
+
+    return (
+        <Button
+            size="xs"
+            variant="default"
+            fz="sm"
+            leftSection={<MantineIcon icon={IconAppWindow} color="ldGray.6" />}
+            onClick={() => navigate(`/projects/${projectUuid}/apps/generate`)}
+        >
+            Build App
+        </Button>
+    );
+};

--- a/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
+++ b/packages/frontend/src/components/NavBar/MainNavBarContent.tsx
@@ -7,6 +7,7 @@ import useApp from '../../providers/App/useApp';
 import Logo from '../../svgs/logo-icon.svg?react';
 import { AiAgentsButton } from './AiAgentsButton';
 import BrowseMenu from './BrowseMenu';
+import { BuildAppButton } from './BuildAppButton';
 import ExploreMenu from './ExploreMenu';
 import HeadwayMenuItem from './HeadwayMenuItem';
 import HelpMenu from './HelpMenu';
@@ -58,6 +59,7 @@ export const MainNavBarContent: FC<Props> = ({
                                 <MetricsLink projectUuid={activeProjectUuid} />
                             )}
                             <AiAgentsButton />
+                            <BuildAppButton />
                         </Button.Group>
                         <Omnibar projectUuid={activeProjectUuid} />
                     </>


### PR DESCRIPTION
### Description:
Adding a menu item (behind FF) to let users navigate to the app generation page:
<img width="604" height="73" alt="image" src="https://github.com/user-attachments/assets/c87d79f2-00a4-41cb-a284-dd9b528f9d2f" />

