### PR TITLE
docs: add missing details to timezone handling doc

### DIFF
--- a/docs/timezone-handling.md
+++ b/docs/timezone-handling.md
@@ -65,8 +65,13 @@ Plumbing exists to run `SET TimeZone = '<tz>'` if `options.timezone` is provided
 
 Plumbing exists to run `SET TIME ZONE '<tz>'` if `options.timezone` is provided, but no caller passes it.
 
+### ClickHouse
+**File:** `packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts`
+
+Plumbing exists to set `clickhouse_settings.timezone` on the query request if `options.timezone` is provided, but no caller passes it.
+
 ### Other warehouses
-BigQuery, Redshift, ClickHouse — no session timezone handling exists.
+BigQuery, Redshift — no session timezone handling exists.
 
 ---
 


### PR DESCRIPTION
## Summary
- Corrects Layer 1 to list DuckDB and Trino/Athena as having session timezone plumbing (previously listed as "no handling")
- Documents the `disableTimestampConversion` escape hatch in Layer 2
- Adds `LIGHTDASH_QUERY_TIMEZONE` env var to the timezone fallback chain in Layer 3
- Adds section on absolute date filters ignoring timezone entirely
- Adds `useUTC: true` ECharts detail to Layer 7
- Adds gaps #11-13 to the summary table (absolute filters, disableTimestampConversion, timezone picker coverage)

## Context
Follow-up to #21510 — fills in gaps found during a full codebase audit of timezone handling.

## Test plan
- [ ] Review for accuracy against the referenced code paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)