### PR TITLE
chore: rename getCsvUrl to getGsheetExportStatus for clarity

### DIFF
--- a/packages/backend/src/controllers/csvController.ts
+++ b/packages/backend/src/controllers/csvController.ts
@@ -23,15 +23,15 @@ import { BaseController } from './baseController';
 @Tags('Exports')
 export class CsvController extends BaseController {
     /**
-     * Get a Csv
-     * @summary Get CSV URL
-     * @param jobId the jobId for the CSV
+     * Get the status/URL of a Google Sheets export job
+     * @summary Get export status
+     * @param jobId the jobId for the export
      * @param req express request
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
     @Get('{jobId}')
-    @OperationId('getCsvUrl')
+    @OperationId('getGsheetExportStatus')
     async get(
         @Path() jobId: string,
         @Request() req: express.Request,
@@ -39,7 +39,7 @@ export class CsvController extends BaseController {
         this.setStatus(200);
         const csvDetails = await this.services
             .getSchedulerService()
-            .getCsvUrl(req.user!, jobId);
+            .getGsheetExportStatus(req.user!, jobId);
         return {
             status: 'ok',
             results: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -29137,7 +29137,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2684.0",
+        "version": "0.2686.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -43709,7 +43709,7 @@
         },
         "/api/v1/csv/{jobId}": {
             "get": {
-                "operationId": "getCsvUrl",
+                "operationId": "getGsheetExportStatus",
                 "responses": {
                     "200": {
                         "description": "Success",
@@ -43732,13 +43732,13 @@
                         }
                     }
                 },
-                "description": "Get a Csv",
-                "summary": "Get CSV URL",
+                "description": "Get the status/URL of a Google Sheets export job",
+                "summary": "Get export status",
                 "tags": ["Exports"],
                 "security": [],
                 "parameters": [
                     {
-                        "description": "the jobId for the CSV",
+                        "description": "the jobId for the export",
                         "in": "path",
                         "name": "jobId",
                         "required": true,

--- a/packages/backend/src/models/SchedulerModel/index.ts
+++ b/packages/backend/src/models/SchedulerModel/index.ts
@@ -1547,7 +1547,7 @@ export class SchedulerModel {
         return b.scheduledTime.getTime() - a.scheduledTime.getTime();
     };
 
-    async getCsvUrl(jobId: string, userUuid: string) {
+    async getGsheetExportStatus(jobId: string, userUuid: string) {
         const jobs = await this.database(SchedulerLogTableName)
             .where(`job_id`, jobId)
             .andWhere('task', 'uploadGsheetFromQuery')
@@ -1559,7 +1559,7 @@ export class SchedulerModel {
                 statusOrder.indexOf(a.status) - statusOrder.indexOf(b.status),
         )[0];
         if (!job || job.details?.createdByUserUuid !== userUuid)
-            throw new NotFoundError('Download CSV job not found');
+            throw new NotFoundError('Google Sheets export job not found');
 
         return job;
     }

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1017,8 +1017,11 @@ export class SchedulerService extends BaseService {
         await this.schedulerModel.logSchedulerJob(log);
     }
 
-    async getCsvUrl(user: SessionUser, jobId: string) {
-        const job = await this.schedulerModel.getCsvUrl(jobId, user.userUuid);
+    async getGsheetExportStatus(user: SessionUser, jobId: string) {
+        const job = await this.schedulerModel.getGsheetExportStatus(
+            jobId,
+            user.userUuid,
+        );
         if (
             user.ability.cannot(
                 'view',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Follow up of: #21506

### Description:

Renamed CSV-related methods and documentation to better reflect their purpose for Google Sheets exports. The `getCsvUrl` method has been renamed to `getGsheetExportStatus` across the controller, service, and model layers to more accurately describe its functionality of retrieving the status and URL of Google Sheets export jobs. Updated API documentation, error messages, and parameter descriptions to clarify that this endpoint handles Google Sheets exports rather than generic CSV operations.