### PR TITLE
feat: add parameters support to dashboard-as-code

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -407,6 +407,9 @@ export class CoderService extends BaseService {
             tabs: dashboard.tabs,
             slug: dashboard.slug,
             ...(dashboard.config ? { config: dashboard.config } : {}),
+            ...(dashboard.parameters
+                ? { parameters: dashboard.parameters }
+                : {}),
 
             spaceSlug,
             version: currentVersion,

--- a/packages/common/src/schemas/json/dashboard-as-code-1.0.json
+++ b/packages/common/src/schemas/json/dashboard-as-code-1.0.json
@@ -467,6 +467,36 @@
                 }
             }
         },
+        "parameters": {
+            "type": "object",
+            "description": "Dashboard parameter values that override default parameter values defined in the dbt project. Keys are parameter identifiers, values contain the parameter name and its override value.",
+            "additionalProperties": {
+                "type": "object",
+                "required": ["parameterName", "value"],
+                "additionalProperties": false,
+                "properties": {
+                    "parameterName": {
+                        "type": "string",
+                        "description": "Name of the parameter as defined in the dbt project"
+                    },
+                    "value": {
+                        "description": "Override value for the parameter",
+                        "oneOf": [
+                            { "type": "string" },
+                            { "type": "number" },
+                            {
+                                "type": "array",
+                                "items": { "type": "string" }
+                            },
+                            {
+                                "type": "array",
+                                "items": { "type": "number" }
+                            }
+                        ]
+                    }
+                }
+            }
+        },
         "config": {
             "type": "object",
             "description": "Dashboard configuration settings such as date zoom behavior",

--- a/packages/common/src/types/coder.ts
+++ b/packages/common/src/types/coder.ts
@@ -157,7 +157,7 @@ export type DashboardTileWithSlug = DashboardTile & {
 
 export type DashboardAsCode = Pick<
     Dashboard,
-    'name' | 'description' | 'tabs' | 'slug' | 'config'
+    'name' | 'description' | 'tabs' | 'slug' | 'config' | 'parameters'
 > & {
     /** Not modifiable by user, but useful to know if it has been updated. Defaults to now if omitted. */
     updatedAt?: Date;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds support for dashboard parameters in the dashboard-as-code functionality. The changes include:

- Added `parameters` field to the `DashboardAsCode` type definition to include parameter overrides alongside existing dashboard properties
- Updated the CoderService to handle dashboard parameters when processing dashboard-as-code configurations
- Extended the JSON schema to define the structure for dashboard parameters, supporting string, number, and array values with parameter name and value mappings

The parameters feature allows dashboard-as-code configurations to override default parameter values defined in dbt projects, providing more flexibility in dashboard customization.

<!-- Even better add a screenshot / gif / loom -->