### PR TITLE
feat: add manage:DataApp permission check to app pages

### DIFF
--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ActionIcon,
     Box,
@@ -20,6 +21,8 @@ import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import useHealth from '../hooks/health/useHealth';
+import { useAbilityContext } from '../providers/Ability/useAbilityContext';
+import useApp from '../providers/App/useApp';
 import classes from './AppGenerate.module.css';
 
 type ChatMessage = {
@@ -84,6 +87,8 @@ const AppGenerate: FC = () => {
     const [messages, setMessages] = useState<ChatMessage[]>([]);
     const { mutate, isLoading, reset } = useGenerateApp();
     const health = useHealth();
+    const { user } = useApp();
+    const ability = useAbilityContext();
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
@@ -100,6 +105,18 @@ const AppGenerate: FC = () => {
     }, [messages, isLoading, scrollToBottom]);
 
     if (health.data && !health.data.dataApps.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    if (
+        !ability.can(
+            'manage',
+            subject('DataApp', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        )
+    ) {
         return <Navigate to={`/projects/${projectUuid}/home`} replace />;
     }
 

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,8 +1,11 @@
+import { subject } from '@casl/ability';
 import { Group, Loader, Stack, Text } from '@mantine-8/core';
 import { Navigate, useParams } from 'react-router';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import useHealth from '../hooks/health/useHealth';
+import { useAbilityContext } from '../providers/Ability/useAbilityContext';
+import useApp from '../providers/App/useApp';
 
 export default function AppPreviewTest() {
     const {
@@ -17,6 +20,8 @@ export default function AppPreviewTest() {
 
     const version = versionParam ? Number(versionParam) : undefined;
     const health = useHealth();
+    const { user } = useApp();
+    const ability = useAbilityContext();
 
     const {
         data: token,
@@ -25,6 +30,18 @@ export default function AppPreviewTest() {
     } = useAppPreviewToken(projectUuid, appUuid, version);
 
     if (health.data && !health.data.dataApps.enabled) {
+        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    if (
+        !ability.can(
+            'manage',
+            subject('DataApp', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+            }),
+        )
+    ) {
         return <Navigate to={`/projects/${projectUuid}/home`} replace />;
     }
 


### PR DESCRIPTION
### Description:
Previously we only checked whether the FF is enabled in the frontend. While the backend already does the permission checking, the frontend should also check, so we don't even end up showing the UI.
