### PR TITLE
fix: prevent duplicate query pages in useInfiniteQueryResults

### DIFF
--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -485,7 +485,19 @@ export const useInfiniteQueryResults = (
     useEffect(() => {
         const pageData = nextPage.data;
         if (pageData?.status === QueryHistoryStatus.READY) {
-            setFetchedPages((prevState) => [...prevState, pageData]);
+            setFetchedPages((prevState) => {
+                const pageAlreadyFetched = prevState.some(
+                    (page) =>
+                        page.queryUuid === pageData.queryUuid &&
+                        page.page === pageData.page,
+                );
+
+                if (pageAlreadyFetched) {
+                    return prevState;
+                }
+
+                return [...prevState, pageData];
+            });
         }
     }, [nextPage.data]);
 


### PR DESCRIPTION
### Motivation
- `useInfiniteQueryResults` could append the same READY page multiple times during refetch/invalidation cycles, causing duplicated rows and increased memory usage (reported in #21478).

### Description
- Update `useInfiniteQueryResults` in `packages/frontend/src/hooks/useQueryResults.ts` to deduplicate READY pages before appending to `fetchedPages` by checking `(queryUuid, page)` identity.
- The effect that previously did `setFetchedPages(prev => [...prev, pageData])` now returns the previous state unchanged when the page is already present, preventing duplicate accumulation while preserving normal page appends.

### Testing
- Ran the frontend linter with `pnpm -F frontend run linter ./src/hooks/useQueryResults.ts`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69ca7bb7b9848323901e070b887838c0)