### PR TITLE
fix: show missing user names in AI agent admin threads overview

### DIFF
--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -952,7 +952,7 @@ export class AiAgentModel {
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiPromptTableName}.ai_thread_uuid`,
             )
-            .join(
+            .leftJoin(
                 UserTableName,
                 `${AiPromptTableName}.created_by_user_uuid`,
                 `${UserTableName}.user_uuid`,
@@ -985,10 +985,10 @@ export class AiAgentModel {
                     | 'title'
                     | 'title_generated_at'
                 > &
-                    Pick<DbAiPrompt, 'prompt' | 'ai_prompt_uuid'> &
-                    Pick<DbUser, 'user_uuid'> &
-                    Pick<DbAiSlackThread, 'slack_user_id'> & {
-                        user_name: string;
+                    Pick<DbAiPrompt, 'prompt' | 'ai_prompt_uuid'> & {
+                        user_uuid: DbUser['user_uuid'] | null;
+                    } & Pick<DbAiSlackThread, 'slack_user_id'> & {
+                        user_name: string | null;
                     })[]
             >(
                 `${AiThreadTableName}.ai_thread_uuid`,
@@ -1001,7 +1001,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${UserTableName}.user_uuid`,
                 this.database.raw(
-                    `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
+                    `COALESCE(NULLIF(TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)), ''), 'Unknown user') as user_name`,
                 ),
                 `${AiSlackThreadTableName}.slack_user_id`,
             )
@@ -1041,8 +1041,8 @@ export class AiAgentModel {
                 message: row.prompt,
             },
             user: {
-                uuid: row.user_uuid,
-                name: row.user_name,
+                uuid: row.user_uuid ?? '',
+                name: row.user_name || 'Unknown user',
                 slackUserId: row.slack_user_id,
             },
         }));
@@ -1092,9 +1092,9 @@ export class AiAgentModel {
                     title: DbAiThread['title'];
                     title_generated_at: DbAiThread['title_generated_at'];
                     first_prompt: DbAiPrompt['prompt'];
-                    user_uuid: DbUser['user_uuid'];
-                    user_name: string;
-                    user_email: DbEmail['email'];
+                    user_uuid: DbUser['user_uuid'] | null;
+                    user_name: string | null;
+                    user_email: DbEmail['email'] | null;
                     slack_user_id: DbAiSlackThread['slack_user_id'];
                     slack_channel_id: DbAiSlackThread['slack_channel_id'];
                     slack_thread_ts: DbAiSlackThread['slack_thread_ts'];
@@ -1123,7 +1123,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.prompt as first_prompt`,
                 `${UserTableName}.user_uuid`,
                 this.database.raw(
-                    `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
+                    `COALESCE(NULLIF(TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)), ''), ${EmailTableName}.email, 'Unknown user') as user_name`,
                 ),
                 `${EmailTableName}.email as user_email`,
                 `${AiSlackThreadTableName}.slack_user_id`,
@@ -1149,18 +1149,18 @@ export class AiAgentModel {
                 `${AiThreadTableName}.ai_thread_uuid`,
                 `${AiPromptTableName}.ai_thread_uuid`,
             )
-            .join(
+            .leftJoin(
                 UserTableName,
                 `${AiPromptTableName}.created_by_user_uuid`,
                 `${UserTableName}.user_uuid`,
             )
-            .leftJoin(
-                EmailTableName,
-                `${EmailTableName}.user_id`,
-                '=',
-                `${UserTableName}.user_id`,
-            )
-            .andWhere(`${EmailTableName}.is_primary`, true)
+            .leftJoin(EmailTableName, function joinEmails() {
+                this.on(
+                    `${EmailTableName}.user_id`,
+                    '=',
+                    `${UserTableName}.user_id`,
+                ).andOnVal(`${EmailTableName}.is_primary`, '=', true);
+            })
             .join(
                 AiAgentTableName,
                 `${AiThreadTableName}.agent_uuid`,
@@ -1304,8 +1304,8 @@ export class AiAgentModel {
                 createdFrom: row.created_from,
                 title: row.title || row.first_prompt,
                 user: {
-                    uuid: row.user_uuid,
-                    name: row.user_name,
+                    uuid: row.user_uuid ?? '',
+                    name: row.user_name || 'Unknown user',
                     slackUserId: row.slack_user_id,
                     email: row.user_email,
                 },
@@ -1430,7 +1430,7 @@ export class AiAgentModel {
                 `${AiSlackPromptTableName}.slack_user_id`,
                 `${AiWebAppPromptTableName}.user_uuid`,
                 this.database.raw(
-                    `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
+                    `COALESCE(NULLIF(TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)), ''), 'Unknown user') as user_name`,
                 ),
             )
             .leftJoin(
@@ -2055,7 +2055,7 @@ export class AiAgentModel {
                 `${AiSlackPromptTableName}.slack_user_id`,
                 `${AiWebAppPromptTableName}.user_uuid`,
                 this.database.raw(
-                    `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
+                    `COALESCE(NULLIF(TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)), ''), 'Unknown user') as user_name`,
                 ),
             )
             .join(
@@ -2295,7 +2295,7 @@ export class AiAgentModel {
                 `${AiPromptTableName}.ai_prompt_uuid`,
                 `${UserTableName}.user_uuid`,
                 this.database.raw(
-                    `CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name) as user_name`,
+                    `COALESCE(NULLIF(TRIM(CONCAT(${UserTableName}.first_name, ' ', ${UserTableName}.last_name)), ''), 'Unknown user') as user_name`,
                 ),
             )
             .orderBy(`${AiThreadTableName}.created_at`, 'desc');


### PR DESCRIPTION
## Summary

Fixes #21500 — some AI agent threads in the admin overview showed a blank User column.

**Root causes:**

1. **Blank names for users with NULL first/last name** — `CONCAT(NULL, ' ', NULL)` returns `' '` in PostgreSQL, which renders as blank. This affects users created via SSO/SCIM where the identity provider didn't supply name info.

2. **`is_primary` email filter in WHERE instead of JOIN ON** — the `emails.is_primary = true` condition was in the main `WHERE` clause rather than the `JOIN ON` clause, which turned the `LEFT JOIN` on emails into an effective `INNER JOIN`. Threads by users without a primary email were silently hidden entirely.

3. **INNER JOIN on users hid threads with NULL `created_by_user_uuid`** — the DB column allows NULL, so threads where the first prompt had no associated user were completely invisible in the admin view.

**Fix:**

- User display name now uses a fallback chain: **full name → email → "Unknown user"**
- Changed users `JOIN` to `LEFT JOIN` so threads are never silently hidden
- Moved `is_primary` filter into the `JOIN ON` clause
- Applied consistent `COALESCE`/`TRIM` handling across all 5 user name concatenation sites in the model

No other behavioral changes — filtering, sorting, and API response shapes are unchanged.

## Test plan

- [ ] Verify threads with normal users still display correctly (first + last name)
- [ ] Verify threads by users with NULL first/last name show their email instead
- [ ] Verify threads with no user association show "Unknown user"
- [ ] Verify user filters in admin toolbar still work correctly
- [ ] Verify thread list pagination and sorting are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)