### PR TITLE
fix: show specific error when AI context window is exceeded

### DIFF
--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -146,6 +146,7 @@ import {
     StoreToolResultsFn,
     UpdateProgressFn,
 } from '../ai/types/aiAgentDependencies';
+import { getUserFacingErrorMessage } from '../ai/utils/errorMessages';
 import {
     getAgentConfirmationBlocks,
     getAgentSelectionBlocks,
@@ -3297,9 +3298,13 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 },
             );
         } catch (e) {
+            const userFacingMessage = getUserFacingErrorMessage(
+                e,
+                'Co-pilot failed to generate a response. Please try again.',
+            );
             await this.slackClient.postMessage({
                 organizationUuid: slackPrompt.organizationUuid,
-                text: `🔴 Co-pilot failed to generate a response 😥 Please try again.`,
+                text: `🔴 ${userFacingMessage}`,
                 channel: slackPrompt.slackChannelId,
                 thread_ts: slackPrompt.slackThreadTs,
                 username: agent?.name,

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.test.ts
@@ -1,0 +1,95 @@
+import { getUserFacingErrorMessage } from './errorMessages';
+
+const CONTEXT_LIMIT_MESSAGE =
+    "This request exceeded the AI model's context limit, usually because the conversation or tool results became too large. Please start a new thread or break the request into smaller steps.";
+
+const RATE_LIMIT_MESSAGE =
+    'The service is experiencing high demand. Please try again in a few moments.';
+
+const TIMEOUT_MESSAGE =
+    'This request took too long to process. Try breaking it into smaller questions or start a new thread.';
+
+describe('getUserFacingErrorMessage', () => {
+    describe('context/token limit errors', () => {
+        it.each([
+            // OpenAI error code
+            'context_length_exceeded',
+            // OpenAI user-facing message
+            'Your input exceeds the context window of this model. Please adjust your input and try again.',
+            // Anthropic-style
+            'input exceeds the context window',
+            // Generic provider messages
+            'maximum context length is 128000 tokens',
+            'This model has a token limit of 200000',
+            'Request too long for model',
+            'context window exceeded',
+            // Token count pattern: "12345 tokens > 8000"
+            '150000 tokens > 128000',
+            '12345 token > 8000',
+            // Verbose provider error
+            'The request exceeds the maximum context length for this model',
+            "exceeds the model's maximum token limit",
+        ])('detects context limit error: %s', (message) => {
+            expect(getUserFacingErrorMessage(new Error(message))).toBe(
+                CONTEXT_LIMIT_MESSAGE,
+            );
+        });
+
+        it('detects context limit from an Error object', () => {
+            const error = new Error('context_length_exceeded: input too large');
+            expect(getUserFacingErrorMessage(error)).toBe(
+                CONTEXT_LIMIT_MESSAGE,
+            );
+        });
+
+        it('detects context limit from a plain string', () => {
+            expect(
+                getUserFacingErrorMessage(
+                    'Your input exceeds the context window',
+                ),
+            ).toBe(CONTEXT_LIMIT_MESSAGE);
+        });
+    });
+
+    describe('rate limiting errors', () => {
+        it.each([
+            'rate limit exceeded',
+            'You have exceeded your quota',
+            'Request was throttled',
+        ])('detects rate limit error: %s', (message) => {
+            expect(getUserFacingErrorMessage(new Error(message))).toBe(
+                RATE_LIMIT_MESSAGE,
+            );
+        });
+    });
+
+    describe('timeout errors', () => {
+        it.each(['Request timeout', 'The operation timed out'])(
+            'detects timeout error: %s',
+            (message) => {
+                expect(getUserFacingErrorMessage(new Error(message))).toBe(
+                    TIMEOUT_MESSAGE,
+                );
+            },
+        );
+    });
+
+    describe('default fallback', () => {
+        it('returns default message for unknown errors', () => {
+            expect(
+                getUserFacingErrorMessage(new Error('Something unexpected')),
+            ).toBe(
+                'Something went wrong while processing your request. Please try again.',
+            );
+        });
+
+        it('returns custom default message when provided', () => {
+            expect(
+                getUserFacingErrorMessage(
+                    new Error('Something unexpected'),
+                    'Custom fallback',
+                ),
+            ).toBe('Custom fallback');
+        });
+    });
+});

--- a/packages/backend/src/ee/services/ai/utils/errorMessages.ts
+++ b/packages/backend/src/ee/services/ai/utils/errorMessages.ts
@@ -13,11 +13,18 @@ export const getUserFacingErrorMessage = (
 
     // Context/token limit errors
     if (
+        errorMessage.includes('context_length_exceeded') ||
+        errorMessage.includes('input exceeds the context window') ||
+        errorMessage.includes('maximum context length') ||
+        errorMessage.includes('token limit') ||
         errorMessage.includes('too long') ||
-        errorMessage.includes('maximum') ||
-        errorMessage.match(/\d+\s*tokens?\s*>\s*\d+/i)
+        errorMessage.includes('context window') ||
+        errorMessage.match(/\d+\s*tokens?\s*>\s*\d+/i) ||
+        errorMessage.match(
+            /exceeds?\s*(the\s+)?(model'?s?\s+)?maximum\s+(token|context)/i,
+        )
     ) {
-        return 'This conversation has become too long to process. Please start a new thread to continue.';
+        return "This request exceeded the AI model's context limit, usually because the conversation or tool results became too large. Please start a new thread or break the request into smaller steps.";
     }
 
     // Rate limiting / quota errors

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AgentChatAssistantBubble.tsx
@@ -135,6 +135,8 @@ const AssistantBubbleContent: FC<{
                             }
                             color="ldGray.0"
                             variant="outline"
+                            radius="md"
+                            w="80%"
                         >
                             <Stack gap={4}>
                                 <Text size="sm" fw={500} c="dimmed">


### PR DESCRIPTION
## Summary
- Expanded `getUserFacingErrorMessage()` to detect provider-specific context-length errors (`context_length_exceeded`, `input exceeds the context window`, `maximum context length`, `token limit`, `context window`, etc.)
- Updated the user-facing message to clearly explain the cause and suggest actionable next steps
- Wired the Slack error handler in `AiAgentService.replyToSlackPrompt()` to use `getUserFacingErrorMessage()` instead of a hardcoded generic message — Slack users now see the same specific error as web users
- Added 20 regression tests covering context-limit detection (including the exact OpenAI error from production), rate limiting, timeouts, and default fallback behavior

## Context
Closes: https://linear.app/lightdash/issue/PROD-6579

When AI Analyst fails because the request exceeds the model context window, users currently get a generic failure. This PR detects the specific failure mode and surfaces a clear message:

> *"This request exceeded the AI model's context limit, usually because the conversation or tool results became too large. Please start a new thread or break the request into smaller steps."*

The exact error from a self-hoster confirmed the patterns: `context_length_exceeded` error code with message `"Your input exceeds the context window of this model"`.

<img width="1104" height="145" alt="image" src="https://github.com/user-attachments/assets/63e75e6e-066a-4ed3-97c8-cdd9496d1f9e" />


