### PR TITLE
fix: show 'View in Lightdash' button on mobile email clients

### DIFF
--- a/packages/backend/src/clients/EmailClient/templates/chartCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/chartCsvNotification.html
@@ -1627,7 +1627,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <div
-                                                                                        class="t31 hm"
+                                                                                        class="t31"
                                                                                         style="
                                                                                             mso-line-height-rule: exactly;
                                                                                             mso-line-height-alt: 12px;
@@ -1646,7 +1646,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <table
-                                                                                        class="t33 hm"
+                                                                                        class="t33"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
@@ -1655,15 +1655,15 @@
                                                                                         <tr>
                                                                                             <!--[if !mso]><!-->
                                                                                             <td
-                                                                                                class="t34 hm"
+                                                                                                class="t34"
                                                                                                 style="
                                                                                                     width: 600px;
                                                                                                 "
                                                                                             >
                                                                                                 <!--<![endif]-->
-                                                                                                <!--[if mso]><td class="t34 hm" style="width:600px;"><![endif]-->
+                                                                                                <!--[if mso]><td class="t34" style="width:600px;"><![endif]-->
                                                                                                 <p
-                                                                                                    class="t40 hm"
+                                                                                                    class="t40"
                                                                                                     style="
                                                                                                         margin-bottom: 0;
                                                                                                         margin-bottom: 0;
@@ -1727,7 +1727,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <div
-                                                                                        class="t224 hm"
+                                                                                        class="t224"
                                                                                         style="
                                                                                             mso-line-height-rule: exactly;
                                                                                             mso-line-height-alt: 12px;
@@ -1743,7 +1743,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <table
-                                                                                        class="t226 hm"
+                                                                                        class="t226"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
@@ -1752,15 +1752,15 @@
                                                                                         <tr>
                                                                                             <!--[if !mso]><!-->
                                                                                             <td
-                                                                                                class="t227 hm"
+                                                                                                class="t227"
                                                                                                 style="
                                                                                                     width: 600px;
                                                                                                 "
                                                                                             >
                                                                                                 <!--<![endif]-->
-                                                                                                <!--[if mso]><td class="t227 hm" style="width:600px;"><![endif]-->
+                                                                                                <!--[if mso]><td class="t227" style="width:600px;"><![endif]-->
                                                                                                 <p
-                                                                                                    class="t233 hm"
+                                                                                                    class="t233"
                                                                                                     style="
                                                                                                         margin-bottom: 0;
                                                                                                         margin-bottom: 0;

--- a/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/dashboardCsvNotification.html
@@ -1714,7 +1714,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <div
-                                                                                        class="t31 hm"
+                                                                                        class="t31"
                                                                                         style="
                                                                                             mso-line-height-rule: exactly;
                                                                                             mso-line-height-alt: 12px;
@@ -1732,7 +1732,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <table
-                                                                                        class="t33 hm"
+                                                                                        class="t33"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
@@ -1741,15 +1741,15 @@
                                                                                         <tr>
                                                                                             <!--[if !mso]><!-->
                                                                                             <td
-                                                                                                class="t34 hm"
+                                                                                                class="t34"
                                                                                                 style="
                                                                                                     width: 600px;
                                                                                                 "
                                                                                             >
                                                                                                 <!--<![endif]-->
-                                                                                                <!--[if mso]><td class="t34 hm" style="width:600px;"><![endif]-->
+                                                                                                <!--[if mso]><td class="t34" style="width:600px;"><![endif]-->
                                                                                                 <p
-                                                                                                    class="t40 hm"
+                                                                                                    class="t40"
                                                                                                     style="
                                                                                                         margin-bottom: 0;
                                                                                                         margin-bottom: 0;
@@ -1813,7 +1813,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <div
-                                                                                        class="t274 hm"
+                                                                                        class="t274"
                                                                                         style="
                                                                                             mso-line-height-rule: exactly;
                                                                                             mso-line-height-alt: 12px;
@@ -1829,7 +1829,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <table
-                                                                                        class="t276 hm"
+                                                                                        class="t276"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
@@ -1838,15 +1838,15 @@
                                                                                         <tr>
                                                                                             <!--[if !mso]><!-->
                                                                                             <td
-                                                                                                class="t277 hm"
+                                                                                                class="t277"
                                                                                                 style="
                                                                                                     width: 600px;
                                                                                                 "
                                                                                             >
                                                                                                 <!--<![endif]-->
-                                                                                                <!--[if mso]><td class="t277 hm" style="width:600px;"><![endif]-->
+                                                                                                <!--[if mso]><td class="t277" style="width:600px;"><![endif]-->
                                                                                                 <p
-                                                                                                    class="t283 hm"
+                                                                                                    class="t283"
                                                                                                     style="
                                                                                                         margin-bottom: 0;
                                                                                                         margin-bottom: 0;

--- a/packages/backend/src/clients/EmailClient/templates/imageNotification.html
+++ b/packages/backend/src/clients/EmailClient/templates/imageNotification.html
@@ -939,7 +939,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <div
-                                                                                        class="t31 hm"
+                                                                                        class="t31"
                                                                                         style="
                                                                                             mso-line-height-rule: exactly;
                                                                                             mso-line-height-alt: 31px;
@@ -957,7 +957,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <table
-                                                                                        class="t33 hm"
+                                                                                        class="t33"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
@@ -966,7 +966,7 @@
                                                                                         <tr>
                                                                                             <!--[if !mso]><!-->
                                                                                             <td
-                                                                                                class="t34 hm"
+                                                                                                class="t34"
                                                                                                 style="
                                                                                                     background-color: #7262ff;
                                                                                                     overflow: hidden;
@@ -982,9 +982,9 @@
                                                                                                 "
                                                                                             >
                                                                                                 <!--<![endif]-->
-                                                                                                <!--[if mso]><td class="t34 hm" style="background-color:#7262FF;overflow:hidden;width:198px;text-align:center;line-height:40px;mso-line-height-rule:exactly;mso-text-raise:8px;border-radius:3px 3px 3px 3px;"><![endif]-->
+                                                                                                <!--[if mso]><td class="t34" style="background-color:#7262FF;overflow:hidden;width:198px;text-align:center;line-height:40px;mso-line-height-rule:exactly;mso-text-raise:8px;border-radius:3px 3px 3px 3px;"><![endif]-->
                                                                                                 <a
-                                                                                                    class="t40 hm"
+                                                                                                    class="t40"
                                                                                                     href="{{url}}"
                                                                                                     style="
                                                                                                         display: block;
@@ -1024,7 +1024,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <div
-                                                                                        class="t43 hm"
+                                                                                        class="t43"
                                                                                         style="
                                                                                             mso-line-height-rule: exactly;
                                                                                             mso-line-height-alt: 12px;
@@ -1040,7 +1040,7 @@
                                                                             <tr>
                                                                                 <td>
                                                                                     <table
-                                                                                        class="t45 hm"
+                                                                                        class="t45"
                                                                                         role="presentation"
                                                                                         cellpadding="0"
                                                                                         cellspacing="0"
@@ -1049,15 +1049,15 @@
                                                                                         <tr>
                                                                                             <!--[if !mso]><!-->
                                                                                             <td
-                                                                                                class="t46 hm"
+                                                                                                class="t46"
                                                                                                 style="
                                                                                                     width: 600px;
                                                                                                 "
                                                                                             >
                                                                                                 <!--<![endif]-->
-                                                                                                <!--[if mso]><td class="t46 hm" style="width:600px;"><![endif]-->
+                                                                                                <!--[if mso]><td class="t46" style="width:600px;"><![endif]-->
                                                                                                 <p
-                                                                                                    class="t52 hm"
+                                                                                                    class="t52"
                                                                                                     style="
                                                                                                         margin-bottom: 0;
                                                                                                         margin-bottom: 0;


### PR DESCRIPTION
## Summary
- Remove `hm` (hide-mobile) CSS class from the "View in Lightdash" button, footer text, and spacer elements in scheduled delivery email templates
- The `hm` class was an unintentional artifact from the email design tool export in #4696, causing `display: none !important` on screens ≤ 480px
- Affects `imageNotification.html`, `chartCsvNotification.html`, and `dashboardCsvNotification.html`

Fixes #21384

## Test plan
- [ ] Trigger a scheduled delivery (chart image, chart CSV, or dashboard CSV)
- [ ] Open the email on a mobile client (or resize to ≤ 480px) — "View in Lightdash" button and footer text should be visible
- [ ] Open on desktop — email should look unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)