### PR TITLE
fix: re-encrypt warehouse credentials after branch DB template copy

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -37,6 +37,7 @@
         "migrate-or-rollback-database:dev": "tsx src/migrateOrRollbackDatabase.ts",
         "seed": "knex seed:run --knexfile src/knexfile.ts",
         "seed-production": "knex seed:run --knexfile dist/knexfile.js",
+        "reseed-encrypted-credentials": "tsx src/scripts/reseed-encrypted-credentials.ts",
         "rollback-last": "knex migrate:down --knexfile src/knexfile.ts",
         "rollback-all": "knex migrate:rollback --all --knexfile src/knexfile.ts",
         "rollback-all-production": "knex migrate:rollback --all --knexfile dist/knexfile.js",

--- a/packages/backend/src/scripts/reseed-encrypted-credentials.ts
+++ b/packages/backend/src/scripts/reseed-encrypted-credentials.ts
@@ -1,0 +1,97 @@
+/**
+ * Re-encrypts warehouse credentials and dbt connection settings in the database.
+ *
+ * Used after creating a branch database from the template — the template's
+ * encrypted blobs are tied to the LIGHTDASH_SECRET and PG* env vars that were
+ * active when the template was seeded. This script overwrites them with values
+ * encrypted using the current environment.
+ */
+import {
+    DbtProjectType,
+    SEED_PROJECT,
+    WarehouseTypes,
+} from '@lightdash/common';
+import knex from 'knex';
+import path from 'path';
+import { lightdashConfig } from '../config/lightdashConfig';
+import knexConfig from '../knexfile';
+import { EncryptionUtil } from '../utils/EncryptionUtil/EncryptionUtil';
+
+const enc = new EncryptionUtil({ lightdashConfig });
+
+const demoDir = process.env.DBT_DEMO_DIR;
+if (!demoDir) {
+    throw new Error(
+        'Must specify absolute path to demo project with DBT_DEMO_DIR',
+    );
+}
+
+const pgHost = process.env.PGHOST;
+const pgPort = parseInt(process.env.PGPORT || '', 10);
+const pgUser = process.env.PGUSER;
+const pgPassword = process.env.PGPASSWORD;
+const pgDatabase = process.env.PGDATABASE;
+
+if (!pgHost || Number.isNaN(pgPort) || !pgUser || !pgPassword || !pgDatabase) {
+    throw new Error(
+        'Must specify PGHOST, PGPORT, PGUSER, PGPASSWORD, and PGDATABASE',
+    );
+}
+
+async function main() {
+    const db = knex(
+        knexConfig[
+            (process.env.NODE_ENV as 'production' | 'development') ||
+                'development'
+        ],
+    );
+
+    try {
+        const encryptedDbtConnection = enc.encrypt(
+            JSON.stringify({
+                type: DbtProjectType.DBT,
+                project_dir: path.join(demoDir!, '/dbt'),
+                profiles_dir: path.join(demoDir!, '/profiles'),
+            }),
+        );
+
+        const updatedProjects = await db('projects')
+            .where('project_uuid', SEED_PROJECT.project_uuid)
+            .update({ dbt_connection: encryptedDbtConnection });
+
+        console.log(`Updated dbt_connection for ${updatedProjects} project(s)`);
+
+        const encryptedWarehouseCreds = enc.encrypt(
+            JSON.stringify({
+                type: WarehouseTypes.POSTGRES,
+                schema: 'jaffle',
+                host: pgHost,
+                port: pgPort,
+                user: pgUser,
+                password: pgPassword,
+                dbname: pgDatabase,
+                sslmode: 'disable',
+            }),
+        );
+
+        const updatedCreds = await db('warehouse_credentials')
+            .whereIn(
+                'project_id',
+                db('projects')
+                    .select('project_id')
+                    .where('project_uuid', SEED_PROJECT.project_uuid),
+            )
+            .update({ encrypted_credentials: encryptedWarehouseCreds });
+
+        console.log(
+            `Updated encrypted_credentials for ${updatedCreds} warehouse credential(s)`,
+        );
+    } finally {
+        await db.destroy();
+    }
+}
+
+main().catch((err) => {
+    console.error(err);
+    process.exit(1);
+});

--- a/scripts/setup-branch-db.sh
+++ b/scripts/setup-branch-db.sh
@@ -31,4 +31,7 @@ fi
 echo "Creating '$BRANCH_NAME' from template '$TEMPLATE_DB'..."
 $PSQL -c "CREATE DATABASE \"$BRANCH_NAME\" TEMPLATE $TEMPLATE_DB"
 
+echo "Re-encrypting warehouse credentials for current environment..."
+PGDATABASE="$BRANCH_NAME" pnpm -F backend reseed-encrypted-credentials
+
 echo "Done — branch database '$BRANCH_NAME' is ready."


### PR DESCRIPTION
## Summary

- The shared base DB snapshot bakes in encrypted warehouse credentials and dbt connection settings tied to the `LIGHTDASH_SECRET` and `PG*` env vars of the original seeder
- When a branch DB is created from the template, those encrypted blobs are stale — decryption fails or returns wrong connection details (e.g., Docker-internal `db-dev` hostname instead of `localhost`)
- Adds a `reseed-encrypted-credentials` script that re-encrypts the two affected columns (`projects.dbt_connection` and `warehouse_credentials.encrypted_credentials`) using the current environment
- Calls it automatically from `setup-branch-db.sh` after the template copy

## Test plan

- [x] Bootstrapped a new instance from shared base snapshot
- [x] Ran `reseed-encrypted-credentials` — updated 1 project and 1 warehouse credential
- [x] Verified decryption produces correct values (localhost + current worktree paths)
- [x] Started PM2, logged in, and ran a warehouse query end-to-end (orders explore, 3 rows returned)

🤖 Generated with [Claude Code](https://claude.com/claude-code)