### PR TITLE
feat: wip data app domain set-up

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,4 @@ http-client.private.env.json
 scripts/har-replay-server.ts
 *.har
 agent-harness/cloud/credentials.env
+Caddyfile

--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -374,7 +374,7 @@ export const lightdashConfigMock: LightdashConfig = {
         enabled: false,
         lightdashOrigin: 'https://test.lightdash.cloud',
         cdnOrigin: null,
-        previewOrigin: null,
+        previewDomain: '',
         s3: null,
         e2bApiKey: null,
     },

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1311,7 +1311,15 @@ export type AppRuntimeConfig = {
     enabled: boolean;
     lightdashOrigin: string;
     cdnOrigin: string | null;
-    previewOrigin: string | null;
+    /**
+     * Base domain (with optional port) for app preview subdomains.
+     * Required when enabled. Each project gets its own subdomain:
+     *   {projectUuid}.{previewDomain}
+     * Must be a separate registrable domain from lightdashOrigin
+     * for full cookie/origin isolation.
+     * Examples: "lightdashapp.com", "lightdashapp.local:3002"
+     */
+    previewDomain: string;
     s3: S3Config | null;
     e2bApiKey: string | null;
 };
@@ -1512,11 +1520,22 @@ const parseAppRuntimeConfig = (siteUrl: string): AppRuntimeConfig => {
         };
     }
 
+    const previewDomain = process.env.APP_RUNTIME_PREVIEW_DOMAIN;
+
+    if (enabled && !previewDomain) {
+        throw new ParseError(
+            'APP_RUNTIME_PREVIEW_DOMAIN is required when APPS_RUNTIME_ENABLED=true. ' +
+                'Set it to a separate registrable domain for cookie/origin isolation ' +
+                '(e.g. "lightdashapp.com" or "lightdashapp.local:3002" for local dev).',
+            {},
+        );
+    }
+
     return {
         enabled,
         lightdashOrigin: process.env.APP_RUNTIME_LIGHTDASH_ORIGIN || siteUrl,
         cdnOrigin: process.env.APP_RUNTIME_CDN_ORIGIN || null,
-        previewOrigin: process.env.APP_RUNTIME_PREVIEW_ORIGIN || null,
+        previewDomain: previewDomain || '',
         s3,
         e2bApiKey: process.env.E2B_API_KEY || null,
     };

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -4,11 +4,7 @@ import path from 'path';
 import { validate as isValidUuid } from 'uuid';
 import { type AppRuntimeConfig } from '../config/parseConfig';
 import Logger from '../logging/logger';
-import {
-    PREVIEW_COOKIE_NAME,
-    PREVIEW_TOKEN_MAX_AGE_SECONDS,
-    verifyPreviewToken,
-} from './appPreviewToken';
+import { verifyPreviewToken } from './appPreviewToken';
 
 const CONTENT_TYPE_BY_EXT: Record<string, string> = {
     '.js': 'application/javascript',
@@ -56,18 +52,6 @@ const isSafeFilename = (filename: string): boolean =>
     /^[a-zA-Z0-9._-]+$/.test(filename) && !filename.includes('..');
 
 /**
- * Extracts a named cookie value from the Cookie header.
- */
-const getCookieValue = (
-    cookieHeader: string | undefined,
-    name: string,
-): string | undefined => {
-    if (!cookieHeader) return undefined;
-    const match = cookieHeader.match(new RegExp(`(?:^|;\\s*)${name}=([^;]*)`));
-    return match ? match[1] : undefined;
-};
-
-/**
  * Rewrites Vite-generated asset references in HTML to include a token
  * query parameter so they authenticate without cookies.
  *
@@ -91,24 +75,22 @@ export const createAppPreviewRouter = (
 ): Router => {
     const router = express.Router({ strict: true });
 
-    // Host header validation — defense-in-depth for domain isolation.
-    // When APP_RUNTIME_PREVIEW_ORIGIN is set (production), reject requests
-    // that arrive on the wrong hostname (e.g. the main app domain).
-    // previewOrigin is a full URL (e.g. "https://preview.lightdash.cloud")
-    // consistent with other *_ORIGIN env vars, so we extract the hostname.
-    if (config.previewOrigin) {
-        const previewHostname = new URL(config.previewOrigin).hostname;
-        router.use((req, res, next) => {
-            if (req.hostname !== previewHostname) {
-                res.status(404).json({
-                    status: 'error',
-                    error: { message: 'Not found' },
-                });
-                return;
-            }
-            next();
-        });
-    }
+    // Host header validation — reject requests that don't arrive on a
+    // valid preview subdomain (e.g. {projectUuid}.lightdashapp.com).
+    // previewDomain may include a port (e.g. "lightdashapp.local:3002"),
+    // so we only check the hostname portion against req.hostname.
+    const previewDomainHostname = config.previewDomain.split(':')[0];
+    const expectedSuffix = `.${previewDomainHostname}`;
+    router.use((req, res, next) => {
+        if (!req.hostname.endsWith(expectedSuffix)) {
+            res.status(404).json({
+                status: 'error',
+                error: { message: 'Not found' },
+            });
+            return;
+        }
+        next();
+    });
 
     const s3 =
         config.s3 !== null
@@ -248,39 +230,10 @@ export const createAppPreviewRouter = (
         next();
     };
 
-    /**
-     * Accepts a JWT from the `?token` query param, verifies it, and
-     * promotes it to a path-scoped HttpOnly cookie so subsequent asset
-     * requests are authenticated automatically by the browser.
-     */
-    const requireTokenAndSetCookie: express.RequestHandler = (
-        req,
-        res,
-        next,
-    ) => {
+    /** Requires a valid JWT in the `?token` query param. */
+    const requireToken: express.RequestHandler = (req, res, next) => {
         const token =
             typeof req.query.token === 'string' ? req.query.token : undefined;
-
-        handleTokenVerification(token, req, res, () => {
-            const { appUuid, version } = req.params;
-            const cookiePath = `/api/apps/${appUuid}/versions/${version}/`;
-            res.cookie(PREVIEW_COOKIE_NAME, token!, {
-                path: cookiePath,
-                httpOnly: true,
-                secure: true,
-                sameSite: 'strict',
-                maxAge: PREVIEW_TOKEN_MAX_AGE_SECONDS * 1000,
-            });
-            next();
-        });
-    };
-
-    /** Accepts a JWT from a `?token` query param or the path-scoped cookie. */
-    const requireTokenOrCookie: express.RequestHandler = (req, res, next) => {
-        const token =
-            typeof req.query.token === 'string'
-                ? req.query.token
-                : getCookieValue(req.headers.cookie, PREVIEW_COOKIE_NAME);
         handleTokenVerification(token, req, res, next);
     };
 
@@ -302,7 +255,7 @@ export const createAppPreviewRouter = (
     // (needed when the iframe sandbox omits allow-same-origin).
     router.get(
         '/:appUuid/versions/:version/',
-        requireTokenAndSetCookie,
+        requireToken,
         async (req, res) => {
             const { appUuid, version } = req.params;
             const s3Key = `apps/${appUuid}/versions/${version}/index.html`;
@@ -339,7 +292,7 @@ export const createAppPreviewRouter = (
     // allow-same-origin) or the path-scoped cookie (for normal browsers).
     router.get(
         '/:appUuid/versions/:version/assets/:filename',
-        requireTokenOrCookie,
+        requireToken,
         async (req, res) => {
             const { filename } = req.params;
 

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -134,6 +134,7 @@ export const BaseResponse: HealthState = {
     },
     dataApps: {
         enabled: false,
+        previewDomain: null,
     },
 };
 

--- a/packages/backend/src/services/HealthService/HealthService.ts
+++ b/packages/backend/src/services/HealthService/HealthService.ts
@@ -236,6 +236,8 @@ export class HealthService extends BaseService {
             },
             dataApps: {
                 enabled: this.lightdashConfig.appRuntime.enabled,
+                previewDomain:
+                    this.lightdashConfig.appRuntime.previewDomain || null,
             },
         };
     }

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -491,6 +491,13 @@ export type HealthState = {
     };
     dataApps: {
         enabled: boolean;
+        /**
+         * Base domain for app preview subdomains (e.g. "lightdashapp.com").
+         * The frontend constructs per-project origins as:
+         *   {protocol}//{projectUuid}.{previewDomain}
+         * Null when dataApps is disabled.
+         */
+        previewDomain: string | null;
     };
 };
 

--- a/packages/frontend/src/features/apps/AppIframePreview.tsx
+++ b/packages/frontend/src/features/apps/AppIframePreview.tsx
@@ -3,6 +3,11 @@ import { useAppSdkBridge } from './hooks/useAppSdkBridge';
 
 type Props = {
     src: string;
+    /**
+     * The origin of the preview domain (e.g. "https://apps.example.com").
+     * Used to restrict postMessage to/from the iframe.
+     */
+    previewOrigin: string;
 };
 
 /**
@@ -13,9 +18,9 @@ type Props = {
  * routes all API calls through postMessage, and this component's bridge
  * executes them using the current user's session.
  */
-const AppIframePreview: FC<Props> = ({ src }) => {
+const AppIframePreview: FC<Props> = ({ src, previewOrigin }) => {
     const iframeRef = useRef<HTMLIFrameElement>(null);
-    const { handleIframeLoad } = useAppSdkBridge(iframeRef);
+    const { handleIframeLoad } = useAppSdkBridge(iframeRef, previewOrigin);
 
     return (
         <iframe
@@ -23,7 +28,7 @@ const AppIframePreview: FC<Props> = ({ src }) => {
             src={src}
             style={{ width: '100%', height: '100%', border: 'none' }}
             title="App preview"
-            sandbox="allow-scripts"
+            sandbox="allow-scripts allow-same-origin"
             allow=""
             onLoad={handleIframeLoad}
         />

--- a/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppSdkBridge.ts
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, type RefObject } from 'react';
+import { useCallback, useEffect, useMemo, type RefObject } from 'react';
 
 /**
  * Routes the SDK is allowed to call through the postMessage bridge.
@@ -33,12 +33,23 @@ function isAllowedRoute(method: string, path: string): boolean {
  * no direct API access). This hook receives those requests, validates
  * them against an allowlist, executes them with the current user's
  * session cookies, and posts the raw API response back.
+ *
+ * @param previewOrigin — the origin of the preview domain. Used to
+ *   verify incoming message origins and target outgoing postMessages.
  */
 export function useAppSdkBridge(
     iframeRef: RefObject<HTMLIFrameElement | null>,
+    previewOrigin: string,
 ) {
+    // Strip any trailing slash so origin comparison is consistent.
+    const normalizedOrigin = useMemo(
+        () => previewOrigin.replace(/\/+$/, ''),
+        [previewOrigin],
+    );
+
     const handleMessage = useCallback(
         async (event: MessageEvent) => {
+            if (event.origin !== normalizedOrigin) return;
             if (event.source !== iframeRef.current?.contentWindow) return;
 
             const { data } = event;
@@ -52,7 +63,7 @@ export function useAppSdkBridge(
             }) => {
                 iframeRef.current?.contentWindow?.postMessage(
                     { type: 'lightdash:sdk:fetch-response', id, ...response },
-                    '*',
+                    normalizedOrigin,
                 );
             };
 
@@ -84,7 +95,7 @@ export function useAppSdkBridge(
                 });
             }
         },
-        [iframeRef],
+        [iframeRef, normalizedOrigin],
     );
 
     useEffect(() => {
@@ -95,9 +106,9 @@ export function useAppSdkBridge(
     const handleIframeLoad = useCallback(() => {
         iframeRef.current?.contentWindow?.postMessage(
             { type: 'lightdash:sdk:ready' },
-            '*',
+            normalizedOrigin,
         );
-    }, [iframeRef]);
+    }, [iframeRef, normalizedOrigin]);
 
     return { handleIframeLoad };
 }

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -36,16 +36,16 @@ const AppPreview: FC<{
     projectUuid: string;
     appUuid: string;
     version: number;
-}> = ({ projectUuid, appUuid, version }) => {
+    previewOrigin: string;
+}> = ({ projectUuid, appUuid, version, previewOrigin }) => {
     const {
         data: token,
         isLoading,
         error,
     } = useAppPreviewToken(projectUuid, appUuid, version);
 
-    const baseUrl = window.location.origin;
     const previewUrl = token
-        ? `${baseUrl}/api/apps/${appUuid}/versions/${version}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
+        ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
         : undefined;
 
     if (isLoading) {
@@ -70,7 +70,7 @@ const AppPreview: FC<{
 
     if (!previewUrl) return null;
 
-    return <AppIframePreview src={previewUrl} />;
+    return <AppIframePreview src={previewUrl} previewOrigin={previewOrigin} />;
 };
 
 const LoadingDots: FC = () => (
@@ -120,7 +120,12 @@ const AppGenerate: FC = () => {
         return <Navigate to={`/projects/${projectUuid}/home`} replace />;
     }
 
-    if (!projectUuid) {
+    const previewDomain = health.data?.dataApps.previewDomain;
+    const previewOrigin = previewDomain
+        ? `${window.location.protocol}//${projectUuid}.${previewDomain}`
+        : undefined;
+
+    if (!projectUuid || !previewOrigin) {
         return <Box>Missing project UUID</Box>;
     }
 
@@ -370,6 +375,7 @@ const AppGenerate: FC = () => {
                                     projectUuid={projectUuid}
                                     appUuid={latestApp.appUuid}
                                     version={latestApp.version}
+                                    previewOrigin={previewOrigin}
                                 />
                             ) : (
                                 <Box className={classes.previewEmpty}>

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -49,10 +49,14 @@ export default function AppPreviewTest() {
         return <div>Missing route params</div>;
     }
 
-    const baseUrl = window.location.origin;
-    const previewUrl = token
-        ? `${baseUrl}/api/apps/${appUuid}/versions/${version}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
+    const previewDomain = health.data?.dataApps.previewDomain;
+    const previewOrigin = previewDomain
+        ? `${window.location.protocol}//${projectUuid}.${previewDomain}`
         : undefined;
+    const previewUrl =
+        token && previewOrigin
+            ? `${previewOrigin}/api/apps/${appUuid}/versions/${version}/?token=${token}#transport=postMessage&projectUuid=${projectUuid}`
+            : undefined;
 
     if (isLoading) {
         return (
@@ -76,11 +80,11 @@ export default function AppPreviewTest() {
         );
     }
 
-    if (!previewUrl) return null;
+    if (!previewUrl || !previewOrigin) return null;
 
     return (
         <Group h="calc(100vh - 50px)" w="100%">
-            <AppIframePreview src={previewUrl} />
+            <AppIframePreview src={previewUrl} previewOrigin={previewOrigin} />
         </Group>
     );
 }

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -134,6 +134,7 @@ export default function mockHealthResponse(
         },
         dataApps: {
             enabled: false,
+            previewDomain: null,
         },
         ...overrides,
     };


### PR DESCRIPTION
### Description:
🚧 The goal is to embed the data apps from a different domain for proper isolation. Right now we're relying on an opaque origin.