### PR TITLE
fix: pin axios to exact version 1.12.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
             "@types/react": "19.2.2",
             "@types/react-dom": "19.2.2",
             "linkifyjs": "^4.3.2",
-            "axios": "^1.12.0",
+            "axios": "1.12.2",
             "form-data@2.5.3": "2.5.5",
             "form-data@3.0.1": "3.0.4",
             "form-data@4.0.0": "4.0.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -9,7 +9,7 @@ overrides:
   '@types/react': 19.2.2
   '@types/react-dom': 19.2.2
   linkifyjs: ^4.3.2
-  axios: ^1.12.0
+  axios: 1.12.2
   form-data@2.5.3: 2.5.5
   form-data@3.0.1: 3.0.4
   form-data@4.0.0: 4.0.4
@@ -7750,7 +7750,7 @@ packages:
   axios-retry@4.5.0:
     resolution: {integrity: sha512-aR99oXhpEDGo0UuAlYcn2iGRds30k366Zfa05XWScR9QaQD4JYiP3/1Qt1u7YlefUOK+cn0CcwoL1oefavQUlQ==}
     peerDependencies:
-      axios: ^1.12.0
+      axios: 1.12.2
 
   axios@1.12.2:
     resolution: {integrity: sha512-vMJzPewAlRyOgxV2dU0Cuz2O8zzzx9VYtbJOaBgXFeLc4IV/Eg50n4LowmehOOR61S8ZMpc2K5Sa7g6A4jfkUw==}
@@ -11466,7 +11466,7 @@ packages:
       '@langchain/mistralai': '*'
       '@langchain/ollama': '*'
       '@langchain/xai': '*'
-      axios: ^1.12.0
+      axios: 1.12.2
       cheerio: '*'
       handlebars: ^4.7.8
       peggy: ^3.0.2


### PR DESCRIPTION
## Summary
- Pins the pnpm `axios` override from `^1.12.0` (caret range) to exact `1.12.2`
- Prevents transitive resolution to compromised axios versions (`1.14.1`, `0.30.4`) published today — see https://socket.dev/blog/axios-npm-package-compromised
- The compromised versions have been unpublished from npm, but pinning prevents future similar incidents

## Context
- axios enters our dependency tree transitively via `snowflake-sdk` (`^1.13.4`) and `trino-client` (`1.13.2`)
- The caret range `^1.12.0` in the override would allow resolution to any `1.x >= 1.12.0`, including the malicious `1.14.1`
- Our lockfile already pinned `1.12.2`, so deployed Lightdash instances were **not affected**
- Risk was limited to fresh CLI installs without a lockfile during the brief compromise window

## Test plan
- [x] `pnpm install` succeeds with updated lockfile
- [x] Verified `pnpm why axios --filter @lightdash/cli` resolves to `1.12.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)