### PR TITLE
perf: deduplicate getUserAttributes() in dashboard chart query path

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1315,9 +1315,15 @@ describe('AsyncQueryService', () => {
                 },
             });
             (service as AnyType).preAggregateStrategy = mockStrategy;
-            service.getExplore = jest
+            service.getExploreWithUserAccessControls = jest
                 .fn()
-                .mockResolvedValue(preAggregateExplore);
+                .mockResolvedValue({
+                    explore: preAggregateExplore,
+                    userAccessControls: {
+                        userAttributes: {},
+                        intrinsicUserAttributes: {},
+                    },
+                });
             (service as AnyType).getWarehouseCredentials = jest
                 .fn()
                 .mockResolvedValue(warehouseClientMock.credentials);

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -507,9 +507,9 @@ export class AsyncQueryService extends ProjectService {
         exploreName: string;
         organizationUuid: string;
         materializationRole?: UserAccessControls;
-    }): Promise<Explore> {
+    }): Promise<{ explore: Explore; userAccessControls: UserAccessControls }> {
         if (materializationRole === undefined) {
-            return this.getExplore(
+            return this.getExploreWithUserAccessControls(
                 account,
                 projectUuid,
                 exploreName,
@@ -567,10 +567,16 @@ export class AsyncQueryService extends ProjectService {
         }
 
         if (!exploreHasFilteredAttribute(explore)) {
-            return explore;
+            return { explore, userAccessControls: materializationRole };
         }
 
-        return getFilteredExplore(explore, materializationRole.userAttributes);
+        return {
+            explore: getFilteredExplore(
+                explore,
+                materializationRole.userAttributes,
+            ),
+            userAccessControls: materializationRole,
+        };
     }
 
     public getCacheExpiresAt(baseDate: Date) {
@@ -3200,6 +3206,7 @@ export class AsyncQueryService extends ProjectService {
         columnTimezone,
         sessionTimezone,
         applyDateZoomToFilters,
+        preloadedUserAccessControls,
     }: Pick<
         ExecuteAsyncMetricQueryArgs,
         | 'account'
@@ -3221,11 +3228,14 @@ export class AsyncQueryService extends ProjectService {
          * underlying-data path sets this (PROD-880). See `_compileQuery` doc.
          */
         applyDateZoomToFilters?: boolean;
+        preloadedUserAccessControls?: UserAccessControls;
     }) {
         assertIsAccountWithOrg(account);
 
         const resolvedUserAccessControls =
-            materializationRole ?? (await this.getUserAttributes({ account }));
+            materializationRole ??
+            preloadedUserAccessControls ??
+            (await this.getUserAttributes({ account }));
         const { userAttributes: baseUserAttributes, intrinsicUserAttributes } =
             resolvedUserAccessControls;
         const userAttributes =
@@ -4032,16 +4042,18 @@ export class AsyncQueryService extends ProjectService {
 
         const metricQueryStart = Date.now();
 
-        const explore = await this.getExploreForMetricQueryExecution({
-            account,
-            projectUuid,
-            exploreName: inputMetricQuery.exploreName,
-            organizationUuid,
-            materializationRole:
-                context === QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
-                    ? materializationRole
-                    : undefined,
-        });
+        const { explore, userAccessControls: preloadedUserAccessControls } =
+            await this.getExploreForMetricQueryExecution({
+                account,
+                projectUuid,
+                exploreName: inputMetricQuery.exploreName,
+                organizationUuid,
+                materializationRole:
+                    context ===
+                    QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
+                        ? materializationRole
+                        : undefined,
+            });
         const getExploreMs = Date.now() - metricQueryStart;
 
         // Dashboard filters (e.g. from a data-app tile) are merged once the
@@ -4117,6 +4129,7 @@ export class AsyncQueryService extends ProjectService {
             userAttributeOverrides,
             materializationRole,
             columnTimezone: getColumnTimezone(warehouseCredentials),
+            preloadedUserAccessControls,
         });
         const prepareMs = Date.now() - prepareStart;
 
@@ -4562,12 +4575,13 @@ export class AsyncQueryService extends ProjectService {
             query_context: context,
         };
 
-        const explore = await this.getExplore(
-            account,
-            projectUuid,
-            savedChartTableName,
-            savedChartOrganizationUuid,
-        );
+        const { explore, userAccessControls: preloadedUserAccessControls } =
+            await this.getExploreWithUserAccessControls(
+                account,
+                projectUuid,
+                savedChartTableName,
+                savedChartOrganizationUuid,
+            );
 
         const warehouseCredentials = await this.getWarehouseCredentials({
             projectUuid,
@@ -4626,6 +4640,7 @@ export class AsyncQueryService extends ProjectService {
             projectUuid,
             pivotConfiguration,
             columnTimezone: getColumnTimezone(warehouseCredentials),
+            preloadedUserAccessControls,
         });
 
         const routingDecision = this.getPreAggregationRoutingDecision({
@@ -4786,9 +4801,9 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError('Chart does not belong to project');
         }
 
-        const [space, explore] = await Promise.all([
+        const [space, { explore, userAccessControls }] = await Promise.all([
             this.spaceModel.getSpaceSummary(savedChart.spaceUuid),
-            this.getExplore(
+            this.getExploreWithUserAccessControls(
                 account,
                 projectUuid,
                 savedChart.tableName,
@@ -4942,7 +4957,7 @@ export class AsyncQueryService extends ProjectService {
             missingParameterReferences,
             usedParameters,
             responseMetricQuery,
-            userAccessControls,
+            userAccessControls: queryUserAccessControls,
             availableParameterDefinitions,
             resolvedTimezone,
             displayTimezone,
@@ -4958,6 +4973,7 @@ export class AsyncQueryService extends ProjectService {
             pivotConfiguration,
             columnTimezone: getColumnTimezone(warehouseCredentials),
             sessionTimezone,
+            preloadedUserAccessControls: userAccessControls,
         });
 
         const routingDecision = this.getPreAggregationRoutingDecision({
@@ -5020,7 +5036,7 @@ export class AsyncQueryService extends ProjectService {
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
                     preAggregationRoute: routingDecision.route,
-                    userAccessControls,
+                    userAccessControls: queryUserAccessControls,
                     availableParameterDefinitions,
                 }),
             },
@@ -5098,12 +5114,13 @@ export class AsyncQueryService extends ProjectService {
 
         const { exploreName } = metricQuery;
 
-        const explore = await this.getExplore(
-            account,
-            projectUuid,
-            exploreName,
-            organizationUuid,
-        );
+        const { explore, userAccessControls: preloadedUserAccessControls } =
+            await this.getExploreWithUserAccessControls(
+                account,
+                projectUuid,
+                exploreName,
+                organizationUuid,
+            );
 
         // Combine parameters early so we can filter dimensions by parameter availability
         const combinedParameters = await this.combineParameters(
@@ -5311,6 +5328,7 @@ export class AsyncQueryService extends ProjectService {
             columnTimezone: getColumnTimezone(warehouseCredentials),
             // PROD-880: rewrite WHERE LHS to zoom grain (safe here — filters are click-only)
             applyDateZoomToFilters: true,
+            preloadedUserAccessControls,
         });
 
         const { queryUuid: underlyingDataQueryUuid, cacheMetadata } =

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6383,18 +6383,36 @@ export class ProjectService extends BaseService {
         organizationUuid?: string,
         includeUnfilteredTables: boolean = true,
     ): Promise<Explore> {
+        const { explore } = await this.getExploreWithUserAccessControls(
+            account,
+            projectUuid,
+            exploreName,
+            organizationUuid,
+            includeUnfilteredTables,
+        );
+        return explore;
+    }
+
+    async getExploreWithUserAccessControls(
+        account: Account,
+        projectUuid: string,
+        exploreName: string,
+        organizationUuid?: string,
+        includeUnfilteredTables: boolean = true,
+    ): Promise<{ explore: Explore; userAccessControls: UserAccessControls }> {
         return Sentry.startSpan(
             {
                 op: 'ProjectService.getExplore',
                 name: 'ProjectService.getExplore',
             },
             async () => {
-                const exploresMap = await this.findExplores({
-                    account,
-                    projectUuid,
-                    exploreNames: [exploreName],
-                    organizationUuid,
-                });
+                const { explores: exploresMap, userAccessControls } =
+                    await this.findExploresWithUserAccessControls({
+                        account,
+                        projectUuid,
+                        exploreNames: [exploreName],
+                        organizationUuid,
+                    });
                 const explore = exploresMap[exploreName];
 
                 if (!explore) {
@@ -6409,10 +6427,10 @@ export class ProjectService extends BaseService {
                             .join(', ')}`,
                     );
                 }
-                if (includeUnfilteredTables) {
-                    return explore;
-                }
-                return { ...explore, unfilteredTables: undefined };
+                const finalExplore = includeUnfilteredTables
+                    ? explore
+                    : { ...explore, unfilteredTables: undefined };
+                return { explore: finalExplore, userAccessControls };
             },
         );
     }
@@ -6428,6 +6446,29 @@ export class ProjectService extends BaseService {
         exploreNames: string[];
         organizationUuid?: string;
     }): Promise<Record<string, Explore | ExploreError>> {
+        const { explores } = await this.findExploresWithUserAccessControls({
+            account,
+            projectUuid,
+            exploreNames,
+            organizationUuid,
+        });
+        return explores;
+    }
+
+    async findExploresWithUserAccessControls({
+        account,
+        projectUuid,
+        exploreNames,
+        organizationUuid,
+    }: {
+        account: Account;
+        projectUuid: string;
+        exploreNames: string[];
+        organizationUuid?: string;
+    }): Promise<{
+        explores: Record<string, Explore | ExploreError>;
+        userAccessControls: UserAccessControls;
+    }> {
         return Sentry.startSpan(
             {
                 op: 'ProjectService.findExplores',
@@ -6479,11 +6520,11 @@ export class ProjectService extends BaseService {
                         projectUuid,
                     );
 
-                const { userAttributes } = await this.getUserAttributes({
+                const userAccessControls = await this.getUserAttributes({
                     account,
                 });
 
-                return Object.values(explores).reduce<
+                const filteredExplores = Object.values(explores).reduce<
                     Record<string, Explore | ExploreError>
                 >((acc, explore) => {
                     if (
@@ -6502,12 +6543,17 @@ export class ProjectService extends BaseService {
                         } else {
                             acc[explore.name] = getFilteredExplore(
                                 explore,
-                                userAttributes,
+                                userAccessControls.userAttributes,
                             );
                         }
                     }
                     return acc;
                 }, {});
+
+                return {
+                    explores: filteredExplores,
+                    userAccessControls,
+                };
             },
         );
     }


### PR DESCRIPTION
## Summary

Eliminates a duplicate `getUserAttributes()` call in the dashboard chart query path (`POST /api/v2/projects/{projectUuid}/query/dashboard-chart`).

`getUserAttributes()` runs 4 sequential DB queries (org defaults, user overrides, group attrs, email status). It was called once in `findExplores()` for user-attribute-based explore filtering, then again in `prepareMetricQueryAsyncQueryArgs()` for query compilation — identical inputs, identical results, same request.

**Changes:**
- Add `findExploresWithUserAccessControls()` and `getExploreWithUserAccessControls()` that return both the explore and the user access controls
- `findExplores()` and `getExplore()` become thin wrappers (no behavioral change for existing callers)
- `prepareMetricQueryAsyncQueryArgs()` now requires `preloadedUserAccessControls` — all 4 callers already fetch it via `getExploreWithUserAccessControls`, so the duplicate `getUserAttributes()` call and its DB fallback are fully removed

**Impact:** Saves 4 DB round-trips per chart on a dashboard. For a 10-chart dashboard, that's 40 fewer Postgres queries.

**Out of scope:** The `getUserAttributes` call in `executeAsyncSqlQuery` (SQL chart path) is a different endpoint with no duplication — intentionally left unchanged.

## Test plan

- [ ] Open a dashboard with multiple chart tiles — all charts load correctly
- [ ] Dashboard with user-attribute-based row-level security — filtered data is correct
- [ ] Dashboard with filters applied — filters work as expected
- [ ] Drill into underlying data from a dashboard chart — works correctly

Part 1 of a 7-PR stack to reduce dashboard chart query initialization from ~22 to ~11 Postgres round-trips.