### PR TITLE
feat: promote App menu item to top of New menu with beta badge

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -70,6 +70,26 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                     </Menu.Target>
 
                     <Menu.Dropdown>
+                        {health.data?.dataApps.enabled && (
+                            <Can
+                                I="manage"
+                                this={subject('DataApp', {
+                                    organizationUuid:
+                                        user.data?.organizationUuid,
+                                    projectUuid,
+                                })}
+                            >
+                                <LargeMenuItem
+                                    component={Link}
+                                    title="App"
+                                    description="Build an interactive app powered by your data."
+                                    to={`/projects/${projectUuid}/apps/generate`}
+                                    icon={IconAppWindow}
+                                    isBeta
+                                />
+                            </Can>
+                        )}
+
                         <LargeMenuItem
                             component={Link}
                             title="Chart"
@@ -130,24 +150,6 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                 icon={IconFolder}
                             />
                         </Can>
-                        {health.data?.dataApps.enabled && (
-                            <Can
-                                I="manage"
-                                this={subject('DataApp', {
-                                    organizationUuid:
-                                        user.data?.organizationUuid,
-                                    projectUuid,
-                                })}
-                            >
-                                <LargeMenuItem
-                                    component={Link}
-                                    title="App"
-                                    description="Build an interactive app powered by your data."
-                                    to={`/projects/${projectUuid}/apps/generate`}
-                                    icon={IconAppWindow}
-                                />
-                            </Can>
-                        )}
                     </Menu.Dropdown>
                 </Menu>
             </Can>

--- a/packages/frontend/src/components/common/LargeMenuItem.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.tsx
@@ -1,6 +1,7 @@
 import {
     Card,
     createPolymorphicComponent,
+    Group,
     Menu,
     Stack,
     Text,
@@ -8,6 +9,7 @@ import {
 } from '@mantine-8/core';
 import { type Icon as TablerIconType } from '@tabler/icons-react';
 import { forwardRef, type ReactNode } from 'react';
+import { BetaBadge } from './BetaBadge';
 import MantineIcon, { type MantineIconProps } from './MantineIcon';
 
 interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
@@ -15,13 +17,14 @@ interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
     iconProps?: Omit<MantineIconProps, 'icon'>;
     title: string;
     description: string | ReactNode;
+    isBeta?: boolean;
 }
 
 const LargeMenuItem: ReturnType<
     typeof createPolymorphicComponent<'button', LargeMenuItemProps>
 > = createPolymorphicComponent<'button', LargeMenuItemProps>(
     forwardRef<HTMLButtonElement, LargeMenuItemProps>(
-        ({ icon, title, description, iconProps, ...rest }, ref) => {
+        ({ icon, title, description, iconProps, isBeta, ...rest }, ref) => {
             return (
                 <Menu.Item
                     ref={ref}
@@ -38,9 +41,12 @@ const LargeMenuItem: ReturnType<
                     {...rest}
                 >
                     <Stack gap="xxs">
-                        <Text c="white" fw={600} fz="sm">
-                            {title}
-                        </Text>
+                        <Group gap="xs">
+                            <Text c="white" fw={600} fz="sm">
+                                {title}
+                            </Text>
+                            {isBeta && <BetaBadge />}
+                        </Group>
                         <Text c="ldDark.8" fz="xs">
                             {description}
                         </Text>


### PR DESCRIPTION
### Description:
Moving the new menu item up top and adding a beta badge:

<img width="503" height="341" alt="Screenshot 2026-03-31 at 12 05 48" src="https://github.com/user-attachments/assets/e3644997-eb75-4540-a540-c65276cbd5d5" />
