### PR TITLE
fix: add permission checks for AI agent message feedback and artifact access

### DIFF
--- a/packages/backend/src/ee/controllers/aiAgentController.ts
+++ b/packages/backend/src/ee/controllers/aiAgentController.ts
@@ -613,6 +613,9 @@ export class AiAgentController extends BaseController {
         this.setStatus(200);
         await this.getAiAgentService().updateHumanScoreForMessage(
             req.user!,
+            projectUuid,
+            agentUuid,
+            threadUuid,
             messageUuid,
             body.humanScore,
             body.humanFeedback,
@@ -660,6 +663,7 @@ export class AiAgentController extends BaseController {
             status: 'ok',
             results: (await this.getAiAgentService().getArtifact(
                 req.user!,
+                projectUuid,
                 agentUuid,
                 artifactUuid,
             )) as unknown as AiArtifactTSOACompat,
@@ -685,6 +689,7 @@ export class AiAgentController extends BaseController {
 
             results: (await this.getAiAgentService().getArtifact(
                 req.user!,
+                projectUuid,
                 agentUuid,
                 artifactUuid,
                 versionUuid,

--- a/packages/backend/src/ee/models/AiAgentModel.ts
+++ b/packages/backend/src/ee/models/AiAgentModel.ts
@@ -2345,6 +2345,36 @@ export class AiAgentModel {
             .orderBy(`${AiPromptTableName}.created_at`, 'asc');
     }
 
+    async findPromptContext(
+        promptUuid: string,
+    ): Promise<
+        | Pick<
+              AiWebAppPrompt,
+              | 'organizationUuid'
+              | 'projectUuid'
+              | 'agentUuid'
+              | 'promptUuid'
+              | 'threadUuid'
+          >
+        | undefined
+    > {
+        return this.database(AiPromptTableName)
+            .join(
+                AiThreadTableName,
+                `${AiPromptTableName}.ai_thread_uuid`,
+                `${AiThreadTableName}.ai_thread_uuid`,
+            )
+            .select({
+                organizationUuid: `${AiThreadTableName}.organization_uuid`,
+                projectUuid: `${AiThreadTableName}.project_uuid`,
+                agentUuid: `${AiThreadTableName}.agent_uuid`,
+                promptUuid: `${AiPromptTableName}.ai_prompt_uuid`,
+                threadUuid: `${AiPromptTableName}.ai_thread_uuid`,
+            })
+            .where(`${AiPromptTableName}.ai_prompt_uuid`, promptUuid)
+            .first();
+    }
+
     async findSlackPrompt(
         promptUuid: string,
     ): Promise<SlackPrompt | undefined> {

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -1654,13 +1654,65 @@ export class AiAgentService {
         };
     }
 
-    // TODO: user permissions
     async updateHumanScoreForMessage(
         user: SessionUser,
+        projectUuid: string,
+        agentUuid: string,
+        threadUuid: string,
         messageUuid: string,
         humanScore: number,
         humanFeedback?: string | null,
     ) {
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
+
+        const isCopilotEnabled = await this.getIsCopilotEnabled(user);
+        if (!isCopilotEnabled) {
+            throw new ForbiddenError('Copilot is not enabled');
+        }
+
+        const agent = await this.getAgent(user, agentUuid, projectUuid);
+        const message = await this.aiAgentModel.findPromptContext(messageUuid);
+        if (
+            !message ||
+            message.organizationUuid !== organizationUuid ||
+            message.projectUuid !== agent.projectUuid ||
+            message.agentUuid !== agent.uuid ||
+            message.threadUuid !== threadUuid
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to update feedback for this message',
+            );
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid: agent.uuid,
+            threadUuid,
+        });
+
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to update feedback for this thread',
+            );
+        }
+
+        const threadMessage = await this.aiAgentModel.findThreadMessage(
+            'assistant',
+            {
+                organizationUuid,
+                threadUuid,
+                messageUuid,
+            },
+        );
+
         if (humanScore !== 0) {
             this.analytics.track<AiAgentPromptFeedbackEvent>({
                 event: 'ai_agent_prompt.feedback',
@@ -1668,14 +1720,14 @@ export class AiAgentService {
                 properties: {
                     organizationId: user.organizationUuid,
                     humanScore,
-                    messageId: messageUuid,
+                    messageId: threadMessage.uuid,
                     context: 'web_app',
                 },
             });
         }
 
         await this.aiAgentModel.updateHumanScore({
-            promptUuid: messageUuid,
+            promptUuid: threadMessage.uuid,
             humanScore,
             humanFeedback,
         });
@@ -5971,14 +6023,53 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 
     async getArtifact(
         user: SessionUser,
+        projectUuid: string,
         agentUuid: string,
         artifactUuid: string,
         versionUuid?: string,
     ) {
-        // TODO: Add proper permission checking - for now just check user has access to the agent
-        await this.getAgent(user, agentUuid);
+        const { organizationUuid } = user;
+        if (!organizationUuid) {
+            throw new ForbiddenError('Organization not found');
+        }
 
-        return this.aiAgentModel.getArtifact(artifactUuid, versionUuid);
+        const agent = await this.getAgent(user, agentUuid, projectUuid);
+        const artifact = await this.aiAgentModel.getArtifact(
+            artifactUuid,
+            versionUuid,
+        );
+        const artifactThread = await this.aiAgentModel.findThread(
+            artifact.threadUuid,
+        );
+        if (
+            !artifactThread ||
+            artifactThread.organizationUuid !== organizationUuid ||
+            artifactThread.projectUuid !== agent.projectUuid ||
+            artifactThread.agentUuid !== agent.uuid
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this artifact',
+            );
+        }
+
+        const thread = await this.aiAgentModel.getThread({
+            organizationUuid,
+            agentUuid: agent.uuid,
+            threadUuid: artifact.threadUuid,
+        });
+
+        const hasAccess = await this.checkAgentThreadAccess(
+            user,
+            agent,
+            thread.user.uuid,
+        );
+        if (!hasAccess) {
+            throw new ForbiddenError(
+                'Insufficient permissions to access this artifact',
+            );
+        }
+
+        return artifact;
     }
 
     async appendInstruction(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds proper permission checking for AI agent message feedback updates and artifact access.

**Key changes:**

- **Enhanced message feedback permissions**: The `updateHumanScoreForMessage` method now validates that users can only update feedback for messages within threads they have access to. Added validation for organization, project, agent, and thread ownership before allowing feedback updates.

- **Secured artifact access**: The `getArtifact` method now includes comprehensive permission checks to ensure users can only access artifacts from threads they own or have permission to view. Validates organization, project, agent, and thread access before returning artifact data.

- **Added context lookup**: Introduced `findPromptContext` method in the AI agent model to retrieve organization, project, agent, and thread context for a given prompt UUID, enabling proper permission validation.

- **Updated controller signatures**: Modified controller methods to accept and pass through the required `projectUuid`, `agentUuid`, and `threadUuid` parameters needed for permission validation.

These changes ensure that users cannot access or modify AI agent data outside their permitted scope, preventing unauthorized access to messages and artifacts across different organizations, projects, or threads.