### PR TITLE
docs: add versioning documentation and breaking change guidelines

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -154,6 +154,39 @@ other part of the system, please use the appropriate tag to avoid the extra over
 You can see all
 the [supported types here](https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json).
 
+##### Breaking Changes
+
+When a change breaks backwards compatibility, signal it using one of these conventional commit methods:
+
+- **`!` suffix**: `feat!: remove deprecated /api/v1/charts endpoint`
+- **`BREAKING CHANGE:` footer**:
+  ```
+  feat: redesign project settings API
+
+  BREAKING CHANGE: The /api/v1/projects/:id/settings endpoint now returns
+  a flat object instead of nested groups.
+  ```
+
+Either method triggers a **major version bump** (e.g., `1.5.0` → `2.0.0`).
+
+**What counts as a breaking change for Lightdash:**
+
+- REST API endpoint removals or response shape changes
+- Database migrations requiring manual intervention
+- Removed or renamed environment variables / configuration options
+- CLI command removals or changed flags
+- Changed authentication/authorization behavior
+- npm package API changes (`@lightdash/common`, `@lightdash/warehouses`, `@lightdash/cli`)
+- dbt YAML schema changes that invalidate existing `.yml` files
+
+**Not breaking** (minor or patch):
+
+- New API endpoints or new optional fields on existing responses
+- New environment variables with sensible defaults
+- UI changes (layout, design, new features)
+- New database migrations that run automatically
+- Internal refactors with no user-facing effect
+
 #### Merge Strategy
 
 We use `squash & merge` to keep the main branch history clean.

--- a/docs/versioning-and-compatibility.md
+++ b/docs/versioning-and-compatibility.md
@@ -1,0 +1,58 @@
+# Versioning & Compatibility
+
+Lightdash follows [semantic versioning](https://semver.org/) (semver). Version numbers take the form `MAJOR.MINOR.PATCH` and communicate upgrade risk:
+
+| Part | When it changes | What it means for you |
+|---|---|---|
+| **MAJOR** (e.g., `1.x.x` → `2.0.0`) | Breaking changes to APIs, CLI, config, or data formats | Read the changelog before upgrading. You may need to update configuration, API integrations, or dbt YAML files. |
+| **MINOR** (e.g., `1.0.x` → `1.1.0`) | New features, backwards compatible | Safe to upgrade. New functionality is available but nothing existing is broken. |
+| **PATCH** (e.g., `1.0.0` → `1.0.1`) | Bug fixes only | Safe to upgrade. |
+
+## CLI & SDK compatibility
+
+The Lightdash CLI and any SDKs are compatible with any Lightdash server sharing the **same major version**. For example:
+
+- CLI `1.3.0` works with Server `1.50.0`
+- CLI `1.3.0` does **not** work with Server `2.0.0`
+
+The CLI checks compatibility automatically and warns if there is a major version mismatch.
+
+## Docker version pinning
+
+When self-hosting, you can pin to a specific version or range:
+
+```yaml
+# Pin to exact version
+image: lightdash/lightdash:1.5.2
+
+# Pin to major version (recommended) — gets minor and patch updates
+image: lightdash/lightdash:1
+
+# Always latest (default)
+image: lightdash/lightdash:latest
+```
+
+We recommend pinning to the **major version** to automatically receive bug fixes and new features while avoiding breaking changes.
+
+## npm version pinning
+
+For projects depending on Lightdash packages:
+
+```json
+{
+  "dependencies": {
+    "@lightdash/cli": "^1.0.0"
+  }
+}
+```
+
+The `^` prefix ensures you get minor and patch updates within the same major version.
+
+## When to check the changelog
+
+- **Major version bump**: Always read the [changelog](https://github.com/lightdash/lightdash/releases) before upgrading. Look for the "BREAKING CHANGES" section.
+- **Minor / patch bump**: Safe to upgrade without reviewing, but the changelog may contain useful information about new features.
+
+## Maintenance & backports
+
+When a new major version is released, we may maintain the previous major version with critical bug fixes for a limited period. Check the [releases page](https://github.com/lightdash/lightdash/releases) for available versions.

--- a/docs/versioning.md
+++ b/docs/versioning.md
@@ -1,0 +1,47 @@
+# Versioning
+
+Lightdash uses [semantic versioning](https://semver.org/) with [conventional commits](https://www.conventionalcommits.org/) to automate releases.
+
+## How versions work
+
+| Commit type | Version bump | Example | Meaning |
+|---|---|---|---|
+| `fix:` | Patch | `1.0.0` → `1.0.1` | Bug fixes, safe to upgrade |
+| `feat:` | Minor | `1.0.0` → `1.1.0` | New functionality, backwards compatible |
+| `feat!:` / `BREAKING CHANGE:` | Major | `1.0.0` → `2.0.0` | Breaking change, read changelog before upgrading |
+
+Other commit types (`chore:`, `docs:`, `refactor:`, `test:`, `ci:`) do **not** trigger a release.
+
+## Release pipeline
+
+1. Developer merges a PR with conventional commit messages
+2. [semantic-release](https://github.com/semantic-release/semantic-release) analyzes commits since last release
+3. Determines version bump from commit types
+4. Publishes: GitHub release, npm packages, Docker images, Homebrew formula
+
+All packages in the monorepo release in **lockstep** at the same version. There is no independent versioning per package.
+
+## Breaking change checklist
+
+Before adding `!` or `BREAKING CHANGE:` footer, verify which surfaces are affected:
+
+- [ ] **REST API** — Endpoint removed, response shape changed, or status codes altered
+- [ ] **CLI** — Command removed, flag renamed, or output format changed
+- [ ] **Environment variables** — Variable removed or renamed (adding new ones with defaults is not breaking)
+- [ ] **Database migrations** — Migration requires manual steps beyond `pnpm migrate`
+- [ ] **dbt YAML schema** — Existing `.yml` files would fail validation
+- [ ] **npm packages** — Public API of `@lightdash/common`, `@lightdash/warehouses`, or `@lightdash/cli` changed
+- [ ] **Auth/permissions** — A previously-allowed action is now denied
+
+## Package compatibility
+
+All packages release at the same version from the monorepo. CLI and SDK versions are compatible with any Lightdash server sharing the **same major version**:
+
+- CLI `1.3.0` + Server `1.50.0` → compatible
+- CLI `1.3.0` + Server `2.0.0` → **incompatible**, upgrade CLI
+
+The CLI performs a major-version check against the server's health endpoint and warns on mismatch.
+
+## Maintenance branches
+
+When a new major version ships (e.g., `2.0.0`), a `1.x` maintenance branch can be created to backport critical fixes. The `release.config.js` already supports this pattern.


### PR DESCRIPTION
## Summary
- Expand `.github/CONTRIBUTING.md` with a "Breaking Changes" section covering `!` suffix and `BREAKING CHANGE:` footer conventions, plus what does/doesn't count as breaking for Lightdash
- Add `docs/versioning.md` — internal developer reference (release pipeline, breaking change checklist, package compatibility)
- Add `docs/versioning-and-compatibility.md` — user-facing guide for self-hosters (semver meaning, CLI compatibility, Docker/npm pinning)

## Test plan
- [ ] Review docs for accuracy and completeness
- [ ] Verify markdown renders correctly on GitHub