### PR TITLE
feat: add start of week configuration support to DuckDB warehouse client

### DIFF
--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.test.ts
@@ -2,6 +2,7 @@ import {
     DimensionType,
     QueryExecutionContext,
     WarehouseTypes,
+    WeekDay,
 } from '@lightdash/common';
 import fs from 'fs/promises';
 import {
@@ -745,6 +746,18 @@ describe('DuckdbWarehouseClient', () => {
         ).toThrow(
             'MotherDuck token is required for DuckDB warehouse connections',
         );
+    });
+
+    it('should expose the configured start of week', () => {
+        const client = new DuckdbWarehouseClient({
+            type: WarehouseTypes.DUCKDB,
+            database: 'analytics',
+            schema: 'main',
+            token: 'motherduck_token',
+            startOfWeek: WeekDay.SUNDAY,
+        });
+
+        expect(client.getStartOfWeek()).toBe(WeekDay.SUNDAY);
     });
 
     it('should default getFields database to the configured DuckDB database', async () => {

--- a/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/DuckdbWarehouseClient.ts
@@ -312,7 +312,10 @@ export class DuckdbWarehouseClient extends WarehouseBaseClient<CreateDuckdbCrede
                 : ((credentials as CreateDuckdbCredentials) ??
                   DUCKDB_INTERNAL_CREDENTIALS);
 
-        super(effectiveCredentials, new DuckdbSqlBuilder());
+        super(
+            effectiveCredentials,
+            new DuckdbSqlBuilder(effectiveCredentials.startOfWeek),
+        );
 
         // Determine s3Config from either the old DuckdbConnectionCredentials or options
         if (


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

This PR adds support for configurable start of week settings in the DuckDB warehouse client. The `DuckdbWarehouseClient` now passes the `startOfWeek` configuration from its credentials to the `DuckdbSqlBuilder` constructor, enabling week-based date calculations to respect the configured start of week day. A test has been added to verify that the client properly exposes the configured start of week value through the `getStartOfWeek()` method.

<!-- Even better add a screenshot / gif / loom -->