### PR TITLE
fix: wrap PoP queries in outer CTE to resolve ambiguous ORDER BY

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -1054,6 +1054,21 @@ describe('Query builder', () => {
         expect(query).not.toMatch(/INNER JOIN pop_metrics_/);
     });
 
+    test('Should wrap PoP queries in an outer metrics CTE so ORDER BY is not ambiguous', () => {
+        const { query } = buildQuery({
+            explore: POP_TEST_EXPLORE,
+            compiledMetricQuery: POP_TEST_METRIC_QUERY,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+        });
+
+        expect(query).toMatch(/metrics AS \(\nSELECT\n {2}base_metrics\.\*/);
+        expect(query).toMatch(
+            /SELECT\s+\*\s+FROM metrics\s+ORDER BY "orders_order_date_year" DESC\s+LIMIT 500$/,
+        );
+    });
+
     test('Should reuse non-time filters for PoP metrics in fanout-protected CTEs while shifting the comparison period', () => {
         const { query } = buildQuery({
             explore: POP_TEST_FANOUT_EXPLORE,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -3660,7 +3660,9 @@ export class MetricQueryBuilder {
         ].join(',\n')}`;
         const sqlFrom = this.getBaseTableFromSQL();
         const sqlLimit = this.getLimitSQL();
-        const { sqlOrderBy, requiresQueryInCTE } = this.getSortSQL();
+        const { sqlOrderBy, requiresQueryInCTE: initialRequiresQueryInCTE } =
+            this.getSortSQL();
+        let requiresQueryInCTE = initialRequiresQueryInCTE;
         const ctes = [...dimensionsSQL.ctes];
         let finalSelectParts: Array<string | undefined> = [
             sqlSelect,
@@ -3823,6 +3825,10 @@ export class MetricQueryBuilder {
                     `FROM ${baseCteName}`,
                     ...popJoins,
                 ];
+                // DuckDB resolves ORDER BY names against joined sources here, so
+                // sorting by a shared dimension alias becomes ambiguous unless we
+                // sort from an outer projection.
+                requiresQueryInCTE = true;
             }
         }
         warnings.push(...experimentalMetricsCteSQL.warnings);


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Fixed ambiguous ORDER BY clause in Period-over-Period (PoP) queries by forcing them to be wrapped in an outer metrics CTE. This resolves an issue where DuckDB would encounter ambiguous column references when sorting by shared dimension aliases across joined sources in PoP queries.

The fix ensures that PoP queries always use an outer projection for sorting, eliminating the ambiguity that occurs when ORDER BY names are resolved against multiple joined sources.