### PR TITLE
feat: add feature flag database entity types (GLITCH-307)

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -77,6 +77,12 @@ import {
 } from '../database/entities/emailOneTimePasscodes';
 import { EmailTable, EmailTableName } from '../database/entities/emails';
 import {
+    FeatureFlagOverridesTable,
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTable,
+    FeatureFlagsTableName,
+} from '../database/entities/featureFlags';
+import {
     GithubAppInstallationTable,
     GithubAppInstallationTableName,
 } from '../database/entities/githubAppInstallation';
@@ -363,6 +369,8 @@ declare module 'knex/types/tables' {
         [OrganizationTableName]: OrganizationTable;
         [UserTableName]: UserTable;
         [EmailTableName]: EmailTable;
+        [FeatureFlagsTableName]: FeatureFlagsTable;
+        [FeatureFlagOverridesTableName]: FeatureFlagOverridesTable;
         [SessionTableName]: SessionTable;
         [WarehouseCredentialTableName]: WarehouseCredentialTable;
         [UserWarehouseCredentialsTableName]: UserWarehouseCredentialsTable;

--- a/packages/backend/src/database/entities/featureFlags.ts
+++ b/packages/backend/src/database/entities/featureFlags.ts
@@ -1,0 +1,35 @@
+import { Knex } from 'knex';
+
+export const FeatureFlagsTableName = 'feature_flags';
+export const FeatureFlagOverridesTableName = 'feature_flag_overrides';
+
+export type DbFeatureFlag = {
+    flag_id: string;
+    default_enabled: boolean;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type FeatureFlagsTable = Knex.CompositeTableType<
+    DbFeatureFlag,
+    Pick<DbFeatureFlag, 'flag_id'> &
+        Partial<Pick<DbFeatureFlag, 'default_enabled'>>,
+    Pick<DbFeatureFlag, 'default_enabled'>
+>;
+
+export type DbFeatureFlagOverride = {
+    feature_flag_override_id: number;
+    flag_id: string;
+    user_uuid: string | null;
+    organization_uuid: string | null;
+    enabled: boolean;
+    created_at: Date;
+    updated_at: Date;
+};
+
+export type FeatureFlagOverridesTable = Knex.CompositeTableType<
+    DbFeatureFlagOverride,
+    Pick<DbFeatureFlagOverride, 'flag_id' | 'enabled'> &
+        Partial<Pick<DbFeatureFlagOverride, 'user_uuid' | 'organization_uuid'>>,
+    Pick<DbFeatureFlagOverride, 'enabled'>
+>;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- reference the related issue e.g. #150 -->

### Description:

This PR adds database entity definitions for feature flags functionality. It introduces two new database tables:

- `feature_flags` table to store feature flag definitions with their default enabled state
- `feature_flag_overrides` table to store user or organization-specific overrides for feature flags

The implementation includes TypeScript type definitions for both tables using Knex's CompositeTableType, with appropriate insert and update type constraints. The feature flags table uses a string-based flag ID as the primary key, while the overrides table supports targeting either specific users or organizations through nullable UUID fields.