### PR TITLE
feat: add feature_flags and feature_flag_overrides migration (GLITCH-308)

### DIFF
--- a/packages/backend/src/database/migrations/20260331142508_add_feature_flags_tables.ts
+++ b/packages/backend/src/database/migrations/20260331142508_add_feature_flags_tables.ts
@@ -1,0 +1,77 @@
+import { type Knex } from 'knex';
+import {
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../entities/featureFlags';
+
+export const up = async (knex: Knex): Promise<void> => {
+    await knex.schema.createTable(FeatureFlagsTableName, (table) => {
+        table.string('flag_id').primary();
+        table.boolean('default_enabled').notNullable().defaultTo(false);
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+
+    await knex.schema.createTable(FeatureFlagOverridesTableName, (table) => {
+        table.increments('feature_flag_override_id').primary();
+        table
+            .string('flag_id')
+            .notNullable()
+            .references('flag_id')
+            .inTable(FeatureFlagsTableName)
+            .onDelete('CASCADE');
+        table
+            .uuid('user_uuid')
+            .nullable()
+            .references('user_uuid')
+            .inTable('users')
+            .onDelete('CASCADE');
+        table
+            .uuid('organization_uuid')
+            .nullable()
+            .references('organization_uuid')
+            .inTable('organizations')
+            .onDelete('CASCADE');
+        table.boolean('enabled').notNullable();
+        table
+            .timestamp('created_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+        table
+            .timestamp('updated_at', { useTz: false })
+            .notNullable()
+            .defaultTo(knex.fn.now());
+    });
+
+    // At least one of user_uuid or organization_uuid must be set
+    await knex.raw(`
+        ALTER TABLE ${FeatureFlagOverridesTableName}
+        ADD CONSTRAINT feature_flag_overrides_target_check
+        CHECK (user_uuid IS NOT NULL OR organization_uuid IS NOT NULL)
+    `);
+
+    // One override per flag per user
+    await knex.raw(`
+        CREATE UNIQUE INDEX feature_flag_overrides_user_idx
+        ON ${FeatureFlagOverridesTableName} (flag_id, user_uuid)
+        WHERE user_uuid IS NOT NULL
+    `);
+
+    // One override per flag per org (only org-level, not user-level)
+    await knex.raw(`
+        CREATE UNIQUE INDEX feature_flag_overrides_org_idx
+        ON ${FeatureFlagOverridesTableName} (flag_id, organization_uuid)
+        WHERE organization_uuid IS NOT NULL AND user_uuid IS NULL
+    `);
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+    await knex.schema.dropTableIfExists(FeatureFlagOverridesTableName);
+    await knex.schema.dropTableIfExists(FeatureFlagsTableName);
+};


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- reference the related issue e.g. #150 -->

### Description:

This PR introduces database schema for feature flag management by adding two new tables:

**Feature Flags Table:**

- Stores feature flags with a unique `flag_id` as primary key
- Includes `default_enabled` boolean field to control default behavior
- Tracks creation and update timestamps

**Feature Flag Overrides Table:**

- Allows overriding feature flag states for specific users or organizations
- References both `users` and `organizations` tables with cascade deletion
- Enforces that at least one target (user or organization) must be specified
- Prevents duplicate overrides with unique indexes for user-level and organization-level overrides
- Organization-level overrides only apply when no user-specific override exists

The migration includes proper foreign key constraints, check constraints to ensure data integrity, and unique indexes to prevent conflicting overrides.