### PR TITLE
feat: add LIGHTDASH_ENABLE_FEATURE_FLAGS env var config (GLITCH-309)

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -378,4 +378,5 @@ export const lightdashConfigMock: LightdashConfig = {
         s3: null,
         e2bApiKey: null,
     },
+    enabledFeatureFlags: new Set<string>(),
 };

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1266,6 +1266,7 @@ export type LightdashConfig = {
         enabled: boolean | undefined;
     };
     appRuntime: AppRuntimeConfig;
+    enabledFeatureFlags: Set<string>;
 };
 
 export type SlackConfig = {
@@ -2276,5 +2277,11 @@ export const parseConfig = (): LightdashConfig => {
                 : undefined,
         },
         appRuntime: parseAppRuntimeConfig(siteUrl),
+        enabledFeatureFlags: new Set(
+            (process.env.LIGHTDASH_ENABLE_FEATURE_FLAGS ?? '')
+                .split(',')
+                .map((s) => s.trim())
+                .filter(Boolean),
+        ),
     };
 };


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

<!-- reference the related issue e.g. #150 -->

### Description:

Added feature flag configuration support to the Lightdash backend. The configuration now includes an `enabledFeatureFlags` property that parses comma-separated feature flag names from the `LIGHTDASH_ENABLE_FEATURE_FLAGS` environment variable and stores them in a Set for efficient lookup.

The feature flags are automatically trimmed of whitespace and empty values are filtered out during parsing.