### PR TITLE
fix: throttle token last used date updates to once per minute

### DIFF
--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -29,6 +29,11 @@ type ServiceAccountServiceArguments = {
     commercialFeatureFlagModel: CommercialFeatureFlagModel;
 };
 
+function isSameMinute(a: Date | null, b: Date): boolean {
+    if (!a) return false;
+    return Math.floor(a.getTime() / 60000) === Math.floor(b.getTime() / 60000);
+}
+
 export class ServiceAccountService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
@@ -290,8 +295,10 @@ export class ServiceAccountService extends BaseService {
                         requestRoutePath: request.routePath,
                     },
                 });
-                // Update last used date
-                await this.serviceAccountModel.updateUsedDate(dbToken.uuid);
+                // Update last used date (throttled to once per minute)
+                if (!isSameMinute(dbToken.lastUsedAt, new Date())) {
+                    await this.serviceAccountModel.updateUsedDate(dbToken.uuid);
+                }
                 // finally return organization uuid
                 return {
                     organizationUuid: dbToken.organizationUuid,
@@ -319,8 +326,10 @@ export class ServiceAccountService extends BaseService {
 
                 // TODO add analytics
 
-                // Update last used date
-                await this.serviceAccountModel.updateUsedDate(dbToken.uuid);
+                // Update last used date (throttled to once per minute)
+                if (!isSameMinute(dbToken.lastUsedAt, new Date())) {
+                    await this.serviceAccountModel.updateUsedDate(dbToken.uuid);
+                }
                 // finally return organization uuid
                 return dbToken;
             }

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -98,6 +98,11 @@ type UserServiceArguments = {
     featureFlagModel: FeatureFlagModel;
 };
 
+function isSameMinute(a: Date | null, b: Date): boolean {
+    if (!a) return false;
+    return Math.floor(a.getTime() / 60000) === Math.floor(b.getTime() / 60000);
+}
+
 export class UserService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
@@ -1376,10 +1381,12 @@ export class UserService extends BaseService {
             }
             throw new AuthorizationError();
         }
-        // Update last used date
-        await this.personalAccessTokenModel.updateUsedDate(
-            personalAccessToken.uuid,
-        );
+        // Update last used date (throttled to once per minute)
+        if (!isSameMinute(personalAccessToken.lastUsedAt, now)) {
+            await this.personalAccessTokenModel.updateUsedDate(
+                personalAccessToken.uuid,
+            );
+        }
         return userWithOrganization;
     }
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-6685 <!-- reference the related issue e.g. #150 -->

### Description:

Throttles the frequency of "last used" timestamp updates for both service account tokens and personal access tokens to once per minute. This optimization reduces unnecessary database writes by checking if the current time and the last recorded usage time fall within the same minute before performing the update operation.

The change affects token authentication flows in both the ServiceAccountService and UserService, where previously every token usage would trigger a database update regardless of how recently the token was last used.

<!-- Even better add a screenshot / gif / loom -->