### PR TITLE
feat: add database-backed feature flag overrides with priority hierarchy

### DIFF
--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -7,6 +7,11 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
+import {
+    FeatureFlagOverridesTableName,
+    FeatureFlagsTableName,
+} from '../../database/entities/featureFlags';
+import Logger from '../../logging/logger';
 import { isFeatureFlagEnabled } from '../../postHog';
 
 export type FeatureFlagLogicArgs = {
@@ -62,11 +67,30 @@ export class FeatureFlagModel {
     }
 
     public async get(args: FeatureFlagLogicArgs): Promise<FeatureFlag> {
+        // 1. Check env var override (self-hosted escape hatch, enable-only)
+        if (this.lightdashConfig.enabledFeatureFlags.has(args.featureFlagId)) {
+            return { id: args.featureFlagId, enabled: true };
+        }
+
+        // 2. Check per-flag config handlers
         const handler = this.featureFlagHandlers[args.featureFlagId];
         if (handler) {
             return handler(args);
         }
-        // Default to check Posthog feature flag
+
+        // 3. Check database (user override > org override > flag default)
+        try {
+            const dbResult = await this.getFromDatabase(args);
+            if (dbResult !== null) {
+                return dbResult;
+            }
+        } catch (e) {
+            Logger.warn(
+                `Failed to check feature flag ${args.featureFlagId} from database, falling through to PostHog: ${e}`,
+            );
+        }
+
+        // 4. Fallback to PostHog (temporary, will be removed after migration)
         if (args.user && isFeatureFlags(args.featureFlagId)) {
             return FeatureFlagModel.getPosthogFeatureFlag(
                 args.user,
@@ -411,5 +435,51 @@ export class FeatureFlagModel {
             id: featureFlagId,
             enabled: this.lightdashConfig.query.enableTimezoneSupport ?? false,
         };
+    }
+
+    private async getFromDatabase(
+        args: FeatureFlagLogicArgs,
+    ): Promise<FeatureFlag | null> {
+        const flag = await this.database(FeatureFlagsTableName)
+            .where('flag_id', args.featureFlagId)
+            .first();
+
+        if (!flag) {
+            return null;
+        }
+
+        // Priority: user override > org override > flag default
+        if (args.user?.userUuid) {
+            const userOverride = await this.database(
+                FeatureFlagOverridesTableName,
+            )
+                .where('flag_id', args.featureFlagId)
+                .where('user_uuid', args.user.userUuid)
+                .first();
+            if (userOverride) {
+                return {
+                    id: args.featureFlagId,
+                    enabled: userOverride.enabled,
+                };
+            }
+        }
+
+        if (args.user?.organizationUuid) {
+            const orgOverride = await this.database(
+                FeatureFlagOverridesTableName,
+            )
+                .where('flag_id', args.featureFlagId)
+                .where('organization_uuid', args.user.organizationUuid)
+                .whereNull('user_uuid')
+                .first();
+            if (orgOverride) {
+                return {
+                    id: args.featureFlagId,
+                    enabled: orgOverride.enabled,
+                };
+            }
+        }
+
+        return { id: args.featureFlagId, enabled: flag.default_enabled };
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-310 <!-- reference the related issue e.g. #150 -->

### Description:

This PR implements database-backed feature flag resolution with a hierarchical priority system. The feature flag resolution now follows this order:

1. **Environment variable override** - Self-hosted escape hatch for enabling flags
2. **Custom handlers** - Per-flag configuration handlers  
3. **Database lookup** - New database-backed system with priority hierarchy:
   - User-specific overrides (highest priority)
   - Organization-level overrides 
   - Flag default values (lowest priority)
4. **PostHog fallback** - Existing PostHog integration as temporary fallback

The database integration includes proper error handling that gracefully falls through to PostHog if database queries fail, ensuring system reliability during the migration period.

<!-- Even better add a screenshot / gif / loom -->