### PR TITLE
fix: add dataTimezone to CreateDuckdbCredentials

### DIFF
--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -224,6 +224,7 @@ export type CreateDuckdbCredentials = {
     threads?: number;
     requireUserCredentials?: boolean;
     startOfWeek?: WeekDay | null;
+    dataTimezone?: string;
 };
 export type DuckdbCredentials = Omit<
     CreateDuckdbCredentials,


### PR DESCRIPTION
Relates to: https://github.com/lightdash/lightdash/pull/21533
