### PR TITLE
fix: lowercase Docker Compose project name in dev-ports.sh

### DIFF
--- a/scripts/dev-ports.sh
+++ b/scripts/dev-ports.sh
@@ -141,7 +141,7 @@ write_instance_file() {
 
     compute_ports "$slot"
 
-    local compose_project="ld-${id}"
+    local compose_project="ld-$(echo "$id" | tr '[:upper:]' '[:lower:]')"
     local file="$REGISTRY_DIR/${id}.json"
 
     # Escape backslashes and quotes in paths for valid JSON


### PR DESCRIPTION
## Summary
- Lowercase the Docker Compose project name derived from the instance ID in `dev-ports.sh`
- Docker Compose v2 normalizes project names to lowercase internally, but `LD_CONTAINER_PREFIX` / `LD_VOLUME_PREFIX` were using the original casing — causing container-not-found errors for branches with uppercase letters

## Test plan
- [ ] Create a worktree with uppercase letters in the name (e.g. `w lightdash MyFeature`)
- [ ] Run `/docker-dev start` and verify state detection checks find the correct container
- [ ] Verify `LD_COMPOSE_PROJECT`, `LD_VOLUME_PREFIX`, `LD_CONTAINER_PREFIX` are all lowercase in `dev-ports.sh env` output

🤖 Generated with [Claude Code](https://claude.com/claude-code)