### PR TITLE
feat(cli): support spark dbt adapter in deploy command

### DIFF
--- a/packages/backend/src/dbt/DbtMetadataApiClient.ts
+++ b/packages/backend/src/dbt/DbtMetadataApiClient.ts
@@ -21,6 +21,7 @@ const quoteChars: Record<SupportedDbtAdapter, string> = {
     trino: `"`,
     clickhouse: `"`,
     athena: `"`,
+    spark: '`',
 };
 
 const PAGE_SIZE = 500;

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -186,9 +186,10 @@ export function getIntervalSyntax(
             // BigQuery always uses DATE_ADD/DATE_SUB
             intervalExpression = `DATE_${operation}(DATE(${columnWithInterval}), INTERVAL ${value} ${granularity})`;
             break;
-        case SupportedDbtAdapter.DATABRICKS: {
-            // Databricks uses interval arithmetic with quoted values
-            // Databricks doesn't support QUARTER interval, convert to months
+        case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK: {
+            // Databricks/Spark uses interval arithmetic with quoted values
+            // Doesn't support QUARTER interval, convert to months
             const [dbValue, dbGranularity] = normalizeIntervalGranularity(
                 value,
                 granularity,

--- a/packages/cli/src/dbt/profile.ts
+++ b/packages/cli/src/dbt/profile.ts
@@ -15,6 +15,7 @@ import { convertDuckdbSchema } from './targets/duckdb';
 import { convertPostgresSchema } from './targets/postgres';
 import { convertRedshiftSchema } from './targets/redshift';
 import { convertSnowflakeSchema } from './targets/snowflake';
+import { convertSparkSchema } from './targets/spark';
 import { convertTrinoSchema } from './targets/trino';
 import { renderProfilesYml } from './templating';
 import { LoadProfileArgs, Profiles, Target } from './types';
@@ -77,6 +78,8 @@ export const warehouseCredentialsFromDbtTarget = async (
             return convertAthenaSchema(target);
         case 'duckdb':
             return convertDuckdbSchema(target);
+        case 'spark':
+            return convertSparkSchema();
         default:
             throw new ParseError(
                 `Sorry! Lightdash doesn't yet support ${target.type} dbt targets`,

--- a/packages/cli/src/dbt/targets/spark.ts
+++ b/packages/cli/src/dbt/targets/spark.ts
@@ -1,0 +1,9 @@
+import { ParseError } from '@lightdash/common';
+
+export const convertSparkSchema = (): never => {
+    throw new ParseError(
+        `Spark dbt projects don't provide warehouse credentials directly. ` +
+            `Use --no-warehouse-credentials flag, then configure your ` +
+            `query engine (e.g., Athena) in the Lightdash UI.`,
+    );
+};

--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -170,6 +170,16 @@ function getMockCredentials(
                 httpPath: '',
                 personalAccessToken: '',
             };
+        case SupportedDbtAdapter.SPARK:
+            // Spark uses same SQL dialect as Databricks
+            return {
+                type: WarehouseTypes.DATABRICKS,
+                catalog: '',
+                database: '',
+                serverHostName: '',
+                httpPath: '',
+                personalAccessToken: '',
+            };
         case SupportedDbtAdapter.TRINO:
             return {
                 type: WarehouseTypes.TRINO,

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -19,6 +19,7 @@ import { v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../analytics/analytics';
 import { getConfig, setProject } from '../config';
 import { getDbtContext } from '../dbt/context';
+import { loadDbtTarget } from '../dbt/profile';
 import GlobalState from '../globalState';
 import { readAndLoadLightdashProjectConfig } from '../lightdash-config';
 import { CliProjectType, detectProjectType } from '../lightdash/projectType';
@@ -470,6 +471,43 @@ export const deployHandler = async (originalOptions: DeployHandlerOptions) => {
     options.warehouseCredentials = projectTypeConfig.warehouseCredentials;
     options.skipDbtCompile = projectTypeConfig.skipDbtCompile;
     options.skipWarehouseCatalog = projectTypeConfig.skipWarehouseCatalog;
+
+    // Auto-detect Spark adapter and skip warehouse credentials
+    // Spark session-based projects have no warehouse server to connect to;
+    // users configure their actual query engine (e.g., Athena) in the UI.
+    if (
+        projectTypeConfig.type === CliProjectType.Dbt &&
+        options.warehouseCredentials !== false
+    ) {
+        try {
+            const context = await getDbtContext({
+                projectDir: path.resolve(options.projectDir),
+                targetPath: options.targetPath,
+            });
+            const { target } = await loadDbtTarget({
+                profilesDir: path.resolve(options.profilesDir),
+                profileName: options.profile || context.profileName,
+                targetName: options.target,
+            });
+            if (target.type === 'spark') {
+                options.warehouseCredentials = false;
+                options.skipWarehouseCatalog = true;
+                GlobalState.debug(
+                    '> Spark adapter detected, skipping warehouse credentials',
+                );
+                console.error(
+                    styles.warning(
+                        `Spark adapter detected. Project will be created without warehouse credentials.\nConfigure your query engine (e.g., Athena) in the Lightdash UI.`,
+                    ),
+                );
+            }
+        } catch (e) {
+            // If we can't read the profile, let the normal flow handle it
+            GlobalState.debug(
+                `> Could not detect adapter type: ${getErrorMessage(e)}`,
+            );
+        }
+    }
 
     // Resolve organization credentials early before doing any heavy work
     if (options.organizationCredentials) {

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -95,6 +95,7 @@ const convertTimezone = (
         case SupportedDbtAdapter.DUCKDB:
             return timestampSql;
         case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
             return timestampSql;
         // Athena uses Trino SQL, timestamps return in server timezone
         case SupportedDbtAdapter.TRINO:

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -39,6 +39,7 @@ export enum SupportedDbtAdapter {
     TRINO = 'trino',
     CLICKHOUSE = 'clickhouse',
     ATHENA = 'athena',
+    SPARK = 'spark',
 }
 
 export type DbtNodeConfig = {
@@ -293,6 +294,7 @@ export const normaliseModelDatabase = (
         case SupportedDbtAdapter.CLICKHOUSE:
             return { ...model, database: '' }; // Clickhouse doesn't have a database field
         case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
             return { ...model, database: model.database || 'DEFAULT' };
         default:
             return assertUnreachable(

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -447,6 +447,7 @@ const warehouseConfigs: Record<SupportedDbtAdapter, WarehouseConfig> = {
     [SupportedDbtAdapter.POSTGRES]: postgresConfig,
     [SupportedDbtAdapter.DUCKDB]: postgresConfig,
     [SupportedDbtAdapter.DATABRICKS]: databricksConfig,
+    [SupportedDbtAdapter.SPARK]: databricksConfig, // Spark uses same SQL dialect as Databricks
     [SupportedDbtAdapter.TRINO]: trinoConfig,
     [SupportedDbtAdapter.ATHENA]: trinoConfig, // Athena uses Trino SQL dialect
     [SupportedDbtAdapter.CLICKHOUSE]: clickhouseConfig,

--- a/packages/common/src/utils/warehouse.ts
+++ b/packages/common/src/utils/warehouse.ts
@@ -44,6 +44,7 @@ export const getAggregatedField = (
     switch (adapterType) {
         case SupportedDbtAdapter.BIGQUERY:
         case SupportedDbtAdapter.DATABRICKS:
+        case SupportedDbtAdapter.SPARK:
         case SupportedDbtAdapter.SNOWFLAKE:
         case SupportedDbtAdapter.REDSHIFT:
         case SupportedDbtAdapter.TRINO:

--- a/packages/warehouses/src/warehouseSqlBuilderFromType.ts
+++ b/packages/warehouses/src/warehouseSqlBuilderFromType.ts
@@ -44,6 +44,8 @@ export const warehouseSqlBuilderFromType = (
             return new TrinoSqlBuilder(...args);
         case SupportedDbtAdapter.ATHENA:
             return new AthenaSqlBuilder(...args);
+        case SupportedDbtAdapter.SPARK:
+            return new DatabricksSqlBuilder(...args);
         default:
             const never: never = adapterType;
             throw new Error(`Unsupported adapter type: ${adapterType}`);


### PR DESCRIPTION
## Summary

- Adds `SupportedDbtAdapter.SPARK` so the CLI and compiler can handle dbt projects using the `spark` adapter
- Auto-detects Spark adapter in `deploy --create` and skips warehouse credential extraction, since Spark `session`-based projects have no warehouse server to connect to
- Users configure their actual query engine (e.g., Athena) in the Lightdash UI after project creation
- Maps Spark to Databricks SQL behavior throughout (same dialect)

## Motivation

dbt projects using the `spark` adapter (common with PySpark on EMR/Glue writing Iceberg tables) were rejected by the CLI with "dbt adapter not supported". These projects typically query data through a separate engine like Athena, so Lightdash doesn't need a Spark warehouse client — it just needs to accept the adapter type for manifest parsing and SQL compilation.

## Test plan

- [x] `lightdash deploy --create` works with a `type: spark, method: session` dbt project
- [x] All packages typecheck cleanly (`common`, `backend`, `frontend`, `warehouses`, `cli`)
- [x] `pnpm -F common test` passes (57 suites, 1637 tests)
- [x] `pnpm -F backend test:dev:nowatch` relevant tests pass (`DbtMetadataApiClient`, `MetricQueryBuilder`)
- [x] Verify project is accessible in Lightdash UI after deploy
- [ ] Verify Athena warehouse connection can be configured in project settings