### PR TITLE
chore: update typescript and vite versions in mcp-chart-app

### DIFF
--- a/packages/backend/src/ee/services/McpService/mcp-chart-app/package.json
+++ b/packages/backend/src/ee/services/McpService/mcp-chart-app/package.json
@@ -11,8 +11,8 @@
         "echarts": "5.6.0"
     },
     "devDependencies": {
-        "typescript": "5.7.0",
-        "vite": "6.3.0",
+        "typescript": "5.7.2",
+        "vite": "5.4.21",
         "vite-plugin-singlefile": "2.0.3"
     }
 }


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Updates TypeScript from version 5.7.0 to 5.7.2 and downgrades Vite from version 6.3.0 to ^5.4.10 in the mcp-chart-app package dependencies.