### PR TITLE
fix: resolve MCP chart app release build dependency pins

### DIFF
--- a/packages/backend/src/ee/services/McpService/mcp-chart-app/package.json
+++ b/packages/backend/src/ee/services/McpService/mcp-chart-app/package.json
@@ -11,8 +11,8 @@
         "echarts": "5.6.0"
     },
     "devDependencies": {
-        "typescript": "5.7.0",
+        "typescript": "5.7.3",
         "vite": "6.3.0",
-        "vite-plugin-singlefile": "2.0.3"
+        "vite-plugin-singlefile": "2.3.2"
     }
 }


### PR DESCRIPTION
## Summary
- update the embedded MCP chart app dependency pins to keep `vite@6.3.0` compatible with `vite-plugin-singlefile`
- replace the invalid `typescript@5.7.0` pin with `5.7.3` so `npm install` succeeds in the release build path
- unblock the post-release Docker image workflow failure caused by the MCP chart app install step

## Testing
- `env npm_config_cache=/tmp/codex-npm-cache npm install --ignore-scripts`
- `env npm_config_cache=/tmp/codex-npm-cache npm run build`