### PR TITLE
feat: add progress feedback during data app generation

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -47,6 +47,8 @@ export type DbAppVersion = {
     prompt: string;
     status: AppVersionStatus;
     error: string | null;
+    status_message: string | null;
+    status_updated_at: Date | null;
     created_at: Date;
     created_by_user_uuid: string;
 };
@@ -58,5 +60,10 @@ export type AppVersionsTable = Knex.CompositeTableType<
         'app_id' | 'version' | 'prompt' | 'status' | 'created_by_user_uuid'
     > &
         Partial<Pick<DbAppVersion, 'app_version_id'>>,
-    Partial<Pick<DbAppVersion, 'status' | 'error'>>
+    Partial<
+        Pick<
+            DbAppVersion,
+            'status' | 'error' | 'status_message' | 'status_updated_at'
+        >
+    >
 >;

--- a/packages/backend/src/database/migrations/20260401120000_add_status_message_to_app_versions.ts
+++ b/packages/backend/src/database/migrations/20260401120000_add_status_message_to_app_versions.ts
@@ -1,0 +1,15 @@
+import { type Knex } from 'knex';
+
+export const up = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable('app_versions', (table) => {
+        table.text('status_message');
+        table.timestamp('status_updated_at', { useTz: false });
+    });
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable('app_versions', (table) => {
+        table.dropColumn('status_updated_at');
+        table.dropColumn('status_message');
+    });
+};

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -120,6 +120,7 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
         version: number,
         error: unknown,
+        userMessage: string,
     ): Promise<void> {
         try {
             await this.appModel.updateVersionStatus(
@@ -127,6 +128,7 @@ export class AppGenerateService extends BaseService {
                 version,
                 'error',
                 AppGenerateService.truncateEnd(getErrorMessage(error), 4000),
+                userMessage,
             );
         } catch (dbError) {
             this.logger.error(
@@ -266,35 +268,29 @@ export class AppGenerateService extends BaseService {
         }
 
         // Fallback: create new sandbox and restore source from latest ready version
-        try {
-            const createResult = await this.createSandbox(
-                appUuid,
-                e2bApiKey,
-                anthropicApiKey,
-            );
-            durations.sandboxMs = createResult.durationMs;
-            await this.appModel.updateSandboxId(
-                appUuid,
-                createResult.sandbox.sandboxId,
-            );
+        const createResult = await this.createSandbox(
+            appUuid,
+            e2bApiKey,
+            anthropicApiKey,
+        );
+        durations.sandboxMs = createResult.durationMs;
+        await this.appModel.updateSandboxId(
+            appUuid,
+            createResult.sandbox.sandboxId,
+        );
 
-            const latestReady =
-                await this.appModel.getLatestReadyVersion(appUuid);
-            if (latestReady) {
-                durations.restoreMs = await this.restoreSourceFromS3(
-                    createResult.sandbox,
-                    s3Client,
-                    bucket,
-                    appUuid,
-                    latestReady.version,
-                );
-            }
-
-            return { sandbox: createResult.sandbox, durations };
-        } catch (error) {
-            await this.markError(appUuid, newVersion, error);
-            throw error;
+        const latestReady = await this.appModel.getLatestReadyVersion(appUuid);
+        if (latestReady) {
+            durations.restoreMs = await this.restoreSourceFromS3(
+                createResult.sandbox,
+                s3Client,
+                bucket,
+                appUuid,
+                latestReady.version,
+            );
         }
+
+        return { sandbox: createResult.sandbox, durations };
     }
 
     private async writeCatalogAndPrompt(
@@ -382,9 +378,52 @@ export class AppGenerateService extends BaseService {
         return tools.length > 0 ? tools.join(', ') : undefined;
     }
 
+    private static readonly CODING_PHRASES = [
+        'Shipping BI like we ship code',
+        'Turning your metrics into pixels',
+        'Claude is in the zone',
+        'Wiring up your data',
+        'Making your dashboards jealous',
+        'Teaching your data new tricks',
+        'Brewing some fresh analytics',
+        '10x-ing your data app',
+    ];
+
+    private static randomCodingPhrase(): string {
+        return AppGenerateService.CODING_PHRASES[
+            Math.floor(Math.random() * AppGenerateService.CODING_PHRASES.length)
+        ];
+    }
+
+    /**
+     * Convert an internal tool description (e.g. "Write /app/src/Dashboard.tsx")
+     * into a user-friendly status message (e.g. "Creating Dashboard.tsx").
+     */
+    private static toolDescriptionToStatusMessage(description: string): string {
+        const parts = description.split(' ');
+        const tool = parts[0];
+        const filePath = parts.slice(1).join(' ');
+        const fileName = filePath ? filePath.split('/').pop() : undefined;
+
+        switch (tool) {
+            case 'Write':
+                return fileName ? `Creating ${fileName}` : 'Creating files';
+            case 'Edit':
+                return fileName ? `Editing ${fileName}` : 'Editing files';
+            case 'Read':
+                return fileName ? `Reading ${fileName}` : 'Reading files';
+            case 'Glob':
+            case 'Grep':
+                return 'Searching codebase';
+            default:
+                return AppGenerateService.randomCodingPhrase();
+        }
+    }
+
     private async runClaudeGeneration(
         sandbox: Sandbox,
         appUuid: string,
+        version: number,
     ): Promise<number> {
         const start = performance.now();
         let stdoutBuffer = '';
@@ -412,6 +451,22 @@ export class AppGenerateService extends BaseService {
                                 this.logger.info(
                                     `App ${appUuid}: claude tool #${toolCallCount}: ${description}`,
                                 );
+
+                                // description can be comma-separated
+                                // (e.g. "Write foo.tsx, Read bar.tsx") —
+                                // use only the first tool for the status.
+                                const firstTool = description.split(', ')[0];
+                                const msg =
+                                    AppGenerateService.toolDescriptionToStatusMessage(
+                                        firstTool,
+                                    );
+                                void this.appModel
+                                    .updateStatusMessage(appUuid, version, msg)
+                                    .catch((e) => {
+                                        this.logger.warn(
+                                            `App ${appUuid}: failed to update status message: ${getErrorMessage(e)}`,
+                                        );
+                                    });
                             }
                         }
                     }
@@ -537,6 +592,219 @@ export class AppGenerateService extends BaseService {
         return durationMs;
     }
 
+    private async runNewAppPipeline(
+        appUuid: string,
+        version: number,
+        projectUuid: string,
+        prompt: string,
+    ): Promise<void> {
+        let anthropicApiKey: string;
+        let e2bApiKey: string;
+        let s3Client: S3Client;
+        let bucket: string;
+        try {
+            anthropicApiKey = this.getAnthropicApiKey();
+            e2bApiKey = this.getE2bApiKey();
+            ({ client: s3Client, bucket } = this.getS3Client());
+        } catch (error) {
+            await this.markError(
+                appUuid,
+                version,
+                error,
+                'Something went wrong. Please try again.',
+            );
+            return;
+        }
+
+        const overallStart = performance.now();
+        const durations: Record<string, number> = {};
+
+        await this.appModel.updateStatusMessage(
+            appUuid,
+            version,
+            'Setting up build environment',
+        );
+
+        let sandbox: Sandbox;
+        try {
+            const result = await this.createSandbox(
+                appUuid,
+                e2bApiKey,
+                anthropicApiKey,
+            );
+            sandbox = result.sandbox;
+            durations.sandboxMs = result.durationMs;
+            await this.appModel.updateSandboxId(appUuid, sandbox.sandboxId);
+        } catch (error) {
+            await this.markError(
+                appUuid,
+                version,
+                error,
+                'Failed to set up build environment. Please try again.',
+            );
+            return;
+        }
+
+        try {
+            await this.runPipelineStages(
+                sandbox,
+                appUuid,
+                version,
+                projectUuid,
+                prompt,
+                s3Client,
+                bucket,
+                durations,
+                overallStart,
+            );
+        } finally {
+            await this.pauseSandbox(sandbox, appUuid);
+        }
+    }
+
+    private async runPipelineStages(
+        sandbox: Sandbox,
+        appUuid: string,
+        version: number,
+        projectUuid: string,
+        prompt: string,
+        s3Client: S3Client,
+        bucket: string,
+        extraDurations: Record<string, number>,
+        overallStart: number,
+    ): Promise<void> {
+        const durations: Record<string, number> = { ...extraDurations };
+
+        try {
+            await this.appModel.updateStatusMessage(
+                appUuid,
+                version,
+                'Loading your data models',
+            );
+            durations.catalogMs = await this.writeCatalogAndPrompt(
+                sandbox,
+                appUuid,
+                projectUuid,
+                prompt,
+            );
+        } catch (error) {
+            const totalMs = AppGenerateService.elapsed(overallStart);
+            this.logger.error(
+                `App ${appUuid}: catalog failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+            );
+            await this.markError(
+                appUuid,
+                version,
+                error,
+                'Failed to load your data models. Please try again.',
+            );
+            return;
+        }
+
+        try {
+            await this.appModel.updateStatusMessage(
+                appUuid,
+                version,
+                AppGenerateService.randomCodingPhrase(),
+            );
+            durations.generateMs = await this.runClaudeGeneration(
+                sandbox,
+                appUuid,
+                version,
+            );
+        } catch (error) {
+            const totalMs = AppGenerateService.elapsed(overallStart);
+            this.logger.error(
+                `App ${appUuid}: generation failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+            );
+            await this.markError(
+                appUuid,
+                version,
+                error,
+                'Failed to generate app code. Try rephrasing your request.',
+            );
+            return;
+        }
+
+        try {
+            await this.appModel.updateStatusMessage(
+                appUuid,
+                version,
+                'Packaging your app',
+            );
+            durations.buildMs = await this.runBuild(sandbox, appUuid);
+        } catch (error) {
+            const totalMs = AppGenerateService.elapsed(overallStart);
+            this.logger.error(
+                `App ${appUuid}: build failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+            );
+            await this.markError(
+                appUuid,
+                version,
+                error,
+                "The generated code couldn't be compiled. Try again or simplify your request.",
+            );
+            return;
+        }
+
+        try {
+            await this.appModel.updateStatusMessage(
+                appUuid,
+                version,
+                'Deploying your app',
+            );
+            const artifacts = await this.packageArtifacts(sandbox, appUuid);
+            durations.packageMs = artifacts.durationMs;
+
+            durations.uploadMs = await this.uploadToS3(
+                s3Client,
+                bucket,
+                appUuid,
+                version,
+                artifacts.distTar,
+                artifacts.sourceTar,
+            );
+        } catch (error) {
+            const totalMs = AppGenerateService.elapsed(overallStart);
+            this.logger.error(
+                `App ${appUuid}: deploy failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+            );
+            await this.markError(
+                appUuid,
+                version,
+                error,
+                'Failed to deploy your app. Please try again.',
+            );
+            return;
+        }
+
+        try {
+            const dbStart = performance.now();
+            await this.appModel.updateVersionStatus(appUuid, version, 'ready');
+            durations.dbMs = AppGenerateService.elapsed(dbStart);
+        } catch (error) {
+            this.logger.error(
+                `App ${appUuid}: failed to mark version as ready: ${getErrorMessage(error)}`,
+            );
+            await this.markError(
+                appUuid,
+                version,
+                error,
+                'Something went wrong. Please try again.',
+            );
+            return;
+        }
+
+        const totalMs = AppGenerateService.elapsed(overallStart);
+        this.logger.info(
+            `App ${appUuid}: generation completed successfully in ${totalMs}ms (${Object.entries(
+                durations,
+            )
+                .map(([k, v]) => `${k}=${v}ms`)
+                .join(', ')})`,
+        );
+    }
+
     async generateApp(
         user: SessionUser,
         projectUuid: string,
@@ -559,18 +827,12 @@ export class AppGenerateService extends BaseService {
 
         const appUuid = uuidv4();
         const version = 1;
-        const anthropicApiKey = this.getAnthropicApiKey();
-        const e2bApiKey = this.getE2bApiKey();
-        const { client: s3Client, bucket } = this.getS3Client();
-
-        const overallStart = performance.now();
-        const durations: Record<string, number> = {};
 
         this.logger.info(
             `App ${appUuid}: generation started (promptLength=${prompt.length})`,
         );
 
-        // Persist app record early so we can track status
+        // Persist app record so we can track status immediately
         try {
             await this.appModel.createWithVersion(
                 {
@@ -588,67 +850,87 @@ export class AppGenerateService extends BaseService {
             throw error;
         }
 
+        // Fire pipeline in background — status updates flow through DB polling
+        this.runNewAppPipeline(appUuid, version, projectUuid, prompt).catch(
+            (error) => {
+                this.logger.error(
+                    `App ${appUuid}: unhandled pipeline error: ${getErrorMessage(error)}`,
+                );
+            },
+        );
+
+        return { appUuid, version };
+    }
+
+    private async runIterationPipeline(
+        app: DbApp,
+        appUuid: string,
+        newVersion: number,
+        projectUuid: string,
+        prompt: string,
+    ): Promise<void> {
+        let anthropicApiKey: string;
+        let e2bApiKey: string;
+        let s3Client: S3Client;
+        let bucket: string;
+        try {
+            anthropicApiKey = this.getAnthropicApiKey();
+            e2bApiKey = this.getE2bApiKey();
+            ({ client: s3Client, bucket } = this.getS3Client());
+        } catch (error) {
+            await this.markError(
+                appUuid,
+                newVersion,
+                error,
+                'Something went wrong. Please try again.',
+            );
+            return;
+        }
+
+        const overallStart = performance.now();
+        const durations: Record<string, number> = {};
+
+        await this.appModel.updateStatusMessage(
+            appUuid,
+            newVersion,
+            'Setting up build environment',
+        );
+
         let sandbox: Sandbox;
         try {
-            const result = await this.createSandbox(
+            const acquired = await this.acquireSandbox(
+                app,
                 appUuid,
+                newVersion,
                 e2bApiKey,
                 anthropicApiKey,
+                s3Client,
+                bucket,
             );
-            sandbox = result.sandbox;
-            durations.sandboxMs = result.durationMs;
-            await this.appModel.updateSandboxId(appUuid, sandbox.sandboxId);
+            sandbox = acquired.sandbox;
+            Object.assign(durations, acquired.durations);
         } catch (error) {
-            await this.markError(appUuid, version, error);
-            throw error;
+            await this.markError(
+                appUuid,
+                newVersion,
+                error,
+                'Failed to set up build environment. Please try again.',
+            );
+            return;
         }
 
         try {
-            durations.catalogMs = await this.writeCatalogAndPrompt(
+            await this.runPipelineStages(
                 sandbox,
                 appUuid,
+                newVersion,
                 projectUuid,
                 prompt,
-            );
-            durations.generateMs = await this.runClaudeGeneration(
-                sandbox,
-                appUuid,
-            );
-            durations.buildMs = await this.runBuild(sandbox, appUuid);
-
-            const artifacts = await this.packageArtifacts(sandbox, appUuid);
-            durations.packageMs = artifacts.durationMs;
-
-            durations.uploadMs = await this.uploadToS3(
                 s3Client,
                 bucket,
-                appUuid,
-                version,
-                artifacts.distTar,
-                artifacts.sourceTar,
+                durations,
+                overallStart,
             );
-
-            const dbStart = performance.now();
-            await this.appModel.updateVersionStatus(appUuid, version, 'ready');
-            durations.dbMs = AppGenerateService.elapsed(dbStart);
-
-            const totalMs = AppGenerateService.elapsed(overallStart);
-            this.logger.info(
-                `App ${appUuid}: generation completed successfully in ${totalMs}ms (${Object.entries(
-                    durations,
-                )
-                    .map(([k, v]) => `${k}=${v}ms`)
-                    .join(', ')})`,
-            );
-
-            return { appUuid, version };
-        } catch (error) {
-            const totalMs = AppGenerateService.elapsed(overallStart);
-            this.logger.error(
-                `App ${appUuid}: generation failed after ${totalMs}ms: ${getErrorMessage(error)}`,
-            );
-            await this.markError(appUuid, version, error);
-            throw error;
         } finally {
             await this.pauseSandbox(sandbox, appUuid);
         }
@@ -685,12 +967,6 @@ export class AppGenerateService extends BaseService {
         }
 
         const newVersion = (latestVersion?.version ?? 0) + 1;
-        const anthropicApiKey = this.getAnthropicApiKey();
-        const e2bApiKey = this.getE2bApiKey();
-        const { client: s3Client, bucket } = this.getS3Client();
-
-        const overallStart = performance.now();
-        const durations: Record<string, number> = {};
 
         this.logger.info(
             `App ${appUuid}: iteration started (version=${newVersion}, promptLength=${prompt.length})`,
@@ -703,71 +979,20 @@ export class AppGenerateService extends BaseService {
             user.userUuid,
         );
 
-        const acquired = await this.acquireSandbox(
+        // Fire pipeline in background — status updates flow through DB polling
+        this.runIterationPipeline(
             app,
             appUuid,
             newVersion,
-            e2bApiKey,
-            anthropicApiKey,
-            s3Client,
-            bucket,
-        );
-        const { sandbox } = acquired;
-        Object.assign(durations, acquired.durations);
-
-        try {
-            durations.catalogMs = await this.writeCatalogAndPrompt(
-                sandbox,
-                appUuid,
-                projectUuid,
-                prompt,
-            );
-            durations.generateMs = await this.runClaudeGeneration(
-                sandbox,
-                appUuid,
-            );
-            durations.buildMs = await this.runBuild(sandbox, appUuid);
-
-            const artifacts = await this.packageArtifacts(sandbox, appUuid);
-            durations.packageMs = artifacts.durationMs;
-
-            durations.uploadMs = await this.uploadToS3(
-                s3Client,
-                bucket,
-                appUuid,
-                newVersion,
-                artifacts.distTar,
-                artifacts.sourceTar,
-            );
-
-            const dbStart = performance.now();
-            await this.appModel.updateVersionStatus(
-                appUuid,
-                newVersion,
-                'ready',
-            );
-            durations.dbMs = AppGenerateService.elapsed(dbStart);
-
-            const totalMs = AppGenerateService.elapsed(overallStart);
-            this.logger.info(
-                `App ${appUuid}: iteration completed successfully in ${totalMs}ms (${Object.entries(
-                    durations,
-                )
-                    .map(([k, v]) => `${k}=${v}ms`)
-                    .join(', ')})`,
-            );
-
-            return { appUuid, version: newVersion };
-        } catch (error) {
-            const totalMs = AppGenerateService.elapsed(overallStart);
+            projectUuid,
+            prompt,
+        ).catch((error) => {
             this.logger.error(
-                `App ${appUuid}: iteration failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+                `App ${appUuid}: unhandled iteration pipeline error: ${getErrorMessage(error)}`,
             );
-            await this.markError(appUuid, newVersion, error);
-            throw error;
-        } finally {
-            await this.pauseSandbox(sandbox, appUuid);
-        }
+        });
+
+        return { appUuid, version: newVersion };
     }
 
     async getAppVersions(
@@ -781,6 +1006,7 @@ export class AppGenerateService extends BaseService {
             version: number;
             prompt: string;
             status: string;
+            statusMessage: string | null;
             createdAt: Date;
         }[];
         hasMore: boolean;
@@ -806,12 +1032,49 @@ export class AppGenerateService extends BaseService {
             opts,
         );
 
+        // Auto-heal stale builds: if the pipeline died (e.g. server restart)
+        // the version stays "building" forever. Detect via heartbeat timeout.
+        const STALE_THRESHOLD_MS = 10 * 60_000;
+        const now = Date.now();
+        const staleVersions = versions.filter((v) => {
+            if (v.status !== 'building') return false;
+            const lastActivity = v.status_updated_at ?? v.created_at;
+            return now - new Date(lastActivity).getTime() > STALE_THRESHOLD_MS;
+        });
+        // Best-effort — don't let a failed DB write break the GET response
+        try {
+            await Promise.all(
+                staleVersions.map(async (v) => {
+                    this.logger.warn(
+                        `App ${appUuid}: auto-healing stale build (version=${v.version})`,
+                    );
+                    await this.appModel.updateVersionStatus(
+                        appUuid,
+                        v.version,
+                        'error',
+                        'Build process was interrupted',
+                        'Something went wrong. Please try again.',
+                    );
+                }),
+            );
+        } catch (healError) {
+            this.logger.error(
+                `App ${appUuid}: auto-heal failed: ${getErrorMessage(healError)}`,
+            );
+        }
+        const staleVersionNumbers = new Set(
+            staleVersions.map((v) => v.version),
+        );
+
         return {
             appUuid,
             versions: versions.map((v) => ({
                 version: v.version,
                 prompt: v.prompt,
-                status: v.status,
+                status: staleVersionNumbers.has(v.version) ? 'error' : v.status,
+                statusMessage: staleVersionNumbers.has(v.version)
+                    ? 'Something went wrong. Please try again.'
+                    : v.status_message,
                 createdAt: v.created_at,
             })),
             hasMore,

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -46,10 +46,29 @@ export class AppModel {
         version: number,
         status: AppVersionStatus,
         error?: string | null,
+        statusMessage?: string | null,
     ): Promise<void> {
         await this.database(AppVersionsTableName)
             .where({ app_id: appId, version })
-            .update({ status, error: error ?? null });
+            .update({
+                status,
+                error: error ?? null,
+                status_message: statusMessage ?? null,
+                status_updated_at: new Date(),
+            });
+    }
+
+    async updateStatusMessage(
+        appId: string,
+        version: number,
+        statusMessage: string,
+    ): Promise<void> {
+        await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version })
+            .update({
+                status_message: statusMessage,
+                status_updated_at: new Date(),
+            });
     }
 
     async getApp(appId: string, projectUuid: string): Promise<DbApp> {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -13,6 +13,7 @@ export type ApiAppVersionSummary = {
     version: number;
     prompt: string;
     status: string;
+    statusMessage: string | null;
     createdAt: Date;
 };
 

--- a/packages/frontend/src/features/apps/hooks/useGetApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGetApp.ts
@@ -28,8 +28,8 @@ const fetchAppVersions = async (
 export const useGetApp = (
     projectUuid: string | undefined,
     appUuid: string | undefined,
-) =>
-    useInfiniteQuery<GetAppResult, ApiError>({
+) => {
+    const query = useInfiniteQuery<GetAppResult, ApiError>({
         queryKey: ['app', projectUuid, appUuid],
         queryFn: ({ pageParam }) =>
             fetchAppVersions(
@@ -43,4 +43,15 @@ export const useGetApp = (
             return lastPage.versions[lastPage.versions.length - 1].version;
         },
         enabled: !!projectUuid && !!appUuid,
+        // Poll every 2s while the latest version is still building
+        refetchInterval: (data) => {
+            const firstPage = data?.pages?.[0];
+            if (!firstPage) return false;
+            // First page has the newest versions (sorted desc)
+            const latestVersion = firstPage.versions[0];
+            if (latestVersion?.status === 'building') return 2000;
+            return false;
+        },
     });
+    return query;
+};

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -14,6 +14,7 @@ import {
     IconExternalLink,
     IconSparkles,
 } from '@tabler/icons-react';
+import { useQueryClient } from '@tanstack/react-query';
 import {
     useCallback,
     useEffect,
@@ -95,8 +96,18 @@ const AppGenerate: FC = () => {
         projectUuid: string;
         appUuid: string;
     }>();
+    const queryClient = useQueryClient();
     const [prompt, setPrompt] = useState('');
     const [localMessages, setLocalMessages] = useState<ChatMessage[]>([]);
+    // Track appUuid in local state so polling starts immediately after creation
+    // (before the URL param updates via replaceState)
+    const [activeAppUuid, setActiveAppUuid] = useState<string | undefined>(
+        urlAppUuid,
+    );
+    // Sync from URL when navigating (e.g. browser back/forward)
+    useEffect(() => {
+        setActiveAppUuid(urlAppUuid);
+    }, [urlAppUuid]);
     const {
         mutate: generateMutate,
         isLoading: isGenerating,
@@ -107,20 +118,39 @@ const AppGenerate: FC = () => {
         isLoading: isIterating,
         reset: resetIterate,
     } = useIterateApp();
-    const isLoading = isGenerating || isIterating;
     const health = useHealth();
     const { user } = useApp();
     const ability = useAbilityContext();
     const messagesEndRef = useRef<HTMLDivElement>(null);
     const textareaRef = useRef<HTMLTextAreaElement>(null);
 
-    // Fetch version history when we have an appUuid in the URL
+    // Fetch version history — polls every 2s while latest version is building
     const {
         data: appData,
         fetchNextPage,
         hasNextPage,
         isFetchingNextPage,
-    } = useGetApp(projectUuid, urlAppUuid);
+    } = useGetApp(projectUuid, activeAppUuid ?? urlAppUuid);
+
+    // Derive building state from the latest version in fetched data
+    const latestBuildingVersion = useMemo(() => {
+        if (!appData?.pages?.[0]) return null;
+        const latest = appData.pages[0].versions[0];
+        if (latest?.status === 'building') return latest;
+        return null;
+    }, [appData]);
+    const isBuilding = latestBuildingVersion !== null;
+    const isLoading = isGenerating || isIterating || isBuilding;
+
+    // Clear local messages once server data takes over (avoids duplicates).
+    // Use the version count as dependency so this doesn't fire on every poll.
+    const serverVersionCount =
+        appData?.pages?.reduce((n, p) => n + p.versions.length, 0) ?? 0;
+    useEffect(() => {
+        if (serverVersionCount > 0) {
+            setLocalMessages([]);
+        }
+    }, [serverVersionCount]);
 
     // Convert fetched versions into chat messages (oldest first)
     const historyMessages = useMemo<ChatMessage[]>(() => {
@@ -150,11 +180,15 @@ const AppGenerate: FC = () => {
             } else if (v.status === 'error') {
                 msgs.push({
                     role: 'assistant',
-                    content: 'Generation failed',
+                    content:
+                        v.statusMessage ??
+                        'Generation failed. Please try again.',
                     appUuid: null,
                     version: null,
                 });
             }
+            // 'building' status is not rendered as a history message —
+            // it's shown as a live progress indicator below
             return msgs;
         });
     }, [appData]);
@@ -165,9 +199,30 @@ const AppGenerate: FC = () => {
         [historyMessages, localMessages],
     );
 
+    // Used for chat links + handleSubmit (recalculated every render, fine)
     const latestApp = [...messages]
         .reverse()
         .find((m) => m.appUuid !== null && m.version !== null);
+
+    // Stable reference for the preview — only updates when a new version
+    // becomes ready, preventing iframe reloads during status polling.
+    const latestReadyPreview = useMemo(() => {
+        if (!appData?.pages?.[0]) return null;
+        const allVersions = appData.pages.flatMap((p) => p.versions);
+        const ready = allVersions.find((v) => v.status === 'ready');
+        if (!ready) return null;
+        return { appUuid: appData.pages[0].appUuid, version: ready.version };
+    }, [appData]);
+    const [previewApp, setPreviewApp] = useState(latestReadyPreview);
+    useEffect(() => {
+        if (
+            latestReadyPreview &&
+            (latestReadyPreview.appUuid !== previewApp?.appUuid ||
+                latestReadyPreview.version !== previewApp?.version)
+        ) {
+            setPreviewApp(latestReadyPreview);
+        }
+    }, [latestReadyPreview, previewApp?.appUuid, previewApp?.version]);
 
     const scrollToBottom = useCallback(() => {
         messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
@@ -225,20 +280,15 @@ const AppGenerate: FC = () => {
 
         const callbacks = {
             onSuccess: (data: { appUuid: string; version: number }) => {
-                setLocalMessages((prev) => [
-                    ...prev,
-                    {
-                        role: 'assistant' as const,
-                        content:
-                            data.version === 1
-                                ? 'Your app is ready!'
-                                : `Version ${data.version} is ready!`,
-                        appUuid: data.appUuid,
-                        version: data.version,
-                    },
-                ]);
-                // Update URL so the session is resumable, without triggering
-                // a re-render or refetch — just silently swap the URL.
+                // Set active app so polling starts immediately
+                setActiveAppUuid(data.appUuid);
+                // Invalidate so useGetApp refetches and picks up the new
+                // building version — otherwise stale cache shows "ready"
+                // and refetchInterval stays off.
+                void queryClient.invalidateQueries({
+                    queryKey: ['app', projectUuid, data.appUuid],
+                });
+                // Update URL so the session is resumable
                 if (!urlAppUuid) {
                     window.history.replaceState(
                         null,
@@ -426,7 +476,8 @@ const AppGenerate: FC = () => {
                                                 }
                                             >
                                                 <Text size="sm" c="dimmed">
-                                                    Generating your app{' '}
+                                                    {latestBuildingVersion?.statusMessage ??
+                                                        'Generating your app'}{' '}
                                                     <LoadingDots />
                                                 </Text>
                                             </Box>
@@ -485,10 +536,10 @@ const AppGenerate: FC = () => {
                             <Text size="sm" fw={500}>
                                 Preview
                             </Text>
-                            {latestApp?.appUuid && latestApp?.version && (
+                            {previewApp && (
                                 <ActionIcon
                                     component={Link}
-                                    to={`/projects/${projectUuid}/apps/${latestApp.appUuid}/versions/${latestApp.version}/preview`}
+                                    to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/versions/${previewApp.version}/preview`}
                                     target="_blank"
                                     variant="subtle"
                                     size="sm"
@@ -500,11 +551,11 @@ const AppGenerate: FC = () => {
                         </Box>
 
                         <Box className={classes.previewContent}>
-                            {latestApp?.appUuid && latestApp?.version ? (
+                            {previewApp ? (
                                 <AppPreview
                                     projectUuid={projectUuid}
-                                    appUuid={latestApp.appUuid}
-                                    version={latestApp.version}
+                                    appUuid={previewApp.appUuid}
+                                    version={previewApp.version}
                                 />
                             ) : (
                                 <Box className={classes.previewEmpty}>


### PR DESCRIPTION
### Description:
Make app generation endpoints return immediately after creating the DB record, then run the pipeline in the background. The frontend polls every 2s for status updates, showing stage-specific progress messages instead of a static spinner.

Errors show user-friendly messages per failure stage. Raw error details kept in the error column for debugging.

Stale builds (e.g. server restart mid-pipeline) are auto-healed: if a building version has no heartbeat for >10 minutes, the GET endpoint marks it as errored.


### Why not Websockets?
While a great idea, we're currently moving fast and not going all out on building the most sophisticated solution. Since it would be a lot more work to set-up (incl. infra), we're currently going with the simple polling approach.

### Testing


https://github.com/user-attachments/assets/d84f7d7d-dd46-4e77-ad5f-51d77c03c0aa


Some failure simulation:
<img width="797" height="531" alt="image" src="https://github.com/user-attachments/assets/65c7eaa5-d984-4cd7-a4a0-81ef0a5f6a36" />


