### PR TITLE
feat: add editable name and description for data apps

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -3,6 +3,8 @@ import {
     type ApiGenerateAppResponse,
     type ApiGetAppResponse,
     type ApiPreviewTokenResponse,
+    type ApiUpdateAppRequest,
+    type ApiUpdateAppResponse,
 } from '@lightdash/common';
 import {
     Body,
@@ -10,6 +12,7 @@ import {
     Hidden,
     Middlewares,
     OperationId,
+    Patch,
     Path,
     Post,
     Query,
@@ -103,6 +106,32 @@ export class AppGenerateController extends BaseController {
             projectUuid,
             appUuid,
             body.prompt,
+        );
+        return {
+            status: 'ok',
+            results: result,
+        };
+    }
+
+    /**
+     * Update an app's name and/or description.
+     * @summary Update app
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{appUuid}')
+    @OperationId('updateApp')
+    async updateApp(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+        @Body() body: ApiUpdateAppRequest,
+    ): Promise<ApiUpdateAppResponse> {
+        const result = await this.getAppGenerateService().updateApp(
+            req.user!,
+            projectUuid,
+            appUuid,
+            body,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1002,6 +1002,8 @@ export class AppGenerateService extends BaseService {
         opts: { beforeVersion?: number; limit?: number },
     ): Promise<{
         appUuid: string;
+        name: string;
+        description: string;
         versions: {
             version: number;
             prompt: string;
@@ -1026,11 +1028,8 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const { versions, hasMore } = await this.appModel.getAppWithVersions(
-            appUuid,
-            projectUuid,
-            opts,
-        );
+        const { name, description, versions, hasMore } =
+            await this.appModel.getAppWithVersions(appUuid, projectUuid, opts);
 
         // Auto-heal stale builds: if the pipeline died (e.g. server restart)
         // the version stays "building" forever. Detect via heartbeat timeout.
@@ -1068,6 +1067,8 @@ export class AppGenerateService extends BaseService {
 
         return {
             appUuid,
+            name,
+            description,
             versions: versions.map((v) => ({
                 version: v.version,
                 prompt: v.prompt,
@@ -1078,6 +1079,69 @@ export class AppGenerateService extends BaseService {
                 createdAt: v.created_at,
             })),
             hasMore,
+        };
+    }
+
+    async updateApp(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+        update: { name?: string; description?: string },
+    ): Promise<{ appUuid: string; name: string; description: string }> {
+        this.assertDataAppsEnabled();
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('DataApp', {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to manage data apps',
+            );
+        }
+
+        const fieldsToUpdate: Partial<{ name: string; description: string }> =
+            {};
+        if (update.name !== undefined) {
+            const trimmedName = update.name.trim();
+            if (trimmedName.length === 0) {
+                throw new ParameterError('App name cannot be empty');
+            }
+            if (trimmedName.length > 255) {
+                throw new ParameterError(
+                    'App name must be 255 characters or fewer',
+                );
+            }
+            fieldsToUpdate.name = trimmedName;
+        }
+        if (update.description !== undefined) {
+            const trimmedDescription = update.description.trim();
+            if (trimmedDescription.length > 1024) {
+                throw new ParameterError(
+                    'App description must be 1024 characters or fewer',
+                );
+            }
+            fieldsToUpdate.description = trimmedDescription;
+        }
+
+        if (Object.keys(fieldsToUpdate).length === 0) {
+            throw new ParameterError(
+                'At least one of name or description must be provided',
+            );
+        }
+
+        const app = await this.appModel.updateApp(
+            appUuid,
+            projectUuid,
+            fieldsToUpdate,
+        );
+        return {
+            appUuid: app.app_id,
+            name: app.name,
+            description: app.description,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6595,6 +6595,14 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 createdAt: { dataType: 'datetime', required: true },
+                statusMessage: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 status: { dataType: 'string', required: true },
                 prompt: { dataType: 'string', required: true },
                 version: { dataType: 'double', required: true },
@@ -6603,7 +6611,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__appUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
+    'ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
         {
             dataType: 'refAlias',
             type: {
@@ -6621,6 +6629,8 @@ const models: TsoaRoute.Models = {
                                 },
                                 required: true,
                             },
+                            description: { dataType: 'string', required: true },
+                            name: { dataType: 'string', required: true },
                             appUuid: { dataType: 'string', required: true },
                         },
                         required: true,
@@ -6634,7 +6644,47 @@ const models: TsoaRoute.Models = {
     ApiGetAppResponse: {
         dataType: 'refAlias',
         type: {
-            ref: 'ApiSuccess__appUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
+            ref: 'ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ApiSuccess__appUuid-string--name-string--description-string__': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        description: { dataType: 'string', required: true },
+                        name: { dataType: 'string', required: true },
+                        appUuid: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateAppResponse: {
+        dataType: 'refAlias',
+        type: {
+            ref: 'ApiSuccess__appUuid-string--name-string--description-string__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiUpdateAppRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                description: { dataType: 'string' },
+                name: { dataType: 'string' },
+            },
             validators: {},
         },
     },
@@ -10521,6 +10571,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    dataTimezone: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     quotedIdentifiersIgnoreCase: {
                         dataType: 'union',
                         subSchemas: [
@@ -10609,6 +10666,13 @@ const models: TsoaRoute.Models = {
                         subSchemas: [
                             { ref: 'WeekDay' },
                             { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    dataTimezone: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -10738,6 +10802,13 @@ const models: TsoaRoute.Models = {
                         subSchemas: [
                             { ref: 'WeekDay' },
                             { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    dataTimezone: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -10895,6 +10966,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    dataTimezone: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     timeoutSeconds: {
                         dataType: 'union',
                         subSchemas: [
@@ -11006,6 +11084,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    dataTimezone: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     catalog: {
                         dataType: 'union',
                         subSchemas: [
@@ -11086,6 +11171,13 @@ const models: TsoaRoute.Models = {
                             { dataType: 'undefined' },
                         ],
                     },
+                    dataTimezone: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
+                            { dataType: 'undefined' },
+                        ],
+                    },
                     host: { dataType: 'string', required: true },
                     port: { dataType: 'double', required: true },
                     dbname: { dataType: 'string', required: true },
@@ -11143,6 +11235,13 @@ const models: TsoaRoute.Models = {
                         subSchemas: [
                             { ref: 'WeekDay' },
                             { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    dataTimezone: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -11228,6 +11327,13 @@ const models: TsoaRoute.Models = {
                         subSchemas: [
                             { ref: 'WeekDay' },
                             { dataType: 'enum', enums: [null] },
+                            { dataType: 'undefined' },
+                        ],
+                    },
+                    dataTimezone: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'string' },
                             { dataType: 'undefined' },
                         ],
                     },
@@ -11512,6 +11618,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         timeoutSeconds: { dataType: 'double' },
+                        dataTimezone: { dataType: 'string' },
                         startOfWeek: {
                             dataType: 'union',
                             subSchemas: [
@@ -11547,6 +11654,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 executionProject: { dataType: 'string' },
+                dataTimezone: { dataType: 'string' },
                 startOfWeek: {
                     dataType: 'union',
                     subSchemas: [
@@ -11656,6 +11764,7 @@ const models: TsoaRoute.Models = {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
                         timeoutSeconds: { dataType: 'double' },
+                        dataTimezone: { dataType: 'string' },
                         startOfWeek: {
                             dataType: 'union',
                             subSchemas: [
@@ -11695,6 +11804,7 @@ const models: TsoaRoute.Models = {
                 timeoutSeconds: { dataType: 'double' },
                 disableTimestampConversion: { dataType: 'boolean' },
                 quotedIdentifiersIgnoreCase: { dataType: 'boolean' },
+                dataTimezone: { dataType: 'string' },
                 startOfWeek: {
                     dataType: 'union',
                     subSchemas: [
@@ -11740,6 +11850,7 @@ const models: TsoaRoute.Models = {
                         },
                     },
                 },
+                dataTimezone: { dataType: 'string' },
                 startOfWeek: {
                     dataType: 'union',
                     subSchemas: [
@@ -11769,6 +11880,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                dataTimezone: { dataType: 'string' },
                 startOfWeek: {
                     dataType: 'union',
                     subSchemas: [
@@ -11797,6 +11909,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 timeoutSeconds: { dataType: 'double' },
+                dataTimezone: { dataType: 'string' },
                 startOfWeek: {
                     dataType: 'union',
                     subSchemas: [
@@ -11822,6 +11935,7 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                dataTimezone: { dataType: 'string' },
                 startOfWeek: {
                     dataType: 'union',
                     subSchemas: [
@@ -31141,6 +31255,79 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'iterateApp',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_updateApp: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiUpdateAppRequest',
+        },
+    };
+    app.patch(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.updateApp,
+        ),
+
+        async function AppGenerateController_updateApp(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_updateApp,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'updateApp',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7941,6 +7941,10 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "statusMessage": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "status": {
                         "type": "string"
                     },
@@ -7952,10 +7956,16 @@
                         "format": "double"
                     }
                 },
-                "required": ["createdAt", "status", "prompt", "version"],
+                "required": [
+                    "createdAt",
+                    "statusMessage",
+                    "status",
+                    "prompt",
+                    "version"
+                ],
                 "type": "object"
             },
-            "ApiSuccess__appUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
+            "ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
                 "properties": {
                     "results": {
                         "properties": {
@@ -7968,11 +7978,23 @@
                                 },
                                 "type": "array"
                             },
+                            "description": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
                             "appUuid": {
                                 "type": "string"
                             }
                         },
-                        "required": ["hasMore", "versions", "appUuid"],
+                        "required": [
+                            "hasMore",
+                            "versions",
+                            "description",
+                            "name",
+                            "appUuid"
+                        ],
                         "type": "object"
                     },
                     "status": {
@@ -7985,7 +8007,47 @@
                 "type": "object"
             },
             "ApiGetAppResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
+            },
+            "ApiSuccess__appUuid-string--name-string--description-string__": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "description": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "appUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["description", "name", "appUuid"],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiUpdateAppResponse": {
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string__"
+            },
+            "ApiUpdateAppRequest": {
+                "properties": {
+                    "description": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    }
+                },
+                "type": "object"
             },
             "ApiSuccess__token-string__": {
                 "properties": {
@@ -11422,6 +11484,9 @@
                         ],
                         "nullable": true
                     },
+                    "dataTimezone": {
+                        "type": "string"
+                    },
                     "quotedIdentifiersIgnoreCase": {
                         "type": "boolean"
                     },
@@ -11482,6 +11547,9 @@
                             }
                         ],
                         "nullable": true
+                    },
+                    "dataTimezone": {
+                        "type": "string"
                     },
                     "timeoutSeconds": {
                         "type": "number",
@@ -11564,6 +11632,9 @@
                             }
                         ],
                         "nullable": true
+                    },
+                    "dataTimezone": {
+                        "type": "string"
                     },
                     "timeoutSeconds": {
                         "type": "number",
@@ -11657,6 +11728,9 @@
                         ],
                         "nullable": true
                     },
+                    "dataTimezone": {
+                        "type": "string"
+                    },
                     "timeoutSeconds": {
                         "type": "number",
                         "format": "double"
@@ -11727,6 +11801,9 @@
                         ],
                         "nullable": true
                     },
+                    "dataTimezone": {
+                        "type": "string"
+                    },
                     "catalog": {
                         "type": "string"
                     },
@@ -11786,6 +11863,9 @@
                         ],
                         "nullable": true
                     },
+                    "dataTimezone": {
+                        "type": "string"
+                    },
                     "host": {
                         "type": "string"
                     },
@@ -11843,6 +11923,9 @@
                             }
                         ],
                         "nullable": true
+                    },
+                    "dataTimezone": {
+                        "type": "string"
                     },
                     "timeoutSeconds": {
                         "type": "number",
@@ -11906,6 +11989,9 @@
                             }
                         ],
                         "nullable": true
+                    },
+                    "dataTimezone": {
+                        "type": "string"
                     },
                     "region": {
                         "type": "string"
@@ -12174,6 +12260,9 @@
                                 "type": "number",
                                 "format": "double"
                             },
+                            "dataTimezone": {
+                                "type": "string"
+                            },
                             "startOfWeek": {
                                 "allOf": [
                                     {
@@ -12238,6 +12327,9 @@
             "CreateBigqueryCredentials": {
                 "properties": {
                     "executionProject": {
+                        "type": "string"
+                    },
+                    "dataTimezone": {
                         "type": "string"
                     },
                     "startOfWeek": {
@@ -12336,6 +12428,9 @@
                                 "type": "number",
                                 "format": "double"
                             },
+                            "dataTimezone": {
+                                "type": "string"
+                            },
                             "startOfWeek": {
                                 "allOf": [
                                     {
@@ -12414,6 +12509,9 @@
                     },
                     "quotedIdentifiersIgnoreCase": {
                         "type": "boolean"
+                    },
+                    "dataTimezone": {
+                        "type": "string"
                     },
                     "startOfWeek": {
                         "allOf": [
@@ -12506,6 +12604,9 @@
                         },
                         "type": "array"
                     },
+                    "dataTimezone": {
+                        "type": "string"
+                    },
                     "startOfWeek": {
                         "allOf": [
                             {
@@ -12556,6 +12657,9 @@
             },
             "CreateTrinoCredentials": {
                 "properties": {
+                    "dataTimezone": {
+                        "type": "string"
+                    },
                     "startOfWeek": {
                         "allOf": [
                             {
@@ -12614,6 +12718,9 @@
                         "type": "number",
                         "format": "double"
                     },
+                    "dataTimezone": {
+                        "type": "string"
+                    },
                     "startOfWeek": {
                         "allOf": [
                             {
@@ -12660,6 +12767,9 @@
             },
             "CreateAthenaCredentials": {
                 "properties": {
+                    "dataTimezone": {
+                        "type": "string"
+                    },
                     "startOfWeek": {
                         "allOf": [
                             {
@@ -29318,7 +29428,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2696.1",
+        "version": "0.2701.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -119,7 +119,12 @@ export class AppModel {
         appId: string,
         projectUuid: string,
         opts: { beforeVersion?: number; limit?: number } = {},
-    ): Promise<{ versions: DbAppVersion[]; hasMore: boolean }> {
+    ): Promise<{
+        name: string;
+        description: string;
+        versions: DbAppVersion[];
+        hasMore: boolean;
+    }> {
         const limit = opts.limit ?? 20;
         const query = this.database(AppsTableName)
             .leftJoin(
@@ -130,7 +135,11 @@ export class AppModel {
             .where(`${AppsTableName}.app_id`, appId)
             .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
             .whereNull(`${AppsTableName}.deleted_at`)
-            .select(`${AppVersionsTableName}.*`)
+            .select(
+                `${AppVersionsTableName}.*`,
+                `${AppsTableName}.name`,
+                `${AppsTableName}.description`,
+            )
             .orderBy(`${AppVersionsTableName}.version`, 'desc')
             .limit(limit + 1);
 
@@ -142,22 +151,47 @@ export class AppModel {
             );
         }
 
-        const rows: (DbAppVersion | Record<string, null>)[] = await query;
+        const rows: ((DbAppVersion | Record<string, null>) & {
+            name: string;
+            description: string;
+        })[] = await query;
 
         // Left join: if app doesn't exist, zero rows → 404
         if (rows.length === 0) {
             throw new NotFoundError(`App not found: ${appId}`);
         }
 
+        // App-level fields come from every row (same values); grab from first
+        const { name, description } = rows[0];
+
         // If app exists but no versions match, we get one row with all nulls
         const versions = rows.filter(
-            (r): r is DbAppVersion => r.version !== null,
+            (r): r is DbAppVersion & { name: string; description: string } =>
+                r.version !== null,
         );
         const hasMore = versions.length > limit;
         return {
+            name,
+            description,
             versions: versions.slice(0, limit),
             hasMore,
         };
+    }
+
+    async updateApp(
+        appId: string,
+        projectUuid: string,
+        update: Partial<Pick<DbApp, 'name' | 'description'>>,
+    ): Promise<DbApp> {
+        const [row] = await this.database(AppsTableName)
+            .where({ app_id: appId, project_uuid: projectUuid })
+            .whereNull('deleted_at')
+            .update(update)
+            .returning('*');
+        if (!row) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
+        return row;
     }
 
     async updateSandboxId(

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -19,6 +19,19 @@ export type ApiAppVersionSummary = {
 
 export type ApiGetAppResponse = ApiSuccess<{
     appUuid: string;
+    name: string;
+    description: string;
     versions: ApiAppVersionSummary[];
     hasMore: boolean;
+}>;
+
+export type ApiUpdateAppRequest = {
+    name?: string;
+    description?: string;
+};
+
+export type ApiUpdateAppResponse = ApiSuccess<{
+    appUuid: string;
+    name: string;
+    description: string;
 }>;

--- a/packages/frontend/src/features/apps/hooks/useUpdateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useUpdateApp.ts
@@ -1,0 +1,55 @@
+import {
+    type ApiError,
+    type ApiUpdateAppRequest,
+    type ApiUpdateAppResponse,
+} from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+type UpdateAppParams = {
+    projectUuid: string;
+    appUuid: string;
+} & ApiUpdateAppRequest;
+
+type UpdateAppResult = ApiUpdateAppResponse['results'];
+
+const updateApp = async ({
+    projectUuid,
+    appUuid,
+    ...body
+}: UpdateAppParams): Promise<UpdateAppResult> => {
+    const data = await lightdashApi<UpdateAppResult>({
+        method: 'PATCH',
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}`,
+        body: JSON.stringify(body),
+    });
+    return data;
+};
+
+export const useUpdateApp = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<UpdateAppResult, ApiError, UpdateAppParams>({
+        mutationFn: updateApp,
+        onSuccess: (_data, variables) => {
+            void queryClient.invalidateQueries({
+                queryKey: ['app', variables.projectUuid, variables.appUuid],
+            });
+            const field = variables.name
+                ? 'name'
+                : variables.description
+                  ? 'description'
+                  : 'metadata';
+            showToastSuccess({
+                title: `App ${field} updated successfully`,
+            });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to update app',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -214,6 +214,14 @@
     }
 }
 
+.previewHeaderInfo {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+    min-width: 0;
+    flex: 1;
+}
+
 .previewContent {
     flex: 1;
     overflow: hidden;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -25,11 +25,13 @@ import {
 } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { Link, Navigate, useParams } from 'react-router';
+import { EditableText } from '../components/VisualizationConfigs/common/EditableText';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
+import { useUpdateApp } from '../features/apps/hooks/useUpdateApp';
 import useHealth from '../hooks/health/useHealth';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
 import useApp from '../providers/App/useApp';
@@ -118,6 +120,7 @@ const AppGenerate: FC = () => {
         isLoading: isIterating,
         reset: resetIterate,
     } = useIterateApp();
+    const { mutate: updateAppMutate } = useUpdateApp();
     const health = useHealth();
     const { user } = useApp();
     const ability = useAbilityContext();
@@ -131,6 +134,22 @@ const AppGenerate: FC = () => {
         hasNextPage,
         isFetchingNextPage,
     } = useGetApp(projectUuid, activeAppUuid ?? urlAppUuid);
+
+    // Derive app name/description from fetched data
+    const appName = appData?.pages?.[0]?.name ?? '';
+    const appDescription = appData?.pages?.[0]?.description ?? '';
+
+    // Draft state for inline editing (synced from server, saved on blur)
+    const [draftName, setDraftName] = useState(appName);
+    const [draftDescription, setDraftDescription] = useState(appDescription);
+    const isEditingName = useRef(false);
+    const isEditingDescription = useRef(false);
+    useEffect(() => {
+        if (!isEditingName.current) setDraftName(appName);
+    }, [appName]);
+    useEffect(() => {
+        if (!isEditingDescription.current) setDraftDescription(appDescription);
+    }, [appDescription]);
 
     // Derive building state from the latest version in fetched data
     const latestBuildingVersion = useMemo(() => {
@@ -531,24 +550,80 @@ const AppGenerate: FC = () => {
                 {/* Preview Panel */}
                 <Panel minSize={40}>
                     <Box className={classes.previewPanel}>
-                        <Box className={classes.previewHeader}>
-                            <IconAppWindow size={16} />
-                            <Text size="sm" fw={500}>
-                                Preview
-                            </Text>
-                            {previewApp && (
-                                <ActionIcon
-                                    component={Link}
-                                    to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/versions/${previewApp.version}/preview`}
-                                    target="_blank"
-                                    variant="subtle"
-                                    size="sm"
-                                    ml="auto"
-                                >
-                                    <IconExternalLink size={14} />
-                                </ActionIcon>
-                            )}
-                        </Box>
+                        {activeAppUuid && (
+                            <Box className={classes.previewHeader}>
+                                <Box className={classes.previewHeaderInfo}>
+                                    <EditableText
+                                        value={draftName}
+                                        placeholder="Untitled app"
+                                        fw={500}
+                                        onFocus={() => {
+                                            isEditingName.current = true;
+                                        }}
+                                        onChange={(e) =>
+                                            setDraftName(e.currentTarget.value)
+                                        }
+                                        onBlur={() => {
+                                            isEditingName.current = false;
+                                            const trimmed = draftName.trim();
+                                            if (
+                                                trimmed &&
+                                                trimmed !== appName
+                                            ) {
+                                                updateAppMutate({
+                                                    projectUuid,
+                                                    appUuid: activeAppUuid,
+                                                    name: trimmed,
+                                                });
+                                            } else {
+                                                setDraftName(appName);
+                                            }
+                                        }}
+                                    />
+                                    <EditableText
+                                        value={draftDescription}
+                                        placeholder="Add a description..."
+                                        lighter
+                                        onFocus={() => {
+                                            isEditingDescription.current = true;
+                                        }}
+                                        onChange={(e) =>
+                                            setDraftDescription(
+                                                e.currentTarget.value,
+                                            )
+                                        }
+                                        onBlur={() => {
+                                            isEditingDescription.current = false;
+                                            const trimmed =
+                                                draftDescription.trim();
+                                            if (trimmed !== appDescription) {
+                                                updateAppMutate({
+                                                    projectUuid,
+                                                    appUuid: activeAppUuid,
+                                                    description: trimmed,
+                                                });
+                                            } else {
+                                                setDraftDescription(
+                                                    appDescription,
+                                                );
+                                            }
+                                        }}
+                                    />
+                                </Box>
+                                {previewApp && (
+                                    <ActionIcon
+                                        component={Link}
+                                        to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/versions/${previewApp.version}/preview`}
+                                        target="_blank"
+                                        variant="subtle"
+                                        size="sm"
+                                        ml="auto"
+                                    >
+                                        <IconExternalLink size={14} />
+                                    </ActionIcon>
+                                )}
+                            </Box>
+                        )}
 
                         <Box className={classes.previewContent}>
                             {previewApp ? (


### PR DESCRIPTION
### Description:
Letting the users add/change the name and description of a generated app, just like charts. This is in preparation to show apps in relevant places.


#### Pre-creation state (app doesn't exist yet)
<img width="2643" height="1643" alt="1" src="https://github.com/user-attachments/assets/b86d006c-75a7-4ff3-b5f5-114b0361f717" />


#### Default state (app exists but no name/description)
<img width="2643" height="1643" alt="2" src="https://github.com/user-attachments/assets/7bab2cac-148b-4cad-bfa8-c2c9eba59fd6" />

#### Changed name/description
<img width="2643" height="1643" alt="3" src="https://github.com/user-attachments/assets/8aa050db-990a-4509-adc2-e977e44a809d" />


