### PR TITLE
feat: add AI agent management tools to MCP service

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -379,6 +379,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     featureFlagService: repository.getFeatureFlagService(),
                     aiOrganizationSettingsService:
                         repository.getAiOrganizationSettingsService(),
+                    aiAgentService: repository.getAiAgentService(),
                 }),
             slackService: ({ repository, clients }) =>
                 new CommercialSlackService({

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -564,7 +564,22 @@ export class AiAgentService {
         user: SessionUser,
         agentUuid: string,
         projectUuid?: string,
-    ) {
+        options?: { includeSummaryContext: true },
+    ): Promise<AiAgentWithContext>;
+
+    public async getAgent(
+        user: SessionUser,
+        agentUuid: string,
+        projectUuid?: string,
+        options?: { includeSummaryContext?: false },
+    ): Promise<AiAgent>;
+
+    public async getAgent(
+        user: SessionUser,
+        agentUuid: string,
+        projectUuid?: string,
+        options?: { includeSummaryContext?: boolean },
+    ): Promise<AiAgent | AiAgentWithContext> {
         const { organizationUuid } = user;
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
@@ -591,6 +606,11 @@ export class AiAgentService {
             throw new ForbiddenError(
                 'Insufficient permissions to access this agent',
             );
+        }
+
+        if (options?.includeSummaryContext) {
+            const context = await this.getAgentSummaryContext(user, agent);
+            return { ...agent, context };
         }
 
         return agent;

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -99,6 +99,7 @@ import { AgentContext } from '../ai/utils/AgentContext';
 import { getPivotedResults } from '../ai/utils/getPivotedResults';
 import { populateCustomMetricsSQL } from '../ai/utils/populateCustomMetricsSQL';
 import { serializeData } from '../ai/utils/serializeData';
+import { AiAgentService } from '../AiAgentService/AiAgentService';
 import { AiOrganizationSettingsService } from '../AiOrganizationSettingsService';
 import {
     registerAppResource,
@@ -116,6 +117,10 @@ export enum McpToolName {
     LIST_PROJECTS = 'list_projects',
     SET_PROJECT = 'set_project',
     GET_CURRENT_PROJECT = 'get_current_project',
+    LIST_AGENTS = 'list_agents',
+    SET_AGENT = 'set_agent',
+    CLEAR_AGENT = 'clear_agent',
+    GET_CURRENT_AGENT = 'get_current_agent',
     RUN_METRIC_QUERY = 'run_metric_query',
     RUN_SQL = 'run_sql',
     SEARCH_FIELD_VALUES = 'search_field_values',
@@ -137,6 +142,7 @@ type McpServiceArguments = {
     mcpContextModel: McpContextModel;
     featureFlagService: FeatureFlagService;
     aiOrganizationSettingsService: AiOrganizationSettingsService;
+    aiAgentService: AiAgentService;
 };
 
 export type ExtraContext = {
@@ -182,6 +188,8 @@ export class McpService extends BaseService {
 
     private aiOrganizationSettingsService: AiOrganizationSettingsService;
 
+    private aiAgentService: AiAgentService;
+
     private mcpServer: McpServer;
 
     private mcpCompatLayer: McpSchemaCompatLayer;
@@ -202,6 +210,7 @@ export class McpService extends BaseService {
         mcpContextModel,
         featureFlagService,
         aiOrganizationSettingsService,
+        aiAgentService,
     }: McpServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -219,6 +228,7 @@ export class McpService extends BaseService {
         this.mcpContextModel = mcpContextModel;
         this.featureFlagService = featureFlagService;
         this.aiOrganizationSettingsService = aiOrganizationSettingsService;
+        this.aiAgentService = aiAgentService;
         this.mcpCompatLayer = new McpSchemaCompatLayer();
         try {
             this.mcpServer = Sentry.wrapMcpServerWithSentry(
@@ -567,7 +577,8 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             McpToolName.LIST_PROJECTS,
             {
-                description: 'List all accessible projects in the organization',
+                description:
+                    'List all accessible projects in the organization. Projects contain explores, fields, and content. Use this to discover available projects before calling set_project to select one as the active context for subsequent operations.',
                 inputSchema: {},
             },
             async (
@@ -612,7 +623,7 @@ export class McpService extends BaseService {
             McpToolName.SET_PROJECT,
             {
                 description:
-                    'Set the active project for subsequent MCP operations',
+                    'Set the active project for all subsequent MCP operations. Most tools (list_explores, find_fields, run_metric_query, etc.) require an active project. Setting a project clears any previously selected agent, since agents are scoped to a project. After setting a project, use list_agents to discover available AI agents and optionally set_agent to activate one.',
                 inputSchema: {
                     projectUuid: z.string(),
                     tags: z.array(z.string()).optional(),
@@ -664,13 +675,7 @@ export class McpService extends BaseService {
                     tagsToSet = args.tags.length > 0 ? args.tags : null;
                 }
 
-                // Get existing context to preserve user attribute overrides
-                const existingContext = await this.mcpContextModel.getContext(
-                    user.userUuid,
-                    organizationUuid,
-                );
-
-                // Set context
+                // Agent is cleared because agents are scoped to a project
                 await this.mcpContextModel.setContext({
                     userUuid: user.userUuid,
                     organizationUuid,
@@ -678,6 +683,8 @@ export class McpService extends BaseService {
                         projectUuid: args.projectUuid,
                         projectName: project.name,
                         tags: tagsToSet,
+                        agentUuid: null,
+                        agentName: null,
                     },
                 });
 
@@ -701,7 +708,8 @@ export class McpService extends BaseService {
         this.mcpServer.registerTool(
             McpToolName.GET_CURRENT_PROJECT,
             {
-                description: 'Get the currently active project',
+                description:
+                    'Get the currently active project and its configuration. Returns the project UUID, name, and any selected tags. Use this to verify context before calling data tools.',
                 inputSchema: {},
             },
             async (
@@ -750,6 +758,258 @@ export class McpService extends BaseService {
                                     projectUuid,
                                     projectName,
                                     selectedTags: tags,
+                                },
+                                null,
+                                2,
+                            ),
+                        },
+                    ],
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.LIST_AGENTS,
+            {
+                description:
+                    'List all accessible AI agents. Optionally filter by project UUID. Each agent is pre-configured with specific explores, tags, verified questions, and instructions that define its domain expertise. Use this to discover which agents are available before calling set_agent.',
+                inputSchema: {
+                    projectUuid: z.string().optional(),
+                },
+            },
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
+                const args = _args as { projectUuid?: string };
+                const { user } = this.getAccount(extra as McpProtocolContext);
+
+                this.trackToolCall(
+                    extra as McpProtocolContext,
+                    McpToolName.LIST_AGENTS,
+                );
+
+                const agents = await this.aiAgentService.listAgents(
+                    user,
+                    args.projectUuid,
+                );
+
+                const agentList = agents.map((agent) => ({
+                    uuid: agent.uuid,
+                    name: agent.name,
+                    description: agent.description,
+                    tags: agent.tags,
+                    projectUuid: agent.projectUuid,
+                }));
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(agentList, null, 2),
+                        },
+                    ],
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.SET_AGENT,
+            {
+                description:
+                    "Set the active AI agent. Returns the agent's full context including: explores it has access to, verified questions (curated example queries that demonstrate correct usage of the data model), and custom instructions. Use this context to guide subsequent tool calls — prefer the agent's explores when calling find_explores/find_fields, reference verified questions as patterns for building queries with run_metric_query, and follow the agent's instructions for domain-specific conventions.",
+                inputSchema: {
+                    agentUuid: z.string(),
+                },
+            },
+            async (
+                _args: AnyType,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
+                const args = _args as { agentUuid: string };
+                const { user, organizationUuid } = this.getAccount(
+                    extra as McpProtocolContext,
+                );
+
+                this.trackToolCall(
+                    extra as McpProtocolContext,
+                    McpToolName.SET_AGENT,
+                    args.agentUuid,
+                );
+
+                if (!args.agentUuid) {
+                    throw new ParameterError('Agent UUID is required');
+                }
+
+                // Validates copilot enabled, agent exists, user has access, and returns summary context
+                const agent = await this.aiAgentService.getAgent(
+                    user,
+                    args.agentUuid,
+                    undefined,
+                    { includeSummaryContext: true },
+                );
+
+                const existingContext = await this.mcpContextModel.getContext(
+                    user.userUuid,
+                    organizationUuid,
+                );
+
+                await this.mcpContextModel.setContext({
+                    userUuid: user.userUuid,
+                    organizationUuid,
+                    context: {
+                        projectUuid: existingContext?.context.projectUuid ?? '',
+                        projectName: existingContext?.context.projectName ?? '',
+                        tags: existingContext?.context.tags ?? null,
+                        agentUuid: agent.uuid,
+                        agentName: agent.name,
+                    },
+                });
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(
+                                {
+                                    agentUuid: agent.uuid,
+                                    agentName: agent.name,
+                                    agentDescription: agent.description,
+                                    agentTags: agent.tags,
+                                    agentProjectUuid: agent.projectUuid,
+                                    explores: agent.context.explores,
+                                    verifiedQuestions:
+                                        agent.context.verifiedQuestions,
+                                    instruction: agent.context.instruction,
+                                },
+                                null,
+                                2,
+                            ),
+                        },
+                    ],
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.CLEAR_AGENT,
+            {
+                description:
+                    "Clear the active AI agent from context. After clearing, tool calls will no longer be scoped to a specific agent's explores, tags, or instructions. The active project is preserved.",
+                inputSchema: {},
+            },
+            async (
+                _args: Record<string, never>,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
+                const { user, organizationUuid } = this.getAccount(
+                    extra as McpProtocolContext,
+                );
+
+                this.trackToolCall(
+                    extra as McpProtocolContext,
+                    McpToolName.CLEAR_AGENT,
+                );
+
+                const existingContext = await this.mcpContextModel.getContext(
+                    user.userUuid,
+                    organizationUuid,
+                );
+
+                await this.mcpContextModel.setContext({
+                    userUuid: user.userUuid,
+                    organizationUuid,
+                    context: {
+                        projectUuid: existingContext?.context.projectUuid ?? '',
+                        projectName: existingContext?.context.projectName ?? '',
+                        tags: existingContext?.context.tags ?? null,
+                        agentUuid: null,
+                        agentName: null,
+                    },
+                });
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(
+                                {
+                                    message:
+                                        'Agent context cleared successfully.',
+                                },
+                                null,
+                                2,
+                            ),
+                        },
+                    ],
+                };
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.GET_CURRENT_AGENT,
+            {
+                description:
+                    "Get the currently active AI agent with its full context: explores it has access to, verified questions (curated example queries), and custom instructions. Use this to retrieve the agent's domain knowledge before making data queries.",
+                inputSchema: {},
+            },
+            async (
+                _args: Record<string, never>,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
+                const { user, organizationUuid } = this.getAccount(
+                    extra as McpProtocolContext,
+                );
+
+                this.trackToolCall(
+                    extra as McpProtocolContext,
+                    McpToolName.GET_CURRENT_AGENT,
+                );
+
+                const contextRow = await this.mcpContextModel.getContext(
+                    user.userUuid,
+                    organizationUuid,
+                );
+
+                if (!contextRow?.context.agentUuid) {
+                    return {
+                        content: [
+                            {
+                                type: 'text',
+                                text: JSON.stringify(
+                                    {
+                                        error: 'No active agent set. Use set_agent to set one.',
+                                    },
+                                    null,
+                                    2,
+                                ),
+                            },
+                        ],
+                    };
+                }
+
+                const agent = await this.aiAgentService.getAgent(
+                    user,
+                    contextRow.context.agentUuid,
+                    undefined,
+                    { includeSummaryContext: true },
+                );
+
+                return {
+                    content: [
+                        {
+                            type: 'text',
+                            text: JSON.stringify(
+                                {
+                                    agentUuid: agent.uuid,
+                                    agentName: agent.name,
+                                    agentDescription: agent.description,
+                                    agentTags: agent.tags,
+                                    agentProjectUuid: agent.projectUuid,
+                                    explores: agent.context.explores,
+                                    verifiedQuestions:
+                                        agent.context.verifiedQuestions,
+                                    instruction: agent.context.instruction,
                                 },
                                 null,
                                 2,
@@ -1252,6 +1512,24 @@ export class McpService extends BaseService {
         );
 
         return contextRow?.context.tags || null;
+    }
+
+    async getAgentUuidFromContext(
+        context: McpProtocolContext,
+    ): Promise<string | null> {
+        const { user } = context.authInfo!.extra;
+        const { organizationUuid } = user;
+
+        if (!user || !organizationUuid) {
+            return null;
+        }
+
+        const contextRow = await this.mcpContextModel.getContext(
+            user.userUuid,
+            organizationUuid,
+        );
+
+        return contextRow?.context.agentUuid ?? null;
     }
 
     async getMergedUserAttributes(

--- a/packages/backend/src/models/McpContextModel.ts
+++ b/packages/backend/src/models/McpContextModel.ts
@@ -6,6 +6,8 @@ export interface McpContext {
     projectUuid: string;
     projectName: string;
     tags: string[] | null;
+    agentUuid: string | null;
+    agentName: string | null;
 }
 
 export interface McpContextRow {


### PR DESCRIPTION
Closes: ZAP-303

### Description:
Added 3 new tools in mcp server to gather information about agents. This can be used by clients to make informed decisions when using tools based on agents configurations