### PR TITLE
fix: mock worker_threads in ProjectService test

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -81,6 +81,41 @@ import {
     virtualExplore,
 } from './ProjectService.mock';
 
+// Mock worker_threads so the >500 rows test doesn't need a compiled
+// dist/services/ProjectService/formatRows.js artifact. In production,
+// formatRows runs in a Worker thread for large result sets, but the Worker
+// constructor requires the built JS file which only exists after `pnpm build`.
+// This mock runs formatRows synchronously in the main thread instead.
+jest.mock('worker_threads', () => {
+    const { formatRows } = jest.requireActual('@lightdash/common');
+    return {
+        Worker: jest.fn().mockImplementation(
+            (
+                _path: string,
+                options: {
+                    workerData: { rows: unknown[]; itemMap: unknown };
+                },
+            ) => {
+                const { rows, itemMap } = options.workerData;
+                const result = formatRows(rows, itemMap);
+                return {
+                    on: jest.fn(
+                        (
+                            event: string,
+                            callback: (...args: unknown[]) => void,
+                        ) => {
+                            if (event === 'message') {
+                                setTimeout(() => callback(result), 0);
+                            }
+                        },
+                    ),
+                    terminate: jest.fn(),
+                };
+            },
+        ),
+    };
+});
+
 jest.mock('@lightdash/warehouses', () => ({
     SshTunnel: jest.fn(() => ({
         connect: jest.fn(() => warehouseClientMock.credentials),


### PR DESCRIPTION
## Summary

- The `should get results with 501 rows` test in `ProjectService.test.ts` fails when run standalone (`pnpm -F backend test`) because it spawns a `Worker` thread that requires the compiled `dist/services/ProjectService/formatRows.js` artifact
- This file only exists after a full `pnpm build`, which CI runs but local dev doesn't
- Mocks `worker_threads` so `formatRows` runs synchronously in the main thread, removing the build dependency

## Test plan

- [x] Confirmed test fails without the fix (`Cannot find module .../dist/services/ProjectService/formatRows.js`)
- [x] Confirmed all 35 tests pass with the fix