### PR TITLE
feat: audit logging foundation

### DIFF
--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -1,0 +1,339 @@
+# Audit Logging Architecture
+
+This document describes how audit logging works in Lightdash, covering the system design, actor types, event schema, and
+how to add audit logging to new services.
+
+---
+
+## Overview
+
+Lightdash uses a CASL-based authorization system where every permission check (`can`/`cannot`) can be automatically
+audit-logged. The audit logging layer wraps CASL's Ability class to intercept permission checks and emit structured
+events at Winston's `audit` log level.
+
+This enables ITGC compliance by tracking:
+
+- **Machine actions**: SCIM, service accounts
+- **Administrative actions**: Role/permission changes, configuration changes
+- **User edits**: Dashboard and chart modifications, folder structure changes
+
+---
+
+## Key Components
+
+| Component                            | Location                                                   | Purpose                                                            |
+|--------------------------------------|------------------------------------------------------------|--------------------------------------------------------------------|
+| `AuditLogEvent` schema               | `packages/backend/src/logging/auditLog.ts`                 | Zod-validated event structure                                      |
+| `CaslAuditWrapper`                   | `packages/backend/src/logging/caslAuditWrapper.ts`         | Wraps CASL Ability to intercept `can`/`cannot` calls               |
+| `BaseService.createAuditedAbility()` | `packages/backend/src/services/BaseService.ts`             | Helper that creates a CaslAuditWrapper with logging pre-configured |
+| `logAuditEvent()`                    | `packages/backend/src/logging/winston.ts`                  | Emits audit events to Winston at the `audit` level                 |
+| ESLint rule                          | `packages/backend/eslint-rules/no-direct-ability-check.js` | Prevents direct `.ability.can/cannot` calls in services            |
+
+---
+
+## Actor Types (Discriminated Union)
+
+Audit actors are modeled as a discriminated union on the `type` field:
+
+| Actor Type          | `type` values             | Description                            | Key Fields                                                                      |
+|---------------------|---------------------------|----------------------------------------|---------------------------------------------------------------------------------|
+| **User**            | `session`, `pat`, `oauth` | Human users via browser, PAT, or OAuth | `uuid`, `email`, `firstName`, `lastName`, `organizationRole`, `impersonatedBy?` |
+| **Service Account** | `service-account`         | Machine-to-machine CI/CD accounts      | `uuid`, `email`, `organizationRole`                                             |
+| **Anonymous**       | `anonymous`               | Embedded dashboard viewers (JWT auth)  | `uuid`, `organizationUuid`                                                      |
+
+The `impersonatedBy` field on user actors tracks admin impersonation for compliance. When an admin acts as another user,
+both the target user and the impersonating admin are recorded.
+
+---
+
+## Event Schema
+
+Every audit event contains:
+
+```typescript
+{
+    id: string;              // UUID, auto-generated
+    timestamp: string;       // ISO 8601 UTC
+    actor: AuditActor;       // Who performed the action (see Actor Types)
+    action: string;          // CASL action: 'view', 'create', 'update', 'delete', 'manage'
+    resource: {
+        type: string;          // CASL subject: 'Dashboard', 'SavedChart', 'Space', etc.
+        uuid ? : string;         // Resource identifier
+        name ? : string;         // Human-readable name
+        organizationUuid: string;
+        projectUuid ? : string;
+    }
+    ;
+    context: {
+        ip ? : string;           // Client IP address
+        userAgent ? : string;    // Client user agent
+        requestId ? : string;    // Correlation ID for request tracing
+    }
+    ;
+    status: 'allowed' | 'denied';  // Permission check result
+    reason ? : string;                // CASL rule `.because()` explanation
+    ruleConditions ? : string;        // Serialized CASL rule conditions (JSON)
+    callStack ? : Array<{      // Which service methods triggered this check
+        serviceName: string;
+        methodName: string;
+        depth: number;
+    }>;
+}
+```
+
+---
+
+## Winston Log Levels
+
+Audit events use a custom Winston log level:
+
+```
+error: 0    (highest priority)
+warn:  1
+info:  2
+http:  3
+audit: 4    <-- audit events
+debug: 5    (lowest priority)
+```
+
+Configure audit logging via environment variables:
+
+```bash
+# File output for SIEM ingestion
+LIGHTDASH_LOG_FILE_PATH="/var/log/lightdash/audit.log"
+LIGHTDASH_LOG_FILE_LEVEL="audit"
+LIGHTDASH_LOG_FILE_FORMAT="json"
+
+# Console can be set independently
+LIGHTDASH_LOG_LEVEL="info"
+LIGHTDASH_LOG_FORMAT="json"
+LIGHTDASH_LOG_OUTPUTS="console,file"
+```
+
+---
+
+## How to Add Audit Logging to a Service
+
+### Step 1: Use `createAuditedAbility()` Instead of Direct Ability Checks
+
+Every service that extends `BaseService` has access to `this.createAuditedAbility()`. This is a drop-in replacement for
+accessing `user.ability` directly.
+
+**Before (no audit logging):**
+
+```typescript
+import { subject } from '@casl/ability';
+import { ForbiddenError } from '@lightdash/common';
+
+class MyService extends BaseService {
+    async getResource(user: SessionUser, resourceUuid: string) {
+        const resource = await this.model.get(resourceUuid);
+
+        // Direct ability check - NOT audit logged
+        if (user.ability.cannot('view', subject('MyResource', resource))) {
+            throw new ForbiddenError();
+        }
+
+        return resource;
+    }
+}
+```
+
+**After (audit logged):**
+
+```typescript
+import { subject } from '@casl/ability';
+import { ForbiddenError } from '@lightdash/common';
+
+class MyService extends BaseService {
+    async getResource(user: SessionUser, resourceUuid: string) {
+        const resource = await this.model.get(resourceUuid);
+
+        // Audited ability - every can/cannot call is logged
+        const auditedAbility = this.createAuditedAbility(user);
+        if (auditedAbility.cannot('view', subject('MyResource', resource))) {
+            throw new ForbiddenError();
+        }
+
+        return resource;
+    }
+}
+```
+
+### Step 2: Reuse the Audited Ability Within a Method
+
+If a method makes multiple permission checks, create the audited ability once and reuse it:
+
+```typescript
+class MyService extends BaseService {
+    async updateResource(user: SessionUser, uuid: string, data: UpdateData) {
+        const resource = await this.model.get(uuid);
+        const auditedAbility = this.createAuditedAbility(user);
+
+        // Check 1: Can user update in current space?
+        if (auditedAbility.cannot('update', subject('MyResource', resource))) {
+            throw new ForbiddenError();
+        }
+
+        // Check 2: If moving to new space, can user update there?
+        if (data.spaceUuid && data.spaceUuid !== resource.spaceUuid) {
+            const newSpace = await this.spaceModel.get(data.spaceUuid);
+            if (auditedAbility.cannot('update', subject('MyResource', newSpace))) {
+                throw new ForbiddenError("No access to the target space");
+            }
+        }
+
+        return this.model.update(uuid, data);
+    }
+}
+```
+
+### Step 3: Works with Account Type Too
+
+For services that receive the `Account` type (newer pattern), the same method works:
+
+```typescript
+class MyService extends BaseService {
+    async listRoles(account: Account) {
+        const auditedAbility = this.createAuditedAbility(account);
+        if (auditedAbility.cannot('view', subject('Organization', { ... }))) {
+            throw new ForbiddenError();
+        }
+        // ...
+    }
+}
+```
+
+### Step 4: Always Use `subject()` for Typed Subjects
+
+Always wrap permission checks with CASL's `subject()` helper. This ensures the audit log captures the correct resource
+type name. Without `subject()`, the `__caslSubjectType__` field is missing and the resource type in the audit log will
+be `"unknown"`.
+
+```typescript
+// Good - audit log will show resource.type = "Dashboard"
+auditedAbility.cannot('view', subject('Dashboard', { organizationUuid, projectUuid, uuid: dashboardUuid }))
+
+// Bad - audit log will show resource.type = "unknown"
+auditedAbility.cannot('view', { organizationUuid, projectUuid })
+```
+
+### Step 5: Generate UUIDs Before Permission Checks on Create Actions
+
+For create operations, generate the resource UUID *before* the permission check so the audit log includes the UUID of
+the resource that will be created. This makes it possible to correlate the permission check with the resulting resource.
+
+```typescript
+async createDashboard(user: SessionUser, projectUuid: string, data: CreateDashboard) {
+    const dashboardUuid = uuidv4(); // Generate UUID first
+    const auditedAbility = this.createAuditedAbility(user);
+
+    // Audit log will include uuid: "abc-123" even for the create check
+    if (auditedAbility.cannot('create', subject('Dashboard', {
+        organizationUuid,
+        projectUuid,
+        uuid: dashboardUuid,
+    }))) {
+        throw new ForbiddenError();
+    }
+
+    // Pass the pre-generated UUID to the model
+    return this.dashboardModel.create({ ...data, uuid: dashboardUuid });
+}
+```
+
+---
+
+## Example: Full Audit Log Output
+
+When a developer with PAT authentication views a dashboard:
+
+```json
+{
+  "level": "audit",
+  "message": "view Dashboard abc-123-uuid by user-456 (allowed)",
+  "id": "evt-789",
+  "timestamp": "2026-04-01T10:30:00.000Z",
+  "actor": {
+    "type": "pat",
+    "uuid": "user-456",
+    "email": "developer@company.com",
+    "firstName": "Jane",
+    "lastName": "Dev",
+    "organizationUuid": "org-001",
+    "organizationRole": "developer",
+    "groupMemberships": []
+  },
+  "action": "view",
+  "resource": {
+    "type": "Dashboard",
+    "uuid": "abc-123-uuid",
+    "organizationUuid": "org-001",
+    "projectUuid": "proj-001"
+  },
+  "context": {},
+  "status": "allowed",
+  "ruleConditions": "{\"organizationUuid\":\"org-001\"}",
+  "callStack": [
+    {
+      "serviceName": "DashboardService",
+      "methodName": "getByIdOrSlug",
+      "depth": 0
+    }
+  ]
+}
+```
+
+When a denied access attempt occurs (e.g., viewer trying to delete):
+
+```json
+{
+  "level": "audit",
+  "message": "delete Dashboard abc-123-uuid by user-789 (denied)",
+  "id": "evt-012",
+  "timestamp": "2026-04-01T10:31:00.000Z",
+  "actor": {
+    "type": "session",
+    "uuid": "user-789",
+    "email": "viewer@company.com",
+    "firstName": "Bob",
+    "lastName": "Viewer",
+    "organizationUuid": "org-001",
+    "organizationRole": "viewer",
+    "groupMemberships": []
+  },
+  "action": "delete",
+  "resource": {
+    "type": "Dashboard",
+    "uuid": "abc-123-uuid",
+    "organizationUuid": "org-001",
+    "projectUuid": "proj-001"
+  },
+  "context": {},
+  "status": "denied",
+  "reason": "Viewers cannot delete dashboards",
+  "callStack": [
+    {
+      "serviceName": "DashboardService",
+      "methodName": "delete",
+      "depth": 0
+    }
+  ]
+}
+```
+
+---
+
+## ESLint Enforcement
+
+The custom ESLint rule `no-direct-ability-check` (loaded via `--rulesdir eslint-rules`) detects direct `.ability.can()` /
+`.ability.cannot()` usage in service files and flags them. It is currently set to **warning** during the migration period,
+and will be promoted to **error** once all services are migrated.
+
+The rule catches patterns like:
+
+- `user.ability.can('view', ...)`
+- `account.user.ability.cannot('manage', ...)`
+- `actor.ability.can('update', ...)`
+
+And suggests using `this.createAuditedAbility()` instead.

--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -88,6 +88,16 @@ module.exports = {
             },
         },
         {
+            // Warn on direct ability checks in services - use createAuditedAbility() instead
+            files: [
+                'src/services/**/*.ts',
+                'src/ee/services/**/*.ts',
+            ],
+            rules: {
+                'no-direct-ability-check': 'warn',
+            },
+        },
+        {
             // Require @summary tag in JSDoc comments for controller API endpoints
             // This ensures API documentation has human-readable names
             // Only applies to methods with decorators (API endpoints have @Get, @Post, etc.)

--- a/packages/backend/eslint-rules/no-direct-ability-check.js
+++ b/packages/backend/eslint-rules/no-direct-ability-check.js
@@ -1,0 +1,86 @@
+/**
+ * ESLint rule: no-direct-ability-check
+ *
+ * Prevents direct usage of .ability.can() and .ability.cannot() in service files.
+ * All permission checks should go through this.createAuditedAbility() to ensure
+ * audit logging for compliance.
+ *
+ * Detects patterns:
+ * - user.ability.can(...)
+ * - user.ability.cannot(...)
+ * - account.user.ability.can(...)
+ * - account.user.ability.cannot(...)
+ * - actor.ability.can(...)
+ * - actor.ability.cannot(...)
+ * - *.ability.can(...)  (any object).ability.can/cannot
+ */
+module.exports = {
+    meta: {
+        type: 'suggestion',
+        docs: {
+            description:
+                'Disallow direct ability.can/cannot calls in services. Use this.createAuditedAbility() instead for audit logging.',
+        },
+        messages: {
+            noDirectAbilityCheck:
+                'Direct ability.can/cannot calls bypass audit logging. Use `const ability = this.createAuditedAbility({{source}});` then `ability.{{method}}(...)` instead.',
+        },
+        schema: [],
+    },
+    create(context) {
+        return {
+            // Match: *.ability.can(...) and *.ability.cannot(...)
+            CallExpression(node) {
+                const { callee } = node;
+
+                if (
+                    callee.type !== 'MemberExpression' ||
+                    callee.property.type !== 'Identifier' ||
+                    (callee.property.name !== 'can' &&
+                        callee.property.name !== 'cannot')
+                ) {
+                    return;
+                }
+
+                // Check that the object is *.ability
+                const obj = callee.object;
+                if (
+                    obj.type !== 'MemberExpression' ||
+                    obj.property.type !== 'Identifier' ||
+                    obj.property.name !== 'ability'
+                ) {
+                    return;
+                }
+
+                // Determine the source variable name for the error message
+                let sourceName = 'accountOrUser';
+                const abilityOwner = obj.object;
+
+                if (abilityOwner.type === 'MemberExpression') {
+                    // e.g., account.user.ability - source is "account"
+                    if (
+                        abilityOwner.object.type === 'Identifier' ||
+                        abilityOwner.object.type === 'MemberExpression'
+                    ) {
+                        sourceName =
+                            abilityOwner.object.type === 'Identifier'
+                                ? abilityOwner.object.name
+                                : 'account';
+                    }
+                } else if (abilityOwner.type === 'Identifier') {
+                    // e.g., user.ability - source is "user"
+                    sourceName = abilityOwner.name;
+                }
+
+                context.report({
+                    node,
+                    messageId: 'noDirectAbilityCheck',
+                    data: {
+                        source: sourceName,
+                        method: callee.property.name,
+                    },
+                });
+            },
+        };
+    },
+};

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -24,7 +24,7 @@
         "test:dev:nowatch": "TZ=UTC LANG=en_US.UTF-8 jest --config jest.config.dev.js --onlyChanged",
         "test:integration": "vitest run --config vitest.config.integration.ts",
         "test:integration:dev": "vitest run --config vitest.config.integration.ts --watch",
-        "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore",
+        "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore --rulesdir eslint-rules",
         "formatter": "oxfmt",
         "lint": "pnpm run linter ./src",
         "fix-lint": "pnpm run linter ./src --fix",

--- a/packages/backend/src/logging/auditLog.ts
+++ b/packages/backend/src/logging/auditLog.ts
@@ -5,7 +5,8 @@ export type AuditStatusType = 'allowed' | 'denied';
 
 export const AuditStatusSchema = z.enum(['allowed', 'denied']);
 
-export const AuditActorSchema = z.object({
+// Discriminated union for audit actors
+const BaseUserActorSchema = z.object({
     uuid: z.string(),
     firstName: z.string().optional(),
     lastName: z.string().optional(),
@@ -13,9 +14,44 @@ export const AuditActorSchema = z.object({
     organizationUuid: z.string(),
     organizationRole: z.string(),
     groupMemberships: z.array(z.string()).optional(),
+    impersonatedBy: z
+        .object({
+            uuid: z.string(),
+            email: z.string().optional(),
+            firstName: z.string().optional(),
+            lastName: z.string().optional(),
+            role: z.string(),
+        })
+        .optional(),
 });
 
+export const UserAuditActorSchema = BaseUserActorSchema.extend({
+    type: z.enum(['session', 'pat', 'oauth']),
+});
+
+export const ServiceAccountAuditActorSchema = BaseUserActorSchema.extend({
+    type: z.literal('service-account'),
+});
+
+export const AnonymousAuditActorSchema = z.object({
+    type: z.literal('anonymous'),
+    uuid: z.string(),
+    organizationUuid: z.string(),
+});
+
+export const AuditActorSchema = z.discriminatedUnion('type', [
+    UserAuditActorSchema,
+    ServiceAccountAuditActorSchema,
+    AnonymousAuditActorSchema,
+]);
+
 export type AuditActor = z.infer<typeof AuditActorSchema>;
+
+export type CallStackEntry = {
+    serviceName: string;
+    methodName: string;
+    depth: number;
+};
 
 export const AuditResourceSchema = z.object({
     type: z.string(),
@@ -35,6 +71,12 @@ export const AuditContextSchema = z.object({
 
 export type AuditContext = z.infer<typeof AuditContextSchema>;
 
+export const CallStackEntrySchema = z.object({
+    serviceName: z.string(),
+    methodName: z.string(),
+    depth: z.number(),
+});
+
 export const AuditLogEventSchema = z.object({
     id: z.string().default(() => uuidv4()),
     timestamp: z.string().default(() => new Date().toISOString()),
@@ -45,6 +87,7 @@ export const AuditLogEventSchema = z.object({
     status: AuditStatusSchema,
     reason: z.string().optional(),
     ruleConditions: z.string().optional(),
+    callStack: z.array(CallStackEntrySchema).optional(),
 });
 
 export type AuditLogEvent = z.infer<typeof AuditLogEventSchema>;
@@ -60,6 +103,7 @@ export const createAuditLogEvent = (
     status: AuditStatusType,
     reason?: string,
     ruleConditions?: string,
+    callStack?: CallStackEntry[],
 ): AuditLogEvent =>
     validateAuditLogEvent({
         actor,
@@ -69,4 +113,5 @@ export const createAuditLogEvent = (
         status,
         reason,
         ruleConditions,
+        callStack,
     });

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -1,18 +1,28 @@
 import { type Ability } from '@casl/ability';
 import type { Rule as CaslRule } from '@casl/ability/dist/types/Rule';
 import { Abilities, ForcedSubject } from '@casl/ability/dist/types/types';
-import { CaslSubjectNames, type SessionUser } from '@lightdash/common';
 import {
-    AuditActor,
-    AuditContext,
-    AuditResource,
-    AuditStatusType,
+    CaslSubjectNames,
+    type Account,
+    type AnonymousAccount,
+    type SessionUser,
+} from '@lightdash/common';
+import {
     createAuditLogEvent,
+    type AuditActor,
+    type AuditContext,
     type AuditLogEvent,
+    type AuditResource,
+    type AuditStatusType,
+    type CallStackEntry,
 } from './auditLog';
 
 export type AuditLogger = (event: AuditLogEvent) => void;
 
+/**
+ * @deprecated Use Account type directly with createAuditedAbility() in BaseService.
+ * Kept for backward compatibility during migration.
+ */
 export type AuditableUser = Pick<
     SessionUser,
     | 'userUuid'
@@ -23,7 +33,6 @@ export type AuditableUser = Pick<
     | 'role'
 >;
 
-// Todo: can we remove the & { properties } by improving typing of CaslSubjectNames?
 type AuditableCaslSubject = ForcedSubject<CaslSubjectNames> & {
     organizationUuid: string;
     uuid: string;
@@ -32,19 +41,79 @@ type AuditableCaslSubject = ForcedSubject<CaslSubjectNames> & {
 };
 
 type AuditHelperArgs = {
-    user: AuditableUser;
+    actor: AuditActor;
     action: string;
     subject: AuditableCaslSubject;
     ip?: string;
     userAgent?: string;
     requestId?: string;
     ruleConditions?: string;
+    callStack?: CallStackEntry[];
 };
 
 /**
- * Creates an audit actor from a user
+ * Creates an audit actor from an Account (discriminated union by auth type)
  */
-const createActorFromUser = (user: AuditableUser): AuditActor => ({
+export const createActorFromAccount = (account: Account): AuditActor => {
+    if (account.isAnonymousUser()) {
+        const anonAccount = account as AnonymousAccount;
+        return {
+            type: 'anonymous' as const,
+            uuid: anonAccount.user.id,
+            organizationUuid:
+                anonAccount.organization.organizationUuid || 'unknown',
+        };
+    }
+
+    if (account.isServiceAccount()) {
+        return {
+            type: 'service-account' as const,
+            uuid: account.user.id,
+            email: account.user.email || '',
+            organizationUuid:
+                account.organization.organizationUuid || 'unknown',
+            organizationRole:
+                'role' in account.user
+                    ? (account.user as { role?: string }).role || 'unknown'
+                    : 'unknown',
+        };
+    }
+
+    // Session, PAT, or OAuth users
+    const authType = account.authentication.type;
+    const actorType =
+        authType === 'session' || authType === 'pat' || authType === 'oauth'
+            ? authType
+            : 'session';
+
+    const user = account.user as {
+        userUuid?: string;
+        firstName?: string;
+        lastName?: string;
+        email?: string;
+        role?: string;
+        id: string;
+    };
+
+    return {
+        type: actorType,
+        uuid: user.userUuid || user.id,
+        email: user.email || '',
+        firstName: user.firstName || '',
+        lastName: user.lastName || '',
+        organizationUuid: account.organization.organizationUuid || 'unknown',
+        organizationRole: user.role || 'unknown',
+        // TODO: Add group memberships
+        groupMemberships: [],
+    };
+};
+
+/**
+ * Creates an audit actor from a SessionUser (legacy support)
+ * @deprecated Prefer createActorFromAccount with Account type
+ */
+export const createActorFromUser = (user: AuditableUser): AuditActor => ({
+    type: 'session' as const,
     uuid: user.userUuid,
     email: user.email || '',
     firstName: user.firstName || '',
@@ -61,7 +130,7 @@ const createResourceFromSubject = (
     type: subject.__caslSubjectType__ || 'unknown',
     uuid: subject.uuid,
     name: subject.name,
-    organizationUuid: subject.organizationUuid,
+    organizationUuid: subject.organizationUuid || 'unknown',
     projectUuid: subject.projectUuid,
 });
 
@@ -94,7 +163,7 @@ const extractRuleConditions = <A extends Abilities, C>(
 export class CaslAuditWrapper<T extends Ability> {
     private wrappedAbility: T;
 
-    private user: AuditableUser;
+    private actor: AuditActor;
 
     private ip?: string;
 
@@ -102,23 +171,33 @@ export class CaslAuditWrapper<T extends Ability> {
 
     private requestId?: string;
 
+    private callStack?: CallStackEntry[];
+
     private auditLogger: AuditLogger;
 
     constructor(
         ability: T,
-        user: AuditableUser,
+        actorSource: Account | AuditableUser,
         options?: {
             ip?: string;
             userAgent?: string;
             requestId?: string;
+            callStack?: CallStackEntry[];
             auditLogger?: AuditLogger;
         },
     ) {
         this.wrappedAbility = ability;
-        this.user = user;
+
+        if ('authentication' in actorSource) {
+            this.actor = createActorFromAccount(actorSource as Account);
+        } else {
+            this.actor = createActorFromUser(actorSource as AuditableUser);
+        }
+
         this.ip = options?.ip;
         this.userAgent = options?.userAgent;
         this.requestId = options?.requestId;
+        this.callStack = options?.callStack;
         this.auditLogger = options?.auditLogger || ((_event) => {});
     }
 
@@ -127,18 +206,18 @@ export class CaslAuditWrapper<T extends Ability> {
         status: AuditStatusType,
         reason?: string,
     ): void {
-        const actor = createActorFromUser(args.user);
         const resource = createResourceFromSubject(args.subject);
         const context = createContextFromArgs(args);
 
         const event = createAuditLogEvent(
-            actor,
+            args.actor,
             args.action,
             resource,
             context,
             status,
             reason,
             args.ruleConditions,
+            args.callStack,
         );
 
         this.auditLogger(event);
@@ -155,13 +234,14 @@ export class CaslAuditWrapper<T extends Ability> {
 
         this.logAbilityCheck(
             {
-                user: this.user,
+                actor: this.actor,
                 action,
                 subject,
                 ip: this.ip,
                 userAgent: this.userAgent,
                 requestId: this.requestId,
                 ruleConditions,
+                callStack: this.callStack,
             },
             result ? 'allowed' : 'denied',
             reason,
@@ -178,13 +258,14 @@ export class CaslAuditWrapper<T extends Ability> {
 
         this.logAbilityCheck(
             {
-                user: this.user,
+                actor: this.actor,
                 action,
                 subject,
                 ip: this.ip,
                 userAgent: this.userAgent,
                 requestId: this.requestId,
                 ruleConditions,
+                callStack: this.callStack,
             },
             result ? 'denied' : 'allowed',
             reason,

--- a/packages/backend/src/services/BaseService.ts
+++ b/packages/backend/src/services/BaseService.ts
@@ -1,4 +1,41 @@
+import { type Ability } from '@casl/ability';
+import { isAccount, type Account, type SessionUser } from '@lightdash/common';
+import type { CallStackEntry } from '../logging/auditLog';
+import { CaslAuditWrapper } from '../logging/caslAuditWrapper';
 import Logger from '../logging/logger';
+import { logAuditEvent } from '../logging/winston';
+
+const SKIP_METHODS = new Set(['createAuditedAbility', 'constructor']);
+
+/**
+ * Captures the service call stack from the current stack trace.
+ * Extracts up to `maxDepth` service method calls by looking for
+ * class methods on classes ending in "Service".
+ */
+const captureCallStack = (maxDepth: number = 10): CallStackEntry[] => {
+    const { stack } = new Error();
+    if (!stack) return [];
+
+    const entries: CallStackEntry[] = [];
+    const lines = stack.split('\n');
+
+    // eslint-disable-next-line no-restricted-syntax
+    for (const line of lines) {
+        if (entries.length >= maxDepth) break;
+
+        // Match patterns like "at ClassName.methodName" where ClassName ends with Service
+        const match = line.match(/at (\w*Service)\.(\w+)/);
+        if (match && !SKIP_METHODS.has(match[2])) {
+            entries.push({
+                serviceName: match[1],
+                methodName: match[2],
+                depth: entries.length,
+            });
+        }
+    }
+
+    return entries;
+};
 
 export abstract class BaseService {
     protected logger: typeof Logger;
@@ -28,5 +65,45 @@ export abstract class BaseService {
                 serviceName: serviceName ?? this.constructor.name,
                 ...(loggerParams ?? {}),
             });
+    }
+
+    /**
+     * Creates a CASL ability wrapper that automatically logs audit events
+     * for all permission checks (can/cannot).
+     *
+     * Use this instead of accessing `user.ability` or `account.user.ability` directly.
+     *
+     * @example
+     * ```typescript
+     * const ability = this.createAuditedAbility(account);
+     * if (ability.cannot('view', subject('Dashboard', dashboard))) {
+     *     throw new ForbiddenError();
+     * }
+     * ```
+     */
+    protected createAuditedAbility(
+        accountOrUser: Account | SessionUser,
+    ): CaslAuditWrapper<Ability> {
+        const callStack = captureCallStack();
+
+        if (isAccount(accountOrUser)) {
+            this.logger.debug('Creating audited ability', {
+                accountType: accountOrUser.authentication.type,
+            });
+            return new CaslAuditWrapper(
+                accountOrUser.user.ability,
+                accountOrUser,
+                { callStack, auditLogger: logAuditEvent },
+            );
+        }
+
+        // Legacy SessionUser type
+        this.logger.debug('Creating audited ability', {
+            accountType: 'session-user',
+        });
+        return new CaslAuditWrapper(accountOrUser.ability, accountOrUser, {
+            callStack,
+            auditLogger: logAuditEvent,
+        });
     }
 }

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -60,8 +60,7 @@ import {
 import { SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { getSchedulerTargetType } from '../../database/entities/scheduler';
-import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
-import { logAuditEvent } from '../../logging/winston';
+// CaslAuditWrapper is now used via this.createAuditedAbility() from BaseService
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { getChartFieldUsageChanges } from '../../models/CatalogModel/utils';
@@ -203,9 +202,7 @@ export class DashboardService
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const { organizationUuid, projectUuid } = dashboard;
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -258,9 +255,7 @@ export class DashboardService
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const { organizationUuid, projectUuid } = dashboard;
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -451,12 +446,13 @@ export class DashboardService
                 spaceUuids,
             );
 
+        const auditedAbility = this.createAuditedAbility(user);
         return dashboards.filter((dashboard) => {
             const spaceContext = spaceContexts[dashboard.spaceUuid];
             if (!spaceContext) return false;
-            const hasAbility = user.ability.can(
+            const hasAbility = auditedAbility.can(
                 'view',
-                subject('Dashboard', spaceContext),
+                subject('Dashboard', { ...spaceContext, uuid: dashboard.uuid }),
             );
             return includePrivate
                 ? hasAbility
@@ -487,10 +483,7 @@ export class DashboardService
             access,
         };
 
-        // TODO: normally this would be pre-constructed (perhaps in the Service Repository or on the user object when we create the CASL type)
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (auditedAbility.cannot('view', subject('Dashboard', dashboard))) {
             throw new ForbiddenError(
@@ -571,14 +564,16 @@ export class DashboardService
                 space.uuid,
             );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('Dashboard', {
                     organizationUuid: space.organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
+                    uuid: '',
                 }),
             )
         ) {
@@ -632,7 +627,8 @@ export class DashboardService
             access,
         };
 
-        if (user.ability.cannot('create', subject('Dashboard', dashboard))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (auditedAbility.cannot('create', subject('Dashboard', dashboard))) {
             throw new ForbiddenError(
                 "You don't have access to the space this dashboard belongs to",
             );
@@ -791,9 +787,13 @@ export class DashboardService
                 user.userUuid,
                 existingDashboardDao.spaceUuid,
             );
-        const canUpdateDashboardInCurrentSpace = user.ability.can(
+        const auditedAbility = this.createAuditedAbility(user);
+        const canUpdateDashboardInCurrentSpace = auditedAbility.can(
             'update',
-            subject('Dashboard', currentSpace),
+            subject('Dashboard', {
+                ...currentSpace,
+                uuid: existingDashboardDao.uuid,
+            }),
         );
 
         if (!canUpdateDashboardInCurrentSpace) {
@@ -809,9 +809,12 @@ export class DashboardService
                         user.userUuid,
                         dashboard.spaceUuid,
                     );
-                const canUpdateDashboardInNewSpace = user.ability.can(
+                const canUpdateDashboardInNewSpace = auditedAbility.can(
                     'update',
-                    subject('Dashboard', newSpace),
+                    subject('Dashboard', {
+                        ...newSpace,
+                        uuid: existingDashboardDao.uuid,
+                    }),
                 );
                 if (!canUpdateDashboardInNewSpace) {
                     throw new ForbiddenError(
@@ -1008,17 +1011,25 @@ export class DashboardService
 
         const { projectUuid, organizationUuid, pinnedListUuid, spaceUuid } =
             existingDashboard;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('PinnedItems', { projectUuid, organizationUuid }),
+                subject('PinnedItems', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: existingDashboard.uuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
         }
 
         if (
-            user.ability.cannot('view', subject('Dashboard', existingDashboard))
+            auditedAbility.cannot(
+                'view',
+                subject('Dashboard', existingDashboard),
+            )
         ) {
             throw new ForbiddenError(
                 "You don't have access to the space this dashboard belongs to",
@@ -1068,6 +1079,7 @@ export class DashboardService
         projectUuid: string,
         dashboards: UpdateMultipleDashboards[],
     ): Promise<Dashboard[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         const userHasAccessToDashboards = await Promise.all(
             dashboards.map(async (dashboardToUpdate) => {
                 const dashboard = await this.dashboardModel.getByIdOrSlug(
@@ -1078,18 +1090,24 @@ export class DashboardService
                         user.userUuid,
                         dashboard.spaceUuid,
                     );
-                const canUpdateDashboardInCurrentSpace = user.ability.can(
+                const canUpdateDashboardInCurrentSpace = auditedAbility.can(
                     'update',
-                    subject('Dashboard', currentSpaceContext),
+                    subject('Dashboard', {
+                        ...currentSpaceContext,
+                        uuid: dashboard.uuid,
+                    }),
                 );
                 const newSpaceContext =
                     await this.spacePermissionService.getSpaceAccessContext(
                         user.userUuid,
                         dashboardToUpdate.spaceUuid,
                     );
-                const canUpdateDashboardInNewSpace = user.ability.can(
+                const canUpdateDashboardInNewSpace = auditedAbility.can(
                     'update',
-                    subject('Dashboard', newSpaceContext),
+                    subject('Dashboard', {
+                        ...newSpaceContext,
+                        uuid: dashboardToUpdate.uuid,
+                    }),
                 );
                 return (
                     canUpdateDashboardInCurrentSpace &&
@@ -1157,14 +1175,16 @@ export class DashboardService
                     user.userUuid,
                     spaceUuid,
                 );
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'delete',
                     subject('Dashboard', {
                         organizationUuid,
                         projectUuid,
                         inheritsFromOrgOrProject,
                         access,
+                        uuid: dashboardUuid,
                     }),
                 )
             ) {
@@ -1258,14 +1278,16 @@ export class DashboardService
                     user.userUuid,
                     dashboard.spaceUuid,
                 );
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'delete',
                     subject('Dashboard', {
                         organizationUuid: dashboard.organizationUuid,
                         projectUuid: dashboard.projectUuid,
                         inheritsFromOrgOrProject,
                         access,
+                        uuid: dashboardUuid,
                     }),
                 )
             ) {
@@ -1302,12 +1324,14 @@ export class DashboardService
         );
 
         if (!options?.bypassPermissions) {
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('DeletedContent', {
                         organizationUuid: dashboard.organizationUuid,
                         projectUuid: dashboard.projectUuid,
+                        uuid: dashboardUuid,
                     }),
                 )
             ) {
@@ -1347,12 +1371,14 @@ export class DashboardService
                 dashboardUuid,
                 { deleted: true },
             );
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('DeletedContent', {
                         organizationUuid: dashboard.organizationUuid,
                         projectUuid: dashboard.projectUuid,
+                        uuid: dashboardUuid,
                     }),
                 )
             ) {
@@ -1483,18 +1509,20 @@ export class DashboardService
             access,
         };
         const { organizationUuid, projectUuid } = dashboard;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
+                    uuid: '',
                 }),
             )
         ) {
             throw new ForbiddenError();
         }
-        if (user.ability.cannot('view', subject('Dashboard', dashboard))) {
+        if (auditedAbility.cannot('view', subject('Dashboard', dashboard))) {
             throw new ForbiddenError(
                 "You don't have access to the space this dashboard belongs to",
             );
@@ -1525,13 +1553,15 @@ export class DashboardService
                 dashboard.spaceUuid,
             );
 
-        const isActorAllowedToPerformAction = actor.user.ability.can(
+        const auditedAbility = this.createAuditedAbility(actor.user);
+        const isActorAllowedToPerformAction = auditedAbility.can(
             action,
             subject('Dashboard', {
-                organizationUuid: actor.user.organizationUuid,
+                organizationUuid: actor.user.organizationUuid || '',
                 projectUuid: actor.projectUuid,
                 inheritsFromOrgOrProject,
                 access,
+                uuid: dashboard.uuid,
             }),
         );
 
@@ -1548,17 +1578,16 @@ export class DashboardService
                     resource.spaceUuid,
                 );
 
-            const isActorAllowedToPerformActionInNewSpace =
-                actor.user.ability.can(
-                    action,
-                    subject('Dashboard', {
-                        organizationUuid: newSpace.organizationUuid,
-                        projectUuid: actor.projectUuid,
-                        inheritsFromOrgOrProject:
-                            newSpace.inheritsFromOrgOrProject,
-                        access: newSpace.access,
-                    }),
-                );
+            const isActorAllowedToPerformActionInNewSpace = auditedAbility.can(
+                action,
+                subject('Dashboard', {
+                    organizationUuid: newSpace.organizationUuid,
+                    projectUuid: actor.projectUuid,
+                    inheritsFromOrgOrProject: newSpace.inheritsFromOrgOrProject,
+                    access: newSpace.access,
+                    uuid: dashboard.uuid,
+                }),
+            );
 
             if (!isActorAllowedToPerformActionInNewSpace) {
                 throw new ForbiddenError(
@@ -1579,8 +1608,9 @@ export class DashboardService
                 user.userUuid,
                 dashboardDao.spaceUuid,
             );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Dashboard', {
                     ...dashboardDao,
@@ -1622,8 +1652,9 @@ export class DashboardService
                 user.userUuid,
                 dashboardDao.spaceUuid,
             );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
                     ...dashboardDao,
@@ -1763,8 +1794,9 @@ export class DashboardService
                 user.userUuid,
                 dashboardDao.spaceUuid,
             );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Dashboard', {
                     ...dashboardDao,

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -11,6 +11,7 @@ import {
     type IntrinsicUserAttributes,
     type LightdashSessionUser,
     type LightdashUser,
+    type SessionUser,
 } from './user';
 import { type UserAttributeValueMap } from './userAttributes';
 
@@ -205,6 +206,12 @@ export function assertSessionAuth(
             `${account?.authentication.type} Account is not session auth`,
         );
     }
+}
+
+export function isAccount(
+    accountOrUser: Account | SessionUser,
+): accountOrUser is Account {
+    return 'authentication' in accountOrUser;
 }
 
 export function isJwtUser(account?: Account): account is AnonymousAccount {


### PR DESCRIPTION
Closes: SPK-337

## Summary
- Update `AuditActor` schema with discriminated union: User (`session`/`pat`/`oauth`), ServiceAccount, Anonymous
- Add `callStack` field to `AuditLogEvent` for compliance tracing
- Update `CaslAuditWrapper` to accept `Account` type (backward compatible with `SessionUser`)
- Add `createAuditedAbility()` helper to `BaseService` — standardized way to create audited ability wrappers
- Create ESLint custom rule `no-direct-ability-check` as warning
- Migrate `DashboardService` as reference implementation (all 20 ability checks)
- Add `docs/audit-logging.md` architecture documentation

## Demo

<img width="1422" height="1396" alt="CleanShot 2026-04-02 at 10 56 33@2x" src="https://github.com/user-attachments/assets/6f27454c-6925-4844-a105-f002efaa1c76" />


## Force e2e tests

test-frontend


## Test plan
- [x] `pnpm -F backend typecheck` passes
- [x] `pnpm -F backend test:dev:nowatch` — 850 tests pass
- [x] ESLint rule detects violations on unmigrated services
- [x] ESLint rule passes clean on migrated DashboardService