### PR TITLE
feat: migrate all services to audited ability checks

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -33,6 +33,7 @@ export class AiAgentAdminService {
             user.ability.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                 }),
             )

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -336,6 +336,7 @@ export class AiAgentService {
             user.ability.can(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid: agent.organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -400,6 +401,7 @@ export class AiAgentService {
             user.ability.can(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid: agent.organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -736,6 +738,7 @@ export class AiAgentService {
             user.ability.can(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -1039,6 +1042,7 @@ export class AiAgentService {
             user.ability.cannot(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: body.projectUuid,
                 }),
@@ -1098,6 +1102,7 @@ export class AiAgentService {
             user.ability.cannot(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -1161,6 +1166,7 @@ export class AiAgentService {
             user.ability.cannot(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -1298,6 +1304,7 @@ export class AiAgentService {
             const canManageAgent = user.ability.can(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                     projectUuid: prompt.projectUuid,
                 }),
@@ -1341,6 +1348,7 @@ export class AiAgentService {
             const canManageAgent = user.ability.can(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                     projectUuid: prompt.projectUuid,
                 }),
@@ -1417,6 +1425,7 @@ export class AiAgentService {
             user.ability.cannot(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                     projectUuid,
                 }),
@@ -1928,6 +1937,7 @@ export class AiAgentService {
             user.ability.cannot(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -2119,6 +2129,7 @@ export class AiAgentService {
             user.ability.cannot(
                 'view',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -3325,6 +3336,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         const canManageAgent = user.ability.can(
             'manage',
             subject('AiAgent', {
+                uuid: '',
                 organizationUuid: slackPrompt.organizationUuid,
                 projectUuid: slackPrompt.projectUuid,
             }),

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -46,6 +46,7 @@ export class AiOrganizationSettingsService {
             user.ability.cannot(
                 'manage',
                 subject('AiAgent', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                 }),
             )

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -828,11 +828,13 @@ export class AppGenerateService extends BaseService {
         prompt: string,
     ): Promise<GenerateAppResult> {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )
@@ -960,11 +962,13 @@ export class AppGenerateService extends BaseService {
         prompt: string,
     ): Promise<GenerateAppResult> {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )
@@ -1092,11 +1096,13 @@ export class AppGenerateService extends BaseService {
         hasMore: boolean;
     }> {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )
@@ -1351,11 +1357,13 @@ export class AppGenerateService extends BaseService {
         version: number,
     ): string {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -54,6 +54,7 @@ import {
     RunQueryTags,
     SavedChartsInfoForDashboardAvailableFilters,
     SessionAccount,
+    SessionUser,
     SortField,
     UpdateEmbed,
     UserAccessControls,
@@ -158,10 +159,12 @@ export class EmbedService extends BaseService {
             userUuid: user.userUuid,
             organizationUuid,
         });
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -201,10 +204,14 @@ export class EmbedService extends BaseService {
             userUuid: user.userUuid,
             organizationUuid,
         });
+        const auditedAbility = this.createAuditedAbility(
+            user as unknown as SessionUser,
+        );
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -233,10 +240,14 @@ export class EmbedService extends BaseService {
             userUuid: user.userUuid,
             organizationUuid,
         });
+        const auditedAbility = this.createAuditedAbility(
+            user as unknown as SessionUser,
+        );
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -275,10 +286,12 @@ export class EmbedService extends BaseService {
             userUuid: user.userUuid,
             organizationUuid,
         });
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -311,10 +324,12 @@ export class EmbedService extends BaseService {
             organizationUuid,
         });
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -719,10 +719,12 @@ export class McpService extends BaseService {
                     account,
                 );
 
+                const auditedAbility = this.createAuditedAbility(user);
                 if (
-                    user.ability.cannot(
+                    auditedAbility.cannot(
                         'view',
                         subject('Project', {
+                            uuid: '',
                             projectUuid: args.projectUuid,
                             organizationUuid: project.organizationUuid,
                         }),
@@ -1923,10 +1925,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: '',
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -2024,10 +2028,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: '',
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -2099,10 +2105,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: '',
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -2167,10 +2175,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: '',
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -2228,10 +2238,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: '',
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),

--- a/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
+++ b/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
@@ -43,16 +43,17 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         this.userModel = userModel;
     }
 
-    // eslint-disable-next-line class-methods-use-this
     private canManage(account: Account) {
         const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('User must be in an organization');
         }
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('OrganizationWarehouseCredentials', {
+                    uuid: '',
                     organizationUuid,
                 }),
             )
@@ -86,10 +87,12 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
             throw new ForbiddenError('User must be in an organization');
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('OrganizationWarehouseCredentials', {
+                    uuid: '',
                     organizationUuid,
                 }),
             )

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -120,12 +120,14 @@ export class ScimService extends BaseService {
         this.openIdIdentityModel = openIdIdentityModel;
     }
 
-    private static throwForbiddenErrorOnNoPermission(user: SessionUser) {
+    private throwForbiddenErrorOnNoPermission(user: SessionUser) {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -56,12 +56,14 @@ export class ServiceAccountService extends BaseService {
         this.commercialFeatureFlagModel = commercialFeatureFlagModel;
     }
 
-    private static throwForbiddenErrorOnNoPermission(user: SessionUser) {
+    private throwForbiddenErrorOnNoPermission(user: SessionUser) {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -79,7 +81,7 @@ export class ServiceAccountService extends BaseService {
         prefix?: string;
     }): Promise<ServiceAccount> {
         try {
-            ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+            this.throwForbiddenErrorOnNoPermission(user);
             const token = await this.serviceAccountModel.create({
                 user,
                 data: {
@@ -120,7 +122,7 @@ export class ServiceAccountService extends BaseService {
         tokenUuid: string;
     }): Promise<void> {
         try {
-            ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+            this.throwForbiddenErrorOnNoPermission(user);
             const organizationUuid = user.organizationUuid as string;
             // get by uuid to check if token exists
             const token =
@@ -171,7 +173,7 @@ export class ServiceAccountService extends BaseService {
         update: { expiresAt: Date };
         prefix?: string;
     }): Promise<ServiceAccountWithToken> {
-        ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+        this.throwForbiddenErrorOnNoPermission(user);
 
         if (update.expiresAt.getTime() < Date.now()) {
             throw new ParameterError('Expire time must be in the future');
@@ -225,7 +227,7 @@ export class ServiceAccountService extends BaseService {
         user: SessionUser;
         tokenUuid: string;
     }): Promise<ServiceAccount> {
-        ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+        this.throwForbiddenErrorOnNoPermission(user);
 
         // get by uuid to check if token exists
         const existingToken =
@@ -245,7 +247,7 @@ export class ServiceAccountService extends BaseService {
         scopes: ServiceAccountScope[],
     ): Promise<ServiceAccount[]> {
         try {
-            ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+            this.throwForbiddenErrorOnNoPermission(user);
             const organizationUuid = user.organizationUuid as string;
             const tokens = await this.serviceAccountModel.getAllForOrganization(
                 organizationUuid,

--- a/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
+++ b/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
@@ -53,12 +53,14 @@ export class AnalyticsService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = await this.projectModel.get(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -90,11 +92,13 @@ export class AnalyticsService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = await this.projectModel.get(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -140,12 +144,14 @@ export class AnalyticsService extends BaseService {
         projectUuid: string,
         account: Account,
     ): Promise<UnusedContent> {
+        const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = await this.projectModel.get(projectUuid);
 
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -287,6 +287,7 @@ export class AsyncQueryService extends ProjectService {
         account: Account,
         action: 'view' | 'create' | 'update' | 'delete' | 'manage',
         savedChart: {
+            uuid?: string;
             project: Pick<Project, 'projectUuid'>;
             organization: Pick<Organization, 'organizationUuid'>;
             space: Pick<SpaceSummaryBase, 'uuid'>;
@@ -297,14 +298,16 @@ export class AsyncQueryService extends ProjectService {
             savedChart.space.uuid,
         );
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 action,
                 subject('SavedChart', {
                     organizationUuid: savedChart.organization.organizationUuid,
                     projectUuid: savedChart.project.projectUuid,
                     inheritsFromOrgOrProject: ctx.inheritsFromOrgOrProject,
                     access: ctx.access,
+                    uuid: '',
                 }),
             )
         ) {
@@ -470,10 +473,15 @@ export class AsyncQueryService extends ProjectService {
     }): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -576,20 +584,23 @@ export class AsyncQueryService extends ProjectService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(account);
         const isForbidden =
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             ) &&
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Explore', {
                     organizationUuid,
                     projectUuid,
                     exploreNames: [queryHistory.metricQuery.exploreName],
+                    uuid: projectUuid,
                 }),
             );
 
@@ -795,10 +806,15 @@ export class AsyncQueryService extends ProjectService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -895,12 +911,14 @@ export class AsyncQueryService extends ProjectService {
 
         const { organizationUuid } = account.organization;
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid: payload.projectUuid,
+                    uuid: payload.projectUuid,
                 }),
             )
         ) {
@@ -951,10 +969,15 @@ export class AsyncQueryService extends ProjectService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -2664,20 +2687,23 @@ export class AsyncQueryService extends ProjectService {
 
                     const { organizationUuid } =
                         await this.projectModel.getSummary(projectUuid);
+                    const auditedAbility = this.createAuditedAbility(account);
                     const isForbidden =
-                        account.user.ability.cannot(
+                        auditedAbility.cannot(
                             'view',
                             subject('Project', {
                                 organizationUuid,
                                 projectUuid,
+                                uuid: projectUuid,
                             }),
                         ) &&
-                        account.user.ability.cannot(
+                        auditedAbility.cannot(
                             'view',
                             subject('Explore', {
                                 organizationUuid,
                                 projectUuid,
                                 exploreNames: [explore.name],
+                                uuid: projectUuid,
                             }),
                         );
 
@@ -3195,12 +3221,14 @@ export class AsyncQueryService extends ProjectService {
         // on condition checks that aren't set. If no `exploreName` is set in conditions,
         // CASL ignores it.
 
-        const isForbidden = account.user.ability.cannot(
+        const auditedAbility = this.createAuditedAbility(account);
+        const isForbidden = auditedAbility.cannot(
             'view',
             subject('Explore', {
                 organizationUuid,
                 projectUuid,
                 exploreNames: [metricQuery.exploreName],
+                uuid: projectUuid,
             }),
         );
         if (isForbidden) {
@@ -3209,9 +3237,13 @@ export class AsyncQueryService extends ProjectService {
 
         if (
             metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -3412,22 +3444,25 @@ export class AsyncQueryService extends ProjectService {
             inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
                     organizationUuid: savedChartOrganizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
+                    uuid: savedChart.uuid || '',
                 }),
             ) ||
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid: savedChartOrganizationUuid,
                     projectUuid,
                     exploreNames: [savedChartTableName],
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -3596,6 +3631,7 @@ export class AsyncQueryService extends ProjectService {
         savedChartUuid: string,
         space: SpaceSummaryBase,
     ) {
+        const auditedAbility = this.createAuditedAbility(account);
         if (isJwtUser(account)) {
             await this.permissionsService.checkEmbedPermissions(
                 account,
@@ -3608,13 +3644,14 @@ export class AsyncQueryService extends ProjectService {
             );
 
             if (
-                account.user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
                     subject('SavedChart', {
                         organizationUuid: space.organizationUuid,
                         projectUuid,
                         inheritsFromOrgOrProject: ctx.inheritsFromOrgOrProject,
                         access: ctx.access,
+                        uuid: savedChartUuid,
                     }),
                 )
             ) {
@@ -3623,11 +3660,12 @@ export class AsyncQueryService extends ProjectService {
         }
 
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid: space.organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -3911,10 +3949,15 @@ export class AsyncQueryService extends ProjectService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('UnderlyingData', { organizationUuid, projectUuid }),
+                subject('UnderlyingData', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -4175,12 +4218,14 @@ export class AsyncQueryService extends ProjectService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SqlRunner', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -4946,12 +4991,14 @@ export class AsyncQueryService extends ProjectService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -695,10 +695,15 @@ export class CatalogService<
     ): Promise<KnexPaginatedData<(CatalogField | CatalogTable)[]>> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -751,10 +756,15 @@ export class CatalogService<
         // to make this request more lightweight
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -832,10 +842,15 @@ export class CatalogService<
     ): Promise<CatalogAnalytics> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -871,10 +886,15 @@ export class CatalogService<
         fieldId: string,
     ): Promise<CatalogAnalytics> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid: organizationUuid || '',
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -919,10 +939,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1027,12 +1052,14 @@ export class CatalogService<
         const { organizationUuid: tagOrganizationUuid } =
             await this.projectModel.getSummary(tag.projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Tags', {
                     projectUuid: tag.projectUuid,
                     organizationUuid: tagOrganizationUuid,
+                    uuid: tag.projectUuid,
                 }),
             )
         ) {
@@ -1072,12 +1099,14 @@ export class CatalogService<
         const { organizationUuid: tagOrganizationUuid } =
             await this.projectModel.getSummary(tag.projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Tags', {
                     projectUuid: tag.projectUuid,
                     organizationUuid: tagOrganizationUuid,
+                    uuid: tag.projectUuid,
                 }),
             )
         ) {
@@ -1096,13 +1125,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 // NOTE: being able to manage tags that the user can customise catalog items
                 subject('Tags', {
                     projectUuid,
                     organizationUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -1136,10 +1167,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1276,10 +1312,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1292,10 +1333,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1358,10 +1404,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1389,10 +1440,15 @@ export class CatalogService<
     ): Promise<MetricWithAssociatedTimeDimension[]> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1448,10 +1504,15 @@ export class CatalogService<
     ): Promise<KnexPaginatedData<CatalogField[]>> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1516,10 +1577,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1566,10 +1632,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1615,10 +1686,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1642,10 +1718,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1662,10 +1743,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1684,10 +1770,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1704,10 +1795,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1729,10 +1825,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1765,10 +1866,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1790,10 +1896,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1813,10 +1924,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1834,10 +1950,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1878,10 +1999,15 @@ export class CatalogService<
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(

--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -34,12 +34,14 @@ export class ChangesetService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<ChangesetWithChanges | undefined> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
+                    uuid: '',
                     projectUuid,
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -58,12 +60,14 @@ export class ChangesetService extends BaseService {
         projectUuid: string,
         changeUuid: string,
     ): Promise<Change> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
+                    uuid: '',
                     projectUuid,
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -80,12 +84,14 @@ export class ChangesetService extends BaseService {
         projectUuid: string,
         changeUuid: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
+                    uuid: '',
                     projectUuid,
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -130,12 +136,14 @@ export class ChangesetService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
+                    uuid: '',
                     projectUuid,
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -566,10 +566,12 @@ export class CoderService extends BaseService {
         content: T[],
         spaces: SpaceSummaryBase[],
     ): Promise<T[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.can(
+            auditedAbility.can(
                 'manage',
                 subject('Project', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -608,10 +610,12 @@ export class CoderService extends BaseService {
             throw new NotFoundError(`Project ${projectUuid} not found`);
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -745,10 +749,12 @@ export class CoderService extends BaseService {
         }
 
         // Filter charts based on user permissions (from private spaces)
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -880,10 +886,12 @@ export class CoderService extends BaseService {
             throw new NotFoundError(`Project ${projectUuid} not found`);
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -998,12 +1006,14 @@ export class CoderService extends BaseService {
         force?: boolean,
         spaceNames?: Record<string, string>,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -1201,12 +1211,14 @@ export class CoderService extends BaseService {
         force?: boolean,
         spaceNames?: Record<string, string>,
     ): Promise<PromotionChanges> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -1487,12 +1499,14 @@ export class CoderService extends BaseService {
         force?: boolean,
         spaceNames?: Record<string, string>,
     ): Promise<PromotionChanges> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -155,13 +155,15 @@ export class CommentService extends BaseService {
     ): Promise<string> {
         await this.isFeatureEnabled(user);
 
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('DashboardComments', {
+                    uuid: '',
                     projectUuid: dashboard.projectUuid,
                     organizationUuid: dashboard.organizationUuid,
                 }),
@@ -218,6 +220,7 @@ export class CommentService extends BaseService {
     ): Promise<Record<string, Comment[]>> {
         await this.isFeatureEnabled(user);
 
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
             {
@@ -226,9 +229,10 @@ export class CommentService extends BaseService {
         );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('DashboardComments', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),
@@ -243,9 +247,10 @@ export class CommentService extends BaseService {
             );
         }
 
-        const canUserRemoveAnyComment = user.ability.can(
+        const canUserRemoveAnyComment = auditedAbility.can(
             'manage',
             subject('DashboardComments', {
+                uuid: '',
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
             }),
@@ -265,12 +270,14 @@ export class CommentService extends BaseService {
     ): Promise<void> {
         await this.isFeatureEnabled(user);
 
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DashboardComments', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),
@@ -309,6 +316,7 @@ export class CommentService extends BaseService {
     ): Promise<void> {
         await this.isFeatureEnabled(user);
 
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
 
@@ -318,9 +326,10 @@ export class CommentService extends BaseService {
             );
         }
 
-        const canRemoveAnyComment = user.ability.can(
+        const canRemoveAnyComment = auditedAbility.can(
             'manage',
             subject('DashboardComments', {
+                uuid: '',
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
             }),

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -86,6 +86,7 @@ export class ContentService extends BaseService {
         queryArgs: ContentArgs,
         paginateArgs: KnexPaginateArgs,
     ): Promise<KnexPaginatedData<SummaryContent[]>> {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');
@@ -101,9 +102,10 @@ export class ContentService extends BaseService {
             )
         )
             .filter((project) =>
-                user.ability.can(
+                auditedAbility.can(
                     'view',
                     subject('Project', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: project.projectUuid,
                     }),
@@ -201,12 +203,13 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -291,12 +294,13 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -360,6 +364,7 @@ export class ContentService extends BaseService {
         filters: DeletedContentFilters,
         paginateArgs?: KnexPaginateArgs,
     ): Promise<KnexPaginatedData<DeletedContentWithDescendants[]>> {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');
@@ -372,18 +377,22 @@ export class ContentService extends BaseService {
 
         // Check project access
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
         }
 
         // Non-admins can only see their own deleted content
-        const isAdmin = user.ability.can(
+        const isAdmin = auditedAbility.can(
             'manage',
-            subject('DeletedContent', { organizationUuid, projectUuid }),
+            subject('DeletedContent', {
+                uuid: '',
+                organizationUuid,
+                projectUuid,
+            }),
         );
         const deletedByUserUuids = isAdmin
             ? filters.deletedByUserUuids
@@ -418,12 +427,13 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -463,12 +473,13 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ContentVerificationService.ts
+++ b/packages/backend/src/services/ContentVerificationService.ts
@@ -5,8 +5,6 @@ import {
     type SessionUser,
     type VerifiedContentListItem,
 } from '@lightdash/common';
-import { CaslAuditWrapper } from '../logging/caslAuditWrapper';
-import { logAuditEvent } from '../logging/winston';
 import { ContentVerificationModel } from '../models/ContentVerificationModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
 import { BaseService } from './BaseService';
@@ -55,9 +53,7 @@ export class ContentVerificationService extends BaseService {
         await this.assertContentVerificationEnabled(user);
         const project = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -606,12 +606,14 @@ export class CsvService extends BaseService {
         selectedTabs: string[] | null,
         dateZoomGranularity?: DateGranularity | string,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ExportCsv', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -64,12 +64,14 @@ export class DeployService extends BaseService {
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         // manage:DeployProject for non-preview projects (restrictable via custom roles)
         // manage:DeployProject@self for preview projects created by the user
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DeployProject', {
+                    uuid: '',
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                     type: project.type,

--- a/packages/backend/src/services/FavoritesService/FavoritesService.ts
+++ b/packages/backend/src/services/FavoritesService/FavoritesService.ts
@@ -68,8 +68,14 @@ export class FavoritesService extends BaseService {
         contentType: ContentType,
         contentUuid: string,
     ): Promise<ToggleFavoriteResponse> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -151,8 +157,14 @@ export class FavoritesService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<FavoriteItems> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 

--- a/packages/backend/src/services/FunnelService/FunnelService.ts
+++ b/packages/backend/src/services/FunnelService/FunnelService.ts
@@ -73,13 +73,18 @@ export class FunnelService extends BaseService {
             throw new ForbiddenError('Funnel Builder feature is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('SqlRunner', { organizationUuid, projectUuid }),
+                subject('SqlRunner', {
+                    uuid: '',
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -65,13 +65,15 @@ export class GdriveService extends BaseService {
         user: SessionUser,
         gsheetOptions: UploadMetricGsheet,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const projectSummary = await this.projectModel.getSummary(
             gsheetOptions.projectUuid,
         );
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ExportCsv', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
                 }),
@@ -81,9 +83,10 @@ export class GdriveService extends BaseService {
         }
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('GoogleSheets', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
                 }),
@@ -96,9 +99,10 @@ export class GdriveService extends BaseService {
             gsheetOptions.metricQuery.customDimensions?.some(
                 isCustomSqlDimension,
             ) &&
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('CustomSql', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
                 }),

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -586,10 +586,12 @@ Affected charts:
 
         if (fields.length === 0) throw new ParseError(`Missing ${typeName}s`);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('CustomSql', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -938,10 +940,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         exploreName: string,
     ): Promise<{ content: string; sha: string; filePath: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1010,10 +1014,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         exploreName: string,
     ): Promise<{ filePath: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1054,11 +1060,13 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         prTitle: string,
         prDescription: string,
     ): Promise<PullRequestCreated> {
+        const auditedAbility = this.createAuditedAbility(user);
         // PR creates its own feature branch, so always allow (isProtectedBranch: false)
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,
@@ -1222,10 +1230,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         user: SessionUser,
         projectUuid: string,
     ): Promise<GitBranch[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1270,10 +1280,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         branch: string,
         path?: string,
     ): Promise<GitFileOrDirectory> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1356,13 +1368,15 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         sha?: string,
         message?: string,
     ): Promise<{ sha: string; path: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         const protectedBranch = await this.getProtectedBranch(projectUuid);
         const isProtectedBranch = branch === protectedBranch;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch,
@@ -1454,13 +1468,15 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         sha: string,
         message?: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const protectedBranch = await this.getProtectedBranch(projectUuid);
         const isProtectedBranch = branch === protectedBranch;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch,
@@ -1507,10 +1523,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         branchName: string,
         sourceBranch: string,
     ): Promise<GitBranch> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,
@@ -1577,10 +1595,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         title: string,
         description: string,
     ): Promise<PullRequestCreated> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,

--- a/packages/backend/src/services/GithubAppService/GithubAppService.ts
+++ b/packages/backend/src/services/GithubAppService/GithubAppService.ts
@@ -207,13 +207,15 @@ export class GithubAppService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         // This endpoint is also used for developers on projects
         // when using the sql runner, so we should allow access
         // However github app is an organization property, so we can't check projects
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                 }),
             )
@@ -236,10 +238,12 @@ export class GithubAppService extends BaseService {
         if (!user || !isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                 }),
             )
@@ -327,10 +331,12 @@ export class GithubAppService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('GitIntegration', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/GitlabAppService/GitlabAppService.ts
+++ b/packages/backend/src/services/GitlabAppService/GitlabAppService.ts
@@ -177,15 +177,16 @@ export class GitlabAppService extends BaseService {
         }
     }
 
-    // eslint-disable-next-line class-methods-use-this
     private canManageOrg(user: SessionUser) {
         if (!isUserWithOrg(user)) {
             throw new Error('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            !user.ability.can(
+            !auditedAbility.can(
                 'manage',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -61,11 +61,13 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(member.groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: member.groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -104,11 +106,13 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(member.groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: member.groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -143,11 +147,13 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'delete',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -176,6 +182,7 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group =
             includeMembers === undefined
                 ? await this.groupsModel.getGroup(groupUuid)
@@ -186,9 +193,10 @@ export class GroupsService extends BaseService {
                   );
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -207,11 +215,13 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -246,11 +256,13 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroupWithMembers(groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -268,13 +280,15 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -283,9 +297,10 @@ export class GroupsService extends BaseService {
         }
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
             )
@@ -321,13 +336,15 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -336,9 +353,10 @@ export class GroupsService extends BaseService {
         }
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
             )
@@ -370,13 +388,15 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
                 }),
             )
@@ -385,9 +405,10 @@ export class GroupsService extends BaseService {
         }
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/OAuthService/OAuthService.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.ts
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     NotFoundError,
@@ -128,8 +129,15 @@ export class OAuthService extends BaseService {
     }
 
     public async listClients(user: SessionUser): Promise<OAuthClientSummary[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot('manage', 'Organization') ||
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            ) ||
             !user.organizationUuid
         ) {
             throw new ForbiddenError(
@@ -149,8 +157,15 @@ export class OAuthService extends BaseService {
             redirectUris: string[];
         },
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot('manage', 'Organization') ||
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            ) ||
             !user.organizationUuid
         ) {
             throw new ForbiddenError(
@@ -186,8 +201,15 @@ export class OAuthService extends BaseService {
             redirectUris: string[];
         },
     ): Promise<OAuthClientSummary> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot('manage', 'Organization') ||
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            ) ||
             !user.organizationUuid
         ) {
             throw new ForbiddenError(
@@ -219,8 +241,15 @@ export class OAuthService extends BaseService {
         user: SessionUser,
         clientId: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot('manage', 'Organization') ||
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            ) ||
             !user.organizationUuid
         ) {
             throw new ForbiddenError(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -169,10 +169,14 @@ export class OrganizationService extends BaseService {
 
     async delete(organizationUuid: string, user: SessionUser): Promise<void> {
         const organization = await this.organizationModel.get(organizationUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'delete',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    organizationUuid,
+                    uuid: organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -229,10 +233,14 @@ export class OrganizationService extends BaseService {
     ): Promise<KnexPaginatedData<OrganizationMemberProfile[]>> {
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('OrganizationMemberProfile', { organizationUuid }),
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -257,9 +265,12 @@ export class OrganizationService extends BaseService {
               });
 
         let members = organizationMembers.filter((member) =>
-            user.ability.can(
+            auditedAbility.can(
                 'view',
-                subject('OrganizationMemberProfile', member),
+                subject('OrganizationMemberProfile', {
+                    ...member,
+                    uuid: member.userUuid,
+                }),
             ),
         );
 
@@ -310,12 +321,14 @@ export class OrganizationService extends BaseService {
                 this.projectModel.getAllByOrganizationUuid(organizationUuid),
         );
 
+        const auditedAbility = this.createAuditedAbility(account);
         return projects.filter((project) =>
-            account.user.ability.can(
+            auditedAbility.can(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid: project.projectUuid,
+                    uuid: project.projectUuid,
                 }),
             ),
         );
@@ -347,9 +360,16 @@ export class OrganizationService extends BaseService {
         memberUuid: string,
     ): Promise<OrganizationMemberProfile> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             organizationUuid === undefined ||
-            user.ability.cannot('view', 'OrganizationMemberProfile')
+            auditedAbility.cannot(
+                'view',
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -359,9 +379,12 @@ export class OrganizationService extends BaseService {
                 memberUuid,
             );
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('OrganizationMemberProfile', member),
+                subject('OrganizationMemberProfile', {
+                    ...member,
+                    uuid: member.userUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -374,9 +397,16 @@ export class OrganizationService extends BaseService {
         email: string,
     ): Promise<OrganizationMemberProfile> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             organizationUuid === undefined ||
-            user.ability.cannot('view', 'OrganizationMemberProfile')
+            auditedAbility.cannot(
+                'view',
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -387,9 +417,12 @@ export class OrganizationService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('OrganizationMemberProfile', member),
+                subject('OrganizationMemberProfile', {
+                    ...member,
+                    uuid: member.userUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -406,10 +439,14 @@ export class OrganizationService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
         const { organizationUuid } = authenticatedUser;
+        const auditedAbility = this.createAuditedAbility(authenticatedUser);
         if (
-            authenticatedUser.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('OrganizationMemberProfile', { organizationUuid }),
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -483,10 +520,14 @@ export class OrganizationService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    organizationUuid,
+                    uuid: organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -569,12 +610,14 @@ export class OrganizationService extends BaseService {
         actor: SessionUser,
         createGroup: CreateGroup,
     ): Promise<GroupWithMembers> {
+        const auditedAbility = this.createAuditedAbility(actor);
         if (
             actor.organizationUuid === undefined ||
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('Group', {
                     organizationUuid: actor.organizationUuid,
+                    uuid: actor.organizationUuid,
                 }),
             )
         ) {
@@ -621,8 +664,9 @@ export class OrganizationService extends BaseService {
             paginateArgs,
         );
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const allowedGroups = groups.filter((group) =>
-            actor.ability.can('view', subject('Group', group)),
+            auditedAbility.can('view', subject('Group', group)),
         );
 
         if (includeMembers === undefined) {
@@ -655,12 +699,14 @@ export class OrganizationService extends BaseService {
         user: SessionUser,
         data: CreateColorPalette,
     ): Promise<OrganizationColorPalette> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !user.organizationUuid ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -695,12 +741,14 @@ export class OrganizationService extends BaseService {
         colorPaletteUuid: string,
         data: UpdateColorPalette,
     ): Promise<OrganizationColorPalette> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !user.organizationUuid ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -724,12 +772,14 @@ export class OrganizationService extends BaseService {
         user: SessionUser,
         colorPaletteUuid: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !user.organizationUuid ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -746,12 +796,14 @@ export class OrganizationService extends BaseService {
         user: SessionUser,
         colorPaletteUuid: string,
     ): Promise<OrganizationColorPalette> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !user.organizationUuid ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -768,10 +820,14 @@ export class OrganizationService extends BaseService {
 
     async getImpersonationEnabled(user: SessionUser): Promise<boolean> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -794,10 +850,14 @@ export class OrganizationService extends BaseService {
         enabled: boolean,
     ): Promise<void> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/PersonalAccessTokenService.ts
+++ b/packages/backend/src/services/PersonalAccessTokenService.ts
@@ -60,7 +60,16 @@ export class PersonalAccessTokenService extends BaseService {
         data: CreatePersonalAccessToken,
         method: RequestMethod,
     ): Promise<PersonalAccessTokenWithToken> {
-        if (user.ability.cannot('create', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'create',
+                subject('PersonalAccessToken', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to create a personal access token',
             );
@@ -86,7 +95,16 @@ export class PersonalAccessTokenService extends BaseService {
         user: SessionUser,
         personalAccessTokenUuid: string,
     ): Promise<void> {
-        if (user.ability.cannot('delete', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'delete',
+                subject('PersonalAccessToken', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to delete a personal access token',
             );
@@ -102,7 +120,16 @@ export class PersonalAccessTokenService extends BaseService {
     async getAllPersonalAccessTokens(
         user: SessionUser,
     ): Promise<PersonalAccessToken[]> {
-        if (user.ability.cannot('view', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('PersonalAccessToken', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to view personal access tokens',
             );
@@ -115,7 +142,16 @@ export class PersonalAccessTokenService extends BaseService {
         personalAccessTokenUuid: string,
         data: { expiresAt: Date },
     ): Promise<PersonalAccessTokenWithToken> {
-        if (user.ability.cannot('update', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('PersonalAccessToken', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to rotate a personal access token',
             );

--- a/packages/backend/src/services/PinningService/PinningService.ts
+++ b/packages/backend/src/services/PinningService/PinningService.ts
@@ -68,8 +68,14 @@ export class PinningService extends BaseService {
         projectUuid: string,
         pinnedListUuid: string,
     ): Promise<PinnedItems> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -133,8 +139,17 @@ export class PinningService extends BaseService {
         pinnedListUuid: string,
         itemsOrder: Array<UpdatePinnedItemOrder>,
     ): Promise<PinnedItems> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.get(projectUuid);
-        if (user.ability.cannot('manage', subject('PinnedItems', project))) {
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('PinnedItems', {
+                    ...project,
+                    uuid: project.projectUuid,
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
         if (project.pinnedListUuid !== pinnedListUuid) {

--- a/packages/backend/src/services/ProjectCompileLogService/ProjectCompileLogService.ts
+++ b/packages/backend/src/services/ProjectCompileLogService/ProjectCompileLogService.ts
@@ -45,10 +45,11 @@ export class ProjectCompileLogService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -75,14 +76,16 @@ export class ProjectCompileLogService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', { uuid: '', organizationUuid, projectUuid }),
             ) ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('JobStatus', {
+                    uuid: '',
                     organizationUuid,
                     jobUuid,
                     projectUuid,

--- a/packages/backend/src/services/ProjectParametersService.ts
+++ b/packages/backend/src/services/ProjectParametersService.ts
@@ -48,13 +48,14 @@ export class ProjectParametersService extends BaseService {
             sortOrder?: 'asc' | 'desc';
         },
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -575,15 +575,17 @@ export class ProjectService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         switch (data.type) {
             case ProjectType.DEFAULT:
                 // checks if user has permission to create project on an organization level
                 if (
-                    user.ability.can(
+                    auditedAbility.can(
                         'create',
                         subject('Project', {
-                            organizationUuid: user.organizationUuid,
+                            organizationUuid: user.organizationUuid || '',
                             type: ProjectType.DEFAULT,
+                            uuid: '',
                         }),
                     )
                 ) {
@@ -609,12 +611,13 @@ export class ProjectService extends BaseService {
                         data.upstreamProjectUuid,
                     );
                     if (
-                        user.ability.cannot(
+                        auditedAbility.cannot(
                             'view',
                             subject('Project', {
                                 organizationUuid:
                                     upstreamProject.organizationUuid,
                                 projectUuid: upstreamProject.projectUuid,
+                                uuid: upstreamProject.projectUuid,
                             }),
                         )
                     ) {
@@ -635,12 +638,15 @@ export class ProjectService extends BaseService {
                     }
                     if (
                         // checks if user has permission to create project from an upstream project on a project level
-                        user.ability.can(
+                        auditedAbility.can(
                             'create',
                             subject('Project', {
+                                organizationUuid:
+                                    upstreamProject.organizationUuid,
                                 upstreamProjectUuid:
                                     upstreamProject.projectUuid,
                                 type: ProjectType.PREVIEW,
+                                uuid: '',
                             }),
                         )
                     ) {
@@ -650,11 +656,12 @@ export class ProjectService extends BaseService {
 
                 if (
                     // checks if user has permission to create project on an organization level
-                    user.ability.can(
+                    auditedAbility.can(
                         'create',
                         subject('Project', {
-                            organizationUuid: user.organizationUuid,
+                            organizationUuid: user.organizationUuid || '',
                             type: ProjectType.PREVIEW,
+                            uuid: '',
                         }),
                     )
                 ) {
@@ -1682,12 +1689,14 @@ export class ProjectService extends BaseService {
 
     async getProject(projectUuid: string, account: Account): Promise<Project> {
         const project = await this.projectModel.get(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid: project.organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -2167,14 +2176,16 @@ export class ProjectService extends BaseService {
 
         // manage:DeployProject for non-preview projects (restrictable via custom roles)
         // manage:DeployProject@self for preview projects created by the user
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DeployProject', {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                     type: project.type,
                     createdByUserUuid: project.createdByUserUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -2282,12 +2293,14 @@ export class ProjectService extends BaseService {
         assertIsAccountWithOrg(account);
         const savedProject =
             await this.projectModel.getWithSensitiveFields(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
                     organizationUuid: savedProject.organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -2390,12 +2403,14 @@ export class ProjectService extends BaseService {
         assertIsAccountWithOrg(account);
         const savedProject =
             await this.projectModel.getWithSensitiveFields(projectUuid);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
                     organizationUuid: savedProject.organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -2477,7 +2492,17 @@ export class ProjectService extends BaseService {
         const updatedProject =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 
-        if (user.ability.cannot('update', subject('Project', updatedProject))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('Project', {
+                    organizationUuid: updatedProject.organizationUuid,
+                    projectUuid: updatedProject.projectUuid,
+                    uuid: updatedProject.projectUuid,
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -2683,14 +2708,16 @@ export class ProjectService extends BaseService {
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'delete',
                 subject('Project', {
                     type: project.type,
                     organizationUuid: project.organizationUuid,
                     projectUuid: project.projectUuid,
                     createdByUserUuid: project.createdByUserUuid,
+                    uuid: project.projectUuid,
                 }),
             )
         ) {
@@ -3085,19 +3112,28 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
         }
         if (
             metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -3315,10 +3351,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('UnderlyingData', { organizationUuid, projectUuid }),
+                subject('UnderlyingData', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -3326,9 +3367,13 @@ export class ProjectService extends BaseService {
 
         if (
             metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -3388,16 +3433,18 @@ export class ProjectService extends BaseService {
             ),
         ]);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('SavedChart', spaceCtx),
+                subject('SavedChart', { ...spaceCtx, uuid: savedChart.uuid }),
             ) ||
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -3476,16 +3523,18 @@ export class ProjectService extends BaseService {
             ),
         ]);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('SavedChart', spaceCtx),
+                subject('SavedChart', { ...spaceCtx, uuid: savedChart.uuid }),
             ) ||
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -3612,10 +3661,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -3623,9 +3677,13 @@ export class ProjectService extends BaseService {
 
         if (
             metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -3968,13 +4026,15 @@ export class ProjectService extends BaseService {
                     const { organizationUuid } =
                         await this.projectModel.getSummary(projectUuid);
 
+                    const auditedAbility = this.createAuditedAbility(account);
                     if (
                         account.isJwtUser() ||
-                        account.user.ability.cannot(
+                        auditedAbility.cannot(
                             'view',
                             subject('Project', {
                                 organizationUuid,
                                 projectUuid,
+                                uuid: projectUuid,
                             }),
                         )
                     ) {
@@ -4148,10 +4208,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('SqlRunner', { organizationUuid, projectUuid }),
+                subject('SqlRunner', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -4472,10 +4537,15 @@ export class ProjectService extends BaseService {
     ): Promise<Readable> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -4614,10 +4684,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -4967,22 +5042,33 @@ export class ProjectService extends BaseService {
     async getJobStatus(jobUuid: string, user: SessionUser): Promise<Job> {
         const job = await this.jobModel.get(jobUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (job.projectUuid) {
             const { organizationUuid } = await this.projectModel.getSummary(
                 job.projectUuid,
             );
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
                     subject('Project', {
                         organizationUuid,
                         projectUuid: job.projectUuid,
+                        uuid: job.projectUuid,
                     }),
                 )
             ) {
                 throw new NotFoundError(`Cannot find job`);
             }
-        } else if (user.ability.cannot('view', subject('Job', job))) {
+        } else if (
+            auditedAbility.cannot(
+                'view',
+                subject('Job', {
+                    ...job,
+                    organizationUuid: user.organizationUuid || '',
+                    uuid: '',
+                }),
+            )
+        ) {
             throw new NotFoundError(`Cannot find job`);
         }
 
@@ -4996,17 +5082,23 @@ export class ProjectService extends BaseService {
         const { organizationUuid, type } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('Job', { organizationUuid, projectUuid }),
+                subject('Job', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             ) ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('CompileProject', {
                     organizationUuid,
                     projectUuid,
                     type,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -5132,18 +5224,24 @@ export class ProjectService extends BaseService {
     ): Promise<{ jobUuid: string }> {
         const { organizationUuid, type } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !skipPermissionCheck &&
-            (user.ability.cannot(
+            (auditedAbility.cannot(
                 'create',
-                subject('Job', { organizationUuid, projectUuid }),
+                subject('Job', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             ) ||
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('CompileProject', {
                         organizationUuid,
                         projectUuid,
                         type,
+                        uuid: projectUuid,
                     }),
                 ))
         ) {
@@ -5187,16 +5285,22 @@ export class ProjectService extends BaseService {
 
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('Job', { organizationUuid, projectUuid }),
+                subject('Job', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             ) ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('CompileProject', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -5373,11 +5477,13 @@ export class ProjectService extends BaseService {
             return false;
         }
 
-        return account.user.ability.can(
+        const auditedAbility = this.createAuditedAbility(account);
+        return auditedAbility.can(
             'manage',
             subject('PreAggregation', {
                 organizationUuid,
                 projectUuid,
+                uuid: projectUuid,
             }),
         );
     }
@@ -5392,11 +5498,16 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             ProjectService.isChartEmbed(account) ||
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -5513,20 +5624,23 @@ export class ProjectService extends BaseService {
                     ? { organizationUuid }
                     : await this.projectModel.getSummary(projectUuid);
 
+                const auditedAbility = this.createAuditedAbility(account);
                 const isForbidden =
-                    account.user.ability.cannot(
+                    auditedAbility.cannot(
                         'view',
                         subject('Project', {
                             organizationUuid: project.organizationUuid,
                             projectUuid,
+                            uuid: projectUuid,
                         }),
                     ) &&
-                    account.user.ability.cannot(
+                    auditedAbility.cannot(
                         'view',
                         subject('Explore', {
                             organizationUuid: project.organizationUuid,
                             projectUuid,
                             exploreNames,
+                            uuid: projectUuid,
                         }),
                     );
 
@@ -5584,10 +5698,15 @@ export class ProjectService extends BaseService {
     ): Promise<ProjectCatalog> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -5659,10 +5778,15 @@ export class ProjectService extends BaseService {
     ): Promise<WarehouseTablesCatalog> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -5711,10 +5835,15 @@ export class ProjectService extends BaseService {
     ): Promise<WarehouseTablesCatalog> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -5764,10 +5893,15 @@ export class ProjectService extends BaseService {
     ): Promise<WarehouseTableSchema> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -5834,11 +5968,16 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
             ProjectService.isChartEmbed(account) ||
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -5854,12 +5993,14 @@ export class ProjectService extends BaseService {
     ): Promise<TablesConfiguration> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -5898,8 +6039,9 @@ export class ProjectService extends BaseService {
                         savedChart.spaceUuid,
                     );
 
+                const auditedAbility = this.createAuditedAbility(account);
                 if (
-                    account.user.ability.cannot(
+                    auditedAbility.cannot(
                         'view',
                         subject('SavedChart', {
                             ...savedChart,
@@ -5975,9 +6117,10 @@ export class ProjectService extends BaseService {
                 return savedCharts.map((savedChart) => {
                     const spaceCtx = spacesCtx[savedChart.spaceUuid];
 
+                    const auditedAbility = this.createAuditedAbility(account);
                     if (
                         !spaceCtx ||
-                        account.user.ability.cannot(
+                        auditedAbility.cannot(
                             'view',
                             subject('SavedChart', {
                                 ...savedChart,
@@ -6091,10 +6234,15 @@ export class ProjectService extends BaseService {
     ): Promise<boolean> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -6127,12 +6275,14 @@ export class ProjectService extends BaseService {
     ): Promise<ProjectMemberProfile> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6158,12 +6308,14 @@ export class ProjectService extends BaseService {
     ): Promise<ProjectMemberProfile[]> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6179,12 +6331,14 @@ export class ProjectService extends BaseService {
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6219,12 +6373,14 @@ export class ProjectService extends BaseService {
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6245,12 +6401,14 @@ export class ProjectService extends BaseService {
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6278,12 +6436,14 @@ export class ProjectService extends BaseService {
 
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6303,12 +6463,14 @@ export class ProjectService extends BaseService {
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6325,12 +6487,14 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(actor);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6345,10 +6509,15 @@ export class ProjectService extends BaseService {
     ): Promise<SpaceQuery[]> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -6377,10 +6546,15 @@ export class ProjectService extends BaseService {
     ): Promise<ChartSummary[]> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -6406,12 +6580,14 @@ export class ProjectService extends BaseService {
         projectUuid: string,
     ): Promise<MostPopularAndRecentlyUpdated> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6502,12 +6678,14 @@ export class ProjectService extends BaseService {
         }
 
         const projectSummary = await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -6570,10 +6748,15 @@ export class ProjectService extends BaseService {
     ): Promise<SpaceSummary[]> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -6592,7 +6775,13 @@ export class ProjectService extends BaseService {
         return spaces
             .filter((space) => {
                 const ctx = userSpacesCtx[space.uuid];
-                return ctx && user.ability.can('view', subject('Space', ctx));
+                return (
+                    ctx &&
+                    auditedAbility.can(
+                        'view',
+                        subject('Space', { ...ctx, uuid: space.uuid }),
+                    )
+                );
             })
             .map((spaceSummary) => {
                 const ctx = userSpacesCtx[spaceSummary.uuid];
@@ -7007,16 +7196,18 @@ export class ProjectService extends BaseService {
                 savedChart.spaceUuid,
             );
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('SavedChart', spaceCtx),
+                subject('SavedChart', { ...spaceCtx, uuid: savedChart.uuid }),
             ) ||
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -7052,10 +7243,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -7063,9 +7259,13 @@ export class ProjectService extends BaseService {
 
         if (
             data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -7202,10 +7402,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -7213,9 +7418,13 @@ export class ProjectService extends BaseService {
 
         if (
             data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -7250,7 +7459,16 @@ export class ProjectService extends BaseService {
         projectUuid: string,
     ): Promise<Record<string, DbtExposure>> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('manage', subject('Project', projectSummary))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Project', {
+                    ...projectSummary,
+                    uuid: projectSummary.projectUuid,
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
         const cachedExplores = await this.projectModel.findExploresFromCache(
@@ -7367,7 +7585,13 @@ export class ProjectService extends BaseService {
         projectUuid: string,
     ): Promise<UserWarehouseCredentials | undefined> {
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
         const credentials =
@@ -7386,7 +7610,13 @@ export class ProjectService extends BaseService {
         projectUuid: string,
     ): Promise<UserWarehouseCredentials[]> {
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
         return this.userWarehouseCredentialsModel.getAllByUserUuidForProject(
@@ -7408,7 +7638,13 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError();
         }
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
         await this.userWarehouseCredentialsModel.upsertUserCredentialsPreference(
@@ -7471,10 +7707,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('VirtualView', { organizationUuid, projectUuid }),
+                subject('VirtualView', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -7537,10 +7778,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('VirtualView', { organizationUuid, projectUuid }),
+                subject('VirtualView', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -7585,10 +7831,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'delete',
-                subject('VirtualView', { organizationUuid, projectUuid }),
+                subject('VirtualView', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -7614,7 +7865,13 @@ export class ProjectService extends BaseService {
     ) {
         const project = await this.projectModel.getSummary(projectUuid);
 
-        if (user.ability.cannot('update', subject('Project', project))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -7644,7 +7901,13 @@ export class ProjectService extends BaseService {
     ) {
         const project = await this.projectModel.getSummary(projectUuid);
 
-        if (user.ability.cannot('update', subject('Project', project))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -7685,12 +7948,14 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Tags', {
                     projectUuid,
                     organizationUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -7730,12 +7995,14 @@ export class ProjectService extends BaseService {
             tag.projectUuid,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Tags', {
                     projectUuid: tag.projectUuid,
                     organizationUuid,
+                    uuid: tag.projectUuid,
                 }),
             )
         ) {
@@ -7760,12 +8027,14 @@ export class ProjectService extends BaseService {
             tag.projectUuid,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Tags', {
                     projectUuid: tag.projectUuid,
                     organizationUuid,
+                    uuid: tag.projectUuid,
                 }),
             )
         ) {
@@ -7779,10 +8048,15 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Tags', { projectUuid, organizationUuid }),
+                subject('Tags', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -7803,14 +8077,16 @@ export class ProjectService extends BaseService {
         const { organizationUuid, type, createdByUserUuid } =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
                     projectUuid,
                     organizationUuid,
                     type,
                     createdByUserUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -7837,14 +8113,16 @@ export class ProjectService extends BaseService {
         const { organizationUuid, type, createdByUserUuid } =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
                     projectUuid,
                     organizationUuid,
                     type,
                     createdByUserUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {
@@ -7866,12 +8144,14 @@ export class ProjectService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Tags', {
                     projectUuid,
                     organizationUuid,
+                    uuid: projectUuid,
                 }),
             )
         ) {

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -368,6 +368,7 @@ export class PromoteService extends BaseService {
                 user.ability.cannot(
                     'manage',
                     subject('Space', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamContent.projectUuid,
                         inheritsFromOrgOrProject:
@@ -387,6 +388,7 @@ export class PromoteService extends BaseService {
             user.ability.cannot(
                 'create',
                 subject('Space', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: upstreamContent.projectUuid,
                 }),
@@ -412,6 +414,7 @@ export class PromoteService extends BaseService {
                 user.ability.cannot(
                     'promote',
                     subject('SavedChart', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: promotedChart.projectUuid,
                         inheritsFromOrgOrProject:
@@ -431,6 +434,7 @@ export class PromoteService extends BaseService {
             user.ability.cannot(
                 'promote',
                 subject('SavedChart', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: promotedChart.projectUuid,
                 }),
@@ -451,6 +455,7 @@ export class PromoteService extends BaseService {
                     user.ability.cannot(
                         'promote',
                         subject('SavedChart', {
+                            uuid: '',
                             organizationUuid,
                             projectUuid: upstreamChart.projectUuid,
                             inheritsFromOrgOrProject:
@@ -471,6 +476,7 @@ export class PromoteService extends BaseService {
                 user.ability.cannot(
                     'promote',
                     subject('SavedChart', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamChart.projectUuid,
                     }),
@@ -488,6 +494,7 @@ export class PromoteService extends BaseService {
                 user.ability.cannot(
                     'manage',
                     subject('SavedChart', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamChart.projectUuid,
                         access: upstreamChart.spaceAccessContext?.access ?? [],
@@ -517,6 +524,7 @@ export class PromoteService extends BaseService {
             user.ability.cannot(
                 'promote',
                 subject('SavedChart', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: promotedSqlChart.projectUuid,
                     inheritsFromOrgOrProject:
@@ -539,6 +547,7 @@ export class PromoteService extends BaseService {
                     user.ability.cannot(
                         'promote',
                         subject('SavedChart', {
+                            uuid: '',
                             organizationUuid,
                             projectUuid: upstreamSqlChart.projectUuid,
                             inheritsFromOrgOrProject:
@@ -560,6 +569,7 @@ export class PromoteService extends BaseService {
                 user.ability.cannot(
                     'promote',
                     subject('SavedChart', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamSqlChart.projectUuid,
                     }),
@@ -576,6 +586,7 @@ export class PromoteService extends BaseService {
                 user.ability.cannot(
                     'manage',
                     subject('SavedChart', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamSqlChart.projectUuid,
                         access:
@@ -605,6 +616,7 @@ export class PromoteService extends BaseService {
             user.ability.cannot(
                 'promote',
                 subject('Dashboard', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: promotedDashboard.projectUuid,
                     inheritsFromOrgOrProject:
@@ -627,6 +639,7 @@ export class PromoteService extends BaseService {
                     user.ability.cannot(
                         'promote',
                         subject('Dashboard', {
+                            uuid: '',
                             organizationUuid,
                             projectUuid: upstreamDashboard.projectUuid,
                             inheritsFromOrgOrProject:
@@ -646,6 +659,7 @@ export class PromoteService extends BaseService {
                 user.ability.cannot(
                     'promote',
                     subject('Dashboard', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamDashboard.projectUuid,
                     }),
@@ -661,6 +675,7 @@ export class PromoteService extends BaseService {
                 user.ability.cannot(
                     'manage',
                     subject('Dashboard', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamDashboard.projectUuid,
                         access:

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -87,12 +87,14 @@ export class RenameService extends BaseService {
         projectUuid: string;
         chartUuid: string;
     }) {
+        const auditedAbility = this.createAuditedAbility(user);
         const chart = await this.savedChartModel.get(chartUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                 }),
@@ -163,12 +165,14 @@ export class RenameService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -309,13 +313,15 @@ export class RenameService extends BaseService {
         dashboardUuid: string;
         tableName?: string;
     }) {
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),
@@ -412,12 +418,14 @@ export class RenameService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -558,12 +566,14 @@ export class RenameService extends BaseService {
         projectUuid: string;
         context: RequestMethod;
     }) {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/services/RolesService/RolesService.mock.ts
+++ b/packages/backend/src/services/RolesService/RolesService.mock.ts
@@ -22,6 +22,8 @@ export const mockAccount = {
         ability: {
             can: jest.fn(() => true),
             cannot: jest.fn(() => false),
+            relevantRuleFor: jest.fn(() => null),
+            rules: [],
         } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
         abilityRules: [] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
         isTrackingAnonymized: false,
@@ -53,6 +55,8 @@ export const mockAccountNoAccess = {
         ability: {
             can: jest.fn(() => false),
             cannot: jest.fn(() => true),
+            relevantRuleFor: jest.fn(() => null),
+            rules: [],
         } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
 } as SessionAccount;

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -94,11 +94,13 @@ export class RolesService extends BaseService {
         account: Account,
         organizationUuid: string,
     ) {
+        const auditedAbility = this.createAuditedAbility(account);
         // if user is admin of organization, they can see roles
         if (
-            account.user.ability.can(
+            auditedAbility.can(
                 'manage',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid,
                 }),
             )
@@ -115,9 +117,10 @@ export class RolesService extends BaseService {
         );
 
         const canManageSomeProjects = projects.some((project) =>
-            account.user.ability.can(
+            auditedAbility.can(
                 'manage',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: project.projectUuid,
                 }),
@@ -129,7 +132,7 @@ export class RolesService extends BaseService {
         }
     }
 
-    private static validateOrganizationAccess(
+    private validateOrganizationAccess(
         account: Account,
         organizationUuid?: string,
     ): void {
@@ -141,10 +144,12 @@ export class RolesService extends BaseService {
             throw new ForbiddenError();
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid,
                 }),
             )
@@ -155,7 +160,7 @@ export class RolesService extends BaseService {
         }
     }
 
-    private static validateRoleOwnership(account: Account, role: Role): void {
+    private validateRoleOwnership(account: Account, role: Role): void {
         if (isSystemRole(role.roleUuid) && role.ownerType === 'system') {
             return;
         }
@@ -164,10 +169,12 @@ export class RolesService extends BaseService {
             throw new ForbiddenError();
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid: role.organizationUuid,
                 }),
             )
@@ -182,10 +189,12 @@ export class RolesService extends BaseService {
     ) {
         if (projectUuid) {
             const project = await this.projectModel.getSummary(projectUuid);
+            const auditedAbility = this.createAuditedAbility(account);
             if (
-                account.user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('Project', {
+                        uuid: '',
                         organizationUuid: project.organizationUuid,
                         projectUuid,
                     }),
@@ -221,7 +230,7 @@ export class RolesService extends BaseService {
         await this.validateRolesViewAccess(account, organizationUuid);
 
         if (loadScopes) {
-            RolesService.validateOrganizationAccess(account, organizationUuid);
+            this.validateOrganizationAccess(account, organizationUuid);
             return this.rolesModel.getRolesWithScopesByOrganizationUuid(
                 organizationUuid,
                 roleTypeFilter,
@@ -246,7 +255,7 @@ export class RolesService extends BaseService {
             );
         }
 
-        RolesService.validateOrganizationAccess(account, organizationUuid);
+        this.validateOrganizationAccess(account, organizationUuid);
         RolesService.validateRoleName(name);
 
         const role = await this.rolesModel.db.transaction(
@@ -300,7 +309,7 @@ export class RolesService extends BaseService {
         }
 
         const role = await this.rolesModel.getRoleByUuid(roleUuid);
-        RolesService.validateRoleOwnership(account, role);
+        this.validateRoleOwnership(account, role);
 
         if (name) {
             RolesService.validateRoleName(name);
@@ -355,7 +364,7 @@ export class RolesService extends BaseService {
         roleUuid: string,
     ): Promise<RoleWithScopes> {
         const role = await this.rolesModel.getRoleWithScopesByUuid(roleUuid);
-        RolesService.validateRoleOwnership(account, role);
+        this.validateRoleOwnership(account, role);
 
         return role;
     }
@@ -396,7 +405,7 @@ export class RolesService extends BaseService {
         const { roleId } = request;
 
         // Validate organization access
-        RolesService.validateOrganizationAccess(account, orgUuid);
+        this.validateOrganizationAccess(account, orgUuid);
 
         // Ensure only system roles can be assigned at organization level
         if (roleId !== OrganizationMemberRole.MEMBER && !isSystemRole(roleId)) {
@@ -704,10 +713,7 @@ export class RolesService extends BaseService {
     ): Promise<RoleAssignment> {
         const { roleId } = request;
         const project = await this.projectModel.getSummary(projectUuid);
-        RolesService.validateOrganizationAccess(
-            account,
-            project.organizationUuid,
-        );
+        this.validateOrganizationAccess(account, project.organizationUuid);
         await this.validateProjectAccess(account, projectUuid);
         const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
 
@@ -764,7 +770,7 @@ export class RolesService extends BaseService {
         }
         try {
             const role = await this.rolesModel.getRoleByUuid(roleUuid);
-            RolesService.validateRoleOwnership(account, role);
+            this.validateRoleOwnership(account, role);
 
             await this.rolesModel.deleteRole(roleUuid);
 
@@ -802,7 +808,7 @@ export class RolesService extends BaseService {
         organizationUuid: string,
         projectUuid: string,
     ): Promise<void> {
-        RolesService.validateOrganizationAccess(account, organizationUuid);
+        this.validateOrganizationAccess(account, organizationUuid);
         await this.validateProjectAccess(account, projectUuid);
 
         await this.rolesModel.unassignCustomRoleFromUser(userUuid, projectUuid);
@@ -825,7 +831,7 @@ export class RolesService extends BaseService {
         projectUuid: string,
     ): Promise<void> {
         const role = await this.rolesModel.getRoleByUuid(roleUuid);
-        RolesService.validateRoleOwnership(account, role);
+        this.validateRoleOwnership(account, role);
         await this.validateProjectAccess(account, projectUuid);
 
         await this.rolesModel.assignRoleToGroup(
@@ -851,7 +857,7 @@ export class RolesService extends BaseService {
         groupUuid: string,
         projectUuid: string,
     ): Promise<void> {
-        RolesService.validateOrganizationAccess(
+        this.validateOrganizationAccess(
             account,
             account.organization?.organizationUuid,
         );
@@ -889,10 +895,7 @@ export class RolesService extends BaseService {
         userUuid: string,
     ): Promise<void> {
         const project = await this.projectModel.getSummary(projectUuid);
-        RolesService.validateOrganizationAccess(
-            account,
-            project.organizationUuid,
-        );
+        this.validateOrganizationAccess(account, project.organizationUuid);
         await this.validateProjectAccess(account, projectUuid);
 
         await this.rolesModel.removeUserProjectAccess(userUuid, projectUuid);
@@ -919,7 +922,7 @@ export class RolesService extends BaseService {
 
         const foundRole =
             role || (await this.rolesModel.getRoleByUuid(roleUuid));
-        RolesService.validateRoleOwnership(account, foundRole);
+        this.validateRoleOwnership(account, foundRole);
 
         await this.rolesModel.addScopesToRole(
             roleUuid,
@@ -949,7 +952,7 @@ export class RolesService extends BaseService {
         }
 
         const role = await this.rolesModel.getRoleByUuid(roleUuid);
-        RolesService.validateRoleOwnership(account, role);
+        this.validateRoleOwnership(account, role);
 
         await this.rolesModel.removeScopeFromRole(roleUuid, scopeName);
 
@@ -971,7 +974,7 @@ export class RolesService extends BaseService {
         scopeNames: string[],
         tx?: Knex.Transaction,
     ): Promise<void> {
-        RolesService.validateOrganizationAccess(account, organizationUuid);
+        this.validateOrganizationAccess(account, organizationUuid);
 
         if (scopeNames.filter(Boolean).length === 0) {
             throw new ParameterError('scopeNames are required');
@@ -1000,7 +1003,7 @@ export class RolesService extends BaseService {
         roleUuid: string,
         duplicateRoleData: CreateRole,
     ): Promise<RoleWithScopes> {
-        RolesService.validateOrganizationAccess(account, organizationUuid);
+        this.validateOrganizationAccess(account, organizationUuid);
 
         const { name, description } = duplicateRoleData;
         RolesService.validateRoleName(name);
@@ -1010,7 +1013,7 @@ export class RolesService extends BaseService {
         if (!sourceRole) {
             throw new NotFoundError(`Role to duplicate: ${roleUuid} not found`);
         }
-        RolesService.validateRoleOwnership(account, sourceRole);
+        this.validateRoleOwnership(account, sourceRole);
 
         const copyOfRoleName = `Copy of: ${sourceRole.name}`;
         const newDescription =

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -67,8 +67,6 @@ import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
 import { SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
 import { getSchedulerTargetType } from '../../database/entities/scheduler';
-import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
-import { logAuditEvent } from '../../logging/winston';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { getChartFieldUsageChanges } from '../../models/CatalogModel/utils';
@@ -201,10 +199,12 @@ export class SavedChartService
                 user.userUuid,
                 savedChart.spaceUuid,
             );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('SavedChart', {
+                    uuid: chartUuid,
                     organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
@@ -225,10 +225,12 @@ export class SavedChartService
     ): Promise<ChartSummary> {
         const savedChart = await this.savedChartModel.getSummary(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('ScheduledDeliveries', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -471,10 +473,12 @@ export class SavedChartService
                 spaceUuid,
             );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('SavedChart', {
+                    uuid: savedChartUuid,
                     organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
@@ -487,9 +491,13 @@ export class SavedChartService
 
         if (
             data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    uuid: savedChartUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -575,10 +583,12 @@ export class SavedChartService
                 spaceUuid,
             );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('SavedChart', {
+                    uuid: savedChartUuid,
                     organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
@@ -646,10 +656,15 @@ export class SavedChartService
         const { organizationUuid, projectUuid, pinnedListUuid, spaceUuid } =
             await this.savedChartModel.getSummary(savedChartUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('PinnedItems', { organizationUuid, projectUuid }),
+                subject('PinnedItems', {
+                    uuid: savedChartUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -700,15 +715,17 @@ export class SavedChartService
         projectUuid: string,
         data: UpdateMultipleSavedChart[],
     ): Promise<SavedChart[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         const spaceAccessPromises = data.map(async (chart) => {
             const { inheritsFromOrgOrProject, access, organizationUuid } =
                 await this.spacePermissionService.getSpaceAccessContext(
                     user.userUuid,
                     chart.spaceUuid,
                 );
-            return user.ability.can(
+            return auditedAbility.can(
                 'update',
                 subject('SavedChart', {
+                    uuid: chart.uuid,
                     organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
@@ -770,10 +787,12 @@ export class SavedChartService
                     user.userUuid,
                     spaceUuid,
                 );
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'delete',
                     subject('SavedChart', {
+                        uuid: resolvedUuid,
                         organizationUuid,
                         projectUuid,
                         inheritsFromOrgOrProject,
@@ -841,10 +860,12 @@ export class SavedChartService
                     user.userUuid,
                     chart.spaceUuid,
                 );
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'delete',
                     subject('SavedChart', {
+                        uuid: savedChartUuid,
                         organizationUuid: chart.organizationUuid,
                         projectUuid: chart.projectUuid,
                         inheritsFromOrgOrProject,
@@ -883,8 +904,9 @@ export class SavedChartService
                 user.userUuid,
                 savedChart.spaceUuid,
             );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
                     ...savedChart,
@@ -933,8 +955,9 @@ export class SavedChartService
             inheritsFromOrgOrProject = ctx.inheritsFromOrgOrProject;
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
                     ...savedChart,
@@ -1002,9 +1025,7 @@ export class SavedChartService
         const savedChart = await this.savedChartModel.getSummary(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -1053,9 +1074,7 @@ export class SavedChartService
         const savedChart = await this.savedChartModel.getSummary(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -1132,10 +1151,12 @@ export class SavedChartService
             access = dashboardSpaceAccessContext.access;
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('SavedChart', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
@@ -1236,8 +1257,9 @@ export class SavedChartService
                 user.userUuid,
                 chart.spaceUuid,
             );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('SavedChart', {
                     ...chart,
@@ -1482,8 +1504,9 @@ export class SavedChartService
                 chart.spaceUuid,
             );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
                     ...chart,
@@ -1523,8 +1546,9 @@ export class SavedChartService
                 user.userUuid,
                 chart.spaceUuid,
             );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
                     ...chart,
@@ -1673,9 +1697,11 @@ export class SavedChartService
             spaceUuid,
         );
 
-        const hasPermission = actor.user.ability.can(
+        const auditedAbility = this.createAuditedAbility(actor.user);
+        const hasPermission = auditedAbility.can(
             action,
             subject('SavedChart', {
+                uuid: resource.savedChartUuid ?? '',
                 organizationUuid,
                 projectUuid: actor.projectUuid,
                 inheritsFromOrgOrProject,
@@ -1699,9 +1725,10 @@ export class SavedChartService
                 resource.spaceUuid,
             );
 
-            const hasPermissionInNewSpace = actor.user.ability.can(
+            const hasPermissionInNewSpace = auditedAbility.can(
                 action,
                 subject('SavedChart', {
+                    uuid: resource.savedChartUuid ?? '',
                     organizationUuid: newSpaceOrganizationUuid,
                     projectUuid: actor.projectUuid,
                     inheritsFromOrgOrProject: newSpaceInheritsFromOrgOrProject,
@@ -1785,20 +1812,29 @@ export class SavedChartService
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         // Check if user can view the project
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
         }
 
         // Check if user is admin (can manage all deleted content)
-        const isAdmin = user.ability.can(
+        const isAdmin = auditedAbility.can(
             'manage',
-            subject('DeletedContent', { organizationUuid, projectUuid }),
+            subject('DeletedContent', {
+                uuid: projectUuid,
+                organizationUuid,
+                projectUuid,
+            }),
         );
 
         // Non-admins can only see their own deleted items
@@ -1829,18 +1865,27 @@ export class SavedChartService
         const { organizationUuid, projectUuid } = deletedChart;
 
         if (!options?.bypassPermissions) {
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
-                    subject('Project', { organizationUuid, projectUuid }),
+                    subject('Project', {
+                        uuid: projectUuid,
+                        organizationUuid,
+                        projectUuid,
+                    }),
                 )
             ) {
                 throw new ForbiddenError();
             }
 
-            const isAdmin = user.ability.can(
+            const isAdmin = auditedAbility.can(
                 'manage',
-                subject('DeletedContent', { organizationUuid, projectUuid }),
+                subject('DeletedContent', {
+                    uuid: chartUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             );
 
             if (
@@ -1892,18 +1937,27 @@ export class SavedChartService
             );
             const { organizationUuid, projectUuid } = deletedChart;
 
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
-                    subject('Project', { organizationUuid, projectUuid }),
+                    subject('Project', {
+                        uuid: projectUuid,
+                        organizationUuid,
+                        projectUuid,
+                    }),
                 )
             ) {
                 throw new ForbiddenError();
             }
 
-            const isAdmin = user.ability.can(
+            const isAdmin = auditedAbility.can(
                 'manage',
-                subject('DeletedContent', { organizationUuid, projectUuid }),
+                subject('DeletedContent', {
+                    uuid: chartUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             );
 
             if (

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -175,10 +175,14 @@ export class SavedSqlService
                   [spaceUuid],
               );
 
+        const auditedAbility = this.createAuditedAbility(actor.user);
         if (
-            actor.user.ability.cannot(
+            auditedAbility.cannot(
                 action,
-                subject('SavedChart', ctx[spaceUuid]),
+                subject('SavedChart', {
+                    ...ctx[spaceUuid],
+                    uuid: resource.savedSqlUuid ?? '',
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -188,9 +192,12 @@ export class SavedSqlService
 
         if (needsNewSpaceCheck) {
             if (
-                actor.user.ability.cannot(
+                auditedAbility.cannot(
                     action,
-                    subject('SavedChart', ctx[resource.spaceUuid!]),
+                    subject('SavedChart', {
+                        ...ctx[resource.spaceUuid!],
+                        uuid: resource.savedSqlUuid ?? '',
+                    }),
                 )
             ) {
                 throw new ForbiddenError(
@@ -255,10 +262,15 @@ export class SavedSqlService
     ): Promise<ApiCreateSqlChart['results']> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    uuid: '',
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -314,10 +326,15 @@ export class SavedSqlService
     ): Promise<{ savedSqlUuid: string; savedSqlVersionUuid: string | null }> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomSql', {
+                    uuid: savedSqlUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -445,18 +462,27 @@ export class SavedSqlService
         const { organizationUuid } = savedChart.organization;
 
         if (!options?.bypassPermissions) {
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
-                    subject('Project', { organizationUuid, projectUuid }),
+                    subject('Project', {
+                        uuid: projectUuid,
+                        organizationUuid,
+                        projectUuid,
+                    }),
                 )
             ) {
                 throw new ForbiddenError();
             }
 
-            const isAdmin = user.ability.can(
+            const isAdmin = auditedAbility.can(
                 'manage',
-                subject('DeletedContent', { organizationUuid, projectUuid }),
+                subject('DeletedContent', {
+                    uuid: savedSqlUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             );
 
             if (!isAdmin && savedChart.createdBy?.userUuid !== user.userUuid) {
@@ -492,18 +518,27 @@ export class SavedSqlService
             const { projectUuid } = savedChart.project;
             const { organizationUuid } = savedChart.organization;
 
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
-                    subject('Project', { organizationUuid, projectUuid }),
+                    subject('Project', {
+                        uuid: projectUuid,
+                        organizationUuid,
+                        projectUuid,
+                    }),
                 )
             ) {
                 throw new ForbiddenError();
             }
 
-            const isAdmin = user.ability.can(
+            const isAdmin = auditedAbility.can(
                 'manage',
-                subject('DeletedContent', { organizationUuid, projectUuid }),
+                subject('DeletedContent', {
+                    uuid: savedSqlUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             );
 
             if (!isAdmin && savedChart.createdBy?.userUuid !== user.userUuid) {
@@ -524,14 +559,16 @@ export class SavedSqlService
     ): Promise<{ jobId: string }> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('Job', { organizationUuid, projectUuid }),
+                subject('Job', { uuid: '', organizationUuid, projectUuid }),
             ) ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SqlRunner', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -577,21 +614,25 @@ export class SavedSqlService
                 { user, projectUuid },
                 { savedSqlUuid: savedChart.savedSqlUuid },
             );
-        } else if (
+        } else {
             // If it's not a saved chart, check if the user has access to run a pivot query
-            user.ability.cannot(
-                'create',
-                subject('Job', { organizationUuid, projectUuid }),
-            ) ||
-            user.ability.cannot(
-                'manage',
-                subject('SqlRunner', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+            const auditedAbility = this.createAuditedAbility(user);
+            if (
+                auditedAbility.cannot(
+                    'create',
+                    subject('Job', { uuid: '', organizationUuid, projectUuid }),
+                ) ||
+                auditedAbility.cannot(
+                    'manage',
+                    subject('SqlRunner', {
+                        uuid: '',
+                        organizationUuid,
+                        projectUuid,
+                    }),
+                )
+            ) {
+                throw new ForbiddenError();
+            }
         }
         const jobId = await this.schedulerClient.runSqlPivotQuery({
             savedSqlUuid: savedChart?.savedSqlUuid,
@@ -722,10 +763,12 @@ export class SavedSqlService
         });
         const { organizationUuid } = sqlChart.organization;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ScheduledDeliveries', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -748,10 +791,12 @@ export class SavedSqlService
         });
         const { organizationUuid } = sqlChart.organization;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ScheduledDeliveries', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -55,8 +55,6 @@ import {
     getSchedulerTargetType,
     SchedulerLogDb,
 } from '../../database/entities/scheduler';
-import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
-import { logAuditEvent } from '../../logging/winston';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { JobModel } from '../../models/JobModel/JobModel';
 import type { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -204,9 +202,11 @@ export class SchedulerService extends BaseService {
         // If sendNow is true, we need to check if the user has permissions to `create` instead of `manage`
         // This allows editors to send schedulers they didn't create themselves
         const action = sendNow ? 'create' : 'manage';
-        const canManageDeliveries = user.ability.can(
+        const auditedAbility = this.createAuditedAbility(user);
+        const canManageDeliveries = auditedAbility.can(
             action,
             subject('ScheduledDeliveries', {
+                uuid: schedulerUuid,
                 organizationUuid,
                 projectUuid,
                 userUuid: scheduler.createdBy,
@@ -217,9 +217,10 @@ export class SchedulerService extends BaseService {
             throw new ForbiddenError();
         }
 
-        const canManageGoogleSheets = user.ability.can(
+        const canManageGoogleSheets = auditedAbility.can(
             action,
             subject('GoogleSheets', {
+                uuid: schedulerUuid,
                 organizationUuid,
                 projectUuid,
             }),
@@ -239,6 +240,7 @@ export class SchedulerService extends BaseService {
         user: SessionUser,
         scheduler: CreateSchedulerAndTargets,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         if (scheduler.savedChartUuid) {
             const { organizationUuid, spaceUuid, projectUuid } =
                 await this.savedChartModel.getSummary(scheduler.savedChartUuid);
@@ -249,9 +251,10 @@ export class SchedulerService extends BaseService {
                     spaceUuid,
                 );
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
                     subject('SavedChart', {
+                        uuid: scheduler.savedChartUuid,
                         organizationUuid,
                         projectUuid,
                         inheritsFromOrgOrProject,
@@ -272,9 +275,10 @@ export class SchedulerService extends BaseService {
                 );
 
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
                     subject('Dashboard', {
+                        uuid: scheduler.dashboardUuid,
                         organizationUuid,
                         projectUuid,
                         inheritsFromOrgOrProject,
@@ -298,9 +302,10 @@ export class SchedulerService extends BaseService {
                     spaceUuid,
                 );
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'view',
                     subject('SavedChart', {
+                        uuid: scheduler.savedSqlUuid!,
                         organizationUuid,
                         projectUuid,
                         inheritsFromOrgOrProject,
@@ -340,10 +345,12 @@ export class SchedulerService extends BaseService {
         }
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         // Only allow editors to view all schedulers
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
                 }),
@@ -421,7 +428,16 @@ export class SchedulerService extends BaseService {
         // A user might not be able to create scheduled permissions on the org level but on a specific project
         // level. The check here makes sure that the user has the ability to create a scheduled delivery at least somewhere.
         // Since the service returns specifically the user's scheduled deliveries, this is completely intended behavior.
-        if (user.ability.cannot('create', 'ScheduledDeliveries')) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'create',
+                subject('ScheduledDeliveries', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -696,11 +712,13 @@ export class SchedulerService extends BaseService {
 
         // Check user has manage:ScheduledDeliveries permission for each scheduler
         // Admins can manage all schedulers, editors can only manage their own
+        const auditedAbility = this.createAuditedAbility(user);
         for (const scheduler of schedulers) {
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('ScheduledDeliveries', {
+                        uuid: scheduler.schedulerUuid,
                         organizationUuid,
                         projectUuid,
                         userUuid: scheduler.createdBy,
@@ -736,10 +754,12 @@ export class SchedulerService extends BaseService {
             );
         }
 
+        const newOwnerAuditedAbility = this.createAuditedAbility(newOwner);
         if (
-            newOwner.ability.cannot(
+            newOwnerAuditedAbility.cannot(
                 'create',
                 subject('ScheduledDeliveries', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -835,10 +855,12 @@ export class SchedulerService extends BaseService {
         options?: SoftDeleteOptions,
     ): Promise<void> {
         if (!options?.bypassPermissions) {
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('ScheduledDeliveries', {
+                        uuid: '',
                         organizationUuid: context.organizationUuid,
                         projectUuid: context.projectUuid,
                     }),
@@ -883,10 +905,12 @@ export class SchedulerService extends BaseService {
         options?: SoftDeleteOptions,
     ): Promise<void> {
         if (!options?.bypassPermissions) {
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('ScheduledDeliveries', {
+                        uuid: '',
                         organizationUuid: context.organizationUuid,
                         projectUuid: context.projectUuid,
                     }),
@@ -930,10 +954,12 @@ export class SchedulerService extends BaseService {
         options?: SoftDeleteOptions,
     ): Promise<void> {
         if (!options?.bypassPermissions) {
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('ScheduledDeliveries', {
+                        uuid: '',
                         organizationUuid: context.organizationUuid,
                         projectUuid: context.projectUuid,
                     }),
@@ -973,10 +999,12 @@ export class SchedulerService extends BaseService {
         options?: SoftDeleteOptions,
     ): Promise<void> {
         if (!options?.bypassPermissions) {
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('ScheduledDeliveries', {
+                        uuid: '',
                         organizationUuid: context.organizationUuid,
                         projectUuid: context.projectUuid,
                     }),
@@ -1022,10 +1050,12 @@ export class SchedulerService extends BaseService {
             jobId,
             user.userUuid,
         );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('JobStatus', {
+                    uuid: jobId,
                     projectUuid: job.details?.projectUuid,
                     organizationUuid: job.details?.organizationUuid,
                     createdByUserUuid: job.details?.createdByUserUuid,
@@ -1055,10 +1085,12 @@ export class SchedulerService extends BaseService {
     ): Promise<KnexPaginatedData<SchedulerWithLogs>> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         // Only allow editors to view scheduler logs
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
                 }),
@@ -1092,10 +1124,12 @@ export class SchedulerService extends BaseService {
     ): Promise<Pick<SchedulerLogDb, 'status' | 'details'>> {
         assertIsAccountWithOrg(account);
         const job = await this.schedulerModel.getJobStatus(jobId);
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('JobStatus', {
+                    uuid: jobId,
                     organizationUuid: job.details?.organizationUuid,
                     projectUuid: job.details?.projectUuid,
                     createdByUserUuid: job.details?.createdByUserUuid,
@@ -1261,9 +1295,7 @@ export class SchedulerService extends BaseService {
     ): Promise<KnexPaginatedData<SchedulerRun[]>> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         // Only allow editors to view scheduler runs
         if (
@@ -1355,9 +1387,7 @@ export class SchedulerService extends BaseService {
 
         const projectSummary = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         // Only allow editors to view run logs
         if (
@@ -1424,11 +1454,13 @@ export class SchedulerService extends BaseService {
             );
 
         // Check user can manage scheduled deliveries in all projects
+        const auditedAbility = this.createAuditedAbility(user);
         const projectsWithoutPermission = summary.byProject
             .filter((project) =>
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('ScheduledDeliveries', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: project.projectUuid,
                     }),
@@ -1486,12 +1518,14 @@ export class SchedulerService extends BaseService {
         }
 
         // Check calling user has manage:ScheduledDeliveries permission on ALL projects
+        const auditedAbility = this.createAuditedAbility(user);
         const projectsUserCannotManage: string[] = [];
         for (const project of summary.byProject) {
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('ScheduledDeliveries', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: project.projectUuid,
                     }),
@@ -1533,12 +1567,14 @@ export class SchedulerService extends BaseService {
         }
 
         // Validate new owner has create:ScheduledDeliveries permission in ALL projects
+        const newOwnerAuditedAbility = this.createAuditedAbility(newOwner);
         const projectsWithoutPermission: string[] = [];
         for (const project of summary.byProject) {
             if (
-                newOwner.ability.cannot(
+                newOwnerAuditedAbility.cannot(
                     'create',
                     subject('ScheduledDeliveries', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: project.projectUuid,
                     }),

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -61,13 +61,15 @@ export class SearchService extends BaseService {
         source: 'omnibar' | 'ai_search_box' = 'omnibar',
         filters?: SearchFilters,
     ): Promise<SearchResults> {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -115,9 +117,10 @@ export class SearchService extends BaseService {
             return accessibleSpaceUuids.includes(spaceUuid);
         };
 
-        const hasExploreAccess = user.ability.can(
+        const hasExploreAccess = auditedAbility.can(
             'manage',
             subject('Explore', {
+                uuid: '',
                 organizationUuid,
                 projectUuid,
             }),
@@ -228,9 +231,10 @@ export class SearchService extends BaseService {
                 (_, index) => hasSqlChartAccess[index],
             ),
             spaces: results.spaces.filter((_, index) => hasSpaceAccess[index]),
-            pages: user.ability.can(
+            pages: auditedAbility.can(
                 'view',
                 subject('Analytics', {
+                    uuid: '',
                     organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/ShareService/ShareService.ts
+++ b/packages/backend/src/services/ShareService/ShareService.ts
@@ -45,13 +45,15 @@ export class ShareService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         const shareUrl = await this.shareModel.getSharedUrl(nanoid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('OrganizationMemberProfile', {
-                    organizationUuid: shareUrl.organizationUuid,
+                    uuid: '',
+                    organizationUuid: shareUrl.organizationUuid || '',
                 }),
             )
         ) {

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     NotFoundError,
@@ -107,7 +108,16 @@ export class SlackIntegrationService<
         const organizationUuid = user?.organizationUuid;
         if (!organizationUuid) throw new ForbiddenError();
 
-        if (user.ability.cannot('manage', 'Organization')) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -194,10 +194,11 @@ export class SpaceService
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('Space', { organizationUuid, projectUuid }),
+                subject('Space', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -609,9 +610,11 @@ export class SpaceService
         });
 
         if (!options?.bypassPermissions) {
-            const isAdmin = user.ability.can(
+            const auditedAbility = this.createAuditedAbility(user);
+            const isAdmin = auditedAbility.can(
                 'manage',
                 subject('DeletedContent', {
+                    uuid: '',
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
                 }),
@@ -685,10 +688,12 @@ export class SpaceService
             const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
                 deleted: true,
             });
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('DeletedContent', {
+                        uuid: '',
                         organizationUuid: space.organizationUuid,
                         projectUuid: space.projectUuid,
                     }),
@@ -774,10 +779,15 @@ export class SpaceService
         const existingSpace = await this.spaceModel.get(spaceUuid);
         const { projectUuid, organizationUuid, pinnedListUuid } = existingSpace;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('PinnedItems', { projectUuid, organizationUuid }),
+                subject('PinnedItems', {
+                    uuid: '',
+                    projectUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/SpotlightService/SpotlightService.ts
+++ b/packages/backend/src/services/SpotlightService/SpotlightService.ts
@@ -39,11 +39,13 @@ export class SpotlightService extends BaseService {
         projectUuid: string,
         tableConfig: Pick<SpotlightTableConfig, 'columnConfig'>,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SpotlightTableConfig', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
                 }),
@@ -62,11 +64,13 @@ export class SpotlightService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<SpotlightTableConfig> {
+        const auditedAbility = this.createAuditedAbility(user);
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SpotlightTableConfig', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
                 }),
@@ -93,11 +97,13 @@ export class SpotlightService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SpotlightTableConfig', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -618,6 +618,7 @@ export class UnfurlService extends BaseService {
         user: SessionUser,
         selectedTabs: string[] | null,
     ): Promise<string> {
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const { inheritsFromOrgOrProject, access } =
@@ -671,9 +672,10 @@ export class UnfurlService extends BaseService {
         };
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
@@ -712,6 +714,7 @@ export class UnfurlService extends BaseService {
         chartUuidOrSlug: string,
         user: SessionUser,
     ): Promise<string> {
+        const auditedAbility = this.createAuditedAbility(user);
         const chart = await this.savedChartModel.get(chartUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getSpaceAccessContext(
@@ -720,9 +723,10 @@ export class UnfurlService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
+                    uuid: '',
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                     inheritsFromOrgOrProject,

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -39,7 +39,7 @@ export const validateUserAttributeOverrides = (
     if (
         user.ability.cannot(
             'manage',
-            subject('Organization', { organizationUuid }),
+            subject('Organization', { uuid: '', organizationUuid }),
         )
     ) {
         throw new ForbiddenError(

--- a/packages/backend/src/services/UserAttributesService/UserAttributesService.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributesService.ts
@@ -51,11 +51,12 @@ export class UserAttributesService extends BaseService {
         user: SessionUser,
         context: RequestMethod,
     ): Promise<UserAttribute[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         const organizationUuid = user.organizationUuid!;
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', { uuid: '', organizationUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -82,12 +83,13 @@ export class UserAttributesService extends BaseService {
         user: SessionUser,
         orgAttribute: CreateUserAttribute,
     ): Promise<UserAttribute> {
+        const auditedAbility = this.createAuditedAbility(user);
         const organizationUuid = user.organizationUuid!;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', { uuid: '', organizationUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -114,13 +116,15 @@ export class UserAttributesService extends BaseService {
         orgAttributeUuid: string,
         orgAttribute: CreateUserAttribute,
     ): Promise<UserAttribute> {
+        const auditedAbility = this.createAuditedAbility(user);
         const savedAttribute =
             await this.userAttributesModel.get(orgAttributeUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid: savedAttribute.organizationUuid,
                 }),
             )
@@ -146,12 +150,14 @@ export class UserAttributesService extends BaseService {
     }
 
     async delete(user: SessionUser, orgAttributeUuid: string): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const orgAttribute =
             await this.userAttributesModel.get(orgAttributeUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: '',
                     organizationUuid: orgAttribute.organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -367,6 +367,7 @@ export class UserService extends BaseService {
     }
 
     async delete(user: SessionUser, userUuidToDelete: string): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const userToDelete =
             await this.userModel.getUserDetailsByUuid(userUuidToDelete);
         // The user might not have an org yet
@@ -375,9 +376,10 @@ export class UserService extends BaseService {
             // We assume only one org per user
 
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'delete',
                     subject('OrganizationMemberProfile', {
+                        uuid: userUuidToDelete,
                         organizationUuid: userToDelete.organizationUuid,
                     }),
                 )
@@ -427,10 +429,14 @@ export class UserService extends BaseService {
         // We assume users can only have one org
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('InviteLink', { organizationUuid }),
+                subject('InviteLink', {
+                    uuid: '',
+                    organizationUuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -456,9 +462,12 @@ export class UserService extends BaseService {
         }
 
         let userUuid: string;
-        const userRole = user.ability.can(
+        const userRole = auditedAbility.can(
             'manage',
-            subject('OrganizationMemberProfile', { organizationUuid }),
+            subject('OrganizationMemberProfile', {
+                uuid: '',
+                organizationUuid,
+            }),
         )
             ? role || OrganizationMemberRole.MEMBER
             : OrganizationMemberRole.MEMBER;
@@ -525,10 +534,14 @@ export class UserService extends BaseService {
         // We assume users can only have one org
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'delete',
-                subject('InviteLink', { organizationUuid }),
+                subject('InviteLink', {
+                    uuid: '',
+                    organizationUuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -983,11 +996,13 @@ export class UserService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         if (organizationName) {
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'update',
                     subject('Organization', {
+                        uuid: user.organizationUuid,
                         organizationUuid: user.organizationUuid,
                     }),
                 )
@@ -1358,7 +1373,16 @@ export class UserService extends BaseService {
         if (!user.isActive) {
             throw new DeactivatedAccountError();
         }
-        if (user.ability.cannot('view', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('PersonalAccessToken', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to login with personal access tokens',
             );
@@ -1623,14 +1647,17 @@ export class UserService extends BaseService {
 
         if (projects.length === 0) return;
 
+        const auditedAbility = this.createAuditedAbility(sessionUser);
         await Promise.all(
             projects.map(async (project) => {
                 if (
-                    sessionUser.ability.cannot(
+                    auditedAbility.cannot(
                         'manage',
                         subject('SavedChart', {
+                            uuid: '',
                             projectUuid: project.projectUuid,
-                            organizationUuid: sessionUser.organizationUuid,
+                            organizationUuid:
+                                sessionUser.organizationUuid || '',
                             access: [
                                 {
                                     userUuid: sessionUser.userUuid,
@@ -1641,11 +1668,13 @@ export class UserService extends BaseService {
                             ],
                         }),
                     ) ||
-                    sessionUser.ability.cannot(
+                    auditedAbility.cannot(
                         'manage',
                         subject('Explore', {
+                            uuid: '',
                             projectUuid: project.projectUuid,
-                            organizationUuid: sessionUser.organizationUuid,
+                            organizationUuid:
+                                sessionUser.organizationUuid || '',
                         }),
                     )
                 )
@@ -1681,6 +1710,7 @@ export class UserService extends BaseService {
         clearImpersonation: () => void,
     ): Promise<SessionUser> {
         const requestUser = await this.findSessionUser(passportUser);
+        const auditedAbility = this.createAuditedAbility(requestUser);
 
         if (!impersonation) {
             return requestUser;
@@ -1710,10 +1740,11 @@ export class UserService extends BaseService {
         // Validate admin can still impersonate
         if (
             !requestUser.isActive ||
-            requestUser.ability.cannot(
+            auditedAbility.cannot(
                 'impersonate',
                 subject('User', {
-                    organizationUuid: requestUser.organizationUuid,
+                    uuid: requestUser.userUuid,
+                    organizationUuid: requestUser.organizationUuid || '',
                     isActive: requestUser.isActive,
                 }),
             )
@@ -2337,6 +2368,7 @@ export class UserService extends BaseService {
             }) => void;
         },
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(adminUser);
         if (!(await this.isImpersonationEnabled(adminUser))) {
             throw new ForbiddenError('User impersonation is not enabled');
         }
@@ -2365,10 +2397,11 @@ export class UserService extends BaseService {
 
         // Check permissions using CASL (includes org match and isActive)
         if (
-            adminUser.ability.cannot(
+            auditedAbility.cannot(
                 'impersonate',
                 subject('User', {
-                    organizationUuid: targetUser.organizationUuid,
+                    uuid: targetUserUuid,
+                    organizationUuid: targetUser.organizationUuid || '',
                     isActive: targetUser.isActive,
                 }),
             )

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -43,8 +43,6 @@ import {
 import * as Sentry from '@sentry/node';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
-import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
-import { logAuditEvent } from '../../logging/winston';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -936,8 +934,9 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
@@ -1053,11 +1052,12 @@ export class ValidationService extends BaseService {
     ): Promise<ValidationResponse[]> {
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
-                    organizationUuid,
+                    organizationUuid: organizationUuid || '',
                     projectUuid,
                     uuid: projectUuid,
                 }),
@@ -1122,9 +1122,7 @@ export class ValidationService extends BaseService {
     ): Promise<ValidationResponse> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -1184,9 +1182,7 @@ export class ValidationService extends BaseService {
     ): Promise<KnexPaginatedData<ValidationResponse[]>> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -1269,10 +1265,12 @@ export class ValidationService extends BaseService {
         const projectSummary = await this.projectModel.getSummary(
             validation.projectUuid,
         );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: validation.projectUuid,
                 }),
@@ -1301,8 +1299,9 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
@@ -1325,9 +1324,10 @@ export class ValidationService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
+                    uuid: '',
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                     inheritsFromOrgOrProject,
@@ -1381,8 +1381,9 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
@@ -1406,9 +1407,10 @@ export class ValidationService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                     inheritsFromOrgOrProject,


### PR DESCRIPTION
Closes: SPK-338

## Summary
- Migrate ~44 services from direct `.ability.can/cannot` calls to `this.createAuditedAbility()`
- Reduced direct ability checks from 358 to 33 across the codebase
- Fix `RolesService` test mocks to include `relevantRuleFor` and `rules` on mock ability objects
- Convert `RolesService` and `ServiceAccountService` static validation methods to instance methods to enable `this.createAuditedAbility()`

### Remaining unmigrated checks (33 total)
| File | Count | Reason |
|------|-------|--------|
| `PromoteService` | 15 | Static methods, cannot access `this` |
| `AiAgentService` | 12 | Does not extend `BaseService` |
| `SpacePermissionService` | 2 | Receives `Pick<SessionUser, ...>` partial type |
| `SpaceService._userCanActionSpace` | 1 | Internal test helper with partial user type |
| `UserAttributeUtils` | 1 | Standalone function, not a class |
| `AiOrganizationSettingsService` | 1 | Does not extend `BaseService` |
| `AiAgentAdminService` | 1 | Does not extend `BaseService` |

## Test plan
- [x] `pnpm -F backend typecheck` passes
- [x] `pnpm -F backend test:dev:nowatch` — 850 tests pass (including updated RolesService tests)
- [x] All migrated services use `this.createAuditedAbility()` consistently