### PR TITLE
feat: enforce ESLint no-direct-ability-check as error

### DIFF
--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -327,8 +327,8 @@ When a denied access attempt occurs (e.g., viewer trying to delete):
 ## ESLint Enforcement
 
 The custom ESLint rule `no-direct-ability-check` (loaded via `--rulesdir eslint-rules`) detects direct `.ability.can()` /
-`.ability.cannot()` usage in service files and flags them. It is currently set to **warning** during the migration period,
-and will be promoted to **error** once all services are migrated.
+`.ability.cannot()` usage in service files and flags them as **errors**. The build will fail if any new code uses direct
+ability checks without going through `createAuditedAbility()`.
 
 The rule catches patterns like:
 

--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -88,13 +88,25 @@ module.exports = {
             },
         },
         {
-            // Warn on direct ability checks in services - use createAuditedAbility() instead
+            // Enforce audited ability checks in services - use createAuditedAbility() instead
             files: [
                 'src/services/**/*.ts',
                 'src/ee/services/**/*.ts',
             ],
+            excludedFiles: [
+                // Static methods that cannot access this.createAuditedAbility()
+                'src/services/PromoteService/PromoteService.ts',
+                // Standalone utility function, not a class method
+                'src/services/UserAttributesService/UserAttributeUtils.ts',
+                // Receives partial user type (Pick<SessionUser, ...>)
+                'src/services/SpaceService/SpacePermissionService.ts',
+                // Do not extend BaseService
+                'src/ee/services/AiAgentService/AiAgentService.ts',
+                'src/ee/services/AiOrganizationSettingsService.ts',
+                'src/ee/services/AiAgentAdminService.ts',
+            ],
             rules: {
-                'no-direct-ability-check': 'warn',
+                'no-direct-ability-check': 'error',
             },
         },
         {

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -112,6 +112,7 @@ export class SpaceService
                 user.userUuid,
                 space.uuid,
             );
+        // eslint-disable-next-line no-direct-ability-check -- internal test helper receives partial user type
         return user.ability.can(action, subject(contentType, spaceCtx));
     }
 


### PR DESCRIPTION
Closes: SPK-339

## Summary
- Flip `custom-rules/no-direct-ability-check` ESLint rule from `warn` to `error`
- Build will now fail if any new code uses direct `.ability.can/cannot` calls in services
- Excluded 6 files that cannot be migrated (static methods, non-BaseService classes, partial user types)
- Add inline `eslint-disable` for `SpaceService._userCanActionSpace` internal test helper
- Update `docs/audit-logging.md` to reflect enforcement status

## Test plan
- [x] `pnpm -F backend lint` passes with zero violations
- [x] `pnpm -F backend typecheck` passes