### PR TITLE
fix(slack): update AI block link text and remove debug drawer navigation

### DIFF
--- a/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
+++ b/packages/backend/src/ee/services/ai/utils/getSlackBlocks.ts
@@ -408,7 +408,7 @@ export function getDeepLinkBlocks(
             type: 'section',
             text: {
                 type: 'mrkdwn',
-                text: `<${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}/messages/${slackPrompt.promptUuid}/debug|View message data in Lightdash ⚡️>`,
+                text: `<${siteUrl}/projects/${slackPrompt.projectUuid}/ai-agents/${agentUuid}/threads/${slackPrompt.threadUuid}|View chat in Lightdash ⚡️>`,
             },
         },
     ];


### PR DESCRIPTION
Changes the Slack AI block link from "View message data in Lightdash" to "View chat in Lightdash" and navigates to the thread view instead of the debug panel.

Slack thread: https://lightdash.slack.com/archives/C03MCQ08UKS/p1775052218682799

https://claude.ai/code/session_01Qd7ZDa37rBz2mqSQ7VVZxY

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
