### PR TITLE
feat: wire metricQuery.timezone into timezone resolution hierarchy

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -50,6 +50,7 @@ import {
     NotSupportedError,
     ParameterError,
     QueryExecutionContext,
+    resolveQueryTimezone,
     RunQueryTags,
     SavedChartsInfoForDashboardAvailableFilters,
     SessionAccount,
@@ -82,7 +83,6 @@ import {
     getDashboardParametersValuesMap,
 } from '../../../services/ProjectService/parameters';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
-import { resolveQueryTimezone } from '../../../services/resolveQueryTimezone';
 import { getFilteredExplore } from '../../../services/UserAttributesService/UserAttributeUtils';
 import { wrapSentryTransaction } from '../../../utils';
 import { EncryptionUtil } from '../../../utils/EncryptionUtil/EncryptionUtil';

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -59,6 +59,7 @@ import {
     PivotConfiguration,
     QueryExecutionContext,
     QueryHistoryStatus,
+    resolveQueryTimezone,
     ResultRow,
     ResultsExpiredError,
     S3Error,
@@ -146,7 +147,6 @@ import {
     getNextAndPreviousPage,
     validatePagination,
 } from '../ProjectService/resultsPagination';
-import { resolveQueryTimezone } from '../resolveQueryTimezone';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -132,6 +132,7 @@ import {
     replaceDimensionInExplore,
     RequestMethod,
     resolveBaseDimension,
+    resolveQueryTimezone,
     resolveToBaseTimeDimension,
     ResultRow,
     SavedChartDAO,
@@ -259,7 +260,6 @@ import { applyLimitToSqlQuery } from '../../utils/QueryBuilder/utils';
 import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import { AdminNotificationService } from '../AdminNotificationService/AdminNotificationService';
 import { BaseService } from '../BaseService';
-import { resolveQueryTimezone } from '../resolveQueryTimezone';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
 import {
     doesExploreMatchRequiredAttributes,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -219,6 +219,7 @@ export * from './utils/dateZoom';
 export * from './utils/tableCalculationFunctions';
 export * from './utils/time';
 export * from './utils/timeFrames';
+export * from './utils/resolveQueryTimezone';
 export * from './utils/virtualView';
 export * from './utils/warehouse';
 export * from './visualizations/CartesianChartDataModel';

--- a/packages/common/src/utils/resolveQueryTimezone.test.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.test.ts
@@ -1,0 +1,22 @@
+import { resolveQueryTimezone } from './resolveQueryTimezone';
+
+describe('resolveQueryTimezone', () => {
+    it('returns metricQuery.timezone when set', () => {
+        expect(
+            resolveQueryTimezone(
+                { timezone: 'America/New_York' },
+                'Australia/Brisbane',
+            ),
+        ).toBe('America/New_York');
+    });
+
+    it('falls back to project timezone when metricQuery.timezone is undefined', () => {
+        expect(
+            resolveQueryTimezone({ timezone: undefined }, 'Australia/Brisbane'),
+        ).toBe('Australia/Brisbane');
+    });
+
+    it('falls back to project timezone when timezone field is missing', () => {
+        expect(resolveQueryTimezone({}, 'Europe/London')).toBe('Europe/London');
+    });
+});

--- a/packages/common/src/utils/resolveQueryTimezone.ts
+++ b/packages/common/src/utils/resolveQueryTimezone.ts
@@ -1,4 +1,4 @@
-import { type MetricQuery } from '@lightdash/common';
+import { type MetricQuery } from '../types/metricQuery';
 
 /**
  * Resolves the effective timezone for a query using the hierarchy:


### PR DESCRIPTION
## Summary

- Add `resolveQueryTimezone()` helper implementing the priority chain: `metricQuery.timezone → project timezone → 'UTC'`
- Replace all 11 `getQueryTimezoneForProject()` call sites (ProjectService, AsyncQueryService, EmbedService) to use the resolver
- Enables per-chart timezone overrides when the `EnableUserTimezones` flag is on

**No feature flag gating** — this is a pure refactor. The resolver adds a layer on top of the existing `getQueryTimezoneForProject()`. When `metricQuery.timezone` is undefined (which is always the case today since the per-chart picker UI is behind a separate flag), the behavior is identical.

Closes GLITCH-287