### PR TITLE
fix: resolve MotherDuck query builder bugs

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -844,21 +844,6 @@ describe('Query builder', () => {
         expect(query).not.toMatch(/INNER JOIN pop_metrics_/);
     });
 
-    test('Should wrap PoP queries in an outer metrics CTE so ORDER BY is not ambiguous', () => {
-        const { query } = buildQuery({
-            explore: POP_TEST_EXPLORE,
-            compiledMetricQuery: POP_TEST_METRIC_QUERY,
-            warehouseSqlBuilder: warehouseClientMock,
-            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-            timezone: QUERY_BUILDER_UTC_TIMEZONE,
-        });
-
-        expect(query).toMatch(/metrics AS \(\nSELECT\n {2}base_metrics\.\*/);
-        expect(query).toMatch(
-            /SELECT\s+\*\s+FROM metrics\s+ORDER BY "orders_order_date_year" DESC\s+LIMIT 500$/,
-        );
-    });
-
     test('Should reuse non-time filters for PoP metrics in fanout-protected CTEs while shifting the comparison period', () => {
         const { query } = buildQuery({
             explore: POP_TEST_FANOUT_EXPLORE,
@@ -1625,30 +1610,6 @@ LIMIT 10`;
             expect(result.warnings).toHaveLength(0);
         });
 
-        test('Should wrap fanout-protected joins in an outer metrics CTE so ORDER BY dimension aliases are not ambiguous', () => {
-            const result = buildQuery({
-                explore: EXPLORE,
-                compiledMetricQuery: {
-                    ...METRIC_QUERY_TWO_TABLES,
-                    tableCalculations: [],
-                    compiledTableCalculations: [],
-                    dimensions: ['table1_dim1'],
-                    metrics: ['table1_metric1', 'table2_metric3'],
-                    sorts: [{ fieldId: 'table1_dim1', descending: false }],
-                },
-                warehouseSqlBuilder: warehouseClientMock,
-                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                timezone: QUERY_BUILDER_UTC_TIMEZONE,
-            });
-
-            expect(result.query).toMatch(
-                /metrics AS \(\nSELECT\n {2}cte_unaffected\.\*/,
-            );
-            expect(result.query).toMatch(
-                /SELECT\s+\*\s+FROM metrics\s+ORDER BY "table1_dim1"\s+LIMIT 10$/,
-            );
-        });
-
         test('Should handle inflation-proof metrics correctly', () => {
             // Create a metric query that includes both the count distinct metric and the sum metric
             const metricQueryWithMixedMetrics = {
@@ -2290,28 +2251,6 @@ LIMIT 10`;
             );
             expect(result.query).toContain('GROUP BY');
             expect(result.query).toContain('dd_orders_avg_shipping_cost');
-        });
-
-        test('distinct metric joins should be wrapped in an outer metrics CTE so ORDER BY dimension aliases are not ambiguous', () => {
-            const result = buildQuery({
-                explore: EXPLORE_WITH_SUM_DISTINCT,
-                compiledMetricQuery: {
-                    ...METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
-                    sorts: [
-                        { fieldId: 'orders_payment_method', descending: false },
-                    ],
-                },
-                warehouseSqlBuilder: warehouseClientMock,
-                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                timezone: QUERY_BUILDER_UTC_TIMEZONE,
-            });
-
-            expect(result.query).toMatch(
-                /metrics AS \(\nSELECT\n {2}dd_base\.\*/,
-            );
-            expect(result.query).toMatch(
-                /SELECT\s+\*\s+FROM metrics\s+ORDER BY "orders_payment_method"\s+LIMIT 10$/,
-            );
         });
     });
 
@@ -4000,97 +3939,6 @@ describe('Query Structure Tests', () => {
      * AVG(order_value) — each metric gets its own correct aggregation,
      * they don't all default to SUM.
      */
-    test('Should use correct aggregation per metric when multiple metric types use total()', () => {
-        const exploreWithMultipleMetrics: Explore = {
-            ...EXPLORE,
-            tables: {
-                ...EXPLORE.tables,
-                table1: {
-                    ...EXPLORE.tables.table1,
-                    metrics: {
-                        ...EXPLORE.tables.table1.metrics,
-                        total_revenue: {
-                            type: MetricType.SUM,
-                            fieldType: FieldType.METRIC,
-                            table: 'table1',
-                            tableLabel: 'table1',
-                            name: 'total_revenue',
-                            label: 'total_revenue',
-                            sql: '${TABLE}.revenue',
-                            compiledSql: 'SUM("table1".revenue)',
-                            tablesReferences: ['table1'],
-                            hidden: false,
-                        } as CompiledMetric,
-                        avg_order_value: {
-                            type: MetricType.AVERAGE,
-                            fieldType: FieldType.METRIC,
-                            table: 'table1',
-                            tableLabel: 'table1',
-                            name: 'avg_order_value',
-                            label: 'avg_order_value',
-                            sql: '${TABLE}.order_value',
-                            compiledSql: 'AVG("table1".order_value)',
-                            tablesReferences: ['table1'],
-                            hidden: false,
-                        } as CompiledMetric,
-                    },
-                },
-            },
-        };
-
-        const metricQueryWithMultipleTotals = {
-            ...METRIC_QUERY,
-            metrics: ['table1_total_revenue', 'table1_avg_order_value'],
-            tableCalculations: [
-                {
-                    name: 'revenue_pct',
-                    displayName: 'Revenue %',
-                    sql: '${table1.total_revenue} / total(${table1.total_revenue})',
-                },
-                {
-                    name: 'avg_pct',
-                    displayName: 'Avg %',
-                    sql: '${table1.avg_order_value} / total(${table1.avg_order_value})',
-                },
-            ],
-            compiledTableCalculations: [
-                {
-                    name: 'revenue_pct',
-                    displayName: 'Revenue %',
-                    sql: '${table1.total_revenue} / total(${table1.total_revenue})',
-                    compiledSql:
-                        '"table1_total_revenue" / total("table1_total_revenue")',
-                    dependsOn: [],
-                },
-                {
-                    name: 'avg_pct',
-                    displayName: 'Avg %',
-                    sql: '${table1.avg_order_value} / total(${table1.avg_order_value})',
-                    compiledSql:
-                        '"table1_avg_order_value" / total("table1_avg_order_value")',
-                    dependsOn: [],
-                },
-            ],
-        };
-
-        const result = buildQuery({
-            explore: exploreWithMultipleMetrics,
-            compiledMetricQuery: metricQueryWithMultipleTotals,
-            warehouseSqlBuilder: warehouseClientMock,
-            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-            timezone: QUERY_BUILDER_UTC_TIMEZONE,
-        });
-
-        // SUM metric should use SUM in column_totals
-        expect(result.query).toContain(
-            'SUM("table1".revenue) AS "table1_total_revenue__total"',
-        );
-        // AVG metric should use AVG in column_totals (not SUM)
-        expect(result.query).toContain(
-            'AVG("table1".order_value) AS "table1_avg_order_value__total"',
-        );
-    });
-
     /**
      * "Avg Order Value" pivoted by region: North=$50, South=$45, East=$60.
      * row_total() gives $50+$45+$60 = $155 — a SUM of the averages.

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1343,22 +1343,55 @@ export class MetricQueryBuilder {
         return undefined;
     }
 
-    private getSortSQL(excludePostCalculationMetrics: boolean = false) {
-        const { compiledMetricQuery, warehouseSqlBuilder } = this.args;
-        const { sorts, metrics, compiledCustomDimensions } =
-            compiledMetricQuery;
-        const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
-        const startOfWeek = warehouseSqlBuilder.getStartOfWeek();
-        let requiresQueryInCTE = false;
+    private getEffectiveSorts(
+        excludePostCalculationMetrics: boolean = false,
+    ): SortField[] {
+        const { compiledMetricQuery } = this.args;
+        const { sorts, metrics } = compiledMetricQuery;
 
-        // Apply default sort if no sorts are specified
         let effectiveSorts: SortField[] = sorts;
         if (sorts.length === 0) {
             const defaultSort = this.getDefaultSort();
             effectiveSorts = defaultSort ? [defaultSort] : [];
         }
 
-        const fieldOrders = effectiveSorts.reduce<string[]>((acc, sort) => {
+        if (!excludePostCalculationMetrics) {
+            return effectiveSorts;
+        }
+
+        return effectiveSorts.filter((sort) => {
+            if (!metrics.includes(sort.fieldId)) return true;
+
+            const metric = this.getMetricFromId(sort.fieldId);
+            return !isPostCalculationMetric(metric);
+        });
+    }
+
+    private isSortingBySelectedDimensionAlias(): boolean {
+        const { compiledMetricQuery } = this.args;
+        const customBinDimensionIds = new Set(
+            compiledMetricQuery.compiledCustomDimensions
+                .filter(isCustomBinDimension)
+                .map(getItemId),
+        );
+
+        return this.getEffectiveSorts().some(
+            (sort) =>
+                compiledMetricQuery.dimensions.includes(sort.fieldId) &&
+                !customBinDimensionIds.has(sort.fieldId),
+        );
+    }
+
+    private getSortSQL(excludePostCalculationMetrics: boolean = false) {
+        const { compiledMetricQuery, warehouseSqlBuilder } = this.args;
+        const { compiledCustomDimensions } = compiledMetricQuery;
+        const fieldQuoteChar = warehouseSqlBuilder.getFieldQuoteChar();
+        const startOfWeek = warehouseSqlBuilder.getStartOfWeek();
+        let requiresQueryInCTE = false;
+
+        const fieldOrders = this.getEffectiveSorts(
+            excludePostCalculationMetrics,
+        ).reduce<string[]>((acc, sort) => {
             // Default sort
             let fieldSort: string = `${fieldQuoteChar}${
                 sort.fieldId
@@ -1409,15 +1442,6 @@ export class MetricQueryBuilder {
                     warehouseSqlBuilder.getFieldQuoteChar(),
                     sort.descending,
                 );
-            } else if (
-                excludePostCalculationMetrics &&
-                metrics.includes(sort.fieldId)
-            ) {
-                const metric = this.getMetricFromId(sort.fieldId);
-                if (isPostCalculationMetric(metric)) {
-                    // Skip sorting by PostCalculation metrics
-                    return acc;
-                }
             }
             acc.push(fieldSort);
             return acc;
@@ -2391,7 +2415,7 @@ export class MetricQueryBuilder {
                     }),
                 ];
                 if (
-                    Object.keys(dimensionSelects).length > 0 &&
+                    this.isSortingBySelectedDimensionAlias() &&
                     (metricCtes.length > 0 || popMetricCtes.length > 0)
                 ) {
                     requiresQueryInCTE = true;
@@ -3424,6 +3448,31 @@ export class MetricQueryBuilder {
         return [];
     }
 
+    private static shouldUseGroupedResultsForTotal(
+        metric: CompiledMetric,
+    ): boolean {
+        return (
+            metric.type === MetricType.SUM || metric.type === MetricType.COUNT
+        );
+    }
+
+    private getGroupedResultsTotalSql(
+        fieldId: string,
+        metric: CompiledMetric,
+    ): string {
+        const fieldQuoteChar =
+            this.args.warehouseSqlBuilder.getFieldQuoteChar();
+        const fieldRef = `${fieldQuoteChar}${fieldId}${fieldQuoteChar}`;
+
+        switch (metric.type) {
+            case MetricType.SUM:
+            case MetricType.COUNT:
+                return `SUM(${fieldRef})`;
+            default:
+                return metric.compiledSql;
+        }
+    }
+
     private replaceTotalReferences(compiledSql: string): string {
         const q = this.args.warehouseSqlBuilder.getFieldQuoteChar();
         const { totalRegex, rowTotalRegex } = buildTotalFieldRegex(q);
@@ -3446,6 +3495,7 @@ export class MetricQueryBuilder {
         totalFields: string[];
         rowTotalFields: string[];
         currentCteName: string;
+        allowGroupedTotals: boolean;
         sqlFrom: string;
         joinsSql: string | undefined;
         dimensionJoins: string[];
@@ -3455,20 +3505,71 @@ export class MetricQueryBuilder {
         const fieldQuoteChar =
             this.args.warehouseSqlBuilder.getFieldQuoteChar();
         const ctes: string[] = [];
+        const groupedTotalFields = opts.allowGroupedTotals
+            ? opts.totalFields.filter((fieldId) =>
+                  MetricQueryBuilder.shouldUseGroupedResultsForTotal(
+                      this.getMetricFromId(fieldId),
+                  ),
+              )
+            : [];
+        const rawTotalFields = opts.totalFields.filter(
+            (fieldId) => !groupedTotalFields.includes(fieldId),
+        );
 
         // column_totals CTE: grand total with no GROUP BY
-        if (opts.totalFields.length > 0) {
-            const totalSelects = opts.totalFields.map((fieldId) => {
+        if (groupedTotalFields.length > 0) {
+            const groupedTotalSelects = groupedTotalFields.map((fieldId) => {
+                const metric = this.getMetricFromId(fieldId);
+                return `  ${this.getGroupedResultsTotalSql(
+                    fieldId,
+                    metric,
+                )} AS ${fieldQuoteChar}${fieldId}__total${fieldQuoteChar}`;
+            });
+            ctes.push(
+                MetricQueryBuilder.wrapAsCte('column_totals_grouped', [
+                    `SELECT\n${groupedTotalSelects.join(',\n')}`,
+                    `FROM ${opts.currentCteName}`,
+                ]),
+            );
+        }
+
+        if (rawTotalFields.length > 0) {
+            const rawTotalSelects = rawTotalFields.map((fieldId) => {
                 const metric = this.getMetricFromId(fieldId);
                 return `  ${metric.compiledSql} AS ${fieldQuoteChar}${fieldId}__total${fieldQuoteChar}`;
             });
             ctes.push(
-                MetricQueryBuilder.wrapAsCte('column_totals', [
-                    `SELECT\n${totalSelects.join(',\n')}`,
+                MetricQueryBuilder.wrapAsCte('column_totals_raw', [
+                    `SELECT\n${rawTotalSelects.join(',\n')}`,
                     opts.sqlFrom,
                     opts.joinsSql,
                     ...opts.dimensionJoins,
                     opts.dimensionFilters,
+                ]),
+            );
+        }
+
+        if (opts.totalFields.length > 0) {
+            const totalColumnRefs = opts.totalFields.map(
+                (fieldId) =>
+                    `  ${fieldQuoteChar}${fieldId}__total${fieldQuoteChar}`,
+            );
+            let columnTotalsFrom: string[];
+            if (groupedTotalFields.length > 0 && rawTotalFields.length > 0) {
+                columnTotalsFrom = [
+                    'FROM column_totals_grouped',
+                    'CROSS JOIN column_totals_raw',
+                ];
+            } else if (groupedTotalFields.length > 0) {
+                columnTotalsFrom = ['FROM column_totals_grouped'];
+            } else {
+                columnTotalsFrom = ['FROM column_totals_raw'];
+            }
+
+            ctes.push(
+                MetricQueryBuilder.wrapAsCte('column_totals', [
+                    `SELECT\n${totalColumnRefs.join(',\n')}`,
+                    ...columnTotalsFrom,
                 ]),
             );
         }
@@ -3863,7 +3964,7 @@ export class MetricQueryBuilder {
                 // DuckDB resolves ORDER BY names against joined sources here, so
                 // sorting by a shared dimension alias becomes ambiguous unless we
                 // sort from an outer projection.
-                requiresQueryInCTE = true;
+                requiresQueryInCTE = this.isSortingBySelectedDimensionAlias();
             }
         }
         warnings.push(...experimentalMetricsCteSQL.warnings);
@@ -3919,7 +4020,7 @@ export class MetricQueryBuilder {
                     `FROM ${ddBaseCteName}`,
                     ...ddJoins,
                 ];
-                if (Object.keys(dimensionsSQL.selects).length > 0) {
+                if (this.isSortingBySelectedDimensionAlias()) {
                     requiresQueryInCTE = true;
                 }
             } else {
@@ -4013,6 +4114,10 @@ export class MetricQueryBuilder {
             (this.args.pivotDimensions && this.args.pivotDimensions.length > 0);
         const needsTotalsCtes =
             totalFields.length > 0 || (rowTotalFields.length > 0 && hasPivot);
+        const allowGroupedTotals =
+            !experimentalMetricsCteSQL.finalSelectParts &&
+            ddMetricIds.length === 0 &&
+            nestedAggMetrics.length === 0;
 
         if (needsPostAgg) {
             const fieldQuoteChar =
@@ -4054,6 +4159,7 @@ export class MetricQueryBuilder {
                         totalFields,
                         rowTotalFields,
                         currentCteName,
+                        allowGroupedTotals,
                         sqlFrom,
                         joinsSql: joins.joinSQL,
                         dimensionJoins: dimensionsSQL.joins,

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
@@ -68,6 +68,80 @@ LIMIT
   10"
 `;
 
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a sum-distinct query with dimensions sorted by dimension 1`] = `
+"WITH
+  dd_orders_total_revenue AS (
+    SELECT
+      "orders_payment_method",
+      "orders_status",
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "orders_total_revenue"
+    FROM
+      (
+        SELECT
+          "orders".payment_method AS "orders_payment_method",
+          "orders".status AS "orders_status",
+          "orders".amount AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "orders".line_item_id,
+              "orders".payment_method,
+              "orders".status
+            ORDER BY
+              "orders".amount
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."orders" AS "orders"
+      ) __dd_sub
+    GROUP BY
+      1,
+      2
+  ),
+  dd_base AS (
+    SELECT
+      "orders".payment_method AS "orders_payment_method",
+      "orders".status AS "orders_status"
+    FROM
+      "db"."schema"."orders" AS "orders"
+    GROUP BY
+      1,
+      2
+  ),
+  metrics AS (
+    SELECT
+      dd_base.*,
+      dd_orders_total_revenue."orders_total_revenue" AS "orders_total_revenue"
+    FROM
+      dd_base
+      INNER JOIN dd_orders_total_revenue ON (
+        dd_base."orders_payment_method" = dd_orders_total_revenue."orders_payment_method"
+        OR (
+          dd_base."orders_payment_method" IS NULL
+          AND dd_orders_total_revenue."orders_payment_method" IS NULL
+        )
+      )
+      AND (
+        dd_base."orders_status" = dd_orders_total_revenue."orders_status"
+        OR (
+          dd_base."orders_status" IS NULL
+          AND dd_orders_total_revenue."orders_status" IS NULL
+        )
+      )
+  )
+SELECT
+  *
+FROM
+  metrics
+ORDER BY
+  "orders_payment_method"
+LIMIT
+  10"
+`;
+
 exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a sum-distinct query without dimensions 1`] = `
 "WITH
   dd_orders_total_revenue AS (

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap
@@ -88,6 +88,108 @@ LIMIT
   10"
 `;
 
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a fanout-protected metric query sorted by dimension 1`] = `
+"WITH
+  cte_keys_table2 AS (
+    SELECT DISTINCT
+      "table1".dim1 AS "table1_dim1",
+      "table2".dim2 AS "pk_dim2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  ),
+  cte_metrics_table2 AS (
+    SELECT
+      cte_keys_table2."table1_dim1",
+      SUM("table2".number_column) AS "table2_metric3"
+    FROM
+      cte_keys_table2
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_dim2" = "table2".dim2
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    GROUP BY
+      1
+  ),
+  metrics AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_table2."table2_metric3" AS "table2_metric3"
+    FROM
+      cte_unaffected
+      INNER JOIN cte_metrics_table2 ON (
+        cte_unaffected."table1_dim1" = cte_metrics_table2."table1_dim1"
+        OR (
+          cte_unaffected."table1_dim1" IS NULL
+          AND cte_metrics_table2."table1_dim1" IS NULL
+        )
+      )
+  )
+SELECT
+  *
+FROM
+  metrics
+ORDER BY
+  "table1_dim1"
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a fanout-protected metric query sorted by metric without wrapper 1`] = `
+"WITH
+  cte_keys_table2 AS (
+    SELECT DISTINCT
+      "table1".dim1 AS "table1_dim1",
+      "table2".dim2 AS "pk_dim2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  ),
+  cte_metrics_table2 AS (
+    SELECT
+      cte_keys_table2."table1_dim1",
+      SUM("table2".number_column) AS "table2_metric3"
+    FROM
+      cte_keys_table2
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_dim2" = "table2".dim2
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    GROUP BY
+      1
+  )
+SELECT
+  cte_unaffected.*,
+  cte_metrics_table2."table2_metric3" AS "table2_metric3"
+FROM
+  cte_unaffected
+  INNER JOIN cte_metrics_table2 ON (
+    cte_unaffected."table1_dim1" = cte_metrics_table2."table1_dim1"
+    OR (
+      cte_unaffected."table1_dim1" IS NULL
+      AND cte_metrics_table2."table1_dim1" IS NULL
+    )
+  )
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
 exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a fanout-protected metric query without dimensions 1`] = `
 "WITH
   cte_keys_table2 AS (

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/periodOverPeriodQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/periodOverPeriodQueries.test.ts.snap
@@ -73,24 +73,30 @@ exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapsho
       )
     GROUP BY
       1
+  ),
+  metrics AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_table2."table2_metric_amount" AS "table2_metric_amount",
+      cte_metrics_table2."table2_metric_amount__pop__year_1__fanout" AS "table2_metric_amount__pop__year_1__fanout",
+      cte_pop_metrics_table2__year_1__00355f4s."table2_metric_amount__pop__year_1__fanout" AS "table2_metric_amount__pop__year_1__fanout"
+    FROM
+      cte_unaffected
+      INNER JOIN cte_metrics_table2 ON (
+        cte_unaffected."table2_order_date_year" = cte_metrics_table2."table2_order_date_year"
+        OR (
+          cte_unaffected."table2_order_date_year" IS NULL
+          AND cte_metrics_table2."table2_order_date_year" IS NULL
+        )
+      )
+      LEFT JOIN cte_pop_metrics_table2__year_1__00355f4s ON (
+        cte_unaffected."table2_order_date_year" = cte_pop_metrics_table2__year_1__00355f4s."table2_order_date_year" + INTERVAL '1 YEAR'
+      )
   )
 SELECT
-  cte_unaffected.*,
-  cte_metrics_table2."table2_metric_amount" AS "table2_metric_amount",
-  cte_metrics_table2."table2_metric_amount__pop__year_1__fanout" AS "table2_metric_amount__pop__year_1__fanout",
-  cte_pop_metrics_table2__year_1__00355f4s."table2_metric_amount__pop__year_1__fanout" AS "table2_metric_amount__pop__year_1__fanout"
+  *
 FROM
-  cte_unaffected
-  INNER JOIN cte_metrics_table2 ON (
-    cte_unaffected."table2_order_date_year" = cte_metrics_table2."table2_order_date_year"
-    OR (
-      cte_unaffected."table2_order_date_year" IS NULL
-      AND cte_metrics_table2."table2_order_date_year" IS NULL
-    )
-  )
-  LEFT JOIN cte_pop_metrics_table2__year_1__00355f4s ON (
-    cte_unaffected."table2_order_date_year" = cte_pop_metrics_table2__year_1__00355f4s."table2_order_date_year" + INTERVAL '1 YEAR'
-  )
+  metrics
 ORDER BY
   "table2_order_date_year" DESC
 LIMIT
@@ -175,52 +181,58 @@ exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapsho
       1,
       2,
       3
+  ),
+  metrics AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_country_orders."country_orders_total_order_amount" AS "country_orders_total_order_amount",
+      cte_metrics_country_orders."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country",
+      cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country"
+    FROM
+      cte_unaffected
+      INNER JOIN cte_metrics_country_orders ON (
+        cte_unaffected."country_orders_order_date_year" = cte_metrics_country_orders."country_orders_order_date_year"
+        OR (
+          cte_unaffected."country_orders_order_date_year" IS NULL
+          AND cte_metrics_country_orders."country_orders_order_date_year" IS NULL
+        )
+      )
+      AND (
+        cte_unaffected."country_orders_country" = cte_metrics_country_orders."country_orders_country"
+        OR (
+          cte_unaffected."country_orders_country" IS NULL
+          AND cte_metrics_country_orders."country_orders_country" IS NULL
+        )
+      )
+      AND (
+        cte_unaffected."order_currencies_currency" = cte_metrics_country_orders."order_currencies_currency"
+        OR (
+          cte_unaffected."order_currencies_currency" IS NULL
+          AND cte_metrics_country_orders."order_currencies_currency" IS NULL
+        )
+      )
+      LEFT JOIN cte_pop_metrics_country_orders__year_1__00rp9exa ON (
+        cte_unaffected."country_orders_order_date_year" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_order_date_year" + INTERVAL '1 YEAR'
+      )
+      AND (
+        cte_unaffected."country_orders_country" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_country"
+        OR (
+          cte_unaffected."country_orders_country" IS NULL
+          AND cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_country" IS NULL
+        )
+      )
+      AND (
+        cte_unaffected."order_currencies_currency" = cte_pop_metrics_country_orders__year_1__00rp9exa."order_currencies_currency"
+        OR (
+          cte_unaffected."order_currencies_currency" IS NULL
+          AND cte_pop_metrics_country_orders__year_1__00rp9exa."order_currencies_currency" IS NULL
+        )
+      )
   )
 SELECT
-  cte_unaffected.*,
-  cte_metrics_country_orders."country_orders_total_order_amount" AS "country_orders_total_order_amount",
-  cte_metrics_country_orders."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country",
-  cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country"
+  *
 FROM
-  cte_unaffected
-  INNER JOIN cte_metrics_country_orders ON (
-    cte_unaffected."country_orders_order_date_year" = cte_metrics_country_orders."country_orders_order_date_year"
-    OR (
-      cte_unaffected."country_orders_order_date_year" IS NULL
-      AND cte_metrics_country_orders."country_orders_order_date_year" IS NULL
-    )
-  )
-  AND (
-    cte_unaffected."country_orders_country" = cte_metrics_country_orders."country_orders_country"
-    OR (
-      cte_unaffected."country_orders_country" IS NULL
-      AND cte_metrics_country_orders."country_orders_country" IS NULL
-    )
-  )
-  AND (
-    cte_unaffected."order_currencies_currency" = cte_metrics_country_orders."order_currencies_currency"
-    OR (
-      cte_unaffected."order_currencies_currency" IS NULL
-      AND cte_metrics_country_orders."order_currencies_currency" IS NULL
-    )
-  )
-  LEFT JOIN cte_pop_metrics_country_orders__year_1__00rp9exa ON (
-    cte_unaffected."country_orders_order_date_year" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_order_date_year" + INTERVAL '1 YEAR'
-  )
-  AND (
-    cte_unaffected."country_orders_country" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_country"
-    OR (
-      cte_unaffected."country_orders_country" IS NULL
-      AND cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_country" IS NULL
-    )
-  )
-  AND (
-    cte_unaffected."order_currencies_currency" = cte_pop_metrics_country_orders__year_1__00rp9exa."order_currencies_currency"
-    OR (
-      cte_unaffected."order_currencies_currency" IS NULL
-      AND cte_pop_metrics_country_orders__year_1__00rp9exa."order_currencies_currency" IS NULL
-    )
-  )
+  metrics
 ORDER BY
   "country_orders_order_date_year" DESC
 LIMIT

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/totalsQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/totalsQueries.test.ts.snap
@@ -11,11 +11,17 @@ exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a depe
     GROUP BY
       1
   ),
-  column_totals AS (
+  column_totals_raw AS (
     SELECT
       MAX("table1".number_column) AS "table1_metric1__total"
     FROM
       "db"."schema"."table1" AS "table1"
+  ),
+  column_totals AS (
+    SELECT
+      "table1_metric1__total"
+    FROM
+      column_totals_raw
   ),
   with_totals AS (
     SELECT
@@ -49,6 +55,134 @@ LIMIT
   10"
 `;
 
+exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a fanout-protected additive total query 1`] = `
+"WITH
+  cte_keys_table2 AS (
+    SELECT DISTINCT
+      "table1".dim1 AS "table1_dim1",
+      "table2".dim2 AS "pk_dim2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  ),
+  cte_metrics_table2 AS (
+    SELECT
+      cte_keys_table2."table1_dim1",
+      SUM("table2".number_column) AS "table2_metric3"
+    FROM
+      cte_keys_table2
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_dim2" = "table2".dim2
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    GROUP BY
+      1
+  ),
+  metrics AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_table2."table2_metric3" AS "table2_metric3"
+    FROM
+      cte_unaffected
+      INNER JOIN cte_metrics_table2 ON (
+        cte_unaffected."table1_dim1" = cte_metrics_table2."table1_dim1"
+        OR (
+          cte_unaffected."table1_dim1" IS NULL
+          AND cte_metrics_table2."table1_dim1" IS NULL
+        )
+      )
+  ),
+  column_totals_raw AS (
+    SELECT
+      SUM("table2".number_column) AS "table2_metric3__total"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  ),
+  column_totals AS (
+    SELECT
+      "table2_metric3__total"
+    FROM
+      column_totals_raw
+  ),
+  with_totals AS (
+    SELECT
+      metrics.*,
+      column_totals."table2_metric3__total"
+    FROM
+      metrics
+      CROSS JOIN column_totals
+  )
+SELECT
+  *,
+  "table2_metric3" / "table2_metric3__total" AS "pct_total"
+FROM
+  with_totals
+ORDER BY
+  "table2_metric3" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a mixed additive and non-additive totals query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      SUM("table1".revenue) AS "table1_total_revenue",
+      AVG("table1".order_value) AS "table1_avg_order_value"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  ),
+  column_totals_grouped AS (
+    SELECT
+      SUM("table1_total_revenue") AS "table1_total_revenue__total"
+    FROM
+      metrics
+  ),
+  column_totals_raw AS (
+    SELECT
+      AVG("table1".order_value) AS "table1_avg_order_value__total"
+    FROM
+      "db"."schema"."table1" AS "table1"
+  ),
+  column_totals AS (
+    SELECT
+      "table1_total_revenue__total",
+      "table1_avg_order_value__total"
+    FROM
+      column_totals_grouped
+      CROSS JOIN column_totals_raw
+  ),
+  with_totals AS (
+    SELECT
+      metrics.*,
+      column_totals."table1_total_revenue__total",
+      column_totals."table1_avg_order_value__total"
+    FROM
+      metrics
+      CROSS JOIN column_totals
+  )
+SELECT
+  *,
+  "table1_total_revenue" / "table1_total_revenue__total" AS "revenue_pct",
+  "table1_avg_order_value" / "table1_avg_order_value__total" AS "avg_pct"
+FROM
+  with_totals
+ORDER BY
+  "table1_total_revenue" DESC
+LIMIT
+  10"
+`;
+
 exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a pivoted totals query 1`] = `
 "WITH
   metrics AS (
@@ -60,11 +194,17 @@ exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a pivo
     GROUP BY
       1
   ),
-  column_totals AS (
+  column_totals_raw AS (
     SELECT
       MAX("table1".number_column) AS "table1_metric1__total"
     FROM
       "db"."schema"."table1" AS "table1"
+  ),
+  column_totals AS (
+    SELECT
+      "table1_metric1__total"
+    FROM
+      column_totals_raw
   ),
   row_totals AS (
     SELECT
@@ -181,11 +321,17 @@ exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for an ave
     GROUP BY
       1
   ),
-  column_totals AS (
+  column_totals_raw AS (
     SELECT
       AVG("table1".number_column) AS "table1_avg_metric__total"
     FROM
       "db"."schema"."table1" AS "table1"
+  ),
+  column_totals AS (
+    SELECT
+      "table1_avg_metric__total"
+    FROM
+      column_totals_raw
   ),
   with_totals AS (
     SELECT

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
@@ -20,6 +20,22 @@ describe('MetricQueryBuilder snapshot: distinct queries', () => {
         ).toMatchSnapshot();
     });
 
+    // Covers the distinct-metric join ambiguity fix, where sorting by a selected
+    // dimension alias after rejoining deduplicated metric CTEs requires an outer projection.
+    test('matches snapshot for a sum-distinct query with dimensions sorted by dimension', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
+                    sorts: [
+                        { fieldId: 'orders_payment_method', descending: false },
+                    ],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
     // Covers the no-dimension sum_distinct path, where the deduped aggregate should avoid
     // dimension joins entirely and collapse back to a single-row aggregation shape.
     test('matches snapshot for a sum-distinct query without dimensions', () => {

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts
@@ -22,6 +22,42 @@ describe('MetricQueryBuilder snapshot: fanout queries', () => {
         ).toMatchSnapshot();
     });
 
+    // Covers the DuckDB/MotherDuck ambiguity fix, where sorting a fanout-protected
+    // joined result by a selected dimension alias requires an outer projection CTE.
+    test('matches snapshot for a fanout-protected metric query sorted by dimension', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_TWO_TABLES,
+                    tableCalculations: [],
+                    compiledTableCalculations: [],
+                    dimensions: ['table1_dim1'],
+                    metrics: ['table1_metric1', 'table2_metric3'],
+                    sorts: [{ fieldId: 'table1_dim1', descending: false }],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the non-ambiguous variant of the same fanout-protected join shape,
+    // where sorting by a metric alias should not add the extra outer metrics CTE.
+    test('matches snapshot for a fanout-protected metric query sorted by metric without wrapper', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_TWO_TABLES,
+                    tableCalculations: [],
+                    compiledTableCalculations: [],
+                    dimensions: ['table1_dim1'],
+                    metrics: ['table1_metric1', 'table2_metric3'],
+                    sorts: [{ fieldId: 'table1_metric1', descending: true }],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
     // Covers the no-dimensions variant of the fanout-protection path,
     // where independently aggregated CTEs must be merged with a CROSS JOIN instead of keyed joins.
     test('matches snapshot for a fanout-protected metric query without dimensions', () => {

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/totalsQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/totalsQueries.test.ts
@@ -170,6 +170,106 @@ const METRIC_QUERY_WITH_ROW_TOTAL_PIVOT_DIMENSIONS = {
     ],
 };
 
+const EXPLORE_WITH_MIXED_TOTAL_METRICS: Explore = {
+    ...EXPLORE,
+    tables: {
+        ...EXPLORE.tables,
+        table1: {
+            ...EXPLORE.tables.table1,
+            metrics: {
+                ...EXPLORE.tables.table1.metrics,
+                total_revenue: {
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    name: 'total_revenue',
+                    label: 'total_revenue',
+                    sql: '${TABLE}.revenue',
+                    compiledSql: 'SUM("table1".revenue)',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                } as CompiledMetric,
+                avg_order_value: {
+                    type: MetricType.AVERAGE,
+                    fieldType: FieldType.METRIC,
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    name: 'avg_order_value',
+                    label: 'avg_order_value',
+                    sql: '${TABLE}.order_value',
+                    compiledSql: 'AVG("table1".order_value)',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                } as CompiledMetric,
+            },
+        },
+    },
+};
+
+const METRIC_QUERY_WITH_MIXED_TOTALS = {
+    ...METRIC_QUERY,
+    metrics: ['table1_total_revenue', 'table1_avg_order_value'],
+    sorts: [{ fieldId: 'table1_total_revenue', descending: true }],
+    tableCalculations: [
+        {
+            name: 'revenue_pct',
+            displayName: 'Revenue %',
+            sql: '${table1.total_revenue} / total(${table1.total_revenue})',
+        },
+        {
+            name: 'avg_pct',
+            displayName: 'Avg %',
+            sql: '${table1.avg_order_value} / total(${table1.avg_order_value})',
+        },
+    ],
+    compiledTableCalculations: [
+        {
+            name: 'revenue_pct',
+            displayName: 'Revenue %',
+            sql: '${table1.total_revenue} / total(${table1.total_revenue})',
+            compiledSql:
+                '"table1_total_revenue" / total("table1_total_revenue")',
+            dependsOn: [],
+        },
+        {
+            name: 'avg_pct',
+            displayName: 'Avg %',
+            sql: '${table1.avg_order_value} / total(${table1.avg_order_value})',
+            compiledSql:
+                '"table1_avg_order_value" / total("table1_avg_order_value")',
+            dependsOn: [],
+        },
+    ],
+};
+
+const METRIC_QUERY_WITH_FANOUT_TOTAL = {
+    exploreName: 'table1',
+    dimensions: ['table1_dim1'],
+    metrics: ['table2_metric3'],
+    filters: {},
+    sorts: [{ fieldId: 'table2_metric3', descending: true }],
+    limit: 10,
+    tableCalculations: [
+        {
+            name: 'pct_total',
+            displayName: 'Pct Total',
+            sql: '${table2.metric3} / total(${table2.metric3})',
+        },
+    ],
+    compiledTableCalculations: [
+        {
+            name: 'pct_total',
+            displayName: 'Pct Total',
+            sql: '${table2.metric3} / total(${table2.metric3})',
+            compiledSql: '"table2_metric3" / total("table2_metric3")',
+            dependsOn: [],
+        },
+    ],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
 describe('MetricQueryBuilder snapshot: totals queries', () => {
     // Covers totals referenced by dependent table calculations, where total() must be rewritten
     // before downstream calculations materialize their own chained table-calculation CTEs.
@@ -212,6 +312,28 @@ describe('MetricQueryBuilder snapshot: totals queries', () => {
             buildQuery({
                 explore: EXPLORE_WITH_AVG_METRIC,
                 compiledMetricQuery: METRIC_QUERY_WITH_AVG_TOTAL,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers mixed total() semantics in one query, where additive metrics can roll up
+    // from grouped results while non-additive metrics still re-aggregate from raw rows.
+    test('matches snapshot for a mixed additive and non-additive totals query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_MIXED_TOTAL_METRICS,
+                compiledMetricQuery: METRIC_QUERY_WITH_MIXED_TOTALS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the fanout-protected total() path, where additive metrics must stay on the raw
+    // totals route instead of summing grouped result rows that can repeat across groups.
+    test('matches snapshot for a fanout-protected additive total query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_FANOUT_TOTAL,
             }),
         ).toMatchSnapshot();
     });


### PR DESCRIPTION
## Summary
- fix ambiguous `ORDER BY` bindings for fanout-protected and distinct-metric CTE joins by sorting from an outer projection
- use grouped results for additive `total()` metrics while keeping raw re-aggregation for non-additive metrics
- add MotherDuck profile config for the jaffle demo and adjust MCP chart app dev dependency versions

## Testing
- `pnpm --filter backend test -- --runInBand src/utils/QueryBuilder/MetricQueryBuilder.test.ts`