### PR TITLE
feat: add cancel button for app generation

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    type ApiCancelAppVersionResponse,
     type ApiGenerateAppResponse,
     type ApiGetAppResponse,
     type ApiPreviewTokenResponse,
@@ -110,6 +111,32 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    /**
+     * Cancel a building version, killing the sandbox and marking it as cancelled.
+     * @summary Cancel app version
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Post('/{appUuid}/versions/{version}/cancel')
+    @OperationId('cancelAppVersion')
+    async cancelAppVersion(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+        @Path() version: number,
+    ): Promise<ApiCancelAppVersionResponse> {
+        await this.getAppGenerateService().cancelVersion(
+            req.user!,
+            projectUuid,
+            appUuid,
+            version,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -123,13 +123,18 @@ export class AppGenerateService extends BaseService {
         userMessage: string,
     ): Promise<void> {
         try {
-            await this.appModel.updateVersionStatus(
+            const updated = await this.appModel.updateVersionStatusIfBuilding(
                 appUuid,
                 version,
                 'error',
                 AppGenerateService.truncateEnd(getErrorMessage(error), 4000),
                 userMessage,
             );
+            if (!updated) {
+                this.logger.info(
+                    `App ${appUuid}: skipped markError — version ${version} is no longer building (likely cancelled)`,
+                );
+            }
         } catch (dbError) {
             this.logger.error(
                 `App ${appUuid}: failed to persist error status: ${getErrorMessage(dbError)}`,
@@ -782,8 +787,18 @@ export class AppGenerateService extends BaseService {
 
         try {
             const dbStart = performance.now();
-            await this.appModel.updateVersionStatus(appUuid, version, 'ready');
+            const updated = await this.appModel.updateVersionStatusIfBuilding(
+                appUuid,
+                version,
+                'ready',
+            );
             durations.dbMs = AppGenerateService.elapsed(dbStart);
+            if (!updated) {
+                this.logger.info(
+                    `App ${appUuid}: skipped marking ready — version ${version} is no longer building (likely cancelled)`,
+                );
+                return;
+            }
         } catch (error) {
             this.logger.error(
                 `App ${appUuid}: failed to mark version as ready: ${getErrorMessage(error)}`,
@@ -997,6 +1012,67 @@ export class AppGenerateService extends BaseService {
         return { appUuid, version: newVersion };
     }
 
+    async cancelVersion(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+        version: number,
+    ): Promise<void> {
+        this.assertDataAppsEnabled();
+        if (
+            user.ability.cannot(
+                'manage',
+                subject('DataApp', {
+                    organizationUuid: user.organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'Insufficient permissions to cancel app generation',
+            );
+        }
+
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+
+        // Atomically mark the version as cancelled (only if still building)
+        const updated = await this.appModel.updateVersionStatusIfBuilding(
+            appUuid,
+            version,
+            'error',
+            'Cancelled by user',
+            'Cancelled by user',
+        );
+        if (!updated) {
+            throw new ParameterError('This version is not currently building');
+        }
+
+        this.logger.info(
+            `App ${appUuid}: version ${version} cancelled by user ${user.userUuid}`,
+        );
+
+        // Pause the sandbox to interrupt any running commands while keeping
+        // it resumable for the next iteration.
+        // The pipeline will catch the resulting error, but markError is now
+        // a no-op since the version is already in 'error' state.
+        if (app.sandbox_id) {
+            try {
+                const sandbox = await Sandbox.connect(app.sandbox_id, {
+                    apiKey: this.getE2bApiKey(),
+                });
+                await sandbox.pause();
+                this.logger.info(
+                    `App ${appUuid}: sandbox paused after cancel (sandboxId=${app.sandbox_id})`,
+                );
+            } catch (error) {
+                // Sandbox may already be dead/paused — that's fine
+                this.logger.warn(
+                    `App ${appUuid}: failed to pause sandbox after cancel: ${getErrorMessage(error)}`,
+                );
+            }
+        }
+    }
+
     async getAppVersions(
         user: SessionUser,
         projectUuid: string,
@@ -1035,7 +1111,7 @@ export class AppGenerateService extends BaseService {
 
         // Auto-heal stale builds: if the pipeline died (e.g. server restart)
         // the version stays "building" forever. Detect via heartbeat timeout.
-        const STALE_THRESHOLD_MS = 10 * 60_000;
+        const STALE_THRESHOLD_MS = 60 * 60_000;
         const now = Date.now();
         const staleVersions = versions.filter((v) => {
             if (v.status !== 'building') return false;

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6649,6 +6649,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiCancelAppVersionResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccessEmpty', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__appUuid-string--name-string--description-string__': {
         dataType: 'refAlias',
         type: {
@@ -31255,6 +31260,79 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'iterateApp',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_cancelAppVersion: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+        version: {
+            in: 'path',
+            name: 'version',
+            required: true,
+            dataType: 'double',
+        },
+    };
+    app.post(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/versions/:version/cancel',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.cancelAppVersion,
+        ),
+
+        async function AppGenerateController_cancelAppVersion(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_cancelAppVersion,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'cancelAppVersion',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8009,6 +8009,9 @@
             "ApiGetAppResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
             },
+            "ApiCancelAppVersionResponse": {
+                "$ref": "#/components/schemas/ApiSuccessEmpty"
+            },
             "ApiSuccess__appUuid-string--name-string--description-string__": {
                 "properties": {
                     "results": {
@@ -29428,7 +29431,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2701.0",
+        "version": "0.2705.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -58,6 +58,29 @@ export class AppModel {
             });
     }
 
+    /**
+     * Update version status only if it is currently 'building'.
+     * Returns true if the update was applied, false if the version was
+     * already in a terminal state (e.g. cancelled by the user).
+     */
+    async updateVersionStatusIfBuilding(
+        appId: string,
+        version: number,
+        status: AppVersionStatus,
+        error?: string | null,
+        statusMessage?: string | null,
+    ): Promise<boolean> {
+        const updatedRows = await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version, status: 'building' })
+            .update({
+                status,
+                error: error ?? null,
+                status_message: statusMessage ?? null,
+                status_updated_at: new Date(),
+            });
+        return updatedRows > 0;
+    }
+
     async updateStatusMessage(
         appId: string,
         version: number,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1,4 +1,4 @@
-import { type ApiSuccess } from '../../types/api/success';
+import { type ApiSuccess, type ApiSuccessEmpty } from '../../types/api/success';
 
 export type ApiGenerateAppResponse = ApiSuccess<{
     appUuid: string;
@@ -35,3 +35,5 @@ export type ApiUpdateAppResponse = ApiSuccess<{
     name: string;
     description: string;
 }>;
+
+export type ApiCancelAppVersionResponse = ApiSuccessEmpty;

--- a/packages/frontend/src/features/apps/hooks/useCancelAppVersion.ts
+++ b/packages/frontend/src/features/apps/hooks/useCancelAppVersion.ts
@@ -1,0 +1,27 @@
+import { type ApiError } from '@lightdash/common';
+import { useMutation } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+
+type CancelAppVersionParams = {
+    projectUuid: string;
+    appUuid: string;
+    version: number;
+};
+
+const cancelAppVersion = async ({
+    projectUuid,
+    appUuid,
+    version,
+}: CancelAppVersionParams): Promise<undefined> => {
+    await lightdashApi<undefined>({
+        method: 'POST',
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/versions/${version}/cancel`,
+        body: undefined,
+    });
+    return undefined;
+};
+
+export const useCancelAppVersion = () =>
+    useMutation<undefined, ApiError, CancelAppVersionParams>({
+        mutationFn: cancelAppVersion,
+    });

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -12,6 +12,7 @@ import {
     IconAppWindow,
     IconArrowUp,
     IconExternalLink,
+    IconPlayerStop,
     IconSparkles,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
@@ -28,6 +29,7 @@ import { Link, Navigate, useParams } from 'react-router';
 import { EditableText } from '../components/VisualizationConfigs/common/EditableText';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
+import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion';
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
@@ -121,6 +123,8 @@ const AppGenerate: FC = () => {
         reset: resetIterate,
     } = useIterateApp();
     const { mutate: updateAppMutate } = useUpdateApp();
+    const { mutate: cancelMutate, isLoading: isCancelling } =
+        useCancelAppVersion();
     const health = useHealth();
     const { user } = useApp();
     const ability = useAbilityContext();
@@ -217,11 +221,6 @@ const AppGenerate: FC = () => {
         () => [...historyMessages, ...localMessages],
         [historyMessages, localMessages],
     );
-
-    // Used for chat links + handleSubmit (recalculated every render, fine)
-    const latestApp = [...messages]
-        .reverse()
-        .find((m) => m.appUuid !== null && m.version !== null);
 
     // Stable reference for the preview — only updates when a new version
     // becomes ready, preventing iframe reloads during status polling.
@@ -332,11 +331,11 @@ const AppGenerate: FC = () => {
             },
         };
 
-        if (latestApp?.appUuid) {
+        if (activeAppUuid) {
             iterateMutate(
                 {
                     projectUuid,
-                    appUuid: latestApp.appUuid,
+                    appUuid: activeAppUuid,
                     prompt: trimmed,
                 },
                 callbacks,
@@ -351,6 +350,30 @@ const AppGenerate: FC = () => {
             e.preventDefault();
             handleSubmit();
         }
+    };
+
+    const handleCancel = () => {
+        if (
+            !projectUuid ||
+            !activeAppUuid ||
+            !latestBuildingVersion ||
+            isCancelling
+        )
+            return;
+        cancelMutate(
+            {
+                projectUuid,
+                appUuid: activeAppUuid,
+                version: latestBuildingVersion.version,
+            },
+            {
+                onSuccess: () => {
+                    void queryClient.invalidateQueries({
+                        queryKey: ['app', projectUuid, activeAppUuid],
+                    });
+                },
+            },
+        );
     };
 
     return (
@@ -528,18 +551,32 @@ const AppGenerate: FC = () => {
                                         wrapper: classes.textareaWrapper,
                                     }}
                                 />
-                                <ActionIcon
-                                    size="sm"
-                                    radius="xl"
-                                    variant="filled"
-                                    color="violet"
-                                    onClick={handleSubmit}
-                                    disabled={!prompt.trim() || isLoading}
-                                    loading={isLoading}
-                                    className={classes.submitButton}
-                                >
-                                    <IconArrowUp size={14} />
-                                </ActionIcon>
+                                {isBuilding ? (
+                                    <ActionIcon
+                                        size="sm"
+                                        radius="xl"
+                                        variant="filled"
+                                        color="red"
+                                        onClick={handleCancel}
+                                        loading={isCancelling}
+                                        className={classes.submitButton}
+                                    >
+                                        <IconPlayerStop size={14} />
+                                    </ActionIcon>
+                                ) : (
+                                    <ActionIcon
+                                        size="sm"
+                                        radius="xl"
+                                        variant="filled"
+                                        color="violet"
+                                        onClick={handleSubmit}
+                                        disabled={!prompt.trim() || isLoading}
+                                        loading={isGenerating || isIterating}
+                                        className={classes.submitButton}
+                                    >
+                                        <IconArrowUp size={14} />
+                                    </ActionIcon>
+                                )}
                             </Box>
                         </Box>
                     </Box>


### PR DESCRIPTION
### Description:
Allow users to cancel an in-progress app generation by clicking a stop button that replaces the submit button during builds. The backend kills the e2b sandbox and atomically marks the version as cancelled, using a conditional update (WHERE status='building') to prevent race conditions with the running pipeline. Also raises the stale build threshold from 10 minutes to 1 hour to match the new sandbox lifetime.

<img width="2643" height="1365" alt="image" src="https://github.com/user-attachments/assets/bfc57cde-8788-41ce-bdfb-75479b5c041a" />
