### PR TITLE
refactor: create dashboard Redux store skeleton with 3 slices and selectors

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -133,6 +133,13 @@ export enum FeatureFlags {
      * Enable user-configurable column limit for pivoted queries
      */
     ShowHideColumns = 'show-hide-columns',
+
+    /**
+     * Use Redux store for dashboard state management instead of React Context.
+     * Improves performance by enabling fine-grained selector subscriptions
+     * that only re-render when selected state actually changes.
+     */
+    DashboardReduxStore = 'dashboard-redux-store',
 }
 
 export type FeatureFlag = {

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -263,7 +263,7 @@ const DashboardHeader = memo(
             health.data?.preAggregates.enabled ?? false;
         const userCanManageDashboard = user.data?.ability.can(
             'manage',
-            subject('Dashboard', dashboard),
+            subject('Dashboard', { ...dashboard }),
         );
         const userCanRefreshPreAggregates =
             user.data?.ability.can(

--- a/packages/frontend/src/providers/Dashboard/DashboardBridgeProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardBridgeProvider.tsx
@@ -1,0 +1,1261 @@
+import {
+    DashboardTileTypes,
+    getItemId,
+    isDashboardChartTileType,
+    type CacheMetadata,
+    type Dashboard,
+    type DashboardFilterableField,
+    type DashboardFilterRule,
+    type DashboardFilters,
+    type DashboardParameters,
+    type DateGranularity,
+    type FilterableDimension,
+    type InteractivityOptions,
+    type Metric,
+    type ParameterDefinitions,
+    type ParametersValuesMap,
+    type ParameterValue,
+    type SortField,
+} from '@lightdash/common';
+import React, { useCallback, useMemo, type MutableRefObject } from 'react';
+import { getConditionalRuleLabelFromItem } from '../../components/common/Filters/FilterInputs/utils';
+import { type useDashboardCommentsCheck } from '../../features/comments';
+import { hasSavedFilterValueChanged } from '../../features/dashboardFilters/FilterConfiguration/utils';
+import DashboardContext from './context';
+import { dashboardDataActions } from './store/dashboardDataSlice';
+import {
+    dashboardFiltersActions,
+    EMPTY_FILTERS,
+} from './store/dashboardFiltersSlice';
+import { useDashboardDispatch, useDashboardSelector } from './store/hooks';
+import DashboardTileStatusContext from './tileStatusContext';
+import { type SqlChartTileMetadata } from './types';
+
+type DerivedData = {
+    allFilters: DashboardFilters;
+    filterableFieldsByTileUuid:
+        | Record<string, DashboardFilterableField[]>
+        | undefined;
+    dashboardAvailableFiltersData:
+        | {
+              allFilterableFields: FilterableDimension[];
+              allFilterableMetrics: Metric[];
+              savedQueryFilters: Record<string, number[]>;
+              savedQueryMetricFilters: Record<string, number[]>;
+          }
+        | undefined;
+    overridesForSavedDashboardFilters: DashboardFilters;
+    addSavedFilterOverride: (
+        filter: DashboardFilterRule,
+        type?: 'metrics',
+    ) => void;
+    removeSavedFilterOverride: (
+        filter: DashboardFilterRule,
+        type?: 'metrics',
+    ) => void;
+    resetSavedFilterOverrides: () => void;
+    applyInteractivityFiltering: (
+        filters: DashboardFilters,
+    ) => DashboardFilters;
+    versionRefresh: (
+        dashboard: Dashboard | undefined,
+    ) => Promise<Dashboard | null>;
+    missingRequiredParameters: string[];
+    expectedScreenshotTileUuids: string[];
+    areAllChartsLoaded: boolean;
+    dashboardParameterReferences: Set<string>;
+    parameterValues: ParametersValuesMap;
+    selectedParametersCount: number;
+    dashboard: Dashboard | undefined;
+    originalDashboardFilters: DashboardFilters;
+};
+
+type Props = {
+    children: React.ReactNode;
+    derivedDataRef: MutableRefObject<DerivedData>;
+    dashboardCommentsCheck?: ReturnType<typeof useDashboardCommentsCheck>;
+};
+
+/**
+ * Bridge component that reads all values from the Redux store
+ * and provides them via the existing DashboardContext.
+ * This allows consumers to keep using useDashboardContext unchanged.
+ */
+export const DashboardBridgeProvider: React.FC<Props> = ({
+    children,
+    derivedDataRef,
+    dashboardCommentsCheck,
+}) => {
+    const dispatch = useDashboardDispatch();
+
+    // Read from Redux
+    const projectUuid = useDashboardSelector(
+        (s) => s.dashboardData.projectUuid,
+    );
+    const isDashboardLoading = useDashboardSelector(
+        (s) => s.dashboardData.isDashboardLoading,
+    );
+    const dashboardError = useDashboardSelector(
+        (s) => s.dashboardData.dashboardError,
+    );
+    const dashboardTiles = useDashboardSelector(
+        (s) => s.dashboardData.dashboardTiles,
+    );
+    const haveTilesChanged = useDashboardSelector(
+        (s) => s.dashboardData.haveTilesChanged,
+    );
+    const haveTabsChanged = useDashboardSelector(
+        (s) => s.dashboardData.haveTabsChanged,
+    );
+    const dashboardTabs = useDashboardSelector(
+        (s) => s.dashboardData.dashboardTabs,
+    );
+    const activeTab = useDashboardSelector((s) => s.dashboardData.activeTab);
+    const isAutoRefresh = useDashboardSelector(
+        (s) => s.dashboardData.isAutoRefresh,
+    );
+    const oldestCacheTime = useDashboardSelector(
+        (s) => s.dashboardData.oldestCacheTime,
+    );
+    const invalidateCache = useDashboardSelector(
+        (s) => s.dashboardData.invalidateCache,
+    );
+    const chartSort = useDashboardSelector((s) => s.dashboardData.chartSort);
+    const sqlChartTilesMetadata = useDashboardSelector(
+        (s) => s.dashboardData.sqlChartTilesMetadata,
+    );
+    const dateZoomGranularity = useDashboardSelector(
+        (s) => s.dashboardData.dateZoomGranularity,
+    );
+    const chartsWithDateZoomApplied = useDashboardSelector(
+        (s) => s.dashboardData.chartsWithDateZoomApplied,
+    );
+    const dashboardComments = useDashboardSelector(
+        (s) => s.dashboardData.dashboardComments,
+    );
+    const isDateZoomDisabled = useDashboardSelector(
+        (s) => s.dashboardData.isDateZoomDisabled,
+    );
+    const isAddFilterDisabled = useDashboardSelector(
+        (s) => s.dashboardData.isAddFilterDisabled,
+    );
+    const parametersHaveChanged = useDashboardSelector(
+        (s) => s.dashboardData.parametersHaveChanged,
+    );
+    const parameters = useDashboardSelector((s) => s.dashboardData.parameters);
+    const savedParameters = useDashboardSelector(
+        (s) => s.dashboardData.savedParameters,
+    );
+    const parameterDefinitions = useDashboardSelector(
+        (s) => s.dashboardData.parameterDefinitions,
+    );
+    const tileParameterReferences = useDashboardSelector(
+        (s) => s.dashboardData.tileParameterReferences,
+    );
+    const pinnedParameters = useDashboardSelector(
+        (s) => s.dashboardData.pinnedParameters,
+    );
+    const havePinnedParametersChanged = useDashboardSelector(
+        (s) => s.dashboardData.havePinnedParametersChanged,
+    );
+    const dashboardHasTimestampDimension = useDashboardSelector(
+        (s) => s.dashboardData.tilesWithTimestampDimension.size > 0,
+    );
+    const availableCustomGranularities = useDashboardSelector(
+        (s) => s.dashboardData.availableCustomGranularities,
+    );
+    const dateZoomGranularities = useDashboardSelector(
+        (s) => s.dashboardData.dateZoomGranularities,
+    );
+    const haveDateZoomGranularitiesChanged = useDashboardSelector(
+        (s) => s.dashboardData.haveDateZoomGranularitiesChanged,
+    );
+    const defaultDateZoomGranularity = useDashboardSelector(
+        (s) => s.dashboardData.defaultDateZoomGranularity,
+    );
+    const hasDefaultDateZoomGranularityChanged = useDashboardSelector(
+        (s) => s.dashboardData.hasDefaultDateZoomGranularityChanged,
+    );
+    const preAggregateStatuses = useDashboardSelector(
+        (s) => s.dashboardData.preAggregateStatuses,
+    );
+    const isRefreshingDashboardVersion = useDashboardSelector(
+        (s) => s.dashboardData.isRefreshingDashboardVersion,
+    );
+    const screenshotReadyTiles = useDashboardSelector(
+        (s) => s.dashboardData.screenshotReadyTiles,
+    );
+    const screenshotErroredTiles = useDashboardSelector(
+        (s) => s.dashboardData.screenshotErroredTiles,
+    );
+    const embedDashboard = useDashboardSelector(
+        (s) => s.dashboardData.embedDashboard,
+    );
+    const dashboardFilters = useDashboardSelector(
+        (s) => s.dashboardFilters.dashboardFilters,
+    );
+    const dashboardTemporaryFilters = useDashboardSelector(
+        (s) => s.dashboardFilters.dashboardTemporaryFilters,
+    );
+    const haveFiltersChanged = useDashboardSelector(
+        (s) => s.dashboardFilters.haveFiltersChanged,
+    );
+    const isLoadingDashboardFilters = useDashboardSelector(
+        (s) => s.dashboardData.isLoadingDashboardFilters,
+    );
+    const isFetchingDashboardFilters = useDashboardSelector(
+        (s) => s.dashboardData.isFetchingDashboardFilters,
+    );
+
+    // Derived data from ref
+    const {
+        allFilters,
+        filterableFieldsByTileUuid,
+        dashboardAvailableFiltersData,
+        overridesForSavedDashboardFilters: _overridesForSavedDashboardFilters,
+        addSavedFilterOverride,
+        removeSavedFilterOverride,
+        resetSavedFilterOverrides,
+        applyInteractivityFiltering,
+        versionRefresh,
+        missingRequiredParameters,
+        expectedScreenshotTileUuids,
+        areAllChartsLoaded,
+        dashboardParameterReferences,
+        parameterValues,
+        selectedParametersCount,
+        dashboard: resolvedDashboard,
+        originalDashboardFilters,
+    } = derivedDataRef.current;
+
+    // Computed values
+    const allFilterableFieldsMap = useMemo(() => {
+        if (!dashboardAvailableFiltersData?.allFilterableFields?.length)
+            return {};
+        return dashboardAvailableFiltersData.allFilterableFields.reduce<
+            Record<string, FilterableDimension>
+        >(
+            (sum, field) => ({
+                ...sum,
+                [getItemId(field)]: field,
+            }),
+            {},
+        );
+    }, [dashboardAvailableFiltersData]);
+
+    const allFilterableMetricsMap = useMemo(() => {
+        if (!dashboardAvailableFiltersData?.allFilterableMetrics?.length)
+            return {};
+        return dashboardAvailableFiltersData.allFilterableMetrics.reduce<
+            Record<string, Metric>
+        >(
+            (sum, field) => ({
+                ...sum,
+                [getItemId(field)]: field,
+            }),
+            {},
+        );
+    }, [dashboardAvailableFiltersData]);
+
+    const hasTilesThatSupportFilters = useMemo(() => {
+        const tileTypesThatSupportFilters = [
+            DashboardTileTypes.SQL_CHART,
+            DashboardTileTypes.SAVED_CHART,
+        ];
+        return !!dashboardTiles?.some(({ type }) =>
+            tileTypesThatSupportFilters.includes(type),
+        );
+    }, [dashboardTiles]);
+
+    const tileNamesById = useMemo(() => {
+        if (!dashboardTiles) return {};
+        return dashboardTiles.reduce<Record<string, string>>((acc, tile) => {
+            const tileWithoutTitle =
+                !tile.properties.title || tile.properties.title.length === 0;
+            const isChartTileType = isDashboardChartTileType(tile);
+            let tileName = '';
+            if (tileWithoutTitle && isChartTileType) {
+                tileName = tile.properties.chartName || '';
+            } else if (tile.properties.title) {
+                tileName = tile.properties.title;
+            }
+            acc[tile.uuid] = tileName;
+            return acc;
+        }, {});
+    }, [dashboardTiles]);
+
+    const tileTabsById = useMemo(() => {
+        if (!dashboardTiles) return {};
+        return dashboardTiles.reduce<Record<string, string | null | undefined>>(
+            (acc, tile) => {
+                acc[tile.uuid] = tile.tabUuid;
+                return acc;
+            },
+            {},
+        );
+    }, [dashboardTiles]);
+
+    const requiredDashboardFilters = useMemo(
+        () =>
+            [...dashboardFilters.dimensions, ...dashboardFilters.metrics]
+                .filter((f) => f.required && f.disabled)
+                .reduce<Pick<DashboardFilterRule, 'id' | 'label'>[]>(
+                    (acc, f) => {
+                        const field =
+                            allFilterableFieldsMap[f.target.fieldId] ??
+                            allFilterableMetricsMap[f.target.fieldId];
+                        let label = '';
+                        if (f.label) {
+                            label = f.label;
+                        } else if (field) {
+                            label = getConditionalRuleLabelFromItem(
+                                f,
+                                field,
+                            ).field;
+                        }
+                        return [...acc, { id: f.id, label }];
+                    },
+                    [],
+                ),
+        [
+            dashboardFilters.dimensions,
+            dashboardFilters.metrics,
+            allFilterableFieldsMap,
+            allFilterableMetricsMap,
+        ],
+    );
+
+    const isReadyForScreenshot = useMemo(() => {
+        if (expectedScreenshotTileUuids.length === 0) {
+            return !!dashboardTiles;
+        }
+        return expectedScreenshotTileUuids.every(
+            (tileUuid) =>
+                screenshotReadyTiles.has(tileUuid) ||
+                screenshotErroredTiles.has(tileUuid),
+        );
+    }, [
+        expectedScreenshotTileUuids,
+        screenshotReadyTiles,
+        screenshotErroredTiles,
+        dashboardTiles,
+    ]);
+
+    // Dispatch wrappers that match the DashboardContextType signatures
+    const hasTileComments = useCallback(
+        (tileUuid: string) =>
+            !!(
+                dashboardComments &&
+                dashboardComments[tileUuid] &&
+                dashboardComments[tileUuid].length > 0
+            ),
+        [dashboardComments],
+    );
+
+    const setEmbedDashboard = useCallback(
+        (
+            value:
+                | ((Dashboard & InteractivityOptions) | undefined)
+                | ((
+                      prev: (Dashboard & InteractivityOptions) | undefined,
+                  ) => (Dashboard & InteractivityOptions) | undefined),
+        ) => {
+            if (typeof value === 'function') {
+                // For function updates, we need to read current state
+                // This is a simplification - the set state action pattern
+                const result = value(embedDashboard);
+                dispatch(dashboardDataActions.setEmbedDashboard(result));
+            } else {
+                dispatch(dashboardDataActions.setEmbedDashboard(value));
+            }
+        },
+        [dispatch, embedDashboard],
+    );
+
+    const setDashboardTiles = useCallback(
+        (
+            value:
+                | (Dashboard['tiles'] | undefined)
+                | ((
+                      prev: Dashboard['tiles'] | undefined,
+                  ) => Dashboard['tiles'] | undefined),
+        ) => {
+            if (typeof value === 'function') {
+                const result = value(dashboardTiles);
+                dispatch(dashboardDataActions.setDashboardTiles(result));
+            } else {
+                dispatch(dashboardDataActions.setDashboardTiles(value));
+            }
+        },
+        [dispatch, dashboardTiles],
+    );
+
+    const setHaveTilesChanged = useCallback(
+        (value: boolean | ((prev: boolean) => boolean)) => {
+            const resolved =
+                typeof value === 'function' ? value(haveTilesChanged) : value;
+            dispatch(dashboardDataActions.setHaveTilesChanged(resolved));
+        },
+        [dispatch, haveTilesChanged],
+    );
+
+    const setHaveTabsChanged = useCallback(
+        (value: boolean | ((prev: boolean) => boolean)) => {
+            const resolved =
+                typeof value === 'function' ? value(haveTabsChanged) : value;
+            dispatch(dashboardDataActions.setHaveTabsChanged(resolved));
+        },
+        [dispatch, haveTabsChanged],
+    );
+
+    const setDashboardTabs = useCallback(
+        (
+            value:
+                | Dashboard['tabs']
+                | ((prev: Dashboard['tabs']) => Dashboard['tabs']),
+        ) => {
+            if (typeof value === 'function') {
+                const result = value(dashboardTabs);
+                dispatch(
+                    dashboardDataActions.setDashboardTabs(
+                        [...result].sort((a, b) => a.order - b.order),
+                    ),
+                );
+            } else {
+                dispatch(
+                    dashboardDataActions.setDashboardTabs(
+                        [...value].sort((a, b) => a.order - b.order),
+                    ),
+                );
+            }
+        },
+        [dispatch, dashboardTabs],
+    );
+
+    const setActiveTab = useCallback(
+        (
+            value:
+                | (Dashboard['tabs'][number] | undefined)
+                | ((
+                      prev: Dashboard['tabs'][number] | undefined,
+                  ) => Dashboard['tabs'][number] | undefined),
+        ) => {
+            if (typeof value === 'function') {
+                const result = value(activeTab);
+                dispatch(dashboardDataActions.setActiveTab(result));
+            } else {
+                dispatch(dashboardDataActions.setActiveTab(value));
+            }
+        },
+        [dispatch, activeTab],
+    );
+
+    const setDashboardFilters = useCallback(
+        (
+            value:
+                | DashboardFilters
+                | ((prev: DashboardFilters) => DashboardFilters),
+        ) => {
+            if (typeof value === 'function') {
+                const result = value(dashboardFilters);
+                dispatch(dashboardFiltersActions.setDashboardFilters(result));
+            } else {
+                dispatch(dashboardFiltersActions.setDashboardFilters(value));
+            }
+        },
+        [dispatch, dashboardFilters],
+    );
+
+    const setDashboardTemporaryFilters = useCallback(
+        (
+            value:
+                | DashboardFilters
+                | ((prev: DashboardFilters) => DashboardFilters),
+        ) => {
+            if (typeof value === 'function') {
+                const result = value(dashboardTemporaryFilters);
+                dispatch(
+                    dashboardFiltersActions.setDashboardTemporaryFilters(
+                        result,
+                    ),
+                );
+            } else {
+                dispatch(
+                    dashboardFiltersActions.setDashboardTemporaryFilters(value),
+                );
+            }
+        },
+        [dispatch, dashboardTemporaryFilters],
+    );
+
+    const setHaveFiltersChanged = useCallback(
+        (value: boolean | ((prev: boolean) => boolean)) => {
+            const resolved =
+                typeof value === 'function' ? value(haveFiltersChanged) : value;
+            dispatch(dashboardFiltersActions.setHaveFiltersChanged(resolved));
+        },
+        [dispatch, haveFiltersChanged],
+    );
+
+    const addDimensionDashboardFilter = useCallback(
+        (filter: DashboardFilterRule, isTemporary: boolean) => {
+            dispatch(
+                dashboardFiltersActions.addDimensionDashboardFilter({
+                    filter,
+                    isTemporary,
+                }),
+            );
+        },
+        [dispatch],
+    );
+
+    const updateDimensionDashboardFilter = useCallback(
+        (
+            item: DashboardFilterRule,
+            index: number,
+            isTemporary: boolean,
+            isInEditMode: boolean,
+        ) => {
+            // Handle saved filter override side effects
+            if (!isTemporary) {
+                const filters = resolvedDashboard?.filters?.dimensions || [];
+                const isFilterSaved = filters.some(({ id }) => id === item.id);
+
+                if (isInEditMode) {
+                    removeSavedFilterOverride(item);
+                } else {
+                    const isReverted =
+                        originalDashboardFilters.dimensions[index] &&
+                        !hasSavedFilterValueChanged(
+                            originalDashboardFilters.dimensions[index],
+                            item,
+                        );
+                    if (isReverted) {
+                        removeSavedFilterOverride(item);
+                        dispatch(
+                            dashboardFiltersActions.setHaveFiltersChanged(
+                                false,
+                            ),
+                        );
+                    } else {
+                        const hasChanged = hasSavedFilterValueChanged(
+                            dashboardFilters.dimensions[index],
+                            item,
+                        );
+                        if (hasChanged && isFilterSaved) {
+                            addSavedFilterOverride(item);
+                        }
+                    }
+                }
+            }
+            dispatch(
+                dashboardFiltersActions.updateDimensionDashboardFilter({
+                    filter: item,
+                    index,
+                    isTemporary,
+                }),
+            );
+        },
+        [
+            dispatch,
+            addSavedFilterOverride,
+            resolvedDashboard?.filters?.dimensions,
+            originalDashboardFilters.dimensions,
+            dashboardFilters.dimensions,
+            removeSavedFilterOverride,
+        ],
+    );
+
+    const removeDimensionDashboardFilter = useCallback(
+        (index: number, isTemporary: boolean) => {
+            if (!isTemporary) {
+                removeSavedFilterOverride(dashboardFilters.dimensions[index]);
+            }
+            dispatch(
+                dashboardFiltersActions.removeDimensionDashboardFilter({
+                    index,
+                    isTemporary,
+                }),
+            );
+        },
+        [dispatch, removeSavedFilterOverride, dashboardFilters.dimensions],
+    );
+
+    const addMetricDashboardFilter = useCallback(
+        (filter: DashboardFilterRule, isTemporary: boolean) => {
+            dispatch(
+                dashboardFiltersActions.addMetricDashboardFilter({
+                    filter,
+                    isTemporary,
+                }),
+            );
+        },
+        [dispatch],
+    );
+
+    const updateMetricDashboardFilter = useCallback(
+        (
+            item: DashboardFilterRule,
+            index: number,
+            isTemporary: boolean,
+            isInEditMode: boolean,
+        ) => {
+            if (!isTemporary) {
+                const filters = resolvedDashboard?.filters?.metrics || [];
+                const isFilterSaved = filters.some(({ id }) => id === item.id);
+
+                if (isInEditMode) {
+                    removeSavedFilterOverride(item, 'metrics');
+                } else {
+                    const isReverted =
+                        originalDashboardFilters.metrics[index] &&
+                        !hasSavedFilterValueChanged(
+                            originalDashboardFilters.metrics[index],
+                            item,
+                        );
+                    if (isReverted) {
+                        removeSavedFilterOverride(item, 'metrics');
+                        dispatch(
+                            dashboardFiltersActions.setHaveFiltersChanged(
+                                false,
+                            ),
+                        );
+                    } else {
+                        const hasChanged = hasSavedFilterValueChanged(
+                            dashboardFilters.metrics[index],
+                            item,
+                        );
+                        if (hasChanged && isFilterSaved) {
+                            addSavedFilterOverride(item, 'metrics');
+                        }
+                    }
+                }
+            }
+            dispatch(
+                dashboardFiltersActions.updateMetricDashboardFilter({
+                    filter: item,
+                    index,
+                    isTemporary,
+                }),
+            );
+        },
+        [
+            dispatch,
+            addSavedFilterOverride,
+            resolvedDashboard?.filters?.metrics,
+            originalDashboardFilters.metrics,
+            dashboardFilters.metrics,
+            removeSavedFilterOverride,
+        ],
+    );
+
+    const removeMetricDashboardFilter = useCallback(
+        (index: number, isTemporary: boolean) => {
+            if (!isTemporary) {
+                removeSavedFilterOverride(
+                    dashboardFilters.metrics[index],
+                    'metrics',
+                );
+            }
+            dispatch(
+                dashboardFiltersActions.removeMetricDashboardFilter({
+                    index,
+                    isTemporary,
+                }),
+            );
+        },
+        [dispatch, removeSavedFilterOverride, dashboardFilters.metrics],
+    );
+
+    const resetDashboardFilters = useCallback(() => {
+        const filters = resolvedDashboard?.filters ?? EMPTY_FILTERS;
+        const filteredFilters = embedDashboard
+            ? applyInteractivityFiltering(filters)
+            : filters;
+        dispatch(
+            dashboardFiltersActions.resetDashboardFilters(filteredFilters),
+        );
+        resetSavedFilterOverrides();
+    }, [
+        dispatch,
+        resolvedDashboard?.filters,
+        embedDashboard,
+        applyInteractivityFiltering,
+        resetSavedFilterOverrides,
+    ]);
+
+    const addResultsCacheTime = useCallback(
+        (cacheMetadata?: CacheMetadata) => {
+            dispatch(dashboardDataActions.addResultsCacheTime(cacheMetadata));
+        },
+        [dispatch],
+    );
+
+    const clearCacheAndFetch = useCallback(() => {
+        dispatch(dashboardDataActions.clearCacheAndFetch());
+    }, [dispatch]);
+
+    const markTileLoaded = useCallback(
+        (tileUuid: string) => {
+            dispatch(dashboardDataActions.markTileLoaded(tileUuid));
+        },
+        [dispatch],
+    );
+
+    const setIsAutoRefresh = useCallback(
+        (autoRefresh: boolean) => {
+            dispatch(dashboardDataActions.setIsAutoRefresh(autoRefresh));
+        },
+        [dispatch],
+    );
+
+    const setChartSort = useCallback(
+        (sort: Record<string, SortField[]>) => {
+            dispatch(dashboardDataActions.setChartSort(sort));
+        },
+        [dispatch],
+    );
+
+    const updateSqlChartTilesMetadata = useCallback(
+        (tileUuid: string, metadata: SqlChartTileMetadata) => {
+            dispatch(
+                dashboardDataActions.updateSqlChartTilesMetadata({
+                    tileUuid,
+                    metadata,
+                }),
+            );
+        },
+        [dispatch],
+    );
+
+    const setDateZoomGranularity = useCallback(
+        (
+            value:
+                | (DateGranularity | string | undefined)
+                | ((
+                      prev: DateGranularity | string | undefined,
+                  ) => DateGranularity | string | undefined),
+        ) => {
+            if (typeof value === 'function') {
+                const result = value(dateZoomGranularity);
+                dispatch(dashboardDataActions.setDateZoomGranularity(result));
+            } else {
+                dispatch(dashboardDataActions.setDateZoomGranularity(value));
+            }
+        },
+        [dispatch, dateZoomGranularity],
+    );
+
+    const setChartsWithDateZoomApplied = useCallback(
+        (
+            value:
+                | (Set<string> | undefined)
+                | ((prev: Set<string> | undefined) => Set<string> | undefined),
+        ) => {
+            if (typeof value === 'function') {
+                const result = value(chartsWithDateZoomApplied);
+                dispatch(
+                    dashboardDataActions.setChartsWithDateZoomApplied(result),
+                );
+            } else {
+                dispatch(
+                    dashboardDataActions.setChartsWithDateZoomApplied(value),
+                );
+            }
+        },
+        [dispatch, chartsWithDateZoomApplied],
+    );
+
+    const setIsDateZoomDisabled = useCallback(
+        (value: boolean | ((prev: boolean) => boolean)) => {
+            const resolved =
+                typeof value === 'function' ? value(isDateZoomDisabled) : value;
+            dispatch(dashboardDataActions.setIsDateZoomDisabled(resolved));
+        },
+        [dispatch, isDateZoomDisabled],
+    );
+
+    const setIsAddFilterDisabled = useCallback(
+        (value: boolean | ((prev: boolean) => boolean)) => {
+            const resolved =
+                typeof value === 'function'
+                    ? value(isAddFilterDisabled)
+                    : value;
+            dispatch(dashboardDataActions.setIsAddFilterDisabled(resolved));
+        },
+        [dispatch, isAddFilterDisabled],
+    );
+
+    const setSavedParameters = useCallback(
+        (
+            value:
+                | DashboardParameters
+                | ((prev: DashboardParameters) => DashboardParameters),
+        ) => {
+            if (typeof value === 'function') {
+                const result = value(savedParameters);
+                dispatch(dashboardDataActions.setSavedParameters(result));
+            } else {
+                dispatch(dashboardDataActions.setSavedParameters(value));
+            }
+        },
+        [dispatch, savedParameters],
+    );
+
+    const setParameter = useCallback(
+        (key: string, value: ParameterValue | null) => {
+            dispatch(dashboardDataActions.setParameter({ key, value }));
+        },
+        [dispatch],
+    );
+
+    const clearAllParameters = useCallback(() => {
+        dispatch(dashboardDataActions.clearAllParameters());
+    }, [dispatch]);
+
+    const addParameterReferences = useCallback(
+        (tileUuid: string, references: string[]) => {
+            dispatch(
+                dashboardDataActions.addParameterReferences({
+                    tileUuid,
+                    references,
+                }),
+            );
+        },
+        [dispatch],
+    );
+
+    const addParameterDefinitions = useCallback(
+        (params: ParameterDefinitions) => {
+            dispatch(dashboardDataActions.addParameterDefinitions(params));
+        },
+        [dispatch],
+    );
+
+    const addAvailableCustomGranularities = useCallback(
+        (granularities: Record<string, string>) => {
+            dispatch(
+                dashboardDataActions.addAvailableCustomGranularities(
+                    granularities,
+                ),
+            );
+        },
+        [dispatch],
+    );
+
+    const setPinnedParameters = useCallback(
+        (pinnedParams: string[]) => {
+            dispatch(dashboardDataActions.setPinnedParameters(pinnedParams));
+        },
+        [dispatch],
+    );
+
+    const toggleParameterPin = useCallback(
+        (parameterKey: string) => {
+            dispatch(dashboardDataActions.toggleParameterPin(parameterKey));
+        },
+        [dispatch],
+    );
+
+    const setHavePinnedParametersChanged = useCallback(
+        (value: boolean | ((prev: boolean) => boolean)) => {
+            const resolved =
+                typeof value === 'function'
+                    ? value(havePinnedParametersChanged)
+                    : value;
+            dispatch(
+                dashboardDataActions.setHavePinnedParametersChanged(resolved),
+            );
+        },
+        [dispatch, havePinnedParametersChanged],
+    );
+
+    const setTileHasTimestampDimension = useCallback(
+        (tileUuid: string, hasTimestamp: boolean) => {
+            dispatch(
+                dashboardDataActions.setTileHasTimestampDimension({
+                    tileUuid,
+                    hasTimestamp,
+                }),
+            );
+        },
+        [dispatch],
+    );
+
+    const setDateZoomGranularities = useCallback(
+        (granularities: (DateGranularity | string)[]) => {
+            dispatch(
+                dashboardDataActions.setDateZoomGranularities(granularities),
+            );
+        },
+        [dispatch],
+    );
+
+    const setHaveDateZoomGranularitiesChanged = useCallback(
+        (value: boolean | ((prev: boolean) => boolean)) => {
+            const resolved =
+                typeof value === 'function'
+                    ? value(haveDateZoomGranularitiesChanged)
+                    : value;
+            dispatch(
+                dashboardDataActions.setHaveDateZoomGranularitiesChanged(
+                    resolved,
+                ),
+            );
+        },
+        [dispatch, haveDateZoomGranularitiesChanged],
+    );
+
+    const setDefaultDateZoomGranularity = useCallback(
+        (granularity: DateGranularity | string | undefined) => {
+            dispatch(
+                dashboardDataActions.setDefaultDateZoomGranularity(granularity),
+            );
+        },
+        [dispatch],
+    );
+
+    const setHasDefaultDateZoomGranularityChanged = useCallback(
+        (value: boolean | ((prev: boolean) => boolean)) => {
+            const resolved =
+                typeof value === 'function'
+                    ? value(hasDefaultDateZoomGranularityChanged)
+                    : value;
+            dispatch(
+                dashboardDataActions.setHasDefaultDateZoomGranularityChanged(
+                    resolved,
+                ),
+            );
+        },
+        [dispatch, hasDefaultDateZoomGranularityChanged],
+    );
+
+    const addPreAggregateStatus = useCallback(
+        (tileUuid: string, cacheMetadata?: CacheMetadata) => {
+            const preAggregate = cacheMetadata?.preAggregate ?? null;
+            dispatch(
+                dashboardDataActions.addPreAggregateStatus({
+                    tileUuid,
+                    status: {
+                        tileUuid,
+                        tileName: tileNamesById[tileUuid] ?? tileUuid,
+                        hit: preAggregate?.hit ?? false,
+                        preAggregateName: preAggregate?.name ?? null,
+                        reason: preAggregate?.reason ?? null,
+                        hasPreAggregateMetadata: preAggregate !== null,
+                        tabUuid: tileTabsById[tileUuid],
+                    },
+                }),
+            );
+        },
+        [dispatch, tileNamesById, tileTabsById],
+    );
+
+    const refreshDashboardVersion = useCallback(async () => {
+        try {
+            const freshDashboard = await versionRefresh(resolvedDashboard);
+            if (freshDashboard) {
+                dispatch(
+                    dashboardDataActions.setDashboardTiles(
+                        freshDashboard.tiles,
+                    ),
+                );
+                dispatch(
+                    dashboardDataActions.setDashboardTabs(freshDashboard.tabs),
+                );
+                dispatch(
+                    dashboardDataActions.setSavedParameters(
+                        freshDashboard.parameters ?? {},
+                    ),
+                );
+            }
+        } catch (error) {
+            console.error('Failed to refresh dashboard:', error);
+        }
+    }, [dispatch, versionRefresh, resolvedDashboard]);
+
+    const markTileScreenshotReady = useCallback(
+        (tileUuid: string) => {
+            dispatch(dashboardDataActions.markTileScreenshotReady(tileUuid));
+        },
+        [dispatch],
+    );
+
+    const markTileScreenshotErrored = useCallback(
+        (tileUuid: string) => {
+            dispatch(dashboardDataActions.markTileScreenshotErrored(tileUuid));
+        },
+        [dispatch],
+    );
+
+    const value = useMemo(
+        () => ({
+            projectUuid,
+            isDashboardLoading,
+            dashboard: resolvedDashboard,
+            setEmbedDashboard,
+            dashboardError,
+            dashboardTiles,
+            setDashboardTiles,
+            haveTilesChanged,
+            setHaveTilesChanged,
+            haveTabsChanged,
+            setHaveTabsChanged,
+            dashboardTabs,
+            setDashboardTabs,
+            activeTab,
+            setActiveTab,
+            setDashboardTemporaryFilters,
+            dashboardFilters,
+            dashboardTemporaryFilters,
+            addDimensionDashboardFilter,
+            updateDimensionDashboardFilter,
+            removeDimensionDashboardFilter,
+            addMetricDashboardFilter,
+            updateMetricDashboardFilter,
+            removeMetricDashboardFilter,
+            resetDashboardFilters,
+            setDashboardFilters,
+            haveFiltersChanged,
+            setHaveFiltersChanged,
+            addResultsCacheTime,
+            oldestCacheTime,
+            invalidateCache,
+            clearCacheAndFetch,
+            isAutoRefresh,
+            setIsAutoRefresh,
+            allFilterableFieldsMap,
+            allFilterableMetricsMap,
+            allFilterableFields:
+                dashboardAvailableFiltersData?.allFilterableFields,
+            allFilterableMetrics:
+                dashboardAvailableFiltersData?.allFilterableMetrics,
+            isLoadingDashboardFilters,
+            isFetchingDashboardFilters,
+            filterableFieldsByTileUuid,
+            allFilters,
+            hasTilesThatSupportFilters,
+            chartSort,
+            setChartSort,
+            sqlChartTilesMetadata,
+            updateSqlChartTilesMetadata,
+            dateZoomGranularity,
+            setDateZoomGranularity,
+            chartsWithDateZoomApplied,
+            setChartsWithDateZoomApplied,
+            dashboardCommentsCheck,
+            dashboardComments,
+            hasTileComments,
+            requiredDashboardFilters,
+            isDateZoomDisabled,
+            setIsDateZoomDisabled,
+            isAddFilterDisabled,
+            setIsAddFilterDisabled,
+            setSavedParameters,
+            parametersHaveChanged,
+            dashboardParameters: parameters,
+            parameterValues,
+            selectedParametersCount,
+            setParameter,
+            parameterDefinitions,
+            clearAllParameters,
+            dashboardParameterReferences,
+            addParameterReferences,
+            tileParameterReferences,
+            areAllChartsLoaded,
+            missingRequiredParameters,
+            pinnedParameters,
+            setPinnedParameters,
+            toggleParameterPin,
+            havePinnedParametersChanged,
+            setHavePinnedParametersChanged,
+            dateZoomGranularities,
+            setDateZoomGranularities,
+            haveDateZoomGranularitiesChanged,
+            setHaveDateZoomGranularitiesChanged,
+            defaultDateZoomGranularity,
+            setDefaultDateZoomGranularity,
+            hasDefaultDateZoomGranularityChanged,
+            setHasDefaultDateZoomGranularityChanged,
+            addParameterDefinitions,
+            dashboardHasTimestampDimension,
+            setTileHasTimestampDimension,
+            availableCustomGranularities,
+            addAvailableCustomGranularities,
+            tileNamesById,
+            preAggregateStatuses,
+            addPreAggregateStatus,
+            refreshDashboardVersion,
+            isRefreshingDashboardVersion,
+            markTileScreenshotReady,
+            markTileScreenshotErrored,
+            isReadyForScreenshot,
+            screenshotReadyTilesCount: screenshotReadyTiles.size,
+            screenshotErroredTilesCount: screenshotErroredTiles.size,
+            expectedScreenshotTilesCount: expectedScreenshotTileUuids.length,
+        }),
+        [
+            projectUuid,
+            isDashboardLoading,
+            resolvedDashboard,
+            setEmbedDashboard,
+            dashboardError,
+            dashboardTiles,
+            setDashboardTiles,
+            haveTilesChanged,
+            setHaveTilesChanged,
+            haveTabsChanged,
+            setHaveTabsChanged,
+            dashboardTabs,
+            setDashboardTabs,
+            activeTab,
+            setActiveTab,
+            setDashboardTemporaryFilters,
+            dashboardFilters,
+            dashboardTemporaryFilters,
+            addDimensionDashboardFilter,
+            updateDimensionDashboardFilter,
+            removeDimensionDashboardFilter,
+            addMetricDashboardFilter,
+            updateMetricDashboardFilter,
+            removeMetricDashboardFilter,
+            resetDashboardFilters,
+            setDashboardFilters,
+            haveFiltersChanged,
+            setHaveFiltersChanged,
+            addResultsCacheTime,
+            oldestCacheTime,
+            invalidateCache,
+            clearCacheAndFetch,
+            isAutoRefresh,
+            setIsAutoRefresh,
+            allFilterableFieldsMap,
+            allFilterableMetricsMap,
+            dashboardAvailableFiltersData,
+            isLoadingDashboardFilters,
+            isFetchingDashboardFilters,
+            filterableFieldsByTileUuid,
+            allFilters,
+            hasTilesThatSupportFilters,
+            chartSort,
+            setChartSort,
+            sqlChartTilesMetadata,
+            updateSqlChartTilesMetadata,
+            dateZoomGranularity,
+            setDateZoomGranularity,
+            chartsWithDateZoomApplied,
+            setChartsWithDateZoomApplied,
+            dashboardCommentsCheck,
+            dashboardComments,
+            hasTileComments,
+            requiredDashboardFilters,
+            isDateZoomDisabled,
+            setIsDateZoomDisabled,
+            isAddFilterDisabled,
+            setIsAddFilterDisabled,
+            setSavedParameters,
+            parametersHaveChanged,
+            parameters,
+            parameterValues,
+            selectedParametersCount,
+            setParameter,
+            parameterDefinitions,
+            clearAllParameters,
+            dashboardParameterReferences,
+            addParameterReferences,
+            tileParameterReferences,
+            areAllChartsLoaded,
+            missingRequiredParameters,
+            pinnedParameters,
+            setPinnedParameters,
+            toggleParameterPin,
+            havePinnedParametersChanged,
+            setHavePinnedParametersChanged,
+            dateZoomGranularities,
+            setDateZoomGranularities,
+            haveDateZoomGranularitiesChanged,
+            setHaveDateZoomGranularitiesChanged,
+            defaultDateZoomGranularity,
+            setDefaultDateZoomGranularity,
+            hasDefaultDateZoomGranularityChanged,
+            setHasDefaultDateZoomGranularityChanged,
+            addParameterDefinitions,
+            dashboardHasTimestampDimension,
+            setTileHasTimestampDimension,
+            availableCustomGranularities,
+            addAvailableCustomGranularities,
+            tileNamesById,
+            preAggregateStatuses,
+            addPreAggregateStatus,
+            refreshDashboardVersion,
+            isRefreshingDashboardVersion,
+            markTileScreenshotReady,
+            markTileScreenshotErrored,
+            isReadyForScreenshot,
+            screenshotReadyTiles,
+            screenshotErroredTiles,
+            expectedScreenshotTileUuids,
+        ],
+    );
+
+    const tileStatusValue = useMemo(
+        () => ({
+            oldestCacheTime,
+            addResultsCacheTime,
+            preAggregateStatuses,
+            addPreAggregateStatus,
+            invalidateCache,
+            isAutoRefresh,
+            setIsAutoRefresh,
+            clearCacheAndFetch,
+            sqlChartTilesMetadata,
+            updateSqlChartTilesMetadata,
+            markTileLoaded,
+            areAllChartsLoaded,
+            dashboardHasTimestampDimension,
+            setTileHasTimestampDimension,
+            availableCustomGranularities,
+            addAvailableCustomGranularities,
+            tileNamesById,
+            markTileScreenshotReady,
+            markTileScreenshotErrored,
+            isReadyForScreenshot,
+            screenshotReadyTilesCount: screenshotReadyTiles.size,
+            screenshotErroredTilesCount: screenshotErroredTiles.size,
+            expectedScreenshotTilesCount: expectedScreenshotTileUuids.length,
+        }),
+        [
+            oldestCacheTime,
+            addResultsCacheTime,
+            preAggregateStatuses,
+            addPreAggregateStatus,
+            invalidateCache,
+            isAutoRefresh,
+            setIsAutoRefresh,
+            clearCacheAndFetch,
+            sqlChartTilesMetadata,
+            updateSqlChartTilesMetadata,
+            markTileLoaded,
+            areAllChartsLoaded,
+            dashboardHasTimestampDimension,
+            setTileHasTimestampDimension,
+            availableCustomGranularities,
+            addAvailableCustomGranularities,
+            tileNamesById,
+            markTileScreenshotReady,
+            markTileScreenshotErrored,
+            isReadyForScreenshot,
+            screenshotReadyTiles,
+            screenshotErroredTiles,
+            expectedScreenshotTileUuids,
+        ],
+    );
+
+    return (
+        <DashboardContext.Provider value={value}>
+            <DashboardTileStatusContext.Provider value={tileStatusValue}>
+                {children}
+            </DashboardTileStatusContext.Provider>
+        </DashboardContext.Provider>
+    );
+};

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -4,12 +4,15 @@ import {
     convertDashboardFiltersParamToDashboardFilters,
     DashboardTileTypes,
     DateGranularity,
+    FeatureFlags,
     FilterInteractivityValues,
     getFilterInteractivityValue,
     getItemId,
     isDashboardChartTileType,
+    isDashboardSqlChartTile,
     isStandardDateGranularity,
     isSubDayGranularity,
+    type CacheMetadata,
     type Dashboard,
     type DashboardFilterableField,
     type DashboardFilterRule,
@@ -26,6 +29,7 @@ import {
 } from '@lightdash/common';
 import clone from 'lodash/clone';
 import isEqual from 'lodash/isEqual';
+import min from 'lodash/min';
 import sortBy from 'lodash/sortBy';
 import React, {
     useCallback,
@@ -58,10 +62,14 @@ import {
     hasSavedFiltersOverrides,
     useSavedDashboardFiltersOverrides,
 } from '../../hooks/useSavedDashboardFiltersOverrides';
+import { useClientFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import DashboardContext from './context';
+import DashboardReduxProvider from './DashboardReduxProvider';
 import DashboardTileStatusProvider from './DashboardTileStatusProvider';
-import useDashboardContext from './useDashboardContext';
-import useDashboardTileStatusContext from './useDashboardTileStatusContext';
+import {
+    type SqlChartTileMetadata,
+    type TilePreAggregateStatus,
+} from './types';
 
 const emptyFilters: DashboardFilters = {
     dimensions: [],
@@ -111,6 +119,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         mutateAsync: versionRefresh,
         isLoading: isRefreshingDashboardVersion,
     } = useDashboardVersionRefresh(dashboardUuid, projectUuid);
+
+    const [isAutoRefresh, setIsAutoRefresh] = useState<boolean>(false);
 
     // Embedded dashboards will not be using this query hook to load the dashboard,
     // so we need to set the dashboard manually
@@ -186,6 +196,14 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         useState<DashboardFilters>(emptyFilters);
     const [haveFiltersChanged, setHaveFiltersChanged] =
         useState<boolean>(false);
+    const [oldestCacheTime, setOldestCacheTime] = useState<Date | undefined>();
+    const [preAggregateStatuses, setPreAggregateStatuses] = useState<
+        Record<string, TilePreAggregateStatus>
+    >({});
+    const [invalidateCache, setInvalidateCache] = useState<boolean>(
+        defaultInvalidateCache === true,
+    );
+
     // Event system for filter change tracking
     const { dispatchEmbedEvent } = useEmbedEventEmitter();
     const embed = useEmbed();
@@ -193,37 +211,31 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
 
     const [chartSort, setChartSort] = useState<Record<string, SortField[]>>({});
 
+    const [sqlChartTilesMetadata, setSqlChartTilesMetadata] = useState<
+        Record<string, SqlChartTileMetadata>
+    >({});
+
     const [dateZoomGranularity, setDateZoomGranularity] = useState<
         DateGranularity | string | undefined
     >(dateZoom);
 
     // Allows users to disable date zoom on view mode,
-    // by default it is enabled. Togglable in edit mode.
+    // by default it is enabled
     const [isDateZoomDisabled, setIsDateZoomDisabled] =
         useState<boolean>(false);
-    const hasInitDateZoomDisabled = useRef(false);
     useEffect(() => {
-        if (hasInitDateZoomDisabled.current) return;
         if (dashboard?.config?.isDateZoomDisabled === true) {
             setIsDateZoomDisabled(true);
-            hasInitDateZoomDisabled.current = true;
-        } else if (dashboard) {
-            hasInitDateZoomDisabled.current = true;
         }
     }, [dashboard]);
 
     // Allows users to disable add filter button on view mode,
-    // by default it is enabled. Togglable in edit mode.
+    // by default it is enabled
     const [isAddFilterDisabled, setIsAddFilterDisabled] =
         useState<boolean>(false);
-    const hasInitAddFilterDisabled = useRef(false);
     useEffect(() => {
-        if (hasInitAddFilterDisabled.current) return;
         if (dashboard?.config?.isAddFilterDisabled === true) {
             setIsAddFilterDisabled(true);
-            hasInitAddFilterDisabled.current = true;
-        } else if (dashboard) {
-            hasInitAddFilterDisabled.current = true;
         }
     }, [dashboard]);
 
@@ -246,6 +258,9 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     );
     // parameters that are currently applied to the dashboard
     const [parameters, setParameters] = useState<DashboardParameters>({});
+    const [parametersHaveChanged, setParametersHaveChanged] =
+        useState<boolean>(false);
+
     // Pinned parameters state
     const [pinnedParameters, setPinnedParametersState] = useState<string[]>([]);
     const [havePinnedParametersChanged, setHavePinnedParametersChanged] =
@@ -255,6 +270,55 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     const allStandardGranularities = useMemo(
         () => Object.values(DateGranularity),
         [],
+    );
+
+    // Track which tiles have TIMESTAMP dimensions; derive boolean from set size
+    const [tilesWithTimestampDimension, setTilesWithTimestampDimension] =
+        useState<Set<string>>(new Set());
+    const dashboardHasTimestampDimension = tilesWithTimestampDimension.size > 0;
+
+    const setTileHasTimestampDimension = useCallback(
+        (tileUuid: string, hasTimestamp: boolean) => {
+            setTilesWithTimestampDimension((prev) => {
+                // If the current state already matches the desired, return it
+                if (prev.has(tileUuid) === hasTimestamp) {
+                    return prev;
+                }
+                const next = new Set(prev);
+                if (hasTimestamp) {
+                    next.add(tileUuid);
+                } else {
+                    next.delete(tileUuid);
+                }
+                return next;
+            });
+        },
+        [],
+    );
+
+    // Custom granularities discovered from explores: key → label (e.g., "fiscal_quarter" → "Fiscal Quarter")
+    const [availableCustomGranularities, setAvailableCustomGranularities] =
+        useState<Record<string, string>>({});
+
+    const addAvailableCustomGranularities = useCallback(
+        (granularities: Record<string, string>) => {
+            setAvailableCustomGranularities((prev) => {
+                const newKeys = Object.keys(granularities).filter(
+                    (k) => !(k in prev),
+                );
+                if (newKeys.length === 0) return prev;
+                return { ...prev, ...granularities };
+            });
+        },
+        [],
+    );
+
+    const allGranularities = useMemo(
+        () => [
+            ...allStandardGranularities,
+            ...Object.keys(availableCustomGranularities),
+        ],
+        [allStandardGranularities, availableCustomGranularities],
     );
 
     const [dateZoomGranularities, setDateZoomGranularitiesState] = useState<
@@ -290,16 +354,15 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     }, [dashboard?.config?.pinnedParameters, dashboard?.config]);
 
     // Sync date zoom granularities from dashboard config
-    // Note: Custom granularities from explores are added by DashboardGranularitySync
     useEffect(() => {
         if (dashboard?.config?.dateZoomGranularities !== undefined) {
             setDateZoomGranularitiesState(
                 dashboard.config.dateZoomGranularities,
             );
         } else {
-            setDateZoomGranularitiesState(allStandardGranularities);
+            setDateZoomGranularitiesState(allGranularities);
         }
-    }, [dashboard?.config?.dateZoomGranularities, allStandardGranularities]);
+    }, [dashboard?.config?.dateZoomGranularities, allGranularities]);
 
     // Sync default date zoom granularity from dashboard config
     useEffect(() => {
@@ -336,11 +399,12 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         }
     }, [schedulerParameters]);
 
-    // Derived — no effect needed
-    const parametersHaveChanged = useMemo(
-        () => !isEqual(parameters, savedParameters),
-        [parameters, savedParameters],
-    );
+    // Set parametersHaveChanged to true if parameters have changed
+    useEffect(() => {
+        if (!isEqual(parameters, savedParameters)) {
+            setParametersHaveChanged(true);
+        }
+    }, [parameters, savedParameters]);
 
     const setParameter = useCallback(
         (key: string, value: ParameterValue | null) => {
@@ -404,38 +468,6 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         [],
     );
 
-    // Track parameter references from each tile
-    const [tileParameterReferences, setTileParameterReferences] = useState<
-        Record<string, string[]>
-    >({});
-
-    const addParameterReferences = useCallback(
-        (tileUuid: string, references: string[]) => {
-            setTileParameterReferences((prev) => ({
-                ...prev,
-                [tileUuid]: references,
-            }));
-        },
-        [],
-    );
-
-    // Remove parameter references for tiles that are no longer in the dashboard
-    useEffect(() => {
-        if (dashboardTiles) {
-            setTileParameterReferences((old) => {
-                if (!dashboardTiles) return {};
-                const tileIds = new Set(
-                    dashboardTiles.map((tile) => tile.uuid),
-                );
-                return Object.fromEntries(
-                    Object.entries(old).filter(([tileId]) =>
-                        tileIds.has(tileId),
-                    ),
-                );
-            });
-        }
-    }, [dashboardTiles]);
-
     const parameterValues = useMemo(() => {
         return Object.entries(parameters).reduce((acc, [key, parameter]) => {
             if (
@@ -454,6 +486,25 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             (value) => value !== null && value !== '' && value !== undefined,
         ).length;
     }, [parameterValues]);
+
+    // Track parameter references from each tile
+    const [tileParameterReferences, setTileParameterReferences] = useState<
+        Record<string, string[]>
+    >({});
+
+    // Track which tiles have loaded (to know when all are complete)
+    const [loadedTiles, setLoadedTiles] = useState<Set<string>>(new Set());
+
+    const addParameterReferences = useCallback(
+        (tileUuid: string, references: string[]) => {
+            setTileParameterReferences((prev) => ({
+                ...prev,
+                [tileUuid]: references,
+            }));
+            setLoadedTiles((prev) => new Set(prev).add(tileUuid));
+        },
+        [],
+    );
 
     // Calculate aggregated parameter references from all tiles
     const dashboardParameterReferences = useMemo(() => {
@@ -475,6 +526,139 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         }
     }, [projectParameters, addParameterDefinitions]);
 
+    // Determine if all chart tiles have loaded their parameter references
+    const areAllChartsLoaded = useMemo(() => {
+        if (!dashboardTiles) return false;
+
+        // If tabs exist, but no active tab is specified, tiles are not loaded
+        if (dashboardTabs && dashboardTabs.length > 0 && !activeTab)
+            return false;
+
+        const chartTileUuids = dashboardTiles
+            .filter(isDashboardChartTileType)
+            .filter((tile) => {
+                // If no active tab specified, include all tiles (backwards compatibility)
+                if (!activeTab) return true;
+
+                // If tabs exist, only include tiles from the active tab or no tabUuid
+                return !tile.tabUuid || tile.tabUuid === activeTab.uuid;
+            })
+            .map((tile) => tile.uuid);
+
+        return chartTileUuids.every((tileUuid) => loadedTiles.has(tileUuid));
+    }, [dashboardTiles, loadedTiles, activeTab, dashboardTabs]);
+
+    // Once all charts have loaded, clean up stale granularities:
+    // - Custom granularities no longer provided by any explore
+    // - Sub-day granularities when no TIMESTAMP dimensions exist
+    useEffect(() => {
+        if (!areAllChartsLoaded) return;
+
+        const availableCustomGranularityKeys = new Set(
+            Object.keys(availableCustomGranularities),
+        );
+        const isAvailable = (g: string) => {
+            if (!isStandardDateGranularity(g)) {
+                return availableCustomGranularityKeys.has(g);
+            }
+            // Strip sub-day standard granularities when no timestamp dims
+            if (!dashboardHasTimestampDimension && isSubDayGranularity(g)) {
+                return false;
+            }
+            return true;
+        };
+
+        setDateZoomGranularitiesState((prev) => {
+            const filtered = prev.filter(isAvailable);
+            if (
+                filtered.length === prev.length &&
+                filtered.every((g, i) => prev[i] === g)
+            )
+                return prev;
+            setHaveDateZoomGranularitiesChanged(true);
+            return filtered;
+        });
+
+        setDefaultDateZoomGranularityState((prev) => {
+            if (prev && !isAvailable(prev)) {
+                setHasDefaultDateZoomGranularityChanged(true);
+                return undefined;
+            }
+            return prev;
+        });
+    }, [
+        areAllChartsLoaded,
+        availableCustomGranularities,
+        dashboardHasTimestampDimension,
+    ]);
+
+    const [screenshotReadyTiles, setScreenshotReadyTiles] = useState<
+        Set<string>
+    >(new Set());
+    const [screenshotErroredTiles, setScreenshotErroredTiles] = useState<
+        Set<string>
+    >(new Set());
+
+    const markTileScreenshotReady = useCallback((tileUuid: string) => {
+        setScreenshotReadyTiles((prev) => new Set(prev).add(tileUuid));
+    }, []);
+
+    const markTileScreenshotErrored = useCallback((tileUuid: string) => {
+        setScreenshotErroredTiles((prev) => new Set(prev).add(tileUuid));
+    }, []);
+
+    const expectedScreenshotTileUuids = useMemo(() => {
+        if (!dashboardTiles) return [];
+
+        // When schedulerTabsSelected is provided, use it to filter tiles for screenshots
+        if (schedulerTabsSelected && schedulerTabsSelected.length > 0) {
+            return dashboardTiles
+                .filter(
+                    (tile) =>
+                        isDashboardChartTileType(tile) ||
+                        isDashboardSqlChartTile(tile),
+                )
+                .filter((tile) => schedulerTabsSelected.includes(tile.tabUuid!))
+                .map((tile) => tile.uuid);
+        }
+
+        if (dashboardTabs && dashboardTabs.length > 0 && !activeTab) return [];
+
+        return dashboardTiles
+            .filter(
+                (tile) =>
+                    isDashboardChartTileType(tile) ||
+                    isDashboardSqlChartTile(tile),
+            )
+            .filter((tile) => {
+                if (!activeTab) return true;
+                return !tile.tabUuid || tile.tabUuid === activeTab.uuid;
+            })
+            .map((tile) => tile.uuid);
+    }, [dashboardTiles, activeTab, dashboardTabs, schedulerTabsSelected]);
+
+    const isReadyForScreenshot = useMemo(() => {
+        if (expectedScreenshotTileUuids.length === 0) {
+            return !!dashboardTiles;
+        }
+
+        return expectedScreenshotTileUuids.every(
+            (tileUuid) =>
+                screenshotReadyTiles.has(tileUuid) ||
+                screenshotErroredTiles.has(tileUuid),
+        );
+    }, [
+        expectedScreenshotTileUuids,
+        screenshotReadyTiles,
+        screenshotErroredTiles,
+        dashboardTiles,
+    ]);
+
+    useEffect(() => {
+        setScreenshotReadyTiles(new Set());
+        setScreenshotErroredTiles(new Set());
+    }, [dashboardTiles, activeTab]);
+
     const missingRequiredParameters = useMemo(() => {
         // If no parameter references, return empty array
         if (!dashboardParameterReferences.size) return [];
@@ -487,42 +671,54 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         );
     }, [dashboardParameterReferences, parameters, parameterDefinitions]);
 
+    // Remove parameter references for tiles that are no longer in the dashboard
+    useEffect(() => {
+        if (dashboardTiles) {
+            setTileParameterReferences((old) => {
+                if (!dashboardTiles) return {};
+                const tileIds = new Set(
+                    dashboardTiles.map((tile) => tile.uuid),
+                );
+                return Object.fromEntries(
+                    Object.entries(old).filter(([tileId]) =>
+                        tileIds.has(tileId),
+                    ),
+                );
+            });
+        }
+    }, [dashboardTiles]);
+
     const [chartsWithDateZoomApplied, setChartsWithDateZoomApplied] =
         useState<Set<string>>();
 
     // Update dashboard url date zoom change
     // Only sync URL in regular dashboards or 'direct' embed mode (not 'sdk' mode)
-    // Uses refs for search/pathname to avoid re-running when unrelated URL params change.
-    const searchRefForDateZoom = useRef(search);
-    searchRefForDateZoom.current = search;
-    const pathnameRef = useRef(pathname);
-    pathnameRef.current = pathname;
     useEffect(() => {
         if (embed.mode === 'sdk') {
             return;
         }
 
-        const currentSearch = searchRefForDateZoom.current;
-        const currentParams = new URLSearchParams(currentSearch);
-        const newParams = new URLSearchParams(currentSearch);
+        const currentParams = new URLSearchParams(search);
+        const newParams = new URLSearchParams(search);
         if (dateZoomGranularity === undefined) {
             newParams.delete('dateZoom');
         } else {
             newParams.set('dateZoom', dateZoomGranularity.toLowerCase());
         }
 
+        const currentSearch = currentParams.toString();
         const newSearch = newParams.toString();
 
-        if (currentParams.toString() !== newSearch) {
+        if (currentSearch !== newSearch) {
             void navigate(
                 {
-                    pathname: pathnameRef.current,
-                    search: newSearch,
+                    pathname,
+                    search: newParams.toString(),
                 },
                 { replace: true },
             );
         }
-    }, [dateZoomGranularity, navigate, embed.mode]);
+    }, [dateZoomGranularity, search, navigate, pathname, embed.mode]);
 
     const {
         overridesForSavedDashboardFilters,
@@ -667,84 +863,81 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     // 2. Apply overrides for iframe embed or replace SDK filters in SDK mode
     // 3. Apply interactivity filtering (embedded dashboards only)
     //
-    // This runs once when the dashboard first loads. A ref guard prevents
-    // re-running on subsequent filter/embed changes.
-    const hasInitFilters = useRef(false);
+    // This happens on the first load when emptyFilters is the initial value of dashboardFilters
     useEffect(() => {
         const currentDashboard = dashboard || embedDashboard;
 
         if (!currentDashboard) return;
 
-        // Always keep original filters in sync with the source dashboard
-        setOriginalDashboardFilters(currentDashboard.filters);
+        if (dashboardFilters === emptyFilters) {
+            let overrides = clone(overridesForSavedDashboardFilters);
 
-        // Only initialize filters once
-        if (hasInitFilters.current) return;
+            // Step 1: Start with base filters
+            let updatedDashboardFilters = clone(currentDashboard.filters);
 
-        let overrides = clone(overridesForSavedDashboardFilters);
+            // Step 2: Apply SDK Filters
+            // For SDK mode, SDK filters replace embedded dashboard filters
+            const sdkFilters =
+                embed.mode === 'sdk' && embed.filters ? embed.filters : [];
+            if (sdkFilters.length > 0) {
+                // Wait for available filters query to finish (success or error)
+                // so we can build cross-explore tileTargets.
+                // If the query failed, filterableFieldsByTileUuid will be
+                // undefined and we gracefully fall back to tileTargets: {}
+                if (isLoadingDashboardFilters) return;
 
-        // Step 1: Start with base filters
-        let updatedDashboardFilters = clone(currentDashboard.filters);
+                updatedDashboardFilters.dimensions = sdkFilters.map(
+                    (sdkFilter) =>
+                        convertSdkFilterToDashboardFilter(
+                            sdkFilter,
+                            filterableFieldsByTileUuid,
+                        ),
+                );
+            }
 
-        // Step 2: Apply SDK Filters
-        // For SDK mode, SDK filters replace embedded dashboard filters
-        const sdkFilters =
-            embed.mode === 'sdk' && embed.filters ? embed.filters : [];
-        if (sdkFilters.length > 0) {
-            // Wait for available filters query to finish (success or error)
-            // so we can build cross-explore tileTargets.
-            // If the query failed, filterableFieldsByTileUuid will be
-            // undefined and we gracefully fall back to tileTargets: {}
-            if (isLoadingDashboardFilters) return;
+            // Apply overrides from URL
+            if (embed.mode === 'direct') {
+                // For direct mode, only read from URL if not SDK mode
+                if (hasSavedFiltersOverrides(overrides)) {
+                    updatedDashboardFilters = {
+                        ...updatedDashboardFilters,
+                        dimensions: applyDimensionOverrides(
+                            updatedDashboardFilters,
+                            overrides,
+                        ),
+                    };
+                    setHaveFiltersChanged(true);
+                } else {
+                    setHaveFiltersChanged(false);
+                }
+            } else {
+                if (overrides && overrides.dimensions.length > 0) {
+                    updatedDashboardFilters = {
+                        ...updatedDashboardFilters,
+                        dimensions: applyDimensionOverrides(
+                            updatedDashboardFilters,
+                            overrides,
+                        ),
+                    };
+                    setHaveFiltersChanged(true);
+                } else {
+                    setHaveFiltersChanged(false);
+                }
+            }
 
-            updatedDashboardFilters.dimensions = sdkFilters.map((sdkFilter) =>
-                convertSdkFilterToDashboardFilter(
-                    sdkFilter,
-                    filterableFieldsByTileUuid,
-                ),
+            // Step 3: Apply interactivity filtering for embedded dashboards
+            updatedDashboardFilters = applyInteractivityFiltering(
+                updatedDashboardFilters,
             );
+
+            setDashboardFilters(updatedDashboardFilters);
         }
 
-        // Apply overrides from URL
-        if (embed.mode === 'direct') {
-            // For direct mode, only read from URL if not SDK mode
-            if (hasSavedFiltersOverrides(overrides)) {
-                updatedDashboardFilters = {
-                    ...updatedDashboardFilters,
-                    dimensions: applyDimensionOverrides(
-                        updatedDashboardFilters,
-                        overrides,
-                    ),
-                };
-                setHaveFiltersChanged(true);
-            } else {
-                setHaveFiltersChanged(false);
-            }
-        } else {
-            if (overrides && overrides.dimensions.length > 0) {
-                updatedDashboardFilters = {
-                    ...updatedDashboardFilters,
-                    dimensions: applyDimensionOverrides(
-                        updatedDashboardFilters,
-                        overrides,
-                    ),
-                };
-                setHaveFiltersChanged(true);
-            } else {
-                setHaveFiltersChanged(false);
-            }
-        }
-
-        // Step 3: Apply interactivity filtering for embedded dashboards
-        updatedDashboardFilters = applyInteractivityFiltering(
-            updatedDashboardFilters,
-        );
-
-        setDashboardFilters(updatedDashboardFilters);
-        hasInitFilters.current = true;
+        setOriginalDashboardFilters(currentDashboard.filters);
     }, [
         dashboard,
         embedDashboard,
+        dashboardFilters,
         overridesForSavedDashboardFilters,
         embed,
         applyInteractivityFiltering,
@@ -1266,6 +1459,38 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         [removeSavedFilterOverride],
     );
 
+    const addResultsCacheTime = useCallback((cacheMetadata?: CacheMetadata) => {
+        if (
+            cacheMetadata &&
+            cacheMetadata.cacheHit &&
+            cacheMetadata.cacheUpdatedTime
+        ) {
+            const newTime = cacheMetadata.cacheUpdatedTime;
+            setOldestCacheTime((prev) =>
+                prev === undefined ? newTime : min([prev, newTime])!,
+            );
+        }
+    }, []);
+
+    const clearCacheAndFetch = useCallback(() => {
+        setOldestCacheTime(undefined);
+        setPreAggregateStatuses({});
+        setLoadedTiles(new Set());
+
+        // Causes results refetch
+        setInvalidateCache(true);
+    }, []);
+
+    const updateSqlChartTilesMetadata = useCallback(
+        (tileUuid: string, metadata: SqlChartTileMetadata) => {
+            setSqlChartTilesMetadata((prev) => ({
+                ...prev,
+                [tileUuid]: metadata,
+            }));
+        },
+        [],
+    );
+
     const refreshDashboardVersion = useCallback(async () => {
         try {
             const freshDashboard = await versionRefresh(dashboard);
@@ -1330,6 +1555,57 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         ],
     );
 
+    // Memoized mapping of tile UUIDs to their display names
+    const tileNamesById = useMemo(() => {
+        if (!dashboardTiles) return {};
+
+        return dashboardTiles.reduce<Record<string, string>>((acc, tile) => {
+            const tileWithoutTitle =
+                !tile.properties.title || tile.properties.title.length === 0;
+            const isChartTileType = isDashboardChartTileType(tile);
+
+            let tileName = '';
+            if (tileWithoutTitle && isChartTileType) {
+                tileName = tile.properties.chartName || '';
+            } else if (tile.properties.title) {
+                tileName = tile.properties.title;
+            }
+
+            acc[tile.uuid] = tileName;
+            return acc;
+        }, {});
+    }, [dashboardTiles]);
+
+    const tileTabsById = useMemo(() => {
+        if (!dashboardTiles) return {};
+        return dashboardTiles.reduce<Record<string, string | null | undefined>>(
+            (acc, tile) => {
+                acc[tile.uuid] = tile.tabUuid;
+                return acc;
+            },
+            {},
+        );
+    }, [dashboardTiles]);
+
+    const addPreAggregateStatus = useCallback(
+        (tileUuid: string, cacheMetadata?: CacheMetadata) => {
+            const preAggregate = cacheMetadata?.preAggregate ?? null;
+            setPreAggregateStatuses((prev) => ({
+                ...prev,
+                [tileUuid]: {
+                    tileUuid,
+                    tileName: tileNamesById[tileUuid] ?? tileUuid,
+                    hit: preAggregate?.hit ?? false,
+                    preAggregateName: preAggregate?.name ?? null,
+                    reason: preAggregate?.reason ?? null,
+                    hasPreAggregateMetadata: preAggregate !== null,
+                    tabUuid: tileTabsById[tileUuid],
+                },
+            }));
+        },
+        [tileNamesById, tileTabsById],
+    );
+
     const value = {
         projectUuid,
         isDashboardLoading,
@@ -1359,6 +1635,12 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         setDashboardFilters,
         haveFiltersChanged,
         setHaveFiltersChanged,
+        addResultsCacheTime,
+        oldestCacheTime,
+        invalidateCache,
+        clearCacheAndFetch,
+        isAutoRefresh,
+        setIsAutoRefresh,
         allFilterableFieldsMap,
         allFilterableMetricsMap,
         allFilterableFields: dashboardAvailableFiltersData?.allFilterableFields,
@@ -1371,6 +1653,8 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         hasTilesThatSupportFilters,
         chartSort,
         setChartSort,
+        sqlChartTilesMetadata,
+        updateSqlChartTilesMetadata,
         dateZoomGranularity,
         setDateZoomGranularity,
         chartsWithDateZoomApplied,
@@ -1394,6 +1678,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         dashboardParameterReferences,
         addParameterReferences,
         tileParameterReferences,
+        areAllChartsLoaded,
         missingRequiredParameters,
         pinnedParameters,
         setPinnedParameters,
@@ -1409,8 +1694,21 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         hasDefaultDateZoomGranularityChanged,
         setHasDefaultDateZoomGranularityChanged,
         addParameterDefinitions,
+        dashboardHasTimestampDimension,
+        setTileHasTimestampDimension,
+        availableCustomGranularities,
+        addAvailableCustomGranularities,
+        tileNamesById,
+        preAggregateStatuses,
+        addPreAggregateStatus,
         refreshDashboardVersion,
         isRefreshingDashboardVersion,
+        markTileScreenshotReady,
+        markTileScreenshotErrored,
+        isReadyForScreenshot,
+        screenshotReadyTilesCount: screenshotReadyTiles.size,
+        screenshotErroredTilesCount: screenshotErroredTiles.size,
+        expectedScreenshotTilesCount: expectedScreenshotTileUuids.length,
     };
     return (
         <DashboardContext.Provider value={value}>
@@ -1421,99 +1719,21 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
                 schedulerTabsSelected={schedulerTabsSelected}
                 defaultInvalidateCache={defaultInvalidateCache}
             >
-                <DashboardGranularitySync />
                 {children}
             </DashboardTileStatusProvider>
         </DashboardContext.Provider>
     );
 };
 
-/**
- * Bridge component that reads tile-status context values
- * and syncs them back to the main dashboard context via effects.
- * This exists because DashboardProviderInner cannot use useDashboardTileStatusContext
- * (tile status provider is rendered as its child).
- */
-const DashboardGranularitySync: React.FC = () => {
-    const areAllChartsLoaded = useDashboardTileStatusContext(
-        (c) => c.areAllChartsLoaded,
-    );
-    const availableCustomGranularities = useDashboardTileStatusContext(
-        (c) => c.availableCustomGranularities,
-    );
-    const dashboardHasTimestampDimension = useDashboardTileStatusContext(
-        (c) => c.dashboardHasTimestampDimension,
-    );
-
-    // Use refs for values we read but should NOT trigger re-runs of the effect.
-    // Reading dateZoomGranularities directly in the dep array would cause an
-    // infinite loop: effect filters → setDateZoomGranularities (which also sets
-    // haveDateZoomGranularitiesChanged) → new context value → effect re-fires.
-    const dateZoomGranularities = useDashboardContext(
-        (c) => c.dateZoomGranularities,
-    );
-    const dateZoomGranularitiesRef = useRef(dateZoomGranularities);
-    dateZoomGranularitiesRef.current = dateZoomGranularities;
-
-    const defaultDateZoomGranularity = useDashboardContext(
-        (c) => c.defaultDateZoomGranularity,
-    );
-    const defaultDateZoomGranularityRef = useRef(defaultDateZoomGranularity);
-    defaultDateZoomGranularityRef.current = defaultDateZoomGranularity;
-
-    const setDateZoomGranularities = useDashboardContext(
-        (c) => c.setDateZoomGranularities,
-    );
-    const setDefaultDateZoomGranularity = useDashboardContext(
-        (c) => c.setDefaultDateZoomGranularity,
-    );
-
-    // Once all charts have loaded, clean up stale granularities:
-    // - Custom granularities no longer provided by any explore
-    // - Sub-day granularities when no TIMESTAMP dimensions exist
-    useEffect(() => {
-        if (!areAllChartsLoaded) return;
-
-        const currentGranularities = dateZoomGranularitiesRef.current;
-        const currentDefault = defaultDateZoomGranularityRef.current;
-
-        const availableCustomGranularityKeys = new Set(
-            Object.keys(availableCustomGranularities),
-        );
-        const isAvailable = (g: string) => {
-            if (!isStandardDateGranularity(g)) {
-                return availableCustomGranularityKeys.has(g);
-            }
-            // Strip sub-day standard granularities when no timestamp dims
-            if (!dashboardHasTimestampDimension && isSubDayGranularity(g)) {
-                return false;
-            }
-            return true;
-        };
-
-        const filtered = currentGranularities.filter(isAvailable);
-        if (
-            filtered.length !== currentGranularities.length ||
-            !filtered.every((g, i) => currentGranularities[i] === g)
-        ) {
-            setDateZoomGranularities(filtered);
-        }
-
-        if (currentDefault && !isAvailable(currentDefault)) {
-            setDefaultDateZoomGranularity(undefined);
-        }
-    }, [
-        areAllChartsLoaded,
-        availableCustomGranularities,
-        dashboardHasTimestampDimension,
-        setDateZoomGranularities,
-        setDefaultDateZoomGranularity,
-    ]);
-
-    return null;
-};
-
 const DashboardProvider: React.FC<DashboardProviderProps> = (props) => {
+    const useReduxStore = useClientFeatureFlag(
+        FeatureFlags.DashboardReduxStore,
+    );
+
+    if (useReduxStore) {
+        return <DashboardReduxProvider {...props} />;
+    }
+
     return <DashboardProviderInner {...props} />;
 };
 

--- a/packages/frontend/src/providers/Dashboard/DashboardReduxProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardReduxProvider.tsx
@@ -1,0 +1,1133 @@
+import {
+    applyDimensionOverrides,
+    compressDashboardFiltersToParam,
+    convertDashboardFiltersParamToDashboardFilters,
+    DateGranularity,
+    FilterInteractivityValues,
+    getFilterInteractivityValue,
+    isDashboardChartTileType,
+    isDashboardSqlChartTile,
+    isStandardDateGranularity,
+    isSubDayGranularity,
+    type DashboardFilterableField,
+    type DashboardFilterRule,
+    type DashboardFilters,
+    type ParametersValuesMap,
+    type SavedChartsInfoForDashboardAvailableFilters,
+} from '@lightdash/common';
+import clone from 'lodash/clone';
+import isEqual from 'lodash/isEqual';
+import sortBy from 'lodash/sortBy';
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+} from 'react';
+import { Provider as ReduxProvider } from 'react-redux';
+import { useLocation, useNavigate, useParams } from 'react-router';
+import { useDeepCompareEffect, useMount } from 'react-use';
+import { type SdkFilter } from '../../ee/features/embed/EmbedDashboard/types';
+import { convertSdkFilterToDashboardFilter } from '../../ee/features/embed/EmbedDashboard/utils';
+import { LightdashEventType } from '../../ee/features/embed/events/types';
+import { useEmbedEventEmitter } from '../../ee/features/embed/hooks/useEmbedEventEmitter';
+import useEmbed from '../../ee/providers/Embed/useEmbed';
+import {
+    useGetComments,
+    type useDashboardCommentsCheck,
+} from '../../features/comments';
+import { useParameters } from '../../features/parameters';
+import {
+    useDashboardQuery,
+    useDashboardsAvailableFilters,
+    useDashboardVersionRefresh,
+} from '../../hooks/dashboard/useDashboard';
+import useToaster from '../../hooks/toaster/useToaster';
+import {
+    hasSavedFiltersOverrides,
+    useSavedDashboardFiltersOverrides,
+} from '../../hooks/useSavedDashboardFiltersOverrides';
+import { DashboardBridgeProvider } from './DashboardBridgeProvider';
+import { dashboardDataActions } from './store/dashboardDataSlice';
+import {
+    dashboardFiltersActions,
+    EMPTY_FILTERS,
+} from './store/dashboardFiltersSlice';
+import { useDashboardDispatch, useDashboardSelector } from './store/hooks';
+import { createDashboardStore } from './store/index';
+
+type Props = React.PropsWithChildren<{
+    schedulerFilters?: DashboardFilterRule[] | undefined;
+    schedulerParameters?: ParametersValuesMap | undefined;
+    schedulerTabsSelected?: string[] | undefined;
+    dateZoom?: DateGranularity | string | undefined;
+    projectUuid?: string;
+    embedToken?: string;
+    dashboardCommentsCheck?: ReturnType<typeof useDashboardCommentsCheck>;
+    defaultInvalidateCache?: boolean;
+    sdkFilters?: SdkFilter[];
+}>;
+
+/**
+ * Inner component that runs inside the Redux Provider.
+ * It uses the same hooks as the original DashboardProvider but dispatches
+ * results to the Redux store instead of useState.
+ */
+const DashboardReduxSync: React.FC<Props> = ({
+    schedulerFilters,
+    schedulerParameters,
+    schedulerTabsSelected,
+    dateZoom,
+    projectUuid,
+    embedToken,
+    dashboardCommentsCheck,
+    defaultInvalidateCache,
+    children,
+}) => {
+    const dispatch = useDashboardDispatch();
+
+    // Read state from Redux
+    const dashboardFilters = useDashboardSelector(
+        (s) => s.dashboardFilters.dashboardFilters,
+    );
+    const dashboardTemporaryFilters = useDashboardSelector(
+        (s) => s.dashboardFilters.dashboardTemporaryFilters,
+    );
+    const originalDashboardFilters = useDashboardSelector(
+        (s) => s.dashboardFilters.originalDashboardFilters,
+    );
+    const dashboardTiles = useDashboardSelector(
+        (s) => s.dashboardData.dashboardTiles,
+    );
+    const dashboardTabs = useDashboardSelector(
+        (s) => s.dashboardData.dashboardTabs,
+    );
+    const activeTab = useDashboardSelector((s) => s.dashboardData.activeTab);
+    const embedDashboard = useDashboardSelector(
+        (s) => s.dashboardData.embedDashboard,
+    );
+    const dateZoomGranularity = useDashboardSelector(
+        (s) => s.dashboardData.dateZoomGranularity,
+    );
+    const dateZoomGranularities = useDashboardSelector(
+        (s) => s.dashboardData.dateZoomGranularities,
+    );
+    const defaultDateZoomGranularity = useDashboardSelector(
+        (s) => s.dashboardData.defaultDateZoomGranularity,
+    );
+    const availableCustomGranularities = useDashboardSelector(
+        (s) => s.dashboardData.availableCustomGranularities,
+    );
+    const tilesWithTimestampDimension = useDashboardSelector(
+        (s) => s.dashboardData.tilesWithTimestampDimension,
+    );
+    const loadedTiles = useDashboardSelector(
+        (s) => s.dashboardData.loadedTiles,
+    );
+    const tileParameterReferences = useDashboardSelector(
+        (s) => s.dashboardData.tileParameterReferences,
+    );
+    const parameters = useDashboardSelector((s) => s.dashboardData.parameters);
+    const savedParameters = useDashboardSelector(
+        (s) => s.dashboardData.savedParameters,
+    );
+    const parameterDefinitions = useDashboardSelector(
+        (s) => s.dashboardData.parameterDefinitions,
+    );
+    const _screenshotReadyTiles = useDashboardSelector(
+        (s) => s.dashboardData.screenshotReadyTiles,
+    );
+    const _screenshotErroredTiles = useDashboardSelector(
+        (s) => s.dashboardData.screenshotErroredTiles,
+    );
+
+    const { search, pathname } = useLocation();
+    const navigate = useNavigate();
+    const { showToastWarning } = useToaster();
+
+    const { dashboardUuid, tabUuid, mode } = useParams<{
+        dashboardUuid: string;
+        tabUuid?: string;
+        mode?: string;
+    }>() as {
+        dashboardUuid: string;
+        tabUuid?: string;
+        mode?: string;
+    };
+    const isEditMode = mode === 'edit';
+
+    // Set project uuid
+    useEffect(() => {
+        dispatch(dashboardDataActions.setProjectUuid(projectUuid));
+    }, [dispatch, projectUuid]);
+
+    // Set default invalidate cache
+    useEffect(() => {
+        if (defaultInvalidateCache === true) {
+            dispatch(dashboardDataActions.setInvalidateCache(true));
+        }
+    }, [dispatch, defaultInvalidateCache]);
+
+    // Set date zoom from prop
+    useEffect(() => {
+        if (dateZoom !== undefined) {
+            dispatch(dashboardDataActions.setDateZoomGranularity(dateZoom));
+        }
+    }, [dispatch, dateZoom]);
+
+    // Set dashboard comments check
+    useEffect(() => {
+        dispatch(
+            dashboardDataActions.setDashboardCommentsCheck(
+                dashboardCommentsCheck,
+            ),
+        );
+    }, [dispatch, dashboardCommentsCheck]);
+
+    const {
+        mutateAsync: versionRefresh,
+        isLoading: isRefreshingDashboardVersion,
+    } = useDashboardVersionRefresh(dashboardUuid, projectUuid);
+
+    useEffect(() => {
+        dispatch(
+            dashboardDataActions.setIsRefreshingDashboardVersion(
+                isRefreshingDashboardVersion,
+            ),
+        );
+    }, [dispatch, isRefreshingDashboardVersion]);
+
+    // Dashboard query
+    const {
+        data: dashboard,
+        isInitialLoading: isDashboardLoading,
+        error: dashboardError,
+    } = useDashboardQuery({
+        uuidOrSlug: dashboardUuid,
+        projectUuid,
+        useQueryOptions: {
+            select: (d) => {
+                if (schedulerFilters) {
+                    const overriddenDimensions = applyDimensionOverrides(
+                        d.filters,
+                        schedulerFilters,
+                    );
+                    return {
+                        ...d,
+                        filters: {
+                            ...d.filters,
+                            dimensions: overriddenDimensions,
+                        },
+                    };
+                }
+                return d;
+            },
+        },
+    });
+
+    // Sync dashboard query results to Redux
+    useEffect(() => {
+        dispatch(dashboardDataActions.setDashboard(dashboard ?? undefined));
+        dispatch(
+            dashboardDataActions.setIsDashboardLoading(isDashboardLoading),
+        );
+        dispatch(dashboardDataActions.setDashboardError(dashboardError));
+    }, [dispatch, dashboard, isDashboardLoading, dashboardError]);
+
+    // Dashboard comments
+    const { data: dashboardComments } = useGetComments(
+        dashboardUuid,
+        projectUuid,
+        !!dashboardCommentsCheck &&
+            !!dashboardCommentsCheck.canViewDashboardComments,
+    );
+
+    useEffect(() => {
+        dispatch(dashboardDataActions.setDashboardComments(dashboardComments));
+    }, [dispatch, dashboardComments]);
+
+    // Embed
+    const { dispatchEmbedEvent } = useEmbedEventEmitter();
+    const embed = useEmbed();
+    const previousFiltersRef = useRef<DashboardFilters | null>(null);
+
+    // Set tiles/tabs when dashboard loads
+    useEffect(() => {
+        if (dashboard?.tiles) {
+            dispatch(dashboardDataActions.setDashboardTiles(dashboard.tiles));
+        }
+    }, [dispatch, dashboard?.tiles]);
+
+    useEffect(() => {
+        if (dashboard?.tabs) {
+            dispatch(
+                dashboardDataActions.setDashboardTabs(
+                    sortBy(dashboard.tabs, 'order'),
+                ),
+            );
+        }
+    }, [dispatch, dashboard?.tabs]);
+
+    // Sync parameters from dashboard
+    useEffect(() => {
+        if (dashboard?.parameters) {
+            dispatch(
+                dashboardDataActions.setSavedParameters(
+                    dashboard.parameters ?? {},
+                ),
+            );
+        }
+    }, [dispatch, dashboard?.parameters]);
+
+    // Set parameters to saved parameters when they are loaded
+    useEffect(() => {
+        if (savedParameters) {
+            dispatch(dashboardDataActions.setParameters(savedParameters));
+        }
+    }, [dispatch, savedParameters]);
+
+    // Date zoom disabled
+    useEffect(() => {
+        if (dashboard?.config?.isDateZoomDisabled === true) {
+            dispatch(dashboardDataActions.setIsDateZoomDisabled(true));
+        }
+    }, [dispatch, dashboard]);
+
+    // Add filter disabled
+    useEffect(() => {
+        if (dashboard?.config?.isAddFilterDisabled === true) {
+            dispatch(dashboardDataActions.setIsAddFilterDisabled(true));
+        }
+    }, [dispatch, dashboard]);
+
+    // Set pinned parameters when dashboard is loaded
+    useEffect(() => {
+        if (dashboard?.config?.pinnedParameters !== undefined) {
+            dispatch(
+                dashboardDataActions.setPinnedParameters(
+                    dashboard.config.pinnedParameters,
+                ),
+            );
+        } else if (dashboard?.config !== undefined) {
+            dispatch(dashboardDataActions.setPinnedParameters([]));
+        }
+    }, [dispatch, dashboard?.config?.pinnedParameters, dashboard?.config]);
+
+    // All standard granularities
+    const allStandardGranularities = useMemo(
+        () => Object.values(DateGranularity),
+        [],
+    );
+
+    const dashboardHasTimestampDimension = tilesWithTimestampDimension.size > 0;
+
+    const allGranularities = useMemo(
+        () => [
+            ...allStandardGranularities,
+            ...Object.keys(availableCustomGranularities),
+        ],
+        [allStandardGranularities, availableCustomGranularities],
+    );
+
+    // Sync date zoom granularities from dashboard config
+    useEffect(() => {
+        if (dashboard?.config?.dateZoomGranularities !== undefined) {
+            dispatch(
+                dashboardDataActions.setDateZoomGranularitiesState(
+                    dashboard.config.dateZoomGranularities,
+                ),
+            );
+        } else {
+            dispatch(
+                dashboardDataActions.setDateZoomGranularitiesState(
+                    allGranularities,
+                ),
+            );
+        }
+    }, [dispatch, dashboard?.config?.dateZoomGranularities, allGranularities]);
+
+    // Sync default date zoom granularity from dashboard config
+    useEffect(() => {
+        dispatch(
+            dashboardDataActions.setDefaultDateZoomGranularityState(
+                dashboard?.config?.defaultDateZoomGranularity,
+            ),
+        );
+    }, [dispatch, dashboard?.config?.defaultDateZoomGranularity]);
+
+    // Set active tab when dashboard and tabs are loaded
+    useEffect(() => {
+        if (dashboardTabs && dashboardTabs.length > 0) {
+            const matchedTab =
+                dashboardTabs.find((tab) => tab.uuid === tabUuid) ??
+                dashboardTabs[0];
+            dispatch(dashboardDataActions.setActiveTab(matchedTab));
+        }
+    }, [dispatch, dashboardTabs, tabUuid]);
+
+    // Apply scheduler parameters when provided
+    useEffect(() => {
+        if (schedulerParameters) {
+            const dashboardParams = Object.fromEntries(
+                Object.entries(schedulerParameters).map(([key, value]) => [
+                    key,
+                    { parameterName: key, value },
+                ]),
+            );
+            dispatch(dashboardDataActions.setSavedParameters(dashboardParams));
+        }
+    }, [dispatch, schedulerParameters]);
+
+    // Set parametersHaveChanged
+    useEffect(() => {
+        if (!isEqual(parameters, savedParameters)) {
+            dispatch(dashboardDataActions.setParametersHaveChanged(true));
+        }
+    }, [dispatch, parameters, savedParameters]);
+
+    // Parameter values
+    const parameterValues = useMemo(() => {
+        return Object.entries(parameters).reduce((acc, [key, parameter]) => {
+            if (
+                parameter.value !== null &&
+                parameter.value !== undefined &&
+                parameter.value !== ''
+            ) {
+                acc[key] = parameter.value;
+            }
+            return acc;
+        }, {} as ParametersValuesMap);
+    }, [parameters]);
+
+    const selectedParametersCount = useMemo(() => {
+        return Object.values(parameterValues).filter(
+            (value) => value !== null && value !== '' && value !== undefined,
+        ).length;
+    }, [parameterValues]);
+
+    useEffect(() => {
+        dispatch(
+            dashboardDataActions.setSelectedParametersCount(
+                selectedParametersCount,
+            ),
+        );
+    }, [dispatch, selectedParametersCount]);
+
+    // Calculate aggregated parameter references from all tiles
+    const dashboardParameterReferences = useMemo(() => {
+        const allReferences = Object.values(tileParameterReferences).flat();
+        return new Set(allReferences);
+    }, [tileParameterReferences]);
+
+    const { data: projectParameters } = useParameters(
+        projectUuid,
+        Array.from(dashboardParameterReferences ?? []),
+        {
+            enabled: !!projectUuid && !!dashboardParameterReferences,
+        },
+    );
+
+    useEffect(() => {
+        if (projectParameters) {
+            dispatch(
+                dashboardDataActions.addParameterDefinitions(projectParameters),
+            );
+        }
+    }, [dispatch, projectParameters]);
+
+    // Determine if all chart tiles have loaded
+    const areAllChartsLoaded = useMemo(() => {
+        if (!dashboardTiles) return false;
+        if (dashboardTabs && dashboardTabs.length > 0 && !activeTab)
+            return false;
+
+        const chartTileUuids = dashboardTiles
+            .filter(isDashboardChartTileType)
+            .filter((tile) => {
+                if (!activeTab) return true;
+                return !tile.tabUuid || tile.tabUuid === activeTab.uuid;
+            })
+            .map((tile) => tile.uuid);
+
+        return chartTileUuids.every((tileUuid) => loadedTiles.has(tileUuid));
+    }, [dashboardTiles, loadedTiles, activeTab, dashboardTabs]);
+
+    // Clean up stale granularities once all charts loaded
+    useEffect(() => {
+        if (!areAllChartsLoaded) return;
+
+        const availableCustomGranularityKeys = new Set(
+            Object.keys(availableCustomGranularities),
+        );
+        const isAvailable = (g: string) => {
+            if (!isStandardDateGranularity(g)) {
+                return availableCustomGranularityKeys.has(g);
+            }
+            if (!dashboardHasTimestampDimension && isSubDayGranularity(g)) {
+                return false;
+            }
+            return true;
+        };
+
+        const filtered = dateZoomGranularities.filter(isAvailable);
+        if (
+            filtered.length !== dateZoomGranularities.length ||
+            !filtered.every((g, i) => dateZoomGranularities[i] === g)
+        ) {
+            dispatch(dashboardDataActions.setDateZoomGranularities(filtered));
+        }
+
+        if (
+            defaultDateZoomGranularity &&
+            !isAvailable(defaultDateZoomGranularity)
+        ) {
+            dispatch(
+                dashboardDataActions.setDefaultDateZoomGranularity(undefined),
+            );
+        }
+    }, [
+        areAllChartsLoaded,
+        availableCustomGranularities,
+        dashboardHasTimestampDimension,
+        dateZoomGranularities,
+        defaultDateZoomGranularity,
+        dispatch,
+    ]);
+
+    // Screenshot tracking
+    const expectedScreenshotTileUuids = useMemo(() => {
+        if (!dashboardTiles) return [];
+
+        if (schedulerTabsSelected && schedulerTabsSelected.length > 0) {
+            return dashboardTiles
+                .filter(
+                    (tile) =>
+                        isDashboardChartTileType(tile) ||
+                        isDashboardSqlChartTile(tile),
+                )
+                .filter((tile) => schedulerTabsSelected.includes(tile.tabUuid!))
+                .map((tile) => tile.uuid);
+        }
+
+        if (dashboardTabs && dashboardTabs.length > 0 && !activeTab) return [];
+
+        return dashboardTiles
+            .filter(
+                (tile) =>
+                    isDashboardChartTileType(tile) ||
+                    isDashboardSqlChartTile(tile),
+            )
+            .filter((tile) => {
+                if (!activeTab) return true;
+                return !tile.tabUuid || tile.tabUuid === activeTab.uuid;
+            })
+            .map((tile) => tile.uuid);
+    }, [dashboardTiles, activeTab, dashboardTabs, schedulerTabsSelected]);
+
+    // Reset screenshot tiles when tiles or active tab change
+    useEffect(() => {
+        dispatch(dashboardDataActions.resetScreenshotTiles());
+    }, [dispatch, dashboardTiles, activeTab]);
+
+    // Missing required parameters
+    const missingRequiredParameters = useMemo(() => {
+        if (!dashboardParameterReferences.size) return [];
+        return Array.from(dashboardParameterReferences).filter(
+            (parameterName) =>
+                !parameters[parameterName] &&
+                !parameterDefinitions[parameterName]?.default,
+        );
+    }, [dashboardParameterReferences, parameters, parameterDefinitions]);
+
+    // Remove parameter references for tiles no longer in the dashboard
+    useEffect(() => {
+        if (dashboardTiles) {
+            const tileIds = new Set(dashboardTiles.map((tile) => tile.uuid));
+            const filtered = Object.fromEntries(
+                Object.entries(tileParameterReferences).filter(([tileId]) =>
+                    tileIds.has(tileId),
+                ),
+            );
+            if (
+                Object.keys(filtered).length !==
+                Object.keys(tileParameterReferences).length
+            ) {
+                dispatch(
+                    dashboardDataActions.setTileParameterReferences(filtered),
+                );
+            }
+        }
+    }, [dispatch, dashboardTiles, tileParameterReferences]);
+
+    // URL sync for date zoom
+    useEffect(() => {
+        if (embed.mode === 'sdk') return;
+
+        const currentParams = new URLSearchParams(search);
+        const newParams = new URLSearchParams(search);
+        if (dateZoomGranularity === undefined) {
+            newParams.delete('dateZoom');
+        } else {
+            newParams.set('dateZoom', dateZoomGranularity.toLowerCase());
+        }
+
+        const currentSearch = currentParams.toString();
+        const newSearch = newParams.toString();
+
+        if (currentSearch !== newSearch) {
+            void navigate(
+                { pathname, search: newParams.toString() },
+                { replace: true },
+            );
+        }
+    }, [dateZoomGranularity, search, navigate, pathname, embed.mode]);
+
+    const {
+        overridesForSavedDashboardFilters,
+        addSavedFilterOverride,
+        removeSavedFilterOverride,
+        resetSavedFilterOverrides,
+    } = useSavedDashboardFiltersOverrides();
+
+    // Chart tile mapping key
+    const savedChartUuidsAndTileUuidsKey = useMemo(
+        () =>
+            dashboardTiles
+                ?.filter(isDashboardChartTileType)
+                .map(
+                    (tile) =>
+                        `${tile.uuid}:${tile.properties.savedChartUuid ?? ''}`,
+                )
+                .sort()
+                .join(',') ?? '',
+        [dashboardTiles],
+    );
+
+    const savedChartUuidsAndTileUuids = useMemo(
+        () =>
+            dashboardTiles
+                ?.filter(isDashboardChartTileType)
+                .reduce<SavedChartsInfoForDashboardAvailableFilters>(
+                    (acc, tile) => {
+                        if (tile.properties.savedChartUuid) {
+                            acc.push({
+                                tileUuid: tile.uuid,
+                                savedChartUuid: tile.properties.savedChartUuid,
+                            });
+                        }
+                        return acc;
+                    },
+                    [],
+                ),
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+        [savedChartUuidsAndTileUuidsKey],
+    );
+
+    const {
+        isInitialLoading: isLoadingDashboardFilters,
+        isFetching: isFetchingDashboardFilters,
+        data: dashboardAvailableFiltersData,
+    } = useDashboardsAvailableFilters(
+        savedChartUuidsAndTileUuids ?? [],
+        projectUuid,
+        embedToken,
+    );
+
+    // Sync available filters data to Redux
+    useEffect(() => {
+        dispatch(
+            dashboardDataActions.setIsLoadingDashboardFilters(
+                isLoadingDashboardFilters,
+            ),
+        );
+        dispatch(
+            dashboardDataActions.setIsFetchingDashboardFilters(
+                isFetchingDashboardFilters,
+            ),
+        );
+        if (dashboardAvailableFiltersData) {
+            dispatch(
+                dashboardDataActions.setDashboardAvailableFiltersData({
+                    allFilterableFields:
+                        dashboardAvailableFiltersData.allFilterableFields,
+                    allFilterableMetrics:
+                        dashboardAvailableFiltersData.allFilterableMetrics,
+                    savedQueryFilters:
+                        dashboardAvailableFiltersData.savedQueryFilters,
+                    savedQueryMetricFilters:
+                        dashboardAvailableFiltersData.savedQueryMetricFilters,
+                }),
+            );
+        }
+    }, [
+        dispatch,
+        isLoadingDashboardFilters,
+        isFetchingDashboardFilters,
+        dashboardAvailableFiltersData,
+    ]);
+
+    const filterableFieldsByTileUuid = useMemo(() => {
+        if (
+            (!dashboard && !embedToken) ||
+            !savedChartUuidsAndTileUuids ||
+            !dashboardAvailableFiltersData
+        )
+            return undefined;
+
+        return savedChartUuidsAndTileUuids.reduce<
+            Record<string, DashboardFilterableField[]>
+        >((acc, { tileUuid }) => {
+            const dimensionFields =
+                dashboardAvailableFiltersData.savedQueryFilters[tileUuid]?.map(
+                    (index) =>
+                        dashboardAvailableFiltersData.allFilterableFields[
+                            index
+                        ],
+                ) ?? [];
+            const metricFields =
+                dashboardAvailableFiltersData.savedQueryMetricFilters[
+                    tileUuid
+                ]?.map(
+                    (index) =>
+                        dashboardAvailableFiltersData.allFilterableMetrics[
+                            index
+                        ],
+                ) ?? [];
+
+            const combined = [...dimensionFields, ...metricFields];
+            if (combined.length > 0) {
+                acc[tileUuid] = combined;
+            }
+            return acc;
+        }, {});
+    }, [
+        dashboard,
+        dashboardAvailableFiltersData,
+        savedChartUuidsAndTileUuids,
+        embedToken,
+    ]);
+
+    /**
+     * Apply interactivity filtering for embedded dashboards
+     */
+    const applyInteractivityFiltering = useCallback(
+        (filters: DashboardFilters): DashboardFilters => {
+            if (!embedDashboard) return filters;
+            if (!embedDashboard.dashboardFiltersInteractivity)
+                return EMPTY_FILTERS;
+            const interactivityOptions =
+                embedDashboard.dashboardFiltersInteractivity;
+            const filterInteractivityValue = getFilterInteractivityValue(
+                interactivityOptions.enabled,
+            );
+            if (filterInteractivityValue === FilterInteractivityValues.none)
+                return EMPTY_FILTERS;
+            if (filterInteractivityValue === FilterInteractivityValues.some) {
+                return {
+                    ...filters,
+                    dimensions: filters.dimensions.filter((filter) =>
+                        interactivityOptions.allowedFilters?.includes(
+                            filter.id,
+                        ),
+                    ),
+                };
+            }
+            return filters;
+        },
+        [embedDashboard],
+    );
+
+    // Apply filters on dashboard load
+    useEffect(() => {
+        const currentDashboard = dashboard || embedDashboard;
+        if (!currentDashboard) return;
+
+        if (dashboardFilters === EMPTY_FILTERS) {
+            const overrides = clone(overridesForSavedDashboardFilters);
+            let updatedDashboardFilters = clone(currentDashboard.filters);
+
+            // SDK filters
+            const sdkFilters =
+                embed.mode === 'sdk' && embed.filters ? embed.filters : [];
+            if (sdkFilters.length > 0) {
+                if (isLoadingDashboardFilters) return;
+                updatedDashboardFilters.dimensions = sdkFilters.map(
+                    (sdkFilter: SdkFilter) =>
+                        convertSdkFilterToDashboardFilter(
+                            sdkFilter,
+                            filterableFieldsByTileUuid,
+                        ),
+                );
+            }
+
+            // Apply overrides from URL
+            if (embed.mode === 'direct') {
+                if (hasSavedFiltersOverrides(overrides)) {
+                    updatedDashboardFilters = {
+                        ...updatedDashboardFilters,
+                        dimensions: applyDimensionOverrides(
+                            updatedDashboardFilters,
+                            overrides,
+                        ),
+                    };
+                    dispatch(
+                        dashboardFiltersActions.setHaveFiltersChanged(true),
+                    );
+                } else {
+                    dispatch(
+                        dashboardFiltersActions.setHaveFiltersChanged(false),
+                    );
+                }
+            } else {
+                if (overrides && overrides.dimensions.length > 0) {
+                    updatedDashboardFilters = {
+                        ...updatedDashboardFilters,
+                        dimensions: applyDimensionOverrides(
+                            updatedDashboardFilters,
+                            overrides,
+                        ),
+                    };
+                    dispatch(
+                        dashboardFiltersActions.setHaveFiltersChanged(true),
+                    );
+                } else {
+                    dispatch(
+                        dashboardFiltersActions.setHaveFiltersChanged(false),
+                    );
+                }
+            }
+
+            // Apply interactivity filtering
+            updatedDashboardFilters = applyInteractivityFiltering(
+                updatedDashboardFilters,
+            );
+
+            dispatch(
+                dashboardFiltersActions.setDashboardFilters(
+                    updatedDashboardFilters,
+                ),
+            );
+        }
+
+        dispatch(
+            dashboardFiltersActions.setOriginalDashboardFilters(
+                currentDashboard.filters,
+            ),
+        );
+    }, [
+        dashboard,
+        embedDashboard,
+        dashboardFilters,
+        overridesForSavedDashboardFilters,
+        embed,
+        applyInteractivityFiltering,
+        isLoadingDashboardFilters,
+        filterableFieldsByTileUuid,
+        dispatch,
+    ]);
+
+    // URL sync for temp and overridden filters
+    useDeepCompareEffect(() => {
+        if (embed.mode === 'sdk') return;
+
+        const currentParams = new URLSearchParams(search);
+        const newParams = new URLSearchParams(search);
+
+        if (
+            dashboardTemporaryFilters?.dimensions?.length === 0 &&
+            dashboardTemporaryFilters?.metrics?.length === 0
+        ) {
+            newParams.delete('tempFilters');
+        } else {
+            newParams.set(
+                'tempFilters',
+                JSON.stringify(
+                    compressDashboardFiltersToParam(dashboardTemporaryFilters),
+                ),
+            );
+        }
+
+        if (hasSavedFiltersOverrides(overridesForSavedDashboardFilters)) {
+            newParams.set(
+                'filters',
+                JSON.stringify(
+                    compressDashboardFiltersToParam(
+                        overridesForSavedDashboardFilters,
+                    ),
+                ),
+            );
+        } else {
+            newParams.delete('filters');
+        }
+
+        const newSearch = newParams.toString();
+        const currentSearch = currentParams.toString();
+        if (newSearch !== currentSearch) {
+            void navigate({ pathname, search: newSearch }, { replace: true });
+        }
+    }, [
+        dashboardFilters,
+        dashboardTemporaryFilters,
+        navigate,
+        pathname,
+        overridesForSavedDashboardFilters,
+        search,
+        embed.mode,
+    ]);
+
+    // Apply overrides when saved filters change
+    useEffect(() => {
+        if (
+            dashboard?.filters &&
+            hasSavedFiltersOverrides(overridesForSavedDashboardFilters)
+        ) {
+            const updated: DashboardFilters = {
+                ...dashboardFilters,
+                dimensions: applyDimensionOverrides(
+                    dashboardFilters,
+                    overridesForSavedDashboardFilters,
+                ),
+                metrics:
+                    overridesForSavedDashboardFilters.metrics?.length > 0
+                        ? dashboardFilters.metrics.map((metric) => {
+                              const override =
+                                  overridesForSavedDashboardFilters.metrics.find(
+                                      (m) => m.id === metric.id,
+                                  );
+                              return override
+                                  ? {
+                                        ...override,
+                                        tileTargets: metric.tileTargets,
+                                    }
+                                  : metric;
+                          })
+                        : dashboardFilters.metrics,
+                tableCalculations: dashboardFilters.tableCalculations,
+            };
+            dispatch(dashboardFiltersActions.setDashboardFilters(updated));
+        }
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [dashboard?.filters, overridesForSavedDashboardFilters, dispatch]);
+
+    // Read filters/dateZoom from URL on mount
+    useMount(() => {
+        const searchParams = new URLSearchParams(search);
+
+        // Date zoom
+        const dateZoomParam = searchParams.get('dateZoom');
+        if (dateZoomParam) {
+            const standardMatch = Object.values(DateGranularity).find(
+                (granularity) =>
+                    granularity.toLowerCase() === dateZoomParam.toLowerCase(),
+            );
+            if (standardMatch) {
+                dispatch(
+                    dashboardDataActions.setDateZoomGranularity(standardMatch),
+                );
+            } else {
+                dispatch(
+                    dashboardDataActions.setDateZoomGranularity(dateZoomParam),
+                );
+            }
+        }
+
+        // Temp filters
+        const tempFilterSearchParam = searchParams.get('tempFilters');
+        const unsavedDashboardFiltersRaw = sessionStorage.getItem(
+            'unsavedDashboardFilters',
+        );
+
+        sessionStorage.removeItem('unsavedDashboardFilters');
+        if (unsavedDashboardFiltersRaw) {
+            try {
+                const unsavedDashboardFilters = JSON.parse(
+                    unsavedDashboardFiltersRaw,
+                );
+                dispatch(
+                    dashboardFiltersActions.setDashboardFilters(
+                        unsavedDashboardFilters,
+                    ),
+                );
+            } catch {
+                showToastWarning({
+                    title: 'Could not restore unsaved filters',
+                    subtitle:
+                        'Your previous filter changes could not be loaded',
+                });
+            }
+        }
+        if (tempFilterSearchParam) {
+            try {
+                dispatch(
+                    dashboardFiltersActions.setDashboardTemporaryFilters(
+                        convertDashboardFiltersParamToDashboardFilters(
+                            JSON.parse(tempFilterSearchParam),
+                        ),
+                    ),
+                );
+            } catch {
+                showToastWarning({
+                    title: 'Could not restore filters from URL',
+                    subtitle:
+                        'The link appears to be incomplete. Please ask for it to be shared again.',
+                });
+            }
+        }
+    });
+
+    // Apply default date zoom granularity
+    const searchRef = useRef(search);
+    searchRef.current = search;
+    useEffect(() => {
+        if (isEditMode) return;
+        if (
+            dashboard?.config?.defaultDateZoomGranularity &&
+            !dashboard?.config?.isDateZoomDisabled
+        ) {
+            const searchParams = new URLSearchParams(searchRef.current);
+            const dateZoomParam = searchParams.get('dateZoom');
+            if (!dateZoomParam) {
+                dispatch(
+                    dashboardDataActions.setDateZoomGranularity(
+                        dashboard.config.defaultDateZoomGranularity,
+                    ),
+                );
+            }
+        }
+    }, [
+        dispatch,
+        dashboard?.config?.defaultDateZoomGranularity,
+        dashboard?.config?.isDateZoomDisabled,
+        isEditMode,
+    ]);
+
+    // Reset dateZoomGranularity if not in allowed list
+    useEffect(() => {
+        if (
+            dateZoomGranularity &&
+            dateZoomGranularities.length > 0 &&
+            !dateZoomGranularities.includes(dateZoomGranularity)
+        ) {
+            dispatch(
+                dashboardDataActions.setDateZoomGranularity(
+                    defaultDateZoomGranularity ?? undefined,
+                ),
+            );
+        }
+    }, [
+        dispatch,
+        dateZoomGranularities,
+        dateZoomGranularity,
+        defaultDateZoomGranularity,
+    ]);
+
+    // allFilters
+    const allFilters = useMemo(
+        () => ({
+            dimensions: [
+                ...dashboardFilters.dimensions,
+                ...dashboardTemporaryFilters?.dimensions,
+            ],
+            metrics: [
+                ...dashboardFilters.metrics,
+                ...dashboardTemporaryFilters?.metrics,
+            ],
+            tableCalculations: [
+                ...dashboardFilters.tableCalculations,
+                ...dashboardTemporaryFilters?.tableCalculations,
+            ],
+        }),
+        [dashboardFilters, dashboardTemporaryFilters],
+    );
+
+    // Filter change events
+    useEffect(() => {
+        const previousFilters = previousFiltersRef.current;
+        const hasPreviousFilters =
+            previousFilters &&
+            previousFilters.dimensions.length +
+                previousFilters.metrics.length +
+                previousFilters.tableCalculations.length;
+
+        if (hasPreviousFilters && !isEqual(previousFilters, allFilters)) {
+            const filterCount =
+                allFilters.dimensions.length +
+                allFilters.metrics.length +
+                allFilters.tableCalculations.length;
+
+            dispatchEmbedEvent(LightdashEventType.FilterChanged, {
+                hasFilters: filterCount > 0,
+                filterCount,
+            });
+        }
+
+        previousFiltersRef.current = allFilters;
+    }, [allFilters, dispatchEmbedEvent]);
+
+    // Store complex derived data that the bridge needs but that doesn't fit neatly into redux
+    // These are passed via a ref context so the bridge can read them
+    const derivedDataRef = useRef({
+        allFilters,
+        filterableFieldsByTileUuid,
+        dashboardAvailableFiltersData,
+        overridesForSavedDashboardFilters,
+        addSavedFilterOverride,
+        removeSavedFilterOverride,
+        resetSavedFilterOverrides,
+        applyInteractivityFiltering,
+        versionRefresh,
+        missingRequiredParameters,
+        expectedScreenshotTileUuids,
+        areAllChartsLoaded,
+        dashboardParameterReferences,
+        parameterValues,
+        selectedParametersCount,
+        dashboard: dashboard || embedDashboard,
+        originalDashboardFilters,
+    });
+
+    // Keep ref up to date
+    derivedDataRef.current = {
+        allFilters,
+        filterableFieldsByTileUuid,
+        dashboardAvailableFiltersData,
+        overridesForSavedDashboardFilters,
+        addSavedFilterOverride,
+        removeSavedFilterOverride,
+        resetSavedFilterOverrides,
+        applyInteractivityFiltering,
+        versionRefresh,
+        missingRequiredParameters,
+        expectedScreenshotTileUuids,
+        areAllChartsLoaded,
+        dashboardParameterReferences,
+        parameterValues,
+        selectedParametersCount,
+        dashboard: dashboard || embedDashboard,
+        originalDashboardFilters,
+    };
+
+    return (
+        <DashboardBridgeProvider
+            derivedDataRef={derivedDataRef}
+            dashboardCommentsCheck={dashboardCommentsCheck}
+        >
+            {children}
+        </DashboardBridgeProvider>
+    );
+};
+
+/**
+ * Outer component that creates the Redux store and wraps children.
+ */
+const DashboardReduxProvider: React.FC<Props> = (props) => {
+    const [store] = useState(() => createDashboardStore());
+    return (
+        <ReduxProvider store={store}>
+            <DashboardReduxSync {...props} />
+        </ReduxProvider>
+    );
+};
+
+export default DashboardReduxProvider;

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -324,4 +324,5 @@ const DashboardTileStatusProvider: React.FC<
     );
 };
 
+// ts-unused-exports:disable-next-line
 export default DashboardTileStatusProvider;

--- a/packages/frontend/src/providers/Dashboard/store/dashboardDataSlice.ts
+++ b/packages/frontend/src/providers/Dashboard/store/dashboardDataSlice.ts
@@ -1,104 +1,480 @@
-import { type Dashboard } from '@lightdash/common';
+import {
+    type ApiError,
+    type CacheMetadata,
+    type Dashboard,
+    type DashboardParameters,
+    type DateGranularity,
+    type InteractivityOptions,
+    type FilterableDimension,
+    type Metric,
+    type ParameterDefinitions,
+    type ParameterValue,
+    type SavedChartsInfoForDashboardAvailableFilters,
+    type SortField,
+} from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import sortBy from 'lodash/sortBy';
+import min from 'lodash/min';
 import {
     type useDashboardCommentsCheck,
     type useGetComments,
 } from '../../../features/comments';
+import {
+    type SqlChartTileMetadata,
+    type TilePreAggregateStatus,
+} from '../types';
 
-// ts-unused-exports:disable-next-line
 export type DashboardDataState = {
     projectUuid: string | undefined;
     isDashboardLoading: boolean;
     dashboard: Dashboard | undefined;
-    dashboardError: unknown;
+    embedDashboard: (Dashboard & InteractivityOptions) | undefined;
+    dashboardError: ApiError | null;
     dashboardTiles: Dashboard['tiles'] | undefined;
     haveTilesChanged: boolean;
     haveTabsChanged: boolean;
     dashboardTabs: Dashboard['tabs'];
     activeTab: Dashboard['tabs'][number] | undefined;
+    isAutoRefresh: boolean;
+    oldestCacheTime: Date | undefined;
+    invalidateCache: boolean;
+    chartSort: Record<string, SortField[]>;
+    sqlChartTilesMetadata: Record<string, SqlChartTileMetadata>;
+    dateZoomGranularity: DateGranularity | string | undefined;
+    chartsWithDateZoomApplied: Set<string> | undefined;
     dashboardCommentsCheck:
         | ReturnType<typeof useDashboardCommentsCheck>
         | undefined;
     dashboardComments: ReturnType<typeof useGetComments>['data'] | undefined;
+    isDateZoomDisabled: boolean;
+    isAddFilterDisabled: boolean;
+    savedParameters: DashboardParameters;
+    parameters: DashboardParameters;
+    parametersHaveChanged: boolean;
+    parameterDefinitions: ParameterDefinitions;
+    tileParameterReferences: Record<string, string[]>;
+    loadedTiles: Set<string>;
+    pinnedParameters: string[];
+    havePinnedParametersChanged: boolean;
+    tilesWithTimestampDimension: Set<string>;
+    availableCustomGranularities: Record<string, string>;
+    dateZoomGranularities: (DateGranularity | string)[];
+    haveDateZoomGranularitiesChanged: boolean;
+    defaultDateZoomGranularity: DateGranularity | string | undefined;
+    hasDefaultDateZoomGranularityChanged: boolean;
+    preAggregateStatuses: Record<string, TilePreAggregateStatus>;
     isRefreshingDashboardVersion: boolean;
+    screenshotReadyTiles: Set<string>;
+    screenshotErroredTiles: Set<string>;
+
+    // Derived data from React Query (set by sync component)
+    savedChartUuidsAndTileUuids:
+        | SavedChartsInfoForDashboardAvailableFilters
+        | undefined;
+    isLoadingDashboardFilters: boolean;
+    isFetchingDashboardFilters: boolean;
+    dashboardAvailableFiltersAllFilterableFields: Array<FilterableDimension>;
+    dashboardAvailableFiltersAllFilterableMetrics: Array<Metric>;
+    dashboardAvailableFiltersSavedQueryFilters: Record<string, number[]>;
+    dashboardAvailableFiltersSavedQueryMetricFilters: Record<string, number[]>;
+
+    selectedParametersCount: number;
 };
 
 const initialState: DashboardDataState = {
     projectUuid: undefined,
-    isDashboardLoading: true,
+    isDashboardLoading: false,
     dashboard: undefined,
+    embedDashboard: undefined,
     dashboardError: null,
     dashboardTiles: undefined,
     haveTilesChanged: false,
     haveTabsChanged: false,
     dashboardTabs: [],
     activeTab: undefined,
+    isAutoRefresh: false,
+    oldestCacheTime: undefined,
+    invalidateCache: false,
+    chartSort: {},
+    sqlChartTilesMetadata: {},
+    dateZoomGranularity: undefined,
+    chartsWithDateZoomApplied: undefined,
     dashboardCommentsCheck: undefined,
     dashboardComments: undefined,
+    isDateZoomDisabled: false,
+    isAddFilterDisabled: false,
+    savedParameters: {},
+    parameters: {},
+    parametersHaveChanged: false,
+    parameterDefinitions: {},
+    tileParameterReferences: {},
+    loadedTiles: new Set(),
+    pinnedParameters: [],
+    havePinnedParametersChanged: false,
+    tilesWithTimestampDimension: new Set(),
+    availableCustomGranularities: {},
+    dateZoomGranularities: [],
+    haveDateZoomGranularitiesChanged: false,
+    defaultDateZoomGranularity: undefined,
+    hasDefaultDateZoomGranularityChanged: false,
+    preAggregateStatuses: {},
     isRefreshingDashboardVersion: false,
+    screenshotReadyTiles: new Set(),
+    screenshotErroredTiles: new Set(),
+    savedChartUuidsAndTileUuids: undefined,
+    isLoadingDashboardFilters: false,
+    isFetchingDashboardFilters: false,
+    dashboardAvailableFiltersAllFilterableFields: [],
+    dashboardAvailableFiltersAllFilterableMetrics: [],
+    dashboardAvailableFiltersSavedQueryFilters: {},
+    dashboardAvailableFiltersSavedQueryMetricFilters: {},
+    selectedParametersCount: 0,
 };
 
-// ts-unused-exports:disable-next-line
-export const dashboardDataSlice = createSlice({
+const dashboardDataSlice = createSlice({
     name: 'dashboardData',
     initialState,
     reducers: {
-        setProjectUuid: (state, action: PayloadAction<string | undefined>) => {
+        setProjectUuid(state, action: PayloadAction<string | undefined>) {
             state.projectUuid = action.payload;
         },
-        setDashboardLoading: (state, action: PayloadAction<boolean>) => {
+        setIsDashboardLoading(state, action: PayloadAction<boolean>) {
             state.isDashboardLoading = action.payload;
         },
-        setDashboard: (state, action: PayloadAction<Dashboard | undefined>) => {
+        setDashboard(state, action: PayloadAction<Dashboard | undefined>) {
             state.dashboard = action.payload;
         },
-        setDashboardError: (state, action: PayloadAction<unknown>) => {
+        setEmbedDashboard(
+            state,
+            action: PayloadAction<
+                (Dashboard & InteractivityOptions) | undefined
+            >,
+        ) {
+            state.embedDashboard = action.payload;
+        },
+        setDashboardError(state, action: PayloadAction<ApiError | null>) {
             state.dashboardError = action.payload;
         },
-        setDashboardTiles: (
+        setDashboardTiles(
             state,
             action: PayloadAction<Dashboard['tiles'] | undefined>,
-        ) => {
+        ) {
             state.dashboardTiles = action.payload;
         },
-        setHaveTilesChanged: (state, action: PayloadAction<boolean>) => {
+        setHaveTilesChanged(state, action: PayloadAction<boolean>) {
             state.haveTilesChanged = action.payload;
         },
-        setHaveTabsChanged: (state, action: PayloadAction<boolean>) => {
+        setHaveTabsChanged(state, action: PayloadAction<boolean>) {
             state.haveTabsChanged = action.payload;
         },
-        setDashboardTabs: (state, action: PayloadAction<Dashboard['tabs']>) => {
-            state.dashboardTabs = sortBy(action.payload, 'order');
+        setDashboardTabs(state, action: PayloadAction<Dashboard['tabs']>) {
+            state.dashboardTabs = action.payload;
         },
-        setActiveTab: (
+        setActiveTab(
             state,
             action: PayloadAction<Dashboard['tabs'][number] | undefined>,
-        ) => {
+        ) {
             state.activeTab = action.payload;
         },
-        setDashboardComments: (
-            state,
-            action: PayloadAction<DashboardDataState['dashboardComments']>,
-        ) => {
-            state.dashboardComments = action.payload;
+        setIsAutoRefresh(state, action: PayloadAction<boolean>) {
+            state.isAutoRefresh = action.payload;
         },
-        setDashboardCommentsCheck: (
+        addResultsCacheTime(
             state,
-            action: PayloadAction<DashboardDataState['dashboardCommentsCheck']>,
-        ) => {
+            action: PayloadAction<CacheMetadata | undefined>,
+        ) {
+            const cacheMetadata = action.payload;
+            if (
+                cacheMetadata &&
+                cacheMetadata.cacheHit &&
+                cacheMetadata.cacheUpdatedTime
+            ) {
+                const newTime = cacheMetadata.cacheUpdatedTime;
+                state.oldestCacheTime =
+                    state.oldestCacheTime === undefined
+                        ? newTime
+                        : min([state.oldestCacheTime, newTime])!;
+            }
+        },
+        setInvalidateCache(state, action: PayloadAction<boolean>) {
+            state.invalidateCache = action.payload;
+        },
+        clearCacheAndFetch(state) {
+            state.oldestCacheTime = undefined;
+            state.preAggregateStatuses = {};
+            state.loadedTiles = new Set();
+            state.invalidateCache = true;
+        },
+        setChartSort(
+            state,
+            action: PayloadAction<Record<string, SortField[]>>,
+        ) {
+            state.chartSort = action.payload;
+        },
+        updateSqlChartTilesMetadata(
+            state,
+            action: PayloadAction<{
+                tileUuid: string;
+                metadata: SqlChartTileMetadata;
+            }>,
+        ) {
+            state.sqlChartTilesMetadata[action.payload.tileUuid] =
+                action.payload.metadata;
+        },
+        setDateZoomGranularity(
+            state,
+            action: PayloadAction<DateGranularity | string | undefined>,
+        ) {
+            state.dateZoomGranularity = action.payload;
+        },
+        setChartsWithDateZoomApplied(
+            state,
+            action: PayloadAction<Set<string> | undefined>,
+        ) {
+            state.chartsWithDateZoomApplied = action.payload;
+        },
+        setDashboardCommentsCheck(
+            state,
+            action: PayloadAction<
+                ReturnType<typeof useDashboardCommentsCheck> | undefined
+            >,
+        ) {
             state.dashboardCommentsCheck = action.payload;
         },
-        setIsRefreshingDashboardVersion: (
+        setDashboardComments(
+            state,
+            action: PayloadAction<
+                ReturnType<typeof useGetComments>['data'] | undefined
+            >,
+        ) {
+            state.dashboardComments = action.payload;
+        },
+        setIsDateZoomDisabled(state, action: PayloadAction<boolean>) {
+            state.isDateZoomDisabled = action.payload;
+        },
+        setIsAddFilterDisabled(state, action: PayloadAction<boolean>) {
+            state.isAddFilterDisabled = action.payload;
+        },
+        setSavedParameters(state, action: PayloadAction<DashboardParameters>) {
+            state.savedParameters = action.payload;
+        },
+        setParameters(state, action: PayloadAction<DashboardParameters>) {
+            state.parameters = action.payload;
+        },
+        setParameter(
+            state,
+            action: PayloadAction<{
+                key: string;
+                value: ParameterValue | null;
+            }>,
+        ) {
+            const { key, value } = action.payload;
+            if (
+                value === null ||
+                value === undefined ||
+                value === '' ||
+                (Array.isArray(value) && value.length === 0)
+            ) {
+                const newParams = { ...state.parameters };
+                delete newParams[key];
+                state.parameters = newParams;
+            } else {
+                state.parameters = {
+                    ...state.parameters,
+                    [key]: { parameterName: key, value },
+                };
+            }
+        },
+        clearAllParameters(state) {
+            state.parameters = {};
+        },
+        setParametersHaveChanged(state, action: PayloadAction<boolean>) {
+            state.parametersHaveChanged = action.payload;
+        },
+        addParameterDefinitions(
+            state,
+            action: PayloadAction<ParameterDefinitions>,
+        ) {
+            state.parameterDefinitions = {
+                ...state.parameterDefinitions,
+                ...action.payload,
+            };
+        },
+        addParameterReferences(
+            state,
+            action: PayloadAction<{ tileUuid: string; references: string[] }>,
+        ) {
+            state.tileParameterReferences[action.payload.tileUuid] =
+                action.payload.references;
+            state.loadedTiles = new Set(state.loadedTiles).add(
+                action.payload.tileUuid,
+            );
+        },
+        setPinnedParameters(state, action: PayloadAction<string[]>) {
+            state.pinnedParameters = action.payload;
+            state.havePinnedParametersChanged = true;
+        },
+        toggleParameterPin(state, action: PayloadAction<string>) {
+            const parameterKey = action.payload;
+            const isCurrentlyPinned =
+                state.pinnedParameters.includes(parameterKey);
+            state.pinnedParameters = isCurrentlyPinned
+                ? state.pinnedParameters.filter((key) => key !== parameterKey)
+                : [...state.pinnedParameters, parameterKey];
+            state.havePinnedParametersChanged = true;
+        },
+        setHavePinnedParametersChanged(state, action: PayloadAction<boolean>) {
+            state.havePinnedParametersChanged = action.payload;
+        },
+        setTileHasTimestampDimension(
+            state,
+            action: PayloadAction<{ tileUuid: string; hasTimestamp: boolean }>,
+        ) {
+            const { tileUuid, hasTimestamp } = action.payload;
+            const next = new Set(state.tilesWithTimestampDimension);
+            if (hasTimestamp) {
+                next.add(tileUuid);
+            } else {
+                next.delete(tileUuid);
+            }
+            state.tilesWithTimestampDimension = next;
+        },
+        addAvailableCustomGranularities(
+            state,
+            action: PayloadAction<Record<string, string>>,
+        ) {
+            const granularities = action.payload;
+            const newKeys = Object.keys(granularities).filter(
+                (k) => !(k in state.availableCustomGranularities),
+            );
+            if (newKeys.length > 0) {
+                state.availableCustomGranularities = {
+                    ...state.availableCustomGranularities,
+                    ...granularities,
+                };
+            }
+        },
+        setDateZoomGranularities(
+            state,
+            action: PayloadAction<(DateGranularity | string)[]>,
+        ) {
+            state.dateZoomGranularities = action.payload;
+            state.haveDateZoomGranularitiesChanged = true;
+        },
+        setDateZoomGranularitiesState(
+            state,
+            action: PayloadAction<(DateGranularity | string)[]>,
+        ) {
+            state.dateZoomGranularities = action.payload;
+        },
+        setHaveDateZoomGranularitiesChanged(
             state,
             action: PayloadAction<boolean>,
-        ) => {
+        ) {
+            state.haveDateZoomGranularitiesChanged = action.payload;
+        },
+        setDefaultDateZoomGranularity(
+            state,
+            action: PayloadAction<DateGranularity | string | undefined>,
+        ) {
+            state.defaultDateZoomGranularity = action.payload;
+            state.hasDefaultDateZoomGranularityChanged = true;
+        },
+        setDefaultDateZoomGranularityState(
+            state,
+            action: PayloadAction<DateGranularity | string | undefined>,
+        ) {
+            state.defaultDateZoomGranularity = action.payload;
+        },
+        setHasDefaultDateZoomGranularityChanged(
+            state,
+            action: PayloadAction<boolean>,
+        ) {
+            state.hasDefaultDateZoomGranularityChanged = action.payload;
+        },
+        setPreAggregateStatuses(
+            state,
+            action: PayloadAction<Record<string, TilePreAggregateStatus>>,
+        ) {
+            state.preAggregateStatuses = action.payload;
+        },
+        addPreAggregateStatus(
+            state,
+            action: PayloadAction<{
+                tileUuid: string;
+                status: TilePreAggregateStatus;
+            }>,
+        ) {
+            state.preAggregateStatuses[action.payload.tileUuid] =
+                action.payload.status;
+        },
+        setIsRefreshingDashboardVersion(state, action: PayloadAction<boolean>) {
             state.isRefreshingDashboardVersion = action.payload;
+        },
+        markTileScreenshotReady(state, action: PayloadAction<string>) {
+            state.screenshotReadyTiles = new Set(
+                state.screenshotReadyTiles,
+            ).add(action.payload);
+        },
+        markTileScreenshotErrored(state, action: PayloadAction<string>) {
+            state.screenshotErroredTiles = new Set(
+                state.screenshotErroredTiles,
+            ).add(action.payload);
+        },
+        resetScreenshotTiles(state) {
+            state.screenshotReadyTiles = new Set();
+            state.screenshotErroredTiles = new Set();
+        },
+        setTileParameterReferences(
+            state,
+            action: PayloadAction<Record<string, string[]>>,
+        ) {
+            state.tileParameterReferences = action.payload;
+        },
+        setLoadedTiles(state, action: PayloadAction<Set<string>>) {
+            state.loadedTiles = action.payload;
+        },
+        markTileLoaded(state, action: PayloadAction<string>) {
+            state.loadedTiles = new Set(state.loadedTiles).add(action.payload);
+        },
+
+        // Bulk setters for React Query data
+        setSavedChartUuidsAndTileUuids(
+            state,
+            action: PayloadAction<
+                SavedChartsInfoForDashboardAvailableFilters | undefined
+            >,
+        ) {
+            state.savedChartUuidsAndTileUuids = action.payload;
+        },
+        setIsLoadingDashboardFilters(state, action: PayloadAction<boolean>) {
+            state.isLoadingDashboardFilters = action.payload;
+        },
+        setIsFetchingDashboardFilters(state, action: PayloadAction<boolean>) {
+            state.isFetchingDashboardFilters = action.payload;
+        },
+        setDashboardAvailableFiltersData(
+            state,
+            action: PayloadAction<{
+                allFilterableFields: Array<FilterableDimension>;
+                allFilterableMetrics: Array<Metric>;
+                savedQueryFilters: Record<string, number[]>;
+                savedQueryMetricFilters: Record<string, number[]>;
+            }>,
+        ) {
+            state.dashboardAvailableFiltersAllFilterableFields =
+                action.payload.allFilterableFields;
+            state.dashboardAvailableFiltersAllFilterableMetrics =
+                action.payload.allFilterableMetrics;
+            state.dashboardAvailableFiltersSavedQueryFilters =
+                action.payload.savedQueryFilters;
+            state.dashboardAvailableFiltersSavedQueryMetricFilters =
+                action.payload.savedQueryMetricFilters;
+        },
+        setSelectedParametersCount(state, action: PayloadAction<number>) {
+            state.selectedParametersCount = action.payload;
         },
     },
 });
 
-// ts-unused-exports:disable-next-line
 export const dashboardDataActions = dashboardDataSlice.actions;
-// ts-unused-exports:disable-next-line
-export const dashboardDataReducer = dashboardDataSlice.reducer;
+export default dashboardDataSlice.reducer;

--- a/packages/frontend/src/providers/Dashboard/store/dashboardFiltersSlice.ts
+++ b/packages/frontend/src/providers/Dashboard/store/dashboardFiltersSlice.ts
@@ -1,15 +1,15 @@
 import {
-    type Dashboard,
     type DashboardFilterRule,
     type DashboardFilters,
-    type DashboardParameters,
-    type DateGranularity,
-    type InteractivityOptions,
-    type ParameterDefinitions,
-    type ParameterValue,
-    type SortField,
 } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
+
+export type DashboardFiltersState = {
+    dashboardFilters: DashboardFilters;
+    dashboardTemporaryFilters: DashboardFilters;
+    originalDashboardFilters: DashboardFilters;
+    haveFiltersChanged: boolean;
+};
 
 const emptyFilters: DashboardFilters = {
     dimensions: [],
@@ -17,312 +17,160 @@ const emptyFilters: DashboardFilters = {
     tableCalculations: [],
 };
 
-// ts-unused-exports:disable-next-line
-export type DashboardFiltersState = {
-    dashboardFilters: DashboardFilters;
-    dashboardTemporaryFilters: DashboardFilters;
-    originalDashboardFilters: DashboardFilters;
-    haveFiltersChanged: boolean;
-    dateZoomGranularity: DateGranularity | string | undefined;
-    isDateZoomDisabled: boolean;
-    chartsWithDateZoomApplied: string[];
-    dateZoomGranularities: (DateGranularity | string)[];
-    haveDateZoomGranularitiesChanged: boolean;
-    defaultDateZoomGranularity: DateGranularity | string | undefined;
-    hasDefaultDateZoomGranularityChanged: boolean;
-    isAddFilterDisabled: boolean;
-    savedParameters: DashboardParameters;
-    parameters: DashboardParameters;
-    pinnedParameters: string[];
-    havePinnedParametersChanged: boolean;
-    parameterDefinitions: ParameterDefinitions;
-    tileParameterReferences: Record<string, string[]>;
-    chartSort: Record<string, SortField[]>;
-    embedDashboard: (Dashboard & InteractivityOptions) | undefined;
-};
-
 const initialState: DashboardFiltersState = {
     dashboardFilters: emptyFilters,
     dashboardTemporaryFilters: emptyFilters,
     originalDashboardFilters: emptyFilters,
     haveFiltersChanged: false,
-    dateZoomGranularity: undefined,
-    isDateZoomDisabled: false,
-    chartsWithDateZoomApplied: [],
-    dateZoomGranularities: [],
-    haveDateZoomGranularitiesChanged: false,
-    defaultDateZoomGranularity: undefined,
-    hasDefaultDateZoomGranularityChanged: false,
-    isAddFilterDisabled: false,
-    savedParameters: {},
-    parameters: {},
-    pinnedParameters: [],
-    havePinnedParametersChanged: false,
-    parameterDefinitions: {},
-    tileParameterReferences: {},
-    chartSort: {},
-    embedDashboard: undefined,
 };
 
-// ts-unused-exports:disable-next-line
-export const dashboardFiltersSlice = createSlice({
+const dashboardFiltersSlice = createSlice({
     name: 'dashboardFilters',
     initialState,
     reducers: {
-        setDashboardFilters: (
-            state,
-            action: PayloadAction<DashboardFilters>,
-        ) => {
+        setDashboardFilters(state, action: PayloadAction<DashboardFilters>) {
             state.dashboardFilters = action.payload;
         },
-        setDashboardTemporaryFilters: (
+        setDashboardTemporaryFilters(
             state,
             action: PayloadAction<DashboardFilters>,
-        ) => {
+        ) {
             state.dashboardTemporaryFilters = action.payload;
         },
-        setOriginalDashboardFilters: (
+        setOriginalDashboardFilters(
             state,
             action: PayloadAction<DashboardFilters>,
-        ) => {
+        ) {
             state.originalDashboardFilters = action.payload;
         },
-        setHaveFiltersChanged: (state, action: PayloadAction<boolean>) => {
+        setHaveFiltersChanged(state, action: PayloadAction<boolean>) {
             state.haveFiltersChanged = action.payload;
         },
-        addDimensionFilter: (
+        addDimensionDashboardFilter(
             state,
             action: PayloadAction<{
                 filter: DashboardFilterRule;
                 isTemporary: boolean;
             }>,
-        ) => {
-            const target = action.payload.isTemporary
-                ? state.dashboardTemporaryFilters
-                : state.dashboardFilters;
-            target.dimensions.push(action.payload.filter);
+        ) {
+            const { filter, isTemporary } = action.payload;
+            const target = isTemporary
+                ? 'dashboardTemporaryFilters'
+                : 'dashboardFilters';
+            state[target] = {
+                dimensions: [...state[target].dimensions, filter],
+                metrics: state[target].metrics,
+                tableCalculations: state[target].tableCalculations,
+            };
             state.haveFiltersChanged = true;
         },
-        updateDimensionFilter: (
-            state,
-            action: PayloadAction<{
-                filter: DashboardFilterRule;
-                index: number;
-                isTemporary: boolean;
-            }>,
-        ) => {
-            const target = action.payload.isTemporary
-                ? state.dashboardTemporaryFilters
-                : state.dashboardFilters;
-            target.dimensions[action.payload.index] = action.payload.filter;
-            state.haveFiltersChanged = true;
-        },
-        removeDimensionFilter: (
-            state,
-            action: PayloadAction<{
-                index: number;
-                isTemporary: boolean;
-            }>,
-        ) => {
-            const target = action.payload.isTemporary
-                ? state.dashboardTemporaryFilters
-                : state.dashboardFilters;
-            target.dimensions.splice(action.payload.index, 1);
-            state.haveFiltersChanged = true;
-        },
-        addMetricFilter: (
-            state,
-            action: PayloadAction<{
-                filter: DashboardFilterRule;
-                isTemporary: boolean;
-            }>,
-        ) => {
-            const target = action.payload.isTemporary
-                ? state.dashboardTemporaryFilters
-                : state.dashboardFilters;
-            target.metrics.push(action.payload.filter);
-            state.haveFiltersChanged = true;
-        },
-        updateMetricFilter: (
+        updateDimensionDashboardFilter(
             state,
             action: PayloadAction<{
                 filter: DashboardFilterRule;
                 index: number;
                 isTemporary: boolean;
             }>,
-        ) => {
-            const target = action.payload.isTemporary
-                ? state.dashboardTemporaryFilters
-                : state.dashboardFilters;
-            target.metrics[action.payload.index] = action.payload.filter;
+        ) {
+            const { filter, index, isTemporary } = action.payload;
+            const target = isTemporary
+                ? 'dashboardTemporaryFilters'
+                : 'dashboardFilters';
+            state[target] = {
+                dimensions: [
+                    ...state[target].dimensions.slice(0, index),
+                    filter,
+                    ...state[target].dimensions.slice(index + 1),
+                ],
+                metrics: state[target].metrics,
+                tableCalculations: state[target].tableCalculations,
+            };
             state.haveFiltersChanged = true;
         },
-        removeMetricFilter: (
+        removeDimensionDashboardFilter(
+            state,
+            action: PayloadAction<{ index: number; isTemporary: boolean }>,
+        ) {
+            const { index, isTemporary } = action.payload;
+            const target = isTemporary
+                ? 'dashboardTemporaryFilters'
+                : 'dashboardFilters';
+            state[target] = {
+                dimensions: [
+                    ...state[target].dimensions.slice(0, index),
+                    ...state[target].dimensions.slice(index + 1),
+                ],
+                metrics: state[target].metrics,
+                tableCalculations: state[target].tableCalculations,
+            };
+            state.haveFiltersChanged = true;
+        },
+        addMetricDashboardFilter(
             state,
             action: PayloadAction<{
+                filter: DashboardFilterRule;
+                isTemporary: boolean;
+            }>,
+        ) {
+            const { filter, isTemporary } = action.payload;
+            const target = isTemporary
+                ? 'dashboardTemporaryFilters'
+                : 'dashboardFilters';
+            state[target] = {
+                dimensions: state[target].dimensions,
+                metrics: [...state[target].metrics, filter],
+                tableCalculations: state[target].tableCalculations,
+            };
+            state.haveFiltersChanged = true;
+        },
+        updateMetricDashboardFilter(
+            state,
+            action: PayloadAction<{
+                filter: DashboardFilterRule;
                 index: number;
                 isTemporary: boolean;
             }>,
-        ) => {
-            const target = action.payload.isTemporary
-                ? state.dashboardTemporaryFilters
-                : state.dashboardFilters;
-            target.metrics.splice(action.payload.index, 1);
+        ) {
+            const { filter, index, isTemporary } = action.payload;
+            const target = isTemporary
+                ? 'dashboardTemporaryFilters'
+                : 'dashboardFilters';
+            state[target] = {
+                dimensions: state[target].dimensions,
+                metrics: [
+                    ...state[target].metrics.slice(0, index),
+                    filter,
+                    ...state[target].metrics.slice(index + 1),
+                ],
+                tableCalculations: state[target].tableCalculations,
+            };
             state.haveFiltersChanged = true;
         },
-        resetFilters: (state, action: PayloadAction<DashboardFilters>) => {
+        removeMetricDashboardFilter(
+            state,
+            action: PayloadAction<{ index: number; isTemporary: boolean }>,
+        ) {
+            const { index, isTemporary } = action.payload;
+            const target = isTemporary
+                ? 'dashboardTemporaryFilters'
+                : 'dashboardFilters';
+            state[target] = {
+                dimensions: state[target].dimensions,
+                metrics: [
+                    ...state[target].metrics.slice(0, index),
+                    ...state[target].metrics.slice(index + 1),
+                ],
+                tableCalculations: state[target].tableCalculations,
+            };
+            state.haveFiltersChanged = true;
+        },
+        resetDashboardFilters(state, action: PayloadAction<DashboardFilters>) {
             state.dashboardFilters = action.payload;
             state.dashboardTemporaryFilters = emptyFilters;
-            state.haveFiltersChanged = false;
-        },
-        setDateZoomGranularity: (
-            state,
-            action: PayloadAction<DateGranularity | string | undefined>,
-        ) => {
-            state.dateZoomGranularity = action.payload;
-        },
-        setIsDateZoomDisabled: (state, action: PayloadAction<boolean>) => {
-            state.isDateZoomDisabled = action.payload;
-        },
-        setChartsWithDateZoomApplied: (
-            state,
-            action: PayloadAction<string[]>,
-        ) => {
-            state.chartsWithDateZoomApplied = action.payload;
-        },
-        setDateZoomGranularities: (
-            state,
-            action: PayloadAction<(DateGranularity | string)[]>,
-        ) => {
-            state.dateZoomGranularities = action.payload;
-            state.haveDateZoomGranularitiesChanged = true;
-        },
-        setDateZoomGranularitiesRaw: (
-            state,
-            action: PayloadAction<(DateGranularity | string)[]>,
-        ) => {
-            state.dateZoomGranularities = action.payload;
-        },
-        setHaveDateZoomGranularitiesChanged: (
-            state,
-            action: PayloadAction<boolean>,
-        ) => {
-            state.haveDateZoomGranularitiesChanged = action.payload;
-        },
-        setDefaultDateZoomGranularity: (
-            state,
-            action: PayloadAction<DateGranularity | string | undefined>,
-        ) => {
-            state.defaultDateZoomGranularity = action.payload;
-            state.hasDefaultDateZoomGranularityChanged = true;
-        },
-        setDefaultDateZoomGranularityRaw: (
-            state,
-            action: PayloadAction<DateGranularity | string | undefined>,
-        ) => {
-            state.defaultDateZoomGranularity = action.payload;
-        },
-        setHasDefaultDateZoomGranularityChanged: (
-            state,
-            action: PayloadAction<boolean>,
-        ) => {
-            state.hasDefaultDateZoomGranularityChanged = action.payload;
-        },
-        setIsAddFilterDisabled: (state, action: PayloadAction<boolean>) => {
-            state.isAddFilterDisabled = action.payload;
-        },
-        setSavedParameters: (
-            state,
-            action: PayloadAction<DashboardParameters>,
-        ) => {
-            state.savedParameters = action.payload;
-            state.parameters = action.payload;
-        },
-        setParameter: (
-            state,
-            action: PayloadAction<{
-                key: string;
-                value: ParameterValue | null;
-            }>,
-        ) => {
-            const { key, value } = action.payload;
-            if (
-                value === null ||
-                value === undefined ||
-                value === '' ||
-                (Array.isArray(value) && value.length === 0)
-            ) {
-                delete state.parameters[key];
-            } else {
-                state.parameters[key] = { parameterName: key, value };
-            }
-        },
-        clearAllParameters: (state) => {
-            state.parameters = {};
-        },
-        setPinnedParameters: (state, action: PayloadAction<string[]>) => {
-            state.pinnedParameters = action.payload;
-            state.havePinnedParametersChanged = true;
-        },
-        toggleParameterPin: (state, action: PayloadAction<string>) => {
-            const key = action.payload;
-            if (state.pinnedParameters.includes(key)) {
-                state.pinnedParameters = state.pinnedParameters.filter(
-                    (k) => k !== key,
-                );
-            } else {
-                state.pinnedParameters.push(key);
-            }
-            state.havePinnedParametersChanged = true;
-        },
-        setHavePinnedParametersChanged: (
-            state,
-            action: PayloadAction<boolean>,
-        ) => {
-            state.havePinnedParametersChanged = action.payload;
-        },
-        addParameterDefinitions: (
-            state,
-            action: PayloadAction<ParameterDefinitions>,
-        ) => {
-            Object.assign(state.parameterDefinitions, action.payload);
-        },
-        setTileParameterReferences: (
-            state,
-            action: PayloadAction<{
-                tileUuid: string;
-                references: string[];
-            }>,
-        ) => {
-            state.tileParameterReferences[action.payload.tileUuid] =
-                action.payload.references;
-        },
-        cleanupStaleTileParameterReferences: (
-            state,
-            action: PayloadAction<string[]>,
-        ) => {
-            for (const tileId of Object.keys(state.tileParameterReferences)) {
-                if (!action.payload.includes(tileId)) {
-                    delete state.tileParameterReferences[tileId];
-                }
-            }
-        },
-        setChartSort: (
-            state,
-            action: PayloadAction<Record<string, SortField[]>>,
-        ) => {
-            state.chartSort = action.payload;
-        },
-        setEmbedDashboard: (
-            state,
-            action: PayloadAction<DashboardFiltersState['embedDashboard']>,
-        ) => {
-            state.embedDashboard = action.payload;
         },
     },
 });
 
-// ts-unused-exports:disable-next-line
 export const dashboardFiltersActions = dashboardFiltersSlice.actions;
-// ts-unused-exports:disable-next-line
-export const dashboardFiltersReducer = dashboardFiltersSlice.reducer;
+export const EMPTY_FILTERS = emptyFilters;
+export default dashboardFiltersSlice.reducer;

--- a/packages/frontend/src/providers/Dashboard/store/dashboardTileStatusSlice.ts
+++ b/packages/frontend/src/providers/Dashboard/store/dashboardTileStatusSlice.ts
@@ -1,151 +1,34 @@
-import { type CacheMetadata } from '@lightdash/common';
 import { createSlice, type PayloadAction } from '@reduxjs/toolkit';
-import min from 'lodash/min';
-import {
-    type SqlChartTileMetadata,
-    type TilePreAggregateStatus,
-} from '../types';
 
-// ts-unused-exports:disable-next-line
+export type TileLoadingStatus = 'loading' | 'loaded' | 'error';
+
 export type DashboardTileStatusState = {
-    oldestCacheTime: Date | undefined;
-    preAggregateStatuses: Record<string, TilePreAggregateStatus>;
-    invalidateCache: boolean;
-    isAutoRefresh: boolean;
-    loadedTiles: string[];
-    tilesWithTimestampDimension: string[];
-    sqlChartTilesMetadata: Record<string, SqlChartTileMetadata>;
-    availableCustomGranularities: Record<string, string>;
-    screenshotReadyTiles: string[];
-    screenshotErroredTiles: string[];
+    tileStatuses: Record<string, TileLoadingStatus>;
 };
 
 const initialState: DashboardTileStatusState = {
-    oldestCacheTime: undefined,
-    preAggregateStatuses: {},
-    invalidateCache: false,
-    isAutoRefresh: false,
-    loadedTiles: [],
-    tilesWithTimestampDimension: [],
-    sqlChartTilesMetadata: {},
-    availableCustomGranularities: {},
-    screenshotReadyTiles: [],
-    screenshotErroredTiles: [],
+    tileStatuses: {},
 };
 
-// ts-unused-exports:disable-next-line
-export const dashboardTileStatusSlice = createSlice({
+const dashboardTileStatusSlice = createSlice({
     name: 'dashboardTileStatus',
     initialState,
     reducers: {
-        addCacheTime: (
-            state,
-            action: PayloadAction<CacheMetadata | undefined>,
-        ) => {
-            const meta = action.payload;
-            if (!meta?.cacheHit || !meta?.cacheUpdatedTime) return;
-            const newTime = meta.cacheUpdatedTime;
-            state.oldestCacheTime =
-                state.oldestCacheTime === undefined
-                    ? newTime
-                    : min([state.oldestCacheTime, newTime])!;
-        },
-        addPreAggregateStatus: (
+        setTileStatus(
             state,
             action: PayloadAction<{
                 tileUuid: string;
-                tileName: string;
-                tabUuid: string | null | undefined;
-                cacheMetadata: CacheMetadata | undefined;
+                status: TileLoadingStatus;
             }>,
-        ) => {
-            const { tileUuid, tileName, tabUuid, cacheMetadata } =
-                action.payload;
-            const preAggregate = cacheMetadata?.preAggregate ?? null;
-            state.preAggregateStatuses[tileUuid] = {
-                tileUuid,
-                tileName,
-                hit: preAggregate?.hit ?? false,
-                preAggregateName: preAggregate?.name ?? null,
-                reason: preAggregate?.reason ?? null,
-                hasPreAggregateMetadata: preAggregate !== null,
-                tabUuid,
-            };
+        ) {
+            state.tileStatuses[action.payload.tileUuid] = action.payload.status;
         },
-        setInvalidateCache: (state, action: PayloadAction<boolean>) => {
-            state.invalidateCache = action.payload;
-        },
-        setIsAutoRefresh: (state, action: PayloadAction<boolean>) => {
-            state.isAutoRefresh = action.payload;
-        },
-        markTileLoaded: (state, action: PayloadAction<string>) => {
-            if (!state.loadedTiles.includes(action.payload)) {
-                state.loadedTiles.push(action.payload);
-            }
-        },
-        setTileHasTimestampDimension: (
-            state,
-            action: PayloadAction<{
-                tileUuid: string;
-                hasTimestamp: boolean;
-            }>,
-        ) => {
-            const { tileUuid, hasTimestamp } = action.payload;
-            const idx = state.tilesWithTimestampDimension.indexOf(tileUuid);
-            if (hasTimestamp && idx === -1) {
-                state.tilesWithTimestampDimension.push(tileUuid);
-            } else if (!hasTimestamp && idx !== -1) {
-                state.tilesWithTimestampDimension.splice(idx, 1);
-            }
-        },
-        updateSqlChartTileMetadata: (
-            state,
-            action: PayloadAction<{
-                tileUuid: string;
-                metadata: SqlChartTileMetadata;
-            }>,
-        ) => {
-            state.sqlChartTilesMetadata[action.payload.tileUuid] =
-                action.payload.metadata;
-        },
-        addAvailableCustomGranularities: (
-            state,
-            action: PayloadAction<Record<string, string>>,
-        ) => {
-            const newKeys = Object.keys(action.payload).filter(
-                (k) => !(k in state.availableCustomGranularities),
-            );
-            if (newKeys.length > 0) {
-                Object.assign(
-                    state.availableCustomGranularities,
-                    action.payload,
-                );
-            }
-        },
-        markTileScreenshotReady: (state, action: PayloadAction<string>) => {
-            if (!state.screenshotReadyTiles.includes(action.payload)) {
-                state.screenshotReadyTiles.push(action.payload);
-            }
-        },
-        markTileScreenshotErrored: (state, action: PayloadAction<string>) => {
-            if (!state.screenshotErroredTiles.includes(action.payload)) {
-                state.screenshotErroredTiles.push(action.payload);
-            }
-        },
-        resetScreenshotTiles: (state) => {
-            state.screenshotReadyTiles = [];
-            state.screenshotErroredTiles = [];
-        },
-        clearForRefresh: (state) => {
-            state.oldestCacheTime = undefined;
-            state.preAggregateStatuses = {};
-            state.loadedTiles = [];
-            state.invalidateCache = true;
+        resetTileStatuses(state) {
+            state.tileStatuses = {};
         },
     },
 });
 
 // ts-unused-exports:disable-next-line
 export const dashboardTileStatusActions = dashboardTileStatusSlice.actions;
-// ts-unused-exports:disable-next-line
-export const dashboardTileStatusReducer = dashboardTileStatusSlice.reducer;
+export default dashboardTileStatusSlice.reducer;

--- a/packages/frontend/src/providers/Dashboard/store/hooks.ts
+++ b/packages/frontend/src/providers/Dashboard/store/hooks.ts
@@ -1,18 +1,7 @@
-// FIXES ts2742 issue with useDispatch and useSelector
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-import type * as rtk from '@reduxjs/toolkit';
-import { useDispatch, useSelector, useStore } from 'react-redux';
-import type { DashboardStoreDispatch, DashboardStoreState } from '.';
+import { useDispatch, useSelector } from 'react-redux';
+import type { DashboardStoreDispatch, DashboardStoreState } from './index';
 
-// ts-unused-exports:disable-next-line
 export const useDashboardDispatch =
     useDispatch.withTypes<DashboardStoreDispatch>();
-// ts-unused-exports:disable-next-line
 export const useDashboardSelector =
     useSelector.withTypes<DashboardStoreState>();
-
-// ts-unused-exports:disable-next-line
-export const useDashboardStore = () => {
-    const store = useStore();
-    return store as { getState: () => DashboardStoreState };
-};

--- a/packages/frontend/src/providers/Dashboard/store/index.ts
+++ b/packages/frontend/src/providers/Dashboard/store/index.ts
@@ -1,14 +1,10 @@
-// FIXES ts2742 issue with configureStore
-// eslint-disable-next-line @typescript-eslint/no-unused-vars, no-unused-vars
-import type * as rtk from '@reduxjs/toolkit';
 import { configureStore } from '@reduxjs/toolkit';
-import { dashboardDataReducer } from './dashboardDataSlice';
-import { dashboardFiltersReducer } from './dashboardFiltersSlice';
-import { dashboardTileStatusReducer } from './dashboardTileStatusSlice';
+import dashboardDataReducer from './dashboardDataSlice';
+import dashboardFiltersReducer from './dashboardFiltersSlice';
+import dashboardTileStatusReducer from './dashboardTileStatusSlice';
 
-// ts-unused-exports:disable-next-line
-export const createDashboardStore = () =>
-    configureStore({
+export function createDashboardStore() {
+    return configureStore({
         reducer: {
             dashboardData: dashboardDataReducer,
             dashboardFilters: dashboardFiltersReducer,
@@ -16,22 +12,12 @@ export const createDashboardStore = () =>
         },
         middleware: (getDefaultMiddleware) =>
             getDefaultMiddleware({
-                serializableCheck: {
-                    ignoredPaths: [
-                        'dashboardTileStatus.oldestCacheTime',
-                        'dashboardData.dashboard',
-                        'dashboardData.dashboardCommentsCheck',
-                        'dashboardData.dashboardComments',
-                        'dashboardFilters.embedDashboard',
-                    ],
-                    ignoredActionPaths: ['payload'],
-                },
+                // We store non-serializable values (Set, Date, etc.) in the store
+                serializableCheck: false,
             }),
-        devTools: process.env.NODE_ENV === 'development',
     });
+}
 
-type DashboardStore = ReturnType<typeof createDashboardStore>;
-// ts-unused-exports:disable-next-line
+export type DashboardStore = ReturnType<typeof createDashboardStore>;
 export type DashboardStoreState = ReturnType<DashboardStore['getState']>;
-// ts-unused-exports:disable-next-line
 export type DashboardStoreDispatch = DashboardStore['dispatch'];

--- a/packages/frontend/src/providers/Dashboard/store/selectors.ts
+++ b/packages/frontend/src/providers/Dashboard/store/selectors.ts
@@ -9,8 +9,6 @@ import type { DashboardStoreState } from '.';
 
 const selectDashboardData = (state: DashboardStoreState) => state.dashboardData;
 const selectFilters = (state: DashboardStoreState) => state.dashboardFilters;
-const selectTileStatus = (state: DashboardStoreState) =>
-    state.dashboardTileStatus;
 
 // ts-unused-exports:disable-next-line
 export const selectAllFilters = createSelector(
@@ -33,9 +31,9 @@ export const selectAllFilters = createSelector(
 
 // ts-unused-exports:disable-next-line
 export const selectParameterValues = createSelector(
-    [selectFilters],
-    (filters): ParametersValuesMap =>
-        Object.entries(filters.parameters).reduce((acc, [key, param]) => {
+    [selectDashboardData],
+    (data): ParametersValuesMap =>
+        Object.entries(data.parameters).reduce((acc, [key, param]) => {
             if (
                 param.value !== null &&
                 param.value !== undefined &&
@@ -49,20 +47,20 @@ export const selectParameterValues = createSelector(
 
 // ts-unused-exports:disable-next-line
 export const selectParametersHaveChanged = createSelector(
-    [selectFilters],
-    (filters) => !isEqual(filters.parameters, filters.savedParameters),
+    [selectDashboardData],
+    (data) => !isEqual(data.parameters, data.savedParameters),
 );
 
 // ts-unused-exports:disable-next-line
 export const selectDashboardParameterReferences = createSelector(
-    [selectFilters],
-    (filters) => new Set(Object.values(filters.tileParameterReferences).flat()),
+    [selectDashboardData],
+    (data) => new Set(Object.values(data.tileParameterReferences).flat()),
 );
 
 // ts-unused-exports:disable-next-line
 export const selectAreAllChartsLoaded = createSelector(
-    [selectDashboardData, selectTileStatus],
-    (data, tileStatus) => {
+    [selectDashboardData],
+    (data) => {
         if (!data.dashboardTiles) return false;
         if (data.dashboardTabs.length > 0 && !data.activeTab) return false;
 
@@ -74,16 +72,14 @@ export const selectAreAllChartsLoaded = createSelector(
             })
             .map((tile) => tile.uuid);
 
-        return chartTileUuids.every((uuid) =>
-            tileStatus.loadedTiles.includes(uuid),
-        );
+        return chartTileUuids.every((uuid) => data.loadedTiles.has(uuid));
     },
 );
 
 // ts-unused-exports:disable-next-line
 export const selectDashboardHasTimestampDimension = createSelector(
-    [selectTileStatus],
-    (tileStatus) => tileStatus.tilesWithTimestampDimension.length > 0,
+    [selectDashboardData],
+    (data) => data.tilesWithTimestampDimension.size > 0,
 );
 
 // ts-unused-exports:disable-next-line
@@ -133,13 +129,13 @@ export const selectSelectedParametersCount = createSelector(
 
 // ts-unused-exports:disable-next-line
 export const selectMissingRequiredParameters = createSelector(
-    [selectDashboardParameterReferences, selectFilters],
-    (refs, filters) => {
+    [selectDashboardParameterReferences, selectDashboardData],
+    (refs, data) => {
         if (!refs.size) return [];
         return Array.from(refs).filter(
             (parameterName) =>
-                !filters.parameters[parameterName] &&
-                !filters.parameterDefinitions[parameterName]?.default,
+                !data.parameters[parameterName] &&
+                !data.parameterDefinitions[parameterName]?.default,
         );
     },
 );


### PR DESCRIPTION
## Summary

Creates a feature-flagged Redux store for dashboard state management. When the `dashboard-redux-store` feature flag is enabled (via PostHog), the dashboard uses a Redux store instead of React Context. When disabled (default), behavior is completely unchanged.

### Feature Flag

`FeatureFlags.DashboardReduxStore` (`dashboard-redux-store`) — client-side PostHog flag.

### Architecture

```
DashboardProvider (checks feature flag)
├── Flag OFF → DashboardProviderInner (existing context, unchanged)
└── Flag ON  → DashboardReduxProvider
                ├── Redux store (dashboardData + dashboardFilters + dashboardTileStatus slices)
                ├── DashboardReduxSync (runs React Query hooks, dispatches to store)
                └── DashboardBridgeProvider (reads Redux → writes DashboardContext)
                    └── consumers use useDashboardContext unchanged
```

**Zero consumer changes.** The bridge provider reads from Redux and writes the same `DashboardContext`, so all 38 consumer components work without modification.

### Files

| File | Description |
|------|-------------|
| `store/index.ts` | `createDashboardStore()` factory |
| `store/hooks.ts` | Typed `useDashboardDispatch`, `useDashboardSelector` |
| `store/dashboardDataSlice.ts` | Dashboard structure, tiles, tabs, parameters, screenshots |
| `store/dashboardFiltersSlice.ts` | Filters CRUD |
| `store/dashboardTileStatusSlice.ts` | Per-tile loading status |
| `store/selectors.ts` | Memoized selectors via `createSelector` |
| `DashboardReduxProvider.tsx` | Redux store creation + sync effects |
| `DashboardBridgeProvider.tsx` | Redux → Context bridge for backward compatibility |

### Why Redux

- Built-in selector memoization via `useSelector` + `createSelector`
- Redux DevTools for debugging state changes
- Components only re-render when their selected slice changes (no manual `useMemo` on context value)
- Matches existing patterns (explorer store, SQL runner store)

## Test plan

- [ ] With flag OFF: dashboard works exactly as before (default)
- [ ] Enable `dashboard-redux-store` flag in PostHog (or localStorage override)
- [ ] With flag ON: dashboard loads, tabs switch, filters work, date zoom works
- [ ] With flag ON: verify Redux DevTools shows state updates
- [ ] With flag ON: tile loading, screenshot readiness, cache indicators all work
- [ ] With flag ON: edit mode (save, cancel, add tiles) works