### PR TITLE
feat: make project users a group for permissions

### DIFF
--- a/packages/backend/src/database/migrations/20260330133142_add_project_members_sentinel_group.ts
+++ b/packages/backend/src/database/migrations/20260330133142_add_project_members_sentinel_group.ts
@@ -1,0 +1,31 @@
+import { Knex } from 'knex';
+
+const PROJECT_MEMBERS_GROUP_UUID = '00000000-0000-0000-0000-000000000000';
+
+export async function up(knex: Knex): Promise<void> {
+    // Insert a sentinel group record so the FK on space_group_access is
+    // satisfied. The sentinel has no members in group_memberships — the
+    // permission system expands it dynamically to all project members.
+    const [firstOrg] = await knex('organizations')
+        .select('organization_id')
+        .limit(1);
+    if (!firstOrg) return;
+
+    await knex('groups')
+        .insert({
+            group_uuid: PROJECT_MEMBERS_GROUP_UUID,
+            organization_id: firstOrg.organization_id,
+            name: 'All project members',
+        })
+        .onConflict('group_uuid')
+        .ignore();
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex('space_group_access')
+        .where('group_uuid', PROJECT_MEMBERS_GROUP_UUID)
+        .delete();
+    await knex('groups')
+        .where('group_uuid', PROJECT_MEMBERS_GROUP_UUID)
+        .delete();
+}

--- a/packages/backend/src/models/SpacePermissionModel.ts
+++ b/packages/backend/src/models/SpacePermissionModel.ts
@@ -4,6 +4,7 @@ import {
     InvalidSpaceStateError,
     NotFoundError,
     OrganizationSpaceAccess,
+    PROJECT_MEMBERS_GROUP_UUID,
     ProjectSpaceAccess,
     ProjectSpaceAccessOrigin,
     SpaceAccessUserMetadata,
@@ -68,6 +69,7 @@ export class SpacePermissionModel {
                             }
                         })
                         .union(
+                            // Expand real groups via group_memberships
                             this.database(SpaceGroupAccessTableName)
                                 .select({
                                     userUuid: `${UserTableName}.user_uuid`,
@@ -91,6 +93,109 @@ export class SpacePermissionModel {
                                 .whereIn(
                                     `${SpaceGroupAccessTableName}.space_uuid`,
                                     spaceUuids,
+                                )
+                                .where(
+                                    `${SpaceGroupAccessTableName}.group_uuid`,
+                                    '!=',
+                                    PROJECT_MEMBERS_GROUP_UUID,
+                                )
+                                .modify((qb) => {
+                                    if (filters?.userUuid) {
+                                        void qb.where(
+                                            `${UserTableName}.user_uuid`,
+                                            filters.userUuid,
+                                        );
+                                    }
+                                }),
+                        )
+                        .union(
+                            // "All project members" sentinel — explicit project members
+                            this.database(SpaceGroupAccessTableName)
+                                .select({
+                                    userUuid: `${UserTableName}.user_uuid`,
+                                    spaceUuid: `${SpaceGroupAccessTableName}.space_uuid`,
+                                    groupUuid: `${SpaceGroupAccessTableName}.group_uuid`,
+                                    role: `${SpaceGroupAccessTableName}.space_role`,
+                                    from: this.database.raw(
+                                        `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
+                                    ),
+                                })
+                                .innerJoin(
+                                    SpaceTableName,
+                                    `${SpaceTableName}.space_uuid`,
+                                    `${SpaceGroupAccessTableName}.space_uuid`,
+                                )
+                                .innerJoin(
+                                    ProjectMembershipsTableName,
+                                    `${ProjectMembershipsTableName}.project_id`,
+                                    `${SpaceTableName}.project_id`,
+                                )
+                                .innerJoin(
+                                    UserTableName,
+                                    `${ProjectMembershipsTableName}.user_id`,
+                                    `${UserTableName}.user_id`,
+                                )
+                                .whereIn(
+                                    `${SpaceGroupAccessTableName}.space_uuid`,
+                                    spaceUuids,
+                                )
+                                .where(
+                                    `${SpaceGroupAccessTableName}.group_uuid`,
+                                    PROJECT_MEMBERS_GROUP_UUID,
+                                )
+                                .modify((qb) => {
+                                    if (filters?.userUuid) {
+                                        void qb.where(
+                                            `${UserTableName}.user_uuid`,
+                                            filters.userUuid,
+                                        );
+                                    }
+                                }),
+                        )
+                        .union(
+                            // "All project members" sentinel — org members with project access
+                            this.database(SpaceGroupAccessTableName)
+                                .select({
+                                    userUuid: `${UserTableName}.user_uuid`,
+                                    spaceUuid: `${SpaceGroupAccessTableName}.space_uuid`,
+                                    groupUuid: `${SpaceGroupAccessTableName}.group_uuid`,
+                                    role: `${SpaceGroupAccessTableName}.space_role`,
+                                    from: this.database.raw(
+                                        `'${DirectSpaceAccessOrigin.GROUP_ACCESS}'`,
+                                    ),
+                                })
+                                .innerJoin(
+                                    SpaceTableName,
+                                    `${SpaceTableName}.space_uuid`,
+                                    `${SpaceGroupAccessTableName}.space_uuid`,
+                                )
+                                .innerJoin(
+                                    ProjectTableName,
+                                    `${ProjectTableName}.project_id`,
+                                    `${SpaceTableName}.project_id`,
+                                )
+                                .innerJoin(
+                                    OrganizationMembershipsTableName,
+                                    `${OrganizationMembershipsTableName}.organization_id`,
+                                    `${ProjectTableName}.organization_id`,
+                                )
+                                .innerJoin(
+                                    UserTableName,
+                                    `${UserTableName}.user_id`,
+                                    `${OrganizationMembershipsTableName}.user_id`,
+                                )
+                                .whereIn(
+                                    `${SpaceGroupAccessTableName}.space_uuid`,
+                                    spaceUuids,
+                                )
+                                .where(
+                                    `${SpaceGroupAccessTableName}.group_uuid`,
+                                    PROJECT_MEMBERS_GROUP_UUID,
+                                )
+                                .where(
+                                    `${OrganizationMembershipsTableName}.role`,
+                                    '!=',
+                                    'member',
                                 )
                                 .modify((qb) => {
                                     if (filters?.userUuid) {
@@ -397,7 +502,10 @@ export class SpacePermissionModel {
                     .select({
                         groupUuid: `${SpaceGroupAccessTableName}.group_uuid`,
                         spaceRole: `${SpaceGroupAccessTableName}.space_role`,
-                        groupName: `${GroupTableName}.name`,
+                        groupName: this.database.raw(
+                            `COALESCE(${GroupTableName}.name, CASE WHEN ${SpaceGroupAccessTableName}.group_uuid = ? THEN 'All project members' END)`,
+                            [PROJECT_MEMBERS_GROUP_UUID],
+                        ),
                     })
                     .leftJoin(
                         `${GroupTableName}`,

--- a/packages/common/src/types/space.ts
+++ b/packages/common/src/types/space.ts
@@ -168,6 +168,14 @@ export enum SpaceMemberRole {
     ADMIN = 'admin',
 }
 
+/**
+ * Sentinel UUID representing "all project members" as a pseudo-group.
+ * When this UUID appears in space_group_access, the permission system
+ * expands it to all users with project access instead of looking up group_memberships.
+ */
+export const PROJECT_MEMBERS_GROUP_UUID =
+    '00000000-0000-0000-0000-000000000000';
+
 export type ApiSpaceSummaryListResponse = {
     status: 'ok';
     results: SpaceSummary[];

--- a/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
+++ b/packages/frontend/src/components/common/ShareSpaceModal/ShareSpaceAddUser.tsx
@@ -1,5 +1,6 @@
 import {
     OrganizationMemberRole,
+    PROJECT_MEMBERS_GROUP_UUID,
     SpaceMemberRole,
     type OrganizationMemberProfile,
     type Space,
@@ -133,7 +134,11 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
 
     // Set of all known group UUIDs for O(1) lookups
     const groupUuidsSet = useMemo(
-        () => new Set(allSearchedGroups.map((g) => g.uuid)),
+        () =>
+            new Set([
+                ...allSearchedGroups.map((g) => g.uuid),
+                PROJECT_MEMBERS_GROUP_UUID,
+            ]),
         [allSearchedGroups],
     );
 
@@ -227,6 +232,8 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
         const groupsFiltered =
             allSearchedGroups.filter(
                 (group) =>
+                    // Exclude the sentinel — it's shown as the synthetic "All project members" entry
+                    group.uuid !== PROJECT_MEMBERS_GROUP_UUID &&
                     !space.groupsAccess.some(
                         (ga) => ga.groupUuid === group.uuid,
                     ) &&
@@ -239,6 +246,23 @@ export const ShareSpaceAddUser: FC<ShareSpaceAddUserProps> = ({
             value: group.uuid,
             label: group.name,
         }));
+
+        // Prepend "All project members" pseudo-group if not already added
+        const hasProjectMembersGroup = space.groupsAccess.some(
+            (ga) => ga.groupUuid === PROJECT_MEMBERS_GROUP_UUID,
+        );
+        if (
+            !hasProjectMembersGroup &&
+            (!debouncedSearchQuery ||
+                'all project members'.includes(
+                    debouncedSearchQuery.toLowerCase(),
+                ))
+        ) {
+            groupItems.unshift({
+                value: PROJECT_MEMBERS_GROUP_UUID,
+                label: 'All project members',
+            });
+        }
 
         const result: (ComboboxItem | ComboboxItemGroup)[] = [];
 


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: #20840

## Summary

This is an alternative implementation to https://github.com/lightdash/lightdash/pull/21645

Adds an "All project members" option to the space share modal, allowing admins to grant every project member a role on a restricted-access space without adding them individually.

## How it works

A sentinel group record (`00000000-...`) is created via migration in the `groups` table. When a user selects "All project members" in the share modal, a row is inserted into `space_group_access` referencing this sentinel UUID — same flow as adding any other group.

The permission system's `getDirectSpaceAccess` query has two new UNION legs that recognize the sentinel and expand it to actual users:
- One joins through `project_memberships` (explicit project members)
- One joins through `organization_memberships` for non-`member` roles (org members who implicitly have project access)

This means the sentinel behaves like a dynamic group whose membership is always in sync with who can access the project — no background sync jobs, no stale membership.

The existing group UNION leg excludes the sentinel (`WHERE group_uuid != sentinel`) so it doesn't try to expand it via `group_memberships` (which would return zero rows).

On the frontend, the sentinel is filtered out of the regular org groups list to avoid duplicates, and instead shown as a synthetic "All project members" entry at the top of the Groups section in the dropdown.

## Use case

Restricted-access spaces (`inherit_parent_permissions = false`) currently require adding users or groups one by one. This makes it possible to create a space hierarchy like:

- **Top-level space** (inherits from project — everyone sees it)
  - **Child space** (restricted — only specific people)
    - **Grandchild space** (restricted, but all project members granted viewer access)

## Test plan

- [ ] Open a restricted space's share modal — "All project members" appears in the Groups dropdown
- [ ] Add it — all org/project members gain access at the selected role
- [ ] Remove it — access is revoked
- [ ] Verify it doesn't appear as a duplicate (not shown twice in the dropdown)
- [ ] Verify regular groups still work as before
- [ ] Verify spaces without it are unaffected (no perf impact — the UNION legs return zero rows when the sentinel isn't in `space_group_access`)

