### PR TITLE
fix: databricks u2m refresh token cache when deploying using cli

### DIFF
--- a/packages/cli/src/handlers/dbt/getWarehouseClient.ts
+++ b/packages/cli/src/handlers/dbt/getWarehouseClient.ts
@@ -41,7 +41,10 @@ import { lightdashApi } from './apiClient';
  */
 const warehouseClientCache = new Map<
     string,
-    ReturnType<typeof warehouseClientFromCredentials>
+    {
+        warehouseClient: ReturnType<typeof warehouseClientFromCredentials>;
+        credentials: CreateWarehouseCredentials;
+    }
 >();
 
 /**
@@ -355,7 +358,9 @@ export default async function getWarehouseClient(
             GlobalState.debug(
                 `> Reusing cached warehouse client (${credentials.type})`,
             );
-            warehouseClient = warehouseClientCache.get(cacheKey)!;
+            const cached = warehouseClientCache.get(cacheKey)!;
+            warehouseClient = cached.warehouseClient;
+            credentials = cached.credentials;
         } else {
             // Exchange Databricks OAuth M2M credentials for access token if needed
             if (
@@ -425,7 +430,10 @@ export default async function getWarehouseClient(
                     : undefined,
             });
 
-            warehouseClientCache.set(cacheKey, warehouseClient);
+            warehouseClientCache.set(cacheKey, {
+                warehouseClient,
+                credentials,
+            });
         }
     }
     return {


### PR DESCRIPTION
### Description:

Enhanced the warehouse client cache to store both the warehouse client instance and its associated credentials. Previously, the cache only stored the warehouse client, but now it maintains a structured object containing both the `warehouseClient` and `credentials` properties. This allows the cached credentials to be retrieved and reused along with the client instance when a cache hit occurs.