### PR TITLE
feat: add MetricQueryBuilder snapshot tests with SQL formatting

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,7 @@
         "backend-fix-lint": "pnpm -F backend fix-lint",
         "backend-fix-format": "pnpm -F backend fix-format",
         "backend-test": "pnpm -F backend test",
+        "backend-test-metric-query-builder-snapshots:update": "pnpm -F backend test:snapshots:update",
         "backend-test-integration": "pnpm -F backend test:integration",
         "backend-test-sequential": "pnpm -F backend test-sequential",
         "backend-typecheck": "pnpm -F backend typecheck",

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -22,6 +22,7 @@
         "test-sequential": "TZ=UTC LANG=en_US.UTF-8 NODE_ENV=test jest --config jest.config.js --runInBand",
         "test:dev": "TZ=UTC LANG=en_US.UTF-8 jest --config jest.config.dev.js --onlyChanged --watch",
         "test:dev:nowatch": "TZ=UTC LANG=en_US.UTF-8 jest --config jest.config.dev.js --onlyChanged",
+        "test:snapshots:update": "TZ=UTC LANG=en_US.UTF-8 jest --config jest.config.js src/utils/QueryBuilder/metricQueryBuilderSnapshots -u",
         "test:integration": "vitest run --config vitest.config.integration.ts",
         "test:integration:dev": "vitest run --config vitest.config.integration.ts --watch",
         "linter": "eslint -c .eslintrc.js --ignore-path ./../../.gitignore --rulesdir eslint-rules",
@@ -195,6 +196,7 @@
         "jest-fetch-mock": "3.0.3",
         "knex-mock-client": "1.11.0",
         "nodemon": "3.1.9",
+        "sql-formatter": "15.4.2",
         "ts-node": "10.9.2",
         "typescript": "6.0.0-beta"
     }

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -25,38 +25,21 @@ import {
 } from './MetricQueryBuilder';
 import {
     bigqueryClientMock,
-    EXPECTED_SQL_NO_DIMENSIONS_WITH_FILTER,
-    EXPECTED_SQL_WITH_CROSS_JOIN,
-    EXPECTED_SQL_WITH_CROSS_TABLE_METRICS,
-    EXPECTED_SQL_WITH_CUSTOM_DIMENSION_AND_TABLE_CALCULATION,
-    EXPECTED_SQL_WITH_CUSTOM_DIMENSION_BIN_NUMBER,
-    EXPECTED_SQL_WITH_CUSTOM_DIMENSION_BIN_WIDTH,
-    EXPECTED_SQL_WITH_CUSTOM_DIMENSION_BIN_WIDTH_ON_POSTGRES,
-    EXPECTED_SQL_WITH_CUSTOM_SQL_DIMENSION,
-    EXPECTED_SQL_WITH_MANY_TO_ONE_JOIN,
-    EXPECTED_SQL_WITH_SORTED_CUSTOM_DIMENSION,
     EXPLORE,
-    EXPLORE_ALL_JOIN_TYPES_CHAIN,
-    EXPLORE_BIGQUERY,
-    EXPLORE_JOIN_CHAIN,
     EXPLORE_WITH_AVERAGE_DISTINCT,
     EXPLORE_WITH_CROSS_TABLE_METRICS,
     EXPLORE_WITH_DATE_DIMENSION,
     EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
     EXPLORE_WITH_NESTED_AGG,
-    EXPLORE_WITH_REQUIRED_FILTERS,
     EXPLORE_WITH_SQL_FILTER,
     EXPLORE_WITH_SUM_DISTINCT,
     EXPLORE_WITHOUT_JOIN_RELATIONSHIPS,
     EXPLORE_WITHOUT_PRIMARY_KEYS,
     INTRINSIC_USER_ATTRIBUTES,
     METRIC_QUERY,
-    METRIC_QUERY_ALL_JOIN_TYPES_CHAIN_SQL,
     METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
     METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
     METRIC_QUERY_CROSS_TABLE,
-    METRIC_QUERY_JOIN_CHAIN,
-    METRIC_QUERY_JOIN_CHAIN_SQL,
     METRIC_QUERY_NESTED_AGG_COMPLEX,
     METRIC_QUERY_NESTED_AGG_CONDITIONAL,
     METRIC_QUERY_NESTED_AGG_COUNT_DISTINCT,
@@ -71,53 +54,13 @@ import {
     METRIC_QUERY_NESTED_AGG_TRANSITIVE_MIXED,
     METRIC_QUERY_NESTED_AGG_WINDOW_TABLE_REF,
     METRIC_QUERY_NESTED_AGG_WITH_DIMS,
-    METRIC_QUERY_SQL,
-    METRIC_QUERY_SQL_BIGQUERY,
     METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
     METRIC_QUERY_TWO_TABLES,
-    METRIC_QUERY_TWO_TABLES_SQL,
-    METRIC_QUERY_WITH_ADDITIONAL_METRIC,
-    METRIC_QUERY_WITH_ADDITIONAL_METRIC_SQL,
     METRIC_QUERY_WITH_CUSTOM_DIMENSION,
-    METRIC_QUERY_WITH_CUSTOM_SQL_DIMENSION,
     METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
-    METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE_SQL,
     METRIC_QUERY_WITH_DATE_FILTER,
-    METRIC_QUERY_WITH_DATE_ZOOM_FILTER_SQL,
-    METRIC_QUERY_WITH_DAY_OF_WEEK_NAME_SORT,
-    METRIC_QUERY_WITH_DAY_OF_WEEK_NAME_SORT_SQL,
-    METRIC_QUERY_WITH_DISABLED_FILTER,
-    METRIC_QUERY_WITH_DISABLED_FILTER_SQL,
-    METRIC_QUERY_WITH_EMPTY_FILTER,
-    METRIC_QUERY_WITH_EMPTY_FILTER_GROUPS,
-    METRIC_QUERY_WITH_EMPTY_FILTER_SQL,
-    METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
-    METRIC_QUERY_WITH_EMPTY_METRIC_FILTER_SQL,
-    METRIC_QUERY_WITH_FILTER,
-    METRIC_QUERY_WITH_FILTER_AND_DISABLED_FILTER,
-    METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
-    METRIC_QUERY_WITH_FILTER_OR_OPERATOR_SQL,
-    METRIC_QUERY_WITH_FILTER_SQL,
-    METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM,
-    METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM_SQL,
     METRIC_QUERY_WITH_METRIC_FILTER,
-    METRIC_QUERY_WITH_METRIC_FILTER_AND_ONE_DISABLED_SQL,
-    METRIC_QUERY_WITH_METRIC_FILTER_SQL,
-    METRIC_QUERY_WITH_MONTH_NAME_SORT,
-    METRIC_QUERY_WITH_MONTH_NAME_SORT_SQL,
-    METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
-    METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS_SQL,
-    METRIC_QUERY_WITH_NESTED_METRIC_FILTERS,
-    METRIC_QUERY_WITH_NESTED_METRIC_FILTERS_SQL,
-    METRIC_QUERY_WITH_REQUIRED_FILTERS_SQL,
-    METRIC_QUERY_WITH_SQL_FILTER,
-    METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER,
-    METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER_SQL,
-    METRIC_QUERY_WITH_TABLE_REFERENCE,
-    METRIC_QUERY_WITH_TABLE_REFERENCE_SQL,
-    METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE,
-    METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE_SQL,
     QUERY_BUILDER_UTC_TIMEZONE,
     warehouseClientMock,
 } from './MetricQueryBuilder.mock';
@@ -820,159 +763,6 @@ describe('getIntervalSyntax', () => {
 });
 
 describe('Query builder', () => {
-    test('Should build simple metric query', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_SQL));
-    });
-
-    test('Should build simple metric query in BigQuery', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE_BIGQUERY,
-                    compiledMetricQuery: METRIC_QUERY,
-                    warehouseSqlBuilder: bigqueryClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_SQL_BIGQUERY));
-    });
-
-    test('Should build metric query across two tables', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_TWO_TABLES,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_TWO_TABLES_SQL));
-    });
-
-    test('Should build metric query where a field references another table', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_TABLE_REFERENCE,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_TABLE_REFERENCE_SQL),
-        );
-    });
-
-    test('Should join table from filter dimension', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_WITH_FILTER_SQL));
-    });
-
-    test('should join chain of intermediary tables', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE_JOIN_CHAIN,
-                    compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_JOIN_CHAIN_SQL));
-    });
-
-    test('should join chain of intermediary tables', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE_ALL_JOIN_TYPES_CHAIN,
-                    compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_ALL_JOIN_TYPES_CHAIN_SQL),
-        );
-    });
-
-    test('Should build query with filter OR operator', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_FILTER_OR_OPERATOR_SQL),
-        );
-    });
-
-    test('Should build query with disabled filter', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_DISABLED_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_DISABLED_FILTER_SQL),
-        );
-    });
-
-    test('Should build query with a filter and one disabled filter', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery:
-                        METRIC_QUERY_WITH_FILTER_AND_DISABLED_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(
-                METRIC_QUERY_WITH_METRIC_FILTER_AND_ONE_DISABLED_SQL,
-            ),
-        );
-    });
-
     test('Should reuse non-time filters for PoP metrics while shifting the comparison period', () => {
         const { query } = buildQuery({
             explore: POP_TEST_EXPLORE,
@@ -1129,150 +919,6 @@ describe('Query builder', () => {
         expect(query).not.toMatch(/INNER JOIN cte_pop_metrics_/);
     });
 
-    test('Should build query with nested filter operators', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery:
-                        METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS_SQL),
-        );
-    });
-
-    test('Should build query with no filter when there are only empty filter groups ', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER_GROUPS,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_SQL));
-    });
-
-    test('Should build second query with metric filter', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_WITH_METRIC_FILTER_SQL));
-    });
-
-    test('Should build query with metric filter (where filter is disabled) and metric references a dimension from a joined table', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery:
-                        METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(
-                METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM_SQL,
-            ),
-        );
-    });
-
-    test('Should build second query with nested metric filters', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery:
-                        METRIC_QUERY_WITH_NESTED_METRIC_FILTERS,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_NESTED_METRIC_FILTERS_SQL),
-        );
-    });
-
-    test('Should build query with additional metric', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRIC,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_ADDITIONAL_METRIC_SQL),
-        );
-    });
-
-    test('Should build query with empty filter', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_WITH_EMPTY_FILTER_SQL));
-    });
-
-    test('Should build query with empty metric filter', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_EMPTY_METRIC_FILTER_SQL),
-        );
-    });
-
-    test('Should build query with cte in table calculations filter', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery:
-                        METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER_SQL),
-        );
-    });
-
     test('Should throw error if user attributes are missing', () => {
         expect(
             () =>
@@ -1285,64 +931,6 @@ describe('Query builder', () => {
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
         ).toThrow(ForbiddenError);
-    });
-
-    test('Should replace user attributes from sql filter', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE_WITH_SQL_FILTER,
-                    compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    userAttributes: {
-                        country: ['EU'],
-                    },
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_WITH_SQL_FILTER));
-    });
-
-    test('Should replace intrinsic user attributes in filter values', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery:
-                        METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(
-                METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE_SQL,
-            ),
-        );
-    });
-
-    test('Should replace custom user attributes in filter values', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery:
-                        METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    userAttributes: {
-                        country: ['EU'],
-                    },
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(
-                METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE_SQL,
-            ),
-        );
     });
 
     test('Should throw error if user attribute in filter value is missing', () => {
@@ -1358,117 +946,6 @@ describe('Query builder', () => {
                     timezone: QUERY_BUILDER_UTC_TIMEZONE,
                 }).query,
         ).toThrow(ForbiddenError);
-    });
-
-    it('buildQuery with custom dimension bin number', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_CUSTOM_DIMENSION,
-                    warehouseSqlBuilder: bigqueryClientMock,
-                    userAttributes: {},
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(EXPECTED_SQL_WITH_CUSTOM_DIMENSION_BIN_NUMBER),
-        );
-    });
-
-    it('buildQuery with custom dimension bin width', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: {
-                        ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
-                        compiledCustomDimensions: [
-                            {
-                                id: 'age_range',
-                                name: 'Age range',
-                                type: CustomDimensionType.BIN,
-                                dimensionId: 'table1_dim1',
-                                table: 'table1',
-                                binType: BinType.FIXED_WIDTH,
-                                binWidth: 10,
-                            },
-                        ],
-                    },
-                    warehouseSqlBuilder: bigqueryClientMock,
-                    userAttributes: {},
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(EXPECTED_SQL_WITH_CUSTOM_DIMENSION_BIN_WIDTH),
-        );
-    });
-
-    it('buildQuery with custom dimension and table calculation', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: {
-                        ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
-                        tableCalculations: [
-                            {
-                                name: 'calc3',
-                                displayName: '',
-                                sql: '${table1.dim1} + 1',
-                            },
-                        ],
-                        compiledTableCalculations: [
-                            {
-                                name: 'calc3',
-                                displayName: '',
-                                sql: '${table1.dim1} + 1',
-                                compiledSql: 'table1_dim1 + 1',
-                                dependsOn: [],
-                            },
-                        ],
-                    },
-
-                    warehouseSqlBuilder: bigqueryClientMock,
-                    userAttributes: {},
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(
-                EXPECTED_SQL_WITH_CUSTOM_DIMENSION_AND_TABLE_CALCULATION,
-            ),
-        );
-    });
-
-    it('buildQuery with sorted custom dimension', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: {
-                        ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
-                        sorts: [
-                            {
-                                fieldId: 'age_range',
-                                descending: true,
-                            },
-                        ],
-                    },
-
-                    warehouseSqlBuilder: bigqueryClientMock,
-                    userAttributes: {},
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(EXPECTED_SQL_WITH_SORTED_CUSTOM_DIMENSION),
-        );
     });
 
     it('buildQuery with row() table calculation should order by custom bin _order column', () => {
@@ -1505,39 +982,6 @@ describe('Query builder', () => {
         );
     });
 
-    it('buildQuery with custom dimension bin width on postgres', () => {
-        // Concat function is different in postgres/redshift
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: {
-                        ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
-                        compiledCustomDimensions: [
-                            {
-                                id: 'age_range',
-                                name: 'Age range',
-                                type: CustomDimensionType.BIN,
-                                dimensionId: 'table1_dim1',
-                                table: 'table1',
-                                binType: BinType.FIXED_WIDTH,
-                                binWidth: 10,
-                            },
-                        ],
-                    },
-                    warehouseSqlBuilder: warehouseClientMock,
-                    userAttributes: {},
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(
-                EXPECTED_SQL_WITH_CUSTOM_DIMENSION_BIN_WIDTH_ON_POSTGRES,
-            ),
-        );
-    });
-
     it('buildQuery with custom dimension not selected', () => {
         expect(
             buildQuery({
@@ -1553,22 +997,6 @@ describe('Query builder', () => {
             }).query,
         ).not.toContain('age_range');
     });
-    it('Should build query with required filters with joined tables', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE_WITH_REQUIRED_FILTERS,
-                    compiledMetricQuery: METRIC_QUERY,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_REQUIRED_FILTERS_SQL),
-        );
-    });
-
     it('Should not let string-derived time filters satisfy required date filters', () => {
         const exploreWithStringDerivedTimeDimension: Explore = {
             ...EXPLORE_WITH_DATE_DIMENSION,
@@ -1646,105 +1074,6 @@ describe('Query builder', () => {
             replaceWhitespace(
                 '(("orders".created_at) >= (\'2024-09-01\') AND ("orders".created_at) <= (\'2024-09-04\'))',
             ),
-        );
-    });
-
-    it('Should build metric query with metric filters', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(replaceWhitespace(METRIC_QUERY_WITH_METRIC_FILTER_SQL));
-    });
-
-    it('Should build metric query with sort by dimension with timeinterval month name', () => {
-        // Create a modified explore with a month name dimension
-        const exploreWithMonthNameDimension = {
-            ...EXPLORE,
-            tables: {
-                ...EXPLORE.tables,
-                table1: {
-                    ...EXPLORE.tables.table1,
-                    dimensions: {
-                        ...EXPLORE.tables.table1.dimensions,
-                        dim1: {
-                            ...EXPLORE.tables.table1.dimensions.dim1,
-                            timeInterval: TimeFrames.MONTH_NAME,
-                        },
-                    },
-                },
-            },
-        };
-
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: exploreWithMonthNameDimension,
-                    compiledMetricQuery: METRIC_QUERY_WITH_MONTH_NAME_SORT,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_MONTH_NAME_SORT_SQL),
-        );
-    });
-
-    it('Should build metric query with sort by dimension with timeinterval day of the week name', () => {
-        // Create a modified explore with a day of week name dimension
-        const exploreWithDayOfWeekNameDimension = {
-            ...EXPLORE,
-            tables: {
-                ...EXPLORE.tables,
-                table1: {
-                    ...EXPLORE.tables.table1,
-                    dimensions: {
-                        ...EXPLORE.tables.table1.dimensions,
-                        dim1: {
-                            ...EXPLORE.tables.table1.dimensions.dim1,
-                            timeInterval: TimeFrames.DAY_OF_WEEK_NAME,
-                        },
-                    },
-                },
-            },
-        };
-
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: exploreWithDayOfWeekNameDimension,
-                    compiledMetricQuery:
-                        METRIC_QUERY_WITH_DAY_OF_WEEK_NAME_SORT,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_DAY_OF_WEEK_NAME_SORT_SQL),
-        );
-    });
-
-    it('Should build metric query as a custom SQL dimension', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE,
-                    compiledMetricQuery: METRIC_QUERY_WITH_CUSTOM_SQL_DIMENSION,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(EXPECTED_SQL_WITH_CUSTOM_SQL_DIMENSION),
         );
     });
 
@@ -2040,10 +1369,6 @@ SELECT
 FROM postcalculation_metrics
 ORDER BY "table1_metric1" DESC
 LIMIT 10`;
-
-            expect(replaceWhitespace(result.query)).toStrictEqual(
-                replaceWhitespace(expectedSQL),
-            );
         });
 
         test('Should build query with running_total postcalculation metric and pivot configuration', () => {
@@ -2150,9 +1475,6 @@ LIMIT 10`;
             expect(result.query).toContain('"table1_running_total_metric"');
             expect(result.query).toContain('"table1_dim1"');
             expect(result.query).toContain('"table1_category"');
-            expect(replaceWhitespace(result.query)).toStrictEqual(
-                replaceWhitespace(expectedSQL),
-            );
         });
     });
 
@@ -2284,9 +1606,6 @@ LIMIT 10`;
             });
 
             expect(result.warnings).toHaveLength(0);
-            expect(replaceWhitespace(result.query)).toBe(
-                replaceWhitespace(EXPECTED_SQL_WITH_MANY_TO_ONE_JOIN),
-            );
         });
 
         test('Should build query with CTEs for metrics and CROSS join', () => {
@@ -2304,9 +1623,6 @@ LIMIT 10`;
             });
 
             expect(result.warnings).toHaveLength(0);
-            expect(replaceWhitespace(result.query)).toBe(
-                replaceWhitespace(EXPECTED_SQL_WITH_CROSS_JOIN),
-            );
         });
 
         test('Should handle inflation-proof metrics correctly', () => {
@@ -2384,20 +1700,6 @@ LIMIT 10`;
                     ),
                 ),
             ).toBe(true);
-        });
-
-        test('Should handle metrics that reference other metrics from joined tables', () => {
-            const result = buildQuery({
-                explore: EXPLORE_WITH_CROSS_TABLE_METRICS,
-                compiledMetricQuery: METRIC_QUERY_CROSS_TABLE,
-                warehouseSqlBuilder: warehouseClientMock,
-                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                timezone: QUERY_BUILDER_UTC_TIMEZONE,
-            });
-
-            expect(replaceWhitespace(result.query)).toBe(
-                replaceWhitespace(EXPECTED_SQL_WITH_CROSS_TABLE_METRICS),
-            );
         });
 
         test('Should handle metrics referencing other metrics when base metrics are also selected', () => {
@@ -2884,8 +2186,8 @@ LIMIT 10`;
                 timezone: QUERY_BUILDER_UTC_TIMEZONE,
             });
 
-            expect(replaceWhitespace(result.query)).toBe(
-                replaceWhitespace(EXPECTED_SQL_NO_DIMENSIONS_WITH_FILTER),
+            expect(result.query).not.toContain(
+                'cte_unaffected AS (\nSELECT\nFROM',
             );
         });
 
@@ -4883,19 +4185,26 @@ describe('Query Structure Tests', () => {
 
 describe('Date zoom with filters', () => {
     test('Should use raw column in WHERE clause when date zoom is active', () => {
-        expect(
-            replaceWhitespace(
-                buildQuery({
-                    explore: EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
-                    compiledMetricQuery: METRIC_QUERY_WITH_DATE_FILTER,
-                    warehouseSqlBuilder: warehouseClientMock,
-                    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
-                    timezone: QUERY_BUILDER_UTC_TIMEZONE,
-                    originalExplore: EXPLORE_WITH_DATE_DIMENSION,
-                }).query,
-            ),
-        ).toStrictEqual(
-            replaceWhitespace(METRIC_QUERY_WITH_DATE_ZOOM_FILTER_SQL),
+        const result = buildQuery({
+            explore: EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
+            compiledMetricQuery: METRIC_QUERY_WITH_DATE_FILTER,
+            warehouseSqlBuilder: warehouseClientMock,
+            intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+            timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            originalExplore: EXPLORE_WITH_DATE_DIMENSION,
+        });
+
+        expect(result.query).toContain(
+            `DATE_TRUNC('month', "orders".created_at) AS "orders_created_at"`,
+        );
+        expect(result.query).toContain(
+            `("orders".created_at) >= ('2024-09-01')`,
+        );
+        expect(result.query).toContain(
+            `("orders".created_at) <= ('2024-09-04')`,
+        );
+        expect(result.query).not.toContain(
+            `DATE_TRUNC('month', "orders".created_at) >= ('2024-09-01')`,
         );
     });
 

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/coreQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/coreQueries.test.ts.snap
@@ -1,0 +1,158 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for a field-reference query across tables 1`] = `
+"SELECT
+  "table1".dim1 + "table2".dim2 AS "table1_with_reference"
+FROM
+  "db"."schema"."table1" AS "table1"
+  LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+GROUP BY
+  1
+ORDER BY
+  "table1_with_reference"
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for a metric query across two tables 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table2".number_column) AS "table2_metric2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    GROUP BY
+      1
+  )
+SELECT
+  *,
+  table1_dim1 + table2_metric2 AS "calc3"
+FROM
+  metrics
+ORDER BY
+  "table2_metric2" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for a metric-only query without default sorting 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+  )
+SELECT
+  *,
+  table1_dim1 + table1_metric1 AS "calc3"
+FROM
+  metrics
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for a query with additional metrics 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table2".number_column) AS "table2_additional_metric"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    GROUP BY
+      1
+  )
+SELECT
+  *,
+  table1_dim1 + table2_additional_metric AS "calc3"
+FROM
+  metrics
+ORDER BY
+  "table2_additional_metric" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for a simple metric query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  )
+SELECT
+  *,
+  table1_dim1 + table1_metric1 AS "calc3"
+FROM
+  metrics
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for a simple metric query in BigQuery 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      \`table1\`.dim1 AS \`table1_dim1\`,
+      MAX(\`table1\`.number_column) AS \`table1_metric1\`
+    FROM
+      \`db\`.\`schema\`.\`table1\` AS \`table1\`
+    GROUP BY
+      1
+  )
+SELECT
+  *,
+  table1_dim1 + table1_metric1 AS \`calc3\`
+FROM
+  metrics
+ORDER BY
+  \`table1_metric1\` DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for an all-join-types intermediary chain query 1`] = `
+"SELECT
+  "table5".dim1 AS "table5_dim1",
+  MAX("table5".number_column) AS "table5_metric1"
+FROM
+  "db"."schema"."table1" AS "table1"
+  INNER JOIN "db"."schema"."table2" AS "table2" ON ("table2".col) = ("table1".col)
+  FULL OUTER JOIN "db"."schema"."table3" AS "table3" ON ("table3".col) = ("table2".col)
+  LEFT OUTER JOIN "db"."schema"."table4" AS "table4" ON ("table4".col) = ("table3".col)
+  RIGHT OUTER JOIN "db"."schema"."table5" AS "table5" ON ("table5".col) = ("table4".col)
+GROUP BY
+  1
+ORDER BY
+  "table5_metric1" DESC
+LIMIT
+  5"
+`;
+
+exports[`MetricQueryBuilder snapshot: core queries matches snapshot for an intermediary join-chain query 1`] = `
+"SELECT
+  "table5".dim1 AS "table5_dim1",
+  MAX("table5".number_column) AS "table5_metric1"
+FROM
+  "db"."schema"."table1" AS "table1"
+  LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table2".col) = ("table1".col)
+  LEFT OUTER JOIN "db"."schema"."table3" AS "table3" ON ("table3".col) = ("table2".col)
+  LEFT OUTER JOIN "db"."schema"."table4" AS "table4" ON ("table4".col) = ("table3".col)
+  LEFT OUTER JOIN "db"."schema"."table5" AS "table5" ON ("table5".col) = ("table4".col)
+GROUP BY
+  1
+ORDER BY
+  "table5_metric1" DESC
+LIMIT
+  5"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/customDimensionQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/customDimensionQueries.test.ts.snap
@@ -1,0 +1,155 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: custom dimension queries matches snapshot for a binned custom dimension query 1`] = `
+"WITH  age_range_cte AS (
+                    SELECT
+                        FLOOR(MIN("table1".dim1)) AS min_id,
+                        CEIL(MAX("table1".dim1)) AS max_id,
+                        FLOOR((MAX("table1".dim1) - MIN("table1".dim1)) / 3) AS bin_width
+                    FROM "db"."schema"."table1" AS \`table1\`
+                )
+SELECT
+  "table1".dim1 AS \`table1_dim1\`,
+CASE
+                    WHEN "table1".dim1 IS NULL THEN NULL
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 0, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 1)
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 1, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 2)
+ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range_cte.max_id)
+                    END
+                    AS \`age_range\`,
+CASE
+                        WHEN "table1".dim1 IS NULL THEN 3
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN 0
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN 1
+ELSE 2
+                        END
+                        AS \`age_range_order\`,
+  MAX("table1".number_column) AS \`table1_metric1\`
+FROM "db"."schema"."table1" AS \`table1\`
+
+CROSS JOIN age_range_cte
+GROUP BY 1,2,3
+ORDER BY \`table1_metric1\` DESC
+LIMIT 10"
+`;
+
+exports[`MetricQueryBuilder snapshot: custom dimension queries matches snapshot for a custom SQL dimension query 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1",
+  ("table1".dim1 < 18) AS "is_adult",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM
+  "db"."schema"."table1" AS "table1"
+GROUP BY
+  1,
+  2
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: custom dimension queries matches snapshot for a custom dimension query with a table calculation 1`] = `
+"WITH  age_range_cte AS (
+                    SELECT
+                        FLOOR(MIN("table1".dim1)) AS min_id,
+                        CEIL(MAX("table1".dim1)) AS max_id,
+                        FLOOR((MAX("table1".dim1) - MIN("table1".dim1)) / 3) AS bin_width
+                    FROM "db"."schema"."table1" AS \`table1\`
+                ),
+metrics AS (
+SELECT
+  "table1".dim1 AS \`table1_dim1\`,
+CASE
+                    WHEN "table1".dim1 IS NULL THEN NULL
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 0, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 1)
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 1, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 2)
+ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range_cte.max_id)
+                    END
+                    AS \`age_range\`,
+CASE
+                        WHEN "table1".dim1 IS NULL THEN 3
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN 0
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN 1
+ELSE 2
+                        END
+                        AS \`age_range_order\`,
+  MAX("table1".number_column) AS \`table1_metric1\`
+FROM "db"."schema"."table1" AS \`table1\`
+
+CROSS JOIN age_range_cte
+GROUP BY 1,2,3
+)
+SELECT
+  *,
+  table1_dim1 + 1 AS \`calc3\`
+FROM metrics
+ORDER BY \`table1_metric1\` DESC
+LIMIT 10"
+`;
+
+exports[`MetricQueryBuilder snapshot: custom dimension queries matches snapshot for a fixed-width custom dimension query in BigQuery 1`] = `
+"SELECT
+  "table1".dim1 AS \`table1_dim1\`,
+CONCAT(FLOOR("table1".dim1 / 10) * 10, ' - ', (FLOOR("table1".dim1 / 10) + 1) * 10 - 1) AS \`age_range\`,
+FLOOR("table1".dim1 / 10) * 10 AS \`age_range_order\`,
+  MAX("table1".number_column) AS \`table1_metric1\`
+FROM "db"."schema"."table1" AS \`table1\`
+
+GROUP BY 1,2,3
+ORDER BY \`table1_metric1\` DESC
+LIMIT 10"
+`;
+
+exports[`MetricQueryBuilder snapshot: custom dimension queries matches snapshot for a fixed-width custom dimension query in Postgres 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1",
+  (
+    FLOOR("table1".dim1 / 10) * 10 || ' - ' || (FLOOR("table1".dim1 / 10) + 1) * 10 - 1
+  ) AS "age_range",
+  FLOOR("table1".dim1 / 10) * 10 AS "age_range_order",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM
+  "db"."schema"."table1" AS "table1"
+GROUP BY
+  1,
+  2,
+  3
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: custom dimension queries matches snapshot for a sorted custom dimension query 1`] = `
+"WITH  age_range_cte AS (
+                    SELECT
+                        FLOOR(MIN("table1".dim1)) AS min_id,
+                        CEIL(MAX("table1".dim1)) AS max_id,
+                        FLOOR((MAX("table1".dim1) - MIN("table1".dim1)) / 3) AS bin_width
+                    FROM "db"."schema"."table1" AS \`table1\`
+                )
+SELECT
+  "table1".dim1 AS \`table1_dim1\`,
+CASE
+                    WHEN "table1".dim1 IS NULL THEN NULL
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 0, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 1)
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 1, ' - ', age_range_cte.min_id + age_range_cte.bin_width * 2)
+ELSE CONCAT(age_range_cte.min_id + age_range_cte.bin_width * 2, ' - ', age_range_cte.max_id)
+                    END
+                    AS \`age_range\`,
+CASE
+                        WHEN "table1".dim1 IS NULL THEN 3
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 0 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 1 THEN 0
+WHEN "table1".dim1 >= age_range_cte.min_id + age_range_cte.bin_width * 1 AND "table1".dim1 < age_range_cte.min_id + age_range_cte.bin_width * 2 THEN 1
+ELSE 2
+                        END
+                        AS \`age_range_order\`,
+  MAX("table1".number_column) AS \`table1_metric1\`
+FROM "db"."schema"."table1" AS \`table1\`
+
+CROSS JOIN age_range_cte
+GROUP BY 1,2,3
+ORDER BY \`age_range_order\` DESC
+LIMIT 10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/dateZoomQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/dateZoomQueries.test.ts.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: date zoom queries matches snapshot for a date-zoom query with raw-date filtering 1`] = `
+"SELECT
+  DATE_TRUNC('month', "orders".created_at) AS "orders_created_at",
+  COUNT("orders".order_id) AS "orders_order_count"
+FROM
+  "db"."schema"."orders" AS "orders"
+WHERE
+  (
+    (
+      (
+        ("orders".created_at) >= ('2024-09-01')
+        AND ("orders".created_at) <= ('2024-09-04')
+      )
+    )
+  )
+GROUP BY
+  1
+ORDER BY
+  "orders_created_at"
+LIMIT
+  10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/distinctQueries.test.ts.snap
@@ -1,0 +1,214 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a sum-distinct query with dimensions 1`] = `
+"WITH
+  dd_orders_total_revenue AS (
+    SELECT
+      "orders_payment_method",
+      "orders_status",
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "orders_total_revenue"
+    FROM
+      (
+        SELECT
+          "orders".payment_method AS "orders_payment_method",
+          "orders".status AS "orders_status",
+          "orders".amount AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "orders".line_item_id,
+              "orders".payment_method,
+              "orders".status
+            ORDER BY
+              "orders".amount
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."orders" AS "orders"
+      ) __dd_sub
+    GROUP BY
+      1,
+      2
+  ),
+  dd_base AS (
+    SELECT
+      "orders".payment_method AS "orders_payment_method",
+      "orders".status AS "orders_status"
+    FROM
+      "db"."schema"."orders" AS "orders"
+    GROUP BY
+      1,
+      2
+  )
+SELECT
+  dd_base.*,
+  dd_orders_total_revenue."orders_total_revenue" AS "orders_total_revenue"
+FROM
+  dd_base
+  INNER JOIN dd_orders_total_revenue ON (
+    dd_base."orders_payment_method" = dd_orders_total_revenue."orders_payment_method"
+    OR (
+      dd_base."orders_payment_method" IS NULL
+      AND dd_orders_total_revenue."orders_payment_method" IS NULL
+    )
+  )
+  AND (
+    dd_base."orders_status" = dd_orders_total_revenue."orders_status"
+    OR (
+      dd_base."orders_status" IS NULL
+      AND dd_orders_total_revenue."orders_status" IS NULL
+    )
+  )
+ORDER BY
+  "orders_total_revenue" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for a sum-distinct query without dimensions 1`] = `
+"WITH
+  dd_orders_total_revenue AS (
+    SELECT
+      SUM(
+        CASE
+          WHEN __dd_rn = 1 THEN __dd_val
+          ELSE NULL
+        END
+      ) AS "orders_total_revenue"
+    FROM
+      (
+        SELECT
+          "orders".amount AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "orders".line_item_id
+            ORDER BY
+              "orders".amount
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."orders" AS "orders"
+      ) __dd_sub
+  )
+SELECT
+  dd_orders_total_revenue."orders_total_revenue" AS "orders_total_revenue"
+FROM
+  dd_orders_total_revenue
+ORDER BY
+  "orders_total_revenue" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an average-distinct query with dimensions 1`] = `
+"WITH
+  dd_orders_avg_shipping_cost AS (
+    SELECT
+      "orders_payment_method",
+      CAST(
+        SUM(
+          CASE
+            WHEN __dd_rn = 1 THEN __dd_val
+            ELSE NULL
+          END
+        ) AS FLOAT
+      ) / CAST(
+        NULLIF(
+          COUNT(
+            CASE
+              WHEN __dd_rn = 1 THEN __dd_val
+            END
+          ),
+          0
+        ) AS FLOAT
+      ) AS "orders_avg_shipping_cost"
+    FROM
+      (
+        SELECT
+          "orders".payment_method AS "orders_payment_method",
+          "orders".shipping_cost AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "orders".line_item_id,
+              "orders".payment_method
+            ORDER BY
+              "orders".shipping_cost
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."orders" AS "orders"
+      ) __dd_sub
+    GROUP BY
+      1
+  ),
+  dd_base AS (
+    SELECT
+      "orders".payment_method AS "orders_payment_method"
+    FROM
+      "db"."schema"."orders" AS "orders"
+    GROUP BY
+      1
+  )
+SELECT
+  dd_base.*,
+  dd_orders_avg_shipping_cost."orders_avg_shipping_cost" AS "orders_avg_shipping_cost"
+FROM
+  dd_base
+  INNER JOIN dd_orders_avg_shipping_cost ON (
+    dd_base."orders_payment_method" = dd_orders_avg_shipping_cost."orders_payment_method"
+    OR (
+      dd_base."orders_payment_method" IS NULL
+      AND dd_orders_avg_shipping_cost."orders_payment_method" IS NULL
+    )
+  )
+ORDER BY
+  "orders_avg_shipping_cost" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: distinct queries matches snapshot for an average-distinct query without dimensions 1`] = `
+"WITH
+  dd_orders_avg_shipping_cost AS (
+    SELECT
+      CAST(
+        SUM(
+          CASE
+            WHEN __dd_rn = 1 THEN __dd_val
+            ELSE NULL
+          END
+        ) AS FLOAT
+      ) / CAST(
+        NULLIF(
+          COUNT(
+            CASE
+              WHEN __dd_rn = 1 THEN __dd_val
+            END
+          ),
+          0
+        ) AS FLOAT
+      ) AS "orders_avg_shipping_cost"
+    FROM
+      (
+        SELECT
+          "orders".shipping_cost AS __dd_val,
+          ROW_NUMBER() OVER (
+            PARTITION BY
+              "orders".line_item_id
+            ORDER BY
+              "orders".shipping_cost
+          ) AS __dd_rn
+        FROM
+          "db"."schema"."orders" AS "orders"
+      ) __dd_sub
+  )
+SELECT
+  dd_orders_avg_shipping_cost."orders_avg_shipping_cost" AS "orders_avg_shipping_cost"
+FROM
+  dd_orders_avg_shipping_cost
+ORDER BY
+  "orders_avg_shipping_cost" DESC
+LIMIT
+  10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/fanoutQueries.test.ts.snap
@@ -1,0 +1,216 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a cross-table metric query 1`] = `
+"WITH
+  cte_keys_customers AS (
+    SELECT DISTINCT
+      "customers".customer_id AS "pk_customer_id"
+    FROM
+      customers AS "customers"
+      LEFT OUTER JOIN orders AS "orders" ON ("customers".customer_id) = ("orders".customer_id)
+  ),
+  cte_metrics_customers AS (
+    SELECT
+      COUNT("customers".customer_id) AS "customers_total_customers"
+    FROM
+      cte_keys_customers
+      LEFT JOIN customers AS "customers" ON cte_keys_customers."pk_customer_id" = "customers".customer_id
+  ),
+  cte_unaffected AS (
+    SELECT
+      SUM("orders".amount) AS "orders_total_order_amount"
+    FROM
+      customers AS "customers"
+      LEFT OUTER JOIN orders AS "orders" ON ("customers".customer_id) = ("orders".customer_id)
+  )
+SELECT
+  cte_unaffected.*,
+  cte_unaffected."orders_total_order_amount" / cte_metrics_customers."customers_total_customers" AS "orders_revenue_per_customer"
+FROM
+  cte_unaffected
+  CROSS JOIN cte_metrics_customers
+LIMIT
+  100"
+`;
+
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a fanout-protected metric query 1`] = `
+"WITH
+  cte_keys_table2 AS (
+    SELECT DISTINCT
+      "table1".dim1 AS "table1_dim1",
+      "table2".dim2 AS "pk_dim2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  ),
+  cte_metrics_table2 AS (
+    SELECT
+      cte_keys_table2."table1_dim1",
+      SUM("table2".number_column) AS "table2_metric3"
+    FROM
+      cte_keys_table2
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_dim2" = "table2".dim2
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    GROUP BY
+      1
+  ),
+  metrics AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_table2."table2_metric3" AS "table2_metric3"
+    FROM
+      cte_unaffected
+      INNER JOIN cte_metrics_table2 ON (
+        cte_unaffected."table1_dim1" = cte_metrics_table2."table1_dim1"
+        OR (
+          cte_unaffected."table1_dim1" IS NULL
+          AND cte_metrics_table2."table1_dim1" IS NULL
+        )
+      )
+  )
+SELECT
+  *,
+  table1_dim1 + table2_metric2 AS "calc3"
+FROM
+  metrics
+ORDER BY
+  "table2_metric2" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a fanout-protected metric query without dimensions 1`] = `
+"WITH
+  cte_keys_table2 AS (
+    SELECT DISTINCT
+      "table2".dim2 AS "pk_dim2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  ),
+  cte_metrics_table2 AS (
+    SELECT
+      SUM("table2".number_column) AS "table2_metric3"
+    FROM
+      cte_keys_table2
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_dim2" = "table2".dim2
+  ),
+  cte_unaffected AS (
+    SELECT
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  ),
+  metrics AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_table2."table2_metric3" AS "table2_metric3"
+    FROM
+      cte_unaffected
+      CROSS JOIN cte_metrics_table2
+  )
+SELECT
+  *,
+  table1_dim1 + table2_metric2 AS "calc3"
+FROM
+  metrics
+ORDER BY
+  "table2_metric2" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a filter-only fanout metric query 1`] = `
+"WITH
+  cte_keys_table2 AS (
+    SELECT DISTINCT
+      "table1".dim1 AS "table1_dim1",
+      "table2".dim2 AS "pk_dim2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  ),
+  cte_metrics_table2 AS (
+    SELECT
+      cte_keys_table2."table1_dim1",
+      SUM("table2".number_column) AS "table2_metric3"
+    FROM
+      cte_keys_table2
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_dim2" = "table2".dim2
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    GROUP BY
+      1
+  ),
+  metrics AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_table2."table2_metric3" AS "table2_metric3"
+    FROM
+      cte_unaffected
+      INNER JOIN cte_metrics_table2 ON (
+        cte_unaffected."table1_dim1" = cte_metrics_table2."table1_dim1"
+        OR (
+          cte_unaffected."table1_dim1" IS NULL
+          AND cte_metrics_table2."table1_dim1" IS NULL
+        )
+      )
+  )
+SELECT
+  "table1_dim1",
+  "table1_metric1"
+FROM
+  metrics
+WHERE
+  ((("table2_metric3") > (100)))
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: fanout queries matches snapshot for a filter-only fanout query without selected dimensions 1`] = `
+"WITH
+  cte_keys_table2 AS (
+    SELECT DISTINCT
+      "table2".dim2 AS "pk_dim2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    WHERE
+      ((("table1".dim1) IN (2025)))
+  ),
+  cte_metrics_table2 AS (
+    SELECT
+      SUM("table2".number_column) AS "table2_metric3"
+    FROM
+      cte_keys_table2
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_dim2" = "table2".dim2
+  )
+SELECT
+  cte_metrics_table2."table2_metric3" AS "table2_metric3"
+FROM
+  cte_metrics_table2
+ORDER BY
+  "table2_metric3" DESC
+LIMIT
+  500"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/filterQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/filterQueries.test.ts.snap
@@ -1,0 +1,321 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a dimension filter query with OR logic 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1"
+FROM
+  "db"."schema"."table1" AS "table1"
+  LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+WHERE
+  (
+    (("table2".dim2) IN (0))
+    OR (("table2".dim2) IS NOT NULL)
+  )
+GROUP BY
+  1
+ORDER BY
+  "table1_dim1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a joined-dimension filter query 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1"
+FROM
+  "db"."schema"."table1" AS "table1"
+  LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+WHERE
+  ((("table2".dim2) IN (0)))
+GROUP BY
+  1
+ORDER BY
+  "table1_dim1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a metric-filter query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  )
+SELECT
+  *
+FROM
+  metrics
+WHERE
+  ((("table1_metric1") IN (0)))
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a nested metric-filter query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  )
+SELECT
+  *
+FROM
+  metrics
+WHERE
+  (
+    (("table1_metric1") IS NOT NULL)
+    AND (
+      (("table1_metric1") IN (0))
+      OR (("table1_metric1") IN (1))
+    )
+  )
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a nested-filter query 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1"
+FROM
+  "db"."schema"."table1" AS "table1"
+  LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+WHERE
+  (
+    (
+      (("table2".dim2) IN (0))
+      OR (("table2".dim2) IN (1))
+    )
+    AND (("table2".dim2) IS NOT NULL)
+  )
+GROUP BY
+  1
+ORDER BY
+  "table1_dim1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with a SQL filter using user attributes 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM
+  "db"."schema"."table1" AS "table1"
+WHERE
+  ('EU' = 'US')
+GROUP BY
+  1
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with a disabled dimension filter 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  )
+SELECT
+  *
+FROM
+  metrics
+WHERE
+  ((1 = 1))
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with a disabled joined-dimension metric filter 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      MAX("table2".dim2) AS "table1_metric_that_references_dim_from_table2"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+  )
+SELECT
+  *
+FROM
+  metrics
+WHERE
+  ((1 = 1))
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with an empty dimension filter 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1"
+FROM
+  "db"."schema"."table1" AS "table1"
+GROUP BY
+  1
+ORDER BY
+  "table1_dim1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with an empty metric filter 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1",
+  MAX("table1".number_column) AS "table1_metric1"
+FROM
+  "db"."schema"."table1" AS "table1"
+GROUP BY
+  1
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with custom user-attribute filter values 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1"
+FROM
+  "db"."schema"."table1" AS "table1"
+WHERE
+  ((("table1".shared) IN ('EU')))
+GROUP BY
+  1
+ORDER BY
+  "table1_dim1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with empty filter groups 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  )
+SELECT
+  *,
+  table1_dim1 + table1_metric1 AS "calc3"
+FROM
+  metrics
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with enabled and disabled filters 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1"
+FROM
+  "db"."schema"."table1" AS "table1"
+  LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+WHERE
+  (
+    (("table1".dim1) IN (1))
+    AND (1 = 1)
+  )
+GROUP BY
+  1
+ORDER BY
+  "table1_dim1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a query with intrinsic user-attribute filter values 1`] = `
+"SELECT
+  "table1".dim1 AS "table1_dim1"
+FROM
+  "db"."schema"."table1" AS "table1"
+WHERE
+  ((("table1".shared) IN ('mock@lightdash.com')))
+GROUP BY
+  1
+ORDER BY
+  "table1_dim1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a required-filter query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    WHERE
+      (("table2".dim2) IN (10))
+    GROUP BY
+      1
+  )
+SELECT
+  *,
+  table1_dim1 + table1_metric1 AS "calc3"
+FROM
+  metrics
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: filter queries matches snapshot for a table-calculation filter query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  ),
+  table_calculations AS (
+    SELECT
+      *,
+      table1_dim1 + table1_metric1 AS "calc3"
+    FROM
+      metrics
+  )
+SELECT
+  *
+FROM
+  table_calculations
+WHERE
+  ((("calc3") IN ('my value')))
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/nestedAggregateQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/nestedAggregateQueries.test.ts.snap
@@ -1,0 +1,303 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: nested aggregate queries matches snapshot for a fanout-protected nested-aggregate query 1`] = `
+"WITH
+  cte_keys_my_table AS (
+    SELECT DISTINCT
+      "fanout_users".title AS "fanout_users_title",
+      "my_table".id AS "pk_id"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+      LEFT OUTER JOIN "db"."schema"."fanout_users" AS "fanout_users" ON ("my_table".id) = ("fanout_users".account_id)
+  ),
+  cte_metrics_my_table AS (
+    SELECT
+      cte_keys_my_table."fanout_users_title",
+      COUNT("my_table".id) AS "my_table_count_records"
+    FROM
+      cte_keys_my_table
+      LEFT JOIN "db"."schema"."my_table" AS "my_table" ON cte_keys_my_table."pk_id" = "my_table".id
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      "fanout_users".title AS "fanout_users_title"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+      LEFT OUTER JOIN "db"."schema"."fanout_users" AS "fanout_users" ON ("my_table".id) = ("fanout_users".account_id)
+    GROUP BY
+      1
+  ),
+  nested_agg AS (
+    SELECT
+      "fanout_users".title AS "fanout_users_title",
+      MAX("my_table".value) AS "my_table_max_value"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+      LEFT OUTER JOIN "db"."schema"."fanout_users" AS "fanout_users" ON ("my_table".id) = ("fanout_users".account_id)
+    GROUP BY
+      1
+  ),
+  nested_agg_results AS (
+    SELECT
+      nested_agg."fanout_users_title",
+      sum(nested_agg."my_table_max_value") AS "my_table_sum_of_max"
+    FROM
+      nested_agg
+    GROUP BY
+      nested_agg."fanout_users_title",
+      nested_agg."my_table_max_value"
+  ),
+  na_base AS (
+    SELECT
+      cte_unaffected.*,
+      cte_metrics_my_table."my_table_count_records" AS "my_table_count_records"
+    FROM
+      cte_unaffected
+      INNER JOIN cte_metrics_my_table ON (
+        cte_unaffected."fanout_users_title" = cte_metrics_my_table."fanout_users_title"
+        OR (
+          cte_unaffected."fanout_users_title" IS NULL
+          AND cte_metrics_my_table."fanout_users_title" IS NULL
+        )
+      )
+  )
+SELECT
+  na_base.*,
+  nested_agg_results."my_table_sum_of_max"
+FROM
+  na_base
+  INNER JOIN nested_agg_results ON (
+    na_base."fanout_users_title" = nested_agg_results."fanout_users_title"
+    OR (
+      na_base."fanout_users_title" IS NULL
+      AND nested_agg_results."fanout_users_title" IS NULL
+    )
+  )
+ORDER BY
+  "my_table_sum_of_max" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: nested aggregate queries matches snapshot for a max-by query with raw helper metrics 1`] = `
+"WITH
+  nested_agg AS (
+    SELECT
+      "my_table".category AS "my_table_category"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+    GROUP BY
+      1
+  ),
+  nested_agg_mixed AS (
+    SELECT
+      "my_table".category AS "my_table_category",
+      max_by (("my_table".value), ("my_table".updated_on)) AS "my_table_max_by_of_raw"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+      INNER JOIN nested_agg ON (
+        "my_table".category = nested_agg."my_table_category"
+        OR (
+          "my_table".category IS NULL
+          AND nested_agg."my_table_category" IS NULL
+        )
+      )
+    GROUP BY
+      1
+  ),
+  na_base AS (
+    SELECT
+      "my_table".category AS "my_table_category"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+    GROUP BY
+      1
+  )
+SELECT
+  na_base.*,
+  nested_agg_mixed."my_table_max_by_of_raw"
+FROM
+  na_base
+  INNER JOIN nested_agg_mixed ON (
+    na_base."my_table_category" = nested_agg_mixed."my_table_category"
+    OR (
+      na_base."my_table_category" IS NULL
+      AND nested_agg_mixed."my_table_category" IS NULL
+    )
+  )
+ORDER BY
+  "my_table_max_by_of_raw" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: nested aggregate queries matches snapshot for a mixed raw-and-aggregate nested query 1`] = `
+"WITH
+  nested_agg AS (
+    SELECT
+      "my_table".category AS "my_table_category",
+      MAX("my_table".value) AS "my_table_max_value"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+    GROUP BY
+      1
+  ),
+  nested_agg_mixed AS (
+    SELECT
+      "my_table".category AS "my_table_category",
+      (
+        ARRAY_AGG(
+          ("my_table".value)
+          ORDER BY
+            nested_agg."my_table_max_value" DESC
+        )
+      ) [1] AS "my_table_mixed_raw_agg_repro"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+      INNER JOIN nested_agg ON (
+        "my_table".category = nested_agg."my_table_category"
+        OR (
+          "my_table".category IS NULL
+          AND nested_agg."my_table_category" IS NULL
+        )
+      )
+    GROUP BY
+      1
+  ),
+  na_base AS (
+    SELECT
+      "my_table".category AS "my_table_category"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+    GROUP BY
+      1
+  )
+SELECT
+  na_base.*,
+  nested_agg_mixed."my_table_mixed_raw_agg_repro"
+FROM
+  na_base
+  INNER JOIN nested_agg_mixed ON (
+    na_base."my_table_category" = nested_agg_mixed."my_table_category"
+    OR (
+      na_base."my_table_category" IS NULL
+      AND nested_agg_mixed."my_table_category" IS NULL
+    )
+  )
+ORDER BY
+  "my_table_mixed_raw_agg_repro" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: nested aggregate queries matches snapshot for a nested-aggregate query with dimensions 1`] = `
+"WITH
+  nested_agg AS (
+    SELECT
+      "my_table".category AS "my_table_category",
+      MAX("my_table".value) AS "my_table_max_value"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+    GROUP BY
+      1
+  ),
+  nested_agg_results AS (
+    SELECT
+      nested_agg."my_table_category",
+      sum(nested_agg."my_table_max_value") AS "my_table_sum_of_max"
+    FROM
+      nested_agg
+    GROUP BY
+      nested_agg."my_table_category",
+      nested_agg."my_table_max_value"
+  ),
+  na_base AS (
+    SELECT
+      "my_table".category AS "my_table_category"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+    GROUP BY
+      1
+  )
+SELECT
+  na_base.*,
+  nested_agg_results."my_table_sum_of_max"
+FROM
+  na_base
+  INNER JOIN nested_agg_results ON (
+    na_base."my_table_category" = nested_agg_results."my_table_category"
+    OR (
+      na_base."my_table_category" IS NULL
+      AND nested_agg_results."my_table_category" IS NULL
+    )
+  )
+ORDER BY
+  "my_table_sum_of_max" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: nested aggregate queries matches snapshot for a transitive nested-aggregate query 1`] = `
+"WITH
+  nested_agg AS (
+    SELECT
+      "my_table".category AS "my_table_category",
+      COUNT("my_table".id) AS "my_table_count_records",
+      MAX("my_table".value) AS "my_table_max_value"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+    GROUP BY
+      1
+  ),
+  nested_agg_results AS (
+    SELECT
+      nested_agg."my_table_category",
+      SUM(
+        CASE
+          WHEN nested_agg."my_table_max_value" > 100 THEN 1
+          ELSE 0
+        END
+      ) AS "my_table_sum_case_of_max",
+      (
+        SUM(
+          CASE
+            WHEN nested_agg."my_table_max_value" > 100 THEN 1
+            ELSE 0
+          END
+        )
+      ) / NULLIF(nested_agg."my_table_count_records", 0) AS "my_table_ratio_of_sum_case"
+    FROM
+      nested_agg
+    GROUP BY
+      nested_agg."my_table_category",
+      nested_agg."my_table_count_records",
+      nested_agg."my_table_max_value"
+  ),
+  na_base AS (
+    SELECT
+      "my_table".category AS "my_table_category"
+    FROM
+      "db"."schema"."my_table" AS "my_table"
+    GROUP BY
+      1
+  )
+SELECT
+  na_base.*,
+  nested_agg_results."my_table_sum_case_of_max",
+  nested_agg_results."my_table_ratio_of_sum_case"
+FROM
+  na_base
+  INNER JOIN nested_agg_results ON (
+    na_base."my_table_category" = nested_agg_results."my_table_category"
+    OR (
+      na_base."my_table_category" IS NULL
+      AND nested_agg_results."my_table_category" IS NULL
+    )
+  )
+ORDER BY
+  "my_table_ratio_of_sum_case" DESC
+LIMIT
+  10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/periodOverPeriodQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/periodOverPeriodQueries.test.ts.snap
@@ -1,0 +1,395 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapshot for a fanout-protected period-over-period query 1`] = `
+"WITH
+  cte_keys_table2 AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "table2".order_date) AS "table2_order_date_year",
+      "table2".id AS "pk_id"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    WHERE
+      (
+        (("table2".is_completed) = true)
+        AND (
+          (DATE_TRUNC('YEAR', "table2".order_date)) = ('2025-01-01')
+        )
+      )
+  ),
+  cte_metrics_table2 AS (
+    SELECT
+      cte_keys_table2."table2_order_date_year",
+      SUM("table2".amount) AS "table2_metric_amount",
+      SUM("table2".amount) AS "table2_metric_amount__pop__year_1__fanout"
+    FROM
+      cte_keys_table2
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_keys_table2."pk_id" = "table2".id
+    GROUP BY
+      1
+  ),
+  cte_pop_min_max_table2__year_1__00355f4s AS (
+    SELECT
+      MIN(cte_keys_table2."table2_order_date_year") as min_date,
+      MAX(cte_keys_table2."table2_order_date_year") as max_date
+    FROM
+      cte_keys_table2
+  ),
+  cte_pop_keys_table2__year_1__00355f4s AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "table2".order_date) AS "table2_order_date_year",
+      "table2".id AS "pk_id"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+      LEFT JOIN cte_pop_min_max_table2__year_1__00355f4s ON TRUE
+    WHERE
+      ((("table2".is_completed) = true))
+      AND DATE_TRUNC('YEAR', "table2".order_date) >= cte_pop_min_max_table2__year_1__00355f4s.min_date - INTERVAL '1 YEAR'
+      AND DATE_TRUNC('YEAR', "table2".order_date) <= cte_pop_min_max_table2__year_1__00355f4s.max_date - INTERVAL '1 YEAR'
+  ),
+  cte_pop_metrics_table2__year_1__00355f4s AS (
+    SELECT
+      cte_pop_keys_table2__year_1__00355f4s."table2_order_date_year",
+      SUM("table2".amount) AS "table2_metric_amount__pop__year_1__fanout"
+    FROM
+      cte_pop_keys_table2__year_1__00355f4s
+      LEFT JOIN "db"."schema"."table2" AS "table2" ON cte_pop_keys_table2__year_1__00355f4s."pk_id" = "table2".id
+    GROUP BY
+      1
+  ),
+  cte_unaffected AS (
+    SELECT
+      DATE_TRUNC('YEAR', "table2".order_date) AS "table2_order_date_year"
+    FROM
+      "db"."schema"."table1" AS "table1"
+      LEFT OUTER JOIN "db"."schema"."table2" AS "table2" ON ("table1".shared) = ("table2".shared)
+    WHERE
+      (
+        (("table2".is_completed) = true)
+        AND (
+          (DATE_TRUNC('YEAR', "table2".order_date)) = ('2025-01-01')
+        )
+      )
+    GROUP BY
+      1
+  )
+SELECT
+  cte_unaffected.*,
+  cte_metrics_table2."table2_metric_amount" AS "table2_metric_amount",
+  cte_metrics_table2."table2_metric_amount__pop__year_1__fanout" AS "table2_metric_amount__pop__year_1__fanout",
+  cte_pop_metrics_table2__year_1__00355f4s."table2_metric_amount__pop__year_1__fanout" AS "table2_metric_amount__pop__year_1__fanout"
+FROM
+  cte_unaffected
+  INNER JOIN cte_metrics_table2 ON (
+    cte_unaffected."table2_order_date_year" = cte_metrics_table2."table2_order_date_year"
+    OR (
+      cte_unaffected."table2_order_date_year" IS NULL
+      AND cte_metrics_table2."table2_order_date_year" IS NULL
+    )
+  )
+  LEFT JOIN cte_pop_metrics_table2__year_1__00355f4s ON (
+    cte_unaffected."table2_order_date_year" = cte_pop_metrics_table2__year_1__00355f4s."table2_order_date_year" + INTERVAL '1 YEAR'
+  )
+ORDER BY
+  "table2_order_date_year" DESC
+LIMIT
+  100"
+`;
+
+exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapshot for a one-to-many fanout-protected period-over-period query 1`] = `
+"WITH
+  cte_keys_country_orders AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".country AS "country_orders_country",
+      "order_currencies".currency AS "order_currencies_currency",
+      "country_orders".order_id AS "pk_order_id"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+  ),
+  cte_metrics_country_orders AS (
+    SELECT
+      cte_keys_country_orders."country_orders_order_date_year",
+      cte_keys_country_orders."country_orders_country",
+      cte_keys_country_orders."order_currencies_currency",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount__pop__year_1__country"
+    FROM
+      cte_keys_country_orders
+      LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_keys_country_orders."pk_order_id" = "country_orders".order_id
+    GROUP BY
+      1,
+      2,
+      3
+  ),
+  cte_pop_min_max_country_orders__year_1__00rp9exa AS (
+    SELECT
+      MIN(
+        cte_keys_country_orders."country_orders_order_date_year"
+      ) as min_date,
+      MAX(
+        cte_keys_country_orders."country_orders_order_date_year"
+      ) as max_date
+    FROM
+      cte_keys_country_orders
+  ),
+  cte_pop_keys_country_orders__year_1__00rp9exa AS (
+    SELECT DISTINCT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".country AS "country_orders_country",
+      "order_currencies".currency AS "order_currencies_currency",
+      "country_orders".order_id AS "pk_order_id"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+      LEFT JOIN cte_pop_min_max_country_orders__year_1__00rp9exa ON TRUE
+    WHERE
+      DATE_TRUNC('YEAR', "country_orders".order_date) >= cte_pop_min_max_country_orders__year_1__00rp9exa.min_date - INTERVAL '1 YEAR'
+      AND DATE_TRUNC('YEAR', "country_orders".order_date) <= cte_pop_min_max_country_orders__year_1__00rp9exa.max_date - INTERVAL '1 YEAR'
+  ),
+  cte_pop_metrics_country_orders__year_1__00rp9exa AS (
+    SELECT
+      cte_pop_keys_country_orders__year_1__00rp9exa."country_orders_order_date_year",
+      cte_pop_keys_country_orders__year_1__00rp9exa."country_orders_country",
+      cte_pop_keys_country_orders__year_1__00rp9exa."order_currencies_currency",
+      SUM("country_orders".amount) AS "country_orders_total_order_amount__pop__year_1__country"
+    FROM
+      cte_pop_keys_country_orders__year_1__00rp9exa
+      LEFT JOIN "postgres"."jaffle"."country_orders" AS "country_orders" ON cte_pop_keys_country_orders__year_1__00rp9exa."pk_order_id" = "country_orders".order_id
+    GROUP BY
+      1,
+      2,
+      3
+  ),
+  cte_unaffected AS (
+    SELECT
+      DATE_TRUNC('YEAR', "country_orders".order_date) AS "country_orders_order_date_year",
+      "country_orders".country AS "country_orders_country",
+      "order_currencies".currency AS "order_currencies_currency"
+    FROM
+      "postgres"."jaffle"."country_orders" AS "country_orders"
+      LEFT OUTER JOIN "postgres"."jaffle"."order_currencies" AS "order_currencies" ON ("country_orders".order_id) = ("order_currencies".order_id)
+    GROUP BY
+      1,
+      2,
+      3
+  )
+SELECT
+  cte_unaffected.*,
+  cte_metrics_country_orders."country_orders_total_order_amount" AS "country_orders_total_order_amount",
+  cte_metrics_country_orders."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country",
+  cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_total_order_amount__pop__year_1__country" AS "country_orders_total_order_amount__pop__year_1__country"
+FROM
+  cte_unaffected
+  INNER JOIN cte_metrics_country_orders ON (
+    cte_unaffected."country_orders_order_date_year" = cte_metrics_country_orders."country_orders_order_date_year"
+    OR (
+      cte_unaffected."country_orders_order_date_year" IS NULL
+      AND cte_metrics_country_orders."country_orders_order_date_year" IS NULL
+    )
+  )
+  AND (
+    cte_unaffected."country_orders_country" = cte_metrics_country_orders."country_orders_country"
+    OR (
+      cte_unaffected."country_orders_country" IS NULL
+      AND cte_metrics_country_orders."country_orders_country" IS NULL
+    )
+  )
+  AND (
+    cte_unaffected."order_currencies_currency" = cte_metrics_country_orders."order_currencies_currency"
+    OR (
+      cte_unaffected."order_currencies_currency" IS NULL
+      AND cte_metrics_country_orders."order_currencies_currency" IS NULL
+    )
+  )
+  LEFT JOIN cte_pop_metrics_country_orders__year_1__00rp9exa ON (
+    cte_unaffected."country_orders_order_date_year" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_order_date_year" + INTERVAL '1 YEAR'
+  )
+  AND (
+    cte_unaffected."country_orders_country" = cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_country"
+    OR (
+      cte_unaffected."country_orders_country" IS NULL
+      AND cte_pop_metrics_country_orders__year_1__00rp9exa."country_orders_country" IS NULL
+    )
+  )
+  AND (
+    cte_unaffected."order_currencies_currency" = cte_pop_metrics_country_orders__year_1__00rp9exa."order_currencies_currency"
+    OR (
+      cte_unaffected."order_currencies_currency" IS NULL
+      AND cte_pop_metrics_country_orders__year_1__00rp9exa."order_currencies_currency" IS NULL
+    )
+  )
+ORDER BY
+  "country_orders_order_date_year" DESC
+LIMIT
+  100"
+`;
+
+exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapshot for a period-over-period query 1`] = `
+"WITH
+  base_metrics AS (
+    SELECT
+      DATE_TRUNC('YEAR', "orders".order_date) AS "orders_order_date_year",
+      SUM("orders".amount) AS "orders_total_order_amount"
+    FROM
+      "postgres"."jaffle"."orders" AS "orders"
+    WHERE
+      (
+        (("orders".is_completed) = true)
+        AND (
+          (DATE_TRUNC('YEAR', "orders".order_date)) = ('2025-01-01')
+        )
+      )
+    GROUP BY
+      1
+  ),
+  pop_min_max_year_1__00jq2hag AS (
+    SELECT
+      MIN(base_metrics."orders_order_date_year") as min_date,
+      MAX(base_metrics."orders_order_date_year") as max_date
+    FROM
+      base_metrics
+  ),
+  pop_metrics_year_1__00jq2hag AS (
+    SELECT
+      DATE_TRUNC('YEAR', "orders".order_date) AS "orders_order_date_year",
+      SUM("orders".amount) AS "orders_total_order_amount__pop__year_1__snapshot"
+    FROM
+      "postgres"."jaffle"."orders" AS "orders"
+      LEFT JOIN pop_min_max_year_1__00jq2hag ON TRUE
+    WHERE
+      ((("orders".is_completed) = true))
+      AND DATE_TRUNC('YEAR', "orders".order_date) >= pop_min_max_year_1__00jq2hag.min_date - INTERVAL '1 YEAR'
+      AND DATE_TRUNC('YEAR', "orders".order_date) <= pop_min_max_year_1__00jq2hag.max_date - INTERVAL '1 YEAR'
+    GROUP BY
+      1
+  ),
+  metrics AS (
+    SELECT
+      base_metrics.*,
+      pop_metrics_year_1__00jq2hag."orders_total_order_amount__pop__year_1__snapshot" AS "orders_total_order_amount__pop__year_1__snapshot"
+    FROM
+      base_metrics
+      LEFT JOIN pop_metrics_year_1__00jq2hag ON (
+        base_metrics."orders_order_date_year" = pop_metrics_year_1__00jq2hag."orders_order_date_year" + INTERVAL '1 YEAR'
+      )
+  )
+SELECT
+  *
+FROM
+  metrics
+ORDER BY
+  "orders_order_date_year" DESC
+LIMIT
+  500"
+`;
+
+exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapshot for a period-over-period query with only a date filter 1`] = `
+"WITH
+  base_metrics AS (
+    SELECT
+      DATE_TRUNC('YEAR', "orders".order_date) AS "orders_order_date_year",
+      SUM("orders".amount) AS "orders_total_order_amount"
+    FROM
+      "postgres"."jaffle"."orders" AS "orders"
+    WHERE
+      (
+        (
+          (DATE_TRUNC('YEAR', "orders".order_date)) = ('2025-01-01')
+        )
+      )
+    GROUP BY
+      1
+  ),
+  pop_min_max_year_1__00jq2hag AS (
+    SELECT
+      MIN(base_metrics."orders_order_date_year") as min_date,
+      MAX(base_metrics."orders_order_date_year") as max_date
+    FROM
+      base_metrics
+  ),
+  pop_metrics_year_1__00jq2hag AS (
+    SELECT
+      DATE_TRUNC('YEAR', "orders".order_date) AS "orders_order_date_year",
+      SUM("orders".amount) AS "orders_total_order_amount__pop__year_1__snapshot"
+    FROM
+      "postgres"."jaffle"."orders" AS "orders"
+      LEFT JOIN pop_min_max_year_1__00jq2hag ON TRUE
+    WHERE
+      DATE_TRUNC('YEAR', "orders".order_date) >= pop_min_max_year_1__00jq2hag.min_date - INTERVAL '1 YEAR'
+      AND DATE_TRUNC('YEAR', "orders".order_date) <= pop_min_max_year_1__00jq2hag.max_date - INTERVAL '1 YEAR'
+    GROUP BY
+      1
+  ),
+  metrics AS (
+    SELECT
+      base_metrics.*,
+      pop_metrics_year_1__00jq2hag."orders_total_order_amount__pop__year_1__snapshot" AS "orders_total_order_amount__pop__year_1__snapshot"
+    FROM
+      base_metrics
+      LEFT JOIN pop_metrics_year_1__00jq2hag ON (
+        base_metrics."orders_order_date_year" = pop_metrics_year_1__00jq2hag."orders_order_date_year" + INTERVAL '1 YEAR'
+      )
+  )
+SELECT
+  *
+FROM
+  metrics
+ORDER BY
+  "orders_order_date_year" DESC
+LIMIT
+  500"
+`;
+
+exports[`MetricQueryBuilder snapshot: period-over-period queries matches snapshot for a period-over-period query without filters 1`] = `
+"WITH
+  base_metrics AS (
+    SELECT
+      DATE_TRUNC('YEAR', "orders".order_date) AS "orders_order_date_year",
+      SUM("orders".amount) AS "orders_total_order_amount"
+    FROM
+      "postgres"."jaffle"."orders" AS "orders"
+    GROUP BY
+      1
+  ),
+  pop_min_max_year_1__00jq2hag AS (
+    SELECT
+      MIN(base_metrics."orders_order_date_year") as min_date,
+      MAX(base_metrics."orders_order_date_year") as max_date
+    FROM
+      base_metrics
+  ),
+  pop_metrics_year_1__00jq2hag AS (
+    SELECT
+      DATE_TRUNC('YEAR', "orders".order_date) AS "orders_order_date_year",
+      SUM("orders".amount) AS "orders_total_order_amount__pop__year_1__snapshot"
+    FROM
+      "postgres"."jaffle"."orders" AS "orders"
+      LEFT JOIN pop_min_max_year_1__00jq2hag ON TRUE
+    WHERE
+      DATE_TRUNC('YEAR', "orders".order_date) >= pop_min_max_year_1__00jq2hag.min_date - INTERVAL '1 YEAR'
+      AND DATE_TRUNC('YEAR', "orders".order_date) <= pop_min_max_year_1__00jq2hag.max_date - INTERVAL '1 YEAR'
+    GROUP BY
+      1
+  ),
+  metrics AS (
+    SELECT
+      base_metrics.*,
+      pop_metrics_year_1__00jq2hag."orders_total_order_amount__pop__year_1__snapshot" AS "orders_total_order_amount__pop__year_1__snapshot"
+    FROM
+      base_metrics
+      LEFT JOIN pop_metrics_year_1__00jq2hag ON (
+        base_metrics."orders_order_date_year" = pop_metrics_year_1__00jq2hag."orders_order_date_year" + INTERVAL '1 YEAR'
+      )
+  )
+SELECT
+  *
+FROM
+  metrics
+ORDER BY
+  "orders_order_date_year" DESC
+LIMIT
+  500"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/postCalculationQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/postCalculationQueries.test.ts.snap
@@ -1,0 +1,69 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: post-calculation queries matches snapshot for a percent-of-total post-calculation query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  ),
+  postcalculation_metrics AS (
+    SELECT
+      *,
+      (
+        CAST(metrics."table1_metric1" AS FLOAT) / CAST(
+          NULLIF(SUM(metrics."table1_metric1") OVER (), 0) AS FLOAT
+        )
+      ) AS "table1_percent_of_total_metric"
+    FROM
+      metrics
+  )
+SELECT
+  *
+FROM
+  postcalculation_metrics
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: post-calculation queries matches snapshot for a running-total post-calculation query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      "table1".category AS "table1_category",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1,
+      2
+  ),
+  postcalculation_metrics AS (
+    SELECT
+      *,
+      SUM(metrics."table1_metric1") OVER (
+        PARTITION BY
+          "table1_category"
+        ORDER BY
+          "table1_metric1" DESC ROWS BETWEEN UNBOUNDED PRECEDING
+          AND CURRENT ROW
+      ) AS "table1_running_total_metric"
+    FROM
+      metrics
+  )
+SELECT
+  *
+FROM
+  postcalculation_metrics
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/sortQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/sortQueries.test.ts.snap
@@ -1,0 +1,70 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: sort queries matches snapshot for a day-of-week-name sort query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  )
+SELECT
+  *
+FROM
+  metrics
+ORDER BY
+  (
+    CASE
+      WHEN "table1_dim1" = 'Sunday' THEN 1
+      WHEN "table1_dim1" = 'Monday' THEN 2
+      WHEN "table1_dim1" = 'Tuesday' THEN 3
+      WHEN "table1_dim1" = 'Wednesday' THEN 4
+      WHEN "table1_dim1" = 'Thursday' THEN 5
+      WHEN "table1_dim1" = 'Friday' THEN 6
+      WHEN "table1_dim1" = 'Saturday' THEN 7
+      ELSE 0
+    END
+  ) DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: sort queries matches snapshot for a month-name sort query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  )
+SELECT
+  *
+FROM
+  metrics
+ORDER BY
+  (
+    CASE
+      WHEN "table1_dim1" = 'January' THEN 1
+      WHEN "table1_dim1" = 'February' THEN 2
+      WHEN "table1_dim1" = 'March' THEN 3
+      WHEN "table1_dim1" = 'April' THEN 4
+      WHEN "table1_dim1" = 'May' THEN 5
+      WHEN "table1_dim1" = 'June' THEN 6
+      WHEN "table1_dim1" = 'July' THEN 7
+      WHEN "table1_dim1" = 'August' THEN 8
+      WHEN "table1_dim1" = 'September' THEN 9
+      WHEN "table1_dim1" = 'October' THEN 10
+      WHEN "table1_dim1" = 'November' THEN 11
+      WHEN "table1_dim1" = 'December' THEN 12
+      ELSE 0
+    END
+  ) DESC
+LIMIT
+  10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/totalsQueries.test.ts.snap
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/__snapshots__/totalsQueries.test.ts.snap
@@ -1,0 +1,207 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a dependent total-calculation query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  ),
+  column_totals AS (
+    SELECT
+      MAX("table1".number_column) AS "table1_metric1__total"
+    FROM
+      "db"."schema"."table1" AS "table1"
+  ),
+  with_totals AS (
+    SELECT
+      metrics.*,
+      column_totals."table1_metric1__total"
+    FROM
+      metrics
+      CROSS JOIN column_totals
+  ),
+  tc_pct_total AS (
+    SELECT
+      *,
+      "table1_metric1" / "table1_metric1__total" AS "pct_total"
+    FROM
+      with_totals
+  ),
+  tc_double_pct AS (
+    SELECT
+      *,
+      "pct_total" * 2 AS "double_pct"
+    FROM
+      tc_pct_total
+  )
+SELECT
+  *
+FROM
+  tc_double_pct
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a pivoted totals query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  ),
+  column_totals AS (
+    SELECT
+      MAX("table1".number_column) AS "table1_metric1__total"
+    FROM
+      "db"."schema"."table1" AS "table1"
+  ),
+  row_totals AS (
+    SELECT
+      "table1_dim1",
+      SUM("table1_metric1") AS "table1_metric1__row_total"
+    FROM
+      metrics
+    GROUP BY
+      1
+  ),
+  with_totals AS (
+    SELECT
+      metrics.*,
+      column_totals."table1_metric1__total",
+      row_totals."table1_metric1__row_total"
+    FROM
+      metrics
+      CROSS JOIN column_totals
+      LEFT JOIN row_totals ON (
+        metrics."table1_dim1" = row_totals."table1_dim1"
+        OR (
+          metrics."table1_dim1" IS NULL
+          AND row_totals."table1_dim1" IS NULL
+        )
+      )
+  )
+SELECT
+  *,
+  "table1_metric1" / "table1_metric1__total" AS "pct_total",
+  "table1_metric1" / "table1_metric1__row_total" AS "pct_row"
+FROM
+  with_totals
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a row-total query using pivot dimensions 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  ),
+  row_totals AS (
+    SELECT
+      "table1_dim1",
+      SUM("table1_metric1") AS "table1_metric1__row_total"
+    FROM
+      metrics
+    GROUP BY
+      1
+  ),
+  with_totals AS (
+    SELECT
+      metrics.*,
+      row_totals."table1_metric1__row_total"
+    FROM
+      metrics
+      LEFT JOIN row_totals ON (
+        metrics."table1_dim1" = row_totals."table1_dim1"
+        OR (
+          metrics."table1_dim1" IS NULL
+          AND row_totals."table1_dim1" IS NULL
+        )
+      )
+  )
+SELECT
+  *,
+  "table1_metric1" / "table1_metric1__row_total" AS "pct_of_row"
+FROM
+  with_totals
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for a row-total query without pivot metadata 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      MAX("table1".number_column) AS "table1_metric1"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  )
+SELECT
+  *,
+  "table1_metric1" / "table1_metric1" AS "pct_of_row"
+FROM
+  metrics
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;
+
+exports[`MetricQueryBuilder snapshot: totals queries matches snapshot for an average-metric total query 1`] = `
+"WITH
+  metrics AS (
+    SELECT
+      "table1".dim1 AS "table1_dim1",
+      AVG("table1".number_column) AS "table1_avg_metric"
+    FROM
+      "db"."schema"."table1" AS "table1"
+    GROUP BY
+      1
+  ),
+  column_totals AS (
+    SELECT
+      AVG("table1".number_column) AS "table1_avg_metric__total"
+    FROM
+      "db"."schema"."table1" AS "table1"
+  ),
+  with_totals AS (
+    SELECT
+      metrics.*,
+      column_totals."table1_avg_metric__total"
+    FROM
+      metrics
+      CROSS JOIN column_totals
+  )
+SELECT
+  *,
+  "table1_avg_metric" / "table1_avg_metric__total" AS "pct_of_total"
+FROM
+  with_totals
+ORDER BY
+  "table1_metric1" DESC
+LIMIT
+  10"
+`;

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/coreQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/coreQueries.test.ts
@@ -1,0 +1,109 @@
+import {
+    bigqueryClientMock,
+    EXPLORE,
+    EXPLORE_ALL_JOIN_TYPES_CHAIN,
+    EXPLORE_BIGQUERY,
+    EXPLORE_JOIN_CHAIN,
+    METRIC_QUERY,
+    METRIC_QUERY_JOIN_CHAIN,
+    METRIC_QUERY_TWO_TABLES,
+    METRIC_QUERY_WITH_ADDITIONAL_METRIC,
+    METRIC_QUERY_WITH_TABLE_REFERENCE,
+} from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+describe('MetricQueryBuilder snapshot: core queries', () => {
+    // Baseline grouped metric query with one dimension, one aggregate metric,
+    // and an inline table calculation emitted in the final SELECT.
+    test('matches snapshot for a simple metric query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers adapter-specific quoting and SQL shape for the same baseline metric query,
+    // protecting the BigQuery compilation path separately from the Postgres default path.
+    test('matches snapshot for a simple metric query in BigQuery', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_BIGQUERY,
+                compiledMetricQuery: METRIC_QUERY,
+                warehouseSqlBuilder: bigqueryClientMock,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the standard multi-table metric path, where grouped metrics are built from a joined table
+    // and then projected through the top-level metrics CTE with ordering on a joined-table measure.
+    test('matches snapshot for a metric query across two tables', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_TWO_TABLES,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers non-selected table joins introduced by field references,
+    // where a base-table dimension compiles to SQL that directly references a joined table field.
+    test('matches snapshot for a field-reference query across tables', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_TABLE_REFERENCE,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers multi-hop join resolution, ensuring the builder emits the full intermediary join chain
+    // before grouping and sorting on fields that only exist several joins away from the base table.
+    test('matches snapshot for an intermediary join-chain query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_JOIN_CHAIN,
+                compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers mixed join semantics across a multi-hop path, protecting the join-ordering logic
+    // when INNER, LEFT, FULL, and RIGHT joins need to be preserved in the compiled SQL.
+    test('matches snapshot for an all-join-types intermediary chain query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_ALL_JOIN_TYPES_CHAIN,
+                compiledMetricQuery: METRIC_QUERY_JOIN_CHAIN,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers queries with additional metrics that are projected alongside the requested fields,
+    // ensuring the builder materializes helper metrics without changing the primary grouping shape.
+    test('matches snapshot for a query with additional metrics', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_ADDITIONAL_METRIC,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the default-sort fallback when a query returns a single aggregated row,
+    // ensuring MetricQueryBuilder omits ORDER BY entirely when no dimensions are selected.
+    test('matches snapshot for a metric-only query without default sorting', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY,
+                    dimensions: [],
+                    metrics: ['table1_metric1'],
+                    sorts: [],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/customDimensionQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/customDimensionQueries.test.ts
@@ -1,0 +1,137 @@
+import { BinType, CustomDimensionType } from '@lightdash/common';
+import {
+    bigqueryClientMock,
+    EXPLORE,
+    METRIC_QUERY_WITH_CUSTOM_DIMENSION,
+    METRIC_QUERY_WITH_CUSTOM_SQL_DIMENSION,
+} from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+describe('MetricQueryBuilder snapshot: custom dimension queries', () => {
+    // Covers BigQuery numeric bin dimensions using bin-count mode, where the builder must emit
+    // both the rendered bucket label and the hidden order column used for stable sorting.
+    test('matches snapshot for a binned custom dimension query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_CUSTOM_DIMENSION,
+                warehouseSqlBuilder: bigqueryClientMock,
+                userAttributes: {},
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers fixed-width binning on BigQuery, protecting the alternate bucket-label SQL
+    // and order-column generation for width-based custom dimensions.
+    test('matches snapshot for a fixed-width custom dimension query in BigQuery', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
+                    compiledCustomDimensions: [
+                        {
+                            id: 'age_range',
+                            name: 'Age range',
+                            type: CustomDimensionType.BIN,
+                            dimensionId: 'table1_dim1',
+                            table: 'table1',
+                            binType: BinType.FIXED_WIDTH,
+                            binWidth: 10,
+                        },
+                    ],
+                },
+                warehouseSqlBuilder: bigqueryClientMock,
+                userAttributes: {},
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers a custom dimension combined with a table calculation, where the builder must project
+    // the custom dimension alias cleanly into the final calculation-select layer.
+    test('matches snapshot for a custom dimension query with a table calculation', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
+                    tableCalculations: [
+                        {
+                            name: 'calc3',
+                            displayName: '',
+                            sql: '${table1.dim1} + 1',
+                        },
+                    ],
+                    compiledTableCalculations: [
+                        {
+                            name: 'calc3',
+                            displayName: '',
+                            sql: '${table1.dim1} + 1',
+                            compiledSql: 'table1_dim1 + 1',
+                            dependsOn: [],
+                        },
+                    ],
+                },
+                warehouseSqlBuilder: bigqueryClientMock,
+                userAttributes: {},
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers ordering directly by the custom dimension bucket, ensuring the generated SQL
+    // sorts by the hidden bucket-order field rather than the display label.
+    test('matches snapshot for a sorted custom dimension query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
+                    sorts: [
+                        {
+                            fieldId: 'age_range',
+                            descending: true,
+                        },
+                    ],
+                },
+                warehouseSqlBuilder: bigqueryClientMock,
+                userAttributes: {},
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the Postgres fixed-width bin path, which uses a different string-concatenation shape
+    // from BigQuery while preserving the same bucket semantics and sort columns.
+    test('matches snapshot for a fixed-width custom dimension query in Postgres', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_WITH_CUSTOM_DIMENSION,
+                    compiledCustomDimensions: [
+                        {
+                            id: 'age_range',
+                            name: 'Age range',
+                            type: CustomDimensionType.BIN,
+                            dimensionId: 'table1_dim1',
+                            table: 'table1',
+                            binType: BinType.FIXED_WIDTH,
+                            binWidth: 10,
+                        },
+                    ],
+                },
+                userAttributes: {},
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers raw custom SQL dimensions, protecting the path where a user-defined SQL expression
+    // becomes a selected dimension with grouping and ordering in the final query.
+    test('matches snapshot for a custom SQL dimension query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_CUSTOM_SQL_DIMENSION,
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/dateZoomQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/dateZoomQueries.test.ts
@@ -1,0 +1,20 @@
+import {
+    EXPLORE_WITH_DATE_DIMENSION,
+    EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
+    METRIC_QUERY_WITH_DATE_FILTER,
+} from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+describe('MetricQueryBuilder snapshot: date zoom queries', () => {
+    // Covers zoomed date dimensions with filters, where the selected field stays DATE_TRUNC-based
+    // but the WHERE clause must still target the raw underlying date column.
+    test('matches snapshot for a date-zoom query with raw-date filtering', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
+                compiledMetricQuery: METRIC_QUERY_WITH_DATE_FILTER,
+                originalExplore: EXPLORE_WITH_DATE_DIMENSION,
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/distinctQueries.test.ts
@@ -1,0 +1,55 @@
+import {
+    EXPLORE_WITH_AVERAGE_DISTINCT,
+    EXPLORE_WITH_SUM_DISTINCT,
+    METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
+    METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
+    METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
+    METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
+} from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+describe('MetricQueryBuilder snapshot: distinct queries', () => {
+    // Covers sum_distinct with selected dimensions, where the deduplication CTE must partition
+    // by both the distinct key and every selected grouping dimension before rejoining the results.
+    test('matches snapshot for a sum-distinct query with dimensions', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT,
+                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the no-dimension sum_distinct path, where the deduped aggregate should avoid
+    // dimension joins entirely and collapse back to a single-row aggregation shape.
+    test('matches snapshot for a sum-distinct query without dimensions', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SUM_DISTINCT,
+                compiledMetricQuery: METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers average_distinct without dimensions, protecting the FLOAT-based numerator/denominator
+    // rewrite that avoids integer division when deduplicated averages are computed from raw rows.
+    test('matches snapshot for an average-distinct query without dimensions', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_AVERAGE_DISTINCT,
+                compiledMetricQuery: METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers average_distinct with grouping dimensions, where the distinct CTE must partition
+    // by the selected dimensions and then regroup the deduplicated rows into the final result set.
+    test('matches snapshot for an average-distinct query with dimensions', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_AVERAGE_DISTINCT,
+                compiledMetricQuery: METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/fanoutQueries.test.ts
@@ -1,0 +1,118 @@
+import { FilterOperator } from '@lightdash/common';
+import {
+    EXPLORE,
+    EXPLORE_WITH_CROSS_TABLE_METRICS,
+    METRIC_QUERY_CROSS_TABLE,
+    METRIC_QUERY_TWO_TABLES,
+} from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+describe('MetricQueryBuilder snapshot: fanout queries', () => {
+    // Mirrors fanout dashboard queries that mix base-table and joined-table metrics,
+    // exercising the CTE-based de-duplication path that prevents inflated aggregates.
+    test('matches snapshot for a fanout-protected metric query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_TWO_TABLES,
+                    metrics: ['table1_metric1', 'table2_metric3'],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the no-dimensions variant of the fanout-protection path,
+    // where independently aggregated CTEs must be merged with a CROSS JOIN instead of keyed joins.
+    test('matches snapshot for a fanout-protected metric query without dimensions', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_TWO_TABLES,
+                    dimensions: [],
+                    metrics: ['table1_metric1', 'table2_metric3'],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers metrics that are themselves defined in terms of metrics from joined tables,
+    // exercising the deduplicated cross-table metric path rather than plain field aggregation.
+    test('matches snapshot for a cross-table metric query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_CROSS_TABLE_METRICS,
+                compiledMetricQuery: METRIC_QUERY_CROSS_TABLE,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the filter-only metric path where a joined-table metric must be computed in a fanout CTE
+    // for filtering, but omitted from the final projected result columns.
+    test('matches snapshot for a filter-only fanout metric query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_TWO_TABLES,
+                    dimensions: ['table1_dim1'],
+                    metrics: ['table1_metric1'],
+                    filters: {
+                        metrics: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: '1',
+                                    target: {
+                                        fieldId: 'table2_metric3',
+                                    },
+                                    operator: FilterOperator.GREATER_THAN,
+                                    values: [100],
+                                },
+                            ],
+                        },
+                    },
+                    sorts: [{ fieldId: 'table1_metric1', descending: true }],
+                    limit: 10,
+                    tableCalculations: [],
+                    compiledTableCalculations: [],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the filter-only deduplication path with no selected dimensions, where a joined-table
+    // metric is the only projected field and a base-table dimension filter must not create an empty helper CTE.
+    test('matches snapshot for a filter-only fanout query without selected dimensions', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: {
+                    ...METRIC_QUERY_TWO_TABLES,
+                    dimensions: [],
+                    metrics: ['table2_metric3'],
+                    filters: {
+                        dimensions: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: '1',
+                                    target: {
+                                        fieldId: 'table1_dim1',
+                                    },
+                                    operator: FilterOperator.EQUALS,
+                                    values: [2025],
+                                },
+                            ],
+                        },
+                    },
+                    sorts: [{ fieldId: 'table2_metric3', descending: true }],
+                    limit: 500,
+                    tableCalculations: [],
+                    compiledTableCalculations: [],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/filterQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/filterQueries.test.ts
@@ -1,0 +1,209 @@
+import {
+    EXPLORE,
+    EXPLORE_WITH_REQUIRED_FILTERS,
+    EXPLORE_WITH_SQL_FILTER,
+    METRIC_QUERY,
+    METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
+    METRIC_QUERY_WITH_DISABLED_FILTER,
+    METRIC_QUERY_WITH_EMPTY_FILTER,
+    METRIC_QUERY_WITH_EMPTY_FILTER_GROUPS,
+    METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
+    METRIC_QUERY_WITH_FILTER,
+    METRIC_QUERY_WITH_FILTER_AND_DISABLED_FILTER,
+    METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
+    METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM,
+    METRIC_QUERY_WITH_METRIC_FILTER,
+    METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
+    METRIC_QUERY_WITH_NESTED_METRIC_FILTERS,
+    METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER,
+    METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE,
+} from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+describe('MetricQueryBuilder snapshot: filter queries', () => {
+    // Mirrors filter dashboard tiles that depend on nested boolean logic,
+    // with grouped dimension predicates combining AND/OR branches before aggregation.
+    test('matches snapshot for a nested-filter query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_NESTED_FILTER_OPERATORS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers joined-table dimension filters that force an extra join even when the filtered field
+    // is not selected, matching the common dashboard case of filtering on related table attributes.
+    test('matches snapshot for a joined-dimension filter query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_FILTER,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers OR-connected dimension filters, where multiple sibling predicates must stay grouped
+    // in a single WHERE branch instead of being flattened into the default AND path.
+    test('matches snapshot for a dimension filter query with OR logic', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_FILTER_OR_OPERATOR,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers disabled dimension filters, ensuring ignored predicates are fully removed
+    // from the compiled SQL while the rest of the grouped query shape stays unchanged.
+    test('matches snapshot for a query with a disabled dimension filter', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_DISABLED_FILTER,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers mixed enabled and disabled filters in the same query, protecting the path
+    // where only active predicates survive into the final WHERE clause.
+    test('matches snapshot for a query with enabled and disabled filters', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery:
+                    METRIC_QUERY_WITH_FILTER_AND_DISABLED_FILTER,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers aggregate-level metric filters applied after the metrics CTE,
+    // protecting the HAVING-style path where results are filtered on computed measures.
+    test('matches snapshot for a metric-filter query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_METRIC_FILTER,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers nested metric filter groups with mixed boolean logic on aggregated measures,
+    // which is a distinct code path from dimension filters because it filters after metric computation.
+    test('matches snapshot for a nested metric-filter query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_NESTED_METRIC_FILTERS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers disabled metric filters that reference joined-table dimensions, ensuring the builder
+    // does not pull in an unnecessary join path when the filter itself is inactive.
+    test('matches snapshot for a query with a disabled joined-dimension metric filter', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery:
+                    METRIC_QUERY_WITH_METRIC_DISABLED_FILTER_THAT_REFERENCES_JOINED_TABLE_DIM,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers empty filter groups that should compile away entirely, matching the plain baseline SQL
+    // instead of leaving behind an empty WHERE wrapper or redundant boolean scaffolding.
+    test('matches snapshot for a query with empty filter groups', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER_GROUPS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers queries where filtering on a table calculation forces an extra CTE layer,
+    // so the calculation can be materialized before applying its filter predicate.
+    test('matches snapshot for a table-calculation filter query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_TABLE_CALCULATION_FILTER,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers fully empty dimension filters, protecting the path where an empty filter payload
+    // must not inject WHERE noise or change the grouped query shape.
+    test('matches snapshot for a query with an empty dimension filter', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_FILTER,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers fully empty metric filters, ensuring the builder removes the empty post-aggregation
+    // predicate layer instead of producing a malformed HAVING-style filter section.
+    test('matches snapshot for a query with an empty metric filter', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers SQL filters that depend on user attribute substitution, so the snapshot protects
+    // the final compiled predicate after user-provided values are expanded into the SQL filter.
+    test('matches snapshot for a query with a SQL filter using user attributes', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_SQL_FILTER,
+                compiledMetricQuery: METRIC_QUERY_WITH_EMPTY_METRIC_FILTER,
+                userAttributes: {
+                    country: ['EU'],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers intrinsic user attribute placeholders used in filter values, ensuring those values
+    // are resolved before the normal dimension-filter SQL is compiled.
+    test('matches snapshot for a query with intrinsic user-attribute filter values', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery:
+                    METRIC_QUERY_WITH_USER_ATTRIBUTE_FILTER_VALUE,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers custom user attribute placeholders in filter values, protecting the path that injects
+    // user-scoped attribute arrays into the normal dimension filter compilation.
+    test('matches snapshot for a query with custom user-attribute filter values', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery:
+                    METRIC_QUERY_WITH_CUSTOM_USER_ATTRIBUTE_FILTER_VALUE,
+                userAttributes: {
+                    country: ['EU'],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers model-level required filters that are injected alongside user filters,
+    // protecting the path that augments the query with mandatory predicates from the explore.
+    test('matches snapshot for a required-filter query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_REQUIRED_FILTERS,
+                compiledMetricQuery: METRIC_QUERY,
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/helpers.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/helpers.ts
@@ -1,0 +1,76 @@
+import { SupportedDbtAdapter } from '@lightdash/common';
+// eslint-disable-next-line import/no-extraneous-dependencies
+import { format, type FormatOptionsWithLanguage } from 'sql-formatter';
+import { BuildQueryProps, MetricQueryBuilder } from '../MetricQueryBuilder';
+import {
+    INTRINSIC_USER_ATTRIBUTES,
+    QUERY_BUILDER_UTC_TIMEZONE,
+    warehouseClientMock,
+} from '../MetricQueryBuilder.mock';
+
+export const SNAPSHOT_DEFAULTS = {
+    intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+    timezone: QUERY_BUILDER_UTC_TIMEZONE,
+    warehouseSqlBuilder: warehouseClientMock,
+} as const;
+
+const getLanguage = (
+    adapterType?: SupportedDbtAdapter,
+): FormatOptionsWithLanguage['language'] => {
+    switch (adapterType) {
+        case SupportedDbtAdapter.BIGQUERY:
+            return 'bigquery';
+        case SupportedDbtAdapter.SNOWFLAKE:
+            return 'snowflake';
+        case SupportedDbtAdapter.TRINO:
+        case SupportedDbtAdapter.DATABRICKS:
+            return 'spark';
+        case SupportedDbtAdapter.POSTGRES:
+            return 'postgresql';
+        case SupportedDbtAdapter.REDSHIFT:
+            return 'redshift';
+        default:
+            return 'sql';
+    }
+};
+
+const formatSqlForSnapshot = (
+    sql: string,
+    adapterType?: SupportedDbtAdapter,
+): string => {
+    try {
+        return format(sql, {
+            language: getLanguage(adapterType),
+        });
+    } catch {
+        return sql;
+    }
+};
+
+export const buildQuery = (
+    args: Omit<
+        BuildQueryProps,
+        | 'parameterDefinitions'
+        | 'intrinsicUserAttributes'
+        | 'timezone'
+        | 'warehouseSqlBuilder'
+    > &
+        Partial<
+            Pick<
+                BuildQueryProps,
+                'intrinsicUserAttributes' | 'timezone' | 'warehouseSqlBuilder'
+            >
+        >,
+): string => {
+    const { query } = new MetricQueryBuilder({
+        parameterDefinitions: {},
+        ...SNAPSHOT_DEFAULTS,
+        ...args,
+    }).compileQuery();
+
+    return formatSqlForSnapshot(
+        query,
+        args.warehouseSqlBuilder?.getAdapterType() ??
+            SNAPSHOT_DEFAULTS.warehouseSqlBuilder.getAdapterType(),
+    );
+};

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/nestedAggregateQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/nestedAggregateQueries.test.ts
@@ -1,0 +1,174 @@
+import {
+    CompiledMetricQuery,
+    DimensionType,
+    Explore,
+    FieldType,
+    JoinRelationship,
+    MetricType,
+} from '@lightdash/common';
+import {
+    EXPLORE_WITH_NESTED_AGG,
+    METRIC_QUERY_NESTED_AGG_MIXED_RAW,
+    METRIC_QUERY_NESTED_AGG_TRANSITIVE,
+    METRIC_QUERY_NESTED_AGG_WITH_DIMS,
+} from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+const EXPLORE_WITH_NESTED_AGG_AND_FANOUT: Explore = {
+    ...EXPLORE_WITH_NESTED_AGG,
+    joinedTables: [
+        {
+            table: 'fanout_users',
+            sqlOn: '${my_table.id} = ${fanout_users.account_id}',
+            compiledSqlOn: '("my_table".id) = ("fanout_users".account_id)',
+            type: 'left',
+            relationship: JoinRelationship.ONE_TO_MANY,
+            tablesReferences: ['my_table', 'fanout_users'],
+        },
+    ],
+    tables: {
+        ...EXPLORE_WITH_NESTED_AGG.tables,
+        my_table: {
+            ...EXPLORE_WITH_NESTED_AGG.tables.my_table,
+            metrics: {
+                ...EXPLORE_WITH_NESTED_AGG.tables.my_table.metrics,
+                cross_table_sum_of_max: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'my_table',
+                    tableLabel: 'my_table',
+                    name: 'cross_table_sum_of_max',
+                    label: 'cross_table_sum_of_max',
+                    sql: 'sum(${max_value}) / NULLIF(${fanout_users.count_users}, 0)',
+                    compiledSql:
+                        'SUM(MAX("my_table".value)) / NULLIF(COUNT("fanout_users".id), 0)',
+                    tablesReferences: ['my_table', 'fanout_users'],
+                    hidden: false,
+                },
+            },
+        },
+        fanout_users: {
+            name: 'fanout_users',
+            label: 'fanout_users',
+            database: 'db',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."fanout_users"',
+            primaryKey: ['id'],
+            dimensions: {
+                title: {
+                    type: DimensionType.STRING,
+                    name: 'title',
+                    label: 'title',
+                    table: 'fanout_users',
+                    tableLabel: 'fanout_users',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.title',
+                    compiledSql: '"fanout_users".title',
+                    tablesReferences: ['fanout_users'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                count_users: {
+                    type: MetricType.COUNT,
+                    fieldType: FieldType.METRIC,
+                    table: 'fanout_users',
+                    tableLabel: 'fanout_users',
+                    name: 'count_users',
+                    label: 'count_users',
+                    sql: '${TABLE}.id',
+                    compiledSql: 'COUNT("fanout_users".id)',
+                    tablesReferences: ['fanout_users'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+const METRIC_QUERY_NESTED_AGG_WITH_FANOUT: CompiledMetricQuery = {
+    exploreName: 'my_table',
+    dimensions: ['fanout_users_title'],
+    metrics: ['my_table_sum_of_max', 'my_table_count_records'],
+    filters: {},
+    sorts: [{ fieldId: 'my_table_sum_of_max', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+describe('MetricQueryBuilder snapshot: nested aggregate queries', () => {
+    // Covers the baseline nested-aggregate fixup, where MetricQueryBuilder must split an invalid
+    // SUM(MAX(...)) metric into staged nested_agg and nested_agg_results CTEs.
+    test('matches snapshot for a nested-aggregate query with dimensions', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_NESTED_AGG,
+                compiledMetricQuery: METRIC_QUERY_NESTED_AGG_WITH_DIMS,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers transitive nested aggregation, where a metric depends on another custom metric
+    // that already wraps an aggregate, forcing multi-hop CTE routing to avoid nested SQL aggregates.
+    test('matches snapshot for a transitive nested-aggregate query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_NESTED_AGG,
+                compiledMetricQuery: METRIC_QUERY_NESTED_AGG_TRANSITIVE,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers mixed raw and aggregate dependencies, where nested_agg_mixed must join raw base-table
+    // columns with aggregate helper results instead of trying to group raw helper metrics too early.
+    test('matches snapshot for a mixed raw-and-aggregate nested query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_NESTED_AGG,
+                compiledMetricQuery: METRIC_QUERY_NESTED_AGG_MIXED_RAW,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers nested aggregates when fanout protection is also active, ensuring the nested metric
+    // is emitted once and threaded through both the fanout CTE and nested aggregate result layers.
+    test('matches snapshot for a fanout-protected nested-aggregate query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_NESTED_AGG_AND_FANOUT,
+                compiledMetricQuery: METRIC_QUERY_NESTED_AGG_WITH_FANOUT,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the MAX_BY customer pattern where non-aggregate helper metrics still require
+    // nested CTE routing, preventing raw helper columns from leaking into grouped SELECT output.
+    test('matches snapshot for a max-by query with raw helper metrics', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_NESTED_AGG,
+                compiledMetricQuery: {
+                    exploreName: 'my_table',
+                    dimensions: ['my_table_category'],
+                    metrics: ['my_table_max_by_of_raw'],
+                    filters: {},
+                    sorts: [
+                        {
+                            fieldId: 'my_table_max_by_of_raw',
+                            descending: true,
+                        },
+                    ],
+                    limit: 10,
+                    tableCalculations: [],
+                    compiledTableCalculations: [],
+                    compiledAdditionalMetrics: [],
+                    compiledCustomDimensions: [],
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/periodOverPeriodQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/periodOverPeriodQueries.test.ts
@@ -1,0 +1,644 @@
+import {
+    CompiledMetricQuery,
+    DimensionType,
+    Explore,
+    FieldType,
+    FilterOperator,
+    JoinRelationship,
+    MetricType,
+    SupportedDbtAdapter,
+    TimeFrames,
+} from '@lightdash/common';
+import { buildQuery } from './helpers';
+
+const POP_TEST_POP_METRIC_NAME = 'total_order_amount__pop__year_1__snapshot';
+const POP_TEST_POP_METRIC_ID = `orders_${POP_TEST_POP_METRIC_NAME}`;
+
+const POP_TEST_EXPLORE: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'orders',
+    label: 'orders',
+    baseTable: 'orders',
+    tags: [],
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'orders',
+            database: 'postgres',
+            schema: 'jaffle',
+            sqlTable: '"postgres"."jaffle"."orders"',
+            primaryKey: ['order_id'],
+            dimensions: {
+                order_id: {
+                    type: DimensionType.NUMBER,
+                    name: 'order_id',
+                    label: 'order_id',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_id',
+                    compiledSql: '"orders".order_id',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                order_date: {
+                    type: DimensionType.DATE,
+                    name: 'order_date',
+                    label: 'order_date',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_date',
+                    compiledSql: '"orders".order_date',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                order_date_year: {
+                    type: DimensionType.DATE,
+                    name: 'order_date_year',
+                    label: 'order_date_year',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: "DATE_TRUNC('YEAR', ${TABLE}.order_date)",
+                    compiledSql: `DATE_TRUNC('YEAR', "orders".order_date)`,
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                    timeInterval: TimeFrames.YEAR,
+                    timeIntervalBaseDimensionName: 'order_date',
+                },
+                is_completed: {
+                    type: DimensionType.BOOLEAN,
+                    name: 'is_completed',
+                    label: 'is_completed',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.is_completed',
+                    compiledSql: '"orders".is_completed',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_order_amount: {
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    name: 'total_order_amount',
+                    label: 'total_order_amount',
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("orders".amount)',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+const POP_TEST_METRIC_QUERY: CompiledMetricQuery = {
+    exploreName: 'orders',
+    dimensions: ['orders_order_date_year'],
+    metrics: ['orders_total_order_amount', POP_TEST_POP_METRIC_ID],
+    filters: {
+        dimensions: {
+            id: 'root',
+            and: [
+                {
+                    id: 'is-completed',
+                    target: {
+                        fieldId: 'orders_is_completed',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: [true],
+                },
+                {
+                    id: 'base-year',
+                    target: {
+                        fieldId: 'orders_order_date_year',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2025-01-01'],
+                },
+            ],
+        },
+    },
+    sorts: [{ fieldId: 'orders_order_date_year', descending: true }],
+    limit: 500,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    additionalMetrics: [
+        {
+            table: 'orders',
+            name: POP_TEST_POP_METRIC_NAME,
+            label: 'Previous year total_order_amount',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+            generationType: 'periodOverPeriod' as const,
+            baseMetricId: 'orders_total_order_amount',
+            timeDimensionId: 'orders_order_date_year',
+            granularity: TimeFrames.YEAR,
+            periodOffset: 1,
+        },
+    ],
+    compiledAdditionalMetrics: [
+        {
+            type: MetricType.SUM,
+            fieldType: FieldType.METRIC,
+            table: 'orders',
+            tableLabel: 'orders',
+            name: POP_TEST_POP_METRIC_NAME,
+            label: 'Previous year total_order_amount',
+            sql: '${TABLE}.amount',
+            compiledSql: 'SUM("orders".amount)',
+            tablesReferences: ['orders'],
+            hidden: true,
+        },
+    ],
+    compiledCustomDimensions: [],
+};
+
+const POP_TEST_FANOUT_POP_METRIC_NAME = 'metric_amount__pop__year_1__fanout';
+const POP_TEST_FANOUT_POP_METRIC_ID = `table2_${POP_TEST_FANOUT_POP_METRIC_NAME}`;
+
+const POP_TEST_FANOUT_EXPLORE: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'base',
+    label: 'base',
+    baseTable: 'table1',
+    tags: [],
+    joinedTables: [
+        {
+            table: 'table2',
+            sqlOn: '${table1.shared} = ${table2.shared}',
+            compiledSqlOn: '("table1".shared) = ("table2".shared)',
+            type: undefined,
+            tablesReferences: ['table1', 'table2'],
+            relationship: JoinRelationship.MANY_TO_ONE,
+        },
+    ],
+    tables: {
+        table1: {
+            name: 'table1',
+            label: 'table1',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."table1"',
+            primaryKey: ['id'],
+            dimensions: {
+                id: {
+                    type: DimensionType.NUMBER,
+                    name: 'id',
+                    label: 'id',
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.id',
+                    compiledSql: '"table1".id',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                },
+                shared: {
+                    type: DimensionType.STRING,
+                    name: 'shared',
+                    label: 'shared',
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.shared',
+                    compiledSql: '"table1".shared',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                },
+            },
+            metrics: {},
+            lineageGraph: {},
+        },
+        table2: {
+            name: 'table2',
+            label: 'table2',
+            database: 'database',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."table2"',
+            primaryKey: ['id'],
+            dimensions: {
+                id: {
+                    type: DimensionType.NUMBER,
+                    name: 'id',
+                    label: 'id',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.id',
+                    compiledSql: '"table2".id',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+                shared: {
+                    type: DimensionType.STRING,
+                    name: 'shared',
+                    label: 'shared',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.shared',
+                    compiledSql: '"table2".shared',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+                order_date: {
+                    type: DimensionType.DATE,
+                    name: 'order_date',
+                    label: 'order_date',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_date',
+                    compiledSql: '"table2".order_date',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+                order_date_year: {
+                    type: DimensionType.DATE,
+                    name: 'order_date_year',
+                    label: 'order_date_year',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: "DATE_TRUNC('YEAR', ${TABLE}.order_date)",
+                    compiledSql: `DATE_TRUNC('YEAR', "table2".order_date)`,
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                    timeInterval: TimeFrames.YEAR,
+                    timeIntervalBaseDimensionName: 'order_date',
+                },
+                is_completed: {
+                    type: DimensionType.BOOLEAN,
+                    name: 'is_completed',
+                    label: 'is_completed',
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.is_completed',
+                    compiledSql: '"table2".is_completed',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                metric_amount: {
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'table2',
+                    tableLabel: 'table2',
+                    name: 'metric_amount',
+                    label: 'metric_amount',
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("table2".amount)',
+                    tablesReferences: ['table2'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+const POP_TEST_FANOUT_METRIC_QUERY: CompiledMetricQuery = {
+    exploreName: 'base',
+    dimensions: ['table2_order_date_year'],
+    metrics: ['table2_metric_amount', POP_TEST_FANOUT_POP_METRIC_ID],
+    filters: {
+        dimensions: {
+            id: 'root',
+            and: [
+                {
+                    id: 'is-completed',
+                    target: {
+                        fieldId: 'table2_is_completed',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: [true],
+                },
+                {
+                    id: 'base-year',
+                    target: {
+                        fieldId: 'table2_order_date_year',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2025-01-01'],
+                },
+            ],
+        },
+    },
+    sorts: [{ fieldId: 'table2_order_date_year', descending: true }],
+    limit: 100,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    additionalMetrics: [
+        {
+            table: 'table2',
+            name: POP_TEST_FANOUT_POP_METRIC_NAME,
+            label: 'Previous year metric_amount',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+            generationType: 'periodOverPeriod' as const,
+            baseMetricId: 'table2_metric_amount',
+            timeDimensionId: 'table2_order_date_year',
+            granularity: TimeFrames.YEAR,
+            periodOffset: 1,
+        },
+    ],
+    compiledAdditionalMetrics: [
+        {
+            type: MetricType.SUM,
+            fieldType: FieldType.METRIC,
+            table: 'table2',
+            tableLabel: 'table2',
+            name: POP_TEST_FANOUT_POP_METRIC_NAME,
+            label: 'Previous year metric_amount',
+            sql: '${TABLE}.amount',
+            compiledSql: 'SUM("table2".amount)',
+            tablesReferences: ['table2'],
+            hidden: true,
+        },
+    ],
+    compiledCustomDimensions: [],
+};
+
+const POP_TEST_COUNTRY_FANOUT_POP_METRIC_NAME =
+    'total_order_amount__pop__year_1__country';
+const POP_TEST_COUNTRY_FANOUT_POP_METRIC_ID = `country_orders_${POP_TEST_COUNTRY_FANOUT_POP_METRIC_NAME}`;
+
+const POP_TEST_COUNTRY_FANOUT_EXPLORE: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'country_orders',
+    label: 'country_orders',
+    baseTable: 'country_orders',
+    tags: [],
+    joinedTables: [
+        {
+            table: 'order_currencies',
+            sqlOn: '${country_orders.order_id} = ${order_currencies.order_id}',
+            compiledSqlOn:
+                '("country_orders".order_id) = ("order_currencies".order_id)',
+            type: 'left',
+            relationship: JoinRelationship.ONE_TO_MANY,
+            tablesReferences: ['country_orders', 'order_currencies'],
+        },
+    ],
+    tables: {
+        country_orders: {
+            name: 'country_orders',
+            label: 'country_orders',
+            database: 'postgres',
+            schema: 'jaffle',
+            sqlTable: '"postgres"."jaffle"."country_orders"',
+            primaryKey: ['order_id'],
+            dimensions: {
+                order_id: {
+                    type: DimensionType.NUMBER,
+                    name: 'order_id',
+                    label: 'order_id',
+                    table: 'country_orders',
+                    tableLabel: 'country_orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_id',
+                    compiledSql: '"country_orders".order_id',
+                    tablesReferences: ['country_orders'],
+                    hidden: false,
+                },
+                order_date: {
+                    type: DimensionType.DATE,
+                    name: 'order_date',
+                    label: 'order_date',
+                    table: 'country_orders',
+                    tableLabel: 'country_orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_date',
+                    compiledSql: '"country_orders".order_date',
+                    tablesReferences: ['country_orders'],
+                    hidden: false,
+                },
+                order_date_year: {
+                    type: DimensionType.DATE,
+                    name: 'order_date_year',
+                    label: 'order_date_year',
+                    table: 'country_orders',
+                    tableLabel: 'country_orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: "DATE_TRUNC('YEAR', ${TABLE}.order_date)",
+                    compiledSql: `DATE_TRUNC('YEAR', "country_orders".order_date)`,
+                    tablesReferences: ['country_orders'],
+                    hidden: false,
+                    timeInterval: TimeFrames.YEAR,
+                    timeIntervalBaseDimensionName: 'order_date',
+                },
+                country: {
+                    type: DimensionType.STRING,
+                    name: 'country',
+                    label: 'country',
+                    table: 'country_orders',
+                    tableLabel: 'country_orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.country',
+                    compiledSql: '"country_orders".country',
+                    tablesReferences: ['country_orders'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_order_amount: {
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'country_orders',
+                    tableLabel: 'country_orders',
+                    name: 'total_order_amount',
+                    label: 'total_order_amount',
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("country_orders".amount)',
+                    tablesReferences: ['country_orders'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+        order_currencies: {
+            name: 'order_currencies',
+            label: 'order_currencies',
+            database: 'postgres',
+            schema: 'jaffle',
+            sqlTable: '"postgres"."jaffle"."order_currencies"',
+            primaryKey: ['order_id'],
+            dimensions: {
+                order_id: {
+                    type: DimensionType.NUMBER,
+                    name: 'order_id',
+                    label: 'order_id',
+                    table: 'order_currencies',
+                    tableLabel: 'order_currencies',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_id',
+                    compiledSql: '"order_currencies".order_id',
+                    tablesReferences: ['order_currencies'],
+                    hidden: false,
+                },
+                currency: {
+                    type: DimensionType.STRING,
+                    name: 'currency',
+                    label: 'currency',
+                    table: 'order_currencies',
+                    tableLabel: 'order_currencies',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.currency',
+                    compiledSql: '"order_currencies".currency',
+                    tablesReferences: ['order_currencies'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_converted_amount: {
+                    type: MetricType.SUM,
+                    fieldType: FieldType.METRIC,
+                    table: 'order_currencies',
+                    tableLabel: 'order_currencies',
+                    name: 'total_converted_amount',
+                    label: 'total_converted_amount',
+                    sql: '${TABLE}.converted_amount',
+                    compiledSql: 'SUM("order_currencies".converted_amount)',
+                    tablesReferences: ['order_currencies'],
+                    hidden: false,
+                },
+            },
+            lineageGraph: {},
+        },
+    },
+};
+
+const POP_TEST_COUNTRY_FANOUT_METRIC_QUERY: CompiledMetricQuery = {
+    exploreName: 'country_orders',
+    dimensions: [
+        'country_orders_order_date_year',
+        'country_orders_country',
+        'order_currencies_currency',
+    ],
+    metrics: [
+        'country_orders_total_order_amount',
+        POP_TEST_COUNTRY_FANOUT_POP_METRIC_ID,
+    ],
+    filters: {},
+    sorts: [{ fieldId: 'country_orders_order_date_year', descending: true }],
+    limit: 100,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    additionalMetrics: [
+        {
+            table: 'country_orders',
+            name: POP_TEST_COUNTRY_FANOUT_POP_METRIC_NAME,
+            label: 'Previous year total_order_amount',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+            generationType: 'periodOverPeriod' as const,
+            baseMetricId: 'country_orders_total_order_amount',
+            timeDimensionId: 'country_orders_order_date_year',
+            granularity: TimeFrames.YEAR,
+            periodOffset: 1,
+        },
+    ],
+    compiledAdditionalMetrics: [
+        {
+            type: MetricType.SUM,
+            fieldType: FieldType.METRIC,
+            table: 'country_orders',
+            tableLabel: 'country_orders',
+            name: POP_TEST_COUNTRY_FANOUT_POP_METRIC_NAME,
+            label: 'Previous year total_order_amount',
+            sql: '${TABLE}.amount',
+            compiledSql: 'SUM("country_orders".amount)',
+            tablesReferences: ['country_orders'],
+            hidden: true,
+        },
+    ],
+    compiledCustomDimensions: [],
+};
+
+describe('MetricQueryBuilder snapshot: period-over-period queries', () => {
+    // Mirrors period-over-period dashboard tiles on yearly time grains,
+    // including the shifted comparison window and LEFT JOIN merge back to base metrics.
+    test('matches snapshot for a period-over-period query', () => {
+        expect(
+            buildQuery({
+                explore: POP_TEST_EXPLORE,
+                compiledMetricQuery: POP_TEST_METRIC_QUERY,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the base PoP path when the user only filters the current-period time dimension,
+    // so the comparison CTE must derive its shifted range without carrying the raw date predicate through.
+    test('matches snapshot for a period-over-period query with only a date filter', () => {
+        expect(
+            buildQuery({
+                explore: POP_TEST_EXPLORE,
+                compiledMetricQuery: {
+                    ...POP_TEST_METRIC_QUERY,
+                    filters: {
+                        dimensions: {
+                            id: 'root',
+                            and: [
+                                {
+                                    id: 'base-year',
+                                    target: {
+                                        fieldId: 'orders_order_date_year',
+                                    },
+                                    operator: FilterOperator.EQUALS,
+                                    values: ['2025-01-01'],
+                                },
+                            ],
+                        },
+                    },
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the base PoP path with no filters at all,
+    // ensuring the comparison period is merged back with a LEFT JOIN while preserving all base rows.
+    test('matches snapshot for a period-over-period query without filters', () => {
+        expect(
+            buildQuery({
+                explore: POP_TEST_EXPLORE,
+                compiledMetricQuery: {
+                    ...POP_TEST_METRIC_QUERY,
+                    filters: {},
+                },
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the fanout-protected PoP path where the compared metric lives on a joined table,
+    // forcing keyed CTEs before the shifted comparison range can be computed and joined back.
+    test('matches snapshot for a fanout-protected period-over-period query', () => {
+        expect(
+            buildQuery({
+                explore: POP_TEST_FANOUT_EXPLORE,
+                compiledMetricQuery: POP_TEST_FANOUT_METRIC_QUERY,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the true one-to-many fanout PoP path, where the base metric lives on the base table
+    // but a joined-table dimension forces keyed fanout CTEs and a LEFT JOIN merge back to all base rows.
+    test('matches snapshot for a one-to-many fanout-protected period-over-period query', () => {
+        expect(
+            buildQuery({
+                explore: POP_TEST_COUNTRY_FANOUT_EXPLORE,
+                compiledMetricQuery: POP_TEST_COUNTRY_FANOUT_METRIC_QUERY,
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/postCalculationQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/postCalculationQueries.test.ts
@@ -1,0 +1,138 @@
+import {
+    DimensionType,
+    Explore,
+    FieldType,
+    MetricType,
+    SortByDirection,
+    VizAggregationOptions,
+    VizIndexType,
+} from '@lightdash/common';
+import { EXPLORE, METRIC_QUERY } from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+const EXPLORE_WITH_PERCENT_OF_TOTAL_METRIC: Explore = {
+    ...EXPLORE,
+    tables: {
+        ...EXPLORE.tables,
+        table1: {
+            ...EXPLORE.tables.table1,
+            metrics: {
+                ...EXPLORE.tables.table1.metrics,
+                percent_of_total_metric: {
+                    type: MetricType.PERCENT_OF_TOTAL,
+                    fieldType: FieldType.METRIC as const,
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    name: 'percent_of_total_metric',
+                    label: 'Percent of Total',
+                    sql: '${table1.metric1}',
+                    compiledSql: '...',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                },
+            },
+        },
+    },
+};
+
+const METRIC_QUERY_WITH_PERCENT_OF_TOTAL = {
+    ...METRIC_QUERY,
+    metrics: ['table1_metric1', 'table1_percent_of_total_metric'],
+    tableCalculations: [],
+    compiledTableCalculations: [],
+};
+
+const EXPLORE_WITH_RUNNING_TOTAL_AND_DIMENSIONS: Explore = {
+    ...EXPLORE,
+    tables: {
+        ...EXPLORE.tables,
+        table1: {
+            ...EXPLORE.tables.table1,
+            dimensions: {
+                ...EXPLORE.tables.table1.dimensions,
+                category: {
+                    type: DimensionType.STRING,
+                    name: 'category',
+                    label: 'Category',
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    fieldType: FieldType.DIMENSION as const,
+                    sql: '${TABLE}.category',
+                    compiledSql: '"table1".category',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                ...EXPLORE.tables.table1.metrics,
+                running_total_metric: {
+                    type: MetricType.RUNNING_TOTAL,
+                    fieldType: FieldType.METRIC,
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    name: 'running_total_metric',
+                    label: 'Running Total',
+                    sql: '${table1.metric1}',
+                    compiledSql: '...',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                },
+            },
+        },
+    },
+};
+
+const METRIC_QUERY_WITH_RUNNING_TOTAL_PIVOT = {
+    ...METRIC_QUERY,
+    dimensions: ['table1_dim1', 'table1_category'],
+    metrics: ['table1_running_total_metric'],
+    tableCalculations: [],
+    compiledTableCalculations: [],
+};
+
+const RUNNING_TOTAL_PIVOT_CONFIGURATION = {
+    indexColumn: [
+        {
+            reference: 'table1_dim1',
+            type: VizIndexType.CATEGORY,
+        },
+    ],
+    valuesColumns: [
+        {
+            reference: 'table1_running_total_metric',
+            aggregation: VizAggregationOptions.ANY,
+        },
+    ],
+    groupByColumns: [{ reference: 'table1_category' }],
+    sortBy: [
+        {
+            reference: 'table1_dim1',
+            direction: SortByDirection.ASC,
+        },
+    ],
+};
+
+describe('MetricQueryBuilder snapshot: post-calculation queries', () => {
+    // Covers post-calculation metrics that run after the grouped metrics CTE,
+    // using a window aggregate over grouped results to compute percent-of-total safely.
+    test('matches snapshot for a percent-of-total post-calculation query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_PERCENT_OF_TOTAL_METRIC,
+                compiledMetricQuery: METRIC_QUERY_WITH_PERCENT_OF_TOTAL,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers running-total metrics with pivot grouping, where the post-calculation window
+    // must partition by non-index pivot dimensions while preserving grouped metric output.
+    test('matches snapshot for a running-total post-calculation query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_RUNNING_TOTAL_AND_DIMENSIONS,
+                compiledMetricQuery: METRIC_QUERY_WITH_RUNNING_TOTAL_PIVOT,
+                pivotConfiguration: RUNNING_TOTAL_PIVOT_CONFIGURATION,
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/sortQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/sortQueries.test.ts
@@ -1,0 +1,65 @@
+import { TimeFrames } from '@lightdash/common';
+import {
+    EXPLORE,
+    METRIC_QUERY_WITH_DAY_OF_WEEK_NAME_SORT,
+    METRIC_QUERY_WITH_MONTH_NAME_SORT,
+} from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+const EXPLORE_WITH_MONTH_NAME_DIMENSION = {
+    ...EXPLORE,
+    tables: {
+        ...EXPLORE.tables,
+        table1: {
+            ...EXPLORE.tables.table1,
+            dimensions: {
+                ...EXPLORE.tables.table1.dimensions,
+                dim1: {
+                    ...EXPLORE.tables.table1.dimensions.dim1,
+                    timeInterval: TimeFrames.MONTH_NAME,
+                },
+            },
+        },
+    },
+};
+
+const EXPLORE_WITH_DAY_OF_WEEK_NAME_DIMENSION = {
+    ...EXPLORE,
+    tables: {
+        ...EXPLORE.tables,
+        table1: {
+            ...EXPLORE.tables.table1,
+            dimensions: {
+                ...EXPLORE.tables.table1.dimensions,
+                dim1: {
+                    ...EXPLORE.tables.table1.dimensions.dim1,
+                    timeInterval: TimeFrames.DAY_OF_WEEK_NAME,
+                },
+            },
+        },
+    },
+};
+
+describe('MetricQueryBuilder snapshot: sort queries', () => {
+    // Covers month-name sorting, where the displayed label is textual but the SQL must order
+    // by the warehouse-specific month index rather than alphabetic month names.
+    test('matches snapshot for a month-name sort query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_MONTH_NAME_DIMENSION,
+                compiledMetricQuery: METRIC_QUERY_WITH_MONTH_NAME_SORT,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers day-of-week-name sorting, protecting the special ordering SQL that preserves
+    // weekday sequence instead of sorting day labels lexicographically.
+    test('matches snapshot for a day-of-week-name sort query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_DAY_OF_WEEK_NAME_DIMENSION,
+                compiledMetricQuery: METRIC_QUERY_WITH_DAY_OF_WEEK_NAME_SORT,
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/totalsQueries.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/metricQueryBuilderSnapshots/totalsQueries.test.ts
@@ -1,0 +1,231 @@
+import {
+    CompiledMetric,
+    Explore,
+    FieldType,
+    MetricType,
+    VizIndexType,
+} from '@lightdash/common';
+import { EXPLORE, METRIC_QUERY } from '../MetricQueryBuilder.mock';
+import { buildQuery } from './helpers';
+
+const METRIC_QUERY_WITH_TOTAL_AND_ROW_TOTAL = {
+    ...METRIC_QUERY,
+    tableCalculations: [
+        {
+            name: 'pct_total',
+            displayName: 'Pct Total',
+            sql: '${table1.metric1} / total(${table1.metric1})',
+        },
+        {
+            name: 'pct_row',
+            displayName: 'Pct Row',
+            sql: '${table1.metric1} / row_total(${table1.metric1})',
+        },
+    ],
+    compiledTableCalculations: [
+        {
+            name: 'pct_total',
+            displayName: 'Pct Total',
+            sql: '${table1.metric1} / total(${table1.metric1})',
+            compiledSql: '"table1_metric1" / total("table1_metric1")',
+            dependsOn: [],
+        },
+        {
+            name: 'pct_row',
+            displayName: 'Pct Row',
+            sql: '${table1.metric1} / row_total(${table1.metric1})',
+            compiledSql: '"table1_metric1" / row_total("table1_metric1")',
+            dependsOn: [],
+        },
+    ],
+};
+
+const TOTALS_PIVOT_CONFIGURATION = {
+    indexColumn: [
+        {
+            reference: 'table1_dim1',
+            type: VizIndexType.CATEGORY,
+        },
+    ],
+    valuesColumns: [],
+    groupByColumns: undefined,
+    sortBy: undefined,
+};
+
+const METRIC_QUERY_WITH_TOTAL_DEPENDENT_CALC = {
+    ...METRIC_QUERY,
+    tableCalculations: [
+        {
+            name: 'pct_total',
+            displayName: 'Pct Total',
+            sql: '${table1.metric1} / total(${table1.metric1})',
+        },
+        {
+            name: 'double_pct',
+            displayName: 'Double Pct',
+            sql: '${pct_total} * 2',
+        },
+    ],
+    compiledTableCalculations: [
+        {
+            name: 'pct_total',
+            displayName: 'Pct Total',
+            sql: '${table1.metric1} / total(${table1.metric1})',
+            compiledSql: '"table1_metric1" / total("table1_metric1")',
+            dependsOn: [],
+        },
+        {
+            name: 'double_pct',
+            displayName: 'Double Pct',
+            sql: '${pct_total} * 2',
+            compiledSql: '"pct_total" * 2',
+            dependsOn: ['pct_total'],
+        },
+    ],
+};
+
+const METRIC_QUERY_WITH_ROW_TOTAL_NO_PIVOT = {
+    ...METRIC_QUERY,
+    tableCalculations: [
+        {
+            name: 'pct_of_row',
+            displayName: 'Pct of Row',
+            sql: '${table1.metric1} / row_total(${table1.metric1})',
+        },
+    ],
+    compiledTableCalculations: [
+        {
+            name: 'pct_of_row',
+            displayName: 'Pct of Row',
+            sql: '${table1.metric1} / row_total(${table1.metric1})',
+            compiledSql: '"table1_metric1" / row_total("table1_metric1")',
+            dependsOn: [],
+        },
+    ],
+};
+
+const EXPLORE_WITH_AVG_METRIC: Explore = {
+    ...EXPLORE,
+    tables: {
+        ...EXPLORE.tables,
+        table1: {
+            ...EXPLORE.tables.table1,
+            metrics: {
+                ...EXPLORE.tables.table1.metrics,
+                avg_metric: {
+                    type: MetricType.AVERAGE,
+                    fieldType: FieldType.METRIC,
+                    table: 'table1',
+                    tableLabel: 'table1',
+                    name: 'avg_metric',
+                    label: 'avg_metric',
+                    sql: '${TABLE}.number_column',
+                    compiledSql: 'AVG("table1".number_column)',
+                    tablesReferences: ['table1'],
+                    hidden: false,
+                } as CompiledMetric,
+            },
+        },
+    },
+};
+
+const METRIC_QUERY_WITH_AVG_TOTAL = {
+    ...METRIC_QUERY,
+    metrics: ['table1_avg_metric'],
+    tableCalculations: [
+        {
+            name: 'pct_of_total',
+            displayName: 'Pct of Total',
+            sql: '${table1.avg_metric} / total(${table1.avg_metric})',
+        },
+    ],
+    compiledTableCalculations: [
+        {
+            name: 'pct_of_total',
+            displayName: 'Pct of Total',
+            sql: '${table1.avg_metric} / total(${table1.avg_metric})',
+            compiledSql: '"table1_avg_metric" / total("table1_avg_metric")',
+            dependsOn: [],
+        },
+    ],
+};
+
+const METRIC_QUERY_WITH_ROW_TOTAL_PIVOT_DIMENSIONS = {
+    ...METRIC_QUERY,
+    tableCalculations: [
+        {
+            name: 'pct_of_row',
+            displayName: 'Pct of Row',
+            sql: '${table1.metric1} / row_total(${table1.metric1})',
+        },
+    ],
+    compiledTableCalculations: [
+        {
+            name: 'pct_of_row',
+            displayName: 'Pct of Row',
+            sql: '${table1.metric1} / row_total(${table1.metric1})',
+            compiledSql: '"table1_metric1" / row_total("table1_metric1")',
+            dependsOn: [],
+        },
+    ],
+};
+
+describe('MetricQueryBuilder snapshot: totals queries', () => {
+    // Covers totals referenced by dependent table calculations, where total() must be rewritten
+    // before downstream calculations materialize their own chained table-calculation CTEs.
+    test('matches snapshot for a dependent total-calculation query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_TOTAL_DEPENDENT_CALC,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Mirrors pivoted table calculations that use both total() and row_total(),
+    // protecting column_totals and row_totals rewrites in the same grouped query.
+    test('matches snapshot for a pivoted totals query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_TOTAL_AND_ROW_TOTAL,
+                pivotConfiguration: TOTALS_PIVOT_CONFIGURATION,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the no-pivot fallback for row_total(), where the function reduces to the metric itself
+    // and the builder should skip generating row_totals and with_totals helper CTEs entirely.
+    test('matches snapshot for a row-total query without pivot metadata', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery: METRIC_QUERY_WITH_ROW_TOTAL_NO_PIVOT,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers total() on an AVG metric, protecting the path that recomputes totals from raw rows
+    // with the metric's native aggregation instead of summing already-grouped averages.
+    test('matches snapshot for an average-metric total query', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE_WITH_AVG_METRIC,
+                compiledMetricQuery: METRIC_QUERY_WITH_AVG_TOTAL,
+            }),
+        ).toMatchSnapshot();
+    });
+
+    // Covers the pivotDimensions fallback used without a full pivot configuration,
+    // ensuring row_total() still materializes row totals from grouped metric output.
+    test('matches snapshot for a row-total query using pivot dimensions', () => {
+        expect(
+            buildQuery({
+                explore: EXPLORE,
+                compiledMetricQuery:
+                    METRIC_QUERY_WITH_ROW_TOTAL_PIVOT_DIMENSIONS,
+                pivotDimensions: ['table1_dim2'],
+            }),
+        ).toMatchSnapshot();
+    });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -595,6 +595,9 @@ importers:
       nodemon:
         specifier: 3.1.9
         version: 3.1.9
+      sql-formatter:
+        specifier: 15.4.2
+        version: 15.4.2
       ts-node:
         specifier: 10.9.2
         version: 10.9.2(@swc/core@1.13.5)(@types/node@24.3.1)(typescript@6.0.0-beta)
@@ -12365,6 +12368,7 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
+
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.14.1:
@@ -13637,6 +13641,7 @@ packages:
   tar@7.5.7:
     resolution: {integrity: sha512-fov56fJiRuThVFXD6o6/Q354S7pnWMJIVlDBYijsTNx6jKSE4pvrDTs6lUnmGvNyfJwFQQwWy3owKz1ucIhveQ==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tarn@3.0.2:
     resolution: {integrity: sha512-51LAVKUSZSVfI05vjPESNc5vwqqZpbXCsU+/+wxlOrUjk2SnFTt97v9ZgQrD4YmxYW1Px6w2KjaDitCfkvgxMQ==}


### PR DESCRIPTION
### Description:

This PR refactors the MetricQueryBuilder test suite by replacing hardcoded SQL string comparisons with Jest snapshots. The changes include:

- Added a new `sql-formatter` dependency to format SQL output consistently in snapshots
- Created a comprehensive snapshot test suite organized by query type (core queries, filters, custom dimensions, etc.)
- Added a new npm script `backend-test-snapshots-update` for updating snapshots
- Removed the frontend filter from the main build script
- Converted existing string-based assertions to snapshot-based testing for better maintainability

The snapshot tests cover all major query patterns including basic metric queries, cross-table joins, fanout protection, period-over-period comparisons, nested aggregates, and various filter scenarios. This approach makes the tests more maintainable and provides clearer diffs when query generation logic changes.