### PR TITLE
fix: DuckDB pre-agg failure exposes ERROR state to frontend before warehouse fallback completes

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2138,6 +2138,14 @@ export class AsyncQueryService extends ProjectService {
             this.logger.error(
                 `Query ${queryUuid} execution error: ${getErrorMessage(e)}`,
             );
+
+            // Override clients are used for fallback attempts such as DuckDB
+            // pre-aggregate execution. Keep the query history row non-terminal
+            // so polling clients can receive the warehouse retry result.
+            if (warehouseClientOverride) {
+                throw e;
+            }
+
             this.analytics.track({
                 ...analyticsIdentity,
                 event: 'query.error',
@@ -2168,12 +2176,6 @@ export class AsyncQueryService extends ProjectService {
                 queryCreatedAt,
                 queryTags.query_context || 'unknown',
             );
-
-            // Re-throw when using an override client (e.g. DuckDB pre-agg)
-            // so the caller can fall back to the warehouse path
-            if (warehouseClientOverride) {
-                throw e;
-            }
         }
 
         try {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: ZAP-274<!-- reference the related issue e.g. #150 -->

### Description:

<!-- Add a description of the changes proposed in the pull request. -->

Moved the error re-throwing logic for warehouse client overrides to occur before analytics tracking and query history updates. This ensures that when using override clients like DuckDB for pre-aggregate execution, the query history row remains non-terminal so polling clients can receive the warehouse retry result instead of being marked as failed prematurely.

<!-- Even better add a screenshot / gif / loom -->