### PR TITLE
perf: toggle tile hover tooltip with CSS visibility instead of mount/unmount

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -123,4 +123,9 @@
     z-index: calc(
         var(--dashboard-tabs-zindex) + 1 - (var(--tabs-stuck, 0) * 2)
     );
+
+    &[data-hidden='true'] {
+        visibility: hidden;
+        pointer-events: none;
+    }
 }

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -105,9 +105,10 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
 
     return (
         <div ref={containerRef} className={styles.tileWrapper}>
-            {containerHovered && isEditMode && !minimal && (
+            {isEditMode && !minimal && (
                 <Paper
                     className={styles.dragHandleIcon}
+                    data-hidden={!containerHovered}
                     pos="absolute"
                     shadow="sm"
                     top={-6}
@@ -119,154 +120,158 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
                 </Paper>
             )}
 
-            {((containerHovered && !titleHovered && !chartHovered) ||
-                isMenuOpen ||
-                lockHeaderVisibility) &&
-                hasHeaderContent && (
-                    <Paper
-                        p={5}
-                        className={clsx('non-draggable', styles.tileTooltip)}
-                        shadow="sm"
-                        pos="absolute"
-                        top={-6}
-                        right={-2}
-                    >
-                        <Group gap={5} wrap="nowrap">
-                            {titleLeftIcon}
+            {hasHeaderContent && (
+                <Paper
+                    p={5}
+                    className={clsx('non-draggable', styles.tileTooltip)}
+                    data-hidden={
+                        !(
+                            (containerHovered &&
+                                !titleHovered &&
+                                !chartHovered) ||
+                            isMenuOpen ||
+                            lockHeaderVisibility
+                        )
+                    }
+                    shadow="sm"
+                    pos="absolute"
+                    top={-6}
+                    right={-2}
+                >
+                    <Group gap={5} wrap="nowrap">
+                        {titleLeftIcon}
 
-                            {visibleHeaderElement && (
-                                <Group gap="xs" className="non-draggable">
-                                    {visibleHeaderElement}
-                                </Group>
-                            )}
+                        {visibleHeaderElement && (
+                            <Group gap="xs" className="non-draggable">
+                                {visibleHeaderElement}
+                            </Group>
+                        )}
 
-                            {extraHeaderElement}
+                        {extraHeaderElement}
 
-                            {isVerified && (
-                                <Tooltip
-                                    label={
-                                        verification?.verifiedBy
-                                            ? `Verified by ${verification.verifiedBy.firstName} ${verification.verifiedBy.lastName}`
-                                            : 'Verified'
-                                    }
-                                    withArrow
-                                    withinPortal
-                                >
-                                    <IconCircleCheckFilled
-                                        size={14}
-                                        style={{
-                                            flexShrink: 0,
-                                            color: 'var(--mantine-color-green-6)',
-                                        }}
-                                    />
-                                </Tooltip>
-                            )}
+                        {isVerified && (
+                            <Tooltip
+                                label={
+                                    verification?.verifiedBy
+                                        ? `Verified by ${verification.verifiedBy.firstName} ${verification.verifiedBy.lastName}`
+                                        : 'Verified'
+                                }
+                                withArrow
+                                withinPortal
+                            >
+                                <IconCircleCheckFilled
+                                    size={14}
+                                    style={{
+                                        flexShrink: 0,
+                                        color: 'var(--mantine-color-green-6)',
+                                    }}
+                                />
+                            </Tooltip>
+                        )}
 
-                            {hasMenuContent && (
-                                <Menu
-                                    withArrow
-                                    withinPortal
-                                    shadow="md"
-                                    position="bottom-end"
-                                    offset={4}
-                                    arrowOffset={10}
-                                    opened={isMenuOpen}
-                                    onOpen={() => toggleMenu(true)}
-                                    onClose={() => toggleMenu(false)}
-                                >
-                                    <Menu.Dropdown>
-                                        {extraMenuItems}
-                                        {isEditMode && extraMenuItems && (
+                        {hasMenuContent && (
+                            <Menu
+                                withArrow
+                                withinPortal
+                                shadow="md"
+                                position="bottom-end"
+                                offset={4}
+                                arrowOffset={10}
+                                opened={isMenuOpen}
+                                onOpen={() => toggleMenu(true)}
+                                onClose={() => toggleMenu(false)}
+                            >
+                                <Menu.Dropdown>
+                                    {extraMenuItems}
+                                    {isEditMode && extraMenuItems && (
+                                        <Menu.Divider />
+                                    )}
+                                    {isEditMode && (
+                                        <>
+                                            <Box>
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconEdit}
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        setIsEditingTileContent(
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    Edit tile content
+                                                </Menu.Item>
+                                            </Box>
+                                            {tabs && tabs.length > 1 && (
+                                                <Menu.Item
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={
+                                                                IconArrowAutofitContent
+                                                            }
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        setIsMovingTabs(true)
+                                                    }
+                                                >
+                                                    Move to another tab
+                                                </Menu.Item>
+                                            )}
                                             <Menu.Divider />
-                                        )}
-                                        {isEditMode && (
-                                            <>
-                                                <Box>
-                                                    <Menu.Item
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={IconEdit}
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            setIsEditingTileContent(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Edit tile content
-                                                    </Menu.Item>
-                                                </Box>
-                                                {tabs && tabs.length > 1 && (
-                                                    <Menu.Item
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={
-                                                                    IconArrowAutofitContent
-                                                                }
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            setIsMovingTabs(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Move to another tab
-                                                    </Menu.Item>
-                                                )}
-                                                <Menu.Divider />
-                                                {belongsToDashboard ? (
-                                                    <Menu.Item
-                                                        color="red"
-                                                        onClick={() =>
-                                                            setIsDeletingChartThatBelongsToDashboard(
-                                                                true,
-                                                            )
-                                                        }
-                                                    >
-                                                        Delete chart
-                                                    </Menu.Item>
-                                                ) : (
-                                                    <Menu.Item
-                                                        color="red"
-                                                        leftSection={
-                                                            <MantineIcon
-                                                                icon={IconTrash}
-                                                            />
-                                                        }
-                                                        onClick={() =>
-                                                            onDelete(tile)
-                                                        }
-                                                    >
-                                                        Remove tile
-                                                    </Menu.Item>
-                                                )}
-                                            </>
-                                        )}
-                                    </Menu.Dropdown>
+                                            {belongsToDashboard ? (
+                                                <Menu.Item
+                                                    color="red"
+                                                    onClick={() =>
+                                                        setIsDeletingChartThatBelongsToDashboard(
+                                                            true,
+                                                        )
+                                                    }
+                                                >
+                                                    Delete chart
+                                                </Menu.Item>
+                                            ) : (
+                                                <Menu.Item
+                                                    color="red"
+                                                    leftSection={
+                                                        <MantineIcon
+                                                            icon={IconTrash}
+                                                        />
+                                                    }
+                                                    onClick={() =>
+                                                        onDelete(tile)
+                                                    }
+                                                >
+                                                    Remove tile
+                                                </Menu.Item>
+                                            )}
+                                        </>
+                                    )}
+                                </Menu.Dropdown>
 
-                                    <Menu.Target>
-                                        <ActionIcon
-                                            size="sm"
-                                            variant="subtle"
-                                            color="gray"
-                                            style={{
-                                                position: 'relative',
-                                                zIndex: 1,
-                                            }}
-                                        >
-                                            <MantineIcon
-                                                data-testid="tile-icon-more"
-                                                icon={IconDots}
-                                            />
-                                        </ActionIcon>
-                                    </Menu.Target>
-                                </Menu>
-                            )}
-                        </Group>
-                    </Paper>
-                )}
+                                <Menu.Target>
+                                    <ActionIcon
+                                        size="sm"
+                                        variant="subtle"
+                                        color="gray"
+                                        style={{
+                                            position: 'relative',
+                                            zIndex: 1,
+                                        }}
+                                    >
+                                        <MantineIcon
+                                            data-testid="tile-icon-more"
+                                            icon={IconDots}
+                                        />
+                                    </ActionIcon>
+                                </Menu.Target>
+                            </Menu>
+                        )}
+                    </Group>
+                </Paper>
+            )}
 
             <Card
                 className={styles.tileCard}


### PR DESCRIPTION
## Summary

- Always render the tile header tooltip and drag handle in `TileBase`, toggling visibility via CSS `visibility: hidden` + `pointer-events: none` instead of conditionally mounting/unmounting
- Eliminates React reconciliation work on every mouse enter/leave, which was causing jank on dashboards with many tiles

### Before
Each hover triggers mount → render → commit → paint for the tooltip Paper, Menu, icons. Each unhover triggers unmount → cleanup. On a dashboard with 20+ tiles, this creates noticeable lag.

### After
DOM stays stable. Hover just flips a CSS attribute — paint-only, no React work.

## Test plan
- [ ] Hover over chart tiles on a dashboard — tooltip should appear/disappear smoothly
- [ ] Edit mode: drag handle should appear on hover
- [ ] Menu should open/close correctly
- [ ] Verified badge should still show when applicable
- [ ] No visual regressions on tile headers