### PR TITLE
feat: add hidden option to dashboard filters interactivity in embed

### DIFF
--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedCodeSnippet.tsx
@@ -257,6 +257,7 @@ const data = {
         dashboardFiltersInteractivity: {
             enabled: "{{dashboardFiltersInteractivityEnabled}}",
             allowedFilters: {{dashboardFiltersInteractivityAllowedFilters}},
+            hidden: {{dashboardFiltersInteractivityHidden}},
         },
         parameterInteractivity: {
             enabled: {{canChangeParameters}},
@@ -293,6 +294,7 @@ data = {
         "dashboardFiltersInteractivity": {
             "enabled": "{{dashboardFiltersInteractivityEnabled}}",
             "allowedFilters": {{dashboardFiltersInteractivityAllowedFilters}},
+            "hidden": {{dashboardFiltersInteractivityHidden}},
         },
         "parameterInteractivity": {
             "enabled": {{canChangeParameters}},
@@ -339,6 +341,7 @@ func main() {
             DashboardFiltersInteractivity struct {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+                Hidden bool \`json:"hidden"\`
             } \`json:"dashboardFiltersInteractivity"\`
             ParameterInteractivity struct {
                 Enabled bool \`json:"enabled"\`
@@ -367,6 +370,7 @@ func main() {
             DashboardFiltersInteractivity struct {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+                Hidden bool \`json:"hidden"\`
             } \`json:"dashboardFiltersInteractivity"\`
             ParameterInteractivity struct {
                 Enabled bool \`json:"enabled"\`
@@ -384,9 +388,11 @@ func main() {
             DashboardFiltersInteractivity: struct {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+                Hidden bool \`json:"hidden"\`
             }{
                 Enabled: "{{dashboardFiltersInteractivityEnabled}}",
                 AllowedFilters: []string{{{dashboardFiltersInteractivityAllowedFilters}}},
+                Hidden: {{dashboardFiltersInteractivityHidden}},
             },
             ParameterInteractivity: struct {
                 Enabled bool \`json:"enabled"\`
@@ -562,6 +568,7 @@ const data = {
         dashboardFiltersInteractivity: {
             enabled: "{{dashboardFiltersInteractivityEnabled}}",
             allowedFilters: {{dashboardFiltersInteractivityAllowedFilters}},
+            hidden: {{dashboardFiltersInteractivityHidden}},
         },
         parameterInteractivity: {
             enabled: {{canChangeParameters}},
@@ -597,6 +604,7 @@ data = {
         "dashboardFiltersInteractivity": {
             "enabled": "{{dashboardFiltersInteractivityEnabled}}",
             "allowedFilters": {{dashboardFiltersInteractivityAllowedFilters}},
+            "hidden": {{dashboardFiltersInteractivityHidden}},
         },
         "parameterInteractivity": {
             "enabled": {{canChangeParameters}},
@@ -641,6 +649,7 @@ func main() {
             DashboardFiltersInteractivity struct {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+                Hidden bool \`json:"hidden"\`
             } \`json:"dashboardFiltersInteractivity"\`
             ParameterInteractivity struct {
                 Enabled bool \`json:"enabled"\`
@@ -668,6 +677,7 @@ func main() {
             DashboardFiltersInteractivity struct {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+                Hidden bool \`json:"hidden"\`
             } \`json:"dashboardFiltersInteractivity"\`
             ParameterInteractivity struct {
                 Enabled bool \`json:"enabled"\`
@@ -685,9 +695,11 @@ func main() {
             DashboardFiltersInteractivity: struct {
                 Enabled string \`json:"enabled"\`
                 AllowedFilters []string \`json:"allowedFilters,omitempty"\`
+                Hidden bool \`json:"hidden"\`
             }{
                 Enabled: "{{dashboardFiltersInteractivityEnabled}}",
                 AllowedFilters: []string{{{dashboardFiltersInteractivityAllowedFilters}}},
+                Hidden: {{dashboardFiltersInteractivityHidden}},
             },
             ParameterInteractivity: struct {
                 Enabled bool \`json:"enabled"\`
@@ -815,6 +827,14 @@ const getBackendCodeSnippet = (
                         language,
                         data.content.dashboardFiltersInteractivity
                             ?.allowedFilters,
+                    ),
+                )
+                .replace(
+                    '{{dashboardFiltersInteractivityHidden}}',
+                    languageBoolean(
+                        language,
+                        data.content.dashboardFiltersInteractivity?.hidden ??
+                            false,
                     ),
                 )
                 .replace(

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedFiltersInteractivity.tsx
@@ -13,10 +13,14 @@ import {
     Group,
     SegmentedControl,
     Stack,
+    Switch,
     Text,
+    Tooltip,
 } from '@mantine-8/core';
+import { IconInfoCircle } from '@tabler/icons-react';
 import { useCallback, useMemo } from 'react';
 import { getConditionalRuleLabelFromItem } from '../../../../components/common/Filters/FilterInputs/utils';
+import MantineIcon from '../../../../components/common/MantineIcon';
 import { type FieldsWithSuggestions } from '../../../../components/Explorer/FiltersCard/useFieldsWithSuggestions';
 import {
     useDashboardQuery,
@@ -103,9 +107,11 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
         ({
             enabled: newEnabledValue,
             allowedFilters: newAllowedFilters,
+            hidden: newHiddenValue,
         }: {
             enabled?: FilterInteractivityValues;
             allowedFilters?: string[];
+            hidden?: boolean;
         }) => {
             const enabled = getFilterInteractivityValue(
                 newEnabledValue ?? interactivityOptions.enabled,
@@ -132,11 +138,13 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
             onInteractivityOptionsChange({
                 enabled,
                 allowedFilters,
+                hidden: newHiddenValue ?? interactivityOptions.hidden ?? false,
             });
         },
         [
             interactivityOptions.enabled,
             interactivityOptions.allowedFilters,
+            interactivityOptions.hidden,
             onInteractivityOptionsChange,
         ],
     );
@@ -180,6 +188,35 @@ const EmbedFiltersInteractivity: React.FC<Props> = ({
                     size="xs"
                 />
             </Group>
+            <Switch
+                size="sm"
+                checked={interactivityOptions.hidden ?? false}
+                disabled={
+                    getFilterInteractivityValue(
+                        interactivityOptions.enabled,
+                    ) === FilterInteractivityValues.none
+                }
+                label={
+                    <Group gap="xs">
+                        <Text inherit>Hide filters</Text>
+                        <Tooltip
+                            label="Hide filters from the embed UI while still applying them. Useful when building custom filter controls with the React SDK."
+                            withArrow
+                            withinPortal
+                            multiline
+                            maw="300px"
+                            position="right"
+                        >
+                            <MantineIcon icon={IconInfoCircle} size="sm" />
+                        </Tooltip>
+                    </Group>
+                }
+                onChange={(event) => {
+                    setInteractivityOptions({
+                        hidden: event.currentTarget.checked,
+                    });
+                }}
+            />
             {interactivityOptions.enabled ===
                 FilterInteractivityValues.some && (
                 <Checkbox.Group

--- a/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
+++ b/packages/frontend/src/ee/features/embed/SettingsEmbed/EmbedPreviewDashboardForm.tsx
@@ -99,6 +99,7 @@ const EmbedPreviewDashboardForm: FC<{
             email: user?.email,
             dashboardFiltersInteractivity: {
                 enabled: FilterInteractivityValues.none,
+                hidden: false,
             },
             parameterInteractivity: {
                 enabled: false,
@@ -130,6 +131,9 @@ const EmbedPreviewDashboardForm: FC<{
                     dashboardUuid: values.dashboardUuid!,
                     dashboardFiltersInteractivity: {
                         enabled: values.dashboardFiltersInteractivity?.enabled,
+                        hidden:
+                            values.dashboardFiltersInteractivity?.hidden ??
+                            false,
                         ...(values.dashboardFiltersInteractivity?.enabled ===
                         FilterInteractivityValues.some
                             ? {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Added a "Hide filters" option to dashboard embed settings that allows filters to be hidden from the embed UI while still applying them. This feature is useful when building custom filter controls with the React SDK.

The implementation includes:
- New `hidden` boolean property in the `dashboardFiltersInteractivity` configuration
- Switch control in the embed settings UI with tooltip explaining the functionality
- The option is disabled when filter interactivity is set to "none"
- Updated embed code snippets across all supported languages (JavaScript, Python, Go) to include the new hidden parameter
- Default value of `false` to maintain backward compatibility

<!-- Even better add a screenshot / gif / loom -->