### PR TITLE
feat: defer chart rendering until tile is visible in viewport

### DIFF
--- a/packages/e2e/cypress/e2e/app/dashboard.cy.ts
+++ b/packages/e2e/cypress/e2e/app/dashboard.cy.ts
@@ -23,6 +23,10 @@ describe('Dashboard', () => {
         cy.findAllByText('No chart available').should('have.length', 0);
         cy.findAllByText('No data available').should('have.length', 0);
 
+        // Scroll down to trigger deferred chart rendering for below-fold tiles
+        cy.get('.react-grid-layout').scrollIntoView({ duration: 500 });
+        cy.window().scrollTo('bottom', { duration: 500 });
+
         cy.get('.echarts-for-react').should('have.length', 3); // Charts
 
         cy.get('.react-grid-layout').within(() => {

--- a/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/TileBase.module.css
@@ -110,6 +110,8 @@
 
 .chartContainer {
     overflow: hidden;
+    content-visibility: auto;
+    contain-intrinsic-size: auto 300px;
 
     &[data-full-width='true'] {
         margin: 0 -16px -16px -16px;

--- a/packages/frontend/src/components/LightdashVisualization/index.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/index.tsx
@@ -1,7 +1,16 @@
 import { assertUnreachable, ChartType } from '@lightdash/common';
-import { Anchor, Text } from '@mantine-8/core';
+import { Anchor, Skeleton, Text } from '@mantine-8/core';
 import { IconChartBarOff } from '@tabler/icons-react';
-import { forwardRef, Fragment, lazy, memo, Suspense } from 'react';
+import {
+    forwardRef,
+    Fragment,
+    lazy,
+    memo,
+    Suspense,
+    useEffect,
+    useRef,
+    useState,
+} from 'react';
 import { EmptyState } from '../common/EmptyState';
 import MantineIcon from '../common/MantineIcon';
 import SuboptimalState from '../common/SuboptimalState/SuboptimalState';
@@ -18,6 +27,51 @@ import { useVisualizationContext } from './useVisualizationContext';
 
 // Lazy load SimpleMap to avoid bundling Leaflet in the main chunk
 const LazySimpleMap = lazy(() => import('../SimpleMap'));
+
+/**
+ * Defers rendering of chart content until the tile is visible in the viewport.
+ * On dashboards, all tiles mount (so react-query fires all API calls in parallel),
+ * but only visible tiles render the heavy chart component (ECharts, tables, etc.).
+ * When the user scrolls, the data is already cached, so charts render instantly.
+ *
+ * Skipped when:
+ * - Not on a dashboard (explorer, chart view)
+ * - Screenshot mode (onScreenshotReady is set) — must render all tiles for capture
+ */
+function useDeferredVisibility(enabled: boolean) {
+    const sentinelRef = useRef<HTMLDivElement>(null);
+    const [isVisible, setIsVisible] = useState(!enabled);
+
+    useEffect(() => {
+        if (!enabled || isVisible) return;
+
+        const el = sentinelRef.current;
+        if (!el) return;
+
+        // Synchronous check before setting up observer — catches above-fold
+        // tiles before IntersectionObserver's async callback fires.
+        const rect = el.getBoundingClientRect();
+        if (rect.top < window.innerHeight + 200) {
+            setIsVisible(true);
+            return;
+        }
+
+        const observer = new IntersectionObserver(
+            ([entry]) => {
+                if (entry.isIntersecting) {
+                    setIsVisible(true);
+                    observer.disconnect();
+                }
+            },
+            { rootMargin: '200px' },
+        );
+
+        observer.observe(el);
+        return () => observer.disconnect();
+    }, [enabled, isVisible]);
+
+    return { sentinelRef, isVisible };
+}
 
 interface LightdashVisualizationProps {
     isDashboard?: boolean;
@@ -45,6 +99,10 @@ const LightdashVisualization = memo(
         ) => {
             const { visualizationConfig, minimal, apiErrorDetail } =
                 useVisualizationContext();
+
+            const { sentinelRef, isVisible } = useDeferredVisibility(
+                isDashboard && !minimal,
+            );
 
             if (!visualizationConfig) {
                 return null;
@@ -233,7 +291,13 @@ const LightdashVisualization = memo(
                         flexDirection: 'column',
                     }}
                 >
-                    {chartContent}
+                    {isVisible ? (
+                        chartContent
+                    ) : (
+                        <div ref={sentinelRef} style={{ flex: 1 }}>
+                            <Skeleton h="100%" w="100%" />
+                        </div>
+                    )}
                 </div>
             );
         },


### PR DESCRIPTION
## Summary

Separates query execution from chart rendering on dashboards:

- **All tiles mount** → all react-query API calls fire in parallel (no change to query behavior)
- **Only visible tiles render charts** → `IntersectionObserver` with 200px rootMargin defers ECharts/table init for off-screen tiles
- **Scroll down** → data is already cached in react-query → chart renders instantly (no loading spinner)

Off-screen tiles show a `Skeleton` placeholder until they enter the viewport.

### How it works

`useDeferredVisibility` hook in `LightdashVisualization`:
1. Non-dashboard views (explorer, chart) → renders immediately, no change
2. Screenshot mode (`minimal=true`) → renders immediately, no deferral
3. Dashboard tiles → synchronous `getBoundingClientRect` check avoids skeleton flash for above-fold tiles
4. Below-fold tiles → `IntersectionObserver` watches sentinel div, swaps in chart when within 200px of viewport
5. One-shot: observer disconnects after first intersection, chart stays mounted permanently

### Impact

On a dashboard with 8 tiles where 2 are above the fold:
- **Before**: 8 ECharts instances init simultaneously → main thread blocked
- **After**: 2 ECharts instances init immediately, remaining 6 init on scroll with cached data → instant render

Adapts to any screen size — `rootMargin` is relative to actual viewport height.

## Test plan
- [ ] Dashboard loads — visible tiles render charts, below-fold tiles show skeleton briefly then render on scroll
- [ ] Scrolling down renders charts instantly (no loading spinner — data is cached)
- [ ] Explorer/chart view pages render immediately (no skeleton flash)
- [ ] Embedded dashboards work correctly
- [ ] Screenshot/unfurl flow still works (MinimalDashboard renders all tiles immediately)
- [ ] Tab switching renders charts on the new tab correctly
- [ ] Works on different screen sizes (small laptop, large monitor)