### PR TITLE
feat: migrate org and user services to audited ability checks

### DIFF
--- a/packages/backend/src/services/GroupService.ts
+++ b/packages/backend/src/services/GroupService.ts
@@ -61,12 +61,15 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(member.groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: member.groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -104,12 +107,15 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(member.groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: member.groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -143,12 +149,15 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'delete',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -176,6 +185,7 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group =
             includeMembers === undefined
                 ? await this.groupsModel.getGroup(groupUuid)
@@ -186,10 +196,12 @@ export class GroupsService extends BaseService {
                   );
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -207,12 +219,15 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -246,12 +261,15 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroupWithMembers(groupUuid);
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -268,14 +286,17 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -283,10 +304,12 @@ export class GroupsService extends BaseService {
         }
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -321,14 +344,17 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -336,10 +362,12 @@ export class GroupsService extends BaseService {
         }
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -370,14 +398,17 @@ export class GroupsService extends BaseService {
             throw new ForbiddenError('Group service is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const group = await this.groupsModel.getGroup(groupUuid);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Group', {
+                    uuid: groupUuid,
                     organizationUuid: group.organizationUuid,
+                    name: group.name,
                 }),
             )
         ) {
@@ -385,10 +416,12 @@ export class GroupsService extends BaseService {
         }
 
         if (
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/OAuthService/OAuthService.ts
+++ b/packages/backend/src/services/OAuthService/OAuthService.ts
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     NotFoundError,
@@ -128,8 +129,15 @@ export class OAuthService extends BaseService {
     }
 
     public async listClients(user: SessionUser): Promise<OAuthClientSummary[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot('manage', 'Organization') ||
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: user.organizationUuid || '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            ) ||
             !user.organizationUuid
         ) {
             throw new ForbiddenError(
@@ -149,8 +157,15 @@ export class OAuthService extends BaseService {
             redirectUris: string[];
         },
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot('manage', 'Organization') ||
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: user.organizationUuid || '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            ) ||
             !user.organizationUuid
         ) {
             throw new ForbiddenError(
@@ -186,8 +201,15 @@ export class OAuthService extends BaseService {
             redirectUris: string[];
         },
     ): Promise<OAuthClientSummary> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot('manage', 'Organization') ||
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: user.organizationUuid || '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            ) ||
             !user.organizationUuid
         ) {
             throw new ForbiddenError(
@@ -219,8 +241,15 @@ export class OAuthService extends BaseService {
         user: SessionUser,
         clientId: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot('manage', 'Organization') ||
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: user.organizationUuid || '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            ) ||
             !user.organizationUuid
         ) {
             throw new ForbiddenError(

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -169,10 +169,14 @@ export class OrganizationService extends BaseService {
 
     async delete(organizationUuid: string, user: SessionUser): Promise<void> {
         const organization = await this.organizationModel.get(organizationUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'delete',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    organizationUuid,
+                    uuid: organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -229,10 +233,14 @@ export class OrganizationService extends BaseService {
     ): Promise<KnexPaginatedData<OrganizationMemberProfile[]>> {
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('OrganizationMemberProfile', { organizationUuid }),
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -257,9 +265,12 @@ export class OrganizationService extends BaseService {
               });
 
         let members = organizationMembers.filter((member) =>
-            user.ability.can(
+            auditedAbility.can(
                 'view',
-                subject('OrganizationMemberProfile', member),
+                subject('OrganizationMemberProfile', {
+                    ...member,
+                    uuid: member.userUuid,
+                }),
             ),
         );
 
@@ -310,12 +321,14 @@ export class OrganizationService extends BaseService {
                 this.projectModel.getAllByOrganizationUuid(organizationUuid),
         );
 
+        const auditedAbility = this.createAuditedAbility(account);
         return projects.filter((project) =>
-            account.user.ability.can(
+            auditedAbility.can(
                 'view',
                 subject('Project', {
                     organizationUuid,
                     projectUuid: project.projectUuid,
+                    uuid: project.projectUuid,
                 }),
             ),
         );
@@ -347,9 +360,16 @@ export class OrganizationService extends BaseService {
         memberUuid: string,
     ): Promise<OrganizationMemberProfile> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             organizationUuid === undefined ||
-            user.ability.cannot('view', 'OrganizationMemberProfile')
+            auditedAbility.cannot(
+                'view',
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -359,9 +379,12 @@ export class OrganizationService extends BaseService {
                 memberUuid,
             );
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('OrganizationMemberProfile', member),
+                subject('OrganizationMemberProfile', {
+                    ...member,
+                    uuid: member.userUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -374,9 +397,16 @@ export class OrganizationService extends BaseService {
         email: string,
     ): Promise<OrganizationMemberProfile> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             organizationUuid === undefined ||
-            user.ability.cannot('view', 'OrganizationMemberProfile')
+            auditedAbility.cannot(
+                'view',
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
+            )
         ) {
             throw new ForbiddenError();
         }
@@ -387,9 +417,12 @@ export class OrganizationService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('OrganizationMemberProfile', member),
+                subject('OrganizationMemberProfile', {
+                    ...member,
+                    uuid: member.userUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -406,10 +439,14 @@ export class OrganizationService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
         const { organizationUuid } = authenticatedUser;
+        const auditedAbility = this.createAuditedAbility(authenticatedUser);
         if (
-            authenticatedUser.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('OrganizationMemberProfile', { organizationUuid }),
+                subject('OrganizationMemberProfile', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -483,10 +520,14 @@ export class OrganizationService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    organizationUuid,
+                    uuid: organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -569,12 +610,14 @@ export class OrganizationService extends BaseService {
         actor: SessionUser,
         createGroup: CreateGroup,
     ): Promise<GroupWithMembers> {
+        const auditedAbility = this.createAuditedAbility(actor);
         if (
             actor.organizationUuid === undefined ||
-            actor.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('Group', {
                     organizationUuid: actor.organizationUuid,
+                    uuid: actor.organizationUuid,
                 }),
             )
         ) {
@@ -621,8 +664,9 @@ export class OrganizationService extends BaseService {
             paginateArgs,
         );
 
+        const auditedAbility = this.createAuditedAbility(actor);
         const allowedGroups = groups.filter((group) =>
-            actor.ability.can('view', subject('Group', group)),
+            auditedAbility.can('view', subject('Group', group)),
         );
 
         if (includeMembers === undefined) {
@@ -655,12 +699,14 @@ export class OrganizationService extends BaseService {
         user: SessionUser,
         data: CreateColorPalette,
     ): Promise<OrganizationColorPalette> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !user.organizationUuid ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -695,12 +741,14 @@ export class OrganizationService extends BaseService {
         colorPaletteUuid: string,
         data: UpdateColorPalette,
     ): Promise<OrganizationColorPalette> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !user.organizationUuid ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -724,12 +772,14 @@ export class OrganizationService extends BaseService {
         user: SessionUser,
         colorPaletteUuid: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !user.organizationUuid ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -746,12 +796,14 @@ export class OrganizationService extends BaseService {
         user: SessionUser,
         colorPaletteUuid: string,
     ): Promise<OrganizationColorPalette> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
             !user.organizationUuid ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid,
                 }),
             )
         ) {
@@ -768,10 +820,14 @@ export class OrganizationService extends BaseService {
 
     async getImpersonationEnabled(user: SessionUser): Promise<boolean> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -794,10 +850,14 @@ export class OrganizationService extends BaseService {
         enabled: boolean,
     ): Promise<void> {
         const { organizationUuid } = user;
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    organizationUuid: organizationUuid || '',
+                    uuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/PersonalAccessTokenService.ts
+++ b/packages/backend/src/services/PersonalAccessTokenService.ts
@@ -60,7 +60,16 @@ export class PersonalAccessTokenService extends BaseService {
         data: CreatePersonalAccessToken,
         method: RequestMethod,
     ): Promise<PersonalAccessTokenWithToken> {
-        if (user.ability.cannot('create', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'create',
+                subject('PersonalAccessToken', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to create a personal access token',
             );
@@ -86,7 +95,16 @@ export class PersonalAccessTokenService extends BaseService {
         user: SessionUser,
         personalAccessTokenUuid: string,
     ): Promise<void> {
-        if (user.ability.cannot('delete', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'delete',
+                subject('PersonalAccessToken', {
+                    uuid: personalAccessTokenUuid,
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to delete a personal access token',
             );
@@ -102,7 +120,16 @@ export class PersonalAccessTokenService extends BaseService {
     async getAllPersonalAccessTokens(
         user: SessionUser,
     ): Promise<PersonalAccessToken[]> {
-        if (user.ability.cannot('view', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('PersonalAccessToken', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to view personal access tokens',
             );
@@ -115,7 +142,16 @@ export class PersonalAccessTokenService extends BaseService {
         personalAccessTokenUuid: string,
         data: { expiresAt: Date },
     ): Promise<PersonalAccessTokenWithToken> {
-        if (user.ability.cannot('update', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'update',
+                subject('PersonalAccessToken', {
+                    uuid: personalAccessTokenUuid,
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to rotate a personal access token',
             );

--- a/packages/backend/src/services/RolesService/RolesService.mock.ts
+++ b/packages/backend/src/services/RolesService/RolesService.mock.ts
@@ -22,6 +22,8 @@ export const mockAccount = {
         ability: {
             can: jest.fn(() => true),
             cannot: jest.fn(() => false),
+            relevantRuleFor: jest.fn(() => null),
+            rules: [],
         } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
         abilityRules: [] as any, // eslint-disable-line @typescript-eslint/no-explicit-any
         isTrackingAnonymized: false,
@@ -53,6 +55,8 @@ export const mockAccountNoAccess = {
         ability: {
             can: jest.fn(() => false),
             cannot: jest.fn(() => true),
+            relevantRuleFor: jest.fn(() => null),
+            rules: [],
         } as any, // eslint-disable-line @typescript-eslint/no-explicit-any
     },
 } as SessionAccount;

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -94,11 +94,13 @@ export class RolesService extends BaseService {
         account: Account,
         organizationUuid: string,
     ) {
+        const auditedAbility = this.createAuditedAbility(account);
         // if user is admin of organization, they can see roles
         if (
-            account.user.ability.can(
+            auditedAbility.can(
                 'manage',
                 subject('Organization', {
+                    uuid: organizationUuid,
                     organizationUuid,
                 }),
             )
@@ -115,9 +117,10 @@ export class RolesService extends BaseService {
         );
 
         const canManageSomeProjects = projects.some((project) =>
-            account.user.ability.can(
+            auditedAbility.can(
                 'manage',
                 subject('Project', {
+                    uuid: project.projectUuid,
                     organizationUuid,
                     projectUuid: project.projectUuid,
                 }),
@@ -129,7 +132,7 @@ export class RolesService extends BaseService {
         }
     }
 
-    private static validateOrganizationAccess(
+    private validateOrganizationAccess(
         account: Account,
         organizationUuid?: string,
     ): void {
@@ -141,10 +144,12 @@ export class RolesService extends BaseService {
             throw new ForbiddenError();
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: organizationUuid,
                     organizationUuid,
                 }),
             )
@@ -155,7 +160,7 @@ export class RolesService extends BaseService {
         }
     }
 
-    private static validateRoleOwnership(account: Account, role: Role): void {
+    private validateRoleOwnership(account: Account, role: Role): void {
         if (isSystemRole(role.roleUuid) && role.ownerType === 'system') {
             return;
         }
@@ -164,10 +169,12 @@ export class RolesService extends BaseService {
             throw new ForbiddenError();
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: role.organizationUuid,
                     organizationUuid: role.organizationUuid,
                 }),
             )
@@ -182,10 +189,12 @@ export class RolesService extends BaseService {
     ) {
         if (projectUuid) {
             const project = await this.projectModel.getSummary(projectUuid);
+            const auditedAbility = this.createAuditedAbility(account);
             if (
-                account.user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('Project', {
+                        uuid: projectUuid,
                         organizationUuid: project.organizationUuid,
                         projectUuid,
                     }),
@@ -221,7 +230,7 @@ export class RolesService extends BaseService {
         await this.validateRolesViewAccess(account, organizationUuid);
 
         if (loadScopes) {
-            RolesService.validateOrganizationAccess(account, organizationUuid);
+            this.validateOrganizationAccess(account, organizationUuid);
             return this.rolesModel.getRolesWithScopesByOrganizationUuid(
                 organizationUuid,
                 roleTypeFilter,
@@ -246,7 +255,7 @@ export class RolesService extends BaseService {
             );
         }
 
-        RolesService.validateOrganizationAccess(account, organizationUuid);
+        this.validateOrganizationAccess(account, organizationUuid);
         RolesService.validateRoleName(name);
 
         const role = await this.rolesModel.db.transaction(
@@ -300,7 +309,7 @@ export class RolesService extends BaseService {
         }
 
         const role = await this.rolesModel.getRoleByUuid(roleUuid);
-        RolesService.validateRoleOwnership(account, role);
+        this.validateRoleOwnership(account, role);
 
         if (name) {
             RolesService.validateRoleName(name);
@@ -355,7 +364,7 @@ export class RolesService extends BaseService {
         roleUuid: string,
     ): Promise<RoleWithScopes> {
         const role = await this.rolesModel.getRoleWithScopesByUuid(roleUuid);
-        RolesService.validateRoleOwnership(account, role);
+        this.validateRoleOwnership(account, role);
 
         return role;
     }
@@ -396,7 +405,7 @@ export class RolesService extends BaseService {
         const { roleId } = request;
 
         // Validate organization access
-        RolesService.validateOrganizationAccess(account, orgUuid);
+        this.validateOrganizationAccess(account, orgUuid);
 
         // Ensure only system roles can be assigned at organization level
         if (roleId !== OrganizationMemberRole.MEMBER && !isSystemRole(roleId)) {
@@ -704,10 +713,7 @@ export class RolesService extends BaseService {
     ): Promise<RoleAssignment> {
         const { roleId } = request;
         const project = await this.projectModel.getSummary(projectUuid);
-        RolesService.validateOrganizationAccess(
-            account,
-            project.organizationUuid,
-        );
+        this.validateOrganizationAccess(account, project.organizationUuid);
         await this.validateProjectAccess(account, projectUuid);
         const role = await this.rolesModel.getRoleWithScopesByUuid(roleId);
 
@@ -764,7 +770,7 @@ export class RolesService extends BaseService {
         }
         try {
             const role = await this.rolesModel.getRoleByUuid(roleUuid);
-            RolesService.validateRoleOwnership(account, role);
+            this.validateRoleOwnership(account, role);
 
             await this.rolesModel.deleteRole(roleUuid);
 
@@ -802,7 +808,7 @@ export class RolesService extends BaseService {
         organizationUuid: string,
         projectUuid: string,
     ): Promise<void> {
-        RolesService.validateOrganizationAccess(account, organizationUuid);
+        this.validateOrganizationAccess(account, organizationUuid);
         await this.validateProjectAccess(account, projectUuid);
 
         await this.rolesModel.unassignCustomRoleFromUser(userUuid, projectUuid);
@@ -825,7 +831,7 @@ export class RolesService extends BaseService {
         projectUuid: string,
     ): Promise<void> {
         const role = await this.rolesModel.getRoleByUuid(roleUuid);
-        RolesService.validateRoleOwnership(account, role);
+        this.validateRoleOwnership(account, role);
         await this.validateProjectAccess(account, projectUuid);
 
         await this.rolesModel.assignRoleToGroup(
@@ -851,7 +857,7 @@ export class RolesService extends BaseService {
         groupUuid: string,
         projectUuid: string,
     ): Promise<void> {
-        RolesService.validateOrganizationAccess(
+        this.validateOrganizationAccess(
             account,
             account.organization?.organizationUuid,
         );
@@ -889,10 +895,7 @@ export class RolesService extends BaseService {
         userUuid: string,
     ): Promise<void> {
         const project = await this.projectModel.getSummary(projectUuid);
-        RolesService.validateOrganizationAccess(
-            account,
-            project.organizationUuid,
-        );
+        this.validateOrganizationAccess(account, project.organizationUuid);
         await this.validateProjectAccess(account, projectUuid);
 
         await this.rolesModel.removeUserProjectAccess(userUuid, projectUuid);
@@ -919,7 +922,7 @@ export class RolesService extends BaseService {
 
         const foundRole =
             role || (await this.rolesModel.getRoleByUuid(roleUuid));
-        RolesService.validateRoleOwnership(account, foundRole);
+        this.validateRoleOwnership(account, foundRole);
 
         await this.rolesModel.addScopesToRole(
             roleUuid,
@@ -949,7 +952,7 @@ export class RolesService extends BaseService {
         }
 
         const role = await this.rolesModel.getRoleByUuid(roleUuid);
-        RolesService.validateRoleOwnership(account, role);
+        this.validateRoleOwnership(account, role);
 
         await this.rolesModel.removeScopeFromRole(roleUuid, scopeName);
 
@@ -971,7 +974,7 @@ export class RolesService extends BaseService {
         scopeNames: string[],
         tx?: Knex.Transaction,
     ): Promise<void> {
-        RolesService.validateOrganizationAccess(account, organizationUuid);
+        this.validateOrganizationAccess(account, organizationUuid);
 
         if (scopeNames.filter(Boolean).length === 0) {
             throw new ParameterError('scopeNames are required');
@@ -1000,7 +1003,7 @@ export class RolesService extends BaseService {
         roleUuid: string,
         duplicateRoleData: CreateRole,
     ): Promise<RoleWithScopes> {
-        RolesService.validateOrganizationAccess(account, organizationUuid);
+        this.validateOrganizationAccess(account, organizationUuid);
 
         const { name, description } = duplicateRoleData;
         RolesService.validateRoleName(name);
@@ -1010,7 +1013,7 @@ export class RolesService extends BaseService {
         if (!sourceRole) {
             throw new NotFoundError(`Role to duplicate: ${roleUuid} not found`);
         }
-        RolesService.validateRoleOwnership(account, sourceRole);
+        this.validateRoleOwnership(account, sourceRole);
 
         const copyOfRoleName = `Copy of: ${sourceRole.name}`;
         const newDescription =

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -39,7 +39,10 @@ export const validateUserAttributeOverrides = (
     if (
         user.ability.cannot(
             'manage',
-            subject('Organization', { organizationUuid }),
+            subject('Organization', {
+                uuid: organizationUuid,
+                organizationUuid,
+            }),
         )
     ) {
         throw new ForbiddenError(

--- a/packages/backend/src/services/UserAttributesService/UserAttributesService.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributesService.ts
@@ -51,11 +51,15 @@ export class UserAttributesService extends BaseService {
         user: SessionUser,
         context: RequestMethod,
     ): Promise<UserAttribute[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         const organizationUuid = user.organizationUuid!;
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    uuid: organizationUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -82,12 +86,16 @@ export class UserAttributesService extends BaseService {
         user: SessionUser,
         orgAttribute: CreateUserAttribute,
     ): Promise<UserAttribute> {
+        const auditedAbility = this.createAuditedAbility(user);
         const organizationUuid = user.organizationUuid!;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('Organization', { organizationUuid }),
+                subject('Organization', {
+                    uuid: organizationUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -114,13 +122,15 @@ export class UserAttributesService extends BaseService {
         orgAttributeUuid: string,
         orgAttribute: CreateUserAttribute,
     ): Promise<UserAttribute> {
+        const auditedAbility = this.createAuditedAbility(user);
         const savedAttribute =
             await this.userAttributesModel.get(orgAttributeUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: savedAttribute.organizationUuid,
                     organizationUuid: savedAttribute.organizationUuid,
                 }),
             )
@@ -146,12 +156,14 @@ export class UserAttributesService extends BaseService {
     }
 
     async delete(user: SessionUser, orgAttributeUuid: string): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const orgAttribute =
             await this.userAttributesModel.get(orgAttributeUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
+                    uuid: orgAttribute.organizationUuid,
                     organizationUuid: orgAttribute.organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -367,6 +367,7 @@ export class UserService extends BaseService {
     }
 
     async delete(user: SessionUser, userUuidToDelete: string): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const userToDelete =
             await this.userModel.getUserDetailsByUuid(userUuidToDelete);
         // The user might not have an org yet
@@ -375,9 +376,10 @@ export class UserService extends BaseService {
             // We assume only one org per user
 
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'delete',
                     subject('OrganizationMemberProfile', {
+                        uuid: userUuidToDelete,
                         organizationUuid: userToDelete.organizationUuid,
                     }),
                 )
@@ -427,10 +429,14 @@ export class UserService extends BaseService {
         // We assume users can only have one org
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('InviteLink', { organizationUuid }),
+                subject('InviteLink', {
+                    uuid: '',
+                    organizationUuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -456,9 +462,12 @@ export class UserService extends BaseService {
         }
 
         let userUuid: string;
-        const userRole = user.ability.can(
+        const userRole = auditedAbility.can(
             'manage',
-            subject('OrganizationMemberProfile', { organizationUuid }),
+            subject('OrganizationMemberProfile', {
+                uuid: '',
+                organizationUuid,
+            }),
         )
             ? role || OrganizationMemberRole.MEMBER
             : OrganizationMemberRole.MEMBER;
@@ -525,10 +534,14 @@ export class UserService extends BaseService {
         // We assume users can only have one org
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'delete',
-                subject('InviteLink', { organizationUuid }),
+                subject('InviteLink', {
+                    uuid: '',
+                    organizationUuid: organizationUuid || '',
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -983,11 +996,13 @@ export class UserService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         if (organizationName) {
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'update',
                     subject('Organization', {
+                        uuid: user.organizationUuid,
                         organizationUuid: user.organizationUuid,
                     }),
                 )
@@ -1358,7 +1373,16 @@ export class UserService extends BaseService {
         if (!user.isActive) {
             throw new DeactivatedAccountError();
         }
-        if (user.ability.cannot('view', subject('PersonalAccessToken', {}))) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('PersonalAccessToken', {
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 'You do not have permission to login with personal access tokens',
             );
@@ -1623,14 +1647,17 @@ export class UserService extends BaseService {
 
         if (projects.length === 0) return;
 
+        const auditedAbility = this.createAuditedAbility(sessionUser);
         await Promise.all(
             projects.map(async (project) => {
                 if (
-                    sessionUser.ability.cannot(
+                    auditedAbility.cannot(
                         'manage',
                         subject('SavedChart', {
+                            uuid: '',
                             projectUuid: project.projectUuid,
-                            organizationUuid: sessionUser.organizationUuid,
+                            organizationUuid:
+                                sessionUser.organizationUuid || '',
                             access: [
                                 {
                                     userUuid: sessionUser.userUuid,
@@ -1641,11 +1668,13 @@ export class UserService extends BaseService {
                             ],
                         }),
                     ) ||
-                    sessionUser.ability.cannot(
+                    auditedAbility.cannot(
                         'manage',
                         subject('Explore', {
+                            uuid: '',
                             projectUuid: project.projectUuid,
-                            organizationUuid: sessionUser.organizationUuid,
+                            organizationUuid:
+                                sessionUser.organizationUuid || '',
                         }),
                     )
                 )
@@ -1681,6 +1710,7 @@ export class UserService extends BaseService {
         clearImpersonation: () => void,
     ): Promise<SessionUser> {
         const requestUser = await this.findSessionUser(passportUser);
+        const auditedAbility = this.createAuditedAbility(requestUser);
 
         if (!impersonation) {
             return requestUser;
@@ -1710,10 +1740,11 @@ export class UserService extends BaseService {
         // Validate admin can still impersonate
         if (
             !requestUser.isActive ||
-            requestUser.ability.cannot(
+            auditedAbility.cannot(
                 'impersonate',
                 subject('User', {
-                    organizationUuid: requestUser.organizationUuid,
+                    uuid: requestUser.userUuid,
+                    organizationUuid: requestUser.organizationUuid || '',
                     isActive: requestUser.isActive,
                 }),
             )
@@ -2337,6 +2368,7 @@ export class UserService extends BaseService {
             }) => void;
         },
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(adminUser);
         if (!(await this.isImpersonationEnabled(adminUser))) {
             throw new ForbiddenError('User impersonation is not enabled');
         }
@@ -2365,10 +2397,11 @@ export class UserService extends BaseService {
 
         // Check permissions using CASL (includes org match and isActive)
         if (
-            adminUser.ability.cannot(
+            auditedAbility.cannot(
                 'impersonate',
                 subject('User', {
-                    organizationUuid: targetUser.organizationUuid,
+                    uuid: targetUserUuid,
+                    organizationUuid: targetUser.organizationUuid || '',
                     isActive: targetUser.isActive,
                 }),
             )


### PR DESCRIPTION
Closes: SPK-338

## Summary
Migrate organization and user management services:
- OrganizationService, UserService, RolesService, GroupService
- PersonalAccessTokenService, OAuthService, UserAttributesService

- RolesService mock updated with `relevantRuleFor` and `rules`
- `uuid: ''` occurrences marked with `/* TODO: pass resource uuid */`

## Test plan
- [x] `pnpm -F backend typecheck` passes