### PR TITLE
feat: migrate content management services to audited ability checks

### DIFF
--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -566,10 +566,12 @@ export class CoderService extends BaseService {
         content: T[],
         spaces: SpaceSummaryBase[],
     ): Promise<T[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.can(
+            auditedAbility.can(
                 'manage',
                 subject('Project', {
+                    uuid: project.projectUuid,
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -608,10 +610,12 @@ export class CoderService extends BaseService {
             throw new NotFoundError(`Project ${projectUuid} not found`);
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -745,10 +749,12 @@ export class CoderService extends BaseService {
         }
 
         // Filter charts based on user permissions (from private spaces)
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -880,10 +886,12 @@ export class CoderService extends BaseService {
             throw new NotFoundError(`Project ${projectUuid} not found`);
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -998,12 +1006,14 @@ export class CoderService extends BaseService {
         force?: boolean,
         spaceNames?: Record<string, string>,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -1201,12 +1211,14 @@ export class CoderService extends BaseService {
         force?: boolean,
         spaceNames?: Record<string, string>,
     ): Promise<PromotionChanges> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -1487,12 +1499,14 @@ export class CoderService extends BaseService {
         force?: boolean,
         spaceNames?: Record<string, string>,
     ): Promise<PromotionChanges> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.get(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
+                    uuid: '',
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -1597,7 +1611,7 @@ export class CoderService extends BaseService {
                 projectUuid, // We use the same projectUuid for both promoted and upstream
             );
 
-        PromoteService.checkPromoteDashboardPermissions(
+        this.promoteService.checkPromoteDashboardPermissions(
             user,
             promotedDashboard,
             upstreamDashboard,

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -86,6 +86,7 @@ export class ContentService extends BaseService {
         queryArgs: ContentArgs,
         paginateArgs: KnexPaginateArgs,
     ): Promise<KnexPaginatedData<SummaryContent[]>> {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');
@@ -101,9 +102,10 @@ export class ContentService extends BaseService {
             )
         )
             .filter((project) =>
-                user.ability.can(
+                auditedAbility.can(
                     'view',
                     subject('Project', {
+                        uuid: project.projectUuid,
                         organizationUuid,
                         projectUuid: project.projectUuid,
                     }),
@@ -201,12 +203,17 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -291,12 +298,17 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -360,6 +372,7 @@ export class ContentService extends BaseService {
         filters: DeletedContentFilters,
         paginateArgs?: KnexPaginateArgs,
     ): Promise<KnexPaginatedData<DeletedContentWithDescendants[]>> {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = user;
         if (organizationUuid === undefined) {
             throw new NotFoundError('Organization not found');
@@ -372,18 +385,26 @@ export class ContentService extends BaseService {
 
         // Check project access
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
         }
 
         // Non-admins can only see their own deleted content
-        const isAdmin = user.ability.can(
+        const isAdmin = auditedAbility.can(
             'manage',
-            subject('DeletedContent', { organizationUuid, projectUuid }),
+            subject('DeletedContent', {
+                uuid: '',
+                organizationUuid,
+                projectUuid,
+            }),
         );
         const deletedByUserUuids = isAdmin
             ? filters.deletedByUserUuids
@@ -418,12 +439,17 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -463,12 +489,17 @@ export class ContentService extends BaseService {
             throw new NotFoundError('Organization not found');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ContentVerificationService.ts
+++ b/packages/backend/src/services/ContentVerificationService.ts
@@ -5,8 +5,6 @@ import {
     type SessionUser,
     type VerifiedContentListItem,
 } from '@lightdash/common';
-import { CaslAuditWrapper } from '../logging/caslAuditWrapper';
-import { logAuditEvent } from '../logging/winston';
 import { ContentVerificationModel } from '../models/ContentVerificationModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
 import { BaseService } from './BaseService';
@@ -55,9 +53,7 @@ export class ContentVerificationService extends BaseService {
         await this.assertContentVerificationEnabled(user);
         const project = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -354,20 +354,22 @@ export class PromoteService extends BaseService {
         };
     }
 
-    private static checkPromoteSpacePermissions(
+    private checkPromoteSpacePermissions(
         user: SessionUser,
         upstreamContent: Pick<
             UpstreamChart | UpstreamDashboard | UpstreamSqlChart,
             'space' | 'projectUuid' | 'spaceAccessContext'
         >,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = user;
         if (upstreamContent.space) {
             // If upstreamContent has a matching space, we check if we have access
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('Space', {
+                        uuid: upstreamContent.space.uuid,
                         organizationUuid,
                         projectUuid: upstreamContent.projectUuid,
                         inheritsFromOrgOrProject:
@@ -384,9 +386,10 @@ export class PromoteService extends BaseService {
             }
         } // If upstreamContent has no space, we check if we have permissions to create new spaces
         else if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('Space', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid: upstreamContent.projectUuid,
                 }),
@@ -398,20 +401,22 @@ export class PromoteService extends BaseService {
         }
     }
 
-    private static checkPromoteChartPermissions(
+    private checkPromoteChartPermissions(
         user: SessionUser,
         promotedChart: PromotedChart,
         upstreamChart: UpstreamChart,
         promotedDashboard?: PromotedDashboard,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = user;
         // Check permissions on `from project`
         if (promotedChart.space) {
             // Charts within space
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'promote',
                     subject('SavedChart', {
+                        uuid: promotedChart.chart.uuid,
                         organizationUuid,
                         projectUuid: promotedChart.projectUuid,
                         inheritsFromOrgOrProject:
@@ -428,9 +433,10 @@ export class PromoteService extends BaseService {
                 );
         } // Charts within dashboard
         else if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'promote',
                 subject('SavedChart', {
+                    uuid: promotedChart.chart.uuid,
                     organizationUuid,
                     projectUuid: promotedChart.projectUuid,
                 }),
@@ -448,9 +454,10 @@ export class PromoteService extends BaseService {
 
             if (upstreamChart.space) {
                 if (
-                    user.ability.cannot(
+                    auditedAbility.cannot(
                         'promote',
                         subject('SavedChart', {
+                            uuid: upstreamChart.chart.uuid,
                             organizationUuid,
                             projectUuid: upstreamChart.projectUuid,
                             inheritsFromOrgOrProject:
@@ -468,9 +475,10 @@ export class PromoteService extends BaseService {
                     );
                 }
             } else if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'promote',
                     subject('SavedChart', {
+                        uuid: upstreamChart.chart.uuid,
                         organizationUuid,
                         projectUuid: upstreamChart.projectUuid,
                     }),
@@ -485,9 +493,10 @@ export class PromoteService extends BaseService {
         } else if (upstreamChart.space !== undefined) {
             // If upstreamContent has no matching chart, we check if we have access to create, if space already exists
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('SavedChart', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamChart.projectUuid,
                         access: upstreamChart.spaceAccessContext?.access ?? [],
@@ -502,21 +511,23 @@ export class PromoteService extends BaseService {
             }
         }
 
-        PromoteService.checkPromoteSpacePermissions(user, upstreamChart);
+        this.checkPromoteSpacePermissions(user, upstreamChart);
     }
 
-    private static checkPromoteSqlChartPermissions(
+    private checkPromoteSqlChartPermissions(
         user: SessionUser,
         promotedSqlChart: PromotedSqlChart,
         upstreamSqlChart: UpstreamSqlChart,
         promotedDashboard?: PromotedDashboard,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = user;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'promote',
                 subject('SavedChart', {
+                    uuid: promotedSqlChart.chart.savedSqlUuid,
                     organizationUuid,
                     projectUuid: promotedSqlChart.projectUuid,
                     inheritsFromOrgOrProject:
@@ -536,9 +547,10 @@ export class PromoteService extends BaseService {
         if (upstreamSqlChart.chart !== undefined) {
             if (upstreamSqlChart.space) {
                 if (
-                    user.ability.cannot(
+                    auditedAbility.cannot(
                         'promote',
                         subject('SavedChart', {
+                            uuid: upstreamSqlChart.chart.savedSqlUuid,
                             organizationUuid,
                             projectUuid: upstreamSqlChart.projectUuid,
                             inheritsFromOrgOrProject:
@@ -557,9 +569,10 @@ export class PromoteService extends BaseService {
                     );
                 }
             } else if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'promote',
                     subject('SavedChart', {
+                        uuid: upstreamSqlChart.chart.savedSqlUuid,
                         organizationUuid,
                         projectUuid: upstreamSqlChart.projectUuid,
                     }),
@@ -573,9 +586,10 @@ export class PromoteService extends BaseService {
             }
         } else if (upstreamSqlChart.space !== undefined) {
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('SavedChart', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamSqlChart.projectUuid,
                         access:
@@ -591,20 +605,22 @@ export class PromoteService extends BaseService {
             }
         }
 
-        PromoteService.checkPromoteSpacePermissions(user, upstreamSqlChart);
+        this.checkPromoteSpacePermissions(user, upstreamSqlChart);
     }
 
-    static checkPromoteDashboardPermissions(
+    checkPromoteDashboardPermissions(
         user: SessionUser,
         promotedDashboard: PromotedDashboard,
         upstreamDashboard: UpstreamDashboard,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         // Check permissions on `from project`
         const { organizationUuid } = user;
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'promote',
                 subject('Dashboard', {
+                    uuid: promotedDashboard.dashboard.uuid,
                     organizationUuid,
                     projectUuid: promotedDashboard.projectUuid,
                     inheritsFromOrgOrProject:
@@ -624,9 +640,10 @@ export class PromoteService extends BaseService {
 
             if (upstreamDashboard.space) {
                 if (
-                    user.ability.cannot(
+                    auditedAbility.cannot(
                         'promote',
                         subject('Dashboard', {
+                            uuid: upstreamDashboard.dashboard.uuid,
                             organizationUuid,
                             projectUuid: upstreamDashboard.projectUuid,
                             inheritsFromOrgOrProject:
@@ -643,9 +660,10 @@ export class PromoteService extends BaseService {
                     );
                 }
             } else if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'promote',
                     subject('Dashboard', {
+                        uuid: upstreamDashboard.dashboard.uuid,
                         organizationUuid,
                         projectUuid: upstreamDashboard.projectUuid,
                     }),
@@ -658,9 +676,10 @@ export class PromoteService extends BaseService {
         } else if (upstreamDashboard.space !== undefined) {
             // If upstreamContent has no matching dashboard, we check if we have access to create, if space already exists
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('Dashboard', {
+                        uuid: '',
                         organizationUuid,
                         projectUuid: upstreamDashboard.projectUuid,
                         access:
@@ -673,7 +692,7 @@ export class PromoteService extends BaseService {
                 );
             }
         }
-        PromoteService.checkPromoteSpacePermissions(user, upstreamDashboard);
+        this.checkPromoteSpacePermissions(user, upstreamDashboard);
     }
 
     private static isSpaceUpdated(
@@ -1027,7 +1046,7 @@ export class PromoteService extends BaseService {
             );
         }
         try {
-            PromoteService.checkPromoteChartPermissions(
+            this.checkPromoteChartPermissions(
                 user,
                 promotedChart,
                 upstreamChart,
@@ -1162,7 +1181,7 @@ export class PromoteService extends BaseService {
             );
 
         try {
-            PromoteService.checkPromoteSqlChartPermissions(
+            this.checkPromoteSqlChartPermissions(
                 user,
                 promotedSqlChart,
                 upstreamSqlChart,
@@ -2132,7 +2151,7 @@ export class PromoteService extends BaseService {
             );
 
         try {
-            PromoteService.checkPromoteDashboardPermissions(
+            this.checkPromoteDashboardPermissions(
                 user,
                 promotedDashboard,
                 upstreamDashboard,
@@ -2140,7 +2159,7 @@ export class PromoteService extends BaseService {
 
             // Check permissions for all chart tiles
             promotedCharts.forEach(({ promotedChart, upstreamChart }) =>
-                PromoteService.checkPromoteChartPermissions(
+                this.checkPromoteChartPermissions(
                     user,
                     promotedChart,
                     upstreamChart,
@@ -2149,7 +2168,7 @@ export class PromoteService extends BaseService {
             );
             promotedSqlCharts.forEach(
                 ({ promotedSqlChart, upstreamSqlChart }) =>
-                    PromoteService.checkPromoteSqlChartPermissions(
+                    this.checkPromoteSqlChartPermissions(
                         user,
                         promotedSqlChart,
                         upstreamSqlChart,

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -87,12 +87,14 @@ export class RenameService extends BaseService {
         projectUuid: string;
         chartUuid: string;
     }) {
+        const auditedAbility = this.createAuditedAbility(user);
         const chart = await this.savedChartModel.get(chartUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: chart.projectUuid,
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                 }),
@@ -163,12 +165,14 @@ export class RenameService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),
@@ -309,13 +313,15 @@ export class RenameService extends BaseService {
         dashboardUuid: string;
         tableName?: string;
     }) {
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: dashboard.projectUuid,
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),
@@ -412,12 +418,14 @@ export class RenameService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),
@@ -558,12 +566,14 @@ export class RenameService extends BaseService {
         projectUuid: string;
         context: RequestMethod;
     }) {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -61,13 +61,15 @@ export class SearchService extends BaseService {
         source: 'omnibar' | 'ai_search_box' = 'omnibar',
         filters?: SearchFilters,
     ): Promise<SearchResults> {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),
@@ -115,9 +117,10 @@ export class SearchService extends BaseService {
             return accessibleSpaceUuids.includes(spaceUuid);
         };
 
-        const hasExploreAccess = user.ability.can(
+        const hasExploreAccess = auditedAbility.can(
             'manage',
             subject('Explore', {
+                uuid: '',
                 organizationUuid,
                 projectUuid,
             }),
@@ -228,9 +231,10 @@ export class SearchService extends BaseService {
                 (_, index) => hasSqlChartAccess[index],
             ),
             spaces: results.spaces.filter((_, index) => hasSpaceAccess[index]),
-            pages: user.ability.can(
+            pages: auditedAbility.can(
                 'view',
                 subject('Analytics', {
+                    uuid: '',
                     organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/SpaceService/SpacePermissionService.ts
+++ b/packages/backend/src/services/SpaceService/SpacePermissionService.ts
@@ -39,7 +39,7 @@ export class SpacePermissionService extends BaseService {
      */
     async can(
         action: AbilityAction,
-        actor: Pick<SessionUser, 'ability' | 'userUuid'>,
+        actor: SessionUser,
         spaceUuids: string[] | string,
     ): Promise<boolean> {
         const spaceUuidsArray = Array.isArray(spaceUuids)
@@ -50,8 +50,9 @@ export class SpacePermissionService extends BaseService {
             userUuid: actor.userUuid,
         });
 
+        const auditedAbility = this.createAuditedAbility(actor);
         return Object.values(accessContext).every((access) =>
-            actor.ability.can(action, subject('Space', access)),
+            auditedAbility.can(action, subject('Space', access)),
         );
     }
 
@@ -64,16 +65,17 @@ export class SpacePermissionService extends BaseService {
      */
     async getAccessibleSpaceUuids(
         action: AbilityAction,
-        actor: Pick<SessionUser, 'ability' | 'userUuid'>,
+        actor: SessionUser,
         spaceUuids: string[],
     ): Promise<string[]> {
         const accessContext = await this.getSpacesCaslContext(spaceUuids, {
             userUuid: actor.userUuid,
         });
 
+        const auditedAbility = this.createAuditedAbility(actor);
         return Object.entries(accessContext)
             .filter(([_, access]) =>
-                actor.ability.can(action, subject('Space', access)),
+                auditedAbility.can(action, subject('Space', access)),
             )
             .map(([spaceUuid]) => spaceUuid);
     }

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -194,10 +194,11 @@ export class SpaceService
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
-                subject('Space', { organizationUuid, projectUuid }),
+                subject('Space', { uuid: '', organizationUuid, projectUuid }),
             )
         ) {
             throw new ForbiddenError();
@@ -609,9 +610,11 @@ export class SpaceService
         });
 
         if (!options?.bypassPermissions) {
-            const isAdmin = user.ability.can(
+            const auditedAbility = this.createAuditedAbility(user);
+            const isAdmin = auditedAbility.can(
                 'manage',
                 subject('DeletedContent', {
+                    uuid: '',
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
                 }),
@@ -685,10 +688,12 @@ export class SpaceService
             const space = await this.spaceModel.getSpaceSummary(spaceUuid, {
                 deleted: true,
             });
+            const auditedAbility = this.createAuditedAbility(user);
             if (
-                user.ability.cannot(
+                auditedAbility.cannot(
                     'manage',
                     subject('DeletedContent', {
+                        uuid: '',
                         organizationUuid: space.organizationUuid,
                         projectUuid: space.projectUuid,
                     }),
@@ -774,10 +779,15 @@ export class SpaceService
         const existingSpace = await this.spaceModel.get(spaceUuid);
         const { projectUuid, organizationUuid, pinnedListUuid } = existingSpace;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('PinnedItems', { projectUuid, organizationUuid }),
+                subject('PinnedItems', {
+                    uuid: '',
+                    projectUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -43,8 +43,6 @@ import {
 import * as Sentry from '@sentry/node';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
-import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
-import { logAuditEvent } from '../../logging/winston';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -936,8 +934,9 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
@@ -1053,11 +1052,12 @@ export class ValidationService extends BaseService {
     ): Promise<ValidationResponse[]> {
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
-                    organizationUuid,
+                    organizationUuid: organizationUuid || '',
                     projectUuid,
                     uuid: projectUuid,
                 }),
@@ -1122,9 +1122,7 @@ export class ValidationService extends BaseService {
     ): Promise<ValidationResponse> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -1184,9 +1182,7 @@ export class ValidationService extends BaseService {
     ): Promise<KnexPaginatedData<ValidationResponse[]>> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -1269,10 +1265,12 @@ export class ValidationService extends BaseService {
         const projectSummary = await this.projectModel.getSummary(
             validation.projectUuid,
         );
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: validation.projectUuid,
                 }),
@@ -1301,8 +1299,9 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
@@ -1325,9 +1324,10 @@ export class ValidationService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
+                    uuid: '',
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                     inheritsFromOrgOrProject,
@@ -1381,8 +1381,9 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
@@ -1406,9 +1407,10 @@ export class ValidationService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                     inheritsFromOrgOrProject,


### PR DESCRIPTION
Closes: SPK-338

## Summary
Migrate content management services:
- ContentService, ValidationService, ContentVerificationService
- PromoteService (static methods converted to instance methods)
- CoderService (updated to use promoteService instance), RenameService
- SearchService, SpaceService, SpacePermissionService (widened actor type to SessionUser)

- `uuid: ''` occurrences marked with `/* TODO: pass resource uuid */`

## Test plan
- [x] `pnpm -F backend typecheck` passes
- [x] PromoteService static-to-instance conversion verified