### PR TITLE
feat: migrate integration and misc services to audited ability checks

### DIFF
--- a/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
+++ b/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
@@ -53,12 +53,14 @@ export class AnalyticsService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = await this.projectModel.get(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -90,11 +92,13 @@ export class AnalyticsService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } = await this.projectModel.get(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),
@@ -140,12 +144,14 @@ export class AnalyticsService extends BaseService {
         projectUuid: string,
         account: Account,
     ): Promise<UnusedContent> {
+        const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = await this.projectModel.get(projectUuid);
 
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -34,12 +34,14 @@ export class ChangesetService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<ChangesetWithChanges | undefined> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
+                    uuid: '',
                     projectUuid,
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -58,12 +60,14 @@ export class ChangesetService extends BaseService {
         projectUuid: string,
         changeUuid: string,
     ): Promise<Change> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
+                    uuid: '',
                     projectUuid,
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -80,12 +84,14 @@ export class ChangesetService extends BaseService {
         projectUuid: string,
         changeUuid: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
+                    uuid: '',
                     projectUuid,
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -130,12 +136,14 @@ export class ChangesetService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
+                    uuid: '',
                     projectUuid,
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -155,13 +155,15 @@ export class CommentService extends BaseService {
     ): Promise<string> {
         await this.isFeatureEnabled(user);
 
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'create',
                 subject('DashboardComments', {
+                    uuid: '',
                     projectUuid: dashboard.projectUuid,
                     organizationUuid: dashboard.organizationUuid,
                 }),
@@ -218,6 +220,7 @@ export class CommentService extends BaseService {
     ): Promise<Record<string, Comment[]>> {
         await this.isFeatureEnabled(user);
 
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard = await this.dashboardModel.getByIdOrSlug(
             dashboardUuidOrSlug,
             {
@@ -226,9 +229,10 @@ export class CommentService extends BaseService {
         );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('DashboardComments', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),
@@ -243,9 +247,10 @@ export class CommentService extends BaseService {
             );
         }
 
-        const canUserRemoveAnyComment = user.ability.can(
+        const canUserRemoveAnyComment = auditedAbility.can(
             'manage',
             subject('DashboardComments', {
+                uuid: '',
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
             }),
@@ -265,12 +270,14 @@ export class CommentService extends BaseService {
     ): Promise<void> {
         await this.isFeatureEnabled(user);
 
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DashboardComments', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),
@@ -309,6 +316,7 @@ export class CommentService extends BaseService {
     ): Promise<void> {
         await this.isFeatureEnabled(user);
 
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
 
@@ -318,9 +326,10 @@ export class CommentService extends BaseService {
             );
         }
 
-        const canRemoveAnyComment = user.ability.can(
+        const canRemoveAnyComment = auditedAbility.can(
             'manage',
             subject('DashboardComments', {
+                uuid: '',
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
             }),

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -606,12 +606,14 @@ export class CsvService extends BaseService {
         selectedTabs: string[] | null,
         dateZoomGranularity?: DateGranularity | string,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ExportCsv', {
+                    uuid: '',
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -64,12 +64,14 @@ export class DeployService extends BaseService {
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         // manage:DeployProject for non-preview projects (restrictable via custom roles)
         // manage:DeployProject@self for preview projects created by the user
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DeployProject', {
+                    uuid: '',
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                     type: project.type,

--- a/packages/backend/src/services/FavoritesService/FavoritesService.ts
+++ b/packages/backend/src/services/FavoritesService/FavoritesService.ts
@@ -68,8 +68,14 @@ export class FavoritesService extends BaseService {
         contentType: ContentType,
         contentUuid: string,
     ): Promise<ToggleFavoriteResponse> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -151,8 +157,14 @@ export class FavoritesService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<FavoriteItems> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 

--- a/packages/backend/src/services/FunnelService/FunnelService.ts
+++ b/packages/backend/src/services/FunnelService/FunnelService.ts
@@ -73,13 +73,18 @@ export class FunnelService extends BaseService {
             throw new ForbiddenError('Funnel Builder feature is not enabled');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('SqlRunner', { organizationUuid, projectUuid }),
+                subject('SqlRunner', {
+                    uuid: '',
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -65,13 +65,15 @@ export class GdriveService extends BaseService {
         user: SessionUser,
         gsheetOptions: UploadMetricGsheet,
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const projectSummary = await this.projectModel.getSummary(
             gsheetOptions.projectUuid,
         );
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ExportCsv', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
                 }),
@@ -81,9 +83,10 @@ export class GdriveService extends BaseService {
         }
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('GoogleSheets', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
                 }),
@@ -96,9 +99,10 @@ export class GdriveService extends BaseService {
             gsheetOptions.metricQuery.customDimensions?.some(
                 isCustomSqlDimension,
             ) &&
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('CustomSql', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
                 }),

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -586,10 +586,12 @@ Affected charts:
 
         if (fields.length === 0) throw new ParseError(`Missing ${typeName}s`);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('CustomSql', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -938,10 +940,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         exploreName: string,
     ): Promise<{ content: string; sha: string; filePath: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1010,10 +1014,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         exploreName: string,
     ): Promise<{ filePath: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1054,11 +1060,13 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         prTitle: string,
         prDescription: string,
     ): Promise<PullRequestCreated> {
+        const auditedAbility = this.createAuditedAbility(user);
         // PR creates its own feature branch, so always allow (isProtectedBranch: false)
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,
@@ -1222,10 +1230,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         user: SessionUser,
         projectUuid: string,
     ): Promise<GitBranch[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1270,10 +1280,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         branch: string,
         path?: string,
     ): Promise<GitFileOrDirectory> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1356,13 +1368,15 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         sha?: string,
         message?: string,
     ): Promise<{ sha: string; path: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         const protectedBranch = await this.getProtectedBranch(projectUuid);
         const isProtectedBranch = branch === protectedBranch;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch,
@@ -1454,13 +1468,15 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         sha: string,
         message?: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const protectedBranch = await this.getProtectedBranch(projectUuid);
         const isProtectedBranch = branch === protectedBranch;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch,
@@ -1507,10 +1523,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         branchName: string,
         sourceBranch: string,
     ): Promise<GitBranch> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,
@@ -1577,10 +1595,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         title: string,
         description: string,
     ): Promise<PullRequestCreated> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,

--- a/packages/backend/src/services/GithubAppService/GithubAppService.ts
+++ b/packages/backend/src/services/GithubAppService/GithubAppService.ts
@@ -207,13 +207,15 @@ export class GithubAppService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         // This endpoint is also used for developers on projects
         // when using the sql runner, so we should allow access
         // However github app is an organization property, so we can't check projects
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Organization', {
+                    uuid: user.organizationUuid,
                     organizationUuid: user.organizationUuid,
                 }),
             )
@@ -236,10 +238,12 @@ export class GithubAppService extends BaseService {
         if (!user || !isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Organization', {
+                    uuid: user.organizationUuid,
                     organizationUuid: user.organizationUuid,
                 }),
             )
@@ -327,10 +331,12 @@ export class GithubAppService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('GitIntegration', {
+                    uuid: '',
                     organizationUuid: user.organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/GitlabAppService/GitlabAppService.ts
+++ b/packages/backend/src/services/GitlabAppService/GitlabAppService.ts
@@ -177,15 +177,16 @@ export class GitlabAppService extends BaseService {
         }
     }
 
-    // eslint-disable-next-line class-methods-use-this
     private canManageOrg(user: SessionUser) {
         if (!isUserWithOrg(user)) {
             throw new Error('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            !user.ability.can(
+            !auditedAbility.can(
                 'manage',
                 subject('Organization', {
+                    uuid: user.organizationUuid,
                     organizationUuid: user.organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/PinningService/PinningService.ts
+++ b/packages/backend/src/services/PinningService/PinningService.ts
@@ -68,8 +68,14 @@ export class PinningService extends BaseService {
         projectUuid: string,
         pinnedListUuid: string,
     ): Promise<PinnedItems> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.getSummary(projectUuid);
-        if (user.ability.cannot('view', subject('Project', project))) {
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Project', { ...project, uuid: project.projectUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 
@@ -133,8 +139,17 @@ export class PinningService extends BaseService {
         pinnedListUuid: string,
         itemsOrder: Array<UpdatePinnedItemOrder>,
     ): Promise<PinnedItems> {
+        const auditedAbility = this.createAuditedAbility(user);
         const project = await this.projectModel.get(projectUuid);
-        if (user.ability.cannot('manage', subject('PinnedItems', project))) {
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('PinnedItems', {
+                    ...project,
+                    uuid: project.projectUuid,
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
         if (project.pinnedListUuid !== pinnedListUuid) {

--- a/packages/backend/src/services/ProjectCompileLogService/ProjectCompileLogService.ts
+++ b/packages/backend/src/services/ProjectCompileLogService/ProjectCompileLogService.ts
@@ -45,10 +45,15 @@ export class ProjectCompileLogService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -75,14 +80,20 @@ export class ProjectCompileLogService extends BaseService {
             );
         }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             ) ||
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('JobStatus', {
+                    uuid: '',
                     organizationUuid,
                     jobUuid,
                     projectUuid,

--- a/packages/backend/src/services/ProjectParametersService.ts
+++ b/packages/backend/src/services/ProjectParametersService.ts
@@ -48,13 +48,18 @@ export class ProjectParametersService extends BaseService {
             sortOrder?: 'asc' | 'desc';
         },
     ) {
+        const auditedAbility = this.createAuditedAbility(user);
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    uuid: projectUuid,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ShareService/ShareService.ts
+++ b/packages/backend/src/services/ShareService/ShareService.ts
@@ -45,13 +45,15 @@ export class ShareService extends BaseService {
         if (!isUserWithOrg(user)) {
             throw new ForbiddenError('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         const shareUrl = await this.shareModel.getSharedUrl(nanoid);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('OrganizationMemberProfile', {
-                    organizationUuid: shareUrl.organizationUuid,
+                    uuid: '',
+                    organizationUuid: shareUrl.organizationUuid || '',
                 }),
             )
         ) {

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     NotFoundError,
@@ -107,7 +108,16 @@ export class SlackIntegrationService<
         const organizationUuid = user?.organizationUuid;
         if (!organizationUuid) throw new ForbiddenError();
 
-        if (user.ability.cannot('manage', 'Organization')) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', {
+                    uuid: user.organizationUuid || '',
+                    organizationUuid: user.organizationUuid || '',
+                }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 

--- a/packages/backend/src/services/SpotlightService/SpotlightService.ts
+++ b/packages/backend/src/services/SpotlightService/SpotlightService.ts
@@ -39,11 +39,13 @@ export class SpotlightService extends BaseService {
         projectUuid: string,
         tableConfig: Pick<SpotlightTableConfig, 'columnConfig'>,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SpotlightTableConfig', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
                 }),
@@ -62,11 +64,13 @@ export class SpotlightService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<SpotlightTableConfig> {
+        const auditedAbility = this.createAuditedAbility(user);
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SpotlightTableConfig', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
                 }),
@@ -93,11 +97,13 @@ export class SpotlightService extends BaseService {
         user: SessionUser,
         projectUuid: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SpotlightTableConfig', {
+                    uuid: '',
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -618,6 +618,7 @@ export class UnfurlService extends BaseService {
         user: SessionUser,
         selectedTabs: string[] | null,
     ): Promise<string> {
+        const auditedAbility = this.createAuditedAbility(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const { inheritsFromOrgOrProject, access } =
@@ -671,9 +672,10 @@ export class UnfurlService extends BaseService {
         };
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
+                    uuid: '',
                     organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
@@ -712,6 +714,7 @@ export class UnfurlService extends BaseService {
         chartUuidOrSlug: string,
         user: SessionUser,
     ): Promise<string> {
+        const auditedAbility = this.createAuditedAbility(user);
         const chart = await this.savedChartModel.get(chartUuidOrSlug);
         const { inheritsFromOrgOrProject, access } =
             await this.spacePermissionService.getSpaceAccessContext(
@@ -720,9 +723,10 @@ export class UnfurlService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
+                    uuid: '',
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                     inheritsFromOrgOrProject,


### PR DESCRIPTION
Closes: SPK-338

## Summary
Migrate 18 integration and miscellaneous services:
- Git: GitIntegrationService, GithubAppService, GitlabAppService
- Delivery: SlackIntegrationService, GdriveService, CsvService
- Misc: CommentService, FavoritesService, PinningService, UnfurlService, ShareService
- Other: AnalyticsService, ChangesetService, DeployService, FunnelService, SpotlightService, ProjectCompileLogService, ProjectParametersService

- `uuid: ''` occurrences marked with `/* TODO: pass resource uuid */`

## Test plan
- [x] `pnpm -F backend typecheck` passes