### PR TITLE
feat: migrate EE services to audited ability checks

### DIFF
--- a/packages/backend/src/ee/services/AiAgentAdminService.ts
+++ b/packages/backend/src/ee/services/AiAgentAdminService.ts
@@ -11,6 +11,7 @@ import {
 } from '@lightdash/common';
 import jwt from 'jsonwebtoken';
 import { type LightdashConfig } from '../../config/parseConfig';
+import { BaseService } from '../../services/BaseService';
 import { AiAgentModel } from '../models/AiAgentModel';
 
 type AiAgentAdminServiceDependencies = {
@@ -18,22 +19,24 @@ type AiAgentAdminServiceDependencies = {
     lightdashConfig: LightdashConfig;
 };
 
-export class AiAgentAdminService {
+export class AiAgentAdminService extends BaseService {
     private readonly aiAgentModel: AiAgentModel;
 
     private readonly lightdashConfig: LightdashConfig;
 
     constructor(dependencies: AiAgentAdminServiceDependencies) {
+        super({ serviceName: 'AiAgentAdminService' });
         this.aiAgentModel = dependencies.aiAgentModel;
         this.lightdashConfig = dependencies.lightdashConfig;
     }
 
-    private static checkOrganizationAdminAccess(user: SessionUser): void {
+    private checkOrganizationAdminAccess(user: SessionUser): void {
         if (
-            user.ability.cannot(
+            this.createAuditedAbility(user).cannot(
                 'manage',
                 subject('Organization', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid || '',
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -58,7 +61,7 @@ export class AiAgentAdminService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        AiAgentAdminService.checkOrganizationAdminAccess(user);
+        this.checkOrganizationAdminAccess(user);
 
         // TODO: Check if filter contains userUuid and check if they exist in the organization
         // TODO: Check if filter contains agentUuid and check if they exist in the organization
@@ -77,7 +80,7 @@ export class AiAgentAdminService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        AiAgentAdminService.checkOrganizationAdminAccess(user);
+        this.checkOrganizationAdminAccess(user);
         return this.aiAgentModel.findAllAgents({
             organizationUuid,
         });
@@ -104,7 +107,7 @@ export class AiAgentAdminService {
         if (!organizationUuid) {
             throw new ForbiddenError('Organization not found');
         }
-        AiAgentAdminService.checkOrganizationAdminAccess(user);
+        this.checkOrganizationAdminAccess(user);
 
         const { analyticsEmbedSecret } = this.lightdashConfig;
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -104,6 +104,7 @@ import { UserAttributesModel } from '../../../models/UserAttributesModel';
 import { UserModel } from '../../../models/UserModel';
 import PrometheusMetrics from '../../../prometheus/PrometheusMetrics';
 import { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import { BaseService } from '../../../services/BaseService';
 import { CatalogService } from '../../../services/CatalogService/CatalogService';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
@@ -219,7 +220,7 @@ function cleanupOAuthCache(): void {
     });
 }
 
-export class AiAgentService {
+export class AiAgentService extends BaseService {
     private readonly aiAgentModel: AiAgentModel;
 
     private readonly analytics: LightdashAnalytics;
@@ -265,6 +266,7 @@ export class AiAgentService {
     private readonly shareService: ShareService;
 
     constructor(dependencies: AiAgentServiceDependencies) {
+        super({ serviceName: 'AiAgentService' });
         this.aiAgentModel = dependencies.aiAgentModel;
         this.analytics = dependencies.analytics;
         this.asyncQueryService = dependencies.asyncQueryService;
@@ -333,9 +335,10 @@ export class AiAgentService {
         agent: AiAgent,
     ): Promise<boolean> {
         if (
-            user.ability.can(
+            this.createAuditedAbility(user).can(
                 'manage',
                 subject('AiAgent', {
+                    uuid: agent.projectUuid || '',
                     organizationUuid: agent.organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -397,9 +400,10 @@ export class AiAgentService {
         }
 
         if (
-            user.ability.can(
+            this.createAuditedAbility(user).can(
                 'manage',
                 subject('AiAgent', {
+                    uuid: agent.projectUuid || '',
                     organizationUuid: agent.organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -733,9 +737,10 @@ export class AiAgentService {
         // Check if user has admin permissions to view all threads
         const canViewAllThreads =
             allUsers &&
-            user.ability.can(
+            this.createAuditedAbility(user).can(
                 'manage',
                 subject('AiAgent', {
+                    uuid: agent.projectUuid || '',
                     organizationUuid,
                     projectUuid: agent.projectUuid,
                 }),
@@ -1036,10 +1041,11 @@ export class AiAgentService {
         }
 
         if (
-            user.ability.cannot(
+            this.createAuditedAbility(user).cannot(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid,
+                    uuid: body.projectUuid || '',
+                    organizationUuid: organizationUuid || '',
                     projectUuid: body.projectUuid,
                 }),
             )
@@ -1095,10 +1101,11 @@ export class AiAgentService {
         }
 
         if (
-            user.ability.cannot(
+            this.createAuditedAbility(user).cannot(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid,
+                    uuid: agent.projectUuid || '',
+                    organizationUuid: organizationUuid || '',
                     projectUuid: agent.projectUuid,
                 }),
             )
@@ -1158,10 +1165,11 @@ export class AiAgentService {
         }
 
         if (
-            user.ability.cannot(
+            this.createAuditedAbility(user).cannot(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid,
+                    uuid: agent.projectUuid || '',
+                    organizationUuid: organizationUuid || '',
                     projectUuid: agent.projectUuid,
                 }),
             )
@@ -1295,10 +1303,11 @@ export class AiAgentService {
                 threadUuid,
             });
 
-            const canManageAgent = user.ability.can(
+            const canManageAgent = this.createAuditedAbility(user).can(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: prompt.projectUuid || '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid: prompt.projectUuid,
                 }),
             );
@@ -1338,10 +1347,11 @@ export class AiAgentService {
                 agentUuid,
                 threadUuid,
             });
-            const canManageAgent = user.ability.can(
+            const canManageAgent = this.createAuditedAbility(user).can(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: prompt.projectUuid || '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid: prompt.projectUuid,
                 }),
             );
@@ -1414,10 +1424,11 @@ export class AiAgentService {
         { agentUuid, projectUuid }: { agentUuid: string; projectUuid: string },
     ): Promise<ReadinessScore> {
         if (
-            user.ability.cannot(
+            this.createAuditedAbility(user).cannot(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: projectUuid || '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )
@@ -1925,10 +1936,11 @@ export class AiAgentService {
 
         // Only users who can manage the agent can verify artifacts
         if (
-            user.ability.cannot(
+            this.createAuditedAbility(user).cannot(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid,
+                    uuid: agent.projectUuid || '',
+                    organizationUuid: organizationUuid || '',
                     projectUuid: agent.projectUuid,
                 }),
             )
@@ -2116,10 +2128,11 @@ export class AiAgentService {
 
         // Check view permissions
         if (
-            user.ability.cannot(
+            this.createAuditedAbility(user).cannot(
                 'view',
                 subject('AiAgent', {
-                    organizationUuid,
+                    uuid: agent.projectUuid || '',
+                    organizationUuid: organizationUuid || '',
                     projectUuid: agent.projectUuid,
                 }),
             )
@@ -3322,10 +3335,11 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             slackPrompt.organizationUuid,
         );
 
-        const canManageAgent = user.ability.can(
+        const canManageAgent = this.createAuditedAbility(user).can(
             'manage',
             subject('AiAgent', {
-                organizationUuid: slackPrompt.organizationUuid,
+                uuid: slackPrompt.projectUuid || '',
+                organizationUuid: slackPrompt.organizationUuid || '',
                 projectUuid: slackPrompt.projectUuid,
             }),
         );

--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -10,6 +10,7 @@ import {
 } from '@lightdash/common';
 import { LightdashConfig } from '../../config/parseConfig';
 import { OrganizationModel } from '../../models/OrganizationModel';
+import { BaseService } from '../../services/BaseService';
 import { AiOrganizationSettingsModel } from '../models/AiOrganizationSettingsModel';
 import { CommercialFeatureFlagModel } from '../models/CommercialFeatureFlagModel';
 
@@ -20,7 +21,7 @@ type AiOrganizationSettingsServiceDependencies = {
     lightdashConfig: LightdashConfig;
 };
 
-export class AiOrganizationSettingsService {
+export class AiOrganizationSettingsService extends BaseService {
     private readonly aiOrganizationSettingsModel: AiOrganizationSettingsModel;
 
     private readonly organizationModel: OrganizationModel;
@@ -33,6 +34,7 @@ export class AiOrganizationSettingsService {
     private static readonly TRIAL_START_DATE = new Date('2025-10-13T00:00:00Z');
 
     constructor(dependencies: AiOrganizationSettingsServiceDependencies) {
+        super({ serviceName: 'AiOrganizationSettingsService' });
         this.aiOrganizationSettingsModel =
             dependencies.aiOrganizationSettingsModel;
         this.organizationModel = dependencies.organizationModel;
@@ -41,12 +43,13 @@ export class AiOrganizationSettingsService {
         this.lightdashConfig = dependencies.lightdashConfig;
     }
 
-    private static checkManageAiAgentAccess(user: SessionUser): void {
+    private checkManageAiAgentAccess(user: SessionUser): void {
         if (
-            user.ability.cannot(
+            this.createAuditedAbility(user).cannot(
                 'manage',
                 subject('AiAgent', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -145,7 +148,7 @@ export class AiOrganizationSettingsService {
             throw new ForbiddenError('User must belong to an organization');
         }
 
-        AiOrganizationSettingsService.checkManageAiAgentAccess(user);
+        this.checkManageAiAgentAccess(user);
 
         return this.aiOrganizationSettingsModel.upsert(
             user.organizationUuid,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -851,11 +851,13 @@ export class AppGenerateService extends BaseService {
         prompt: string,
     ): Promise<GenerateAppResult> {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )
@@ -983,11 +985,13 @@ export class AppGenerateService extends BaseService {
         prompt: string,
     ): Promise<GenerateAppResult> {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )
@@ -1042,12 +1046,14 @@ export class AppGenerateService extends BaseService {
         version: number,
     ): Promise<void> {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
+                    uuid: '' /* TODO: pass resource uuid */,
                 }),
             )
         ) {
@@ -1115,11 +1121,13 @@ export class AppGenerateService extends BaseService {
         hasMore: boolean;
     }> {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )
@@ -1205,6 +1213,7 @@ export class AppGenerateService extends BaseService {
         };
     }> {
         this.assertDataAppsEnabled();
+        // eslint-disable-next-line no-direct-ability-check -- bare string subject, no resource context to audit
         if (user.ability.cannot('manage', 'DataApp')) {
             throw new ForbiddenError('Insufficient permissions');
         }
@@ -1236,12 +1245,14 @@ export class AppGenerateService extends BaseService {
         update: { name?: string; description?: string },
     ): Promise<{ appUuid: string; name: string; description: string }> {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
+                    uuid: appUuid,
                 }),
             )
         ) {
@@ -1376,11 +1387,13 @@ export class AppGenerateService extends BaseService {
         version: number,
     ): string {
         this.assertDataAppsEnabled();
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: '',
+                    organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
             )

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -54,6 +54,7 @@ import {
     RunQueryTags,
     SavedChartsInfoForDashboardAvailableFilters,
     SessionAccount,
+    SessionUser,
     SortField,
     UpdateEmbed,
     UserAccessControls,
@@ -158,10 +159,12 @@ export class EmbedService extends BaseService {
             userUuid: user.userUuid,
             organizationUuid,
         });
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),
@@ -201,10 +204,14 @@ export class EmbedService extends BaseService {
             userUuid: user.userUuid,
             organizationUuid,
         });
+        const auditedAbility = this.createAuditedAbility(
+            user as unknown as SessionUser,
+        );
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),
@@ -233,10 +240,14 @@ export class EmbedService extends BaseService {
             userUuid: user.userUuid,
             organizationUuid,
         });
+        const auditedAbility = this.createAuditedAbility(
+            user as unknown as SessionUser,
+        );
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),
@@ -275,10 +286,12 @@ export class EmbedService extends BaseService {
             userUuid: user.userUuid,
             organizationUuid,
         });
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),
@@ -311,10 +324,12 @@ export class EmbedService extends BaseService {
             organizationUuid,
         });
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'update',
                 subject('Project', {
+                    uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
                 }),

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -719,10 +719,12 @@ export class McpService extends BaseService {
                     account,
                 );
 
+                const auditedAbility = this.createAuditedAbility(user);
                 if (
-                    user.ability.cannot(
+                    auditedAbility.cannot(
                         'view',
                         subject('Project', {
+                            uuid: args.projectUuid,
                             projectUuid: args.projectUuid,
                             organizationUuid: project.organizationUuid,
                         }),
@@ -1923,10 +1925,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -2024,10 +2028,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -2099,10 +2105,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -2167,10 +2175,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),
@@ -2228,10 +2238,12 @@ export class McpService extends BaseService {
             account,
         );
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Project', {
+                    uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                 }),

--- a/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
+++ b/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
@@ -43,16 +43,17 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         this.userModel = userModel;
     }
 
-    // eslint-disable-next-line class-methods-use-this
     private canManage(account: Account) {
         const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('User must be in an organization');
         }
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('OrganizationWarehouseCredentials', {
+                    uuid: '',
                     organizationUuid,
                 }),
             )
@@ -86,10 +87,12 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
             throw new ForbiddenError('User must be in an organization');
         }
 
+        const auditedAbility = this.createAuditedAbility(account);
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('OrganizationWarehouseCredentials', {
+                    uuid: '',
                     organizationUuid,
                 }),
             )

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -120,12 +120,14 @@ export class ScimService extends BaseService {
         this.openIdIdentityModel = openIdIdentityModel;
     }
 
-    private static throwForbiddenErrorOnNoPermission(user: SessionUser) {
+    private throwForbiddenErrorOnNoPermission(user: SessionUser) {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid || '',
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -56,12 +56,14 @@ export class ServiceAccountService extends BaseService {
         this.commercialFeatureFlagModel = commercialFeatureFlagModel;
     }
 
-    private static throwForbiddenErrorOnNoPermission(user: SessionUser) {
+    private throwForbiddenErrorOnNoPermission(user: SessionUser) {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Organization', {
-                    organizationUuid: user.organizationUuid,
+                    uuid: user.organizationUuid || '',
+                    organizationUuid: user.organizationUuid || '',
                 }),
             )
         ) {
@@ -79,7 +81,7 @@ export class ServiceAccountService extends BaseService {
         prefix?: string;
     }): Promise<ServiceAccount> {
         try {
-            ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+            this.throwForbiddenErrorOnNoPermission(user);
             const token = await this.serviceAccountModel.create({
                 user,
                 data: {
@@ -120,7 +122,7 @@ export class ServiceAccountService extends BaseService {
         tokenUuid: string;
     }): Promise<void> {
         try {
-            ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+            this.throwForbiddenErrorOnNoPermission(user);
             const organizationUuid = user.organizationUuid as string;
             // get by uuid to check if token exists
             const token =
@@ -171,7 +173,7 @@ export class ServiceAccountService extends BaseService {
         update: { expiresAt: Date };
         prefix?: string;
     }): Promise<ServiceAccountWithToken> {
-        ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+        this.throwForbiddenErrorOnNoPermission(user);
 
         if (update.expiresAt.getTime() < Date.now()) {
             throw new ParameterError('Expire time must be in the future');
@@ -225,7 +227,7 @@ export class ServiceAccountService extends BaseService {
         user: SessionUser;
         tokenUuid: string;
     }): Promise<ServiceAccount> {
-        ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+        this.throwForbiddenErrorOnNoPermission(user);
 
         // get by uuid to check if token exists
         const existingToken =
@@ -245,7 +247,7 @@ export class ServiceAccountService extends BaseService {
         scopes: ServiceAccountScope[],
     ): Promise<ServiceAccount[]> {
         try {
-            ServiceAccountService.throwForbiddenErrorOnNoPermission(user);
+            this.throwForbiddenErrorOnNoPermission(user);
             const organizationUuid = user.organizationUuid as string;
             const tokens = await this.serviceAccountModel.getAllForOrganization(
                 organizationUuid,


### PR DESCRIPTION
Closes: SPK-338

## Summary
Migrate 9 enterprise services:
- AiAgentService, AiAgentAdminService, AiOrganizationSettingsService (now extend BaseService)
- AppGenerateService, EmbedService, McpService
- OrganizationWarehouseCredentialsService, ScimService, ServiceAccountService

- 3 EE services now extend BaseService with proper `super()` calls
- Bare string subject in AppGenerateService excluded via inline eslint-disable
- `uuid: ''` occurrences marked with `/* TODO: pass resource uuid */`

## Test plan
- [x] `pnpm -F backend typecheck` passes