### PR TITLE
feat: enforce ESLint no-direct-ability-check as error

### DIFF
--- a/docs/audit-logging.md
+++ b/docs/audit-logging.md
@@ -327,8 +327,8 @@ When a denied access attempt occurs (e.g., viewer trying to delete):
 ## ESLint Enforcement
 
 The custom ESLint rule `no-direct-ability-check` (loaded via `--rulesdir eslint-rules`) detects direct `.ability.can()` /
-`.ability.cannot()` usage in service files and flags them. It is currently set to **warning** during the migration period,
-and will be promoted to **error** once all services are migrated.
+`.ability.cannot()` usage in service files and flags them as **errors**. The build will fail if any new code uses direct
+ability checks without going through `createAuditedAbility()`.
 
 The rule catches patterns like:
 

--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -88,13 +88,17 @@ module.exports = {
             },
         },
         {
-            // Warn on direct ability checks in services - use createAuditedAbility() instead
+            // Enforce audited ability checks in services - use createAuditedAbility() instead
             files: [
                 'src/services/**/*.ts',
                 'src/ee/services/**/*.ts',
             ],
+            excludedFiles: [
+                // Standalone utility function, not a class method
+                'src/services/UserAttributesService/UserAttributeUtils.ts',
+            ],
             rules: {
-                'no-direct-ability-check': 'warn',
+                'no-direct-ability-check': 'error',
             },
         },
         {


### PR DESCRIPTION
Closes: SPK-339

## Summary
- Flip `no-direct-ability-check` ESLint rule from `warn` to `error`
- Only `UserAttributeUtils.ts` excluded (standalone utility function)
- Update audit logging docs to reflect enforcement

## Test plan
- [x] `pnpm -F backend lint` passes with zero violations