### PR TITLE
feat: add impersonation context to audit logs

### DIFF
--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -31,6 +31,7 @@ export type AuditableUser = Pick<
     | 'lastName'
     | 'organizationUuid'
     | 'role'
+    | 'impersonation'
 >;
 
 type AuditableCaslSubject = ForcedSubject<CaslSubjectNames> & {
@@ -93,6 +94,13 @@ export const createActorFromAccount = (account: Account): AuditActor => {
         email?: string;
         role?: string;
         id: string;
+        impersonation?: {
+            adminUserUuid: string;
+            adminEmail: string;
+            adminFirstName: string;
+            adminLastName: string;
+            adminRole: string;
+        };
     };
 
     return {
@@ -105,6 +113,15 @@ export const createActorFromAccount = (account: Account): AuditActor => {
         organizationRole: user.role || 'unknown',
         // TODO: Add group memberships
         groupMemberships: [],
+        ...(user.impersonation && {
+            impersonatedBy: {
+                uuid: user.impersonation.adminUserUuid,
+                email: user.impersonation.adminEmail,
+                firstName: user.impersonation.adminFirstName,
+                lastName: user.impersonation.adminLastName,
+                role: user.impersonation.adminRole,
+            },
+        }),
     };
 };
 
@@ -122,6 +139,15 @@ export const createActorFromUser = (user: AuditableUser): AuditActor => ({
     organizationRole: user.role || 'unknown',
     // TODO: Add group memberships
     groupMemberships: [],
+    ...(user.impersonation && {
+        impersonatedBy: {
+            uuid: user.impersonation.adminUserUuid,
+            email: user.impersonation.adminEmail,
+            firstName: user.impersonation.adminFirstName,
+            lastName: user.impersonation.adminLastName,
+            role: user.impersonation.adminRole,
+        },
+    }),
 });
 
 const createResourceFromSubject = (

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1772,7 +1772,17 @@ export class UserService extends BaseService {
             return requestUser;
         }
 
-        return targetUser;
+        // Attach impersonation context so audit logs record the admin
+        return {
+            ...targetUser,
+            impersonation: {
+                adminUserUuid: requestUser.userUuid,
+                adminEmail: requestUser.email || '',
+                adminFirstName: requestUser.firstName,
+                adminLastName: requestUser.lastName,
+                adminRole: requestUser.role || 'unknown',
+            },
+        };
     }
 
     static async generateGoogleAccessToken(

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -73,8 +73,17 @@ export interface LightdashUserWithAbilityRules extends LightdashUser {
     abilityRules: AbilityBuilder<MemberAbility>['rules'];
 }
 
+export type ImpersonationContext = {
+    adminUserUuid: string;
+    adminEmail: string;
+    adminFirstName: string;
+    adminLastName: string;
+    adminRole: string;
+};
+
 export interface SessionUser extends LightdashUserWithAbilityRules {
     ability: MemberAbility;
+    impersonation?: ImpersonationContext;
 }
 
 export interface UpdatedByUser {


### PR DESCRIPTION
Closes: SPK-340

## Summary
- Add `ImpersonationContext` type to `SessionUser`
- Populate impersonation context in `UserService.resolveSessionUser()`
- Wire `impersonatedBy` through `createActorFromUser` and `createActorFromAccount`

## Test plan
- [x] `pnpm -F common typecheck` passes
- [x] `pnpm -F backend typecheck` passes
- [ ] Manual: impersonate user, verify audit log includes `impersonatedBy`