### PR TITLE
fix: add remountKey to SDK component keys for proper re-rendering

### DIFF
--- a/packages/sdk-test-app/src/examples/FiltersExamplePage.tsx
+++ b/packages/sdk-test-app/src/examples/FiltersExamplePage.tsx
@@ -103,7 +103,7 @@ export function FiltersExamplePage({ embedConfig }: FiltersExamplePageProps) {
                         </p>
                         <div style={dashboardContainerStyle}>
                             <Lightdash.Dashboard
-                                key={JSON.stringify(dashboardFilters)}
+                                key={`${embedConfig.remountKey}:${JSON.stringify(dashboardFilters)}`}
                                 instanceUrl={embedConfig.instanceUrl}
                                 token={embedConfig.token}
                                 filters={dashboardFilters}

--- a/packages/sdk-test-app/src/examples/I18nExamplePage.tsx
+++ b/packages/sdk-test-app/src/examples/I18nExamplePage.tsx
@@ -1,5 +1,5 @@
 import Lightdash from '@lightdash/sdk';
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { SavedChart } from '../../../common/src';
 import { ExampleLayout } from '../components/ExampleLayout';
@@ -35,6 +35,10 @@ export function I18nExamplePage({ embedConfig }: I18nExamplePageProps) {
     const [chartUuidOrSlug, setChartUuidOrSlug] = useState<string>(
         localStorage.getItem(CHART_ID_STORAGE_KEY) || '',
     );
+
+    useEffect(() => {
+        setSavedChart(null);
+    }, [embedConfig.remountKey]);
 
     const controls = (
         <div style={controlsStyle}>
@@ -95,6 +99,7 @@ export function I18nExamplePage({ embedConfig }: I18nExamplePageProps) {
                         <div style={chartContainerStyle}>
                             {savedChart ? (
                                 <Lightdash.Explore
+                                    key={`${embedConfig.remountKey}:${savedChart.uuid}`}
                                     instanceUrl={embedConfig.instanceUrl}
                                     token={embedConfig.token}
                                     exploreId={savedChart.tableName}
@@ -102,7 +107,7 @@ export function I18nExamplePage({ embedConfig }: I18nExamplePageProps) {
                                 />
                             ) : (
                                 <Lightdash.Dashboard
-                                    key={i18n.language}
+                                    key={`${embedConfig.remountKey}:${i18n.language}`}
                                     instanceUrl={embedConfig.instanceUrl}
                                     token={embedConfig.token}
                                     styles={{
@@ -177,6 +182,7 @@ export function I18nExamplePage({ embedConfig }: I18nExamplePageProps) {
                         <div style={singleChartContainerStyle}>
                             {chartUuidOrSlug ? (
                                 <Lightdash.Chart
+                                    key={`${embedConfig.remountKey}:${chartUuidOrSlug}`}
                                     instanceUrl={embedConfig.instanceUrl}
                                     token={embedConfig.token}
                                     styles={{

--- a/packages/sdk-test-app/src/hooks/useEmbedConfig.ts
+++ b/packages/sdk-test-app/src/hooks/useEmbedConfig.ts
@@ -129,6 +129,8 @@ export function useEmbedConfig() {
         localStorage.removeItem(EMBED_URL_STORAGE_KEY);
     };
 
+    const remountKey = `${instanceUrl ?? 'no-instance'}:${token ?? 'no-token'}`;
+
     return {
         applyDraftUrl,
         clearEmbedUrl,
@@ -137,6 +139,7 @@ export function useEmbedConfig() {
         instanceUrl,
         isConfigOpen,
         parsedJwt,
+        remountKey,
         setDraftUrl,
         setIsConfigOpen,
         token,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR improves component remounting behavior in the SDK test app by introducing a `remountKey` that combines instance URL and token values. The key is now used across Dashboard, Explore, and Chart components to ensure proper remounting when the embed configuration changes.

Additionally, the I18n example page now resets the saved chart state when the remount key changes, preventing stale chart data from persisting across configuration updates.

<!-- Even better add a screenshot / gif / loom -->