### PR TITLE
feat: add resource names to audit log subject calls

### DIFF
--- a/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
+++ b/packages/backend/src/ee/services/AiOrganizationSettingsService.ts
@@ -48,7 +48,7 @@ export class AiOrganizationSettingsService extends BaseService {
             this.createAuditedAbility(user).cannot(
                 'manage',
                 subject('AiAgent', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid || '',
                 }),
             )

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -856,7 +856,7 @@ export class AppGenerateService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
@@ -990,7 +990,7 @@ export class AppGenerateService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
@@ -1126,7 +1126,7 @@ export class AppGenerateService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),
@@ -1392,7 +1392,7 @@ export class AppGenerateService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('DataApp', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid || '',
                     projectUuid,
                 }),

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -153,7 +153,7 @@ export class EmbedService extends BaseService {
         { expiresIn, ...jwtData }: CreateEmbedJwt,
     ): Promise<EmbedUrl> {
         const { user } = account;
-        const { organizationUuid } =
+        const { organizationUuid, name } =
             await this.projectModel.getSummary(projectUuid);
         await this.isFeatureEnabled({
             userUuid: user.userUuid,
@@ -167,6 +167,7 @@ export class EmbedService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {
@@ -198,7 +199,7 @@ export class EmbedService extends BaseService {
         user: LightdashSessionUser,
         projectUuid: string,
     ): Promise<DecodedEmbed> {
-        const { organizationUuid } =
+        const { organizationUuid, name } =
             await this.projectModel.getSummary(projectUuid);
         await this.isFeatureEnabled({
             userUuid: user.userUuid,
@@ -214,6 +215,7 @@ export class EmbedService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {
@@ -234,7 +236,7 @@ export class EmbedService extends BaseService {
         projectUuid: string,
         data: CreateEmbedRequestBody,
     ): Promise<DecodedEmbed> {
-        const { organizationUuid } =
+        const { organizationUuid, name } =
             await this.projectModel.getSummary(projectUuid);
         await this.isFeatureEnabled({
             userUuid: user.userUuid,
@@ -250,6 +252,7 @@ export class EmbedService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {
@@ -280,7 +283,7 @@ export class EmbedService extends BaseService {
         }: Pick<UpdateEmbed, 'dashboardUuids' | 'allowAllDashboards'>,
     ) {
         const { user } = account;
-        const { organizationUuid } =
+        const { organizationUuid, name } =
             await this.projectModel.getSummary(projectUuid);
         await this.isFeatureEnabled({
             userUuid: user.userUuid,
@@ -294,6 +297,7 @@ export class EmbedService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {
@@ -316,7 +320,7 @@ export class EmbedService extends BaseService {
         }: UpdateEmbed,
     ) {
         const { user } = account;
-        const { organizationUuid } =
+        const { organizationUuid, name } =
             await this.projectModel.getSummary(projectUuid);
 
         await this.isFeatureEnabled({
@@ -332,6 +336,7 @@ export class EmbedService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -652,13 +652,16 @@ export class McpService extends BaseService {
                         ),
                 );
 
+                const auditedAbility = this.createAuditedAbility(user);
                 const projectList = allProjects
                     .filter((project) =>
-                        user.ability.can(
+                        auditedAbility.can(
                             'view',
                             subject('Project', {
                                 organizationUuid,
                                 projectUuid: project.projectUuid,
+                                uuid: project.projectUuid,
+                                name: project.name,
                             }),
                         ),
                     )
@@ -727,6 +730,7 @@ export class McpService extends BaseService {
                             uuid: args.projectUuid,
                             projectUuid: args.projectUuid,
                             organizationUuid: project.organizationUuid,
+                            name: project.name,
                         }),
                     )
                 ) {
@@ -1933,6 +1937,7 @@ export class McpService extends BaseService {
                     uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -2036,6 +2041,7 @@ export class McpService extends BaseService {
                     uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -2113,6 +2119,7 @@ export class McpService extends BaseService {
                     uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -2183,6 +2190,7 @@ export class McpService extends BaseService {
                     uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -2246,6 +2254,7 @@ export class McpService extends BaseService {
                     uuid: projectUuid,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {

--- a/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
+++ b/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
@@ -44,7 +44,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     private canManage(account: Account) {
-        const { organizationUuid } = account.organization;
+        const { organizationUuid, name } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('User must be in an organization');
         }
@@ -53,8 +53,9 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('OrganizationWarehouseCredentials', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
+                    name,
                 }),
             )
         ) {
@@ -82,7 +83,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     async getAllSummaries(
         account: Account,
     ): Promise<OrganizationWarehouseCredentialsSummary[]> {
-        const { organizationUuid } = account.organization;
+        const { organizationUuid, name } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('User must be in an organization');
         }
@@ -92,8 +93,9 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('OrganizationWarehouseCredentials', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
+                    name,
                 }),
             )
         ) {

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -128,6 +128,7 @@ export class ScimService extends BaseService {
                 subject('Organization', {
                     uuid: user.organizationUuid || '',
                     organizationUuid: user.organizationUuid || '',
+                    name: user.organizationName || '',
                 }),
             )
         ) {

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -64,6 +64,7 @@ export class ServiceAccountService extends BaseService {
                 subject('Organization', {
                     uuid: user.organizationUuid || '',
                     organizationUuid: user.organizationUuid || '',
+                    name: user.organizationName || '',
                 }),
             )
         ) {

--- a/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
+++ b/packages/backend/src/services/AnalyticsService/AnalyticsService.ts
@@ -54,15 +54,17 @@ export class AnalyticsService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid, name } =
+            await this.projectModel.get(projectUuid);
 
         if (
             auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {
@@ -93,14 +95,16 @@ export class AnalyticsService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid, name } =
+            await this.projectModel.get(projectUuid);
         if (
             auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {
@@ -145,15 +149,17 @@ export class AnalyticsService extends BaseService {
         account: Account,
     ): Promise<UnusedContent> {
         const auditedAbility = this.createAuditedAbility(account);
-        const { organizationUuid } = await this.projectModel.get(projectUuid);
+        const { organizationUuid, name } =
+            await this.projectModel.get(projectUuid);
 
         if (
             auditedAbility.cannot(
                 'view',
                 subject('Analytics', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/ChangesetService.ts
+++ b/packages/backend/src/services/ChangesetService.ts
@@ -39,7 +39,7 @@ export class ChangesetService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid,
                     organizationUuid: user.organizationUuid || '',
                 }),
@@ -65,7 +65,7 @@ export class ChangesetService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid,
                     organizationUuid: user.organizationUuid || '',
                 }),
@@ -89,7 +89,7 @@ export class ChangesetService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid,
                     organizationUuid: user.organizationUuid || '',
                 }),
@@ -141,7 +141,7 @@ export class ChangesetService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('Explore', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid,
                     organizationUuid: user.organizationUuid || '',
                 }),

--- a/packages/backend/src/services/CoderService/CoderService.ts
+++ b/packages/backend/src/services/CoderService/CoderService.ts
@@ -574,6 +574,7 @@ export class CoderService extends BaseService {
                     uuid: project.projectUuid,
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -615,9 +616,10 @@ export class CoderService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -754,9 +756,10 @@ export class CoderService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -891,9 +894,10 @@ export class CoderService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -1013,9 +1017,10 @@ export class CoderService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -1218,9 +1223,10 @@ export class CoderService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {
@@ -1506,9 +1512,10 @@ export class CoderService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('ContentAsCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid: project.projectUuid,
                     organizationUuid: project.organizationUuid,
+                    name: project.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -163,7 +163,8 @@ export class CommentService extends BaseService {
             auditedAbility.cannot(
                 'create',
                 subject('DashboardComments', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
+                    name: dashboard.name,
                     projectUuid: dashboard.projectUuid,
                     organizationUuid: dashboard.organizationUuid,
                 }),
@@ -232,7 +233,8 @@ export class CommentService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('DashboardComments', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
+                    name: dashboard.name,
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),
@@ -250,7 +252,8 @@ export class CommentService extends BaseService {
         const canUserRemoveAnyComment = auditedAbility.can(
             'manage',
             subject('DashboardComments', {
-                uuid: '',
+                uuid: '' /* TODO: pass resource uuid */,
+                name: dashboard.name,
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
             }),
@@ -277,7 +280,8 @@ export class CommentService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('DashboardComments', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
+                    name: dashboard.name,
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                 }),
@@ -329,7 +333,8 @@ export class CommentService extends BaseService {
         const canRemoveAnyComment = auditedAbility.can(
             'manage',
             subject('DashboardComments', {
-                uuid: '',
+                uuid: '' /* TODO: pass resource uuid */,
+                name: dashboard.name,
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
             }),

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -108,6 +108,7 @@ export class ContentService extends BaseService {
                         uuid: project.projectUuid,
                         organizationUuid,
                         projectUuid: project.projectUuid,
+                        name: project.name,
                     }),
                 ),
             )
@@ -204,7 +205,7 @@ export class ContentService extends BaseService {
         }
 
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
         if (
             auditedAbility.cannot(
@@ -213,6 +214,7 @@ export class ContentService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name: projectName,
                 }),
             )
         ) {
@@ -299,7 +301,7 @@ export class ContentService extends BaseService {
         }
 
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
         if (
             auditedAbility.cannot(
@@ -308,6 +310,7 @@ export class ContentService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name: projectName,
                 }),
             )
         ) {
@@ -401,7 +404,7 @@ export class ContentService extends BaseService {
         const isAdmin = auditedAbility.can(
             'manage',
             subject('DeletedContent', {
-                uuid: '',
+                uuid: '' /* TODO: pass resource uuid */,
                 organizationUuid,
                 projectUuid,
             }),
@@ -440,7 +443,7 @@ export class ContentService extends BaseService {
         }
 
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
         if (
             auditedAbility.cannot(
@@ -449,6 +452,7 @@ export class ContentService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name: projectName,
                 }),
             )
         ) {
@@ -490,7 +494,7 @@ export class ContentService extends BaseService {
         }
 
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
         if (
             auditedAbility.cannot(
@@ -499,6 +503,7 @@ export class ContentService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name: projectName,
                 }),
             )
         ) {

--- a/packages/backend/src/services/ContentVerificationService.ts
+++ b/packages/backend/src/services/ContentVerificationService.ts
@@ -62,6 +62,7 @@ export class ContentVerificationService extends BaseService {
                     organizationUuid: project.organizationUuid,
                     projectUuid,
                     uuid: projectUuid,
+                    name: project.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -613,9 +613,10 @@ export class CsvService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('ExportCsv', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
+                    name: dashboard.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -573,7 +573,7 @@ export class DashboardService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                 }),
             )
         ) {
@@ -1516,7 +1516,7 @@ export class DashboardService
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                 }),
             )
         ) {

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -71,11 +71,12 @@ export class DeployService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('DeployProject', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                     type: project.type,
                     createdByUserUuid: project.createdByUserUuid,
+                    name: project.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/FavoritesService/FavoritesService.ts
+++ b/packages/backend/src/services/FavoritesService/FavoritesService.ts
@@ -73,7 +73,11 @@ export class FavoritesService extends BaseService {
         if (
             auditedAbility.cannot(
                 'view',
-                subject('Project', { ...project, uuid: project.projectUuid }),
+                subject('Project', {
+                    ...project,
+                    uuid: project.projectUuid,
+                    name: project.name,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -162,7 +166,11 @@ export class FavoritesService extends BaseService {
         if (
             auditedAbility.cannot(
                 'view',
-                subject('Project', { ...project, uuid: project.projectUuid }),
+                subject('Project', {
+                    ...project,
+                    uuid: project.projectUuid,
+                    name: project.name,
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/FunnelService/FunnelService.ts
+++ b/packages/backend/src/services/FunnelService/FunnelService.ts
@@ -74,16 +74,17 @@ export class FunnelService extends BaseService {
         }
 
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
             auditedAbility.cannot(
                 'manage',
                 subject('SqlRunner', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -73,9 +73,10 @@ export class GdriveService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('ExportCsv', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
+                    name: projectSummary.name,
                 }),
             )
         ) {
@@ -86,9 +87,10 @@ export class GdriveService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('GoogleSheets', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
+                    name: projectSummary.name,
                 }),
             )
         ) {
@@ -102,9 +104,10 @@ export class GdriveService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('CustomSql', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
+                    name: projectSummary.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -591,7 +591,7 @@ Affected charts:
             auditedAbility.cannot(
                 'manage',
                 subject('CustomSql', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -945,7 +945,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1019,7 +1019,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1066,7 +1066,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,
@@ -1235,7 +1235,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1285,7 +1285,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),
@@ -1376,7 +1376,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch,
@@ -1476,7 +1476,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch,
@@ -1528,7 +1528,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,
@@ -1600,7 +1600,7 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
             auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                     isProtectedBranch: false,

--- a/packages/backend/src/services/GithubAppService/GithubAppService.ts
+++ b/packages/backend/src/services/GithubAppService/GithubAppService.ts
@@ -336,7 +336,7 @@ export class GithubAppService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('GitIntegration', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid,
                 }),
             )

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -176,6 +176,7 @@ export class OrganizationService extends BaseService {
                 subject('Organization', {
                     organizationUuid,
                     uuid: organizationUuid,
+                    name: organization.name,
                 }),
             )
         ) {
@@ -270,6 +271,7 @@ export class OrganizationService extends BaseService {
                 subject('OrganizationMemberProfile', {
                     ...member,
                     uuid: member.userUuid,
+                    name: `${member.firstName} ${member.lastName}`,
                 }),
             ),
         );
@@ -329,6 +331,7 @@ export class OrganizationService extends BaseService {
                     organizationUuid,
                     projectUuid: project.projectUuid,
                     uuid: project.projectUuid,
+                    name: project.name,
                 }),
             ),
         );
@@ -384,6 +387,7 @@ export class OrganizationService extends BaseService {
                 subject('OrganizationMemberProfile', {
                     ...member,
                     uuid: member.userUuid,
+                    name: `${member.firstName} ${member.lastName}`,
                 }),
             )
         ) {
@@ -422,6 +426,7 @@ export class OrganizationService extends BaseService {
                 subject('OrganizationMemberProfile', {
                     ...member,
                     uuid: member.userUuid,
+                    name: `${member.firstName} ${member.lastName}`,
                 }),
             )
         ) {

--- a/packages/backend/src/services/PersonalAccessTokenService.ts
+++ b/packages/backend/src/services/PersonalAccessTokenService.ts
@@ -65,8 +65,9 @@ export class PersonalAccessTokenService extends BaseService {
             auditedAbility.cannot(
                 'create',
                 subject('PersonalAccessToken', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid || '',
+                    name: data.description,
                 }),
             )
         ) {
@@ -125,7 +126,7 @@ export class PersonalAccessTokenService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('PersonalAccessToken', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid || '',
                 }),
             )

--- a/packages/backend/src/services/PinningService/PinningService.ts
+++ b/packages/backend/src/services/PinningService/PinningService.ts
@@ -73,7 +73,11 @@ export class PinningService extends BaseService {
         if (
             auditedAbility.cannot(
                 'view',
-                subject('Project', { ...project, uuid: project.projectUuid }),
+                subject('Project', {
+                    ...project,
+                    uuid: project.projectUuid,
+                    name: project.name,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -147,6 +151,7 @@ export class PinningService extends BaseService {
                 subject('PinnedItems', {
                     ...project,
                     uuid: project.projectUuid,
+                    name: project.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/ProjectCompileLogService/ProjectCompileLogService.ts
+++ b/packages/backend/src/services/ProjectCompileLogService/ProjectCompileLogService.ts
@@ -93,7 +93,7 @@ export class ProjectCompileLogService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('JobStatus', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
                     jobUuid,
                     projectUuid,

--- a/packages/backend/src/services/ProjectParametersService.ts
+++ b/packages/backend/src/services/ProjectParametersService.ts
@@ -49,7 +49,7 @@ export class ProjectParametersService extends BaseService {
         },
     ) {
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
@@ -59,6 +59,7 @@ export class ProjectParametersService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/PromoteService/PromoteService.ts
+++ b/packages/backend/src/services/PromoteService/PromoteService.ts
@@ -370,6 +370,7 @@ export class PromoteService extends BaseService {
                     'manage',
                     subject('Space', {
                         uuid: upstreamContent.space.uuid,
+                        name: upstreamContent.space.name,
                         organizationUuid,
                         projectUuid: upstreamContent.projectUuid,
                         inheritsFromOrgOrProject:
@@ -389,7 +390,7 @@ export class PromoteService extends BaseService {
             auditedAbility.cannot(
                 'create',
                 subject('Space', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
                     projectUuid: upstreamContent.projectUuid,
                 }),
@@ -417,6 +418,7 @@ export class PromoteService extends BaseService {
                     'promote',
                     subject('SavedChart', {
                         uuid: promotedChart.chart.uuid,
+                        name: promotedChart.chart.name,
                         organizationUuid,
                         projectUuid: promotedChart.projectUuid,
                         inheritsFromOrgOrProject:
@@ -437,6 +439,7 @@ export class PromoteService extends BaseService {
                 'promote',
                 subject('SavedChart', {
                     uuid: promotedChart.chart.uuid,
+                    name: promotedChart.chart.name,
                     organizationUuid,
                     projectUuid: promotedChart.projectUuid,
                 }),
@@ -458,6 +461,7 @@ export class PromoteService extends BaseService {
                         'promote',
                         subject('SavedChart', {
                             uuid: upstreamChart.chart.uuid,
+                            name: upstreamChart.chart.name,
                             organizationUuid,
                             projectUuid: upstreamChart.projectUuid,
                             inheritsFromOrgOrProject:
@@ -479,6 +483,7 @@ export class PromoteService extends BaseService {
                     'promote',
                     subject('SavedChart', {
                         uuid: upstreamChart.chart.uuid,
+                        name: upstreamChart.chart.name,
                         organizationUuid,
                         projectUuid: upstreamChart.projectUuid,
                     }),
@@ -496,7 +501,7 @@ export class PromoteService extends BaseService {
                 auditedAbility.cannot(
                     'manage',
                     subject('SavedChart', {
-                        uuid: '',
+                        uuid: '' /* TODO: pass resource uuid */,
                         organizationUuid,
                         projectUuid: upstreamChart.projectUuid,
                         access: upstreamChart.spaceAccessContext?.access ?? [],
@@ -528,6 +533,7 @@ export class PromoteService extends BaseService {
                 'promote',
                 subject('SavedChart', {
                     uuid: promotedSqlChart.chart.savedSqlUuid,
+                    name: promotedSqlChart.chart.name,
                     organizationUuid,
                     projectUuid: promotedSqlChart.projectUuid,
                     inheritsFromOrgOrProject:
@@ -551,6 +557,7 @@ export class PromoteService extends BaseService {
                         'promote',
                         subject('SavedChart', {
                             uuid: upstreamSqlChart.chart.savedSqlUuid,
+                            name: upstreamSqlChart.chart.name,
                             organizationUuid,
                             projectUuid: upstreamSqlChart.projectUuid,
                             inheritsFromOrgOrProject:
@@ -573,6 +580,7 @@ export class PromoteService extends BaseService {
                     'promote',
                     subject('SavedChart', {
                         uuid: upstreamSqlChart.chart.savedSqlUuid,
+                        name: upstreamSqlChart.chart.name,
                         organizationUuid,
                         projectUuid: upstreamSqlChart.projectUuid,
                     }),
@@ -589,7 +597,7 @@ export class PromoteService extends BaseService {
                 auditedAbility.cannot(
                     'manage',
                     subject('SavedChart', {
-                        uuid: '',
+                        uuid: '' /* TODO: pass resource uuid */,
                         organizationUuid,
                         projectUuid: upstreamSqlChart.projectUuid,
                         access:
@@ -621,6 +629,7 @@ export class PromoteService extends BaseService {
                 'promote',
                 subject('Dashboard', {
                     uuid: promotedDashboard.dashboard.uuid,
+                    name: promotedDashboard.dashboard.name,
                     organizationUuid,
                     projectUuid: promotedDashboard.projectUuid,
                     inheritsFromOrgOrProject:
@@ -644,6 +653,7 @@ export class PromoteService extends BaseService {
                         'promote',
                         subject('Dashboard', {
                             uuid: upstreamDashboard.dashboard.uuid,
+                            name: upstreamDashboard.dashboard.name,
                             organizationUuid,
                             projectUuid: upstreamDashboard.projectUuid,
                             inheritsFromOrgOrProject:
@@ -664,6 +674,7 @@ export class PromoteService extends BaseService {
                     'promote',
                     subject('Dashboard', {
                         uuid: upstreamDashboard.dashboard.uuid,
+                        name: upstreamDashboard.dashboard.name,
                         organizationUuid,
                         projectUuid: upstreamDashboard.projectUuid,
                     }),
@@ -679,7 +690,7 @@ export class PromoteService extends BaseService {
                 auditedAbility.cannot(
                     'manage',
                     subject('Dashboard', {
-                        uuid: '',
+                        uuid: '' /* TODO: pass resource uuid */,
                         organizationUuid,
                         projectUuid: upstreamDashboard.projectUuid,
                         access:

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -97,6 +97,7 @@ export class RenameService extends BaseService {
                     uuid: chart.projectUuid,
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
+                    name: chart.name,
                 }),
             )
         ) {
@@ -166,7 +167,7 @@ export class RenameService extends BaseService {
         }
 
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
         if (
             auditedAbility.cannot(
@@ -175,6 +176,7 @@ export class RenameService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name: projectName,
                 }),
             )
         ) {
@@ -324,6 +326,7 @@ export class RenameService extends BaseService {
                     uuid: dashboard.projectUuid,
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
+                    name: dashboard.name,
                 }),
             )
         ) {
@@ -419,7 +422,7 @@ export class RenameService extends BaseService {
         }
 
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
         if (
             auditedAbility.cannot(
@@ -428,6 +431,7 @@ export class RenameService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name: projectName,
                 }),
             )
         ) {
@@ -567,7 +571,7 @@ export class RenameService extends BaseService {
         context: RequestMethod;
     }) {
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
         if (
             auditedAbility.cannot(
@@ -576,6 +580,7 @@ export class RenameService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name: projectName,
                 }),
             )
         ) {

--- a/packages/backend/src/services/RolesService/RolesService.ts
+++ b/packages/backend/src/services/RolesService/RolesService.ts
@@ -102,6 +102,7 @@ export class RolesService extends BaseService {
                 subject('Organization', {
                     uuid: organizationUuid,
                     organizationUuid,
+                    name: account.organization?.name,
                 }),
             )
         ) {
@@ -123,6 +124,7 @@ export class RolesService extends BaseService {
                     uuid: project.projectUuid,
                     organizationUuid,
                     projectUuid: project.projectUuid,
+                    name: project.name,
                 }),
             ),
         );
@@ -151,6 +153,7 @@ export class RolesService extends BaseService {
                 subject('Organization', {
                     uuid: organizationUuid,
                     organizationUuid,
+                    name: account.organization?.name,
                 }),
             )
         ) {
@@ -197,6 +200,7 @@ export class RolesService extends BaseService {
                         uuid: projectUuid,
                         organizationUuid: project.organizationUuid,
                         projectUuid,
+                        name: project.name,
                     }),
                 )
             ) {

--- a/packages/backend/src/services/SearchService/SearchService.ts
+++ b/packages/backend/src/services/SearchService/SearchService.ts
@@ -62,7 +62,7 @@ export class SearchService extends BaseService {
         filters?: SearchFilters,
     ): Promise<SearchResults> {
         const auditedAbility = this.createAuditedAbility(user);
-        const { organizationUuid } =
+        const { organizationUuid, name } =
             await this.projectModel.getSummary(projectUuid);
 
         if (
@@ -72,6 +72,7 @@ export class SearchService extends BaseService {
                     uuid: projectUuid,
                     organizationUuid,
                     projectUuid,
+                    name,
                 }),
             )
         ) {
@@ -120,9 +121,10 @@ export class SearchService extends BaseService {
         const hasExploreAccess = auditedAbility.can(
             'manage',
             subject('Explore', {
-                uuid: '',
+                uuid: '' /* TODO: pass resource uuid */,
                 organizationUuid,
                 projectUuid,
+                name,
             }),
         );
 
@@ -234,8 +236,9 @@ export class SearchService extends BaseService {
             pages: auditedAbility.can(
                 'view',
                 subject('Analytics', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
+                    name,
                 }),
             )
                 ? results.pages

--- a/packages/backend/src/services/ShareService/ShareService.ts
+++ b/packages/backend/src/services/ShareService/ShareService.ts
@@ -52,7 +52,7 @@ export class ShareService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('OrganizationMemberProfile', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: shareUrl.organizationUuid || '',
                 }),
             )

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -112,6 +112,7 @@ export class SpaceService
                 user.userUuid,
                 space.uuid,
             );
+        // eslint-disable-next-line no-direct-ability-check -- internal test helper receives partial user type
         return user.ability.can(action, subject(contentType, spaceCtx));
     }
 
@@ -198,7 +199,12 @@ export class SpaceService
         if (
             auditedAbility.cannot(
                 'create',
-                subject('Space', { uuid: '', organizationUuid, projectUuid }),
+                subject('Space', {
+                    uuid: '' /* TODO: pass resource uuid */,
+                    name: space.name,
+                    organizationUuid,
+                    projectUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -614,7 +620,8 @@ export class SpaceService
             const isAdmin = auditedAbility.can(
                 'manage',
                 subject('DeletedContent', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
+                    name: space.name,
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
                 }),
@@ -693,7 +700,8 @@ export class SpaceService
                 auditedAbility.cannot(
                     'manage',
                     subject('DeletedContent', {
-                        uuid: '',
+                        uuid: '' /* TODO: pass resource uuid */,
+                        name: space.name,
                         organizationUuid: space.organizationUuid,
                         projectUuid: space.projectUuid,
                     }),
@@ -784,7 +792,8 @@ export class SpaceService
             auditedAbility.cannot(
                 'manage',
                 subject('PinnedItems', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
+                    name: existingSpace.name,
                     projectUuid,
                     organizationUuid,
                 }),

--- a/packages/backend/src/services/SpotlightService/SpotlightService.ts
+++ b/packages/backend/src/services/SpotlightService/SpotlightService.ts
@@ -45,9 +45,10 @@ export class SpotlightService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('SpotlightTableConfig', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
+                    name: projectSummary.name,
                 }),
             )
         ) {
@@ -70,9 +71,10 @@ export class SpotlightService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('SpotlightTableConfig', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
+                    name: projectSummary.name,
                 }),
             )
         ) {
@@ -103,9 +105,10 @@ export class SpotlightService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('SpotlightTableConfig', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
+                    name: projectSummary.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -675,11 +675,12 @@ export class UnfurlService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid,
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
+                    name,
                 }),
             )
         ) {
@@ -726,11 +727,12 @@ export class UnfurlService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                     inheritsFromOrgOrProject,
                     access,
+                    name: chart.name,
                 }),
             )
         ) {

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -381,6 +381,7 @@ export class UserService extends BaseService {
                     subject('OrganizationMemberProfile', {
                         uuid: userUuidToDelete,
                         organizationUuid: userToDelete.organizationUuid,
+                        name: `${userToDelete.firstName} ${userToDelete.lastName}`,
                     }),
                 )
             ) {
@@ -434,7 +435,7 @@ export class UserService extends BaseService {
             auditedAbility.cannot(
                 'create',
                 subject('InviteLink', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: organizationUuid || '',
                 }),
             )
@@ -465,7 +466,7 @@ export class UserService extends BaseService {
         const userRole = auditedAbility.can(
             'manage',
             subject('OrganizationMemberProfile', {
-                uuid: '',
+                uuid: '' /* TODO: pass resource uuid */,
                 organizationUuid,
             }),
         )
@@ -539,7 +540,7 @@ export class UserService extends BaseService {
             auditedAbility.cannot(
                 'delete',
                 subject('InviteLink', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: organizationUuid || '',
                 }),
             )
@@ -1004,6 +1005,7 @@ export class UserService extends BaseService {
                     subject('Organization', {
                         uuid: user.organizationUuid,
                         organizationUuid: user.organizationUuid,
+                        name: user.organizationName,
                     }),
                 )
             ) {
@@ -1378,7 +1380,7 @@ export class UserService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('PersonalAccessToken', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: user.organizationUuid || '',
                 }),
             )
@@ -1654,7 +1656,7 @@ export class UserService extends BaseService {
                     auditedAbility.cannot(
                         'manage',
                         subject('SavedChart', {
-                            uuid: '',
+                            uuid: '' /* TODO: pass resource uuid */,
                             projectUuid: project.projectUuid,
                             organizationUuid:
                                 sessionUser.organizationUuid || '',
@@ -1671,7 +1673,7 @@ export class UserService extends BaseService {
                     auditedAbility.cannot(
                         'manage',
                         subject('Explore', {
-                            uuid: '',
+                            uuid: '' /* TODO: pass resource uuid */,
                             projectUuid: project.projectUuid,
                             organizationUuid:
                                 sessionUser.organizationUuid || '',
@@ -1746,6 +1748,7 @@ export class UserService extends BaseService {
                     uuid: requestUser.userUuid,
                     organizationUuid: requestUser.organizationUuid || '',
                     isActive: requestUser.isActive,
+                    name: `${requestUser.firstName} ${requestUser.lastName}`,
                 }),
             )
         ) {
@@ -2413,6 +2416,7 @@ export class UserService extends BaseService {
                     uuid: targetUserUuid,
                     organizationUuid: targetUser.organizationUuid || '',
                     isActive: targetUser.isActive,
+                    name: `${targetUser.firstName} ${targetUser.lastName}`,
                 }),
             )
         ) {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1270,7 +1270,7 @@ export class ValidationService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: validation.projectUuid,
                 }),
@@ -1327,7 +1327,8 @@ export class ValidationService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
+                    name: chart.name,
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                     inheritsFromOrgOrProject,
@@ -1410,7 +1411,8 @@ export class ValidationService extends BaseService {
             auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
-                    uuid: '',
+                    uuid: '' /* TODO: pass resource uuid */,
+                    name: dashboard.name,
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                     inheritsFromOrgOrProject,


### PR DESCRIPTION
Closes: SPK-338

## Summary
Enrich audit logs with human-readable resource names by passing `name` to `subject()` calls where a loaded resource is already in scope.

Added `name` across 28 service files:
- **Dashboard/Chart**: DashboardService, SavedChartService, SchedulerService, CommentService, UnfurlService, CsvService
- **Project**: ProjectService, ContentService, AnalyticsService, DeployService, FunnelService, GdriveService, PinningService, ProjectParametersService, SearchService, SpotlightService, CoderService, RenameService, EmbedService, McpService, ContentVerificationService
- **Space**: SpaceService, PromoteService
- **Group**: GroupService
- **Org members**: OrganizationService, UserService
- **Role/token**: RolesService, PersonalAccessTokenService

All remaining `uuid: ''` marked with `/* TODO: pass resource uuid */` for future cleanup.

## Test plan
- [x] `pnpm -F backend typecheck` passes
- [x] `pnpm -F backend lint` passes