### PR TITLE
feat: allow disabling Sentry tracing and PostHog recording on dashboard pages

### DIFF
--- a/packages/backend/src/config/lightdashConfig.mock.ts
+++ b/packages/backend/src/config/lightdashConfig.mock.ts
@@ -104,6 +104,8 @@ export const lightdashConfigMock: LightdashConfig = {
         maxTilesPerTab: 50,
         maxTabsPerDashboard: 20,
         versionHistory: { daysLimit: 0 },
+        disableSentryTracking: false,
+        disablePosthogRecording: false,
     },
     database: {
         connectionUri: undefined,

--- a/packages/backend/src/config/parseConfig.ts
+++ b/packages/backend/src/config/parseConfig.ts
@@ -1045,6 +1045,8 @@ export type LightdashConfig = {
         versionHistory: {
             daysLimit: number;
         };
+        disableSentryTracking: boolean;
+        disablePosthogRecording: boolean;
     };
     // This is the override color palette for the organization
     // TODO: allow override for dark theme
@@ -1960,6 +1962,12 @@ export const parseConfig = (): LightdashConfig => {
                         'LIGHTDASH_DASHBOARD_VERSION_HISTORY_DAYS_LIMIT',
                     ) || 3,
             },
+            disableSentryTracking:
+                process.env.LIGHTDASH_DASHBOARD_DISABLE_SENTRY_TRACKING ===
+                'true',
+            disablePosthogRecording:
+                process.env.LIGHTDASH_DASHBOARD_DISABLE_POSTHOG_RECORDING ===
+                'true',
         },
         pivotTable: {
             maxColumnLimit:

--- a/packages/backend/src/services/HealthService/HealthService.mock.ts
+++ b/packages/backend/src/services/HealthService/HealthService.mock.ts
@@ -89,6 +89,8 @@ export const BaseResponse: HealthState = {
         versionHistory: {
             daysLimit: 0,
         },
+        disableSentryTracking: false,
+        disablePosthogRecording: false,
     },
     rudder: {
         dataPlaneUrl: '',

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -445,6 +445,8 @@ export type HealthState = {
         versionHistory: {
             daysLimit: number;
         };
+        disableSentryTracking: boolean;
+        disablePosthogRecording: boolean;
     };
     pivotTable: {
         maxColumnLimit: number;

--- a/packages/frontend/src/hooks/thirdPartyServices/usePausePosthogRecordingOnDashboard.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/usePausePosthogRecordingOnDashboard.ts
@@ -1,0 +1,32 @@
+import posthog from 'posthog-js';
+import { useEffect } from 'react';
+import useApp from '../../providers/App/useApp';
+
+/**
+ * Pauses PostHog session recording while a dashboard page is mounted.
+ * PostHog's DOM mutation observer records every change, which causes
+ * significant main thread blocking when dashboards mount/unmount many
+ * tiles (e.g. tab switches with 20+ charts).
+ *
+ * Recording resumes automatically when the user navigates away.
+ *
+ * Controlled by LIGHTDASH_DASHBOARD_DISABLE_POSTHOG_RECORDING=true
+ */
+export function usePausePosthogRecordingOnDashboard() {
+    const { health } = useApp();
+    const enabled = health?.data?.dashboard?.disablePosthogRecording ?? false;
+
+    useEffect(() => {
+        if (!enabled) return;
+
+        if (posthog.__loaded && posthog.sessionRecordingStarted()) {
+            posthog.stopSessionRecording();
+        }
+
+        return () => {
+            if (posthog.__loaded && !posthog.sessionRecordingStarted()) {
+                posthog.startSessionRecording();
+            }
+        };
+    }, [enabled]);
+}

--- a/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
+++ b/packages/frontend/src/hooks/thirdPartyServices/useSentry.ts
@@ -30,6 +30,7 @@ const SPOTLIGHT_DUMMY_DSN = 'https://0@o0.ingest.sentry.io/0';
 const useSentry = (
     sentryConfig: HealthState['sentry'] | undefined,
     user: LightdashUser | undefined,
+    disableDashboardTracing?: boolean,
 ) => {
     const [isSentryLoaded, setIsSentryLoaded] = useState(false);
     useEffect(() => {
@@ -62,6 +63,20 @@ const useSentry = (
                 tracesSampler(samplingContext) {
                     if (sentrySpotlightEnabled) {
                         return 1.0;
+                    }
+
+                    // Skip tracing on dashboard pages — Sentry's timer
+                    // wrapping causes significant main thread blocking
+                    // when dashboards unmount/mount many tiles at once.
+                    // Controlled by LIGHTDASH_DASHBOARD_DISABLE_SENTRY_TRACKING=true
+                    if (disableDashboardTracing) {
+                        const name =
+                            samplingContext.name ||
+                            samplingContext.transactionContext?.name ||
+                            window.location.pathname;
+                        if (name.includes('/dashboards/')) {
+                            return 0;
+                        }
                     }
 
                     if (samplingContext.parentSampled !== undefined) {
@@ -112,7 +127,13 @@ const useSentry = (
                 'organization.uuid': user.organizationUuid,
             });
         }
-    }, [isSentryLoaded, setIsSentryLoaded, sentryConfig, user]);
+    }, [
+        isSentryLoaded,
+        setIsSentryLoaded,
+        sentryConfig,
+        user,
+        disableDashboardTracing,
+    ]);
 
     const { projectUuid, dashboardUuid } = useParams<{
         projectUuid?: string;

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -29,6 +29,7 @@ import {
 } from '../hooks/dashboard/useDashboard';
 import useDashboardStorage from '../hooks/dashboard/useDashboardStorage';
 import { useOrganization } from '../hooks/organization/useOrganization';
+import { usePausePosthogRecordingOnDashboard } from '../hooks/thirdPartyServices/usePausePosthogRecordingOnDashboard';
 import useToaster from '../hooks/toaster/useToaster';
 import { useContentAction } from '../hooks/useContent';
 import useApp from '../providers/App/useApp';
@@ -39,6 +40,8 @@ import useFullscreen from '../providers/Fullscreen/useFullscreen';
 import '../styles/react-grid.css';
 
 const Dashboard: FC = () => {
+    usePausePosthogRecordingOnDashboard();
+
     const navigate = useNavigate();
     const { projectUuid, dashboardUuid, mode } = useParams<{
         projectUuid: string;

--- a/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
+++ b/packages/frontend/src/providers/ThirdPartyServicesProvider.tsx
@@ -121,7 +121,11 @@ const ThirdPartyServicesEnabledProvider: FC<React.PropsWithChildren<{}>> = ({
 }) => {
     const { health, user } = useApp();
 
-    useSentry(health?.data?.sentry, user.data);
+    useSentry(
+        health?.data?.sentry,
+        user.data,
+        health?.data?.dashboard?.disableSentryTracking,
+    );
     usePylon();
 
     return (

--- a/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
+++ b/packages/frontend/src/testing/__mocks__/api/healthResponse.mock.ts
@@ -54,6 +54,8 @@ export default function mockHealthResponse(
             versionHistory: {
                 daysLimit: 3,
             },
+            disableSentryTracking: false,
+            disablePosthogRecording: false,
         },
         pivotTable: {
             maxColumnLimit: 100,


### PR DESCRIPTION
## Summary

Profiling showed **~80% of CPU during dashboard tab switches** was consumed by observability tooling, not app code:
- **35%** PostHog session recorder (`addEvent` — recording every DOM mutation)
- **45%** Sentry timer wrapping (`setTimeout`/`clearTimeout`/`addEventListener`)

Adds two backend env vars exposed via the health endpoint:

| Env var | Effect |
|---------|--------|
| `LIGHTDASH_DASHBOARD_DISABLE_SENTRY_TRACKING=true` | `tracesSampler` returns 0 for `/dashboards/` routes |
| `LIGHTDASH_DASHBOARD_DISABLE_POSTHOG_RECORDING=true` | Pauses PostHog session recording while Dashboard component is mounted, resumes on navigation away |

Both default to `false` — no change to existing behavior unless explicitly opted in.

Error reporting, event tracking, and replay-on-error remain active regardless of these flags.

## Test plan
- [ ] Set both env vars, restart backend — verify via health endpoint (`/api/v1/health`)
- [ ] Navigate to a dashboard — Sentry errors still report
- [ ] PostHog events still fire on dashboards
- [ ] PostHog session recording resumes when navigating away from dashboard
- [ ] Non-dashboard pages unaffected (Sentry tracing + PostHog recording active)
- [ ] Without env vars set, behavior is unchanged