### PR TITLE
fix: bin custom dimension create button silently failing

### DIFF
--- a/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
+++ b/packages/frontend/src/components/Explorer/CustomDimensionModal/CustomBinDimensionModal.tsx
@@ -437,8 +437,7 @@ export const CustomBinDimensionModal: FC<{
                             minimum: 1,
                             type: 'array',
                             inclusive: true,
-                            message:
-                                'Each group must have at least one value',
+                            message: 'Each group must have at least one value',
                             path: [
                                 'binConfig',
                                 'customGroups',


### PR DESCRIPTION
## Summary
- Fixes the "Create" button doing nothing when creating bin custom dimensions (Fixed number, Fixed width, Custom range)
- Root cause: zod form schema unconditionally validated `customGroups.values` with `.min(1)`, but default state has empty arrays. For non-CUSTOM_GROUP bin types, these hidden fields failed validation and `form.onSubmit()` silently blocked the callback.
- Moves strict `customGroups` validation into a `superRefine` that only runs when `binType === CUSTOM_GROUP`

Closes #21695

## Test plan
- [ ] Open an explore with a numeric dimension, create a bin custom dimension with "Fixed number of bins" -- verify "Create" works
- [ ] Repeat for "Fixed width" and "Custom range" bin types
- [ ] Open an explore with a string dimension, create a "Custom group" bin dimension -- verify validation still enforces non-empty group names and values
- [ ] Edit an existing bin custom dimension -- verify "Save changes" works

🤖 Generated with [Claude Code](https://claude.com/claude-code)