### PR TITLE
fix: format tooltip header for date dimensions

### DIFF
--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -6,7 +6,12 @@ import {
     type TooltipComponentFormatterCallback,
 } from 'echarts';
 import { toNumber } from 'lodash';
-import { isField, isTableCalculation, type ItemsMap } from '../../types/field';
+import {
+    isField,
+    isTableCalculation,
+    isTimeBasedDimension,
+    type ItemsMap,
+} from '../../types/field';
 import { type ParametersValuesMap } from '../../types/parameters';
 import { type ResultRow } from '../../types/results';
 import {
@@ -1311,7 +1316,7 @@ export const buildCartesianTooltipFormatter =
             const hasFormat = isField(field)
                 ? field.format !== undefined
                 : false;
-            if (hasFormat) {
+            if (hasFormat || isTimeBasedDimension(field)) {
                 // Use raw value from data object for the specific dimensionId
                 // Don't use axisValue directly as it may be from a different axis
                 // (e.g., in flipped charts, axisValue might be "Phillip" but dimensionId is the date field)


### PR DESCRIPTION
## Summary

Fixes tooltip header showing raw timestamps (e.g. `2025-10-01T00:00:00.00Z`) instead of formatted values (e.g. `2025-10`) for date dimensions with time intervals like Month granularity.

### Root cause

`getHeader()` in `tooltipFormatter.ts` only routed fields with an explicit `format` property through `getFormattedValue`. Time-based dimensions (Month, Year, etc.) without a custom format fell through to the raw `axisValueLabel` from ECharts, which is the unformatted timestamp.

### Fix

Added `isTimeBasedDimension(field)` check alongside the existing `hasFormat` check, so date dimensions with time intervals always go through the formatting path.

Closes PROD-6742

## Test plan
- [ ] Create a chart with a date dimension set to Month granularity + a metric
- [ ] Hover over a data point — tooltip header should show `2025-10` not `2025-10-01T00:00:00.00Z`
- [ ] Verify other granularities (Year, Week, Day) also format correctly
- [ ] Verify dimensions with explicit custom formats still work
- [ ] Verify table calculations in tooltips still work