### PR TITLE
feat: improve audit log message readability

### DIFF
--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -228,7 +228,9 @@ describe('formatAuditMessage', () => {
                     projectUuid: 'proj-uuid',
                 },
             }),
-        ).toBe('john@company.com viewed Explore in project proj-uuid (allowed)');
+        ).toBe(
+            'john@company.com viewed Explore in project proj-uuid (allowed)',
+        );
     });
 
     it('formats service account event', () => {
@@ -266,8 +268,6 @@ describe('formatAuditMessage', () => {
                 },
                 action: 'view',
             }),
-        ).toBe(
-            'anonymous user viewed Dashboard "Sales Overview" (allowed)',
-        );
+        ).toBe('anonymous user viewed Dashboard "Sales Overview" (allowed)');
     });
 });

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -195,8 +195,7 @@ export const formatAuditResource = (resource: AuditResource): string => {
     }
     if (
         resource.uuid &&
-        (resource.uuid !== resource.projectUuid ||
-            resource.type === 'Project')
+        (resource.uuid !== resource.projectUuid || resource.type === 'Project')
     ) {
         return `${typePart} ${resource.uuid}`;
     }


### PR DESCRIPTION
## Summary
- Replace UUID-based audit log messages with human-readable sentences
- Actor display uses fallback chain: email → name → UUID
- Resource display uses fallback chain: name → UUID → type only
- Actions shown in past tense (viewed, created, updated, etc.)
- Permission-type subjects (Explore, CustomSql, UnderlyingData) handled gracefully with project context

**Before:**
```
update Dashboard 3f8a1b2c-... by a1b2c3d4-... (allowed)
```

**After:**
```
john@company.com updated Dashboard "Sales Overview" (allowed)
```

Closes SPK-370

## Test plan
- [ ] Unit tests for `formatAuditActor`, `formatAuditAction`, `formatAuditResource`, `formatAuditMessage`
- [ ] Verify audit log output in dev with various actor types (session, service-account, anonymous)
- [ ] Verify permission-type subjects (Explore, CustomSql) show project context instead of empty UUID
- [ ] Verify structured metadata (`...event` spread) is unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)