### PR TITLE
fix: clear session state when creating new data app from existing session

### DIFF
--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -112,9 +112,17 @@ const AppGenerate: FC = () => {
     const [activeAppUuid, setActiveAppUuid] = useState<string | undefined>(
         urlAppUuid,
     );
-    // Sync from URL when navigating (e.g. browser back/forward)
+    // Sync from URL when navigating (e.g. browser back/forward).
+    // When navigating to "new app" mode, clear all session state.
     useEffect(() => {
         setActiveAppUuid(urlAppUuid);
+        if (!urlAppUuid) {
+            setPrompt('');
+            setLocalMessages([]);
+            setPreviewApp(null);
+            versionCacheRef.current.clear();
+            versionCacheAppRef.current = undefined;
+        }
     }, [urlAppUuid]);
     const {
         mutate: generateMutate,


### PR DESCRIPTION
### Description:
When navigating from an open app session to "New -> App", the previous session's chat messages, preview iframe, and version cache were not cleared, leaving stale UI from the old app.
