### PR TITLE
fix: use v6 Switch for BigQuery requireUserCredentials field

### DIFF
--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/BigQueryForm.tsx
@@ -15,6 +15,7 @@ import {
     NumberInput,
     Select,
     Stack,
+    Switch,
     Text,
     TextInput,
     Tooltip,
@@ -36,7 +37,6 @@ import TimeZonePicker from '../../common/TimeZonePicker';
 import DocumentationHelpButton from '../../DocumentationHelpButton';
 import FormCollapseButton from '../FormCollapseButton';
 import { useFormContext } from '../formContext';
-import BooleanSwitch from '../Inputs/BooleanSwitch';
 import FormSection from '../Inputs/FormSection';
 import StartOfWeekSelect from '../Inputs/StartOfWeekSelect';
 import { useProjectFormContext } from '../useProjectFormContext';
@@ -490,7 +490,7 @@ const BigQueryForm: FC<{
                 )}
                 <FormSection isOpen={isOpen} name="advanced">
                     <Stack mt={8}>
-                        <BooleanSwitch
+                        <Switch
                             name="warehouse.requireUserCredentials"
                             {...form.getInputProps(
                                 'warehouse.requireUserCredentials',


### PR DESCRIPTION
## Summary
- The `BooleanSwitch` component uses Mantine v8's `Switch`, which is the only v8 form control in the BigQuery warehouse form (everything else is v6)
- In some self-hosted deployments, this toggle doesn't render — likely due to Mantine v8 CSS not loading correctly
- Swaps to a plain Mantine v6 `Switch` for this one field to debug the visibility issue

## Test plan
- [ ] Verify the "Require users to provide their own credentials" toggle appears in BigQuery advanced settings
- [ ] Verify it still functions correctly (toggle on/off, persists on save)

🤖 Generated with [Claude Code](https://claude.com/claude-code)