### PR TITLE
feat: add audit logs for login/logout and auth failures

### DIFF
--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -11,7 +11,12 @@ import {
 import { RequestHandler } from 'express';
 import { fromServiceAccount } from '../../auth/account/account';
 import { buildAccountExistsWarning } from '../../auth/account/warnAccountExists';
+import {
+    createAuthAuditEvent,
+    createUnknownActor,
+} from '../../logging/auditLog';
 import Logger from '../../logging/logger';
+import { logAuditEvent } from '../../logging/winston';
 import { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
 
 const getRoleForScopes = (scopes: ServiceAccountScope[]) => {
@@ -167,6 +172,16 @@ export const authenticateServiceAccount: RequestHandler = async (
 
         next();
     } catch (error) {
+        logAuditEvent(
+            createAuthAuditEvent({
+                actor: createUnknownActor(),
+                action: 'login',
+                resourceType: 'ServiceAccount',
+                organizationUuid: 'unknown',
+                status: 'denied',
+                reason: getErrorMessage(error),
+            }),
+        );
         next(new AuthorizationError(getErrorMessage(error)));
     }
 };

--- a/packages/backend/src/logging/auditLog.ts
+++ b/packages/backend/src/logging/auditLog.ts
@@ -115,3 +115,47 @@ export const createAuditLogEvent = (
         ruleConditions,
         callStack,
     });
+
+/**
+ * Creates a minimal audit actor for failed auth attempts where the user
+ * may not exist in the system.
+ */
+export const createUnknownActor = (email?: string): AuditActor => ({
+    type: 'session' as const,
+    uuid: 'unknown',
+    email: email || 'unknown',
+    organizationUuid: 'unknown',
+    organizationRole: 'unknown',
+});
+
+/**
+ * Creates an audit log event for authentication actions (login, logout, etc.).
+ * Unlike CASL audit events, these don't have CASL rules or conditions.
+ */
+export const createAuthAuditEvent = ({
+    actor,
+    action,
+    resourceType,
+    resourceUuid,
+    organizationUuid,
+    context,
+    status,
+    reason,
+}: {
+    actor: AuditActor;
+    action: string;
+    resourceType: string;
+    resourceUuid?: string;
+    organizationUuid: string;
+    context?: AuditContext;
+    status: AuditStatusType;
+    reason?: string;
+}): AuditLogEvent =>
+    createAuditLogEvent(
+        actor,
+        action,
+        { type: resourceType, uuid: resourceUuid, organizationUuid },
+        context || {},
+        status,
+        reason,
+    );

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -21,7 +21,10 @@ import {
     getDatabricksStrategyName,
 } from '../controllers/authentication/strategies/databricksStrategy';
 import { AiAgentService } from '../ee/services/AiAgentService/AiAgentService';
+import { createAuthAuditEvent } from '../logging/auditLog';
+import { createActorFromUser } from '../logging/caslAuditWrapper';
 import Logger from '../logging/logger';
+import { logAuditEvent } from '../logging/winston';
 import { UserModel } from '../models/UserModel';
 import { dashboardRouter } from './dashboardRouter';
 import { headlessBrowserRouter } from './headlessBrowser';
@@ -458,6 +461,7 @@ apiV1Router.get(
 );
 
 apiV1Router.get('/logout', (req, res, next) => {
+    const { user } = req;
     req.logout((err) => {
         if (err) {
             return next(err);
@@ -466,6 +470,23 @@ apiV1Router.get('/logout', (req, res, next) => {
             if (err2) {
                 next(err2);
             } else {
+                if (user) {
+                    logAuditEvent(
+                        createAuthAuditEvent({
+                            actor: createActorFromUser(user),
+                            action: 'logout',
+                            resourceType: 'Session',
+                            resourceUuid: user.userUuid,
+                            organizationUuid:
+                                user.organizationUuid || 'unknown',
+                            status: 'allowed',
+                            context: {
+                                ip: req.ip,
+                                userAgent: req.headers['user-agent'],
+                            },
+                        }),
+                    );
+                }
                 res.json({
                     status: 'ok',
                 });

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -57,7 +57,10 @@ import refresh from 'passport-oauth2-refresh';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import EmailClient from '../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../config/parseConfig';
+import { createAuthAuditEvent, createUnknownActor } from '../logging/auditLog';
+import { createActorFromUser } from '../logging/caslAuditWrapper';
 import Logger from '../logging/logger';
+import { logAuditEvent } from '../logging/winston';
 import { PersonalAccessTokenModel } from '../models/DashboardModel/PersonalAccessTokenModel';
 import { EmailModel } from '../models/EmailModel';
 import { FeatureFlagModel } from '../models/FeatureFlagModel/FeatureFlagModel';
@@ -636,6 +639,16 @@ export class UserService extends BaseService {
             this.logger.info(
                 `Login method ${openIdUser.openId.issuerType} not allowed for email ${openIdUser.openId.email}`,
             );
+            logAuditEvent(
+                createAuthAuditEvent({
+                    actor: createUnknownActor(openIdUser.openId.email),
+                    action: 'login',
+                    resourceType: 'Session',
+                    organizationUuid: 'unknown',
+                    status: 'denied',
+                    reason: `Login method ${openIdUser.openId.issuerType} not allowed for email domain`,
+                }),
+            );
             throw new ForbiddenError(
                 `User with email ${openIdUser.openId.email} is not allowed to login with ${openIdUser.openId.issuerType}`,
             );
@@ -650,6 +663,18 @@ export class UserService extends BaseService {
             if (!openIdSession.isActive) {
                 this.logger.info(
                     `User ${openIdSession.userUuid} account is deactivated`,
+                );
+                logAuditEvent(
+                    createAuthAuditEvent({
+                        actor: createActorFromUser(openIdSession),
+                        action: 'login',
+                        resourceType: 'Session',
+                        resourceUuid: openIdSession.userUuid,
+                        organizationUuid:
+                            openIdSession.organizationUuid || 'unknown',
+                        status: 'denied',
+                        reason: 'Account deactivated',
+                    }),
                 );
                 throw new DeactivatedAccountError();
             }
@@ -696,6 +721,16 @@ export class UserService extends BaseService {
                     loginProvider: openIdUser.openId.issuerType,
                 },
             });
+            logAuditEvent(
+                createAuthAuditEvent({
+                    actor: createActorFromUser(loginUser),
+                    action: 'login',
+                    resourceType: 'Session',
+                    resourceUuid: loginUser.userUuid,
+                    organizationUuid: loginUser.organizationUuid || 'unknown',
+                    status: 'allowed',
+                }),
+            );
 
             if (
                 this.lightdashConfig.groups.enabled === true &&
@@ -1106,10 +1141,22 @@ export class UserService extends BaseService {
         email: string,
         password: string,
     ): Promise<LightdashUser> {
+        const unknownActor = createUnknownActor(email);
+
         if (
             (await this.isLoginMethodAllowed(email, LocalIssuerTypes.EMAIL)) ===
             false
         ) {
+            logAuditEvent(
+                createAuthAuditEvent({
+                    actor: unknownActor,
+                    action: 'login',
+                    resourceType: 'Session',
+                    organizationUuid: 'unknown',
+                    status: 'denied',
+                    reason: 'Login method not allowed for email domain',
+                }),
+            );
             throw new ForbiddenError(
                 `User with email ${email} is not allowed to login with password`,
             );
@@ -1117,6 +1164,16 @@ export class UserService extends BaseService {
 
         try {
             if (this.lightdashConfig.auth.disablePasswordAuthentication) {
+                logAuditEvent(
+                    createAuthAuditEvent({
+                        actor: unknownActor,
+                        action: 'login',
+                        resourceType: 'Session',
+                        organizationUuid: 'unknown',
+                        status: 'denied',
+                        reason: 'Password authentication disabled',
+                    }),
+                );
                 throw new ForbiddenError(
                     'Password credentials are not allowed',
                 );
@@ -1128,6 +1185,17 @@ export class UserService extends BaseService {
                 password,
             );
             if (!user.isActive) {
+                logAuditEvent(
+                    createAuthAuditEvent({
+                        actor: createActorFromUser(user),
+                        action: 'login',
+                        resourceType: 'Session',
+                        resourceUuid: user.userUuid,
+                        organizationUuid: user.organizationUuid || 'unknown',
+                        status: 'denied',
+                        reason: 'Account deactivated',
+                    }),
+                );
                 throw new DeactivatedAccountError();
             }
             const userOrganization = this.loginToOrganization(
@@ -1146,9 +1214,29 @@ export class UserService extends BaseService {
                     loginProvider: 'password',
                 },
             });
+            logAuditEvent(
+                createAuthAuditEvent({
+                    actor: createActorFromUser(user),
+                    action: 'login',
+                    resourceType: 'Session',
+                    resourceUuid: user.userUuid,
+                    organizationUuid: user.organizationUuid || 'unknown',
+                    status: 'allowed',
+                }),
+            );
             return user;
         } catch (e) {
             if (e instanceof NotFoundError) {
+                logAuditEvent(
+                    createAuthAuditEvent({
+                        actor: unknownActor,
+                        action: 'login',
+                        resourceType: 'Session',
+                        organizationUuid: 'unknown',
+                        status: 'denied',
+                        reason: 'Invalid credentials',
+                    }),
+                );
                 throw new AuthorizationError(
                     'Email and password not recognized',
                 );
@@ -1352,13 +1440,45 @@ export class UserService extends BaseService {
         const results =
             await this.userModel.findSessionUserByPersonalAccessToken(token);
         if (results === undefined) {
+            logAuditEvent(
+                createAuthAuditEvent({
+                    actor: createUnknownActor(),
+                    action: 'login',
+                    resourceType: 'PersonalAccessToken',
+                    organizationUuid: 'unknown',
+                    status: 'denied',
+                    reason: 'Token not recognized',
+                }),
+            );
             throw new AuthorizationError();
         }
         const { user, personalAccessToken } = results;
         if (!user.isActive) {
+            logAuditEvent(
+                createAuthAuditEvent({
+                    actor: createActorFromUser(user),
+                    action: 'login',
+                    resourceType: 'PersonalAccessToken',
+                    resourceUuid: user.userUuid,
+                    organizationUuid: user.organizationUuid || 'unknown',
+                    status: 'denied',
+                    reason: 'Account deactivated',
+                }),
+            );
             throw new DeactivatedAccountError();
         }
         if (user.ability.cannot('view', subject('PersonalAccessToken', {}))) {
+            logAuditEvent(
+                createAuthAuditEvent({
+                    actor: createActorFromUser(user),
+                    action: 'login',
+                    resourceType: 'PersonalAccessToken',
+                    resourceUuid: user.userUuid,
+                    organizationUuid: user.organizationUuid || 'unknown',
+                    status: 'denied',
+                    reason: 'No permission to use personal access tokens',
+                }),
+            );
             throw new ForbiddenError(
                 'You do not have permission to login with personal access tokens',
             );
@@ -1379,6 +1499,17 @@ export class UserService extends BaseService {
                     personalAccessToken.uuid,
                 );
             }
+            logAuditEvent(
+                createAuthAuditEvent({
+                    actor: createActorFromUser(user),
+                    action: 'login',
+                    resourceType: 'PersonalAccessToken',
+                    resourceUuid: user.userUuid,
+                    organizationUuid: user.organizationUuid || 'unknown',
+                    status: 'denied',
+                    reason: 'Token expired',
+                }),
+            );
             throw new AuthorizationError();
         }
         // Update last used date (throttled to once per minute)


### PR DESCRIPTION
## Summary
Adds audit logging for authentication events at session boundaries. Part of [SPK-369](https://linear.app/lightdash/issue/SPK-369/add-audit-logs-for-loginlogout).

### Changes
- **`auditLog.ts`**: Added `createAuthAuditEvent()` helper for building non-CASL audit events, and `createUnknownActor()` for failed auth attempts where the user may not exist
- **`UserService.ts`**: Added audit events to `loginWithPassword()` (success + 4 failure paths), `loginWithOpenId()` (success + 2 failure paths), and `loginWithPersonalAccessToken()` (4 failure paths only — success not logged since per-request auth access is already covered by CASL audit wrapper)
- **`apiV1Router.ts`**: Added audit event on logout (captures user before session destruction)
- **`ee/authentication/middlewares.ts`**: Added audit event for service account auth failures

### Event summary
| Action | Resource | Status | Trigger |
|--------|----------|--------|---------|
| `login` | `Session` | `allowed` | Password/OpenID login success |
| `login` | `Session` | `denied` | Wrong creds, deactivated, disabled method |
| `login` | `PersonalAccessToken` | `denied` | PAT expired/invalid/no permission |
| `login` | `ServiceAccount` | `denied` | Service account auth failure |
| `logout` | `Session` | `allowed` | User logout |

### Design decisions
- **Session vs per-request auth**: Only session login/logout emit success events. PAT/service account are per-request — only failures logged to avoid noise. CASL wrapper already covers resource access.
- **Unknown actors**: Failed logins where the user doesn't exist use `createUnknownActor()` with `uuid: 'unknown'`

## Test plan
- [ ] Login with password → check audit log for `login Session allowed`
- [ ] Login with wrong password → check for `login Session denied`
- [ ] Login with deactivated account → check for `denied` with reason
- [ ] OpenID login success/failure paths
- [ ] Logout → check for `logout Session allowed`
- [ ] PAT auth with expired token → check for `login PersonalAccessToken denied`
- [ ] Existing backend tests pass

🤖 Generated with [Claude Code](https://claude.ai/code)

test-frontend