### PR TITLE
fix: move dashboard info popover next to title

### DIFF
--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -351,6 +351,32 @@ const DashboardHeader = memo(
             >
                 <Group gap="xs" flex={1} wrap="nowrap">
                     <Title order={6}>{dashboard.name}</Title>
+                    <Popover
+                        withinPortal
+                        withArrow
+                        offset={{
+                            mainAxis: -2,
+                            crossAxis: 6,
+                        }}
+                    >
+                        <Popover.Target>
+                            <ActionIcon
+                                variant="subtle"
+                                size="md"
+                                radius="md"
+                                color="ldGray.6"
+                            >
+                                <MantineIcon icon={IconInfoCircle} />
+                            </ActionIcon>
+                        </Popover.Target>
+
+                        <Popover.Dropdown maw={500} p={0}>
+                            <DashboardInfoOverlay
+                                dashboard={dashboard}
+                                projectUuid={projectUuid}
+                            />
+                        </Popover.Dropdown>
+                    </Popover>
 
                     {isContentVerificationEnabled && isDashboardVerified && (
                         <Tooltip
@@ -385,40 +411,16 @@ const DashboardHeader = memo(
                                 });
                             }}
                         >
-                            {isDashboardFavorited ? (
-                                <IconStarFilled size={16} />
-                            ) : (
-                                <IconStar size={16} />
-                            )}
+                            <MantineIcon
+                                icon={
+                                    isDashboardFavorited
+                                        ? IconStarFilled
+                                        : IconStar
+                                }
+                                size={16}
+                            />
                         </ActionIcon>
                     )}
-
-                    <Popover
-                        withinPortal
-                        withArrow
-                        offset={{
-                            mainAxis: -2,
-                            crossAxis: 6,
-                        }}
-                    >
-                        <Popover.Target>
-                            <ActionIcon
-                                variant="subtle"
-                                size="md"
-                                radius="md"
-                                color="ldGray.6"
-                            >
-                                <MantineIcon icon={IconInfoCircle} />
-                            </ActionIcon>
-                        </Popover.Target>
-
-                        <Popover.Dropdown maw={500} p={0}>
-                            <DashboardInfoOverlay
-                                dashboard={dashboard}
-                                projectUuid={projectUuid}
-                            />
-                        </Popover.Dropdown>
-                    </Popover>
 
                     {isEditMode && userCanManageDashboard && (
                         <ActionIcon


### PR DESCRIPTION
## Summary
- Repositions the info circle popover to appear directly after the dashboard title for better discoverability
- Migrates favorite star icons to use the `MantineIcon` wrapper for consistency with other icons in the header

## Test plan
- [ ] Open a dashboard and verify the info icon appears right after the title
- [ ] Click the info icon and confirm the popover opens correctly
- [ ] Verify the favorite star icon still toggles correctly
- [ ] Check light and dark mode appearance

🤖 Generated with [Claude Code](https://claude.com/claude-code)