### PR TITLE
fix: separate bar chart conditional formatting color picker

### DIFF
--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/ChartConditionalFormatting.tsx
@@ -7,7 +7,7 @@ import {
     type FilterableItem,
     type FilterOperator,
 } from '@lightdash/common';
-import { Accordion, Divider } from '@mantine/core';
+import { Accordion, Divider, Group } from '@mantine/core';
 import { produce } from 'immer';
 import {
     Fragment,
@@ -123,12 +123,7 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
                     <ColorSelector
                         color={config.color}
                         swatches={colorPalette}
-                        onColorChange={(color) =>
-                            onChange({
-                                ...config,
-                                color,
-                            })
-                        }
+                        readOnly
                     />
                 }
                 onControlClick={handleControlClick}
@@ -143,6 +138,19 @@ const ChartConditionalFormattingItem: FC<ItemProps> = ({
                         onChange={() => undefined}
                         hasGrouping
                     />
+                    <Group spacing="xs">
+                        <Config.Label>Color</Config.Label>
+                        <ColorSelector
+                            color={config.color}
+                            swatches={colorPalette}
+                            onColorChange={(color) =>
+                                onChange({
+                                    ...config,
+                                    color,
+                                })
+                            }
+                        />
+                    </Group>
                     {config.rules.map((rule, ruleIndex) => (
                         <Fragment key={rule.id ?? ruleIndex}>
                             <ChartConditionalFormattingRule

--- a/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ColorSelector.tsx
@@ -16,6 +16,7 @@ interface Props {
     defaultColor?: string;
     swatches: string[];
     onColorChange?: (newColor: string) => void;
+    readOnly?: boolean;
     colorSwatchProps?: Omit<ColorSwatchProps, 'color'>;
     withAlpha?: boolean;
 }
@@ -25,20 +26,22 @@ const ColorSelector: FC<Props> = ({
     defaultColor = 'rgba(0,0,0,.1)',
     swatches,
     onColorChange,
+    readOnly = false,
     colorSwatchProps,
     withAlpha = false,
 }) => {
     const isValidHexColor = color && isHexCodeColor(color);
+    const isInteractive = Boolean(onColorChange) && !readOnly;
 
-    return (
-        <Popover withinPortal shadow="md" withArrow disabled={!onColorChange}>
+    return isInteractive ? (
+        <Popover withinPortal shadow="md" withArrow>
             <Popover.Target>
                 <ColorSwatch
                     size={20}
                     color={isValidHexColor ? color : defaultColor}
                     {...colorSwatchProps}
                     sx={{
-                        cursor: onColorChange ? 'pointer' : 'default',
+                        cursor: 'pointer',
                         transition: 'opacity 100ms ease',
                         '&:hover': { opacity: 0.8 },
                         ...(typeof colorSwatchProps?.sx === 'object' &&
@@ -93,6 +96,19 @@ const ColorSelector: FC<Props> = ({
                 </Stack>
             </Popover.Dropdown>
         </Popover>
+    ) : (
+        <ColorSwatch
+            size={20}
+            color={isValidHexColor ? color : defaultColor}
+            {...colorSwatchProps}
+            sx={{
+                cursor: 'default',
+                ...(typeof colorSwatchProps?.sx === 'object' &&
+                !Array.isArray(colorSwatchProps.sx)
+                    ? colorSwatchProps.sx
+                    : {}),
+            }}
+        />
     );
 };
 


### PR DESCRIPTION
## Summary
- make the bar chart conditional formatting header swatch display-only
- add a dedicated `Color` picker row under the field selector
- add a `readOnly` mode to `ColorSelector` for passive swatch rendering

## Testing
- Not run (not requested)