### PR TITLE
feat: add color palette override support to embedded dashboards

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -538,7 +538,7 @@ export class OrganizationController extends BaseController {
             status: 'ok',
             results: await this.services
                 .getOrganizationService()
-                .getColorPalettes(req.user!),
+                .getColorPalettes(req.account!),
         };
     }
 

--- a/packages/backend/src/ee/controllers/embedController.ts
+++ b/packages/backend/src/ee/controllers/embedController.ts
@@ -25,8 +25,10 @@ import {
     ExecuteAsyncDashboardChartRequestParams,
     Explore,
     FieldValueSearchResult,
+    GetEmbedDashboardRequest,
     Item,
     MetricQueryResponse,
+    OrganizationColorPalette,
     ParametersValuesMap,
     SavedChart,
     SavedChartsInfoForDashboardAvailableFilters,
@@ -61,8 +63,17 @@ export type ApiEmbedDashboardResponse = {
     results: Dashboard & {
         // declare type as TSOA doesn't understand zod type InteractivityOptions
         dashboardFiltersInteractivity?: CommonEmbedJwtContent['dashboardFiltersInteractivity'];
+        parameterInteractivity?: CommonEmbedJwtContent['parameterInteractivity'];
         canExportCsv?: boolean;
         canExportImages?: boolean;
+        canExportPagePdf?: boolean;
+        canDateZoom?: boolean;
+        canExplore?: boolean;
+        canViewUnderlyingData?: boolean;
+        selectedPalette?: Pick<
+            OrganizationColorPalette,
+            'colors' | 'darkColors'
+        > | null;
     };
 };
 
@@ -218,6 +229,7 @@ export class EmbedController extends BaseController {
     async getEmbedDashboard(
         @Request() req: express.Request,
         @Path() projectUuid: string,
+        @Body() body?: GetEmbedDashboardRequest,
     ): Promise<ApiEmbedDashboardResponse> {
         this.setStatus(200);
 
@@ -228,6 +240,7 @@ export class EmbedController extends BaseController {
             results: await this.getEmbedService().getDashboard(
                 projectUuid,
                 req.account,
+                { paletteUuid: body?.paletteUuid },
             ),
         };
     }

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -10,7 +10,6 @@ import {
     CompiledDimension,
     CreateEmbedJwt,
     CreateEmbedRequestBody,
-    Dashboard,
     DashboardAvailableFilters,
     DashboardDAO,
     DashboardFilters,
@@ -19,6 +18,7 @@ import {
     DecodedEmbed,
     Embed,
     EmbedContent,
+    EmbedDashboard,
     EmbedUrl,
     ExecuteAsyncDashboardChartRequestParams,
     Explore,
@@ -461,9 +461,14 @@ export class EmbedService extends BaseService {
     async getDashboard(
         projectUuid: string,
         account: AnonymousAccount,
-        // TODO: WHY IS THIS OPTIONAL??
-        checkPermissions: boolean = true,
-    ): Promise<Dashboard & InteractivityOptions> {
+        {
+            paletteUuid,
+            checkPermissions = true,
+        }: {
+            paletteUuid?: string;
+            checkPermissions?: boolean;
+        } = {},
+    ): Promise<EmbedDashboard> {
         const { data: decodedToken, source: embedToken } =
             account.authentication;
         const { dashboardUuids, allowAllDashboards, user } =
@@ -507,6 +512,12 @@ export class EmbedService extends BaseService {
             canExportPagePdf,
             canDateZoom,
         } = decodedToken.content;
+        const selectedPalette = paletteUuid
+            ? await this.organizationModel.findColorPalette(
+                  dashboard.organizationUuid,
+                  paletteUuid,
+              )
+            : null;
 
         this.analytics.trackAccount<EmbedDashboardViewed>(account, {
             event: 'embed_dashboard.viewed',
@@ -548,6 +559,7 @@ export class EmbedService extends BaseService {
             canExportImages,
             canExportPagePdf: canExportPagePdf ?? true, // enabled by default for backwards compatibility
             canDateZoom,
+            selectedPalette,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -2202,6 +2202,29 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Pick_OrganizationColorPalette.colors-or-darkColors_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                colors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                darkColors: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'array', array: { dataType: 'string' } },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiEmbedDashboardResponse: {
         dataType: 'refAlias',
         type: {
@@ -2214,8 +2237,30 @@ const models: TsoaRoute.Models = {
                         {
                             dataType: 'nestedObjectLiteral',
                             nestedProperties: {
+                                selectedPalette: {
+                                    dataType: 'union',
+                                    subSchemas: [
+                                        {
+                                            ref: 'Pick_OrganizationColorPalette.colors-or-darkColors_',
+                                        },
+                                        { dataType: 'enum', enums: [null] },
+                                    ],
+                                },
+                                canViewUnderlyingData: { dataType: 'boolean' },
+                                canExplore: { dataType: 'boolean' },
+                                canDateZoom: { dataType: 'boolean' },
+                                canExportPagePdf: { dataType: 'boolean' },
                                 canExportImages: { dataType: 'boolean' },
                                 canExportCsv: { dataType: 'boolean' },
+                                parameterInteractivity: {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        enabled: {
+                                            dataType: 'boolean',
+                                            required: true,
+                                        },
+                                    },
+                                },
                                 dashboardFiltersInteractivity: {
                                     dataType: 'nestedObjectLiteral',
                                     nestedProperties: {
@@ -2254,6 +2299,15 @@ const models: TsoaRoute.Models = {
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    GetEmbedDashboardRequest: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { paletteUuid: { dataType: 'string' } },
             validators: {},
         },
     },
@@ -6763,6 +6817,7 @@ const models: TsoaRoute.Models = {
                     required: true,
                 },
                 createdAt: { dataType: 'datetime', required: true },
+                projectName: { dataType: 'string', required: true },
                 projectUuid: { dataType: 'string', required: true },
                 description: { dataType: 'string', required: true },
                 name: { dataType: 'string', required: true },
@@ -15423,7 +15478,7 @@ const models: TsoaRoute.Models = {
         enums: ['no changes', 'create', 'update', 'delete'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-inheritParentPermissions-or-pinnedListUuid-or-pinnedListOrder-or-slug-or-parentSpaceUuid-or-path_':
+    'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-inheritParentPermissions-or-projectMemberAccessRole-or-pinnedListUuid-or-pinnedListOrder-or-slug-or-parentSpaceUuid-or-path_':
         {
             dataType: 'refAlias',
             type: {
@@ -15435,6 +15490,14 @@ const models: TsoaRoute.Models = {
                     uuid: { dataType: 'string', required: true },
                     inheritParentPermissions: {
                         dataType: 'boolean',
+                        required: true,
+                    },
+                    projectMemberAccessRole: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { ref: 'SpaceMemberRole' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
                         required: true,
                     },
                     pinnedListUuid: {
@@ -15474,7 +15537,7 @@ const models: TsoaRoute.Models = {
             dataType: 'intersection',
             subSchemas: [
                 {
-                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-inheritParentPermissions-or-pinnedListUuid-or-pinnedListOrder-or-slug-or-parentSpaceUuid-or-path_',
+                    ref: 'Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-inheritParentPermissions-or-projectMemberAccessRole-or-pinnedListUuid-or-pinnedListOrder-or-slug-or-parentSpaceUuid-or-path_',
                 },
                 {
                     dataType: 'nestedObjectLiteral',
@@ -17096,6 +17159,14 @@ const models: TsoaRoute.Models = {
                     },
                 },
                 path: { dataType: 'string', required: true },
+                projectMemberAccessRole: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'SpaceMemberRole' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 inheritParentPermissions: {
                     dataType: 'boolean',
                     required: true,
@@ -17284,6 +17355,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                projectMemberAccessRole: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'SpaceMemberRole' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 inheritParentPermissions: { dataType: 'boolean' },
                 name: { dataType: 'string', required: true },
             },
@@ -20074,7 +20152,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20084,7 +20162,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20094,7 +20172,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -20107,7 +20185,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -20510,7 +20588,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20520,7 +20598,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20530,7 +20608,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -20543,7 +20621,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -30526,6 +30604,7 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'string',
         },
+        body: { in: 'body', name: 'body', ref: 'GetEmbedDashboardRequest' },
     };
     app.post(
         '/api/v1/embed/:projectUuid/dashboard',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2385,6 +2385,26 @@
                 ],
                 "type": "object"
             },
+            "Pick_OrganizationColorPalette.colors-or-darkColors_": {
+                "properties": {
+                    "colors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "darkColors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array",
+                        "nullable": true
+                    }
+                },
+                "required": ["colors", "darkColors"],
+                "type": "object",
+                "description": "From T, pick a set of properties whose keys are in the union K"
+            },
             "ApiEmbedDashboardResponse": {
                 "properties": {
                     "results": {
@@ -2394,11 +2414,40 @@
                             },
                             {
                                 "properties": {
+                                    "selectedPalette": {
+                                        "allOf": [
+                                            {
+                                                "$ref": "#/components/schemas/Pick_OrganizationColorPalette.colors-or-darkColors_"
+                                            }
+                                        ],
+                                        "nullable": true
+                                    },
+                                    "canViewUnderlyingData": {
+                                        "type": "boolean"
+                                    },
+                                    "canExplore": {
+                                        "type": "boolean"
+                                    },
+                                    "canDateZoom": {
+                                        "type": "boolean"
+                                    },
+                                    "canExportPagePdf": {
+                                        "type": "boolean"
+                                    },
                                     "canExportImages": {
                                         "type": "boolean"
                                     },
                                     "canExportCsv": {
                                         "type": "boolean"
+                                    },
+                                    "parameterInteractivity": {
+                                        "properties": {
+                                            "enabled": {
+                                                "type": "boolean"
+                                            }
+                                        },
+                                        "required": ["enabled"],
+                                        "type": "object"
                                     },
                                     "dashboardFiltersInteractivity": {
                                         "properties": {
@@ -2438,6 +2487,14 @@
                     }
                 },
                 "required": ["results", "status"],
+                "type": "object"
+            },
+            "GetEmbedDashboardRequest": {
+                "properties": {
+                    "paletteUuid": {
+                        "type": "string"
+                    }
+                },
                 "type": "object"
             },
             "Record_string.number-Array_": {
@@ -8108,6 +8165,9 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "projectName": {
+                        "type": "string"
+                    },
                     "projectUuid": {
                         "type": "string"
                     },
@@ -8125,6 +8185,7 @@
                     "lastVersionStatus",
                     "lastVersionNumber",
                     "createdAt",
+                    "projectName",
                     "projectUuid",
                     "description",
                     "name",
@@ -16298,7 +16359,7 @@
                 "enum": ["no changes", "create", "update", "delete"],
                 "type": "string"
             },
-            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-inheritParentPermissions-or-pinnedListUuid-or-pinnedListOrder-or-slug-or-parentSpaceUuid-or-path_": {
+            "Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-inheritParentPermissions-or-projectMemberAccessRole-or-pinnedListUuid-or-pinnedListOrder-or-slug-or-parentSpaceUuid-or-path_": {
                 "properties": {
                     "name": {
                         "type": "string"
@@ -16314,6 +16375,14 @@
                     },
                     "inheritParentPermissions": {
                         "type": "boolean"
+                    },
+                    "projectMemberAccessRole": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SpaceMemberRole"
+                            }
+                        ],
+                        "nullable": true
                     },
                     "pinnedListUuid": {
                         "type": "string",
@@ -16341,6 +16410,7 @@
                     "organizationUuid",
                     "uuid",
                     "inheritParentPermissions",
+                    "projectMemberAccessRole",
                     "pinnedListUuid",
                     "pinnedListOrder",
                     "slug",
@@ -16353,7 +16423,7 @@
             "SpaceSummaryBase": {
                 "allOf": [
                     {
-                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-inheritParentPermissions-or-pinnedListUuid-or-pinnedListOrder-or-slug-or-parentSpaceUuid-or-path_"
+                        "$ref": "#/components/schemas/Pick_Space.organizationUuid-or-projectUuid-or-uuid-or-name-or-inheritParentPermissions-or-projectMemberAccessRole-or-pinnedListUuid-or-pinnedListOrder-or-slug-or-parentSpaceUuid-or-path_"
                     },
                     {
                         "properties": {
@@ -18146,6 +18216,14 @@
                     "path": {
                         "type": "string"
                     },
+                    "projectMemberAccessRole": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SpaceMemberRole"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "inheritParentPermissions": {
                         "type": "boolean"
                     },
@@ -18213,6 +18291,7 @@
                 },
                 "required": [
                     "path",
+                    "projectMemberAccessRole",
                     "inheritParentPermissions",
                     "parentSpaceUuid",
                     "childSpaces",
@@ -18384,6 +18463,15 @@
             },
             "UpdateSpace": {
                 "properties": {
+                    "projectMemberAccessRole": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/SpaceMemberRole"
+                            }
+                        ],
+                        "nullable": true,
+                        "description": "When set, all project members get this role on the space"
+                    },
                     "inheritParentPermissions": {
                         "type": "boolean"
                     },
@@ -21385,22 +21473,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -21747,22 +21835,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -29610,7 +29698,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2710.0",
+        "version": "0.2720.4",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/OrganizationModel.ts
+++ b/packages/backend/src/models/OrganizationModel.ts
@@ -410,6 +410,20 @@ export class OrganizationModel {
         );
     }
 
+    async findColorPalette(
+        organizationUuid: string,
+        colorPaletteUuid: string,
+    ): Promise<OrganizationColorPalette | undefined> {
+        const palette = await this.database(OrganizationColorPaletteTableName)
+            .where('organization_uuid', organizationUuid)
+            .andWhere('color_palette_uuid', colorPaletteUuid)
+            .first();
+
+        return palette
+            ? OrganizationModel.mapDBColorPalette(palette)
+            : undefined;
+    }
+
     async updateColorPalette(
         organizationUuid: string,
         colorPaletteUuid: string,

--- a/packages/backend/src/services/OrganizationService/OrganizationService.ts
+++ b/packages/backend/src/services/OrganizationService/OrganizationService.ts
@@ -681,13 +681,15 @@ export class OrganizationService extends BaseService {
     }
 
     async getColorPalettes(
-        user: SessionUser,
+        account: Account,
     ): Promise<OrganizationColorPaletteWithIsActive[]> {
-        if (!user.organizationUuid) {
+        const { organizationUuid } = account.organization;
+
+        if (!organizationUuid) {
             throw new NotFoundError('Organization not found');
         }
 
-        return this.organizationModel.getColorPalettes(user.organizationUuid);
+        return this.organizationModel.getColorPalettes(organizationUuid);
     }
 
     async updateColorPalette(

--- a/packages/common/src/ee/embed/index.ts
+++ b/packages/common/src/ee/embed/index.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 import type { EmbedContent, OssEmbed } from '../../types/auth';
+import type { Dashboard } from '../../types/dashboard';
+import type { OrganizationColorPalette } from '../../types/organization';
 import assertUnreachable from '../../utils/assertUnreachable';
 
 /** @deprecated Use OssEmbed instead */
@@ -23,6 +25,10 @@ export type UpdateEmbed = {
     // TODO: Make these required in Settings UI PR
     chartUuids?: string[];
     allowAllCharts?: boolean;
+};
+
+export type GetEmbedDashboardRequest = {
+    paletteUuid?: string;
 };
 
 export enum FilterInteractivityValues {
@@ -69,6 +75,16 @@ export const InteractivityOptionsSchema = z.object({
 });
 
 export type InteractivityOptions = z.infer<typeof InteractivityOptionsSchema>;
+
+export type EmbedSelectedColorPalette = Pick<
+    OrganizationColorPalette,
+    'colors' | 'darkColors'
+>;
+
+export type EmbedDashboard = Dashboard &
+    InteractivityOptions & {
+        selectedPalette?: EmbedSelectedColorPalette | null;
+    };
 
 export const ChartInteractivityOptionsSchema = z.object({
     scopes: z.array(z.string()).optional(),

--- a/packages/frontend/sdk/index.tsx
+++ b/packages/frontend/sdk/index.tsx
@@ -28,7 +28,7 @@ const LIGHTDASH_SDK_INSTANCE_URL_LOCAL_STORAGE_KEY =
     '__lightdash_sdk_instance_url';
 const LIGHTDASH_SDK_VERSION_LOCAL_STORAGE_KEY = '__lightdash_sdk_version';
 
-type Props = {
+type BaseProps = {
     instanceUrl: string;
     token: Promise<string> | string;
     styles?: {
@@ -38,6 +38,10 @@ type Props = {
     filters?: SdkFilter[];
     contentOverrides?: LanguageMap;
     onExplore?: (options: { chart: SavedChart }) => void;
+};
+
+type DashboardProps = BaseProps & {
+    paletteUuid?: string;
 };
 
 const decodeJWT = (token: string) => {
@@ -126,13 +130,14 @@ const SdkProviders: FC<
     );
 };
 
-const Dashboard: FC<Props> = ({
+const Dashboard: FC<DashboardProps> = ({
     token: tokenOrTokenPromise,
     instanceUrl,
     styles,
     filters,
     contentOverrides,
     onExplore,
+    paletteUuid,
 }) => {
     const [token, setToken] = useState<string | null>(null);
     const [projectUuid, setProjectUuid] = useState<string | null>(null);
@@ -179,6 +184,7 @@ const Dashboard: FC<Props> = ({
                 embedToken={token}
                 projectUuid={projectUuid}
                 filters={filters}
+                paletteUuid={paletteUuid}
                 contentOverrides={contentOverrides}
                 onExplore={onExplore}
             >
@@ -196,7 +202,7 @@ const Dashboard: FC<Props> = ({
     );
 };
 
-const Explore: FC<Props & { exploreId: string; savedChart: SavedChart }> = ({
+const Explore: FC<BaseProps & { exploreId: string; savedChart: SavedChart }> = ({
     token: tokenOrTokenPromise,
     instanceUrl,
     styles,
@@ -270,7 +276,7 @@ const Explore: FC<Props & { exploreId: string; savedChart: SavedChart }> = ({
     );
 };
 
-const Chart: FC<Omit<Props, 'filters' | 'onExplore'> & { id: string }> = ({
+const Chart: FC<Omit<BaseProps, 'filters' | 'onExplore'> & { id: string }> = ({
     token: tokenOrTokenPromise,
     instanceUrl,
     styles,

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -72,6 +72,7 @@ import React, {
 import { useParams } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
 import { type EChartsReact } from '../EChartsReactWrapper';
+import { getDashboardChartColorPalette } from './getDashboardChartColorPalette';
 
 type ClientSideError = {
     error: {
@@ -252,6 +253,8 @@ const ValidDashboardChartTile: FC<{
     resultsData: InfiniteQueryResults;
     isTitleHidden?: boolean;
     project: string;
+    colorPaletteOverride?: string[];
+    darkColorPaletteOverride?: string[] | null;
     onSeriesContextMenu?: (
         e: EchartsSeriesClickEvent,
         series: EChartsSeries[],
@@ -263,6 +266,8 @@ const ValidDashboardChartTile: FC<{
         isTitleHidden = false,
         dashboardChartReadyQuery,
         resultsData,
+        colorPaletteOverride,
+        darkColorPaletteOverride,
         onSeriesContextMenu,
         setEchartsRef,
     }) => {
@@ -348,12 +353,18 @@ const ValidDashboardChartTile: FC<{
         );
 
         const colorPalette = useMemo(() => {
-            if (colorScheme === 'dark' && org?.chartDarkColors) {
-                return org.chartDarkColors;
-            }
-            return org?.chartColors ?? chart.colorPalette;
+            return getDashboardChartColorPalette({
+                colorScheme,
+                chartColorPalette: chart.colorPalette,
+                selectedPaletteColors: colorPaletteOverride,
+                selectedPaletteDarkColors: darkColorPaletteOverride,
+                orgColorPalette: org?.chartColors,
+                orgDarkColorPalette: org?.chartDarkColors,
+            });
         }, [
             colorScheme,
+            colorPaletteOverride,
+            darkColorPaletteOverride,
             org?.chartColors,
             org?.chartDarkColors,
             chart.colorPalette,
@@ -409,6 +420,8 @@ const ValidDashboardChartTileMinimal: FC<{
     title: string;
     chart: SavedChart;
     dashboardChartReadyQuery: DashboardChartReadyQuery;
+    colorPaletteOverride?: string[];
+    darkColorPaletteOverride?: string[] | null;
     onSeriesContextMenu?: (
         e: EchartsSeriesClickEvent,
         series: EChartsSeries[],
@@ -420,6 +433,8 @@ const ValidDashboardChartTileMinimal: FC<{
     chart,
     dashboardChartReadyQuery,
     resultsData,
+    colorPaletteOverride,
+    darkColorPaletteOverride,
     isTitleHidden = false,
     onSeriesContextMenu,
     setEchartsRef,
@@ -483,12 +498,18 @@ const ValidDashboardChartTileMinimal: FC<{
     );
 
     const colorPalette = useMemo(() => {
-        if (colorScheme === 'dark' && org?.chartDarkColors) {
-            return org.chartDarkColors;
-        }
-        return org?.chartColors ?? chart.colorPalette;
+        return getDashboardChartColorPalette({
+            colorScheme,
+            chartColorPalette: chart.colorPalette,
+            selectedPaletteColors: colorPaletteOverride,
+            selectedPaletteDarkColors: darkColorPaletteOverride,
+            orgColorPalette: org?.chartColors,
+            orgDarkColorPalette: org?.chartDarkColors,
+        });
     }, [
         colorScheme,
+        colorPaletteOverride,
+        darkColorPaletteOverride,
         org?.chartColors,
         org?.chartDarkColors,
         chart.colorPalette,
@@ -550,6 +571,8 @@ interface DashboardChartTileMainProps extends Pick<
     canExportPagePdf?: boolean;
     canDateZoom?: boolean;
     onExplore?: (options: { chart: SavedChart }) => void;
+    colorPaletteOverride?: string[];
+    darkColorPaletteOverride?: string[] | null;
 }
 
 const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
@@ -579,6 +602,11 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             dashboardChartReadyQuery,
             resultsData,
             isEditMode,
+        } = props;
+        const {
+            colorPaletteOverride: _colorPaletteOverride,
+            darkColorPaletteOverride: _darkColorPaletteOverride,
+            ...tileBaseProps
         } = props;
 
         const {
@@ -1484,7 +1512,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                         chart.chartConfig.type === ChartType.TABLE ||
                         chart.chartConfig.type === ChartType.MAP
                     }
-                    {...props}
+                    {...tileBaseProps}
                 >
                     <>
                         <Menu
@@ -1559,6 +1587,10 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                             resultsData={resultsData}
                             project={chart.projectUuid}
                             isTitleHidden={hideTitle}
+                            colorPaletteOverride={props.colorPaletteOverride}
+                            darkColorPaletteOverride={
+                                props.darkColorPaletteOverride
+                            }
                             onSeriesContextMenu={onSeriesContextMenu}
                             setEchartsRef={setEchartRef}
                         />
@@ -1643,6 +1675,13 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
         canExportCsv,
         canExportImages,
         onExplore,
+        colorPaletteOverride,
+        darkColorPaletteOverride,
+    } = props;
+    const {
+        colorPaletteOverride: _colorPaletteOverride,
+        darkColorPaletteOverride: _darkColorPaletteOverride,
+        ...tileBaseProps
     } = props;
 
     const {
@@ -1822,7 +1861,7 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                     chart.chartConfig.type === ChartType.TABLE ||
                     chart.chartConfig.type === ChartType.MAP
                 }
-                {...props}
+                {...tileBaseProps}
             >
                 <>
                     <Menu
@@ -1872,6 +1911,8 @@ const DashboardChartTileMinimal: FC<DashboardChartTileMainProps> = (props) => {
                         isTitleHidden={hideTitle}
                         chart={chart}
                         dashboardChartReadyQuery={dashboardChartReadyQuery}
+                        colorPaletteOverride={colorPaletteOverride}
+                        darkColorPaletteOverride={darkColorPaletteOverride}
                         onSeriesContextMenu={onSeriesContextMenu}
                         resultsData={resultsData}
                         title={title || chart.name}
@@ -1943,6 +1984,8 @@ export const GenericDashboardChartTile: FC<
     canExportCsv = false,
     canExportImages = false,
     onExplore,
+    colorPaletteOverride,
+    darkColorPaletteOverride,
     ...rest
 }) => {
     const { projectUuid } = useParams<{
@@ -2059,6 +2102,8 @@ export const GenericDashboardChartTile: FC<
                     canExportCsv={canExportCsv}
                     canExportImages={canExportImages}
                     onExplore={onExplore}
+                    colorPaletteOverride={colorPaletteOverride}
+                    darkColorPaletteOverride={darkColorPaletteOverride}
                 />
             ) : (
                 <DashboardChartTileMain
@@ -2068,6 +2113,8 @@ export const GenericDashboardChartTile: FC<
                     resultsData={resultsData}
                     dashboardChartReadyQuery={dashboardChartReadyQuery}
                     onExplore={onExplore}
+                    colorPaletteOverride={colorPaletteOverride}
+                    darkColorPaletteOverride={darkColorPaletteOverride}
                 />
             )}
             <UnderlyingDataModal />

--- a/packages/frontend/src/components/DashboardTiles/getDashboardChartColorPalette.ts
+++ b/packages/frontend/src/components/DashboardTiles/getDashboardChartColorPalette.ts
@@ -1,0 +1,31 @@
+type GetDashboardChartColorPaletteArgs = {
+    colorScheme: 'light' | 'dark';
+    chartColorPalette: string[];
+    selectedPaletteColors?: string[];
+    selectedPaletteDarkColors?: string[] | null;
+    orgColorPalette?: string[];
+    orgDarkColorPalette?: string[];
+};
+
+export const getDashboardChartColorPalette = ({
+    colorScheme,
+    chartColorPalette,
+    selectedPaletteColors,
+    selectedPaletteDarkColors,
+    orgColorPalette,
+    orgDarkColorPalette,
+}: GetDashboardChartColorPaletteArgs): string[] => {
+    if (colorScheme === 'dark' && selectedPaletteDarkColors?.length) {
+        return selectedPaletteDarkColors;
+    }
+
+    if (selectedPaletteColors?.length) {
+        return selectedPaletteColors;
+    }
+
+    if (colorScheme === 'dark' && orgDarkColorPalette?.length) {
+        return orgDarkColorPalette;
+    }
+
+    return orgColorPalette ?? chartColorPalette;
+};

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/api.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/api.ts
@@ -1,10 +1,16 @@
-import type { Dashboard, InteractivityOptions } from '@lightdash/common';
+import type {
+    EmbedDashboard,
+    GetEmbedDashboardRequest,
+} from '@lightdash/common';
 import { lightdashApi } from '../../../../api';
 
-export const postEmbedDashboard = (projectUuid: string) => {
-    return lightdashApi<Dashboard & InteractivityOptions>({
+export const postEmbedDashboard = (
+    projectUuid: string,
+    body?: GetEmbedDashboardRequest,
+) => {
+    return lightdashApi<EmbedDashboard>({
         url: `/embed/${projectUuid}/dashboard`,
         method: 'POST',
-        body: undefined,
+        body: JSON.stringify(body ?? {}),
     });
 };

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboard.tsx
@@ -37,6 +37,8 @@ const EmbedDashboardGrid: FC<{
     layouts: { lg: Layout[]; md: Layout[]; sm: Layout[] };
     dashboard: any;
     projectUuid: string;
+    paletteColors?: string[];
+    paletteDarkColors?: string[] | null;
     hasRequiredDashboardFiltersToSet: boolean;
     isTabEmpty?: boolean;
     gridProps: ResponsiveGridLayoutProps;
@@ -45,6 +47,8 @@ const EmbedDashboardGrid: FC<{
     layouts,
     dashboard,
     projectUuid,
+    paletteColors,
+    paletteDarkColors,
     hasRequiredDashboardFiltersToSet,
     isTabEmpty,
     gridProps,
@@ -76,6 +80,8 @@ const EmbedDashboardGrid: FC<{
                             <EmbedDashboardChartTile
                                 projectUuid={projectUuid}
                                 dashboardSlug={dashboard.slug}
+                                paletteColors={paletteColors}
+                                paletteDarkColors={paletteDarkColors}
                                 key={tile.uuid}
                                 minimal
                                 tile={tile}
@@ -146,7 +152,7 @@ const EmbedDashboard: FC<{
     const dashboardTabs = useDashboardContext((c) => c.dashboardTabs);
     const setDashboardTabs = useDashboardContext((c) => c.setDashboardTabs);
 
-    const { embedToken, mode } = useEmbed();
+    const { embedToken, mode, paletteUuid } = useEmbed();
     const navigate = useNavigate();
     const { pathname, search } = useLocation();
 
@@ -154,8 +160,10 @@ const EmbedDashboard: FC<{
         throw new Error('Embed token is required');
     }
 
-    const { data: dashboard, error: dashboardError } =
-        useEmbedDashboard(projectUuid);
+    const { data: dashboard, error: dashboardError } = useEmbedDashboard(
+        projectUuid,
+        paletteUuid,
+    );
 
     useEffect(() => {
         if (dashboard) {
@@ -362,6 +370,10 @@ const EmbedDashboard: FC<{
                         layouts={layouts}
                         dashboard={dashboard}
                         projectUuid={projectUuid}
+                        paletteColors={dashboard.selectedPalette?.colors}
+                        paletteDarkColors={
+                            dashboard.selectedPalette?.darkColors
+                        }
                         hasRequiredDashboardFiltersToSet={
                             hasRequiredDashboardFiltersToSet
                         }
@@ -375,6 +387,8 @@ const EmbedDashboard: FC<{
                     layouts={layouts}
                     dashboard={dashboard}
                     projectUuid={projectUuid}
+                    paletteColors={dashboard.selectedPalette?.colors}
+                    paletteDarkColors={dashboard.selectedPalette?.darkColors}
                     hasRequiredDashboardFiltersToSet={
                         hasRequiredDashboardFiltersToSet
                     }

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/components/EmbedDashboardChartTile.tsx
@@ -12,6 +12,8 @@ import useEmbed from '../../../../providers/Embed/useEmbed';
 type Props = ComponentProps<typeof DashboardChartTile> & {
     projectUuid: string;
     dashboardSlug: string;
+    paletteColors?: string[];
+    paletteDarkColors?: string[] | null;
     locked: boolean;
     tileIndex: number;
 };
@@ -19,6 +21,8 @@ type Props = ComponentProps<typeof DashboardChartTile> & {
 const EmbedDashboardChartTile: FC<Props> = ({
     projectUuid,
     dashboardSlug,
+    paletteColors,
+    paletteDarkColors,
     locked,
     canExportCsv,
     canExportImages,
@@ -119,6 +123,8 @@ const EmbedDashboardChartTile: FC<Props> = ({
             dashboardChartReadyQuery={dashboardChartReadyQuery}
             error={error}
             onExplore={onExplore}
+            colorPaletteOverride={paletteColors}
+            darkColorPaletteOverride={paletteDarkColors}
         />
     );
 };

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/hooks.ts
@@ -1,15 +1,14 @@
-import type {
-    ApiError,
-    Dashboard,
-    InteractivityOptions,
-} from '@lightdash/common';
+import type { ApiError, EmbedDashboard } from '@lightdash/common';
 import { useQuery } from '@tanstack/react-query';
 import { postEmbedDashboard } from './api';
 
-export const useEmbedDashboard = (projectUuid: string | undefined) => {
-    return useQuery<Dashboard & InteractivityOptions, ApiError>({
-        queryKey: ['embed-dashboard'],
-        queryFn: () => postEmbedDashboard(projectUuid!),
+export const useEmbedDashboard = (
+    projectUuid: string | undefined,
+    paletteUuid?: string,
+) => {
+    return useQuery<EmbedDashboard, ApiError>({
+        queryKey: ['embed-dashboard', projectUuid, paletteUuid],
+        queryFn: () => postEmbedDashboard(projectUuid!, { paletteUuid }),
         enabled: !!projectUuid,
         retry: false,
     });

--- a/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
+++ b/packages/frontend/src/ee/providers/Embed/EmbedProvider.tsx
@@ -40,6 +40,7 @@ type Props = {
     embedToken?: string;
     filters?: SdkFilter[];
     projectUuid?: string;
+    paletteUuid?: string;
     contentOverrides?: LanguageMap;
     embedHeaders?: Record<string, string>;
     onExplore?: (options: { chart: SavedChart }) => void;
@@ -53,6 +54,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
     embedToken: encodedToken,
     filters,
     projectUuid: projectUuidFromProps,
+    paletteUuid,
     contentOverrides,
     onExplore,
     onBackToDashboard,
@@ -122,6 +124,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
             filters,
             t: (input: string) => get(contentOverrides, input),
             projectUuid: embed?.projectUuid || projectUuid,
+            paletteUuid,
             languageMap: contentOverrides,
             onExplore,
             savedChart,
@@ -137,6 +140,7 @@ const EmbedProvider: FC<React.PropsWithChildren<Props>> = ({
         embedToken,
         filters,
         projectUuid,
+        paletteUuid,
         contentOverrides,
         onExplore,
         savedChart,

--- a/packages/frontend/src/ee/providers/Embed/context.ts
+++ b/packages/frontend/src/ee/providers/Embed/context.ts
@@ -6,6 +6,7 @@ const EmbedProviderContext = createContext<EmbedContext>({
     embedToken: undefined,
     filters: undefined,
     projectUuid: undefined,
+    paletteUuid: undefined,
     languageMap: undefined,
     t: (_input: string) => undefined,
     onExplore: (_options: { chart: SavedChart }) => {},

--- a/packages/frontend/src/ee/providers/Embed/types.ts
+++ b/packages/frontend/src/ee/providers/Embed/types.ts
@@ -19,6 +19,8 @@ export interface EmbedContext {
     filters?: SdkFilter[];
     // The project UUID of the project the JWT user is embedded in
     projectUuid?: string;
+    // An optional org palette override for SDK dashboards
+    paletteUuid?: string;
     // Powers localization of the dashboard
     languageMap?: LanguageMap;
     // The function to call when the user clicks "Explore from here"

--- a/packages/frontend/src/ee/providers/Embed/useEmbed.ts
+++ b/packages/frontend/src/ee/providers/Embed/useEmbed.ts
@@ -25,6 +25,7 @@ function useEmbed(): EmbedContext {
             embedToken: undefined,
             filters: undefined,
             projectUuid: undefined,
+            paletteUuid: undefined,
             languageMap: undefined,
             onExplore: (_options: { chart: SavedChart }) => {},
             t: (_input: string) => undefined,

--- a/packages/frontend/src/hooks/appearance/useOrganizationAppearance.tsx
+++ b/packages/frontend/src/hooks/appearance/useOrganizationAppearance.tsx
@@ -73,12 +73,15 @@ export const useCreateColorPalette = () => {
     });
 };
 
-export const useColorPalettes = () => {
+export const useColorPalettes = ({
+    enabled = true,
+}: { enabled?: boolean } = {}) => {
     return useQuery<
         ApiColorPalettesResponse['results'],
         ApiError,
         ApiColorPalettesResponse['results']
     >({
+        enabled,
         queryKey: ['color_palettes'],
         queryFn: getColorPalettesApi,
         select: (data) =>


### PR DESCRIPTION
### Description:

This PR adds support for custom color palette overrides in embedded dashboards. The changes enable passing a `paletteUuid` parameter through the SDK to apply organization-specific color palettes to dashboard charts.

**Key changes:**
- Modified `getColorPalettes` method in `OrganizationService` to accept `Account` instead of `SessionUser` for better data access
- Added `paletteUuid` prop to the SDK Dashboard component and threaded it through the embed provider context
- Created `getDashboardChartColorPalette` utility function to handle color palette priority logic (selected palette > org defaults > chart defaults)
- Updated dashboard chart tiles to accept and apply color palette overrides for both light and dark themes
- Enhanced the embed dashboard components to fetch and apply the selected color palette when `paletteUuid` is provided
- Made `useColorPalettes` hook accept an `enabled` parameter for conditional data fetching

The color palette selection follows this priority order:
1. Selected palette colors (dark colors for dark theme)
2. Organization default colors 
3. Chart's original color palette