### PR TITLE
feat: add palette UUID demo to SDK test app

### DIFF
--- a/packages/sdk-test-app/README.md
+++ b/packages/sdk-test-app/README.md
@@ -48,6 +48,25 @@ Once the app is running in your browser:
 4. The app will automatically extract the `instanceUrl` and `token` from the provided URL to render the embedded components.
 5. Open an example from the home page.
 
+The examples currently include:
+
+- `I18n demo`
+- `Filters demo`
+- `Palette UUID demo`
+
+The palette demo uses a select with three stable options:
+
+- `Default dashboard colors`
+- `Customer Segments Sunrise` (`53eac606-b655-4edc-a9e9-a702e2c68f63`)
+- `Customer Segments Aurora` (`0150adb1-6aba-45b8-b8e6-1e24f6d6164c`)
+
+In a real customer integration, palette UUIDs should come from:
+
+- `Settings → Appearance`, using the `Copy UUID` action on a palette
+- `GET /api/v1/org/color-palettes`, if your host app wants to load the choices dynamically
+
+The local development environment includes two stable example UUIDs so the demo remains reproducible.
+
 ## Generating a Demo Embed URL
 
 The test app includes a helper script that signs a JWT with the project embedding secret and prints a ready-to-paste `VITE_EMBED_URL`.

--- a/packages/sdk-test-app/src/examples/PaletteUuidExamplePage.styles.ts
+++ b/packages/sdk-test-app/src/examples/PaletteUuidExamplePage.styles.ts
@@ -1,0 +1,80 @@
+import type { CSSProperties } from 'react';
+import { monoFontFamily, sansFontFamily } from '../styles';
+
+export const filterPanelGridStyle: CSSProperties = {
+    display: 'grid',
+    gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+    gap: '16px',
+    alignItems: 'start',
+};
+
+export const dashboardContainerStyle: CSSProperties = {
+    width: '100%',
+    height: '700px',
+    minHeight: '320px',
+    border: '1px solid #e5e5e5',
+    borderRadius: '8px',
+    backgroundColor: '#fafafa',
+    overflow: 'auto',
+    resize: 'vertical',
+};
+
+export const pageTitleStyle: CSSProperties = {
+    fontFamily: sansFontFamily,
+    fontSize: '32px',
+    lineHeight: 1.15,
+    letterSpacing: '-0.04em',
+    color: '#171717',
+    margin: 0,
+};
+
+export const pageDescriptionStyle: CSSProperties = {
+    fontSize: '15px',
+    lineHeight: 1.7,
+    color: '#525252',
+    maxWidth: '760px',
+    margin: '12px 0 0 0',
+};
+
+export const sectionTitleStyle: CSSProperties = {
+    fontSize: '14px',
+    fontWeight: 600,
+    color: '#171717',
+    margin: '32px 0 8px 0',
+    letterSpacing: '-0.01em',
+};
+
+export const sectionDescStyle: CSSProperties = {
+    fontSize: '14px',
+    lineHeight: 1.6,
+    color: '#737373',
+    margin: '0 0 20px 0',
+};
+
+export const panelLabelStyle: CSSProperties = {
+    fontSize: '12px',
+    fontWeight: 500,
+    color: '#525252',
+    textTransform: 'uppercase',
+    letterSpacing: '0.5px',
+    marginBottom: '8px',
+    display: 'block',
+};
+
+export const helperTextStyle: CSSProperties = {
+    fontSize: '13px',
+    lineHeight: 1.6,
+    color: '#737373',
+    margin: '8px 0 0 0',
+};
+
+export const infoBoxStyle: CSSProperties = {
+    fontFamily: monoFontFamily,
+    fontSize: '13px',
+    backgroundColor: '#fafafa',
+    border: '1px solid #e5e5e5',
+    padding: '16px',
+    margin: '24px 0',
+    color: '#525252',
+    borderRadius: '6px',
+};

--- a/packages/sdk-test-app/src/examples/PaletteUuidExamplePage.tsx
+++ b/packages/sdk-test-app/src/examples/PaletteUuidExamplePage.tsx
@@ -1,0 +1,135 @@
+import Lightdash from '@lightdash/sdk';
+import { useState } from 'react';
+import { ExampleLayout } from '../components/ExampleLayout';
+import { ExampleSelect } from '../components/ExampleSelect';
+import type { EmbedConfigState } from '../hooks/useEmbedConfig';
+import { getRepoSourceUrl } from '../lib/repo';
+import { emptyStateBoxStyle, emptyStateStyle } from '../styles';
+import {
+    dashboardContainerStyle,
+    filterPanelGridStyle,
+    helperTextStyle,
+    infoBoxStyle,
+    panelLabelStyle,
+    sectionDescStyle,
+    sectionTitleStyle,
+} from './PaletteUuidExamplePage.styles';
+
+type PaletteUuidExamplePageProps = {
+    embedConfig: EmbedConfigState;
+};
+
+const DEFAULT_OPTION = 'default';
+const SEEDED_PALETTE_OPTIONS = [
+    {
+        value: DEFAULT_OPTION,
+        label: 'Default dashboard colors',
+    },
+    {
+        value: '53eac606-b655-4edc-a9e9-a702e2c68f63',
+        label: 'Customer Segments Sunrise',
+    },
+    {
+        value: '0150adb1-6aba-45b8-b8e6-1e24f6d6164c',
+        label: 'Customer Segments Aurora',
+    },
+] as const;
+const sourceUrl = getRepoSourceUrl(
+    'packages/sdk-test-app/src/examples/PaletteUuidExamplePage.tsx',
+);
+
+export function PaletteUuidExamplePage({
+    embedConfig,
+}: PaletteUuidExamplePageProps) {
+    const [selectedPaletteUuid, setSelectedPaletteUuid] =
+        useState(DEFAULT_OPTION);
+    const paletteUuid =
+        selectedPaletteUuid === DEFAULT_OPTION
+            ? undefined
+            : selectedPaletteUuid;
+    const selectedPaletteLabel =
+        SEEDED_PALETTE_OPTIONS.find(
+            (palette) => palette.value === selectedPaletteUuid,
+        )?.label ?? 'Default dashboard colors';
+
+    return (
+        <ExampleLayout
+            embedConfig={embedConfig}
+            sourceUrl={sourceUrl}
+            title="Palette UUID demo"
+            description={
+                <>
+                    This example shows how a host app can point{' '}
+                    <code>Lightdash.Dashboard</code> at a specific org color
+                    palette by UUID. You can get palette UUIDs from{' '}
+                    <strong>Settings → Appearance</strong> or fetch the
+                    available palettes from the
+                    <code> /api/v1/org/color-palettes</code> API.
+                </>
+            }
+        >
+            {embedConfig.instanceUrl && embedConfig.token ? (
+                <>
+                    <section>
+                        <h3 style={sectionTitleStyle}>Palette selector</h3>
+
+                        <div style={filterPanelGridStyle}>
+                            <div>
+                                <ExampleSelect
+                                    label="Palette"
+                                    value={selectedPaletteUuid}
+                                    onChange={setSelectedPaletteUuid}
+                                    options={[...SEEDED_PALETTE_OPTIONS]}
+                                    helperText="These options would usually come from Appearance settings or the org palettes API."
+                                />
+                            </div>
+
+                            <div>
+                                <label style={panelLabelStyle}>
+                                    Current dashboard prop
+                                </label>
+                                <pre style={infoBoxStyle}>
+                                    {JSON.stringify(
+                                        {
+                                            palette: selectedPaletteLabel,
+                                            paletteUuid: paletteUuid ?? null,
+                                        },
+                                        null,
+                                        2,
+                                    )}
+                                </pre>
+                            </div>
+                        </div>
+                    </section>
+
+                    <section>
+                        <h3 style={sectionTitleStyle}>Dashboard</h3>
+                        <p style={sectionDescStyle}>
+                            The embedded dashboard below is rendered with the
+                            selected palette UUID. In your own app, pass the
+                            UUID returned by Appearance settings or by
+                            <code> /api/v1/org/color-palettes</code>.
+                        </p>
+                        <div style={dashboardContainerStyle}>
+                            <Lightdash.Dashboard
+                                key={`${embedConfig.remountKey}:${selectedPaletteUuid}`}
+                                instanceUrl={embedConfig.instanceUrl}
+                                token={embedConfig.token}
+                                {...(paletteUuid ? { paletteUuid } : {})}
+                                styles={{
+                                    backgroundColor: 'transparent',
+                                }}
+                            />
+                        </div>
+                    </section>
+                </>
+            ) : (
+                <div style={emptyStateStyle}>
+                    <div style={emptyStateBoxStyle}>
+                        Click <strong>Config</strong> to add your embed URL
+                    </div>
+                </div>
+            )}
+        </ExampleLayout>
+    );
+}

--- a/packages/sdk-test-app/src/examples/examples.tsx
+++ b/packages/sdk-test-app/src/examples/examples.tsx
@@ -2,6 +2,7 @@ import type { ComponentType } from 'react';
 import type { EmbedConfigState } from '../hooks/useEmbedConfig';
 import { FiltersExamplePage } from './FiltersExamplePage';
 import { I18nExamplePage } from './I18nExamplePage';
+import { PaletteUuidExamplePage } from './PaletteUuidExamplePage';
 
 export type ExampleDefinition = {
     component: ComponentType<{ embedConfig: EmbedConfigState }>;
@@ -30,6 +31,16 @@ export const examples: ExampleDefinition[] = [
             'A host-app select drives an SDK dashboard filter for customer first name.',
         sourcePath: 'packages/sdk-test-app/src/examples/FiltersExamplePage.tsx',
         component: FiltersExamplePage,
+    },
+    {
+        slug: 'palette-uuid',
+        path: '/examples/palette-uuid',
+        title: 'Palette overrides demo',
+        description:
+            'A dashboard example that pins chart colors to a specific org palette UUID.',
+        sourcePath:
+            'packages/sdk-test-app/src/examples/PaletteUuidExamplePage.tsx',
+        component: PaletteUuidExamplePage,
     },
     // Future examples:
     // {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds a new palette UUID demo to the SDK test app that demonstrates how to use specific org color palettes in embedded dashboards.

The new example includes:
- A palette selector with three predefined options: default colors, Customer Segments Sunrise, and Customer Segments Aurora
- Live preview of how the selected palette affects dashboard rendering
- Documentation showing the current palette configuration as JSON
- Helper text explaining how to obtain palette UUIDs in production environments

The demo uses two stable example UUIDs (`53eac606-b655-4edc-a9e9-a702e2c68f63` and `0150adb1-6aba-45b8-b8e6-1e24f6d6164c`) to ensure reproducible testing. The README has been updated to document all available examples and provide guidance on obtaining palette UUIDs from Settings → Appearance or the `/api/v1/org/color-palettes` API endpoint.