### PR TITLE
fix: use React Router navigate instead of replaceState for app generation

### DIFF
--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -27,7 +27,7 @@ import {
     type FC,
 } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
-import { Link, Navigate, useParams } from 'react-router';
+import { Link, Navigate, useNavigate, useParams } from 'react-router';
 import { EditableText } from '../components/VisualizationConfigs/common/EditableText';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppBuildPoller } from '../features/apps/hooks/useAppBuildPoller';
@@ -104,6 +104,7 @@ const AppGenerate: FC = () => {
         projectUuid: string;
         appUuid: string;
     }>();
+    const navigate = useNavigate();
     const queryClient = useQueryClient();
     const [prompt, setPrompt] = useState('');
     const [localMessages, setLocalMessages] = useState<ChatMessage[]>([]);
@@ -333,10 +334,9 @@ const AppGenerate: FC = () => {
                 });
                 // Update URL so the session is resumable
                 if (!urlAppUuid) {
-                    window.history.replaceState(
-                        null,
-                        '',
+                    void navigate(
                         `/projects/${projectUuid}/apps/${data.appUuid}`,
+                        { replace: true },
                     );
                 }
             },


### PR DESCRIPTION
### Description:
This improves the navigation. Previously it was slightly annoying, because we remained on the /apps/generate page, so you couldn't for instance create a new app since you're already on that page.
