### PR TITLE
fix: allow null meta in dbt manifest schemas for Fusion

### DIFF
--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -45,6 +45,9 @@ const getDbtCLIVersion = async () => {
 const isDbtCloudCLI = (version: string): boolean =>
     version.match(DBT_CLOUD_CLI_REGEX) !== null;
 
+const isDbtFusion = (version: string): boolean =>
+    version.match(DBT_FUSION_VERSION_REGEX) !== null;
+
 const getSupportedDbtVersionOption = (
     version: string,
 ): DbtVersionOption | null => {
@@ -74,6 +77,7 @@ export type DbtVersion = {
     verboseVersion: string; // Verbose version returned by dbt --version
     versionOption: DbtVersionOption; // The supported version by Lightdash
     isDbtCloudCLI: boolean; // Whether the version is dbt Cloud CLI
+    isDbtFusion: boolean; // Whether the version is dbt Fusion
 };
 
 export const getDbtVersion = async (): Promise<DbtVersion> => {
@@ -152,6 +156,7 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
     return {
         verboseVersion,
         isDbtCloudCLI: isDbtCloudCLI(verboseVersion),
+        isDbtFusion: isDbtFusion(verboseVersion),
         versionOption: supportedVersionOption ?? fallbackVersionOption,
     };
 };

--- a/packages/common/src/dbt/schemas/lightdashV10.json
+++ b/packages/common/src/dbt/schemas/lightdashV10.json
@@ -9,7 +9,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -24,7 +31,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -51,7 +65,14 @@
                         },
 
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         },
                         "config": {
                             "$ref": "#/definitions/LightdashNodeConfig"

--- a/packages/common/src/dbt/schemas/lightdashV11.json
+++ b/packages/common/src/dbt/schemas/lightdashV11.json
@@ -9,7 +9,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -24,7 +31,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -51,7 +65,14 @@
                         },
 
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         },
                         "config": {
                             "$ref": "#/definitions/LightdashNodeConfig"

--- a/packages/common/src/dbt/schemas/lightdashV12.json
+++ b/packages/common/src/dbt/schemas/lightdashV12.json
@@ -6,7 +6,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -18,7 +25,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -42,7 +56,14 @@
                         },
 
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         },
                         "config": {
                             "$ref": "#/definitions/LightdashNodeConfig"

--- a/packages/common/src/dbt/schemas/lightdashV7.json
+++ b/packages/common/src/dbt/schemas/lightdashV7.json
@@ -9,7 +9,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -24,7 +31,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -51,7 +65,14 @@
                         },
 
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         },
                         "config": {
                             "$ref": "#/definitions/LightdashNodeConfig"

--- a/packages/common/src/dbt/schemas/lightdashV8.json
+++ b/packages/common/src/dbt/schemas/lightdashV8.json
@@ -9,7 +9,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -28,7 +35,14 @@
                             "not": { "enum": ["TABLE"] }
                         },
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -55,7 +69,14 @@
                         },
 
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         },
                         "config": {
                             "$ref": "#/definitions/LightdashNodeConfig"

--- a/packages/common/src/dbt/schemas/lightdashV9.json
+++ b/packages/common/src/dbt/schemas/lightdashV9.json
@@ -9,7 +9,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -24,7 +31,14 @@
                     "type": "object",
                     "properties": {
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashColumnMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         }
                     }
                 }
@@ -51,7 +65,14 @@
                         },
 
                         "meta": {
-                            "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                            "oneOf": [
+                                {
+                                    "$ref": "https://schemas.lightdash.com/lightdash/metadata.json#/definitions/LightdashModelMetadata"
+                                },
+                                {
+                                    "type": "null"
+                                }
+                            ]
                         },
                         "config": {
                             "$ref": "#/definitions/LightdashNodeConfig"


### PR DESCRIPTION
## Summary

- dbt Fusion (preview.164+) outputs `config.meta: null` instead of `config.meta: {}` in its manifest, and reports `dbt_schema_version` as `v12` (older Fusion previews reported `v20`)
- Our `lightdashV12.json` schema requires `meta` to be an object, causing validation to fail with `Field at "/config/meta" must be object` for every model without explicit Lightdash meta
- Updates all lightdash validation schemas (V7–V12) to accept `null` for `meta` fields using `oneOf`, matching the existing V20 schema behavior
- Also adds `isDbtFusion` flag to `DbtVersion` type for future use

**Root cause:** Fusion preview.164 changed `dbt_schema_version` from `v20.json` back to `v12.json` in the manifest metadata. Our V20 schema already allowed null meta, but V12 did not — so the CLI started rejecting Fusion manifests.

**Reproduced locally** with dbt-fusion 2.0.0-preview.164 and confirmed the fix resolves the validation error.

## Test plan

- [x] `pnpm -F common test` — all 60 suites, 1680 tests pass
- [x] `pnpm -F @lightdash/cli lint` — clean
- [x] Local repro: `dbt compile` with Fusion preview.164 → `lightdash compile --skip-dbt-compile --skip-warehouse-catalog` → SUCCESS
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)