### PR TITLE
fix: harden sandbox security

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -459,7 +459,7 @@ export class AppGenerateService extends BaseService {
             `cat /tmp/prompt.txt | claude ${sessionFlags} ` +
                 `--model sonnet ` +
                 `--verbose --output-format stream-json ` +
-                `--allowedTools "Read,Write,Edit,Glob,Grep" ` +
+                `--allowedTools "Read(/app/**),Read(/tmp/dbt-repo/**),Write(/app/src/**),Edit(/app/src/**),Glob(/app/**),Glob(/tmp/dbt-repo/**),Grep(/app/**),Grep(/tmp/dbt-repo/**)" ` +
                 `--append-system-prompt-file /app/skill.md`,
             {
                 cwd: '/app',


### PR DESCRIPTION
### Description:
This PR hardens the sandbox sandbox by:
- Only passing the anthropic api key on the claude command instead of passing it globally to the sandbox
- Restricting the tool calls to only certain paths that we really need access to