### PR TITLE
fix: move app generation pipeline to Graphile Worker for deploy resilience

### DIFF
--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -1,4 +1,12 @@
+import { type AppVersionStatus } from '@lightdash/common';
 import { type Knex } from 'knex';
+
+export {
+    APP_VERSION_STAGE_ORDER,
+    APP_VERSION_TERMINAL_STATUSES,
+    isAppVersionInProgress,
+    type AppVersionStatus,
+} from '@lightdash/common';
 
 export const AppsTableName = 'apps';
 export const AppVersionsTableName = 'app_versions';
@@ -37,8 +45,6 @@ export type AppsTable = Knex.CompositeTableType<
         >
     >
 >;
-
-export type AppVersionStatus = 'building' | 'ready' | 'error';
 
 export type DbAppVersion = {
     app_version_id: string;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -76,12 +76,14 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
 
     return {
         serviceProviders: {
-            appGenerateService: ({ context, models }) =>
+            appGenerateService: ({ context, models, clients }) =>
                 new AppGenerateService({
                     lightdashConfig: context.lightdashConfig,
                     catalogModel: models.getCatalogModel(),
                     appModel: models.getAppModel(),
                     featureFlagModel: models.getFeatureFlagModel(),
+                    schedulerClient:
+                        clients.getSchedulerClient() as CommercialSchedulerClient,
                 }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({
@@ -488,6 +490,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     context.serviceRepository.getPreAggregateMaterializationService(),
                 managedAgentService:
                     context.serviceRepository.getManagedAgentService<ManagedAgentService>(),
+                appGenerateService:
+                    context.serviceRepository.getAppGenerateService(),
             }),
         clientProviders: {
             schedulerClient: ({ context, models }) =>

--- a/packages/backend/src/ee/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerClient.ts
@@ -1,5 +1,6 @@
 import {
     AiAgentEvalRunJobPayload,
+    AppGeneratePipelineJobPayload,
     EE_SCHEDULER_TASKS,
     EmbedArtifactVersionJobPayload,
     GenerateArtifactQuestionJobPayload,
@@ -61,6 +62,20 @@ export class CommercialSchedulerClient extends SchedulerClient {
             {
                 runAt: now,
                 maxAttempts: 3,
+            },
+        );
+        return { jobId };
+    }
+
+    async appGeneratePipeline(payload: AppGeneratePipelineJobPayload) {
+        const graphileClient = await this.graphileUtils;
+        const { id: jobId } = await graphileClient.addJob(
+            EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE,
+            payload,
+            {
+                runAt: new Date(),
+                maxAttempts: 2,
+                jobKey: `app-generate:${payload.appUuid}:${payload.version}`,
             },
         );
         return { jobId };

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -12,15 +12,18 @@ import { SchedulerTaskArguments } from '../../scheduler/SchedulerTask';
 import { SchedulerWorker } from '../../scheduler/SchedulerWorker';
 import { TypedEETaskList } from '../../scheduler/types';
 import { AiAgentService } from '../services/AiAgentService/AiAgentService';
+import { AppGenerateService } from '../services/AppGenerateService/AppGenerateService';
 import type { EmbedService } from '../services/EmbedService/EmbedService';
 import { ManagedAgentService } from '../services/ManagedAgentService/ManagedAgentService';
 
-const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes in milliseconds
+const AI_AGENT_EVAL_TIMEOUT_MS = 10 * 60 * 1000; // 10 minutes
+const APP_GENERATE_TIMEOUT_MS = 60 * 60 * 1000; // 60 minutes
 
 type CommercialSchedulerWorkerArguments = SchedulerTaskArguments & {
     aiAgentService: AiAgentService;
     embedService: EmbedService;
     managedAgentService: ManagedAgentService;
+    appGenerateService: AppGenerateService;
 };
 
 export class CommercialSchedulerWorker extends SchedulerWorker {
@@ -30,11 +33,28 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
     protected readonly managedAgentService: ManagedAgentService;
 
+    protected readonly appGenerateService: AppGenerateService;
+
     constructor(args: CommercialSchedulerWorkerArguments) {
         super(args);
         this.aiAgentService = args.aiAgentService;
         this.embedService = args.embedService;
         this.managedAgentService = args.managedAgentService;
+        this.appGenerateService = args.appGenerateService;
+    }
+
+    protected getCronItems() {
+        return [
+            ...super.getCronItems(),
+            {
+                task: EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS,
+                pattern: '*/2 * * * *', // Every 2 minutes
+                options: {
+                    backfillPeriod: 5 * 60 * 1000, // 5 min
+                    maxAttempts: 1,
+                },
+            },
+        ];
     }
 
     protected getTaskList(): Partial<TypedEETaskList> {
@@ -163,6 +183,35 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                 Logger.info(
                     `Managed agent heartbeat completed for ${enabledProjects.length} project(s)`,
                 );
+            },
+            [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: async (
+                payload,
+                helpers,
+            ) => {
+                await tryJobOrTimeout(
+                    SchedulerClient.processJob(
+                        EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE,
+                        helpers.job.id,
+                        helpers.job.run_at,
+                        payload,
+                        async () => {
+                            await this.appGenerateService.runPipeline(payload);
+                        },
+                    ),
+                    helpers.job,
+                    APP_GENERATE_TIMEOUT_MS,
+                    async (_job, e) => {
+                        await this.appGenerateService.markError(
+                            payload.appUuid,
+                            payload.version,
+                            e,
+                            'Build timed out. Please try again.',
+                        );
+                    },
+                );
+            },
+            [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: async () => {
+                await this.appGenerateService.sweepStaleLocks();
             },
             [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: async (
                 payload,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -10,8 +10,8 @@ import {
     ForbiddenError,
     getErrorMessage,
     MissingConfigError,
-    NotFoundError,
     ParameterError,
+    type AppGeneratePipelineJobPayload,
     type AppImageAttachment,
     type SessionUser,
 } from '@lightdash/common';
@@ -21,18 +21,26 @@ import { PassThrough, Readable } from 'node:stream';
 import { extract, type Headers } from 'tar-stream';
 import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import { LightdashConfig } from '../../../config/parseConfig';
-import { type DbApp } from '../../../database/entities/apps';
+import {
+    APP_VERSION_STAGE_ORDER,
+    APP_VERSION_TERMINAL_STATUSES,
+    isAppVersionInProgress,
+    type AppVersionStatus,
+    type DbApp,
+} from '../../../database/entities/apps';
 import { AppModel } from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
 import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
+import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 
 type AppGenerateServiceDeps = {
     lightdashConfig: LightdashConfig;
     catalogModel: CatalogModel;
     appModel: AppModel;
     featureFlagModel: FeatureFlagModel;
+    schedulerClient: CommercialSchedulerClient;
 };
 
 type GenerateAppResult = {
@@ -49,17 +57,21 @@ export class AppGenerateService extends BaseService {
 
     private readonly featureFlagModel: FeatureFlagModel;
 
+    private readonly schedulerClient: CommercialSchedulerClient;
+
     constructor({
         lightdashConfig,
         catalogModel,
         appModel,
         featureFlagModel,
+        schedulerClient,
     }: AppGenerateServiceDeps) {
         super();
         this.lightdashConfig = lightdashConfig;
         this.catalogModel = catalogModel;
         this.appModel = appModel;
         this.featureFlagModel = featureFlagModel;
+        this.schedulerClient = schedulerClient;
     }
 
     private getAnthropicApiKey(): string {
@@ -198,14 +210,14 @@ export class AppGenerateService extends BaseService {
         return Math.round(performance.now() - start);
     }
 
-    private async markError(
+    async markError(
         appUuid: string,
         version: number,
         error: unknown,
         userMessage: string,
     ): Promise<void> {
         try {
-            const updated = await this.appModel.updateVersionStatusIfBuilding(
+            const updated = await this.appModel.updateVersionStatusIfInProgress(
                 appUuid,
                 version,
                 'error',
@@ -220,6 +232,33 @@ export class AppGenerateService extends BaseService {
         } catch (dbError) {
             this.logger.error(
                 `App ${appUuid}: failed to persist error status: ${getErrorMessage(dbError)}`,
+            );
+        }
+    }
+
+    /**
+     * @internal
+     * Release graphile locks on appGeneratePipeline jobs whose corresponding
+     * app_version hasn't advanced in STALE_THRESHOLD — the previous worker
+     * is presumed dead. Released jobs are picked up on the next poll and
+     * resumed from their last completed stage.
+     *
+     * Invoked only by the scheduler worker as a cron task; not exposed to
+     * user requests, so no CASL permission check applies.
+     *
+     * Heartbeat: every status_message / status transition bumps
+     * status_updated_at (see AppModel.updateStatusMessage etc.), including
+     * Claude's per-tool-call progress updates.
+     */
+    async sweepStaleLocks(): Promise<void> {
+        const STALE_THRESHOLD = '5 minutes';
+        const rowCount = await this.appModel.releaseStaleLocks(
+            APP_VERSION_TERMINAL_STATUSES,
+            STALE_THRESHOLD,
+        );
+        if (rowCount > 0) {
+            this.logger.info(
+                `Released ${rowCount} stale appGeneratePipeline job(s) (no progress in ${STALE_THRESHOLD})`,
             );
         }
     }
@@ -781,13 +820,50 @@ export class AppGenerateService extends BaseService {
         return durationMs;
     }
 
-    private async runNewAppPipeline(
+    private static shouldRunStage(
+        currentStatus: AppVersionStatus,
+        stage: AppVersionStatus,
+    ): boolean {
+        const order = APP_VERSION_STAGE_ORDER as readonly AppVersionStatus[];
+        return order.indexOf(currentStatus) <= order.indexOf(stage);
+    }
+
+    private async advanceStage(
         appUuid: string,
         version: number,
-        projectUuid: string,
-        prompt: string,
-        image?: AppImageAttachment,
+        stage: AppVersionStatus,
+        statusMessage: string,
     ): Promise<void> {
+        await this.appModel.updateVersionStatus(
+            appUuid,
+            version,
+            stage,
+            null,
+            statusMessage,
+        );
+    }
+
+    /**
+     * Main pipeline entry point — called by the Graphile Worker task handler.
+     * On retry after pod death, reads current status from DB and skips
+     * completed stages. `claude --continue` resumes the conversation.
+     */
+    async runPipeline(payload: AppGeneratePipelineJobPayload): Promise<void> {
+        const { appUuid, version, projectUuid, prompt, image, isIteration } =
+            payload;
+
+        // Check if version was cancelled while we were dead
+        const currentStatus = await this.appModel.getVersionStatus(
+            appUuid,
+            version,
+        );
+        if (!isAppVersionInProgress(currentStatus)) {
+            this.logger.info(
+                `App ${appUuid}: pipeline skipped — version ${version} is ${currentStatus}`,
+            );
+            return;
+        }
+
         let anthropicApiKey: string;
         let e2bApiKey: string;
         let s3Client: S3Client;
@@ -809,26 +885,85 @@ export class AppGenerateService extends BaseService {
         const overallStart = performance.now();
         const durations: Record<string, number> = {};
 
-        await this.appModel.updateStatusMessage(
-            appUuid,
-            version,
-            'Setting up build environment',
+        this.logger.info(
+            `App ${appUuid}: pipeline started (version=${version}, status=${currentStatus}, isIteration=${isIteration})`,
         );
 
+        // --- Stage: sandbox ---
         let sandbox: Sandbox;
-        try {
-            const result = await this.createSandbox(appUuid, e2bApiKey);
-            sandbox = result.sandbox;
-            durations.sandboxMs = result.durationMs;
-            await this.appModel.updateSandboxId(appUuid, sandbox.sandboxId);
-        } catch (error) {
-            await this.markError(
+        let wasResumed = false;
+        if (AppGenerateService.shouldRunStage(currentStatus, 'sandbox')) {
+            await this.advanceStage(
                 appUuid,
                 version,
-                error,
-                'Failed to set up build environment. Please try again.',
+                'sandbox',
+                'Setting up build environment',
             );
-            return;
+            try {
+                if (isIteration) {
+                    const app = await this.appModel.getApp(
+                        appUuid,
+                        projectUuid,
+                    );
+                    const acquired = await this.acquireSandbox(
+                        app,
+                        appUuid,
+                        version,
+                        e2bApiKey,
+                        s3Client,
+                        bucket,
+                    );
+                    sandbox = acquired.sandbox;
+                    wasResumed = acquired.wasResumed;
+                    Object.assign(durations, acquired.durations);
+                } else {
+                    const result = await this.createSandbox(appUuid, e2bApiKey);
+                    sandbox = result.sandbox;
+                    durations.sandboxMs = result.durationMs;
+                    await this.appModel.updateSandboxId(
+                        appUuid,
+                        sandbox.sandboxId,
+                    );
+                }
+            } catch (error) {
+                await this.markError(
+                    appUuid,
+                    version,
+                    error,
+                    'Failed to set up build environment. Please try again.',
+                );
+                return;
+            }
+        } else {
+            // Resuming past sandbox stage — reconnect
+            const app = await this.appModel.getApp(appUuid, projectUuid);
+            if (!app.sandbox_id) {
+                await this.markError(
+                    appUuid,
+                    version,
+                    new Error('No sandbox_id found for resume'),
+                    'Failed to resume build environment. Please try again.',
+                );
+                return;
+            }
+            try {
+                const result = await this.resumeSandbox(
+                    app.sandbox_id,
+                    appUuid,
+                    e2bApiKey,
+                );
+                sandbox = result.sandbox;
+                wasResumed = true;
+                durations.resumeMs = result.durationMs;
+            } catch (error) {
+                await this.markError(
+                    appUuid,
+                    version,
+                    error,
+                    'Failed to resume build environment. Please try again.',
+                );
+                return;
+            }
         }
 
         try {
@@ -842,7 +977,8 @@ export class AppGenerateService extends BaseService {
                 bucket,
                 durations,
                 overallStart,
-                false, // fresh sandbox — no previous session to continue
+                currentStatus,
+                wasResumed,
                 anthropicApiKey,
                 image,
             );
@@ -861,127 +997,150 @@ export class AppGenerateService extends BaseService {
         bucket: string,
         extraDurations: Record<string, number>,
         overallStart: number,
-        continueSession: boolean,
+        currentStatus: AppVersionStatus,
+        wasResumed: boolean,
         anthropicApiKey: string,
-        image?: AppImageAttachment,
+        image: AppImageAttachment | undefined,
     ): Promise<void> {
         const durations: Record<string, number> = { ...extraDurations };
+        const shouldRun = (stage: AppVersionStatus) =>
+            AppGenerateService.shouldRunStage(currentStatus, stage);
 
-        try {
-            await this.appModel.updateStatusMessage(
-                appUuid,
-                version,
-                'Loading your data models',
-            );
-            durations.catalogMs = await this.writeCatalogAndPrompt(
-                sandbox,
-                appUuid,
-                projectUuid,
-                prompt,
-                image,
-                s3Client,
-                bucket,
-            );
-        } catch (error) {
-            const totalMs = AppGenerateService.elapsed(overallStart);
-            this.logger.error(
-                `App ${appUuid}: catalog failed after ${totalMs}ms: ${getErrorMessage(error)}`,
-            );
-            await this.markError(
-                appUuid,
-                version,
-                error,
-                'Failed to load your data models. Please try again.',
-            );
-            return;
+        // --- Stage: catalog ---
+        if (shouldRun('catalog')) {
+            try {
+                await this.advanceStage(
+                    appUuid,
+                    version,
+                    'catalog',
+                    'Loading your data models',
+                );
+                durations.catalogMs = await this.writeCatalogAndPrompt(
+                    sandbox,
+                    appUuid,
+                    projectUuid,
+                    prompt,
+                    image,
+                    s3Client,
+                    bucket,
+                );
+            } catch (error) {
+                const totalMs = AppGenerateService.elapsed(overallStart);
+                this.logger.error(
+                    `App ${appUuid}: catalog failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+                );
+                await this.markError(
+                    appUuid,
+                    version,
+                    error,
+                    'Failed to load your data models. Please try again.',
+                );
+                return;
+            }
         }
 
+        // --- Stage: generating ---
         let responseText: string | null = null;
-
-        try {
-            await this.appModel.updateStatusMessage(
-                appUuid,
-                version,
-                AppGenerateService.randomCodingPhrase(),
-            );
-            const generation = await this.runClaudeGeneration(
-                sandbox,
-                appUuid,
-                version,
-                continueSession,
-                anthropicApiKey,
-            );
-            durations.generateMs = generation.durationMs;
-            responseText = generation.responseText;
-        } catch (error) {
-            const totalMs = AppGenerateService.elapsed(overallStart);
-            this.logger.error(
-                `App ${appUuid}: generation failed after ${totalMs}ms: ${getErrorMessage(error)}`,
-            );
-            await this.markError(
-                appUuid,
-                version,
-                error,
-                'Failed to generate app code. Try rephrasing your request.',
-            );
-            return;
+        if (shouldRun('generating')) {
+            try {
+                await this.advanceStage(
+                    appUuid,
+                    version,
+                    'generating',
+                    AppGenerateService.randomCodingPhrase(),
+                );
+                // On retry (currentStatus === 'generating') or iteration
+                // with resumed sandbox, use --continue so Claude picks up
+                // the conversation where it left off.
+                const continueSession =
+                    currentStatus === 'generating' || wasResumed;
+                const generation = await this.runClaudeGeneration(
+                    sandbox,
+                    appUuid,
+                    version,
+                    continueSession,
+                    anthropicApiKey,
+                );
+                durations.generateMs = generation.durationMs;
+                responseText = generation.responseText;
+            } catch (error) {
+                const totalMs = AppGenerateService.elapsed(overallStart);
+                this.logger.error(
+                    `App ${appUuid}: generation failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+                );
+                await this.markError(
+                    appUuid,
+                    version,
+                    error,
+                    'Failed to generate app code. Try rephrasing your request.',
+                );
+                return;
+            }
         }
 
-        try {
-            await this.appModel.updateStatusMessage(
-                appUuid,
-                version,
-                'Packaging your app',
-            );
-            durations.buildMs = await this.runBuild(sandbox, appUuid);
-        } catch (error) {
-            const totalMs = AppGenerateService.elapsed(overallStart);
-            this.logger.error(
-                `App ${appUuid}: build failed after ${totalMs}ms: ${getErrorMessage(error)}`,
-            );
-            await this.markError(
-                appUuid,
-                version,
-                error,
-                "The generated code couldn't be compiled. Try again or simplify your request.",
-            );
-            return;
+        // --- Stage: building ---
+        if (shouldRun('building')) {
+            try {
+                await this.advanceStage(
+                    appUuid,
+                    version,
+                    'building',
+                    'Packaging your app',
+                );
+                durations.buildMs = await this.runBuild(sandbox, appUuid);
+            } catch (error) {
+                const totalMs = AppGenerateService.elapsed(overallStart);
+                this.logger.error(
+                    `App ${appUuid}: build failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+                );
+                await this.markError(
+                    appUuid,
+                    version,
+                    error,
+                    "The generated code couldn't be compiled. Try again or simplify your request.",
+                );
+                return;
+            }
         }
 
-        try {
-            await this.appModel.updateStatusMessage(
-                appUuid,
-                version,
-                'Deploying your app',
-            );
-            const artifacts = await this.packageArtifacts(sandbox, appUuid);
-            durations.packageMs = artifacts.durationMs;
+        // --- Stage: packaging ---
+        if (shouldRun('packaging')) {
+            try {
+                await this.advanceStage(
+                    appUuid,
+                    version,
+                    'packaging',
+                    'Deploying your app',
+                );
+                const artifacts = await this.packageArtifacts(sandbox, appUuid);
+                durations.packageMs = artifacts.durationMs;
 
-            durations.uploadMs = await this.uploadToS3(
-                s3Client,
-                bucket,
-                appUuid,
-                version,
-                artifacts.distTar,
-                artifacts.sourceTar,
-            );
-        } catch (error) {
-            const totalMs = AppGenerateService.elapsed(overallStart);
-            this.logger.error(
-                `App ${appUuid}: deploy failed after ${totalMs}ms: ${getErrorMessage(error)}`,
-            );
-            await this.markError(
-                appUuid,
-                version,
-                error,
-                'Failed to deploy your app. Please try again.',
-            );
-            return;
+                durations.uploadMs = await this.uploadToS3(
+                    s3Client,
+                    bucket,
+                    appUuid,
+                    version,
+                    artifacts.distTar,
+                    artifacts.sourceTar,
+                );
+            } catch (error) {
+                const totalMs = AppGenerateService.elapsed(overallStart);
+                this.logger.error(
+                    `App ${appUuid}: deploy failed after ${totalMs}ms: ${getErrorMessage(error)}`,
+                );
+                await this.markError(
+                    appUuid,
+                    version,
+                    error,
+                    'Failed to deploy your app. Please try again.',
+                );
+                return;
+            }
         }
 
         try {
             const dbStart = performance.now();
-            const updated = await this.appModel.updateVersionStatusIfBuilding(
+            const updated = await this.appModel.updateVersionStatusIfInProgress(
                 appUuid,
                 version,
                 'ready',
@@ -1056,7 +1215,7 @@ export class AppGenerateService extends BaseService {
                     created_by_user_uuid: user.userUuid,
                 },
                 { version, prompt },
-                'building',
+                'pending',
             );
         } catch (error) {
             this.logger.error(
@@ -1065,99 +1224,18 @@ export class AppGenerateService extends BaseService {
             throw error;
         }
 
-        // Fire pipeline in background — status updates flow through DB polling
-        this.runNewAppPipeline(
+        await this.schedulerClient.appGeneratePipeline({
             appUuid,
             version,
             projectUuid,
+            organizationUuid: user.organizationUuid!,
+            userUuid: user.userUuid,
             prompt,
             image,
-        ).catch((error) => {
-            this.logger.error(
-                `App ${appUuid}: unhandled pipeline error: ${getErrorMessage(error)}`,
-            );
+            isIteration: false,
         });
 
         return { appUuid, version };
-    }
-
-    private async runIterationPipeline(
-        app: DbApp,
-        appUuid: string,
-        newVersion: number,
-        projectUuid: string,
-        prompt: string,
-        image?: AppImageAttachment,
-    ): Promise<void> {
-        let anthropicApiKey: string;
-        let e2bApiKey: string;
-        let s3Client: S3Client;
-        let bucket: string;
-        try {
-            anthropicApiKey = this.getAnthropicApiKey();
-            e2bApiKey = this.getE2bApiKey();
-            ({ client: s3Client, bucket } = this.getS3Client());
-        } catch (error) {
-            await this.markError(
-                appUuid,
-                newVersion,
-                error,
-                'Something went wrong. Please try again.',
-            );
-            return;
-        }
-
-        const overallStart = performance.now();
-        const durations: Record<string, number> = {};
-
-        await this.appModel.updateStatusMessage(
-            appUuid,
-            newVersion,
-            'Setting up build environment',
-        );
-
-        let sandbox: Sandbox;
-        let wasResumed = false;
-        try {
-            const acquired = await this.acquireSandbox(
-                app,
-                appUuid,
-                newVersion,
-                e2bApiKey,
-                s3Client,
-                bucket,
-            );
-            sandbox = acquired.sandbox;
-            wasResumed = acquired.wasResumed;
-            Object.assign(durations, acquired.durations);
-        } catch (error) {
-            await this.markError(
-                appUuid,
-                newVersion,
-                error,
-                'Failed to set up build environment. Please try again.',
-            );
-            return;
-        }
-
-        try {
-            await this.runPipelineStages(
-                sandbox,
-                appUuid,
-                newVersion,
-                projectUuid,
-                prompt,
-                s3Client,
-                bucket,
-                durations,
-                overallStart,
-                wasResumed, // continue Claude session if sandbox was resumed
-                anthropicApiKey,
-                image,
-            );
-        } finally {
-            await this.pauseSandbox(sandbox, appUuid);
-        }
     }
 
     async iterateApp(
@@ -1182,10 +1260,13 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const app = await this.appModel.getApp(appUuid, projectUuid);
+        await this.appModel.getApp(appUuid, projectUuid); // validates app exists
 
         const latestVersion = await this.appModel.getLatestVersion(appUuid);
-        if (latestVersion?.status === 'building') {
+        if (
+            latestVersion?.status &&
+            isAppVersionInProgress(latestVersion.status)
+        ) {
             throw new ParameterError(
                 'A version is already building for this app',
             );
@@ -1200,22 +1281,19 @@ export class AppGenerateService extends BaseService {
         await this.appModel.createVersion(
             appUuid,
             { version: newVersion, prompt },
-            'building',
+            'pending',
             user.userUuid,
         );
 
-        // Fire pipeline in background — status updates flow through DB polling
-        this.runIterationPipeline(
-            app,
+        await this.schedulerClient.appGeneratePipeline({
             appUuid,
-            newVersion,
+            version: newVersion,
             projectUuid,
+            organizationUuid: user.organizationUuid!,
+            userUuid: user.userUuid,
             prompt,
             image,
-        ).catch((error) => {
-            this.logger.error(
-                `App ${appUuid}: unhandled iteration pipeline error: ${getErrorMessage(error)}`,
-            );
+            isIteration: true,
         });
 
         return { appUuid, version: newVersion };
@@ -1245,7 +1323,7 @@ export class AppGenerateService extends BaseService {
         const app = await this.appModel.getApp(appUuid, projectUuid);
 
         // Atomically mark the version as cancelled (only if still building)
-        const updated = await this.appModel.updateVersionStatusIfBuilding(
+        const updated = await this.appModel.updateVersionStatusIfInProgress(
             appUuid,
             version,
             'error',
@@ -1295,7 +1373,7 @@ export class AppGenerateService extends BaseService {
         versions: {
             version: number;
             prompt: string;
-            status: string;
+            status: AppVersionStatus;
             statusMessage: string | null;
             createdAt: Date;
         }[];
@@ -1319,40 +1397,6 @@ export class AppGenerateService extends BaseService {
         const { name, description, createdByUserUuid, versions, hasMore } =
             await this.appModel.getAppWithVersions(appUuid, projectUuid, opts);
 
-        // Auto-heal stale builds: if the pipeline died (e.g. server restart)
-        // the version stays "building" forever. Detect via heartbeat timeout.
-        const STALE_THRESHOLD_MS = 60 * 60_000;
-        const now = Date.now();
-        const staleVersions = versions.filter((v) => {
-            if (v.status !== 'building') return false;
-            const lastActivity = v.status_updated_at ?? v.created_at;
-            return now - new Date(lastActivity).getTime() > STALE_THRESHOLD_MS;
-        });
-        // Best-effort — don't let a failed DB write break the GET response
-        try {
-            await Promise.all(
-                staleVersions.map(async (v) => {
-                    this.logger.warn(
-                        `App ${appUuid}: auto-healing stale build (version=${v.version})`,
-                    );
-                    await this.appModel.updateVersionStatus(
-                        appUuid,
-                        v.version,
-                        'error',
-                        'Build process was interrupted',
-                        'Something went wrong. Please try again.',
-                    );
-                }),
-            );
-        } catch (healError) {
-            this.logger.error(
-                `App ${appUuid}: auto-heal failed: ${getErrorMessage(healError)}`,
-            );
-        }
-        const staleVersionNumbers = new Set(
-            staleVersions.map((v) => v.version),
-        );
-
         return {
             appUuid,
             name,
@@ -1361,10 +1405,8 @@ export class AppGenerateService extends BaseService {
             versions: versions.map((v) => ({
                 version: v.version,
                 prompt: v.prompt,
-                status: staleVersionNumbers.has(v.version) ? 'error' : v.status,
-                statusMessage: staleVersionNumbers.has(v.version)
-                    ? 'Something went wrong. Please try again.'
-                    : v.status_message,
+                status: v.status,
+                statusMessage: v.status_message,
                 createdAt: v.created_at,
             })),
             hasMore,
@@ -1383,7 +1425,7 @@ export class AppGenerateService extends BaseService {
             projectName: string;
             createdAt: Date;
             lastVersionNumber: number | null;
-            lastVersionStatus: string | null;
+            lastVersionStatus: AppVersionStatus | null;
         }[];
         pagination?: {
             page: number;

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -5,8 +5,10 @@ import {
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import {
+    APP_VERSION_TERMINAL_STATUSES,
     AppsTableName,
     AppVersionsTableName,
+    isAppVersionInProgress,
     type AppVersionStatus,
     type DbApp,
     type DbAppVersion,
@@ -60,16 +62,16 @@ export class AppModel {
                 status,
                 error: error ?? null,
                 status_message: statusMessage ?? null,
-                status_updated_at: new Date(),
+                status_updated_at: this.database.fn.now() as unknown as Date,
             });
     }
 
     /**
-     * Update version status only if it is currently 'building'.
+     * Update version status only if it is currently in progress.
      * Returns true if the update was applied, false if the version was
      * already in a terminal state (e.g. cancelled by the user).
      */
-    async updateVersionStatusIfBuilding(
+    async updateVersionStatusIfInProgress(
         appId: string,
         version: number,
         status: AppVersionStatus,
@@ -77,12 +79,13 @@ export class AppModel {
         statusMessage?: string | null,
     ): Promise<boolean> {
         const updatedRows = await this.database(AppVersionsTableName)
-            .where({ app_id: appId, version, status: 'building' })
+            .where({ app_id: appId, version })
+            .whereNotIn('status', [...APP_VERSION_TERMINAL_STATUSES])
             .update({
                 status,
                 error: error ?? null,
                 status_message: statusMessage ?? null,
-                status_updated_at: new Date(),
+                status_updated_at: this.database.fn.now() as unknown as Date,
             });
         return updatedRows > 0;
     }
@@ -96,8 +99,24 @@ export class AppModel {
             .where({ app_id: appId, version })
             .update({
                 status_message: statusMessage,
-                status_updated_at: new Date(),
+                status_updated_at: this.database.fn.now() as unknown as Date,
             });
+    }
+
+    async getVersionStatus(
+        appId: string,
+        version: number,
+    ): Promise<AppVersionStatus> {
+        const row = await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version })
+            .select('status')
+            .first();
+        if (!row) {
+            throw new NotFoundError(
+                `App version not found: ${appId} v${version}`,
+            );
+        }
+        return row.status;
     }
 
     async getApp(appId: string, projectUuid: string): Promise<DbApp> {
@@ -311,5 +330,32 @@ export class AppModel {
         await this.database(AppsTableName)
             .where({ app_id: appId })
             .update({ sandbox_id: sandboxId });
+    }
+
+    /**
+     * Release graphile locks on appGeneratePipeline jobs whose corresponding
+     * app_version has not advanced within `threshold` — the previous worker
+     * is presumed dead. Released jobs are picked up on the next poll and
+     * resumed from their last completed stage.
+     *
+     * Returns the number of jobs released.
+     */
+    async releaseStaleLocks(
+        terminalStatuses: readonly string[],
+        threshold: string,
+    ): Promise<number> {
+        const result = await this.database.raw<{ rowCount: number }>(
+            `UPDATE graphile_worker.jobs j
+             SET locked_at = NULL, locked_by = NULL, run_at = now()
+             FROM app_versions v
+             WHERE j.task_identifier = 'appGeneratePipeline'
+               AND j.locked_at IS NOT NULL
+               AND v.app_id = (j.payload->>'appUuid')::uuid
+               AND v.version = (j.payload->>'version')::int
+               AND v.status <> ALL(?::text[])
+               AND v.status_updated_at < now() - ?::interval`,
+            [[...terminalStatuses], threshold],
+        );
+        return result.rowCount ?? 0;
     }
 }

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -183,6 +183,12 @@ const getTagsForTask: {
     [SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS]: () => ({}),
     [SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS]: () => ({}),
     [SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT]: () => ({}),
+    [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
+    [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
 } as const;
 
 // Generic accessor function

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -12,6 +12,7 @@ import {
     parseCronItems,
     run as runGraphileWorker,
     Runner,
+    type CronItem,
 } from 'graphile-worker';
 import moment from 'moment';
 import { DEFAULT_DB_MAX_CONNECTIONS } from '../knexfile';
@@ -72,52 +73,7 @@ export class SchedulerWorker extends SchedulerTask {
             noHandleSignals: true,
             pollInterval: this.lightdashConfig.scheduler.pollInterval,
             maxPoolSize,
-            parsedCronItems: parseCronItems([
-                {
-                    task: 'generateDailyJobs',
-                    pattern: '0 0 * * *',
-                    options: {
-                        backfillPeriod: 12 * 3600 * 1000, // 12 hours in ms
-                        maxAttempts: 3,
-                    },
-                },
-                {
-                    task: SCHEDULER_TASKS.CLEAN_QUERY_HISTORY,
-                    pattern:
-                        this.lightdashConfig.scheduler.queryHistory.cleanup
-                            .schedule,
-                    options: {
-                        backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
-                        maxAttempts: 3,
-                    },
-                },
-                {
-                    task: SCHEDULER_TASKS.GENERATE_SLACK_CHANNEL_SYNC_JOBS,
-                    pattern: '0 6 * * *', // 6am UTC daily
-                    options: {
-                        backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
-                        maxAttempts: 3,
-                    },
-                },
-                {
-                    task: SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS,
-                    pattern: '*/30 * * * *', // Every 30 minutes
-                    options: {
-                        backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
-                        maxAttempts: 3,
-                    },
-                },
-                {
-                    task: SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS,
-                    pattern: '0 * * * *', // Every hour
-                    options: {
-                        backfillPeriod: 2 * 3600 * 1000, // 2 hours in ms
-                        maxAttempts: 3,
-                    },
-                },
-                // Managed agent heartbeat is self-scheduling (not a static cron).
-                // See SchedulerClient.scheduleManagedAgentHeartbeat().
-            ]),
+            parsedCronItems: parseCronItems(this.getCronItems()),
             taskList: traceTasks(this.getTaskList()),
             events: schedulerWorkerEventEmitter,
         });
@@ -127,6 +83,55 @@ export class SchedulerWorker extends SchedulerTask {
         void this.runner.promise.finally(() => {
             this.isRunning = false;
         });
+    }
+
+    protected getCronItems(): CronItem[] {
+        return [
+            {
+                task: 'generateDailyJobs',
+                pattern: '0 0 * * *',
+                options: {
+                    backfillPeriod: 12 * 3600 * 1000, // 12 hours in ms
+                    maxAttempts: 3,
+                },
+            },
+            {
+                task: SCHEDULER_TASKS.CLEAN_QUERY_HISTORY,
+                pattern:
+                    this.lightdashConfig.scheduler.queryHistory.cleanup
+                        .schedule,
+                options: {
+                    backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
+                    maxAttempts: 3,
+                },
+            },
+            {
+                task: SCHEDULER_TASKS.GENERATE_SLACK_CHANNEL_SYNC_JOBS,
+                pattern: '0 6 * * *', // 6am UTC daily
+                options: {
+                    backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
+                    maxAttempts: 3,
+                },
+            },
+            {
+                task: SCHEDULER_TASKS.CHECK_FOR_STUCK_JOBS,
+                pattern: '*/30 * * * *', // Every 30 minutes
+                options: {
+                    backfillPeriod: 24 * 3600 * 1000, // 24 hours in ms
+                    maxAttempts: 3,
+                },
+            },
+            {
+                task: SCHEDULER_TASKS.CLEAN_DEPLOY_SESSIONS,
+                pattern: '0 * * * *', // Every hour
+                options: {
+                    backfillPeriod: 2 * 3600 * 1000, // 2 hours in ms
+                    maxAttempts: 3,
+                },
+            },
+            // Managed agent heartbeat is self-scheduling (not a static cron).
+            // See SchedulerClient.scheduleManagedAgentHeartbeat().
+        ];
     }
 
     protected getTaskList(): Partial<TypedTaskList> {

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -1,6 +1,31 @@
 import { type ApiSuccess, type ApiSuccessEmpty } from '../../types/api/success';
 import { type KnexPaginateArgs } from '../../types/knex-paginate';
 
+/**
+ * Ordered pipeline stages. Index position determines progression — used to
+ * skip completed stages when a build is retried after a worker crash.
+ * 'ready' is included as the final stage; 'error' is terminal but not a
+ * stage (not reachable through normal progression).
+ */
+export const APP_VERSION_STAGE_ORDER = [
+    'pending',
+    'sandbox',
+    'catalog',
+    'generating',
+    'building',
+    'packaging',
+    'ready',
+] as const;
+
+export const APP_VERSION_TERMINAL_STATUSES = ['ready', 'error'] as const;
+
+export type AppVersionStatus =
+    | (typeof APP_VERSION_STAGE_ORDER)[number]
+    | 'error';
+
+export const isAppVersionInProgress = (status: AppVersionStatus): boolean =>
+    !(APP_VERSION_TERMINAL_STATUSES as readonly string[]).includes(status);
+
 export type ApiGenerateAppResponse = ApiSuccess<{
     appUuid: string;
     version: number;
@@ -34,7 +59,7 @@ export type ApiPreviewTokenResponse = ApiSuccess<{
 export type ApiAppVersionSummary = {
     version: number;
     prompt: string;
-    status: string;
+    status: AppVersionStatus;
     statusMessage: string | null;
     createdAt: Date;
 };
@@ -69,7 +94,7 @@ export type ApiAppSummary = {
     projectName: string;
     createdAt: Date;
     lastVersionNumber: number | null;
-    lastVersionStatus: string | null;
+    lastVersionStatus: AppVersionStatus | null;
 };
 
 export type ApiMyAppsResponse = ApiSuccess<{

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -1,6 +1,7 @@
 import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
+    type AppImageAttachment,
     type EmbedArtifactVersionJobPayload,
     type GenerateArtifactQuestionJobPayload,
     type SlackPromptJobPayload,
@@ -34,11 +35,21 @@ import {
     type SqlRunnerPivotQueryPayload,
 } from './sqlRunner';
 
+export type AppGeneratePipelineJobPayload = TraceTaskBase & {
+    appUuid: string;
+    version: number;
+    prompt: string;
+    image?: AppImageAttachment;
+    isIteration: boolean;
+};
+
 export const EE_SCHEDULER_TASKS = {
     SLACK_AI_PROMPT: 'slackAiPrompt',
     AI_AGENT_EVAL_RESULT: 'aiAgentEvalResult',
     EMBED_ARTIFACT_VERSION: 'embedArtifactVersion',
     GENERATE_ARTIFACT_QUESTION: 'generateArtifactQuestion',
+    APP_GENERATE_PIPELINE: 'appGeneratePipeline',
+    SWEEP_STALE_APP_LOCKS: 'sweepStaleAppLocks',
 } as const;
 
 export const SCHEDULER_TASKS = {
@@ -118,6 +129,8 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
+    [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
+    [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
 }
 
 export interface EETaskPayloadMap {
@@ -125,6 +138,8 @@ export interface EETaskPayloadMap {
     [EE_SCHEDULER_TASKS.AI_AGENT_EVAL_RESULT]: AiAgentEvalRunJobPayload;
     [EE_SCHEDULER_TASKS.EMBED_ARTIFACT_VERSION]: EmbedArtifactVersionJobPayload;
     [EE_SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
+    [EE_SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
+    [EE_SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
 }
 
 export type SchedulerTaskName =

--- a/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
@@ -1,9 +1,13 @@
+import { APP_VERSION_TERMINAL_STATUSES } from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
 
 // Inline Web Worker that polls the API in the background.
 // Dedicated Workers continue running even when the parent tab is throttled/frozen.
+// Terminal statuses are interpolated at module load from the shared constant
+// so the worker string stays in sync with backend logic.
 const WORKER_CODE = `
+const TERMINAL_STATUSES = ${JSON.stringify([...APP_VERSION_TERMINAL_STATUSES])};
 let active = true;
 self.onmessage = (e) => {
     if (e.data.type === 'start') pollLoop(e.data.url, e.data.interval);
@@ -17,7 +21,7 @@ async function pollLoop(url, interval) {
                 const data = await res.json();
                 self.postMessage({ type: 'data', results: data.results });
                 const latest = data.results && data.results.versions && data.results.versions[0];
-                if (latest && latest.status !== 'building') {
+                if (latest && TERMINAL_STATUSES.includes(latest.status)) {
                     active = false;
                     return;
                 }
@@ -74,7 +78,12 @@ export function useAppBuildPoller(
                 );
 
                 const latest = e.data.results.versions?.[0];
-                if (latest && latest.status !== 'building') {
+                if (
+                    latest &&
+                    (
+                        APP_VERSION_TERMINAL_STATUSES as readonly string[]
+                    ).includes(latest.status)
+                ) {
                     onDoneRef.current(
                         latest.version as number,
                         latest.status as string,

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     FeatureFlags,
+    isAppVersionInProgress,
     type ApiAppVersionSummary,
     type AppImageAttachment,
 } from '@lightdash/common';
@@ -255,7 +256,8 @@ const AppGenerate: FC = () => {
     const latestBuildingVersion = useMemo(() => {
         if (!appData?.pages?.[0]) return null;
         const latest = appData.pages[0].versions[0];
-        if (latest?.status === 'building') return latest;
+        if (latest?.status && isAppVersionInProgress(latest.status))
+            return latest;
         return null;
     }, [appData]);
     const isBuilding = latestBuildingVersion !== null;


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-314/make-the-app-builder-backend-recoverable

### Description:
The app generation pipeline (up to 55 minutes) previously ran as a fire-and-forget promise. If the backend pod died during a deployment, the results were lost. Now the pipeline runs inside a Graphile Worker job that persists in PostgreSQL and survives deploys.

The main tricky part is the stale detection and resumption:
Basically, we're running now a cronjob every 2 minutes and check for any app versions that haven't finished (not ready/error) and that haven't received any status update in 5 minutes. These we then consider stale, so we unlock the jobs so it can be picked up again, which will gracefully resume it and finish the job.