### PR TITLE
fix: use session_timezone instead of timezone for ClickHouse

### DIFF
--- a/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/ClickhouseWarehouseClient.ts
@@ -1,4 +1,9 @@
-import { createClient, Row, type ClickHouseClient } from '@clickhouse/client';
+import {
+    createClient,
+    Row,
+    type ClickHouseClient,
+    type ClickHouseSettings,
+} from '@clickhouse/client';
 import {
     AnyType,
     CreateClickhouseCredentials,
@@ -235,9 +240,9 @@ export class ClickhouseWarehouseClient extends WarehouseBaseClient<CreateClickho
     ): Promise<void> {
         try {
             // Build clickhouse_settings with optional timezone and log_comment for query tags
-            const clickhouseSettings: Record<string, string> = {};
+            const clickhouseSettings: ClickHouseSettings = {};
             if (options?.timezone) {
-                clickhouseSettings.timezone = options.timezone;
+                clickhouseSettings.session_timezone = options.timezone;
             }
             if (options?.tags) {
                 // Use native log_comment setting - persists in system.query_log


### PR DESCRIPTION
## Summary

- Fix ClickHouse `dataTimezone` support: change the setting name from `timezone` to `session_timezone`
- The old `timezone` setting doesn't exist in ClickHouse and causes queries to fail with _"Setting timezone is neither a builtin setting"_
- Use the typed `ClickHouseSettings` from `@clickhouse/client` instead of `Record<string, string>`

**Before**
<img width="491" height="287" alt="CleanShot 2026-04-03 at 16 54 08" src="https://github.com/user-attachments/assets/e8953a42-0f17-4d8e-a5f3-bddcc6a3f469" />

**After**
<img width="2126" height="569" alt="CleanShot 2026-04-03 at 16 55 42" src="https://github.com/user-attachments/assets/9a4109cf-8e43-4a49-9210-09cffd6b2bba" />

Relates to: https://linear.app/lightdash/project/timezone-handling-4659dc553e25