### PR TITLE
perf(frontend): reduce table body interaction overhead

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -5,27 +5,11 @@ import {
     type RawResultRow,
     type ResultRow,
 } from '@lightdash/common';
-import {
-    getHotkeyHandler,
-    useClipboard,
-    useDisclosure,
-    useTimeout,
-} from '@mantine/hooks';
 import { type Cell } from '@tanstack/react-table';
-import {
-    useCallback,
-    useEffect,
-    useMemo,
-    useRef,
-    useState,
-    type FC,
-} from 'react';
+import { useMemo, type FC } from 'react';
 import { type CSSProperties } from 'styled-components';
-import useToaster from '../../../../hooks/toaster/useToaster';
 import { Td } from '../Table.styles';
 import { type CellContextMenuProps } from '../types';
-import CellMenu from './CellMenu';
-import CellTooltip from './CellTooltip';
 
 interface CommonBodyCellProps {
     cell: Cell<ResultRow, unknown> | Cell<RawResultRow, unknown>;
@@ -40,6 +24,18 @@ interface CommonBodyCellProps {
     isLargeText?: boolean;
     tooltipContent?: string;
     minimal?: boolean;
+    isSelected?: boolean;
+    onMenuToggle?: (
+        cell: Cell<ResultRow, unknown> | Cell<RawResultRow, unknown>,
+        elementBounds: DOMRect,
+        displayValue: string | RawResultRow | null,
+    ) => void;
+    onTooltipShow?: (
+        cellId: string,
+        label: string,
+        elementBounds: DOMRect,
+    ) => void;
+    onTooltipHide?: (cellId: string) => void;
 }
 
 const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
@@ -56,45 +52,17 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
     style,
     tooltipContent,
     minimal = false,
+    isSelected = false,
+    onMenuToggle,
+    onTooltipShow,
+    onTooltipHide,
 }) => {
-    const elementRef = useRef<HTMLTableCellElement>(null);
-    const { showToastSuccess } = useToaster();
-    const { copy } = useClipboard();
-
-    const [isCopying, setCopying] = useState(false);
-    const [isMenuOpen, { toggle: toggleMenu }] = useDisclosure(false);
-    const [isTooltipOpen, { open: openTooltip, close: closeTooltip }] =
-        useDisclosure(false);
-    const [elementBounds, setElementBounds] = useState<DOMRect | null>(null);
-
     const canHaveMenu = !!cellContextMenu && hasData;
     const canHaveTooltip = !!tooltipContent && !minimal;
-
-    const { start: startTooltipTimer, clear: clearTooltipTimer } = useTimeout(
-        openTooltip,
-        500,
-    );
     const item = cell.column.columnDef.meta?.item;
     const hasUrls = isField(item) && item.urls ? item.urls.length > 0 : false;
 
-    const shouldRenderMenu = canHaveMenu && isMenuOpen && elementRef.current;
-    const shouldRenderTooltip =
-        canHaveTooltip &&
-        isTooltipOpen &&
-        elementRef.current &&
-        !shouldRenderMenu;
-
-    // Calculate bounds when menu/tooltip opens, not during every render
-    useEffect(() => {
-        if ((shouldRenderMenu || shouldRenderTooltip) && elementRef.current) {
-            setElementBounds(elementRef.current.getBoundingClientRect());
-        } else if (!isMenuOpen && !isTooltipOpen) {
-            // Clear bounds when closed to free memory
-            setElementBounds(null);
-        }
-    }, [shouldRenderMenu, shouldRenderTooltip, isMenuOpen, isTooltipOpen]);
-
-    const displayValue = useMemo(() => {
+    const displayValue = useMemo<string | RawResultRow | null>(() => {
         if (!hasData) return null;
 
         const cellValue = cell.getValue();
@@ -102,90 +70,60 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
         if (isResultValue(cellValue)) {
             return cellValue.value.formatted;
         } else if (isRawResultRow(cellValue)) {
-            return cellValue;
+            return cellValue as RawResultRow;
         } else {
             return null;
         }
     }, [hasData, cell]);
 
-    const handleCopy = useCallback(() => {
-        if (!isMenuOpen) return;
-
-        copy(displayValue);
-        showToastSuccess({ title: 'Copied to clipboard!' });
-
-        setCopying((copyingState) => {
-            if (!copyingState) {
-                setTimeout(() => setCopying(false), 300);
-            }
-            return true;
-        });
-    }, [isMenuOpen, displayValue, copy, showToastSuccess]);
-
-    useEffect(() => {
-        const handleKeyDown = getHotkeyHandler([['mod+C', handleCopy]]);
-
-        if (isMenuOpen) {
-            document.body.addEventListener('keydown', handleKeyDown);
-        }
-
-        return () => {
-            document.body.removeEventListener('keydown', handleKeyDown);
-        };
-    }, [isMenuOpen, handleCopy]);
-
     return (
-        <>
-            <Td
-                ref={elementRef}
-                className={className}
-                style={style}
-                $rowIndex={index}
-                $isSelected={isMenuOpen}
-                $isLargeText={isLargeText}
-                $isMinimal={minimal}
-                $isInteractive={canHaveMenu || canHaveTooltip}
-                $isCopying={isCopying}
-                $backgroundColor={backgroundColor}
-                $fontColor={fontColor}
-                $hasData={hasData}
-                $isNaN={!hasData || !isNumericItem}
-                $hasUrls={hasUrls}
-                $hasNewlines={
-                    typeof displayValue === 'string' &&
-                    displayValue.includes('\n')
-                }
-                onClick={canHaveMenu ? toggleMenu : undefined}
-                onMouseEnter={canHaveTooltip ? startTooltipTimer : undefined}
-                onMouseLeave={
-                    canHaveTooltip
-                        ? () => {
-                              clearTooltipTimer();
-                              closeTooltip();
-                          }
-                        : undefined
-                }
-            >
-                <span>{children}</span>
-            </Td>
-
-            {shouldRenderMenu ? (
-                <CellMenu
-                    cell={cell as Cell<ResultRow, ResultRow[0]>}
-                    menuItems={cellContextMenu}
-                    elementBounds={elementBounds}
-                    onClose={toggleMenu}
-                />
-            ) : null}
-
-            {shouldRenderTooltip ? (
-                <CellTooltip
-                    position="top"
-                    label={tooltipContent}
-                    elementBounds={elementBounds}
-                />
-            ) : null}
-        </>
+        <Td
+            className={className}
+            style={style}
+            $rowIndex={index}
+            $isSelected={isSelected}
+            $isLargeText={isLargeText}
+            $isMinimal={minimal}
+            $isInteractive={canHaveMenu || canHaveTooltip}
+            $isCopying={false}
+            $backgroundColor={backgroundColor}
+            $fontColor={fontColor}
+            $hasData={hasData}
+            $isNaN={!hasData || !isNumericItem}
+            $hasUrls={hasUrls}
+            $hasNewlines={
+                typeof displayValue === 'string' && displayValue.includes('\n')
+            }
+            onClick={
+                canHaveMenu
+                    ? (e) =>
+                          onMenuToggle?.(
+                              cell,
+                              e.currentTarget.getBoundingClientRect(),
+                              displayValue,
+                          )
+                    : undefined
+            }
+            onMouseEnter={
+                canHaveTooltip
+                    ? (e) =>
+                          onTooltipShow?.(
+                              cell.id,
+                              tooltipContent,
+                              e.currentTarget.getBoundingClientRect(),
+                          )
+                    : undefined
+            }
+            onMouseLeave={
+                canHaveTooltip
+                    ? () => {
+                          onTooltipHide?.(cell.id);
+                      }
+                    : undefined
+            }
+        >
+            <span>{children}</span>
+        </Td>
     );
 };
 

--- a/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx
@@ -6,6 +6,7 @@ import {
     getItemId,
     getReadableTextColor,
     isNumericItem,
+    type RawResultRow,
     type ConditionalFormattingRowFields,
     type ResultRow,
 } from '@lightdash/common';
@@ -18,10 +19,19 @@ import {
     Tooltip,
     useMantineColorScheme,
 } from '@mantine/core';
+import { getHotkeyHandler, useClipboard } from '@mantine/hooks';
 import { IconChevronDown, IconChevronRight } from '@tabler/icons-react';
-import { flexRender, type Row } from '@tanstack/react-table';
+import { flexRender, type Cell, type Row } from '@tanstack/react-table';
 import { useVirtualizer } from '@tanstack/react-virtual';
-import React, { useCallback, useEffect, useMemo, type FC } from 'react';
+import React, {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
+import useToaster from '../../../../hooks/toaster/useToaster';
 import {
     getColorFromRange,
     transformColorsForDarkMode,
@@ -38,6 +48,21 @@ import { type TableContext } from '../types';
 import { useTableContext } from '../useTableContext';
 import { countSubRows } from '../utils';
 import BodyCell from './BodyCell';
+import CellMenu from './CellMenu';
+import CellTooltip from './CellTooltip';
+
+type ActiveMenuState = {
+    cellId: string;
+    cell: Cell<ResultRow, unknown> | Cell<RawResultRow, unknown>;
+    bounds: DOMRect;
+    displayValue: string | RawResultRow | null;
+};
+
+type ActiveTooltipState = {
+    cellId: string;
+    bounds: DOMRect;
+    label: string;
+};
 
 export const VirtualizedArea: FC<{ cellCount: number; padding: number }> = ({
     cellCount,
@@ -66,6 +91,18 @@ interface TableRowProps {
     conditionalFormattings: TableContext['conditionalFormattings'];
     minMaxMap: TableContext['minMaxMap'];
     minimal?: boolean;
+    activeMenuCellId: string | null;
+    onMenuToggle: (
+        cell: Cell<ResultRow, unknown> | Cell<RawResultRow, unknown>,
+        elementBounds: DOMRect,
+        displayValue: string | RawResultRow | null,
+    ) => void;
+    onTooltipShow: (
+        cellId: string,
+        label: string,
+        elementBounds: DOMRect,
+    ) => void;
+    onTooltipHide: (cellId: string) => void;
 }
 
 const TableRow: FC<TableRowProps> = ({
@@ -77,6 +114,10 @@ const TableRow: FC<TableRowProps> = ({
     conditionalFormattings,
     minMaxMap,
     minimal = false,
+    activeMenuCellId,
+    onMenuToggle,
+    onTooltipShow,
+    onTooltipHide,
 }) => {
     const { colorScheme } = useMantineColorScheme();
     const rowFields = useMemo(
@@ -179,6 +220,7 @@ const TableRow: FC<TableRowProps> = ({
                         className={meta?.className}
                         index={index}
                         cell={cell}
+                        isSelected={activeMenuCellId === cell.id}
                         isNumericItem={
                             isNumericItem(meta?.item) &&
                             !(
@@ -196,6 +238,9 @@ const TableRow: FC<TableRowProps> = ({
                             SMALL_TEXT_LENGTH
                         }
                         tooltipContent={tooltipContent}
+                        onMenuToggle={onMenuToggle}
+                        onTooltipShow={onTooltipShow}
+                        onTooltipHide={onTooltipHide}
                     >
                         {cell.getIsGrouped() ? (
                             <Group spacing="xxs">
@@ -275,7 +320,13 @@ const VirtualizedTableBody: FC<{
         isFetchingRows,
         fetchMoreRows,
     } = useTableContext();
+    const { showToastSuccess } = useToaster();
+    const { copy } = useClipboard();
     const { rows } = table.getRowModel();
+    const [activeMenu, setActiveMenu] = useState<ActiveMenuState | null>(null);
+    const [activeTooltip, setActiveTooltip] =
+        useState<ActiveTooltipState | null>(null);
+    const tooltipTimerRef = useRef<number | null>(null);
 
     const rowVirtualizer = useVirtualizer({
         getScrollElement: () => tableContainerRef.current,
@@ -283,6 +334,38 @@ const VirtualizedTableBody: FC<{
         estimateSize: (_index) => ROW_HEIGHT_PX,
         overscan: 25,
     });
+
+    useEffect(() => {
+        if (!activeMenu) return;
+
+        const handleKeyDown = getHotkeyHandler([
+            [
+                'mod+C',
+                () => {
+                    copy(
+                        typeof activeMenu.displayValue === 'string'
+                            ? activeMenu.displayValue
+                            : JSON.stringify(activeMenu.displayValue),
+                    );
+                    showToastSuccess({ title: 'Copied to clipboard!' });
+                },
+            ],
+        ]);
+
+        document.body.addEventListener('keydown', handleKeyDown);
+
+        return () => {
+            document.body.removeEventListener('keydown', handleKeyDown);
+        };
+    }, [activeMenu, copy, showToastSuccess]);
+
+    useEffect(() => {
+        return () => {
+            if (tooltipTimerRef.current !== null) {
+                window.clearTimeout(tooltipTimerRef.current);
+            }
+        };
+    }, []);
 
     useEffect(() => {
         const scrollElement = rowVirtualizer.scrollElement;
@@ -317,6 +400,68 @@ const VirtualizedTableBody: FC<{
             rowVirtualizer.measureElement(node);
         },
         [rowVirtualizer],
+    );
+
+    const clearTooltipTimer = useCallback(() => {
+        if (tooltipTimerRef.current !== null) {
+            window.clearTimeout(tooltipTimerRef.current);
+            tooltipTimerRef.current = null;
+        }
+    }, []);
+
+    const handleMenuToggle = useCallback(
+        (
+            cell: Cell<ResultRow, unknown> | Cell<RawResultRow, unknown>,
+            bounds: DOMRect,
+            displayValue: string | RawResultRow | null,
+        ) => {
+            clearTooltipTimer();
+            setActiveTooltip(null);
+            setActiveMenu((current) =>
+                current?.cellId === cell.id
+                    ? null
+                    : {
+                          cellId: cell.id,
+                          cell,
+                          bounds,
+                          displayValue,
+                      },
+            );
+        },
+        [clearTooltipTimer],
+    );
+
+    const handleTooltipShow = useCallback(
+        (cellId: string, label: string, bounds: DOMRect) => {
+            if (activeMenu) return;
+
+            clearTooltipTimer();
+            tooltipTimerRef.current = window.setTimeout(() => {
+                setActiveTooltip((current) =>
+                    current?.cellId === cellId &&
+                    current.label === label &&
+                    current.bounds.x === bounds.x &&
+                    current.bounds.y === bounds.y
+                        ? current
+                        : {
+                              cellId,
+                              label,
+                              bounds,
+                          },
+                );
+            }, 500);
+        },
+        [activeMenu, clearTooltipTimer],
+    );
+
+    const handleTooltipHide = useCallback(
+        (cellId: string) => {
+            clearTooltipTimer();
+            setActiveTooltip((current) =>
+                current?.cellId === cellId ? null : current,
+            );
+        },
+        [clearTooltipTimer],
     );
 
     const skeletonRows = useMemo(() => {
@@ -403,6 +548,10 @@ const VirtualizedTableBody: FC<{
                               cellContextMenu={cellContextMenu}
                               conditionalFormattings={conditionalFormattings}
                               minMaxMap={minMaxMap}
+                              activeMenuCellId={activeMenu?.cellId ?? null}
+                              onMenuToggle={handleMenuToggle}
+                              onTooltipShow={handleTooltipShow}
+                              onTooltipHide={handleTooltipHide}
                           />
                       );
                   })}
@@ -413,6 +562,23 @@ const VirtualizedTableBody: FC<{
                     padding={paddingBottom}
                 />
             )}
+
+            {activeMenu && cellContextMenu ? (
+                <CellMenu
+                    cell={activeMenu.cell as Cell<ResultRow, ResultRow[0]>}
+                    menuItems={cellContextMenu}
+                    elementBounds={activeMenu.bounds}
+                    onClose={() => setActiveMenu(null)}
+                />
+            ) : null}
+
+            {activeTooltip && !activeMenu ? (
+                <CellTooltip
+                    position="top"
+                    label={activeTooltip.label}
+                    elementBounds={activeTooltip.bounds}
+                />
+            ) : null}
         </tbody>
     );
 };


### PR DESCRIPTION
## Summary

This PR reduces table body interaction overhead by moving shared interaction state out of individual cells and into the table body.

## Root Cause

Profiling after the tab-switching fix still showed table-side cost. `BodyCell` instances were legal React components, but each visible cell carried its own hook/state stack for menus, tooltips, clipboard, and timeouts. On wide visible tables, that added unnecessary per-cell work.

## What Changed

- make `BodyCell` much lighter and mostly stateless
- centralize menu / tooltip coordination in `TableBody`
- keep a single shared overlay path instead of duplicating interaction machinery per visible cell

## Validation

- commit hooks ran frontend lint/format on the touched files during commit
- filtered typecheck for `BodyCell` / `TableBody` returned no matching errors during development
- React Profiler comparison after the change no longer showed `BodyCell` / `TableRow` as prominent hotspots

## Files

- `packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx`
- `packages/frontend/src/components/common/Table/ScrollableTable/TableBody.tsx`
