### PR TITLE
perf(frontend): reduce dashboard tile status rerenders

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -735,10 +735,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             (c) => c.parameterDefinitions,
         );
 
-        const preAggregateStatuses = useDashboardTileStatusContext(
-            (c) => c.preAggregateStatuses,
+        const tilePreAggStatus = useDashboardTileStatusContext(
+            (c) => c.preAggregateStatuses[tileUuid],
         );
-        const tilePreAggStatus = preAggregateStatuses[tileUuid];
         const tilePreAggregateName =
             tilePreAggStatus?.hit && tilePreAggStatus.preAggregateName
                 ? tilePreAggStatus.preAggregateName

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -68,7 +68,7 @@ import { useContentVerificationEnabled } from '../../../hooks/useContentVerifica
 import { useProject } from '../../../hooks/useProject';
 import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
-import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types';
+import useDashboardTileStatusContext from '../../../providers/Dashboard/useDashboardTileStatusContext';
 import useTracking from '../../../providers/Tracking/useTracking';
 import { EventName } from '../../../types/Events';
 import AddTileButton from '../../DashboardTiles/AddTileButton';
@@ -97,9 +97,6 @@ type DashboardHeaderProps = {
     isSaving: boolean;
     isFullScreenFeatureEnabled?: boolean;
     isFullscreen: boolean;
-    oldestCacheTime?: Date;
-    preAggregateStatuses?: Record<string, TilePreAggregateStatus>;
-    allTilesLoaded?: boolean;
     activeTabUuid?: string;
     dashboardTabs?: Dashboard['tabs'];
     dashboardTiles?: Dashboard['tiles'];
@@ -129,9 +126,6 @@ const DashboardHeader = memo(
         onSwitchTab,
         isFullScreenFeatureEnabled,
         isFullscreen,
-        oldestCacheTime,
-        preAggregateStatuses,
-        allTilesLoaded,
         activeTabUuid,
         dashboardTabs,
         dashboardTiles,
@@ -153,6 +147,15 @@ const DashboardHeader = memo(
         );
         const isDashboardSummariesEnabled = useClientFeatureFlag(
             'ai-dashboard-summary' as FeatureFlags,
+        );
+        const oldestCacheTime = useDashboardTileStatusContext(
+            (c) => c.oldestCacheTime,
+        );
+        const preAggregateStatuses = useDashboardTileStatusContext(
+            (c) => c.preAggregateStatuses,
+        );
+        const allTilesLoaded = useDashboardTileStatusContext(
+            (c) => c.areAllChartsLoaded,
         );
 
         const { search, pathname } = useLocation();

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -117,12 +117,6 @@ const Dashboard: FC = () => {
             isAddFilterDisabled
         );
     }, [dashboard, isAddFilterDisabled]);
-    const oldestCacheTime = useDashboardTileStatusContext(
-        (c) => c.oldestCacheTime,
-    );
-    const preAggregateStatuses = useDashboardTileStatusContext(
-        (c) => c.preAggregateStatuses,
-    );
     const dashboardParameters = useDashboardContext(
         (c) => c.dashboardParameters,
     );
@@ -692,9 +686,6 @@ const Dashboard: FC = () => {
         organizationUuid: organization?.organizationUuid,
         isEditMode,
         isSaving,
-        oldestCacheTime,
-        preAggregateStatuses,
-        allTilesLoaded: areAllChartsLoaded,
         isFullscreen,
         activeTabUuid: activeTab?.uuid,
         dashboardTabs,

--- a/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx
@@ -49,7 +49,12 @@ const DashboardTileStatusProvider: React.FC<
     const [loadedTiles, setLoadedTiles] = useState<Set<string>>(new Set());
 
     const markTileLoaded = useCallback((tileUuid: string) => {
-        setLoadedTiles((prev) => new Set(prev).add(tileUuid));
+        setLoadedTiles((prev) => {
+            if (prev.has(tileUuid)) return prev;
+            const next = new Set(prev);
+            next.add(tileUuid);
+            return next;
+        });
     }, []);
 
     // Determine if all chart tiles have loaded
@@ -123,11 +128,21 @@ const DashboardTileStatusProvider: React.FC<
     >(new Set());
 
     const markTileScreenshotReady = useCallback((tileUuid: string) => {
-        setScreenshotReadyTiles((prev) => new Set(prev).add(tileUuid));
+        setScreenshotReadyTiles((prev) => {
+            if (prev.has(tileUuid)) return prev;
+            const next = new Set(prev);
+            next.add(tileUuid);
+            return next;
+        });
     }, []);
 
     const markTileScreenshotErrored = useCallback((tileUuid: string) => {
-        setScreenshotErroredTiles((prev) => new Set(prev).add(tileUuid));
+        setScreenshotErroredTiles((prev) => {
+            if (prev.has(tileUuid)) return prev;
+            const next = new Set(prev);
+            next.add(tileUuid);
+            return next;
+        });
     }, []);
 
     const expectedScreenshotTileUuids = useMemo(() => {
@@ -238,10 +253,13 @@ const DashboardTileStatusProvider: React.FC<
 
     const updateSqlChartTilesMetadata = useCallback(
         (tileUuid: string, metadata: SqlChartTileMetadata) => {
-            setSqlChartTilesMetadata((prev) => ({
-                ...prev,
-                [tileUuid]: metadata,
-            }));
+            setSqlChartTilesMetadata((prev) => {
+                if (prev[tileUuid] === metadata) return prev;
+                return {
+                    ...prev,
+                    [tileUuid]: metadata,
+                };
+            });
         },
         [],
     );
@@ -249,9 +267,8 @@ const DashboardTileStatusProvider: React.FC<
     const addPreAggregateStatus = useCallback(
         (tileUuid: string, cacheMetadata?: CacheMetadata) => {
             const preAggregate = cacheMetadata?.preAggregate ?? null;
-            setPreAggregateStatuses((prev) => ({
-                ...prev,
-                [tileUuid]: {
+            setPreAggregateStatuses((prev) => {
+                const nextStatus = {
                     tileUuid,
                     tileName: tileNamesById[tileUuid] ?? tileUuid,
                     hit: preAggregate?.hit ?? false,
@@ -259,8 +276,28 @@ const DashboardTileStatusProvider: React.FC<
                     reason: preAggregate?.reason ?? null,
                     hasPreAggregateMetadata: preAggregate !== null,
                     tabUuid: tileTabsById[tileUuid],
-                },
-            }));
+                };
+
+                const currentStatus = prev[tileUuid];
+                if (
+                    currentStatus &&
+                    currentStatus.tileName === nextStatus.tileName &&
+                    currentStatus.hit === nextStatus.hit &&
+                    currentStatus.preAggregateName ===
+                        nextStatus.preAggregateName &&
+                    currentStatus.reason === nextStatus.reason &&
+                    currentStatus.hasPreAggregateMetadata ===
+                        nextStatus.hasPreAggregateMetadata &&
+                    currentStatus.tabUuid === nextStatus.tabUuid
+                ) {
+                    return prev;
+                }
+
+                return {
+                    ...prev,
+                    [tileUuid]: nextStatus,
+                };
+            });
         },
         [tileNamesById, tileTabsById],
     );


### PR DESCRIPTION
## Summary

This PR reduces dashboard-wide rerenders caused by tile status updates.

## Root Cause

After the tab-switching and table-cell fixes, profiling still showed update fan-out from dashboard tile status state. Chart tiles were subscribing to the whole pre-aggregate status map, and page-level components were rerendering for header-only status data.

## What Changed

- subscribe each chart tile only to `preAggregateStatuses[tileUuid]`
- move header-specific status reads into `DashboardHeader`
- skip provider updates when loaded-tile, screenshot, SQL metadata, or pre-aggregate values have not actually changed

## Validation

- commit hooks ran frontend lint/format on the touched files during commit
- filtered typecheck for the touched dashboard status files returned no matching errors during development
- React Profiler after the change showed less `DashboardTileStatusProvider`-driven work in the dashboard subtree

## Files

- `packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx`
- `packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx`
- `packages/frontend/src/pages/Dashboard.tsx`
- `packages/frontend/src/providers/Dashboard/DashboardTileStatusProvider.tsx`
