### PR TITLE
fix: use absolute path prefix in --allowedTools for sandbox Claude CLI

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -459,7 +459,7 @@ export class AppGenerateService extends BaseService {
             `cat /tmp/prompt.txt | claude ${sessionFlags} ` +
                 `--model sonnet ` +
                 `--verbose --output-format stream-json ` +
-                `--allowedTools "Read(/app/**),Read(/tmp/dbt-repo/**),Write(/app/src/**),Edit(/app/src/**),Glob(/app/**),Glob(/tmp/dbt-repo/**),Grep(/app/**),Grep(/tmp/dbt-repo/**)" ` +
+                `--allowedTools "Read(//app/**),Read(//tmp/dbt-repo/**),Write(//app/src/**),Edit(//app/src/**),Glob(//app/**),Glob(//tmp/dbt-repo/**),Grep(//app/**),Grep(//tmp/dbt-repo/**)" ` +
                 `--append-system-prompt-file /app/skill.md`,
             {
                 cwd: '/app',


### PR DESCRIPTION
### Description:
The previous path patterns like Read(/app/**) used project-root-relative paths, which caused /tmp/dbt-repo/** to not resolve correctly since it lives outside the project root. Switch to the // prefix (e.g. Read(//app/**)) which denotes absolute paths in Claude CLI's permission system, so both /app/ and /tmp/dbt-repo/ are accessible.
