### PR TITLE
refactor: replace convertToUTC boolean with timezone string in formatting functions

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1539,7 +1539,7 @@ export class AsyncQueryService extends ProjectService {
                                   ? formatItemValue(
                                         field,
                                         row[c.reference],
-                                        false,
+                                        undefined,
                                     )
                                   : String(rawValue);
                               return {

--- a/packages/common/src/ee/AiAgent/chartConfig/web/shared/formatPivotValueLabel.ts
+++ b/packages/common/src/ee/AiAgent/chartConfig/web/shared/formatPivotValueLabel.ts
@@ -19,7 +19,7 @@ export const formatPivotValueLabel = (
     const pivotValue = pivotReference.pivotValues[0].value;
 
     if (pivotField && isField(pivotField)) {
-        return formatItemValue(pivotField, pivotValue, false, undefined);
+        return formatItemValue(pivotField, pivotValue, undefined, undefined);
     }
 
     return friendlyName(String(pivotValue));

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -747,6 +747,7 @@ export function formatRow(
     itemsMap: ItemsMap,
     pivotValuesColumns?: Record<string, PivotValuesColumn> | null,
     parameters?: Record<string, unknown>,
+    timezone?: string,
 ): ResultRow {
     const resultRow: ResultRow = {};
     const columnNames = Object.keys(row || {});
@@ -759,7 +760,7 @@ export function formatRow(
         resultRow[columnName] = {
             value: {
                 raw: formatRawValue(item, value),
-                formatted: formatItemValue(item, value, false, parameters),
+                formatted: formatItemValue(item, value, timezone, parameters),
             },
         };
     }
@@ -772,9 +773,10 @@ export function formatRows(
     itemsMap: ItemsMap,
     pivotValuesColumns?: Record<string, PivotValuesColumn> | null,
     parameters?: Record<string, unknown>,
+    timezone?: string,
 ): ResultRow[] {
     return rows.map((row) =>
-        formatRow(row, itemsMap, pivotValuesColumns, parameters),
+        formatRow(row, itemsMap, pivotValuesColumns, parameters, timezone),
     );
 }
 

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -259,7 +259,12 @@ const combinedRetrofit = (
         if (!isSummable(item)) {
             return null;
         }
-        const formattedValue = formatItemValue(item, total, false, undefined);
+        const formattedValue = formatItemValue(
+            item,
+            total,
+            undefined,
+            undefined,
+        );
 
         return {
             raw: total,
@@ -274,7 +279,12 @@ const combinedRetrofit = (
         if (!field || !field.fieldId) throw new Error('Invalid pivot data');
         const item = getField(field.fieldId);
 
-        const formattedValue = formatItemValue(item, total, false, undefined);
+        const formattedValue = formatItemValue(
+            item,
+            total,
+            undefined,
+            undefined,
+        );
 
         return {
             raw: total,
@@ -1024,7 +1034,7 @@ export const convertSqlPivotedRowsToPivotData = ({
                         ? formatItemValue(
                               field,
                               pivotValue.value,
-                              true,
+                              'UTC',
                               undefined,
                           )
                         : String(pivotValue.value));
@@ -1402,7 +1412,7 @@ export const convertSqlPivotedRowsToPivotData = ({
                         ? formatItemValue(
                               field,
                               rowTotalValue,
-                              false,
+                              undefined,
                               undefined,
                           )
                         : String(rowTotalValue);

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -305,9 +305,8 @@ export const getFilterRuleWithDefaultValue = <T extends FilterRule>(
                               fieldTimeInterval === TimeFrames.QUARTER
                                   ? undefined
                                   : fieldTimeInterval, // Use the field's time interval if it has one
-                              false,
                           )
-                        : formatDate(defaultDate, undefined, false);
+                        : formatDate(defaultDate);
 
                     filterRuleDefaults.values = [dateValue];
                 }

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1,5 +1,5 @@
 import dayjs from 'dayjs';
-import moment from 'moment';
+import moment from 'moment-timezone';
 import {
     Compact,
     CustomFormatType,
@@ -16,8 +16,10 @@ import {
     applyDefaultFormat,
     convertCustomFormatToFormatExpression,
     currencies,
+    formatDate,
     formatItemValue,
     formatNumberValue,
+    formatTimestamp,
     formatValueWithExpression,
     getCustomFormatFromLegacy,
     isMomentInput,
@@ -1593,7 +1595,7 @@ describe('Formatting', () => {
                     formatItemValue(
                         metricWithConditionalFormat,
                         1234.56,
-                        false,
+                        undefined,
                         parameters,
                     ),
                 ).toBe('$1,234.56');
@@ -1611,7 +1613,7 @@ describe('Formatting', () => {
                     formatItemValue(
                         metricWithConditionalFormat,
                         1234.56,
-                        false,
+                        undefined,
                         parameters,
                     ),
                 ).toBe('€1,234.56');
@@ -1625,15 +1627,25 @@ describe('Formatting', () => {
                 };
 
                 expect(
-                    formatItemValue(metricWithSimpleFormat, 1234.56, false, {
-                        symbol: '£',
-                    }),
+                    formatItemValue(
+                        metricWithSimpleFormat,
+                        1234.56,
+                        undefined,
+                        {
+                            symbol: '£',
+                        },
+                    ),
                 ).toBe('£1,234.56');
 
                 expect(
-                    formatItemValue(metricWithSimpleFormat, 1234.56, false, {
-                        symbol: '¥',
-                    }),
+                    formatItemValue(
+                        metricWithSimpleFormat,
+                        1234.56,
+                        undefined,
+                        {
+                            symbol: '¥',
+                        },
+                    ),
                 ).toBe('¥1,234.56');
             });
 
@@ -1649,7 +1661,7 @@ describe('Formatting', () => {
                     formatItemValue(
                         metricWithConditionalFormat,
                         1234.56,
-                        false,
+                        undefined,
                         undefined,
                     ),
                 ).toBe('1,234.56');
@@ -1666,7 +1678,7 @@ describe('Formatting', () => {
                     formatItemValue(
                         metricWithConditionalFormat,
                         1234.567,
-                        false,
+                        undefined,
                         { precision: 'high' },
                     ),
                 ).toBe('$1,234.57');
@@ -1675,7 +1687,7 @@ describe('Formatting', () => {
                     formatItemValue(
                         metricWithConditionalFormat,
                         1234.567,
-                        false,
+                        undefined,
                         { precision: 'low' },
                     ),
                 ).toBe('$1,235');
@@ -1695,15 +1707,20 @@ describe('Formatting', () => {
                 };
 
                 expect(
-                    formatItemValue(metricWithLdPrefix, 1234.56, false, {
+                    formatItemValue(metricWithLdPrefix, 1234.56, undefined, {
                         symbol: '$',
                     }),
                 ).toBe('$1,234.56');
 
                 expect(
-                    formatItemValue(metricWithLightdashPrefix, 1234.56, false, {
-                        symbol: '€',
-                    }),
+                    formatItemValue(
+                        metricWithLightdashPrefix,
+                        1234.56,
+                        undefined,
+                        {
+                            symbol: '€',
+                        },
+                    ),
                 ).toBe('€1,234.56');
             });
 
@@ -1715,22 +1732,79 @@ describe('Formatting', () => {
                 };
 
                 expect(
-                    formatItemValue(metricWithFormat, 1000.5, false, {
+                    formatItemValue(metricWithFormat, 1000.5, undefined, {
                         symbol: '$',
                     }),
                 ).toBe('$1,000.50');
 
                 expect(
-                    formatItemValue(metricWithFormat, 1000.5, false, {
+                    formatItemValue(metricWithFormat, 1000.5, undefined, {
                         symbol: '€',
                     }),
                 ).toBe('€1,000.50');
 
                 expect(
-                    formatItemValue(metricWithFormat, 1000.5, false, {
+                    formatItemValue(metricWithFormat, 1000.5, undefined, {
                         symbol: '£',
                     }),
                 ).toBe('£1,000.50');
+            });
+        });
+    });
+
+    describe('timezone-aware date formatting', () => {
+        // 2020-04-04 02:00 UTC = 2020-04-03 22:00 New York (EDT, UTC-4)
+        const utcTimestamp = '2020-04-04T02:00:00.000Z';
+
+        describe('formatDate', () => {
+            test('formats in UTC when timezone is UTC', () => {
+                expect(formatDate(utcTimestamp, TimeFrames.DAY, 'UTC')).toBe(
+                    '2020-04-04',
+                );
+            });
+
+            test('formats in specified timezone', () => {
+                expect(
+                    formatDate(
+                        utcTimestamp,
+                        TimeFrames.DAY,
+                        'America/New_York',
+                    ),
+                ).toBe('2020-04-03');
+            });
+
+            test('formats in process timezone when no timezone provided (flag off)', () => {
+                expect(formatDate(utcTimestamp, TimeFrames.DAY)).toBe(
+                    '2020-04-04',
+                );
+            });
+        });
+
+        describe('formatTimestamp', () => {
+            test('formats in UTC when timezone is UTC', () => {
+                expect(
+                    formatTimestamp(
+                        utcTimestamp,
+                        TimeFrames.MILLISECOND,
+                        'UTC',
+                    ),
+                ).toBe('2020-04-04, 02:00:00:000 (+00:00)');
+            });
+
+            test('formats in specified timezone', () => {
+                expect(
+                    formatTimestamp(
+                        utcTimestamp,
+                        TimeFrames.MILLISECOND,
+                        'America/New_York',
+                    ),
+                ).toBe('2020-04-03, 22:00:00:000 (-04:00)');
+            });
+
+            test('formats in process timezone when no timezone provided (flag off)', () => {
+                expect(
+                    formatTimestamp(utcTimestamp, TimeFrames.MILLISECOND),
+                ).toBe('2020-04-04, 02:00:00:000 (+00:00)');
             });
         });
     });

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
-import timezone from 'dayjs/plugin/timezone';
-import moment, { type MomentInput } from 'moment';
+import dayjsTimezone from 'dayjs/plugin/timezone';
+import moment, { type MomentInput } from 'moment-timezone';
 import {
     format as formatWithExpression,
     isDateFormat,
@@ -42,7 +42,7 @@ import assertUnreachable from './assertUnreachable';
 import { evaluateConditionalFormatExpression } from './conditionalFormatExpressions';
 import { getItemType, isNumericItem } from './item';
 
-dayjs.extend(timezone);
+dayjs.extend(dayjsTimezone);
 
 export const currencies = [
     'USD',
@@ -134,9 +134,9 @@ export const isMomentInput = (value: unknown): value is MomentInput =>
 export function formatDate(
     date: MomentInput,
     timeInterval: TimeFrames = TimeFrames.DAY,
-    convertToUTC: boolean = false,
+    timezone?: string,
 ): string {
-    const momentDate = convertToUTC ? moment(date).utc() : moment(date);
+    const momentDate = timezone ? moment.utc(date).tz(timezone) : moment(date);
 
     if (!momentDate.isValid()) {
         return 'NaT';
@@ -148,9 +148,11 @@ export function formatDate(
 export function formatTimestamp(
     value: MomentInput,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,
-    convertToUTC: boolean = false,
+    timezone?: string,
 ): string {
-    const momentDate = convertToUTC ? moment(value).utc() : moment(value);
+    const momentDate = timezone
+        ? moment.utc(value).tz(timezone)
+        : moment(value);
 
     if (!momentDate.isValid()) {
         return 'NaT';
@@ -487,7 +489,7 @@ export function applyCustomFormat(
             format.type,
         )
     ) {
-        return formatTimestamp(value, undefined, false);
+        return formatTimestamp(value);
     }
 
     if (valueIsNaN(value) || value === null) {
@@ -513,9 +515,9 @@ export function applyCustomFormat(
 
             return `${currencyFormatted}${compactSuffix}`;
         case CustomFormatType.DATE:
-            return formatDate(value, format?.timeInterval, false);
+            return formatDate(value, format?.timeInterval);
         case CustomFormatType.TIMESTAMP:
-            return formatTimestamp(value, format?.timeInterval, false);
+            return formatTimestamp(value, format?.timeInterval);
         case CustomFormatType.NUMBER:
             const prefix = format.prefix || '';
             const suffix = format.suffix || '';
@@ -770,7 +772,7 @@ export function formatItemValue(
         | CustomDimension
         | undefined,
     value: unknown,
-    convertToUTC?: boolean,
+    timezone?: string,
     parameters?: Record<string, unknown>,
 ): string {
     if (value === null) return '∅';
@@ -837,7 +839,7 @@ export function formatItemValue(
                         ? formatDate(
                               value,
                               isDimension(item) ? item.timeInterval : undefined,
-                              convertToUTC,
+                              timezone,
                           )
                         : 'NaT';
                 case DimensionType.TIMESTAMP:
@@ -847,7 +849,7 @@ export function formatItemValue(
                         ? formatTimestamp(
                               value,
                               isDimension(item) ? item.timeInterval : undefined,
-                              convertToUTC,
+                              timezone,
                           )
                         : 'NaT';
                 case MetricType.MAX:
@@ -856,7 +858,7 @@ export function formatItemValue(
                         return formatTimestamp(
                             value,
                             isDimension(item) ? item.timeInterval : undefined,
-                            convertToUTC,
+                            timezone,
                         );
                     }
                     break;

--- a/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
+++ b/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
@@ -72,7 +72,7 @@ export const getCartesianAxisFormatterConfig = ({
     if (axisItem && (hasFormattingConfig || axisMinInterval)) {
         axisConfig.axisLabel = {
             formatter: (value: AnyType) =>
-                formatItemValue(axisItem, value, true, parameters),
+                formatItemValue(axisItem, value, 'UTC', parameters),
         };
         axisConfig.axisPointer = {
             label: {
@@ -84,7 +84,7 @@ export const getCartesianAxisFormatterConfig = ({
                         ? formatItemValue(
                               axisItem,
                               value.value,
-                              true,
+                              'UTC',
                               parameters,
                           )
                         : undefined,
@@ -109,7 +109,7 @@ export const getCartesianAxisFormatterConfig = ({
                         ? formatItemValue(
                               axisItem,
                               value.value,
-                              true,
+                              'UTC',
                               parameters,
                           )
                         : undefined,
@@ -122,7 +122,7 @@ export const getCartesianAxisFormatterConfig = ({
     ) {
         axisConfig.axisLabel = {
             formatter: (value: AnyType) =>
-                formatItemValue(axisItem, value, false, parameters),
+                formatItemValue(axisItem, value, undefined, parameters),
         };
         axisConfig.axisPointer = {
             label: {
@@ -134,7 +134,7 @@ export const getCartesianAxisFormatterConfig = ({
                         ? formatItemValue(
                               axisItem,
                               value.value,
-                              false,
+                              undefined,
                               parameters,
                           )
                         : undefined,
@@ -153,7 +153,7 @@ export const getCartesianAxisFormatterConfig = ({
             case TimeFrames.WEEK:
                 axisConfig.axisLabel = {
                     formatter: (value: AnyType) =>
-                        formatItemValue(axisItem, value, true, parameters),
+                        formatItemValue(axisItem, value, 'UTC', parameters),
                 };
 
                 axisConfig.axisPointer = {
@@ -166,7 +166,7 @@ export const getCartesianAxisFormatterConfig = ({
                                 ? formatItemValue(
                                       axisItem,
                                       value.value,
-                                      true,
+                                      'UTC',
                                       parameters,
                                   )
                                 : undefined,

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -362,7 +362,7 @@ const getHeader = (
     const rawAxisValue = firstParam?.axisValue;
     if (rawAxisValue !== undefined && rawAxisValue !== null) {
         if (itemsMap && xFieldId) {
-            return getFormattedValue(rawAxisValue, xFieldId, itemsMap, true);
+            return getFormattedValue(rawAxisValue, xFieldId, itemsMap, 'UTC');
         }
         return String(rawAxisValue);
     }
@@ -374,7 +374,7 @@ const getHeader = (
         if (xValue !== undefined && xValue !== null) {
             // Use getFormattedValue for consistent formatting with axis labels
             if (itemsMap && xFieldId) {
-                return getFormattedValue(xValue, xFieldId, itemsMap, true);
+                return getFormattedValue(xValue, xFieldId, itemsMap, 'UTC');
             }
             return String(xValue);
         }
@@ -1306,7 +1306,7 @@ export const buildCartesianTooltipFormatter =
                 const headerText = formatItemValue(
                     field,
                     header,
-                    false,
+                    undefined,
                     parameters,
                 );
                 return `${formatTooltipHeader(

--- a/packages/common/src/visualizations/helpers/valueFormatter.ts
+++ b/packages/common/src/visualizations/helpers/valueFormatter.ts
@@ -8,13 +8,13 @@ export const getFormattedValue = (
     value: AnyType,
     key: string,
     itemsMap: ItemsMap,
-    convertToUTC: boolean = true,
+    timezone?: string,
     pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
     parameters?: ParametersValuesMap,
 ): string => {
     const pivotValuesColumn = pivotValuesColumnsMap?.[key];
     const item = itemsMap[pivotValuesColumn?.referenceField ?? key];
-    return formatItemValue(item, value, convertToUTC, parameters);
+    return formatItemValue(item, value, timezone, parameters);
 };
 
 export const valueFormatter =

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -385,7 +385,7 @@ const SimpleChart: FC<SimpleChartProps> = memo(
                                                           axisValue,
                                                           dim,
                                                           itemsMap,
-                                                          true,
+                                                          'UTC',
                                                       )
                                                     : axisValue;
 

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Legend/ReferenceLine.tsx
@@ -111,7 +111,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                                     formatDate(
                                         dateValue,
                                         TimeFrames.WEEK,
-                                        false,
+                                        undefined,
                                     ),
                                 );
                             }}
@@ -128,7 +128,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                                     formatDate(
                                         dateValue,
                                         TimeFrames.MONTH,
-                                        false,
+                                        undefined,
                                     ),
                                 );
                             }}
@@ -146,7 +146,7 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                                     formatDate(
                                         dateValue,
                                         TimeFrames.YEAR,
-                                        false,
+                                        undefined,
                                     ),
                                 );
                             }}
@@ -161,7 +161,9 @@ const ReferenceLineValue: FC<ReferenceLineValueProps> = ({
                     value={parsedDate}
                     firstDayOfWeek={getFirstDayOfWeek(startOfWeek)}
                     onChange={(newValue) => {
-                        onChange(formatDate(newValue, TimeFrames.DAY, false));
+                        onChange(
+                            formatDate(newValue, TimeFrames.DAY, undefined),
+                        );
                     }}
                 />
             );

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -53,7 +53,7 @@ const getFormatterValue = (
     items: Array<Field | TableCalculation | CustomDimension>,
 ) => {
     const item = items.find((i) => getItemId(i) === key);
-    return formatItemValue(item, value, true);
+    return formatItemValue(item, value, 'UTC');
 };
 
 type DraggablePortalHandlerProps = {

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -62,7 +62,7 @@ const Parameter: FC<Props> = ({
                 ) {
                     const date = parseDate(defaultVal, TimeFrames.DAY);
                     return date
-                        ? formatDate(date, TimeFrames.DAY, false)
+                        ? formatDate(date, TimeFrames.DAY, undefined)
                         : defaultVal;
                 }
                 if (Array.isArray(defaultVal)) {
@@ -75,7 +75,7 @@ const Parameter: FC<Props> = ({
 
         if (parameter.type === 'date' && typeof value === 'string') {
             const date = parseDate(value, TimeFrames.DAY);
-            return date ? formatDate(date, TimeFrames.DAY, false) : value;
+            return date ? formatDate(date, TimeFrames.DAY, undefined) : value;
         }
 
         if (Array.isArray(value)) {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -696,7 +696,7 @@ const seriesValueFormatter = (
         return value;
     }
     if (isTableCalculation(item)) {
-        return formatItemValue(item, value, false, parameters);
+        return formatItemValue(item, value, undefined, parameters);
     } else {
         const defaultFormatOptions = getCustomFormatFromLegacy({
             format: item.format,

--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -45,7 +45,7 @@ const getValueAndPercentage = ({
     maxValue: number;
     parameters?: Record<string, unknown>;
 }) => {
-    const formattedValue = formatItemValue(field, value, false, parameters);
+    const formattedValue = formatItemValue(field, value, undefined, parameters);
 
     const percentOfMax = round((Number(value) / maxValue) * 100, 2);
     return { formattedValue, percentOfMax };

--- a/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
@@ -274,7 +274,7 @@ const useEchartsGaugeConfig = ({
                         return formatItemValue(
                             fieldItem,
                             value,
-                            false,
+                            undefined,
                             parameters,
                         );
                     }
@@ -300,7 +300,7 @@ const useEchartsGaugeConfig = ({
                     const formattedValue = formatItemValue(
                         fieldItem,
                         value,
-                        false,
+                        undefined,
                         parameters,
                     );
 

--- a/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsPieConfig.ts
@@ -195,7 +195,7 @@ const useEchartsPieConfig = (
                     const formattedValue = formatItemValue(
                         selectedMetric,
                         value,
-                        false,
+                        undefined,
                         parameters,
                     );
 

--- a/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsSankeyConfig.ts
@@ -124,7 +124,7 @@ const useEchartsSankeyConfig = (isInDashboard?: boolean) => {
                         const formattedValue = formatItemValue(
                             metricField,
                             params.value,
-                            false,
+                            undefined,
                             parameters,
                         );
                         const source = stripStepSuffix(params.data.source);

--- a/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
@@ -48,7 +48,7 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
             return formatItemValue(
                 itemsMap?.[metricId],
                 value,
-                false,
+                undefined,
                 parameters,
             );
         };

--- a/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
+++ b/packages/frontend/src/hooks/tableVisualization/getDataAndColumns.tsx
@@ -197,7 +197,7 @@ const getDataAndColumns = ({
                             ? formatItemValue(
                                   item,
                                   totals[itemId],
-                                  false,
+                                  undefined,
                                   parameters,
                               )
                             : null,
@@ -264,7 +264,7 @@ const getDataAndColumns = ({
                                     {formatItemValue(
                                         item,
                                         subtotalValue,
-                                        false,
+                                        undefined,
                                         parameters,
                                     )}
                                 </Text>

--- a/packages/frontend/src/hooks/useBigNumberConfig.ts
+++ b/packages/frontend/src/hooks/useBigNumberConfig.ts
@@ -76,7 +76,7 @@ const formatComparisonValue = (
                 return `${prefix}${formatItemValue(
                     item,
                     value,
-                    false,
+                    undefined,
                     parameters,
                 )}`;
             }
@@ -90,12 +90,12 @@ const formatComparisonValue = (
                           compact: bigNumberComparisonStyle,
                       }),
                   )
-                : formatItemValue(item, value, false, parameters);
+                : formatItemValue(item, value, undefined, parameters);
 
             return `${prefix}${formattedValue}`;
         default:
             if (item !== undefined && isTableCalculation(item)) {
-                return formatItemValue(item, value, false, parameters);
+                return formatItemValue(item, value, undefined, parameters);
             }
             return bigNumberComparisonStyle
                 ? applyCustomFormat(
@@ -106,7 +106,7 @@ const formatComparisonValue = (
                           compact: bigNumberComparisonStyle,
                       }),
                   )
-                : formatItemValue(item, value, false, parameters);
+                : formatItemValue(item, value, undefined, parameters);
     }
 };
 
@@ -308,13 +308,23 @@ const useBigNumberConfig = (
                 resultsData?.rows?.[0]?.[selectedField]?.value.formatted
             );
         } else if (item !== undefined && isTableCalculation(item)) {
-            return formatItemValue(item, firstRowValueRaw, false, parameters);
+            return formatItemValue(
+                item,
+                firstRowValueRaw,
+                undefined,
+                parameters,
+            );
         } else if (
             item !== undefined &&
             hasValidFormatExpression(item) &&
             !bigNumberStyle // If the big number has a comparison style, don't use the format expression returned by the backend
         ) {
-            return formatItemValue(item, firstRowValueRaw, false, parameters);
+            return formatItemValue(
+                item,
+                firstRowValueRaw,
+                undefined,
+                parameters,
+            );
         } else if (item !== undefined && hasFormatOptions(item)) {
             // Custom metrics case
 

--- a/packages/frontend/src/hooks/useColumns.tsx
+++ b/packages/frontend/src/hooks/useColumns.tsx
@@ -81,7 +81,7 @@ export const formatCellContent = (
             item.format.includes('${lightdash.parameters'));
 
     if (hasParameterFormat && parameters) {
-        return formatItemValue(item, data.value.raw, false, parameters);
+        return formatItemValue(item, data.value.raw, undefined, parameters);
     }
 
     // Use backend-formatted value by default
@@ -577,7 +577,7 @@ export const useColumns = (): TableColumn[] => {
                         return formatItemValue(
                             currentItem,
                             cellValue.value.raw,
-                            false,
+                            undefined,
                             parameters,
                         );
                     },
@@ -586,7 +586,7 @@ export const useColumns = (): TableColumn[] => {
                             ? formatItemValue(
                                   item,
                                   totals[fieldId],
-                                  false,
+                                  undefined,
                                   parameters,
                               )
                             : null,

--- a/packages/frontend/src/hooks/usePieChartConfig.ts
+++ b/packages/frontend/src/hooks/usePieChartConfig.ts
@@ -301,7 +301,7 @@ const usePieChartConfig: PieChartConfigFn = (
                         formatted: formatItemValue(
                             selectedMetric,
                             value,
-                            false,
+                            undefined,
                             parameters,
                         ),
                         raw: value,


### PR DESCRIPTION
relates to: https://linear.app/lightdash/issue/GLITCH-291/update-result-formatting-to-use-resolved-project-timezone

Pure signature refactor — no behavior change.

Replaces `convertToUTC: boolean` with `timezone?: string` in `formatDate`, `formatTimestamp`, `formatItemValue`, `formatRow`, `formatRows`, `getFormattedValue`, and all callers.

- `true` → `'UTC'` (same behavior via `moment.utc()`)
- `false` → `undefined` (same behavior via `moment()`)

This prepares the formatting stack to accept a project timezone string in the next PR.