### PR TITLE
fix: sql format duckdb sql

### DIFF
--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -3,16 +3,14 @@ import {
     ExploreType,
     FieldType,
     MetricType,
+    PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
     SupportedDbtAdapter,
     TimeFrames,
     type CompiledDimension,
     type CompiledMetric,
     type Explore,
 } from '@lightdash/common';
-import {
-    buildPreAggregateExplore,
-    PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
-} from './buildPreAggregateExplore';
+import { buildPreAggregateExplore } from './buildPreAggregateExplore';
 
 const makeDimension = ({
     name,

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -7,6 +7,7 @@ import {
     getPreAggregateMetricComponentColumnName,
     getSqlForTruncatedDate,
     MetricType,
+    PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
     PreAggregateMetricRepresentationKind,
     preAggregateUtils,
     SupportedDbtAdapter,
@@ -352,9 +353,6 @@ const getEmptyTable = (
     dimensions: {},
     metrics: {},
 });
-
-export const PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER =
-    '${materialized_table}';
 
 export const buildPreAggregateExplore = (
     sourceExplore: Explore,

--- a/packages/backend/src/ee/preAggregates/postProcessor.test.ts
+++ b/packages/backend/src/ee/preAggregates/postProcessor.test.ts
@@ -4,6 +4,7 @@ import {
     DimensionType,
     ExploreType,
     InlineErrorType,
+    PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
     SupportedDbtAdapter,
     TimeFrames,
     type Explore,
@@ -14,7 +15,6 @@ import {
     MODEL_WITH_DEFAULT_SHOW_UNDERLYING_VALUES,
     MODEL_WITH_METRIC,
 } from '@lightdash/common/src/compiler/translator.mock';
-import { PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER } from './buildPreAggregateExplore';
 import { preAggregatePostProcessor } from './postProcessor';
 
 describe('pre-aggregates metadata parsing', () => {

--- a/packages/common/src/ee/preAggregates/naming.ts
+++ b/packages/common/src/ee/preAggregates/naming.ts
@@ -2,6 +2,9 @@ import type { TimeFrames } from '../../types/timeFrames';
 
 export const PRE_AGGREGATE_EXPLORE_PREFIX = '__preagg__';
 
+export const PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER =
+    '${materialized_table}';
+
 export const getPreAggregateExploreName = (
     exploreName: string,
     preAggregateName: string,

--- a/packages/common/src/ee/preAggregates/types.ts
+++ b/packages/common/src/ee/preAggregates/types.ts
@@ -6,6 +6,7 @@ export {
     getPreAggregateMetricComponentColumnName,
     getPreAggregateTimeDimensionColumnName,
     PRE_AGGREGATE_EXPLORE_PREFIX,
+    PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
 } from './naming';
 export { type PreAggregateMatchResult } from './matcher';
 export {


### PR DESCRIPTION
### Description:

Move `PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER` constant from backend module to common package for better code organization and reusability. The constant is now exported from `@lightdash/common` and imported where needed, eliminating the need to import it from the backend-specific module in test files.