### PR TITLE
fix: improve chart resize performance with ResizeObserver and requestAnimationFrame throttling

### DIFF
--- a/packages/frontend/src/components/SimpleSankey/index.tsx
+++ b/packages/frontend/src/components/SimpleSankey/index.tsx
@@ -56,11 +56,29 @@ const SimpleSankey: FC<SimpleSankeyProps> = memo(
         }, [resultsData]);
 
         useEffect(() => {
-            const listener = () =>
-                chartRef.current?.getEchartsInstance().resize();
-            window.addEventListener('resize', listener);
-            return () => window.removeEventListener('resize', listener);
-        });
+            const eCharts = chartRef.current?.getEchartsInstance();
+            const dom = eCharts?.getDom();
+            if (!eCharts || !dom) return;
+
+            let rafId: number | null = null;
+            const resizeChart = () => {
+                if (rafId !== null) return;
+                rafId = requestAnimationFrame(() => {
+                    eCharts.resize();
+                    rafId = null;
+                });
+            };
+
+            const observer = new ResizeObserver(resizeChart);
+            observer.observe(dom);
+            window.addEventListener('resize', resizeChart);
+
+            return () => {
+                window.removeEventListener('resize', resizeChart);
+                observer.disconnect();
+                if (rafId !== null) cancelAnimationFrame(rafId);
+            };
+        }, [chartRef, sankeyChartOptions]);
 
         if (isLoading) return <LoadingChart />;
         if (!sankeyChartOptions) return <EmptyChart />;

--- a/packages/frontend/src/components/SimpleTreemap/index.tsx
+++ b/packages/frontend/src/components/SimpleTreemap/index.tsx
@@ -50,11 +50,29 @@ const SimpleTreemap: FC<SimpleTreemapProps> = memo(
         }, [resultsData]);
 
         useEffect(() => {
-            const listener = () =>
-                chartRef.current?.getEchartsInstance().resize();
-            window.addEventListener('resize', listener);
-            return () => window.removeEventListener('resize', listener);
-        });
+            const eCharts = chartRef.current?.getEchartsInstance();
+            const dom = eCharts?.getDom();
+            if (!eCharts || !dom) return;
+
+            let rafId: number | null = null;
+            const resizeChart = () => {
+                if (rafId !== null) return;
+                rafId = requestAnimationFrame(() => {
+                    eCharts.resize();
+                    rafId = null;
+                });
+            };
+
+            const observer = new ResizeObserver(resizeChart);
+            observer.observe(dom);
+            window.addEventListener('resize', resizeChart);
+
+            return () => {
+                window.removeEventListener('resize', resizeChart);
+                observer.disconnect();
+                if (rafId !== null) cancelAnimationFrame(rafId);
+            };
+        }, [chartRef, treemapOptions]);
 
         if (isLoading) return <LoadingChart />;
         if (!treemapOptions) return <EmptyChart />;


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://github.com/lightdash/lightdash/issues/21755

### Description:

Improved chart resizing performance in SimpleSankey and SimpleTreemap components by implementing throttled resize handling with `requestAnimationFrame` and adding `ResizeObserver` support. The changes replace the basic window resize listener with a more efficient approach that prevents excessive resize calls and also detects container size changes beyond just window resizing.

Key improvements:
- Added `requestAnimationFrame` throttling to prevent multiple resize calls per frame
- Implemented `ResizeObserver` to detect container size changes in addition to window resizing  
- Added proper cleanup for animation frames and observers
- Fixed missing dependency arrays in the `useEffect` hooks

<!-- Even better add a screenshot / gif / loom -->