### PR TITLE
fix: add embedToken to treemap chart config for embed support

### DIFF
--- a/packages/frontend/src/hooks/useTreemapChartConfig.ts
+++ b/packages/frontend/src/hooks/useTreemapChartConfig.ts
@@ -11,6 +11,7 @@ import type {
     TreemapChart,
 } from '@lightdash/common';
 import { useCallback, useEffect, useMemo, useState } from 'react';
+import useEmbed from '../ee/providers/Embed/useEmbed';
 import { useCalculateSubtotals } from './useCalculateSubtotals';
 import { type InfiniteQueryResults } from './useQueryResults';
 
@@ -86,6 +87,8 @@ const useTreemapChartConfig: TreemapChartConfigFn = (
     tableCalculationsMetadata,
     parameters,
 ) => {
+    const { embedToken } = useEmbed();
+
     const [visibleMin, setVisibleMin] = useState(
         treemapConfig?.visibleMin ?? 100,
     );
@@ -218,6 +221,7 @@ const useTreemapChartConfig: TreemapChartConfigFn = (
         columnOrder: groupFieldIds,
         pivotDimensions: undefined,
         parameters,
+        embedToken,
     });
 
     const data = useMemo(() => {


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-6802/treemaps-do-not-render-in-embedded-iframe-environments

Before
<img width="1776" height="980" alt="Screenshot 2026-04-06 at 10 04 02" src="https://github.com/user-attachments/assets/485ffeae-0ca1-4487-bf50-061dc0f499e1" />


After

<img width="1776" height="980" alt="Screenshot 2026-04-06 at 10 04 57" src="https://github.com/user-attachments/assets/6891146a-d338-4f71-af92-6ebe7ed5bfeb" />


### Description:
Add embed token support to treemap chart configuration by integrating the `useEmbed` hook and passing the `embedToken` to the `useCalculateSubtotals` hook. This enables treemap charts to work properly in embedded contexts where authentication tokens are required for data access.

<!-- Even better add a screenshot / gif / loom -->