### PR TITLE
fix: exclude BigQuery from UTC offset in filter timestamp literals

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -61,7 +61,8 @@ const formatTimestampAsUTC = (date: Date): string =>
     moment(date).utc().format('YYYY-MM-DD HH:mm:ssZ');
 
 // ClickHouse's date_time_input_format may be set to 'basic', which cannot
-// parse timezone offsets like +00:00. The value is already computed as UTC.
+// parse timezone offsets like +00:00. BigQuery's DATETIME type also rejects
+// timezone offsets. Both already interpret bare strings correctly as UTC.
 const formatTimestampAsUTCNoOffset = (date: Date): string =>
     moment(date).utc().format('YYYY-MM-DD HH:mm:ss');
 
@@ -634,7 +635,8 @@ export const renderFilterRuleSql = (
                 escapedFilterRule,
                 adapterType,
                 timezone,
-                adapterType === SupportedDbtAdapter.CLICKHOUSE
+                adapterType === SupportedDbtAdapter.CLICKHOUSE ||
+                    adapterType === SupportedDbtAdapter.BIGQUERY
                     ? formatTimestampAsUTCNoOffset
                     : formatTimestampAsUTC,
                 startOfWeek,


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21761

## Problem

PR #21670 added `+00:00` UTC offset to filter timestamp literals to fix timezone issues on Postgres/Databricks. However, BigQuery's `DATETIME` type rejects timezone offsets, causing `Could not cast literal "..." to type DATETIME` errors.

## Fix

Exclude BigQuery from the UTC offset formatter (same as ClickHouse). BigQuery already interprets bare timestamp strings as UTC correctly.

**Before**
<img width="2145" height="1025" alt="CleanShot 2026-04-06 at 10 51 33" src="https://github.com/user-attachments/assets/cf799f6a-a5bd-4a45-b393-34ba4402e0f8" />

**After**
<img width="2149" height="1207" alt="CleanShot 2026-04-06 at 10 52 47" src="https://github.com/user-attachments/assets/55483802-026a-4e97-b477-6b40a9ecd0fc" />
