### PR TITLE
fix: scope autocomplete filter overlap check to active tab tiles

### DIFF
--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -1,6 +1,4 @@
 import {
-    getItemId,
-    isField,
     type DashboardFilterableField,
     type DashboardFilters,
     type DashboardTile,
@@ -11,9 +9,8 @@ import {
 } from '@lightdash/common';
 import { type PopoverProps } from '@mantine/core';
 import { useCallback, type ReactNode } from 'react';
-import { v4 as uuid4 } from 'uuid';
-import { doesFilterApplyToTile } from '../../../features/dashboardFilters/FilterConfiguration/utils';
 import Context, { type DefaultFieldsMap } from './context';
+import { getAutocompleteFilterGroup } from './utils/getAutocompleteFilterGroup';
 
 type Props<T extends DefaultFieldsMap> = {
     projectUuid?: string;
@@ -25,6 +22,7 @@ type Props<T extends DefaultFieldsMap> = {
     filterableFieldsByTileUuid?: Record<string, DashboardFilterableField[]>;
     popoverProps?: Omit<PopoverProps, 'children'>;
     parameterValues?: ParametersValuesMap;
+    activeTabUuid?: string;
     children?: ReactNode;
 };
 
@@ -38,6 +36,7 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
     filterableFieldsByTileUuid,
     popoverProps,
     parameterValues,
+    activeTabUuid,
     children,
 }: Props<T>) => {
     const getField = useCallback(
@@ -49,94 +48,24 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
         [itemsMap],
     );
 
-    const getAutocompleteFilterGroup = useCallback(
-        (filterId: string, item: FilterableItem) => {
-            if (!dashboardFilters || !isField(item)) {
-                return undefined;
-            }
-
-            const currentFieldId = getItemId(item);
-
-            // Find the current filter to get its tileTargets
-            const currentFilter = dashboardFilters.dimensions.find(
-                (f) => f.id === filterId,
-            );
-
-            // Get tiles that the current filter applies to
-            const currentFilterTileUuids =
-                dashboardTiles && filterableFieldsByTileUuid
-                    ? new Set(
-                          dashboardTiles
-                              .filter((tile) => {
-                                  // For new filters (not yet in dashboardFilters),
-                                  // check if tile has the field
-                                  if (!currentFilter) {
-                                      const tileFields =
-                                          filterableFieldsByTileUuid[tile.uuid];
-                                      return tileFields?.some(
-                                          (f) =>
-                                              getItemId(f) === currentFieldId,
-                                      );
-                                  }
-                                  // For existing filters, use doesFilterApplyToTile
-                                  return doesFilterApplyToTile(
-                                      currentFilter,
-                                      tile,
-                                      filterableFieldsByTileUuid,
-                                  );
-                              })
-                              .map((tile) => tile.uuid),
-                      )
-                    : null;
-
-            return {
-                id: uuid4(),
-                and: dashboardFilters.dimensions.filter(
-                    (dimensionFilterRule) => {
-                        // Exclude the current filter itself
-                        if (dimensionFilterRule.id === filterId) {
-                            return false;
-                        }
-
-                        // Exclude same-field filters - otherwise the autocomplete
-                        // would be over-restricted (e.g., if Status=completed is set,
-                        // another Status filter would only see "completed").
-                        if (
-                            dimensionFilterRule.target.fieldId ===
-                            currentFieldId
-                        ) {
-                            return false;
-                        }
-
-                        // For different-field filters, exclude if no tile overlap.
-                        // Filters on different tabs shouldn't affect each other's
-                        // autocomplete queries.
-                        if (
-                            currentFilterTileUuids &&
-                            dashboardTiles &&
-                            filterableFieldsByTileUuid
-                        ) {
-                            const hasOverlap = dashboardTiles.some(
-                                (tile) =>
-                                    currentFilterTileUuids.has(tile.uuid) &&
-                                    doesFilterApplyToTile(
-                                        dimensionFilterRule,
-                                        tile,
-                                        filterableFieldsByTileUuid,
-                                    ),
-                            );
-                            if (!hasOverlap) {
-                                return false;
-                            }
-                        }
-
-                        return true;
-                    },
-                ),
-            };
-        },
-        [dashboardFilters, dashboardTiles, filterableFieldsByTileUuid],
+    const getAutocompleteFilterGroupCallback = useCallback(
+        (filterId: string, item: FilterableItem) =>
+            getAutocompleteFilterGroup({
+                filterId,
+                item,
+                dashboardFilters,
+                dashboardTiles,
+                filterableFieldsByTileUuid,
+                activeTabUuid,
+            }),
+        [
+            dashboardFilters,
+            dashboardTiles,
+            filterableFieldsByTileUuid,
+            activeTabUuid,
+        ],
     );
+
     return (
         <Context.Provider
             value={{
@@ -145,7 +74,7 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
                 startOfWeek,
                 baseTable,
                 getField,
-                getAutocompleteFilterGroup,
+                getAutocompleteFilterGroup: getAutocompleteFilterGroupCallback,
                 popoverProps,
                 parameterValues,
             }}

--- a/packages/frontend/src/components/common/Filters/utils/getAutocompleteFilterGroup.test.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getAutocompleteFilterGroup.test.ts
@@ -1,0 +1,240 @@
+import {
+    DashboardTileTypes,
+    DimensionType,
+    FieldType,
+    FilterOperator,
+    type DashboardChartTile,
+    type DashboardFilterableField,
+    type DashboardFilterRule,
+    type DashboardFilters,
+    type DashboardTile,
+} from '@lightdash/common';
+import { describe, expect, it } from 'vitest';
+import { getAutocompleteFilterGroup } from './getAutocompleteFilterGroup';
+
+// --- Test fixtures ---
+
+const TAB_A_UUID = 'tab-a-uuid';
+const TAB_B_UUID = 'tab-b-uuid';
+
+const makeTile = (uuid: string, tabUuid: string): DashboardChartTile => ({
+    uuid,
+    type: DashboardTileTypes.SAVED_CHART,
+    x: 0,
+    y: 0,
+    h: 1,
+    w: 1,
+    tabUuid,
+    properties: {
+        savedChartUuid: uuid,
+        belongsToDashboard: true,
+        chartName: `Chart ${uuid}`,
+        lastVersionChartKind: null,
+    },
+});
+
+const tileA1 = makeTile('tile-a1', TAB_A_UUID);
+const tileA2 = makeTile('tile-a2', TAB_A_UUID);
+const tileB1 = makeTile('tile-b1', TAB_B_UUID);
+const tileB2 = makeTile('tile-b2', TAB_B_UUID);
+
+const allTiles: DashboardTile[] = [tileA1, tileA2, tileB1, tileB2];
+
+const makeField = (
+    fieldId: string,
+    table: string,
+): DashboardFilterableField => ({
+    name: fieldId.split('_').slice(1).join('_'),
+    type: DimensionType.STRING,
+    table,
+    tableLabel: table,
+    label: fieldId,
+    fieldType: FieldType.DIMENSION,
+    sql: fieldId,
+    hidden: false,
+});
+
+// All chart tiles have access to both orders and payments fields
+// (they're related tables in the same explore)
+const sharedFields = [
+    makeField('payments_payment_method', 'payments'),
+    makeField('orders_is_completed', 'orders'),
+    makeField('orders_order_date_year', 'orders'),
+    makeField('orders_status', 'orders'),
+];
+
+const filterableFieldsByTileUuid: Record<string, DashboardFilterableField[]> = {
+    'tile-a1': sharedFields,
+    'tile-a2': sharedFields,
+    'tile-b1': sharedFields,
+    'tile-b2': sharedFields,
+};
+
+// Global filter: payment_method (undefined tileTargets = applies to all tiles with field)
+const paymentMethodFilter: DashboardFilterRule = {
+    id: 'filter-payment-method',
+    target: { fieldId: 'payments_payment_method', tableName: 'payments' },
+    operator: FilterOperator.EQUALS,
+    values: [],
+    label: undefined,
+};
+
+// Tab B-scoped filter: is_completed = true (explicitly disabled on Tab A tiles)
+// Tiles not in tileTargets auto-apply if they have the field.
+const isCompletedFilter: DashboardFilterRule = {
+    id: 'filter-is-completed',
+    target: { fieldId: 'orders_is_completed', tableName: 'orders' },
+    operator: FilterOperator.EQUALS,
+    values: [true],
+    label: undefined,
+    tileTargets: {
+        'tile-a1': false,
+        'tile-a2': false,
+        // tile-b1 and tile-b2 not listed → auto-apply (have the field)
+    },
+};
+
+// Global filter: order_date (undefined tileTargets = applies to all tiles with field)
+const orderDateFilter: DashboardFilterRule = {
+    id: 'filter-order-date',
+    target: { fieldId: 'orders_order_date_year', tableName: 'orders' },
+    operator: FilterOperator.IN_THE_PAST,
+    values: [10],
+    settings: { completed: true, unitOfTime: 'years' },
+    label: undefined,
+};
+
+const dashboardFilters: DashboardFilters = {
+    dimensions: [paymentMethodFilter, isCompletedFilter, orderDateFilter],
+    metrics: [],
+    tableCalculations: [],
+};
+
+// --- Tests ---
+
+describe('getAutocompleteFilterGroup', () => {
+    it('excludes the current filter from the autocomplete group', () => {
+        const result = getAutocompleteFilterGroup({
+            filterId: paymentMethodFilter.id,
+            item: makeField('payments_payment_method', 'payments'),
+            dashboardFilters,
+            dashboardTiles: allTiles,
+            filterableFieldsByTileUuid,
+            activeTabUuid: TAB_A_UUID,
+        });
+
+        const filterIds = result?.and.map((f) => f.id);
+        expect(filterIds).not.toContain(paymentMethodFilter.id);
+    });
+
+    it('excludes same-field filters from the autocomplete group', () => {
+        const secondPaymentFilter: DashboardFilterRule = {
+            id: 'filter-payment-method-2',
+            target: {
+                fieldId: 'payments_payment_method',
+                tableName: 'payments',
+            },
+            operator: FilterOperator.NOT_EQUALS,
+            values: ['coupon'],
+            label: undefined,
+        };
+
+        const filters: DashboardFilters = {
+            ...dashboardFilters,
+            dimensions: [...dashboardFilters.dimensions, secondPaymentFilter],
+        };
+
+        const result = getAutocompleteFilterGroup({
+            filterId: paymentMethodFilter.id,
+            item: makeField('payments_payment_method', 'payments'),
+            dashboardFilters: filters,
+            dashboardTiles: allTiles,
+            filterableFieldsByTileUuid,
+            activeTabUuid: TAB_A_UUID,
+        });
+
+        const filterIds = result?.and.map((f) => f.id);
+        expect(filterIds).not.toContain(secondPaymentFilter.id);
+    });
+
+    it('includes global filters with tile overlap on the active tab', () => {
+        const result = getAutocompleteFilterGroup({
+            filterId: paymentMethodFilter.id,
+            item: makeField('payments_payment_method', 'payments'),
+            dashboardFilters,
+            dashboardTiles: allTiles,
+            filterableFieldsByTileUuid,
+            activeTabUuid: TAB_A_UUID,
+        });
+
+        const filterIds = result?.and.map((f) => f.id);
+        expect(filterIds).toContain(orderDateFilter.id);
+    });
+
+    it('excludes tab-scoped filters that do not apply to the active tab', () => {
+        // BUG REPRO: When on Tab A, the is_completed filter (scoped to Tab B
+        // only, with Tab A tiles set to false) should NOT be included in the
+        // autocomplete group for the payment_method filter.
+        const result = getAutocompleteFilterGroup({
+            filterId: paymentMethodFilter.id,
+            item: makeField('payments_payment_method', 'payments'),
+            dashboardFilters,
+            dashboardTiles: allTiles,
+            filterableFieldsByTileUuid,
+            activeTabUuid: TAB_A_UUID,
+        });
+
+        const filterIds = result?.and.map((f) => f.id);
+        expect(filterIds).not.toContain(isCompletedFilter.id);
+    });
+
+    it('includes tab-scoped filters when on the same tab', () => {
+        const statusFilter: DashboardFilterRule = {
+            id: 'filter-status',
+            target: { fieldId: 'orders_status', tableName: 'orders' },
+            operator: FilterOperator.EQUALS,
+            values: [],
+            label: undefined,
+            tileTargets: {
+                'tile-a1': false,
+                'tile-a2': false,
+                // tile-b1 and tile-b2 not listed → auto-apply
+            },
+        };
+
+        const filters: DashboardFilters = {
+            ...dashboardFilters,
+            dimensions: [...dashboardFilters.dimensions, statusFilter],
+        };
+
+        const result = getAutocompleteFilterGroup({
+            filterId: statusFilter.id,
+            item: makeField('orders_status', 'orders'),
+            dashboardFilters: filters,
+            dashboardTiles: allTiles,
+            filterableFieldsByTileUuid,
+            activeTabUuid: TAB_B_UUID,
+        });
+
+        const filterIds = result?.and.map((f) => f.id);
+        expect(filterIds).toContain(isCompletedFilter.id);
+    });
+
+    it('works without tabs (activeTabUuid undefined)', () => {
+        // When there are no tabs, all tiles are considered for overlap.
+        // is_completed applies to tile-b1/b2, payment_method applies to all,
+        // so overlap exists on tile-b1/b2.
+        const result = getAutocompleteFilterGroup({
+            filterId: paymentMethodFilter.id,
+            item: makeField('payments_payment_method', 'payments'),
+            dashboardFilters,
+            dashboardTiles: allTiles,
+            filterableFieldsByTileUuid,
+            activeTabUuid: undefined,
+        });
+
+        const filterIds = result?.and.map((f) => f.id);
+        expect(filterIds).toContain(isCompletedFilter.id);
+        expect(filterIds).toContain(orderDateFilter.id);
+    });
+});

--- a/packages/frontend/src/components/common/Filters/utils/getAutocompleteFilterGroup.ts
+++ b/packages/frontend/src/components/common/Filters/utils/getAutocompleteFilterGroup.ts
@@ -1,0 +1,117 @@
+import {
+    getItemId,
+    isField,
+    type AndFilterGroup,
+    type DashboardFilterableField,
+    type DashboardFilters,
+    type DashboardTile,
+    type FilterableItem,
+} from '@lightdash/common';
+import { v4 as uuid4 } from 'uuid';
+import { doesFilterApplyToTile } from '../../../../features/dashboardFilters/FilterConfiguration/utils';
+
+type GetAutocompleteFilterGroupArgs = {
+    filterId: string;
+    item: FilterableItem;
+    dashboardFilters: DashboardFilters | undefined;
+    dashboardTiles: DashboardTile[] | undefined;
+    filterableFieldsByTileUuid:
+        | Record<string, DashboardFilterableField[]>
+        | undefined;
+    activeTabUuid: string | undefined;
+};
+
+export const getAutocompleteFilterGroup = ({
+    filterId,
+    item,
+    dashboardFilters,
+    dashboardTiles,
+    filterableFieldsByTileUuid,
+    activeTabUuid,
+}: GetAutocompleteFilterGroupArgs): AndFilterGroup | undefined => {
+    if (!dashboardFilters || !isField(item)) {
+        return undefined;
+    }
+
+    const currentFieldId = getItemId(item);
+
+    // Find the current filter to get its tileTargets
+    const currentFilter = dashboardFilters.dimensions.find(
+        (f) => f.id === filterId,
+    );
+
+    // Only consider tiles on the active tab when checking overlap.
+    // Without this, tab-scoped filters from other tabs leak into
+    // autocomplete queries via tile overlap on those other tabs.
+    const tilesForOverlapCheck =
+        activeTabUuid && dashboardTiles
+            ? dashboardTiles.filter((tile) => tile.tabUuid === activeTabUuid)
+            : dashboardTiles;
+
+    // Get tiles that the current filter applies to
+    const currentFilterTileUuids =
+        tilesForOverlapCheck && filterableFieldsByTileUuid
+            ? new Set(
+                  tilesForOverlapCheck
+                      .filter((tile) => {
+                          // For new filters (not yet in dashboardFilters),
+                          // check if tile has the field
+                          if (!currentFilter) {
+                              const tileFields =
+                                  filterableFieldsByTileUuid[tile.uuid];
+                              return tileFields?.some(
+                                  (f) => getItemId(f) === currentFieldId,
+                              );
+                          }
+                          // For existing filters, use doesFilterApplyToTile
+                          return doesFilterApplyToTile(
+                              currentFilter,
+                              tile,
+                              filterableFieldsByTileUuid,
+                          );
+                      })
+                      .map((tile) => tile.uuid),
+              )
+            : null;
+
+    return {
+        id: uuid4(),
+        and: dashboardFilters.dimensions.filter((dimensionFilterRule) => {
+            // Exclude the current filter itself
+            if (dimensionFilterRule.id === filterId) {
+                return false;
+            }
+
+            // Exclude same-field filters - otherwise the autocomplete
+            // would be over-restricted (e.g., if Status=completed is set,
+            // another Status filter would only see "completed").
+            if (dimensionFilterRule.target.fieldId === currentFieldId) {
+                return false;
+            }
+
+            // For different-field filters, exclude if no tile overlap.
+            // Filters on different tabs shouldn't affect each other's
+            // autocomplete queries.
+            if (
+                currentFilterTileUuids &&
+                tilesForOverlapCheck &&
+                filterableFieldsByTileUuid
+            ) {
+                const hasOverlap = tilesForOverlapCheck.some(
+                    (tile) =>
+                        currentFilterTileUuids.has(tile.uuid) &&
+                        doesFilterApplyToTile(
+                            dimensionFilterRule,
+                            tile,
+                            filterableFieldsByTileUuid,
+                        ),
+                );
+                if (!hasOverlap) {
+                    return false;
+                }
+            }
+
+            return true;
+        }),
+    };
+};

--- a/packages/frontend/src/features/dashboardFilters/index.tsx
+++ b/packages/frontend/src/features/dashboardFilters/index.tsx
@@ -99,6 +99,7 @@ const DashboardFilters: FC<Props> = ({ isEditMode, activeTabUuid }) => {
             dashboardFilters={allFilters}
             dashboardTiles={dashboardTiles}
             filterableFieldsByTileUuid={filterableFieldsByTileUuid}
+            activeTabUuid={activeTabUuid}
         >
             <AddFilterButton
                 isEditMode={isEditMode}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-6618/tab-scoped-filter-default-values-leak-into-autocomplete-suggestions-on

### Description:
Tab-scoped filter default values were leaking into autocomplete suggestions on other tabs because getAutocompleteFilterGroup checked tile overlap across all dashboard tiles instead of only the active tab.

Extracts the logic into a pure testable function, adds activeTabUuid parameter, and passes it through from DashboardFilters.
