### PR TITLE
fix: accept filters nested inside queryConfig in MCP run_metric_query

### DIFF
--- a/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
+++ b/packages/common/src/ee/AiAgent/schemas/tools/toolRunQueryArgs.ts
@@ -39,6 +39,11 @@ const queryConfigSchema = z.object({
         .describe(
             'The total number of data points / rows allowed on the chart.',
         ),
+    // External LLMs frequently nest filters inside queryConfig instead of at
+    // the top level. Accepting them here prevents Zod from silently stripping
+    // the key. The transform in `toolRunQueryArgsSchemaTransformed` lifts
+    // nested filters to the top level.
+    filters: filtersSchemaV2.optional(),
 });
 
 // Chart-specific configuration for rendering hints
@@ -181,11 +186,19 @@ export const toolRunQueryArgsSchemaTransformed = toolRunQueryArgsSchema
         tableCalculations: tableCalcsSchema.default(null),
         chartConfig: chartConfigSchema.default(null),
     })
-    .transform((data) => ({
-        ...data,
-        filters: filtersSchemaTransformed.parse(data.filters),
-        customMetrics: customMetricsSchemaTransformed.parse(data.customMetrics),
-    }));
+    .transform((data) => {
+        // LLMs often nest filters inside queryConfig instead of at the top
+        // level. Prefer top-level filters, fall back to queryConfig.filters.
+        const resolvedFilters =
+            data.filters ?? data.queryConfig.filters ?? null;
+        return {
+            ...data,
+            filters: filtersSchemaTransformed.parse(resolvedFilters),
+            customMetrics: customMetricsSchemaTransformed.parse(
+                data.customMetrics,
+            ),
+        };
+    });
 
 export type ToolRunQueryArgsTransformed = z.infer<
     typeof toolRunQueryArgsSchemaTransformed


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-6673/mcp-llms-nest-filters-inside-queryconfig-causing-them-to-be-silently

### Description:
External LLMs frequently place filters inside queryConfig instead of as a top-level parameter. Zod's default strip mode silently removed the misplaced key, causing queries to return unfiltered results. Accept filters in both locations and prefer top-level, falling back to queryConfig.filters.
