### PR TITLE
feat: add SQL limit change listener to refresh chart data in visualization tab

### DIFF
--- a/packages/frontend/src/features/sqlRunner/store/listenerMiddleware.ts
+++ b/packages/frontend/src/features/sqlRunner/store/listenerMiddleware.ts
@@ -6,6 +6,7 @@ import type { AppDispatch, RootState } from './index';
 import {
     addChartConfigListener,
     addChartTypeListener,
+    addLimitChangeListener,
     addSqlRunnerQueryListener,
     addTabSwitchListener,
 } from './sqlRunnerListeners';
@@ -24,3 +25,4 @@ addSqlRunnerQueryListener(startAppListening);
 addChartConfigListener(startAppListening);
 addChartTypeListener(startAppListening);
 addTabSwitchListener(startAppListening);
+addLimitChangeListener(startAppListening);

--- a/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
+++ b/packages/frontend/src/features/sqlRunner/store/sqlRunnerListeners.ts
@@ -13,6 +13,7 @@ import {
     selectSqlRunnerResultsRunner,
     setActiveEditorTab,
     setSelectedChartType,
+    setSqlLimit,
 } from './sqlRunnerSlice';
 import { prepareAndFetchChartData, runSqlQuery } from './thunks';
 
@@ -184,6 +185,28 @@ export const addTabSwitchListener = (
                     setChartOptionsAndConfig(chartResultOptions),
                 );
                 await listenerApi.dispatch(prepareAndFetchChartData());
+            }
+        },
+    });
+};
+
+/**
+ * Add a listener for when the SQL limit is changed.
+ * This listener will re-fetch the pivot chart data with the new limit
+ * when on the visualization tab.
+ * @param startListening - The startAppListening function from listenerMiddleware.ts
+ */
+export const addLimitChangeListener = (
+    startListening: typeof startAppListening,
+) => {
+    startListening({
+        actionCreator: setSqlLimit,
+        effect: async (_, listenerApi) => {
+            const state = listenerApi.getState();
+            if (state.sqlRunner.activeEditorTab === EditorTabs.VISUALIZATION) {
+                await listenerApi.dispatch(
+                    prepareAndFetchChartData({ forceRefresh: true }),
+                );
             }
         },
     });


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes:  https://linear.app/lightdash/issue/PROD-6797/sql-runner-changing-row-limit-on-visualization-tab-has-no-effect

After

<img width="1042" height="739" alt="image" src="https://github.com/user-attachments/assets/ca23d633-e14f-4448-849c-1cf39b6c5144" />

### Description:

Added a new listener to automatically refresh chart data when the SQL limit is changed in the SQL Runner. The `addLimitChangeListener` function monitors for `setSqlLimit` actions and triggers a chart data refresh when the user is on the visualization tab, ensuring the chart reflects the updated row limit immediately.

<!-- Even better add a screenshot / gif / loom -->