### PR TITLE
feat: add cross-filtering support for explore autocomplete filters

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8308,11 +8308,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8790,11 +8790,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8809,11 +8809,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8828,11 +8828,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8847,11 +8847,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8866,11 +8866,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -20588,7 +20588,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20598,7 +20598,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20608,7 +20608,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -20621,7 +20621,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -9740,19 +9740,6 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
                                                             "success",
                                                             "error"
                                                         ]
@@ -21835,22 +21822,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__content-string--title-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__chartName-string--title-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -29725,7 +29712,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2724.3",
+        "version": "0.2726.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
+++ b/packages/frontend/src/components/Explorer/FiltersCard/FiltersCard.tsx
@@ -318,6 +318,7 @@ const FiltersCard: FC = memo(() => {
                         withinPortal: true,
                     }}
                     baseTable={data?.baseTable}
+                    exploreFilters={processedFilters}
                     parameterValues={parameterValues}
                 >
                     <FiltersForm

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -136,8 +136,12 @@ const FilterStringAutoComplete: FC<Props> = ({
     ...rest
 }) => {
     const multiSelectRef = useRef<HTMLInputElement>(null);
-    const { projectUuid, getAutocompleteFilterGroup, parameterValues } =
-        useFiltersContext();
+    const {
+        projectUuid,
+        baseTable,
+        getAutocompleteFilterGroup,
+        parameterValues,
+    } = useFiltersContext();
     if (!projectUuid) {
         throw new Error('projectUuid is required in FiltersProvider');
     }
@@ -194,6 +198,7 @@ const FilterStringAutoComplete: FC<Props> = ({
             refetchOnMount: 'always',
         },
         parameterValues,
+        baseTable,
     );
 
     const refreshedAtRef = useRef(refreshedAt);

--- a/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
+++ b/packages/frontend/src/components/common/Filters/FiltersProvider.tsx
@@ -1,36 +1,67 @@
 import {
+    getFilterRulesFromGroup,
+    getItemId,
+    isFilterRule,
     type DashboardFilterableField,
     type DashboardFilters,
     type DashboardTile,
     type FilterableItem,
     type FilterRule,
+    type Filters,
     type ParametersValuesMap,
     type WeekDay,
 } from '@lightdash/common';
 import { type PopoverProps } from '@mantine/core';
 import { useCallback, type ReactNode } from 'react';
+import { v4 as uuid4 } from 'uuid';
 import Context, { type DefaultFieldsMap } from './context';
 import { getAutocompleteFilterGroup } from './utils/getAutocompleteFilterGroup';
 
-type Props<T extends DefaultFieldsMap> = {
+type CommonProps<T extends DefaultFieldsMap> = {
     projectUuid?: string;
     itemsMap?: T;
     baseTable?: string;
     startOfWeek?: WeekDay;
-    dashboardFilters?: DashboardFilters;
-    dashboardTiles?: DashboardTile[];
-    filterableFieldsByTileUuid?: Record<string, DashboardFilterableField[]>;
     popoverProps?: Omit<PopoverProps, 'children'>;
     parameterValues?: ParametersValuesMap;
     activeTabUuid?: string;
     children?: ReactNode;
 };
 
+type ExploreFilterContextProps = {
+    exploreFilters: Filters;
+    dashboardFilters?: never;
+    dashboardTiles?: never;
+    filterableFieldsByTileUuid?: never;
+};
+
+type DashboardFilterContextProps = {
+    exploreFilters?: never;
+    dashboardFilters: DashboardFilters;
+    dashboardTiles?: DashboardTile[];
+    filterableFieldsByTileUuid?: Record<string, DashboardFilterableField[]>;
+};
+
+type NoFilterContextProps = {
+    exploreFilters?: never;
+    dashboardFilters?: never;
+    dashboardTiles?: never;
+    filterableFieldsByTileUuid?: never;
+};
+
+type FilterContextProps =
+    | ExploreFilterContextProps
+    | DashboardFilterContextProps
+    | NoFilterContextProps;
+
+type Props<T extends DefaultFieldsMap> = CommonProps<T> & FilterContextProps;
+
 const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
     projectUuid,
     itemsMap = {} as T,
     baseTable,
     startOfWeek,
+    exploreFilters,
     dashboardFilters,
     dashboardTiles,
     filterableFieldsByTileUuid,
@@ -49,16 +80,39 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
     );
 
     const getAutocompleteFilterGroupCallback = useCallback(
-        (filterId: string, item: FilterableItem) =>
-            getAutocompleteFilterGroup({
+        (filterId: string, item: FilterableItem) => {
+            // Explore view: use explore's active dimension filters as cross-filters
+            if (exploreFilters && !dashboardFilters) {
+                const currentFieldId = getItemId(item);
+                const dimensionRules = getFilterRulesFromGroup(
+                    exploreFilters.dimensions,
+                );
+                const crossFilterRules = dimensionRules.filter(
+                    (rule) =>
+                        isFilterRule(rule) &&
+                        rule.id !== filterId &&
+                        rule.target.fieldId !== currentFieldId,
+                );
+                if (crossFilterRules.length === 0) {
+                    return undefined;
+                }
+                return {
+                    id: uuid4(),
+                    and: crossFilterRules,
+                };
+            }
+
+            return getAutocompleteFilterGroup({
                 filterId,
                 item,
                 dashboardFilters,
                 dashboardTiles,
                 filterableFieldsByTileUuid,
                 activeTabUuid,
-            }),
+            });
+        },
         [
+            exploreFilters,
             dashboardFilters,
             dashboardTiles,
             filterableFieldsByTileUuid,
@@ -73,6 +127,7 @@ const FiltersProvider = <T extends DefaultFieldsMap = DefaultFieldsMap>({
                 itemsMap,
                 startOfWeek,
                 baseTable,
+                exploreFilters,
                 getField,
                 getAutocompleteFilterGroup: getAutocompleteFilterGroupCallback,
                 popoverProps,

--- a/packages/frontend/src/components/common/Filters/context.ts
+++ b/packages/frontend/src/components/common/Filters/context.ts
@@ -2,6 +2,7 @@ import {
     type AndFilterGroup,
     type FilterableItem,
     type FilterRule,
+    type Filters,
     type ItemsMap,
     type ParametersValuesMap,
     type WeekDay,
@@ -19,6 +20,7 @@ export type FiltersContext<T extends DefaultFieldsMap = DefaultFieldsMap> = {
     itemsMap: T;
     baseTable?: string;
     startOfWeek?: WeekDay;
+    exploreFilters: Filters | undefined;
     getField: (filterRule: FilterRule) => T[keyof T] | undefined;
     getAutocompleteFilterGroup: (
         filterId: string,

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -101,6 +101,7 @@ export const useFieldValues = (
     forceRefresh: boolean = false,
     useQueryOptions?: UseQueryOptions<FieldValueSearchResult, ApiError>,
     parameterValues?: ParametersValuesMap,
+    exploreName: string | undefined = undefined,
 ) => {
     const { embedToken } = useEmbed();
     const [fieldName, setFieldName] = useState<string>(field.name);
@@ -113,8 +114,8 @@ export const useFieldValues = (
     const [refreshedAt, setRefreshedAt] = useState<Date>(new Date());
 
     const tableName = useMemo(
-        () => (isField(field) ? field.table : undefined),
-        [field],
+        () => exploreName ?? (isField(field) ? field.table : undefined),
+        [exploreName, field],
     );
 
     const fieldId = useMemo(() => getItemId(field), [field]);
@@ -153,6 +154,7 @@ export const useFieldValues = (
         'search',
         debouncedSearch,
         parameterValues,
+        filters,
     ];
     const query = useQuery<FieldValueSearchResult, ApiError>(
         cachekey,
@@ -249,6 +251,7 @@ export const useFieldValuesSafely = (
     forceRefresh: boolean = false,
     useQueryOptions?: UseQueryOptions<FieldValueSearchResult, ApiError>,
     parameterValues?: ParametersValuesMap,
+    exploreName: string | undefined = undefined,
 ) => {
     const fieldValuesResult = useFieldValues(
         search,
@@ -273,6 +276,7 @@ export const useFieldValuesSafely = (
             enabled: !!field && useQueryOptions?.enabled !== false,
         },
         parameterValues,
+        exploreName,
     );
 
     if (!field) {


### PR DESCRIPTION
### Description:

This PR implements cross-filtering for autocomplete suggestions in the explore view. When users interact with filter autocomplete dropdowns, the suggestions are now filtered based on other active dimension filters, providing more contextually relevant options.

**Key changes:**
- Modified `FiltersProvider` to accept `exploreFilters` prop and use active dimension filters as cross-filters for autocomplete suggestions
- Updated `FilterStringAutoComplete` to pass the base table name to the field values hook for proper table context
- Enhanced `useFieldValues` hook to accept an optional `exploreName` parameter for better table resolution
- Fixed enum ordering in generated route models where 'success' and 'error' values were swapped
- Corrected property ordering in dashboard tile type definitions where `content` and `title` properties were reordered for markdown tiles

The cross-filtering logic ensures that autocomplete suggestions are filtered by other active filters (excluding the current filter being edited and filters on the same field) to provide more relevant and contextual suggestions to users.