### PR TITLE
feat: add configurable filter operator for autocomplete search

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1838,6 +1838,7 @@ export class EmbedService extends BaseService {
                 search,
                 limit,
                 filters,
+                filterOperator: undefined,
             });
 
         const projectTimezone =

--- a/packages/backend/src/routers/projectRouter.ts
+++ b/packages/backend/src/routers/projectRouter.ts
@@ -139,6 +139,8 @@ projectRouter.post(
                     req.body.filters,
                     req.body.forceRefresh,
                     req.body.parameters,
+                    undefined, // userAttributeOverrides
+                    req.body.filterOperator,
                 );
 
             res.json({

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4494,6 +4494,18 @@ export class ProjectService extends BaseService {
     }
 
     // Note: can't be private method as it is used in EE
+    static getAutocompleteSearchOperator(
+        filterOperator: FilterOperator | undefined,
+    ): FilterOperator {
+        switch (filterOperator) {
+            case FilterOperator.STARTS_WITH:
+            case FilterOperator.ENDS_WITH:
+                return filterOperator;
+            default:
+                return FilterOperator.INCLUDE;
+        }
+    }
+
     async _getFieldValuesMetricQuery({
         projectUuid,
         table,
@@ -4501,6 +4513,7 @@ export class ProjectService extends BaseService {
         search,
         limit,
         filters,
+        filterOperator,
     }: {
         projectUuid: string;
         table: string;
@@ -4508,6 +4521,7 @@ export class ProjectService extends BaseService {
         search: string;
         limit: number;
         filters: AndFilterGroup | undefined;
+        filterOperator: FilterOperator | undefined;
     }) {
         if (limit > this.lightdashConfig.query.maxLimit) {
             throw new ParameterError(
@@ -4548,13 +4562,15 @@ export class ProjectService extends BaseService {
                 `Searching by field is only available for dimensions, but ${fieldId} is a ${field.type}`,
             );
         }
+        const searchOperator =
+            ProjectService.getAutocompleteSearchOperator(filterOperator);
         const autocompleteDimensionFilters: FilterGroupItem[] = [
             {
                 id: uuidv4(),
                 target: {
                     fieldId,
                 },
-                operator: FilterOperator.INCLUDE,
+                operator: searchOperator,
                 values: [search],
             },
             {
@@ -4610,6 +4626,7 @@ export class ProjectService extends BaseService {
         forceRefresh: boolean = false,
         parameters?: ParametersValuesMap,
         userAttributeOverrides?: UserAttributeValueMap, // EXPERIMENTAL: used to override user attributes for MCP
+        filterOperator?: FilterOperator,
     ) {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
@@ -4631,6 +4648,7 @@ export class ProjectService extends BaseService {
                 search,
                 limit,
                 filters,
+                filterOperator,
             });
 
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(

--- a/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/DefaultFilterInputs.tsx
@@ -77,6 +77,7 @@ const DefaultFilterInputs = <T extends BaseFilterRule>({
                         <FilterStringAutoComplete
                             limit={FILTER_SELECT_LIMIT}
                             filterId={rule.id}
+                            filterOperator={rule.operator}
                             disabled={disabled}
                             field={field}
                             data-autofocus

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.test.tsx
@@ -1,6 +1,7 @@
 import {
     DimensionType,
     FieldType,
+    FilterOperator,
     type FilterableItem,
 } from '@lightdash/common';
 import { fireEvent, screen, waitFor } from '@testing-library/react';
@@ -64,6 +65,7 @@ describe('FilterStringAutoComplete', () => {
                 <FilterStringAutoComplete
                     filterId="test-filter"
                     field={mockField}
+                    filterOperator={FilterOperator.INCLUDE}
                     values={values}
                     suggestions={[]}
                     onChange={onChange}
@@ -82,6 +84,7 @@ describe('FilterStringAutoComplete', () => {
                 <FilterStringAutoComplete
                     filterId="test-filter"
                     field={mockField}
+                    filterOperator={FilterOperator.INCLUDE}
                     values={values}
                     suggestions={[]}
                     onChange={onChange}
@@ -108,6 +111,7 @@ describe('FilterStringAutoComplete', () => {
                 <FilterStringAutoComplete
                     filterId="test-filter"
                     field={mockField}
+                    filterOperator={FilterOperator.INCLUDE}
                     values={values}
                     suggestions={[]}
                     onChange={onChange}
@@ -148,6 +152,7 @@ describe('FilterStringAutoComplete', () => {
                 <FilterStringAutoComplete
                     filterId="test-filter"
                     field={mockField}
+                    filterOperator={FilterOperator.INCLUDE}
                     values={values}
                     suggestions={['new-suggestion']}
                     onChange={onChange}
@@ -184,6 +189,7 @@ describe('FilterStringAutoComplete', () => {
                 <FilterStringAutoComplete
                     filterId="test-filter"
                     field={mockField}
+                    filterOperator={FilterOperator.INCLUDE}
                     values={values}
                     suggestions={[]}
                     onChange={onChange}
@@ -209,6 +215,7 @@ describe('FilterStringAutoComplete', () => {
                 <FilterStringAutoComplete
                     filterId="test-filter"
                     field={mockField}
+                    filterOperator={FilterOperator.INCLUDE}
                     values={values}
                     suggestions={[]}
                     onChange={onChange}
@@ -237,6 +244,7 @@ describe('FilterStringAutoComplete', () => {
                 <FilterStringAutoComplete
                     filterId="test-filter"
                     field={mockField}
+                    filterOperator={FilterOperator.INCLUDE}
                     values={values}
                     suggestions={[]}
                     onChange={onChange}

--- a/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterInputs/FilterStringAutoComplete.tsx
@@ -1,4 +1,4 @@
-import { type FilterableItem } from '@lightdash/common';
+import { type FilterableItem, type FilterOperator } from '@lightdash/common';
 import {
     ActionIcon,
     Group,
@@ -55,6 +55,7 @@ import { formatDisplayValue } from './utils';
 type Props = Omit<MultiSelectProps, 'data' | 'onChange'> & {
     filterId: string;
     field: FilterableItem;
+    filterOperator: FilterOperator;
     values: string[];
     suggestions: string[];
     onChange: (values: string[]) => void;
@@ -124,6 +125,7 @@ const FilterStringAutoComplete: FC<Props> = ({
     filterId,
     values,
     field,
+    filterOperator,
     suggestions: initialSuggestionData,
     disabled,
     onChange,
@@ -199,6 +201,7 @@ const FilterStringAutoComplete: FC<Props> = ({
         },
         parameterValues,
         baseTable,
+        filterOperator,
     );
 
     const refreshedAtRef = useRef(refreshedAt);

--- a/packages/frontend/src/hooks/useFieldValues.ts
+++ b/packages/frontend/src/hooks/useFieldValues.ts
@@ -7,6 +7,7 @@ import {
     type DashboardFilterRule,
     type FieldValueSearchResult,
     type FilterableItem,
+    type FilterOperator,
     type ParametersValuesMap,
 } from '@lightdash/common';
 import { useQuery, type UseQueryOptions } from '@tanstack/react-query';
@@ -71,6 +72,7 @@ const getFieldValues = async (
     filters: AndFilterGroup | undefined,
     limit: number = MAX_AUTOCOMPLETE_RESULTS,
     parameterValues?: ParametersValuesMap,
+    filterOperator?: FilterOperator,
 ) => {
     if (!table) {
         throw new Error('Table is required to search for field values');
@@ -86,6 +88,7 @@ const getFieldValues = async (
             filters: stripTileTargetsFromFilters(filters),
             forceRefresh,
             parameters: parameterValues,
+            filterOperator,
         }),
     });
 };
@@ -102,6 +105,7 @@ export const useFieldValues = (
     useQueryOptions?: UseQueryOptions<FieldValueSearchResult, ApiError>,
     parameterValues?: ParametersValuesMap,
     exploreName: string | undefined = undefined,
+    filterOperator: FilterOperator | undefined = undefined,
 ) => {
     const { embedToken } = useEmbed();
     const [fieldName, setFieldName] = useState<string>(field.name);
@@ -155,6 +159,7 @@ export const useFieldValues = (
         debouncedSearch,
         parameterValues,
         filters,
+        filterOperator,
     ];
     const query = useQuery<FieldValueSearchResult, ApiError>(
         cachekey,
@@ -180,6 +185,7 @@ export const useFieldValues = (
                     filters,
                     undefined,
                     parameterValues,
+                    filterOperator,
                 );
             }
         },
@@ -252,6 +258,7 @@ export const useFieldValuesSafely = (
     useQueryOptions?: UseQueryOptions<FieldValueSearchResult, ApiError>,
     parameterValues?: ParametersValuesMap,
     exploreName: string | undefined = undefined,
+    filterOperator: FilterOperator | undefined = undefined,
 ) => {
     const fieldValuesResult = useFieldValues(
         search,
@@ -277,6 +284,7 @@ export const useFieldValuesSafely = (
         },
         parameterValues,
         exploreName,
+        filterOperator,
     );
 
     if (!field) {


### PR DESCRIPTION
### Description:

This PR adds support for configurable filter operators in autocomplete search functionality. Previously, autocomplete searches always used the `INCLUDE` operator, but now users can specify `STARTS_WITH` or `ENDS_WITH` operators for more precise filtering.

**Key changes:**
- Added `filterOperator` parameter to the `FilterStringAutoComplete` component and related hooks
- Implemented `getAutocompleteSearchOperator` method in `ProjectService` to handle operator selection logic
- Updated the field values API endpoint to accept and process the `filterOperator` parameter
- Modified the `useFieldValues` and `useFieldValuesSafely` hooks to support the new operator parameter
- Updated all test cases to include the required `filterOperator` prop

The autocomplete search now respects the filter operator selected by the user, providing more accurate and relevant suggestions based on whether they want to match values that include, start with, or end with their search term.