### PR TITLE
fix: batch insert during preview project copy

### DIFF
--- a/packages/backend/src/models/ProjectModel/ProjectModel.ts
+++ b/packages/backend/src/models/ProjectModel/ProjectModel.ts
@@ -136,6 +136,23 @@ const warehouseCredentialsCache =
           })
         : undefined;
 
+const INSERT_BATCH_SIZE = 1000;
+
+async function chunkedInsertReturning<T extends Record<string, unknown>>(
+    trx: Transaction,
+    tableName: string,
+    rows: Record<string, unknown>[],
+): Promise<T[]> {
+    const results: T[] = [];
+    for (let i = 0; i < rows.length; i += INSERT_BATCH_SIZE) {
+        const batch = rows.slice(i, i + INSERT_BATCH_SIZE);
+        // eslint-disable-next-line no-await-in-loop -- chunked inserts must run sequentially to bound payload size
+        const inserted = await trx(tableName).insert(batch).returning('*');
+        results.push(...(inserted as T[]));
+    }
+    return results;
+}
+
 type RawSummaryRow = {
     name: Explore['name'];
     label: Explore['label'];
@@ -2225,29 +2242,29 @@ export class ProjectModel {
 
             const newCharts =
                 charts.length > 0
-                    ? await trx(SavedChartsTableName)
-                          .insert(
-                              charts.map((d) => {
-                                  if (!d.space_id) {
-                                      throw new Error(
-                                          `Chart ${d.saved_query_id} has no space_id`,
-                                      );
-                                  }
-                                  const createChart: CloneChart = {
-                                      ...d,
-                                      search_vector: undefined,
-                                      saved_query_id: undefined,
-                                      saved_query_uuid: undefined,
-                                      space_id: getNewSpaceId(d.space_id),
-                                      dashboard_uuid: null,
-                                  };
-                                  delete createChart.search_vector;
-                                  delete createChart.saved_query_id;
-                                  delete createChart.saved_query_uuid;
-                                  return createChart;
-                              }),
-                          )
-                          .returning('*')
+                    ? await chunkedInsertReturning<DbSavedChart>(
+                          trx,
+                          SavedChartsTableName,
+                          charts.map((d) => {
+                              if (!d.space_id) {
+                                  throw new Error(
+                                      `Chart ${d.saved_query_id} has no space_id`,
+                                  );
+                              }
+                              const createChart: CloneChart = {
+                                  ...d,
+                                  search_vector: undefined,
+                                  saved_query_id: undefined,
+                                  saved_query_uuid: undefined,
+                                  space_id: getNewSpaceId(d.space_id),
+                                  dashboard_uuid: null,
+                              };
+                              delete createChart.search_vector;
+                              delete createChart.saved_query_id;
+                              delete createChart.saved_query_uuid;
+                              return createChart;
+                          }),
+                      )
                     : [];
 
             const chartsInDashboards = await trx(SavedChartsTableName)
@@ -2280,28 +2297,28 @@ export class ProjectModel {
             // We also copy charts in dashboards, we will replace the dashboard_uuid later
             const newChartsInDashboards =
                 chartsInDashboards.length > 0
-                    ? await trx(SavedChartsTableName)
-                          .insert(
-                              chartsInDashboards.map((d) => {
-                                  if (!d.dashboard_uuid) {
-                                      throw new Error(
-                                          `Chart in dashboard ${d.saved_query_id} has no dashboard_uuid`,
-                                      );
-                                  }
-                                  const createChart: CloneChart = {
-                                      ...d,
-                                      search_vector: undefined,
-                                      space_id: null,
-                                      dashboard_uuid: d.dashboard_uuid, // we'll update this later
-                                  };
-                                  delete createChart.search_vector;
-                                  delete createChart.saved_query_id;
-                                  delete createChart.saved_query_uuid;
+                    ? await chunkedInsertReturning<DbSavedChart>(
+                          trx,
+                          SavedChartsTableName,
+                          chartsInDashboards.map((d) => {
+                              if (!d.dashboard_uuid) {
+                                  throw new Error(
+                                      `Chart in dashboard ${d.saved_query_id} has no dashboard_uuid`,
+                                  );
+                              }
+                              const createChart: CloneChart = {
+                                  ...d,
+                                  search_vector: undefined,
+                                  space_id: null,
+                                  dashboard_uuid: d.dashboard_uuid,
+                              };
+                              delete createChart.search_vector;
+                              delete createChart.saved_query_id;
+                              delete createChart.saved_query_uuid;
 
-                                  return createChart;
-                              }),
-                          )
-                          .returning('*')
+                              return createChart;
+                          }),
+                      )
                     : [];
             const chartInSpacesMapping = charts.map((c, i) => ({
                 id: c.saved_query_id,
@@ -2338,30 +2355,32 @@ export class ProjectModel {
 
             const newChartVersions =
                 chartVersions.length > 0
-                    ? await trx('saved_queries_versions')
-                          .insert(
-                              chartVersions.map((d) => {
-                                  const newSavedQueryId = chartMapping.find(
-                                      (m) => m.id === d.saved_query_id,
-                                  )?.newId;
-                                  if (!newSavedQueryId) {
-                                      throw new Error(
-                                          `Cannot find new chart id for ${d.saved_query_id}`,
-                                      );
-                                  }
-                                  const createChartVersion = {
-                                      ...d,
-                                      saved_queries_version_id: undefined,
-                                      saved_queries_version_uuid: undefined,
-                                      saved_query_id: newSavedQueryId,
-                                  };
-                                  delete createChartVersion.saved_queries_version_id;
-                                  delete createChartVersion.saved_queries_version_uuid;
+                    ? await chunkedInsertReturning<
+                          (typeof chartVersions)[number]
+                      >(
+                          trx,
+                          'saved_queries_versions',
+                          chartVersions.map((d) => {
+                              const newSavedQueryId = chartMapping.find(
+                                  (m) => m.id === d.saved_query_id,
+                              )?.newId;
+                              if (!newSavedQueryId) {
+                                  throw new Error(
+                                      `Cannot find new chart id for ${d.saved_query_id}`,
+                                  );
+                              }
+                              const createChartVersion = {
+                                  ...d,
+                                  saved_queries_version_id: undefined,
+                                  saved_queries_version_uuid: undefined,
+                                  saved_query_id: newSavedQueryId,
+                              };
+                              delete createChartVersion.saved_queries_version_id;
+                              delete createChartVersion.saved_queries_version_uuid;
 
-                                  return createChartVersion;
-                              }),
-                          )
-                          .returning('*')
+                              return createChartVersion;
+                          }),
+                      )
                     : [];
 
             const chartVersionMapping = chartVersions.map((c, i) => ({


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21188
Closes: https://linear.app/lightdash/issue/PROD-6805/review-pr-21749-to-resolve-postgres-batch-insert-failures
Supersedes: #21749

## Summary
- Adds `chunkedInsertReturning` helper that batches database INSERTs (1000 rows per batch) when copying charts/chart versions to a preview project
- Prevents hitting PostgreSQL's 65,535 bind parameter limit with large projects (3000+ charts)

Original PR by @agha4to — re-committed with verified signature.

Co-Authored-By: Tony Orciuoli <tony.orciuoli@workday.com>

## Test plan
- [x] Reproduced failure on `main` with 5,500 charts (72,137 bind params > 65,535 limit)
- [x] Verified fix: same 5,500 charts copy successfully with batched inserts
- [x] End-to-end tested via `POST /api/v1/org/projects` creating a PREVIEW project with `copyContent: true`