### PR TITLE
fix: use deterministic space lookup in seed scripts

### DIFF
--- a/packages/backend/src/database/seeds/development/02_saved_queries.ts
+++ b/packages/backend/src/database/seeds/development/02_saved_queries.ts
@@ -19,10 +19,11 @@ export async function seed(knex: Knex): Promise<void> {
         lightdashConfig,
     });
     const spaceModel = new SpaceModel({ database: knex });
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     // Deletes ALL existing entries

--- a/packages/backend/src/database/seeds/development/03_saved_dashboards.ts
+++ b/packages/backend/src/database/seeds/development/03_saved_dashboards.ts
@@ -46,10 +46,11 @@ async function createDashboardWithAllTileTypes(knex: Knex): Promise<void> {
         lightdashConfig,
     });
 
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     const savedCharts = await chartModel.find({
@@ -263,10 +264,11 @@ async function createDashboardWithDashboardCharts(knex: Knex): Promise<void> {
         database: knex,
     });
 
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     // Create dashboard with charts saved in space

--- a/packages/backend/src/database/seeds/development/06_pivot_table_dashboard.ts
+++ b/packages/backend/src/database/seeds/development/06_pivot_table_dashboard.ts
@@ -43,10 +43,11 @@ async function createPivotTableCharts(knex: Knex): Promise<ChartUuids> {
         database: knex,
     });
 
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     const updatedByUser = {
@@ -730,10 +731,11 @@ async function createPivotTableDashboard(
         database: knex,
     });
 
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     // Create dashboard with conditional formatting demonstration

--- a/packages/backend/src/database/seeds/development/07_cartesian_charts_dashboard.ts
+++ b/packages/backend/src/database/seeds/development/07_cartesian_charts_dashboard.ts
@@ -26,10 +26,11 @@ async function createCharts(knex: Knex): Promise<ChartUuids> {
         database: knex,
     });
 
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     const updatedByUser = {
@@ -1508,10 +1509,11 @@ async function createDashboard(
         database: knex,
     });
 
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     // Create dashboard tiles

--- a/packages/backend/src/database/seeds/development/08_scheduled_delivery_edge_cases_dashboard.ts
+++ b/packages/backend/src/database/seeds/development/08_scheduled_delivery_edge_cases_dashboard.ts
@@ -27,10 +27,11 @@ async function createCharts(knex: Knex): Promise<ChartUuids> {
         database: knex,
     });
 
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     const updatedByUser = {
@@ -296,10 +297,11 @@ async function createDashboard(
         database: knex,
     });
 
-    const rootSpaces = await spaceModel.getRootSpaceUuidsForProject(
-        SEED_PROJECT.project_uuid,
-    );
-    const spaceUuid = rootSpaces[0];
+    const [seedSpace] = await spaceModel.find({
+        projectUuid: SEED_PROJECT.project_uuid,
+        slug: 'jaffle-shop',
+    });
+    const spaceUuid = seedSpace?.uuid;
     if (!spaceUuid) throw new Error('No space found for seeding');
 
     // Create dashboard tiles


### PR DESCRIPTION
## Summary

- Seed scripts 06-08 used `getRootSpaceUuidsForProject(...)[0]` to find the Jaffle shop space, but that query has no `ORDER BY`, so PostgreSQL returns rows in arbitrary order
- After seed 05 creates nested spaces (Parent Space 1-5), `rootSpaces[0]` non-deterministically resolves to a different space (e.g. Parent Space 2), seeding charts and dashboards into the wrong space
- This caused `content.test.ts` permission tests to flake — they expected private spaces to have only their child spaces, but found 32 misplaced items
- Fix: look up the Jaffle shop space by slug instead of taking the first result from an unordered query. Also fixed seeds 02-03 for consistency (they were safe since they run before nested spaces are created)

## Test plan

- [x] Reproduced locally: `reset-db.sh` → `content.test.ts` fails with `expected 32 to be 1`
- [x] After fix: `reset-db.sh` → `content.test.ts` permission tests pass
- [x] CI: both e2e and API tests pass

test-frontend test-backend