### PR TITLE
docs: add dbt Fusion config.meta support to skills

### DIFF
--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -60,12 +60,25 @@ lightdash config set-project --name "My Project"  # Switch project
 | Type | Detection | Key Difference |
 |------|-----------|----------------|
 | **dbt Project** | Has `dbt_project.yml` | Metadata nested under `meta:` |
+| **dbt Fusion / dbt 1.10+** | Has `dbt_project.yml`, uses dbt Fusion or dbt >= 1.10 | Metadata nested under `config: meta:` |
 | **Pure Lightdash** | Has `lightdash.config.yml`, no dbt | Top-level properties |
 
 ```bash
 ls dbt_project.yml 2>/dev/null && echo "dbt project" || echo "Not dbt"
 ls lightdash.config.yml 2>/dev/null && echo "Pure Lightdash" || echo "Not pure Lightdash"
 ```
+
+> **dbt Fusion / dbt 1.10+:** Lightdash metadata must be nested under `config: meta:` instead of `meta:`. The properties are identical — only the nesting changes. Example:
+> ```yaml
+> models:
+>   - name: orders
+>     config:
+>       meta:
+>         metrics:
+>           total_revenue:
+>             type: sum
+>             sql: "${TABLE}.amount"
+> ```
 
 ### Syntax Comparison
 


### PR DESCRIPTION
## Summary
- Updates the `developing-in-lightdash` skill to detect and support dbt Fusion / dbt 1.10+ projects
- Adds `config: meta:` syntax example alongside the legacy `meta:` format
- Adds Fusion compatibility notes to all 4 semantic layer resource files (metrics, dimensions, tables, joins)
- Documents `lightdash metamove` as the migration tool for existing YAML

Context: Trio WFS co-dev call surfaced that the skill generates legacy `meta:` YAML which fails to compile under dbt Fusion. Fusion requires nesting under `config: meta:` instead.

## Test plan
- [ ] Verify skill detects dbt Fusion projects correctly
- [ ] Confirm generated YAML uses `config: meta:` for Fusion users
- [ ] Test with a Fusion project that `lightdash deploy` works with the new format

🤖 Generated with [Claude Code](https://claude.com/claude-code)