### PR TITLE
fix: add tileUuid parameter to support cross-explore dashboard filter mappings

### DIFF
--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -125,6 +125,7 @@ export class SavedChartController extends BaseController {
             invalidateCache?: boolean;
             dashboardSorts: SortField[];
             dashboardUuid: string;
+            tileUuid?: string;
             dateZoom?: DateZoom;
             autoRefresh?: boolean;
         },
@@ -144,6 +145,7 @@ export class SavedChartController extends BaseController {
                     dashboardSorts: body.dashboardSorts,
                     dateZoom: body.dateZoom,
                     dashboardUuid: body.dashboardUuid,
+                    tileUuid: body.tileUuid,
                     autoRefresh: body.autoRefresh,
                     context: getContextFromQueryOrHeader(req),
                 }),

--- a/packages/backend/src/ee/services/AiService/AiService.ts
+++ b/packages/backend/src/ee/services/AiService/AiService.ts
@@ -159,48 +159,62 @@ export class AiService {
         user: SessionUser,
         dashboard: DashboardDAO,
     ): Promise<ChartPromptData[]> {
-        const chartUuids = dashboard.tiles.reduce<string[]>((acc, tile) => {
+        const chartTiles = dashboard.tiles.reduce<
+            Array<{ tileUuid: string; chartUuid: string }>
+        >((acc, tile) => {
             if (
                 isDashboardChartTileType(tile) &&
                 tile.properties.savedChartUuid
             ) {
-                return [...acc, tile.properties.savedChartUuid];
+                return [
+                    ...acc,
+                    {
+                        tileUuid: tile.uuid,
+                        chartUuid: tile.properties.savedChartUuid,
+                    },
+                ];
             }
             return acc;
         }, []);
 
-        const chartResultPromises = chartUuids.map(async (chartUuid) => {
-            const chartAndResults =
-                await this.projectService.getChartAndResults({
-                    account: fromSession(user),
-                    dashboardUuid: dashboard.uuid,
-                    chartUuid,
-                    dashboardFilters: dashboard.filters,
-                    dashboardSorts: [],
-                    context: QueryExecutionContext.AI,
-                });
+        const chartResultPromises = chartTiles.map(
+            async ({ tileUuid, chartUuid }) => {
+                const chartAndResults =
+                    await this.projectService.getChartAndResults({
+                        account: fromSession(user),
+                        dashboardUuid: dashboard.uuid,
+                        chartUuid,
+                        tileUuid,
+                        dashboardFilters: dashboard.filters,
+                        dashboardSorts: [],
+                        context: QueryExecutionContext.AI,
+                    });
 
-            const columns = [
-                ...chartAndResults.metricQuery.dimensions,
-                ...chartAndResults.metricQuery.metrics, // custom metrics are already included here
-                ...chartAndResults.metricQuery.tableCalculations.map(
-                    (tc) => tc.name,
-                ),
-                ...(chartAndResults.metricQuery.customDimensions ?? []).map(
-                    (cd) => cd.id,
-                ),
-            ];
+                const columns = [
+                    ...chartAndResults.metricQuery.dimensions,
+                    ...chartAndResults.metricQuery.metrics, // custom metrics are already included here
+                    ...chartAndResults.metricQuery.tableCalculations.map(
+                        (tc) => tc.name,
+                    ),
+                    ...(chartAndResults.metricQuery.customDimensions ?? []).map(
+                        (cd) => cd.id,
+                    ),
+                ];
 
-            const data = await makeResultsCSV(columns, chartAndResults.rows);
+                const data = await makeResultsCSV(
+                    columns,
+                    chartAndResults.rows,
+                );
 
-            return {
-                name: chartAndResults.chart.name,
-                description: chartAndResults.chart.description,
-                data,
-                columns,
-                fields: chartAndResults.fields,
-            };
-        });
+                return {
+                    name: chartAndResults.chart.name,
+                    description: chartAndResults.chart.description,
+                    data,
+                    columns,
+                    fields: chartAndResults.fields,
+                };
+            },
+        );
 
         return Promise.all(chartResultPromises);
     }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5828,7 +5828,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'PreAggregateDef' },
                 },
-                savedParameterValues: { ref: 'ParametersValuesMap' },
                 parameters: { ref: 'Record_string.LightdashProjectParameter_' },
                 aiHint: {
                     dataType: 'union',
@@ -16044,7 +16043,6 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                parameterValues: { ref: 'ParametersValuesMap' },
                 columns: {
                     dataType: 'array',
                     array: { dataType: 'refAlias', ref: 'VizColumn' },
@@ -21389,13 +21387,6 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
-                savedParameterValues: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'ParametersValuesMap' },
-                        { dataType: 'undefined' },
-                    ],
-                },
                 preAggregates: {
                     dataType: 'union',
                     subSchemas: [
@@ -24242,13 +24233,6 @@ const models: TsoaRoute.Models = {
                     subSchemas: [
                         { dataType: 'string' },
                         { dataType: 'array', array: { dataType: 'string' } },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                savedParameterValues: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { ref: 'ParametersValuesMap' },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -42131,6 +42115,7 @@ export function RegisterRoutes(app: Router) {
             nestedProperties: {
                 autoRefresh: { dataType: 'boolean' },
                 dateZoom: { ref: 'DateZoom' },
+                tileUuid: { dataType: 'string' },
                 dashboardUuid: { dataType: 'string', required: true },
                 dashboardSorts: {
                     dataType: 'array',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7000,9 +7000,6 @@
                         },
                         "type": "array"
                     },
-                    "savedParameterValues": {
-                        "$ref": "#/components/schemas/ParametersValuesMap"
-                    },
                     "parameters": {
                         "$ref": "#/components/schemas/Record_string.LightdashProjectParameter_"
                     },
@@ -16970,9 +16967,6 @@
             },
             "CreateVirtualViewPayload": {
                 "properties": {
-                    "parameterValues": {
-                        "$ref": "#/components/schemas/ParametersValuesMap"
-                    },
                     "columns": {
                         "items": {
                             "$ref": "#/components/schemas/VizColumn"
@@ -22546,9 +22540,6 @@
                     "parameters": {
                         "$ref": "#/components/schemas/Record_string.LightdashProjectParameter_"
                     },
-                    "savedParameterValues": {
-                        "$ref": "#/components/schemas/ParametersValuesMap"
-                    },
                     "preAggregates": {
                         "items": {
                             "$ref": "#/components/schemas/PreAggregateDef"
@@ -25424,9 +25415,6 @@
                                 "type": "array"
                             }
                         ]
-                    },
-                    "savedParameterValues": {
-                        "$ref": "#/components/schemas/ParametersValuesMap"
                     },
                     "preAggregates": {
                         "items": {
@@ -29724,7 +29712,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2726.1",
+        "version": "0.2729.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -36945,6 +36933,9 @@
                                     },
                                     "dateZoom": {
                                         "$ref": "#/components/schemas/DateZoom"
+                                    },
+                                    "tileUuid": {
+                                        "type": "string"
                                     },
                                     "dashboardUuid": {
                                         "type": "string"

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -68,6 +68,7 @@ import {
     getAllDimensionsMap,
     getAvailableParametersFromTables,
     getDashboardFilterRulesForTables,
+    getDashboardFiltersForTileAndTables,
     getDimensions,
     getErrorMessage,
     getFields,
@@ -3446,12 +3447,18 @@ export class ProjectService extends BaseService {
         dashboardSorts,
         dateZoom,
         dashboardUuid,
+        tileUuid,
         autoRefresh,
         context = QueryExecutionContext.DASHBOARD,
     }: {
         account: Account;
         chartUuid: string;
         dashboardUuid: string;
+        // tileUuid is required to correctly resolve cross-explore filter
+        // tileTargets overrides. When omitted, dashboard filters fall back to
+        // matching by the rule's top-level target.tableName, which silently
+        // drops cross-explore mapped filters.
+        tileUuid?: string;
         dashboardFilters: DashboardFilters;
         invalidateCache?: boolean;
         dashboardSorts: SortField[];
@@ -3499,20 +3506,31 @@ export class ProjectService extends BaseService {
         );
 
         const tables = Object.keys(explore.tables);
-        const appliedDashboardFilters = {
-            dimensions: getDashboardFilterRulesForTables(
-                tables,
-                dashboardFilters.dimensions,
-            ),
-            metrics: getDashboardFilterRulesForTables(
-                tables,
-                dashboardFilters.metrics,
-            ),
-            tableCalculations: getDashboardFilterRulesForTables(
-                tables,
-                dashboardFilters.tableCalculations,
-            ),
-        };
+        // When tileUuid is provided, resolve per-tile tileTargets overrides
+        // before filtering by the explore's tables. This is necessary so that
+        // cross-explore filter mappings (where the rule's top-level target
+        // points at a table not in this tile's explore, but tileTargets
+        // remaps it to a table that is) are applied correctly.
+        const appliedDashboardFilters: DashboardFilters = tileUuid
+            ? getDashboardFiltersForTileAndTables(
+                  tileUuid,
+                  tables,
+                  dashboardFilters,
+              )
+            : {
+                  dimensions: getDashboardFilterRulesForTables(
+                      tables,
+                      dashboardFilters.dimensions,
+                  ),
+                  metrics: getDashboardFilterRulesForTables(
+                      tables,
+                      dashboardFilters.metrics,
+                  ),
+                  tableCalculations: getDashboardFilterRulesForTables(
+                      tables,
+                      dashboardFilters.tableCalculations,
+                  ),
+              };
 
         const metricQueryWithDashboardOverrides: MetricQuery = {
             ...addDashboardFiltersToMetricQuery(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds support for tile-specific dashboard filter resolution by introducing an optional `tileUuid` parameter to the chart results endpoint. 

**Key changes:**

- Added optional `tileUuid` parameter to the saved chart controller's chart results endpoint
- Updated the AI service to pass `tileUuid` when fetching chart data for dashboard tiles
- Enhanced the project service's `getChartAndResults` method to use tile-specific filter resolution when `tileUuid` is provided
- Implemented proper cross-explore filter mapping by resolving `tileTargets` overrides before filtering by explore tables

When `tileUuid` is provided, the system now correctly applies dashboard filters that have been remapped for specific tiles, ensuring cross-explore filter mappings work as expected. Without `tileUuid`, the system falls back to the previous behavior of matching filters by table name only.

This improvement ensures that dashboard filters are applied correctly to charts even when they involve cross-explore mappings where the filter's original target table differs from the tile's explore tables.