### PR TITLE
fix: validator model rename resolves wrong model when names share a prefix

### DIFF
--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
@@ -10,7 +10,6 @@ import {
     Box,
     Button,
     Checkbox,
-    Code,
     Group,
     Highlight,
     Radio,
@@ -27,6 +26,7 @@ import { useExplores } from '../../../hooks/useExplores';
 import { useSavedQuery } from '../../../hooks/useSavedQuery';
 import Callout from '../../common/Callout';
 import MantineModal from '../../common/MantineModal';
+import { resolveModelNameFromField } from '../utils/resolveModelName';
 import { getLinkToResource } from '../utils/utils';
 import { useFieldsForChart, useRenameChart } from './hooks/useRenameResource';
 
@@ -95,7 +95,7 @@ export const FixValidationErrorModal: FC<Props> = ({
             return allValidationErrors.filter(
                 (e) =>
                     isChartValidationError(e) &&
-                    (e.fieldName || '').startsWith(tableName ?? ''),
+                    (e.fieldName || '').startsWith(`${tableName}_`),
             ).length;
         } else {
             return assertUnreachable(
@@ -107,16 +107,15 @@ export const FixValidationErrorModal: FC<Props> = ({
 
     const fieldName = validationError?.fieldName;
 
-    // Check if the field belongs to the chart's base table
-    const fieldBaseTableNameCandidate = useMemo(() => {
-        if (!fieldName || !savedQuery?.tableName) return '';
-        if (fieldName.startsWith(savedQuery?.tableName ?? ''))
-            return savedQuery?.tableName;
-        return fieldName.split('_')[0];
-    }, [fieldName, savedQuery?.tableName]);
-
-    const isFieldFromBaseTable =
-        fieldBaseTableNameCandidate === savedQuery?.tableName;
+    const fieldBaseTableNameCandidate = useMemo(
+        () =>
+            resolveModelNameFromField(
+                fieldName ?? '',
+                savedQuery?.tableName,
+                explores?.map((e) => e.name),
+            ),
+        [fieldName, savedQuery?.tableName, explores],
+    );
 
     if (!validationError) {
         return null;
@@ -265,27 +264,30 @@ export const FixValidationErrorModal: FC<Props> = ({
                     ) : renameType === RenameType.MODEL ? (
                         <Stack>
                             <TextInput
-                                disabled={isFieldFromBaseTable}
                                 label="Old model"
-                                placeholder={
-                                    isFieldFromBaseTable
-                                        ? undefined
-                                        : 'Enter the table name (e.g., customers)'
-                                }
+                                placeholder="Enter the table name (e.g., customers)"
                                 value={oldName}
                                 onChange={(e) =>
                                     setOldName(e.currentTarget.value)
                                 }
                             />
-                            {!isFieldFromBaseTable && (
-                                <Text size="xs" c="dimmed">
-                                    The field <Code>{fieldName}</Code> doesn't
-                                    belong to the base model for chart:{' '}
-                                    <Code>{savedQuery?.tableName}</Code>. Enter
-                                    the correct old model name to point the
-                                    field to the correct model.
-                                </Text>
-                            )}
+                            {oldName &&
+                                savedQuery?.tableName &&
+                                oldName !== savedQuery.tableName && (
+                                    <Text size="xs" c="dimmed">
+                                        The field{' '}
+                                        <Text span ff="monospace" size="xs">
+                                            {fieldName}
+                                        </Text>{' '}
+                                        doesn't belong to the base model for
+                                        chart:{' '}
+                                        <Text span ff="monospace" size="xs">
+                                            {savedQuery.tableName}
+                                        </Text>
+                                        . Verify the old model name is correct
+                                        before renaming.
+                                    </Text>
+                                )}
                             <Select
                                 searchValue={search}
                                 onSearchChange={setSearch}

--- a/packages/frontend/src/components/SettingsValidator/utils/resolveModelName.test.ts
+++ b/packages/frontend/src/components/SettingsValidator/utils/resolveModelName.test.ts
@@ -1,0 +1,59 @@
+import { resolveModelNameFromField } from './resolveModelName';
+
+describe('resolveModelNameFromField', () => {
+    const exploreNames = [
+        'orders',
+        'orders_status_history',
+        'orders_line_items',
+    ];
+
+    /**
+     * PROD-5676: When the chart's base table ("orders") is a prefix of the
+     * actual model ("orders_status_history"), the function must return the
+     * specific model — not the base table.
+     */
+    test('should resolve the specific model, not the base table prefix', () => {
+        expect(
+            resolveModelNameFromField(
+                'orders_status_history_created_at',
+                'orders',
+                exploreNames,
+            ),
+        ).toBe('orders_status_history');
+    });
+
+    test('should not match unrelated models that share a prefix', () => {
+        expect(
+            resolveModelNameFromField(
+                'orders_line_items_quantity',
+                'orders',
+                exploreNames,
+            ),
+        ).toBe('orders_line_items');
+    });
+
+    test('should resolve base table fields correctly', () => {
+        expect(
+            resolveModelNameFromField('orders_status', 'orders', exploreNames),
+        ).toBe('orders');
+    });
+
+    test('should resolve a joined model when base table is unrelated', () => {
+        expect(
+            resolveModelNameFromField('payments_created_at', 'customers', [
+                'customers',
+                'payments',
+            ]),
+        ).toBe('payments');
+    });
+
+    test('should return empty string when fieldName is empty', () => {
+        expect(resolveModelNameFromField('', 'orders', exploreNames)).toBe('');
+    });
+
+    test('should fall back to base table when explores are not loaded yet', () => {
+        expect(
+            resolveModelNameFromField('orders_status', 'orders', undefined),
+        ).toBe('orders');
+    });
+});

--- a/packages/frontend/src/components/SettingsValidator/utils/resolveModelName.ts
+++ b/packages/frontend/src/components/SettingsValidator/utils/resolveModelName.ts
@@ -1,0 +1,32 @@
+/**
+ * Given a broken field name from a validation error, resolve which model
+ * (explore) it belongs to.
+ *
+ * @param fieldName - The full field ID, e.g. "orders_status_history_created_at"
+ * @param baseTableName - The chart's base table name, e.g. "orders"
+ * @param exploreNames - All available explore/model names in the project
+ * @returns The model name the field belongs to
+ */
+export const resolveModelNameFromField = (
+    fieldName: string,
+    baseTableName: string | undefined,
+    exploreNames: string[] | undefined,
+): string => {
+    if (!fieldName) return '';
+
+    // Find the longest explore name that is a prefix of the field.
+    // This avoids the collision where e.g. "orders" (the base table) would
+    // match "orders_status_history_created_at" instead of the more specific
+    // model "orders_status_history".
+    if (exploreNames) {
+        const longestMatch = exploreNames
+            .filter((name) => fieldName.startsWith(`${name}_`))
+            .sort((a, b) => b.length - a.length)[0];
+        if (longestMatch) return longestMatch;
+    }
+
+    // Fallback when explores haven't loaded yet
+    if (baseTableName && fieldName.startsWith(`${baseTableName}_`))
+        return baseTableName;
+    return fieldName.split('_')[0];
+};


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/PROD-5676/validator-fix-all-occurrences-model-rename-matches-wrong-model-prefix

### Description:
The "Fix all occurrences" model rename in the validator used the chart's base table name as the old model. When model names share a prefix (e.g. "orders" and "orders_status_history"), the regex would sweep all fields matching the shorter prefix, breaking unrelated charts.

- Extract model name resolution into resolveModelNameFromField() that finds the longest matching explore name as the field's table prefix
- Fix occurrence counting to include underscore separator in startsWith
- Always allow editing the "Old model" input so users can correct wrong auto-detection (previously disabled when field matched base table)
- Show helper text when resolved model differs from chart's base table
