### PR TITLE
feat: add preview step before bulk rename in validator fix modal

### DIFF
--- a/packages/backend/src/controllers/renameController.ts
+++ b/packages/backend/src/controllers/renameController.ts
@@ -7,6 +7,7 @@ import {
     ApiRenameDashboardBody,
     ApiRenameDashboardResponse,
     ApiRenameFieldsResponse,
+    ApiRenameResponse,
     getRequestMethod,
     LightdashRequestMethodHeader,
 } from '@lightdash/common';
@@ -70,6 +71,43 @@ export class RenameController extends BaseController {
         return {
             status: 'ok',
             results: scheduledJob,
+        };
+    }
+
+    /**
+     * Preview which resources would be affected by a bulk rename
+     * @summary Preview rename
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('/preview')
+    @OperationId('previewRename')
+    async previewRename(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+        @Body() body: ApiRenameBody,
+    ): Promise<ApiRenameResponse> {
+        this.setStatus(200);
+        const context = getRequestMethod(
+            req.header(LightdashRequestMethodHeader),
+        );
+
+        const results = await this.services
+            .getRenameService()
+            .previewRenameResources({
+                user: req.user!,
+                projectUuid,
+                context,
+                ...body,
+            });
+
+        return {
+            status: 'ok',
+            results,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6690,7 +6690,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
+    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
         {
             dataType: 'refAlias',
             type: {
@@ -6708,6 +6708,10 @@ const models: TsoaRoute.Models = {
                                 },
                                 required: true,
                             },
+                            createdByUserUuid: {
+                                dataType: 'string',
+                                required: true,
+                            },
                             description: { dataType: 'string', required: true },
                             name: { dataType: 'string', required: true },
                             appUuid: { dataType: 'string', required: true },
@@ -6723,7 +6727,7 @@ const models: TsoaRoute.Models = {
     ApiGetAppResponse: {
         dataType: 'refAlias',
         type: {
-            ref: 'ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
+            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
             validators: {},
         },
     },
@@ -8309,11 +8313,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8791,11 +8795,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8810,11 +8814,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8829,11 +8833,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8848,11 +8852,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8867,11 +8871,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -16114,7 +16118,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SchedulerFormat: {
         dataType: 'refEnum',
-        enums: ['csv', 'xlsx', 'image', 'gsheets'],
+        enums: ['csv', 'xlsx', 'image', 'gsheets', 'pdf'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SchedulerCsvOptions: {
@@ -16162,6 +16166,20 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.never_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    SchedulerPdfOptions: {
+        dataType: 'refAlias',
+        type: { ref: 'Record_string.never_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SchedulerOptions: {
         dataType: 'refAlias',
         type: {
@@ -16170,6 +16188,7 @@ const models: TsoaRoute.Models = {
                 { ref: 'SchedulerCsvOptions' },
                 { ref: 'SchedulerImageOptions' },
                 { ref: 'SchedulerGsheetsOptions' },
+                { ref: 'SchedulerPdfOptions' },
             ],
             validators: {},
         },
@@ -18496,6 +18515,67 @@ const models: TsoaRoute.Models = {
                 type: { ref: 'RenameType', required: true },
                 from: { dataType: 'string', required: true },
                 to: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    RenameChange: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiRenameResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        dashboardSchedulers: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'RenameChange',
+                            },
+                            required: true,
+                        },
+                        alerts: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'RenameChange',
+                            },
+                            required: true,
+                        },
+                        dashboards: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'RenameChange',
+                            },
+                            required: true,
+                        },
+                        charts: {
+                            dataType: 'array',
+                            array: {
+                                dataType: 'refAlias',
+                                ref: 'RenameChange',
+                            },
+                            required: true,
+                        },
+                    },
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
         },
@@ -43010,6 +43090,71 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'rename',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsRenameController_previewRename: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            ref: 'ApiRenameBody',
+        },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/rename/preview',
+        ...fetchMiddlewares<RequestHandler>(RenameController),
+        ...fetchMiddlewares<RequestHandler>(
+            RenameController.prototype.previewRename,
+        ),
+
+        async function RenameController_previewRename(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsRenameController_previewRename,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<RenameController>(RenameController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'previewRename',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8043,7 +8043,7 @@
                 ],
                 "type": "object"
             },
-            "ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
+            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
                 "properties": {
                     "results": {
                         "properties": {
@@ -8055,6 +8055,9 @@
                                     "$ref": "#/components/schemas/ApiAppVersionSummary"
                                 },
                                 "type": "array"
+                            },
+                            "createdByUserUuid": {
+                                "type": "string"
                             },
                             "description": {
                                 "type": "string"
@@ -8069,6 +8072,7 @@
                         "required": [
                             "hasMore",
                             "versions",
+                            "createdByUserUuid",
                             "description",
                             "name",
                             "appUuid"
@@ -8085,7 +8089,7 @@
                 "type": "object"
             },
             "ApiGetAppResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
             },
             "ApiCancelAppVersionResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"
@@ -9733,6 +9737,19 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "error",
+                                                            "success"
+                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -17054,7 +17071,7 @@
                 "type": "object"
             },
             "SchedulerFormat": {
-                "enum": ["csv", "xlsx", "image", "gsheets"],
+                "enum": ["csv", "xlsx", "image", "gsheets", "pdf"],
                 "type": "string"
             },
             "SchedulerCsvOptions": {
@@ -17115,6 +17132,14 @@
                 ],
                 "type": "object"
             },
+            "Record_string.never_": {
+                "properties": {},
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "SchedulerPdfOptions": {
+                "$ref": "#/components/schemas/Record_string.never_"
+            },
             "SchedulerOptions": {
                 "anyOf": [
                     {
@@ -17125,6 +17150,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/SchedulerGsheetsOptions"
+                    },
+                    {
+                        "$ref": "#/components/schemas/SchedulerPdfOptions"
                     }
                 ]
             },
@@ -19676,6 +19704,64 @@
                     }
                 },
                 "required": ["type", "from", "to"],
+                "type": "object"
+            },
+            "RenameChange": {
+                "properties": {
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": ["name", "uuid"],
+                "type": "object"
+            },
+            "ApiRenameResponse": {
+                "properties": {
+                    "results": {
+                        "properties": {
+                            "dashboardSchedulers": {
+                                "items": {
+                                    "$ref": "#/components/schemas/RenameChange"
+                                },
+                                "type": "array"
+                            },
+                            "alerts": {
+                                "items": {
+                                    "$ref": "#/components/schemas/RenameChange"
+                                },
+                                "type": "array"
+                            },
+                            "dashboards": {
+                                "items": {
+                                    "$ref": "#/components/schemas/RenameChange"
+                                },
+                                "type": "array"
+                            },
+                            "charts": {
+                                "items": {
+                                    "$ref": "#/components/schemas/RenameChange"
+                                },
+                                "type": "array"
+                            }
+                        },
+                        "required": [
+                            "dashboardSchedulers",
+                            "alerts",
+                            "dashboards",
+                            "charts"
+                        ],
+                        "type": "object"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
                 "type": "object"
             },
             "ApiRenameChartResponse": {
@@ -29724,7 +29810,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2726.1",
+        "version": "0.2729.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -37549,6 +37635,57 @@
                 },
                 "description": "Rename resources in a project",
                 "summary": "Rename resources",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "$ref": "#/components/schemas/ApiRenameBody"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/rename/preview": {
+            "post": {
+                "operationId": "previewRename",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiRenameResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Preview which resources would be affected by a bulk rename",
+                "summary": "Preview rename",
                 "tags": ["Projects"],
                 "security": [],
                 "parameters": [

--- a/packages/backend/src/services/RenameService/RenameService.ts
+++ b/packages/backend/src/services/RenameService/RenameService.ts
@@ -588,6 +588,56 @@ export class RenameService extends BaseService {
         );
     }
 
+    async previewRenameResources({
+        user,
+        projectUuid,
+        context,
+        ...renameBody
+    }: ApiRenameBody & {
+        user: SessionUser;
+        projectUuid: string;
+        context: RequestMethod;
+    }): Promise<ApiRenameResponse['results']> {
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+        if (
+            user.ability.cannot(
+                'update',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        // Pre-compute nameChanges so runScheduledRenameResources takes
+        // the fast path and doesn't need to look up the (possibly broken)
+        // field in the explore cache.
+        const { from, to, type, model } = renameBody;
+        const nameChanges =
+            model && type === RenameType.FIELD
+                ? getNameChanges({ from, to, table: model, type })
+                : undefined;
+
+        return this.runScheduledRenameResources({
+            ...renameBody,
+            ...(nameChanges && {
+                fromReference: nameChanges.fromReference,
+                toReference: nameChanges.toReference,
+                fromFieldName: nameChanges.fromFieldName,
+                toFieldName: nameChanges.toFieldName,
+            }),
+            dryRun: true,
+            context,
+            organizationUuid,
+            projectUuid,
+            userUuid: user.userUuid,
+            schedulerUuid: undefined,
+        });
+    }
+
     private async findExploreForField({
         projectUuid,
         fieldName,

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -169,7 +169,7 @@ import {
 } from './projects';
 import { type ApiPromotionChangesResponse } from './promotion';
 import { type QueryHistoryStatus } from './queryHistory';
-import { type ApiRenameFieldsResponse } from './rename';
+import { type ApiRenameFieldsResponse, type ApiRenameResponse } from './rename';
 import { type MostPopularAndRecentlyUpdated } from './resourceViewItem';
 import { type ResultColumns, type ResultRow } from './results';
 import {
@@ -952,6 +952,7 @@ type ApiResults =
     | ApiReassignUserSchedulersResponse['results']
     | ApiUserActivityDownloadCsv['results']
     | ApiRenameFieldsResponse['results']
+    | ApiRenameResponse['results']
     | ApiDownloadAsyncQueryResults
     | ApiDownloadAsyncQueryResultsAsXlsx
     | ApiAiAgentThreadResponse['results']

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/FixValidationErrorModal.tsx
@@ -2,6 +2,7 @@ import {
     assertUnreachable,
     isChartValidationError,
     RenameType,
+    type ApiRenameResponse,
     type ValidationErrorChartResponse,
     type ValidationResponse,
 } from '@lightdash/common';
@@ -12,7 +13,9 @@ import {
     Checkbox,
     Group,
     Highlight,
+    List,
     Radio,
+    ScrollArea,
     Select,
     Stack,
     Text,
@@ -28,7 +31,11 @@ import Callout from '../../common/Callout';
 import MantineModal from '../../common/MantineModal';
 import { resolveModelNameFromField } from '../utils/resolveModelName';
 import { getLinkToResource } from '../utils/utils';
-import { useFieldsForChart, useRenameChart } from './hooks/useRenameResource';
+import {
+    useFieldsForChart,
+    usePreviewRename,
+    useRenameChart,
+} from './hooks/useRenameResource';
 
 type Props = {
     validationError: ValidationErrorChartResponse | undefined; // At the moment we can only fix chart errors
@@ -41,6 +48,8 @@ export const FixValidationErrorModal: FC<Props> = ({
     onClose,
 }) => {
     const { mutate: renameChart } = useRenameChart();
+    const { mutate: previewRename, isLoading: isPreviewLoading } =
+        usePreviewRename();
 
     const chartUuid = validationError?.chartUuid;
     const { data: fields, isError: isErrorFields } = useFieldsForChart(
@@ -56,6 +65,9 @@ export const FixValidationErrorModal: FC<Props> = ({
     const [newName, setNewName] = useState('');
     const [fixAll, setFixAll] = useState(false);
     const [renameType, setRenameType] = useState<RenameType>(RenameType.FIELD);
+    const [previewData, setPreviewData] = useState<
+        ApiRenameResponse['results'] | null
+    >(null);
     const form = useForm<{}>();
 
     const [search, setSearch] = useState('');
@@ -126,11 +138,12 @@ export const FixValidationErrorModal: FC<Props> = ({
         setRenameType(RenameType.FIELD);
         setNewName('');
         setFixAll(false);
+        setPreviewData(null);
         form.reset();
         onClose();
     };
 
-    const handleConfirm = form.onSubmit(() => {
+    const executeRename = () => {
         renameChart({
             from: oldName || fieldName || '',
             to: newName,
@@ -146,9 +159,35 @@ export const FixValidationErrorModal: FC<Props> = ({
 
         form.reset();
         handleClose();
+    };
+
+    const handleConfirm = form.onSubmit(() => {
+        if (fixAll && !previewData) {
+            previewRename(
+                {
+                    from: oldName || fieldName || '',
+                    to: newName,
+                    type: renameType,
+                    model: savedQuery?.tableName,
+                    projectUuid: validationError.projectUuid!,
+                },
+                {
+                    onSuccess: (data) => setPreviewData(data),
+                },
+            );
+        } else {
+            executeRename();
+        }
     });
 
     const FIX_VALIDATION_FORM_ID = 'fix-validation-form';
+
+    const totalPreviewChanges = previewData
+        ? previewData.charts.length +
+          previewData.dashboards.length +
+          previewData.alerts.length +
+          previewData.dashboardSchedulers.length
+        : 0;
 
     return (
         <MantineModal
@@ -158,13 +197,26 @@ export const FixValidationErrorModal: FC<Props> = ({
             opened={!!validationError}
             onClose={handleClose}
             actions={
-                <Button
-                    type="submit"
-                    form={FIX_VALIDATION_FORM_ID}
-                    disabled={newName === ''}
-                >
-                    Rename
-                </Button>
+                previewData ? (
+                    <Group>
+                        <Button
+                            variant="default"
+                            onClick={() => setPreviewData(null)}
+                        >
+                            Back
+                        </Button>
+                        <Button onClick={executeRename}>Confirm rename</Button>
+                    </Group>
+                ) : (
+                    <Button
+                        type="submit"
+                        form={FIX_VALIDATION_FORM_ID}
+                        disabled={newName === ''}
+                        loading={isPreviewLoading}
+                    >
+                        {fixAll ? 'Preview changes' : 'Rename'}
+                    </Button>
+                )
             }
         >
             <Text fz="sm">
@@ -187,54 +239,187 @@ export const FixValidationErrorModal: FC<Props> = ({
                 </Anchor>
             </Text>
 
-            <Callout
-                variant="info"
-                title="You can rename the missing dimension by renaming the affected field or model using the drop down below."
-            />
-
-            <form id={FIX_VALIDATION_FORM_ID} onSubmit={handleConfirm}>
+            {previewData ? (
                 <Stack>
-                    <Radio.Group
-                        defaultValue={RenameType.FIELD}
-                        onChange={(e) => {
-                            const type = e as RenameType;
-                            setRenameType(type);
-
-                            switch (type) {
-                                case RenameType.FIELD:
-                                    setOldName(fieldName);
-                                    break;
-                                case RenameType.MODEL:
-                                    setOldName(fieldBaseTableNameCandidate);
-                                    break;
-                                default:
-                                    assertUnreachable(
-                                        type,
-                                        `Unexpected rename type ${type}`,
-                                    );
-                            }
-                        }}
+                    <Callout
+                        variant="warning"
+                        title={`This will rename "${oldName || fieldName}" to "${newName}" in ${totalPreviewChanges} resource(s) across the project.`}
                     >
-                        <Group>
-                            <Radio value={RenameType.FIELD} label="Field" />
-                            <Radio value={RenameType.MODEL} label="Model" />
-                        </Group>
-                    </Radio.Group>
-                    {renameType === RenameType.FIELD ? (
+                        {previewData.charts.length > 0 && (
+                            <>
+                                <Text fw={600} fz="xs" mt="xs">
+                                    Charts ({previewData.charts.length})
+                                </Text>
+                                <ScrollArea.Autosize mah="150px" scrollbars="y">
+                                    <List size="xs">
+                                        {previewData.charts.map((c) => (
+                                            <List.Item key={c.uuid}>
+                                                {c.name}
+                                            </List.Item>
+                                        ))}
+                                    </List>
+                                </ScrollArea.Autosize>
+                            </>
+                        )}
+                        {previewData.dashboards.length > 0 && (
+                            <>
+                                <Text fw={600} fz="xs" mt="xs">
+                                    Dashboards ({previewData.dashboards.length})
+                                </Text>
+                                <ScrollArea.Autosize mah="150px" scrollbars="y">
+                                    <List size="xs">
+                                        {previewData.dashboards.map((d) => (
+                                            <List.Item key={d.uuid}>
+                                                {d.name}
+                                            </List.Item>
+                                        ))}
+                                    </List>
+                                </ScrollArea.Autosize>
+                            </>
+                        )}
+                        {previewData.alerts.length > 0 && (
+                            <Text fz="xs" mt="xs">
+                                + {previewData.alerts.length} alert(s)
+                            </Text>
+                        )}
+                        {previewData.dashboardSchedulers.length > 0 && (
+                            <Text fz="xs" mt="xs">
+                                + {previewData.dashboardSchedulers.length}{' '}
+                                scheduled delivery(ies)
+                            </Text>
+                        )}
+                    </Callout>
+                    {totalPreviewChanges === 0 && (
+                        <Text fz="sm" c="dimmed">
+                            No other resources will be affected. The rename will
+                            only apply to the current chart.
+                        </Text>
+                    )}
+                </Stack>
+            ) : (
+                <>
+                    <Callout
+                        variant="info"
+                        title="You can rename the missing dimension by renaming the affected field or model using the drop down below."
+                    />
+
+                    <form id={FIX_VALIDATION_FORM_ID} onSubmit={handleConfirm}>
                         <Stack>
-                            <TextInput
-                                disabled
-                                label="Old field"
-                                defaultValue={fieldName}
-                                value={oldName}
-                            />
-                            <Tooltip
-                                withinPortal
-                                disabled={!isErrorFields}
-                                label={`Could not find any fields on explore ${savedQuery?.tableName}. Perhaps you want to replace the model instead?`}
+                            <Radio.Group
+                                value={renameType}
+                                onChange={(e) => {
+                                    const type = e as RenameType;
+                                    setRenameType(type);
+                                    setNewName('');
+
+                                    switch (type) {
+                                        case RenameType.FIELD:
+                                            setOldName(fieldName);
+                                            break;
+                                        case RenameType.MODEL:
+                                            setOldName(
+                                                fieldBaseTableNameCandidate,
+                                            );
+                                            break;
+                                        default:
+                                            assertUnreachable(
+                                                type,
+                                                `Unexpected rename type ${type}`,
+                                            );
+                                    }
+                                }}
                             >
-                                <div>
+                                <Group>
+                                    <Radio
+                                        value={RenameType.FIELD}
+                                        label="Field"
+                                    />
+                                    <Radio
+                                        value={RenameType.MODEL}
+                                        label="Model"
+                                    />
+                                </Group>
+                            </Radio.Group>
+                            {renameType === RenameType.FIELD ? (
+                                <Stack>
+                                    <TextInput
+                                        disabled
+                                        label="Old field"
+                                        defaultValue={fieldName}
+                                        value={oldName}
+                                    />
+                                    <Tooltip
+                                        withinPortal
+                                        disabled={!isErrorFields}
+                                        label={`Could not find any fields on explore ${savedQuery?.tableName}. Perhaps you want to replace the model instead?`}
+                                    >
+                                        <div>
+                                            <Select
+                                                renderOption={({ option }) => (
+                                                    <Highlight
+                                                        highlight={search}
+                                                        {...option}
+                                                        fz="sm"
+                                                        color="yellow"
+                                                    >
+                                                        {option.label}
+                                                    </Highlight>
+                                                )}
+                                                onSearchChange={setSearch}
+                                                searchValue={search}
+                                                radius="md"
+                                                data={fieldOptions}
+                                                required
+                                                disabled={isErrorFields}
+                                                searchable
+                                                value={newName || null}
+                                                label="New field"
+                                                placeholder={`Select a field to rename to`}
+                                                onChange={(e) => {
+                                                    if (e) setNewName(e);
+                                                }}
+                                            />
+                                        </div>
+                                    </Tooltip>
+                                </Stack>
+                            ) : renameType === RenameType.MODEL ? (
+                                <Stack>
+                                    <TextInput
+                                        label="Old model"
+                                        placeholder="Enter the table name (e.g., customers)"
+                                        value={oldName}
+                                        onChange={(e) =>
+                                            setOldName(e.currentTarget.value)
+                                        }
+                                    />
+                                    {oldName &&
+                                        savedQuery?.tableName &&
+                                        oldName !== savedQuery.tableName && (
+                                            <Text size="xs" c="dimmed">
+                                                The field{' '}
+                                                <Text
+                                                    span
+                                                    ff="monospace"
+                                                    size="xs"
+                                                >
+                                                    {fieldName}
+                                                </Text>{' '}
+                                                doesn't belong to the base model
+                                                for chart:{' '}
+                                                <Text
+                                                    span
+                                                    ff="monospace"
+                                                    size="xs"
+                                                >
+                                                    {savedQuery.tableName}
+                                                </Text>
+                                                . Verify the old model name is
+                                                correct before renaming.
+                                            </Text>
+                                        )}
                                     <Select
+                                        searchValue={search}
+                                        onSearchChange={setSearch}
                                         renderOption={({ option }) => (
                                             <Highlight
                                                 highlight={search}
@@ -245,102 +430,54 @@ export const FixValidationErrorModal: FC<Props> = ({
                                                 {option.label}
                                             </Highlight>
                                         )}
-                                        onSearchChange={setSearch}
-                                        searchValue={search}
-                                        radius="md"
-                                        data={fieldOptions}
+                                        data={
+                                            explores?.map((e) => e.name) || []
+                                        }
                                         required
-                                        disabled={isErrorFields}
                                         searchable
-                                        label="New field"
-                                        placeholder={`Select a field to rename to`}
+                                        value={newName || null}
+                                        label="New model"
+                                        placeholder={`Select a model to rename to`}
                                         onChange={(e) => {
                                             if (e) setNewName(e);
                                         }}
                                     />
-                                </div>
-                            </Tooltip>
+                                </Stack>
+                            ) : (
+                                assertUnreachable(
+                                    renameType,
+                                    `Unexpected rename type ${renameType}`,
+                                )
+                            )}
+                            {totalOcurrences > 1 ? (
+                                <Tooltip
+                                    withinPortal
+                                    position="left"
+                                    label="Check this to rename all occurrences of this field in other charts and dashboards."
+                                >
+                                    <Box>
+                                        <Checkbox
+                                            size="xs"
+                                            label={`Fix all occurrences (${totalOcurrences})`}
+                                            checked={fixAll}
+                                            onChange={(e) =>
+                                                setFixAll(
+                                                    e.currentTarget.checked,
+                                                )
+                                            }
+                                        />
+                                    </Box>
+                                </Tooltip>
+                            ) : (
+                                <Text fz="xs" c="ldGray.7">
+                                    This {renameType} is not used in any other
+                                    charts.
+                                </Text>
+                            )}
                         </Stack>
-                    ) : renameType === RenameType.MODEL ? (
-                        <Stack>
-                            <TextInput
-                                label="Old model"
-                                placeholder="Enter the table name (e.g., customers)"
-                                value={oldName}
-                                onChange={(e) =>
-                                    setOldName(e.currentTarget.value)
-                                }
-                            />
-                            {oldName &&
-                                savedQuery?.tableName &&
-                                oldName !== savedQuery.tableName && (
-                                    <Text size="xs" c="dimmed">
-                                        The field{' '}
-                                        <Text span ff="monospace" size="xs">
-                                            {fieldName}
-                                        </Text>{' '}
-                                        doesn't belong to the base model for
-                                        chart:{' '}
-                                        <Text span ff="monospace" size="xs">
-                                            {savedQuery.tableName}
-                                        </Text>
-                                        . Verify the old model name is correct
-                                        before renaming.
-                                    </Text>
-                                )}
-                            <Select
-                                searchValue={search}
-                                onSearchChange={setSearch}
-                                renderOption={({ option }) => (
-                                    <Highlight
-                                        highlight={search}
-                                        {...option}
-                                        fz="sm"
-                                        color="yellow"
-                                    >
-                                        {option.label}
-                                    </Highlight>
-                                )}
-                                data={explores?.map((e) => e.name) || []}
-                                required
-                                searchable
-                                label="New model"
-                                placeholder={`Select a model to rename to`}
-                                onChange={(e) => {
-                                    if (e) setNewName(e);
-                                }}
-                            />
-                        </Stack>
-                    ) : (
-                        assertUnreachable(
-                            renameType,
-                            `Unexpected rename type ${renameType}`,
-                        )
-                    )}
-                    {totalOcurrences > 1 ? (
-                        <Tooltip
-                            withinPortal
-                            position="left"
-                            label="Check this to rename all occurrences of this field in other charts and dashboards."
-                        >
-                            <Box>
-                                <Checkbox
-                                    size="xs"
-                                    label={`Fix all occurrences (${totalOcurrences})`}
-                                    checked={fixAll}
-                                    onChange={(e) =>
-                                        setFixAll(e.currentTarget.checked)
-                                    }
-                                />
-                            </Box>
-                        </Tooltip>
-                    ) : (
-                        <Text fz="xs" c="ldGray.7">
-                            This {renameType} is not used in any other charts.
-                        </Text>
-                    )}
-                </Stack>
-            </form>
+                    </form>
+                </>
+            )}
         </MantineModal>
     );
 };

--- a/packages/frontend/src/components/SettingsValidator/ValidatorTable/hooks/useRenameResource.ts
+++ b/packages/frontend/src/components/SettingsValidator/ValidatorTable/hooks/useRenameResource.ts
@@ -2,11 +2,13 @@ import {
     getErrorMessage,
     type ApiError,
     type ApiJobScheduledResponse,
+    type ApiRenameBody,
     type ApiRenameChartBody,
     type ApiRenameChartResponse,
     type ApiRenameDashboardBody,
     type ApiRenameDashboardResponse,
     type ApiRenameFieldsResponse,
+    type ApiRenameResponse,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
 import { useMutation, useQuery } from '@tanstack/react-query';
@@ -122,6 +124,31 @@ export const useRenameChart = () => {
                 subtitle: error.error.message,
             });
         },
+    });
+};
+
+const previewRename = async ({
+    projectUuid,
+    from,
+    to,
+    type,
+    model,
+}: ApiRenameBody & { projectUuid: string }) => {
+    return lightdashApi<ApiRenameResponse['results']>({
+        url: `/projects/${projectUuid}/rename/preview`,
+        method: 'POST',
+        body: JSON.stringify({ from, to, type, model }),
+    });
+};
+
+export const usePreviewRename = () => {
+    return useMutation<
+        ApiRenameResponse['results'],
+        ApiError,
+        ApiRenameBody & { projectUuid: string }
+    >({
+        mutationKey: ['preview-rename'],
+        mutationFn: previewRename,
     });
 };
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-5676/validator-fix-all-occurrences-model-rename-matches-wrong-model-prefix

### Description:
When "Fix all occurrences" is checked, clicking "Rename" now shows a
preview of all charts, dashboards, alerts, and scheduled deliveries that
would be affected before executing. This prevents accidental damage from
wrong model/field name resolution.

- Add POST /api/v1/projects/{projectUuid}/rename/preview endpoint that
    calls runScheduledRenameResources with dryRun: true synchronously
- Add previewRenameResources method to RenameService with permission
    checks and pre-computed nameChanges for field renames
- Add usePreviewRename mutation hook in frontend
- Modal shows two-step flow: form → preview (with Back/Confirm) when
    fixAll is checked; direct rename when not checked
