### PR TITLE
fix: match dashboard filters by field ID instead of table name to prevent filter bypass

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -33,6 +33,7 @@ import {
     getDimensions,
     getFilterInteractivityValue,
     getItemId,
+    getMetrics,
     InteractivityOptions,
     IntrinsicUserAttributes,
     isChartContent,
@@ -926,11 +927,18 @@ export class EmbedService extends BaseService {
         tileUuid: string,
         dashboardFilters?: DashboardFilters,
     ) {
-        const tables = Object.keys(explore.tables);
+        const availableFieldIds = [
+            ...getDimensions(explore)
+                .filter((f) => isFilterableDimension(f) && !f.hidden)
+                .map(getItemId),
+            ...getMetrics(explore)
+                .filter((f) => !f.hidden)
+                .map(getItemId),
+        ];
 
         let appliedDashboardFilters = getDashboardFiltersForTileAndTables(
             tileUuid,
-            tables,
+            availableFieldIds,
             dashboard.filters,
         );
         if (
@@ -939,7 +947,7 @@ export class EmbedService extends BaseService {
         ) {
             appliedDashboardFilters = getDashboardFiltersForTileAndTables(
                 tileUuid,
-                tables,
+                availableFieldIds,
                 dashboardFilters,
             );
         }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -37,6 +37,7 @@ import {
     getFieldsFromMetricQuery,
     getItemId,
     getItemMap,
+    getMetrics,
     getMetricsWithValidParameters,
     isCartesianChartConfig,
     isCustomBinDimension,
@@ -45,6 +46,7 @@ import {
     isDateItem,
     isExploreError,
     isField,
+    isFilterableDimension,
     isJwtUser,
     isMetric,
     isValidTimezone,
@@ -3706,11 +3708,25 @@ export class AsyncQueryService extends ProjectService {
             account.isRegisteredUser() ? account.user.id : null,
         );
 
-        const tables = Object.keys(explore.tables);
+        // Use the explore's actual field ids (dimensions + metrics) as the
+        // source of truth for which dashboard filter rules apply to this tile.
+        // Matching on field id avoids the divergence between the UI and the
+        // server when a filter rule's `target.tableName` is stale (see comment
+        // on getDashboardFilterRulesForTables in @lightdash/common filters).
+        // The set is intentionally aligned with the UI's
+        // getAvailableFiltersForSavedQueries (filterable, non-hidden).
+        const availableFieldIds = [
+            ...getDimensions(explore)
+                .filter((f) => isFilterableDimension(f) && !f.hidden)
+                .map(getItemId),
+            ...getMetrics(explore)
+                .filter((f) => !f.hidden)
+                .map(getItemId),
+        ];
         const appliedDashboardFilters: DashboardFilters =
             getDashboardFiltersForTileAndTables(
                 tileUuid,
-                tables,
+                availableFieldIds,
                 dashboardFilters,
             );
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3498,18 +3498,29 @@ export class ProjectService extends BaseService {
             account.user.id,
         );
 
-        const tables = Object.keys(explore.tables);
+        // Match dashboard filter rules by their actual field id against the
+        // explore's available fields, not by tableName. See comment on
+        // getDashboardFilterRulesForTables for the rationale. Aligned with the
+        // UI's getAvailableFiltersForSavedQueries (filterable, non-hidden).
+        const availableFieldIds = [
+            ...getDimensions(explore)
+                .filter((f) => isFilterableDimension(f) && !f.hidden)
+                .map(getItemId),
+            ...getMetrics(explore)
+                .filter((f) => !f.hidden)
+                .map(getItemId),
+        ];
         const appliedDashboardFilters = {
             dimensions: getDashboardFilterRulesForTables(
-                tables,
+                availableFieldIds,
                 dashboardFilters.dimensions,
             ),
             metrics: getDashboardFilterRulesForTables(
-                tables,
+                availableFieldIds,
                 dashboardFilters.metrics,
             ),
             tableCalculations: getDashboardFilterRulesForTables(
-                tables,
+                availableFieldIds,
                 dashboardFilters.tableCalculations,
             ),
         };
@@ -6976,20 +6987,27 @@ export class ProjectService extends BaseService {
             savedChart.tableName,
             organizationUuid,
         );
-        const tables = Object.keys(explore.tables);
+        const availableFieldIds = [
+            ...getDimensions(explore)
+                .filter((f) => isFilterableDimension(f) && !f.hidden)
+                .map(getItemId),
+            ...getMetrics(explore)
+                .filter((f) => !f.hidden)
+                .map(getItemId),
+        ];
 
         const appliedDashboardFilters = dashboardFilters
             ? {
                   dimensions: getDashboardFilterRulesForTables(
-                      tables,
+                      availableFieldIds,
                       dashboardFilters.dimensions,
                   ),
                   metrics: getDashboardFilterRulesForTables(
-                      tables,
+                      availableFieldIds,
                       dashboardFilters.metrics,
                   ),
                   tableCalculations: getDashboardFilterRulesForTables(
-                      tables,
+                      availableFieldIds,
                       dashboardFilters.tableCalculations,
                   ),
               }

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -805,40 +805,55 @@ export const getDashboardFilterRulesForTileAndReferences = (
         (f) => f.target.isSqlColumn && references.includes(f.target.fieldId),
     );
 
+/**
+ * Filter dashboard filter rules to those whose target field id is actually
+ * present in the explore.
+ *
+ * Previously this matched by `target.tableName` against the explore's joined
+ * table aliases. That diverged from the UI's "is this filter applicable to
+ * this tile?" check, which matches by field id (see TileFilterConfiguration's
+ * `selectedField` computation). When a filter rule's `target.tableName` is
+ * stale (e.g. the dbt model was renamed since the filter was created) but
+ * `target.fieldId` still resolves against the explore, the UI rendered the
+ * filter as applied while the server silently dropped it — resulting in
+ * unfiltered data on dashboards (notably a PII leak risk for org-scoping
+ * filters). Matching by field id makes both checks use the same source of
+ * truth.
+ */
 export const getDashboardFilterRulesForTables = (
-    tables: string[],
+    availableFieldIds: string[],
     rules: DashboardFilterRule[],
 ): DashboardFilterRule[] =>
-    rules.filter((f) => tables.includes(f.target.tableName));
+    rules.filter((f) => availableFieldIds.includes(f.target.fieldId));
 
 export const getDashboardFilterRulesForTileAndTables = (
     tileUuid: string,
-    tables: string[],
+    availableFieldIds: string[],
     rules: DashboardFilterRule[],
 ): DashboardFilterRule[] =>
     getDashboardFilterRulesForTables(
-        tables,
+        availableFieldIds,
         getDashboardFilterRulesForTile(tileUuid, rules),
     );
 
 export const getDashboardFiltersForTileAndTables = (
     tileUuid: string,
-    tables: string[],
+    availableFieldIds: string[],
     dashboardFilters: DashboardFilters,
 ): DashboardFilters => ({
     dimensions: getDashboardFilterRulesForTileAndTables(
         tileUuid,
-        tables,
+        availableFieldIds,
         dashboardFilters.dimensions,
     ),
     metrics: getDashboardFilterRulesForTileAndTables(
         tileUuid,
-        tables,
+        availableFieldIds,
         dashboardFilters.metrics,
     ),
     tableCalculations: getDashboardFilterRulesForTileAndTables(
         tileUuid,
-        tables,
+        availableFieldIds,
         dashboardFilters.tableCalculations,
     ),
 });


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21787

### Description:

Fix dashboard filter application by matching field IDs instead of table names. Previously, dashboard filters were applied by matching the filter rule's `target.tableName` against the explore's table names, which could diverge from the UI's field ID-based matching logic. This caused filters to be silently dropped when table names became stale (e.g., after dbt model renames), resulting in unfiltered data being displayed on dashboards.

The fix changes the filter matching logic to use actual field IDs from the explore's dimensions and metrics as the source of truth. This ensures consistency between the UI and server-side filter application, preventing potential data leaks when organization-scoping filters are inadvertently bypassed.

Key changes:

- Replace table name matching with field ID matching in `getDashboardFilterRulesForTables`
- Generate `availableFieldIds` from explore dimensions and metrics using `getItemId`
- Add comprehensive documentation explaining the rationale for field ID-based matching
- Update all filter application points across EmbedService, AsyncQueryService, and ProjectService



test-frontend test-backend

