### PR TITLE
fix(ci): remove quotes from pinned google-github-actions refs

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -71,12 +71,12 @@ jobs:
       # Login to GCP Artifact Registry (all regions)
       # ========================================
       - id: 'auth'
-        uses: 'google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3'
+        uses: google-github-actions/auth@7c6bc770dae815cd3e89ee6cdf493a5fab2cc093 # v3
         with:
           credentials_json: '${{ secrets.GCP_CREDENTIALS_IMAGE_DEPLOY }}'
 
       - name: 'Set up Cloud SDK'
-        uses: 'google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3'
+        uses: google-github-actions/setup-gcloud@aa5489c8933f4cc7a4f7d45035b3b1440c9c10db # v3
         with:
           version: '>= 381.0.0'
 


### PR DESCRIPTION
## Summary
- Removes single quotes from `google-github-actions/auth` and `google-github-actions/setup-gcloud` in `post-release.yml`
- Single quotes caused the `# v3` YAML comment to be included as part of the action ref, making GitHub unable to resolve the version
- Introduced in #21784 where the pre-existing quotes weren't removed when SHA pinning was added

## Test plan
- [ ] Verify post-release workflow resolves the Google actions correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)