### PR TITLE
feat: add filter support to pre-aggregates

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -8,6 +8,7 @@ import {
     preAggregateUtils,
     SupportedDbtAdapter,
     TimeFrames,
+    UnitOfTime,
     type CompiledDimension,
     type CompiledMetric,
     type Explore,
@@ -213,6 +214,48 @@ describe('findMatch', () => {
                     name: 'orders_daily',
                     dimensions: ['status'],
                     metrics: ['order_count'],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status', 'orders_order_date_month'],
+                metrics: ['orders_order_count'],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_daily',
+            miss: null,
+        });
+    });
+
+    it('still matches pre-aggregates that define materialization filters', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_daily',
+                    dimensions: ['status', 'order_date'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-filter',
+                            target: {
+                                fieldRef: 'order_date',
+                            },
+                            operator: FilterOperator.IN_THE_PAST,
+                            values: [3],
+                            settings: {
+                                unitOfTime: UnitOfTime.days,
+                            },
+                        },
+                    ],
                     timeDimension: 'order_date',
                     granularity: TimeFrames.DAY,
                 },

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -5,6 +5,7 @@ import {
     MetricType,
     SupportedDbtAdapter,
     TimeFrames,
+    UnitOfTime,
     type Explore,
     type PreAggregateDef,
 } from '@lightdash/common';
@@ -259,6 +260,66 @@ describe('buildMaterializationMetricQuery', () => {
             ],
         });
         expect(result.timeDimensionFieldId).toBeNull();
+    });
+
+    it('emits pre-aggregate filters into materialization dimension filters', () => {
+        const preAggregateDef: PreAggregateDef = {
+            name: 'orders_rollup',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+            filters: [
+                {
+                    id: 'relative-date-filter',
+                    target: {
+                        fieldRef: 'order_date',
+                    },
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [3],
+                    settings: {
+                        unitOfTime: UnitOfTime.days,
+                    },
+                },
+                {
+                    id: 'qualified-filter',
+                    target: {
+                        fieldRef: 'orders.status',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+        };
+
+        const result = buildMaterializationMetricQuery({
+            sourceExplore: getSourceExplore(),
+            preAggregateDef,
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.metricQuery.filters.dimensions).toStrictEqual({
+            id: 'pre-aggregate-filters',
+            and: [
+                {
+                    id: 'relative-date-filter',
+                    target: {
+                        fieldId: 'orders_order_date',
+                    },
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [3],
+                    settings: {
+                        unitOfTime: UnitOfTime.days,
+                    },
+                },
+                {
+                    id: 'qualified-filter',
+                    target: {
+                        fieldId: 'orders_status',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+        });
     });
 
     it('throws when generated average metric component field IDs collide with selected metrics', () => {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -1,5 +1,6 @@
 import {
     assertUnreachable,
+    convertFieldRefToFieldId,
     getItemId,
     getPreAggregateMetricComponentColumnName,
     MetricType,
@@ -10,6 +11,7 @@ import {
     type CompiledMetric,
     type Explore,
     type FieldId,
+    type FilterRule,
     type MaterializationMetricComponent,
     type MaterializationMetricQueryPayload,
     type MetricQuery,
@@ -151,6 +153,40 @@ const hasTimeDimensionReference = ({
 
 type MaterializationConfig = {
     maxRows: number | null;
+};
+
+const getPreAggregateDimensionFilters = ({
+    sourceExplore,
+    preAggregateDef,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+}): MetricQuery['filters']['dimensions'] | undefined => {
+    if (!preAggregateDef.filters || preAggregateDef.filters.length === 0) {
+        return undefined;
+    }
+
+    return {
+        id: 'pre-aggregate-filters',
+        and: preAggregateDef.filters.map<FilterRule>((filter) => ({
+            id: filter.id,
+            target: {
+                fieldId: convertFieldRefToFieldId(
+                    filter.target.fieldRef,
+                    sourceExplore.baseTable,
+                ),
+            },
+            operator: filter.operator,
+            values: filter.values,
+            ...(filter.settings ? { settings: filter.settings } : {}),
+            ...(filter.required !== undefined
+                ? { required: filter.required }
+                : {}),
+            ...(filter.disabled !== undefined
+                ? { disabled: filter.disabled }
+                : {}),
+        })),
+    };
 };
 
 export const buildMaterializationMetricQuery = ({
@@ -304,12 +340,16 @@ export const buildMaterializationMetricQuery = ({
         preAggregateDef.maxRows ??
         materializationConfig.maxRows ??
         SYSTEM_MAX_ROWS;
+    const dimensionFilters = getPreAggregateDimensionFilters({
+        sourceExplore,
+        preAggregateDef,
+    });
 
     const metricQuery: MetricQuery = {
         exploreName: sourceExplore.name,
         dimensions,
         metrics: metricFieldIds,
-        filters: {},
+        filters: dimensionFilters ? { dimensions: dimensionFilters } : {},
         sorts: [],
         limit: resolvedMaxRows,
         tableCalculations: [],

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -148,6 +148,8 @@ const getMissForDef = ({
     >;
     metricsByFieldId: ReturnType<typeof getMetricsMapFromTables>;
 }): PreAggregateMatchMiss | null => {
+    // TODO: pre-aggregate filters are ignored for matching in this PR.
+    // Follow-up work should require the query filter set to be equivalent or narrower.
     const defMetrics = new Set(preAggregateDef.metrics);
     for (const metricFieldId of metricQuery.metrics) {
         const metric = metricsByFieldId[metricFieldId];

--- a/packages/common/src/preAggregates/definition.test.ts
+++ b/packages/common/src/preAggregates/definition.test.ts
@@ -1,6 +1,7 @@
 import { ParseError } from '../types/errors';
+import { FilterOperator, UnitOfTime } from '../types/filter';
 import { TimeFrames } from '../types/timeFrames';
-import { parseDbtPreAggregateDef } from './definition';
+import { parseDbtPreAggregateDef, parseDbtPreAggregates } from './definition';
 
 describe('parseDbtPreAggregateDef', () => {
     const basePreAggregate = {
@@ -136,5 +137,63 @@ describe('parseDbtPreAggregateDef', () => {
                 'orders',
             ),
         ).toThrow(ParseError);
+    });
+
+    it('parses pre-aggregate filters using the shared filter grammar', () => {
+        expect(
+            parseDbtPreAggregateDef(
+                {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    time_dimension: 'order_date',
+                    granularity: 'day',
+                    filters: [
+                        { order_date: 'inThePast 3 days' },
+                        { status: 'completed' },
+                    ],
+                },
+                'orders',
+            ),
+        ).toStrictEqual({
+            name: 'orders_rollup',
+            dimensions: ['status'],
+            metrics: ['order_count'],
+            timeDimension: 'order_date',
+            granularity: TimeFrames.DAY,
+            filters: [
+                {
+                    id: expect.any(String),
+                    target: { fieldRef: 'order_date' },
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [3],
+                    settings: {
+                        unitOfTime: UnitOfTime.days,
+                    },
+                },
+                {
+                    id: expect.any(String),
+                    target: { fieldRef: 'status' },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+        });
+    });
+
+    it('throws when pre-aggregate filters use invalid filter grammar', () => {
+        expect(() =>
+            parseDbtPreAggregates(
+                [
+                    {
+                        name: 'orders_rollup',
+                        dimensions: ['status'],
+                        metrics: ['order_count'],
+                        filters: [{ order_date: '"unterminated' }],
+                    },
+                ],
+                'orders',
+            ),
+        ).toThrow();
     });
 });

--- a/packages/common/src/preAggregates/definition.ts
+++ b/packages/common/src/preAggregates/definition.ts
@@ -5,6 +5,7 @@ import isString from 'lodash/isString';
 import keys from 'lodash/keys';
 import type { DbtPreAggregateDef } from '../types/dbt';
 import { ParseError } from '../types/errors';
+import { parseFilters } from '../types/filterGrammar';
 import type {
     PreAggregateDef,
     PreAggregateMaterializationRole,
@@ -206,10 +207,15 @@ export const parseDbtPreAggregateDef = (
               )
             : undefined;
 
+    const filters = safePreAggregate?.filters
+        ? parseFilters(safePreAggregate.filters)
+        : undefined;
+
     return {
         name,
         dimensions,
         metrics,
+        ...(filters ? { filters } : {}),
         ...(timeDimension ? { timeDimension } : {}),
         ...(granularity ? { granularity } : {}),
         ...(maxRows !== undefined ? { maxRows } : {}),

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -112,6 +112,7 @@ export type DbtPreAggregateDef = {
     name: string;
     dimensions: string[];
     metrics: string[];
+    filters?: Record<string, AnyType>[];
     time_dimension?: string;
     granularity?: string;
     max_rows?: number;

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -1,4 +1,5 @@
 import { type FieldId, type MetricType } from './field';
+import { type MetricFilterRule } from './filter';
 import { type KnexPaginatedData } from './knex-paginate';
 import { type MetricQuery } from './metricQuery';
 import { type ResultColumns } from './results';
@@ -43,6 +44,7 @@ export type PreAggregateDef = {
     name: string;
     dimensions: string[];
     metrics: string[];
+    filters?: MetricFilterRule[];
     // Parser validation enforces that timeDimension and granularity are provided together
     timeDimension?: string;
     granularity?: TimeFrames;


### PR DESCRIPTION
Closes: [ZAP-316: Allow users to define filters in pre-aggregation YAML](https://linear.app/lightdash/issue/ZAP-316/allow-users-to-define-filters-in-pre-aggregation-yaml)

### Description:

This PR adds support for filters in pre-aggregate definitions. Pre-aggregates can now include filter conditions that are applied during materialization to limit the data included in the pre-aggregated table.

Key changes:

- Added `filters` field to `PreAggregateDef` and `DbtPreAggregateDef` types using the existing filter grammar
- Updated the pre-aggregate parser to handle filter definitions from dbt configurations
- Modified the materialization service to apply pre-aggregate filters as dimension filters in the generated metric query
- Enhanced the matcher to still find pre-aggregates that have materialization filters defined (matching logic for query filters vs pre-aggregate filters will be addressed in follow-up work)
- Added comprehensive test coverage for parsing filter grammar and applying filters during materialization

The filters use the same grammar as existing metric query filters and support operations like relative date filtering (`inThePast 3 days`) and equality conditions.