### PR TITLE
feat: add pre-aggregate filter matching logic

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -97,6 +97,10 @@ const baseExplore = (): Explore => ({
                     timeInterval: TimeFrames.MONTH,
                     timeIntervalBaseDimensionName: 'order_date',
                 }),
+                amount: makeDimension({
+                    name: 'amount',
+                    type: DimensionType.NUMBER,
+                }),
             },
             metrics: {
                 total_order_amount: makeMetric({
@@ -235,7 +239,7 @@ describe('findMatch', () => {
         });
     });
 
-    it('still matches pre-aggregates that define materialization filters', () => {
+    it('matches when the query filter is equivalent to the pre-aggregate filter', () => {
         const explore = {
             ...baseExplore(),
             preAggregates: [
@@ -266,6 +270,22 @@ describe('findMatch', () => {
             makeMetricQuery({
                 dimensions: ['orders_status', 'orders_order_date_month'],
                 metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-date-filter',
+                                operator: FilterOperator.IN_THE_PAST,
+                                target: { fieldId: 'orders_order_date_day' },
+                                values: [3],
+                                settings: {
+                                    unitOfTime: UnitOfTime.days,
+                                },
+                            },
+                        ],
+                    },
+                },
             }),
             explore,
         );
@@ -274,6 +294,562 @@ describe('findMatch', () => {
             hit: true,
             preAggregateName: 'orders_daily',
             miss: null,
+        });
+    });
+
+    it('matches when the query filter is a narrower subset of the pre-aggregate filter', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_status_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-filter',
+                            target: {
+                                fieldRef: 'status',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed', 'shipped'],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-status-filter',
+                                operator: FilterOperator.EQUALS,
+                                target: { fieldId: 'orders_status' },
+                                values: ['completed'],
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_status_rollup',
+            miss: null,
+        });
+    });
+
+    it('does not match when a string query equals filter has no values', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_status_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-filter',
+                            target: {
+                                fieldRef: 'status',
+                            },
+                            operator: FilterOperator.STARTS_WITH,
+                            values: ['complete'],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-status-filter',
+                                operator: FilterOperator.EQUALS,
+                                target: { fieldId: 'orders_status' },
+                                values: [],
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_status',
+        });
+    });
+
+    it('does not match when a number query equals filter has no values', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_amount_rollup',
+                    dimensions: ['amount'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-filter',
+                            target: {
+                                fieldRef: 'amount',
+                            },
+                            operator: FilterOperator.GREATER_THAN,
+                            values: [5],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_amount'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-amount-filter',
+                                operator: FilterOperator.EQUALS,
+                                target: { fieldId: 'orders_amount' },
+                                values: [],
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_amount',
+        });
+    });
+
+    it('does not match when a date query equals filter has no values', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_date_rollup',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-filter',
+                            target: {
+                                fieldRef: 'order_date',
+                            },
+                            operator: FilterOperator.IN_BETWEEN,
+                            values: ['2024-01-01', '2024-01-31'],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_order_date_day'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-date-filter',
+                                operator: FilterOperator.EQUALS,
+                                target: { fieldId: 'orders_order_date_day' },
+                                values: [],
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_order_date',
+        });
+    });
+
+    it('matches when the query relative date filter is narrower on a sibling time dimension', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_recent_rollup',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-date-filter',
+                            target: {
+                                fieldRef: 'order_date',
+                            },
+                            operator: FilterOperator.IN_THE_PAST,
+                            values: [7],
+                            settings: {
+                                unitOfTime: UnitOfTime.days,
+                            },
+                        },
+                    ],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_order_date_day'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-date-filter',
+                                operator: FilterOperator.IN_THE_PAST,
+                                target: { fieldId: 'orders_order_date_day' },
+                                values: [3],
+                                settings: {
+                                    unitOfTime: UnitOfTime.days,
+                                },
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_recent_rollup',
+            miss: null,
+        });
+    });
+
+    it('does not match when NOT_IN_THE_CURRENT query is broader than the pre-aggregate filter', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_recent_rollup',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-date-filter',
+                            target: {
+                                fieldRef: 'order_date',
+                            },
+                            operator: FilterOperator.NOT_IN_THE_CURRENT,
+                            values: [],
+                            settings: {
+                                unitOfTime: UnitOfTime.months,
+                            },
+                        },
+                    ],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_order_date_day'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-date-filter',
+                                operator: FilterOperator.NOT_IN_THE_CURRENT,
+                                target: { fieldId: 'orders_order_date_day' },
+                                values: [],
+                                settings: {
+                                    unitOfTime: UnitOfTime.days,
+                                },
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_order_date',
+        });
+    });
+
+    it('matches when NULL filtered rollups have identical query filters', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_null_status_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-null-filter',
+                            target: {
+                                fieldRef: 'status',
+                            },
+                            operator: FilterOperator.NULL,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-null-filter',
+                                operator: FilterOperator.NULL,
+                                target: { fieldId: 'orders_status' },
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_null_status_rollup',
+            miss: null,
+        });
+    });
+
+    it('matches when NOT_NULL filtered rollups have identical query filters', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_not_null_status_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-not-null-filter',
+                            target: {
+                                fieldRef: 'status',
+                            },
+                            operator: FilterOperator.NOT_NULL,
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-not-null-filter',
+                                operator: FilterOperator.NOT_NULL,
+                                target: { fieldId: 'orders_status' },
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_not_null_status_rollup',
+            miss: null,
+        });
+    });
+
+    it('does not match when the query is missing a required pre-aggregate filter', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_completed_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-filter',
+                            target: {
+                                fieldRef: 'status',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed'],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_status',
+        });
+    });
+
+    it('does not match when the query filter is broader than the pre-aggregate filter', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_recent_rollup',
+                    dimensions: ['order_date'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-date-filter',
+                            target: {
+                                fieldRef: 'order_date',
+                            },
+                            operator: FilterOperator.IN_THE_PAST,
+                            values: [3],
+                            settings: {
+                                unitOfTime: UnitOfTime.days,
+                            },
+                        },
+                    ],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_order_date_day'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        and: [
+                            {
+                                id: 'query-date-filter',
+                                operator: FilterOperator.IN_THE_PAST,
+                                target: { fieldId: 'orders_order_date_day' },
+                                values: [7],
+                                settings: {
+                                    unitOfTime: UnitOfTime.days,
+                                },
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_order_date',
+        });
+    });
+
+    it('does not match when an OR filter group broadens beyond the pre-aggregate filter', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_completed_rollup',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                    filters: [
+                        {
+                            id: 'rollup-filter',
+                            target: {
+                                fieldRef: 'status',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: ['completed'],
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                filters: {
+                    dimensions: {
+                        id: 'query-filters',
+                        or: [
+                            {
+                                id: 'status-completed',
+                                operator: FilterOperator.EQUALS,
+                                target: { fieldId: 'orders_status' },
+                                values: ['completed'],
+                            },
+                            {
+                                id: 'status-shipped',
+                                operator: FilterOperator.EQUALS,
+                                target: { fieldId: 'orders_status' },
+                                values: ['shipped'],
+                            },
+                        ],
+                    },
+                },
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+            fieldId: 'orders_status',
         });
     });
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -5775,11 +5775,42 @@ const models: TsoaRoute.Models = {
         enums: ['virtual', 'default', 'pre_aggregate'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.string-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: {
+                dataType: 'array',
+                array: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAttributeValueMap: {
+        dataType: 'refAlias',
+        type: { ref: 'Record_string.string-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PreAggregateMaterializationRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                attributes: { ref: 'UserAttributeValueMap', required: true },
+                email: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PreAggregateDef: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                materializationRole: { ref: 'PreAggregateMaterializationRole' },
                 refresh: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: { cron: { dataType: 'string' } },
@@ -5787,6 +5818,10 @@ const models: TsoaRoute.Models = {
                 maxRows: { dataType: 'double' },
                 granularity: { ref: 'TimeFrames' },
                 timeDimension: { dataType: 'string' },
+                filters: {
+                    dataType: 'array',
+                    array: { dataType: 'refObject', ref: 'MetricFilterRule' },
+                },
                 metrics: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -6018,6 +6053,11 @@ const models: TsoaRoute.Models = {
         enums: ['filter_dimension_not_in_pre_aggregate'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED': {
+        dataType: 'refEnum',
+        enums: ['pre_aggregate_filter_not_satisfied'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'PreAggregateMissReason.GRANULARITY_TOO_FINE': {
         dataType: 'refEnum',
         enums: ['granularity_too_fine'],
@@ -6108,6 +6148,16 @@ const models: TsoaRoute.Models = {
                         fieldId: { ref: 'FieldId', required: true },
                         reason: {
                             ref: 'PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        fieldId: { ref: 'FieldId', required: true },
+                        reason: {
+                            ref: 'PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED',
                             required: true,
                         },
                     },
@@ -6658,11 +6708,25 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AppImageAttachment: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                filename: { dataType: 'string', required: true },
+                mimeType: { dataType: 'string', required: true },
+                data: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GenerateAppRequestBody: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                image: { ref: 'AppImageAttachment' },
                 prompt: { dataType: 'string', required: true },
             },
             validators: {},
@@ -10567,6 +10631,14 @@ const models: TsoaRoute.Models = {
                 dimensions: {
                     dataType: 'array',
                     array: { dataType: 'string' },
+                    required: true,
+                },
+                materializationRole: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'PreAggregateMaterializationRole' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
                     required: true,
                 },
                 sourceExploreName: { dataType: 'string', required: true },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -6932,8 +6932,37 @@
                 "enum": ["virtual", "default", "pre_aggregate"],
                 "type": "string"
             },
+            "Record_string.string-Array_": {
+                "properties": {},
+                "additionalProperties": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "UserAttributeValueMap": {
+                "$ref": "#/components/schemas/Record_string.string-Array_"
+            },
+            "PreAggregateMaterializationRole": {
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/UserAttributeValueMap"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "required": ["attributes", "email"],
+                "type": "object"
+            },
             "PreAggregateDef": {
                 "properties": {
+                    "materializationRole": {
+                        "$ref": "#/components/schemas/PreAggregateMaterializationRole"
+                    },
                     "refresh": {
                         "properties": {
                             "cron": {
@@ -6951,6 +6980,12 @@
                     },
                     "timeDimension": {
                         "type": "string"
+                    },
+                    "filters": {
+                        "items": {
+                            "$ref": "#/components/schemas/MetricFilterRule"
+                        },
+                        "type": "array"
                     },
                     "metrics": {
                         "items": {
@@ -7251,6 +7286,10 @@
                 "enum": ["filter_dimension_not_in_pre_aggregate"],
                 "type": "string"
             },
+            "PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED": {
+                "enum": ["pre_aggregate_filter_not_satisfied"],
+                "type": "string"
+            },
             "PreAggregateMissReason.GRANULARITY_TOO_FINE": {
                 "enum": ["granularity_too_fine"],
                 "type": "string"
@@ -7341,6 +7380,18 @@
                             },
                             "reason": {
                                 "$ref": "#/components/schemas/PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE"
+                            }
+                        },
+                        "required": ["fieldId", "reason"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "fieldId": {
+                                "$ref": "#/components/schemas/FieldId"
+                            },
+                            "reason": {
+                                "$ref": "#/components/schemas/PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED"
                             }
                         },
                         "required": ["fieldId", "reason"],
@@ -8005,8 +8056,27 @@
             "ApiGenerateAppResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__appUuid-string--version-number__"
             },
+            "AppImageAttachment": {
+                "properties": {
+                    "filename": {
+                        "type": "string"
+                    },
+                    "mimeType": {
+                        "type": "string"
+                    },
+                    "data": {
+                        "type": "string"
+                    }
+                },
+                "required": ["filename", "mimeType", "data"],
+                "type": "object",
+                "description": "Image attached to a data app generation request.\n\nPhase 1: `data` contains the base64-encoded image sent inline in the JSON body.\nPhase 2: Add an optional `s3Key` field for images pre-uploaded to S3 via\npresigned URL. When `s3Key` is present, `data` can be omitted and the backend\nstreams the image from S3 into the sandbox. This also enables persisting images\nalongside the source tarball for use as app assets."
+            },
             "GenerateAppRequestBody": {
                 "properties": {
+                    "image": {
+                        "$ref": "#/components/schemas/AppImageAttachment"
+                    },
                     "prompt": {
                         "type": "string"
                     }
@@ -11498,6 +11568,14 @@
                         },
                         "type": "array"
                     },
+                    "materializationRole": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PreAggregateMaterializationRole"
+                            }
+                        ],
+                        "nullable": true
+                    },
                     "sourceExploreName": {
                         "type": "string"
                     },
@@ -11521,6 +11599,7 @@
                     "timeDimension",
                     "metrics",
                     "dimensions",
+                    "materializationRole",
                     "sourceExploreName",
                     "preAggExploreName",
                     "preAggregateName",
@@ -29798,7 +29877,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2730.1",
+        "version": "0.2735.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -1,6 +1,21 @@
 import type { Explore } from '../../types/explore';
-import { MetricType, type FieldId } from '../../types/field';
-import { flattenFilterGroup } from '../../types/filter';
+import {
+    convertFieldRefToFieldId,
+    MetricType,
+    type FieldId,
+} from '../../types/field';
+import {
+    FilterOperator,
+    flattenFilterGroup,
+    isAndFilterGroup,
+    isFilterGroup,
+    UnitOfTime,
+    type DateFilterSettings,
+    type FilterGroup,
+    type FilterGroupItem,
+    type FilterRule,
+    type MetricFilterRule,
+} from '../../types/filter';
 import type { MetricQuery } from '../../types/metricQuery';
 import {
     PreAggregateMissReason,
@@ -87,6 +102,666 @@ const extractDimensionFilterFieldIds = (
         .map((target) => target.fieldId);
 };
 
+const getPreAggregateFilterTargetReferences = (
+    filter: MetricFilterRule,
+    baseTable: string,
+): Set<string> =>
+    new Set(
+        filter.target.fieldRef.includes('.')
+            ? [filter.target.fieldRef]
+            : [
+                  filter.target.fieldRef,
+                  `${baseTable}.${filter.target.fieldRef}`,
+              ],
+    );
+
+const matchesPreAggregateFilterTarget = ({
+    queryFilterRule,
+    preAggregateFilter,
+    explore,
+    dimensionsByFieldId,
+}: {
+    queryFilterRule: FilterRule;
+    preAggregateFilter: MetricFilterRule;
+    explore: Explore;
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >;
+}): boolean => {
+    const queryFieldId = queryFilterRule.target.fieldId;
+    const queryDimension = dimensionsByFieldId.get(queryFieldId);
+    if (!queryDimension) {
+        return false;
+    }
+
+    const preAggregateReferences = getPreAggregateFilterTargetReferences(
+        preAggregateFilter,
+        explore.baseTable,
+    );
+
+    return getDimensionReferences({
+        dimension: queryDimension,
+        baseTable: explore.baseTable,
+    }).some((reference) => preAggregateReferences.has(reference));
+};
+
+const isValueSubset = (
+    queryValues: unknown[] | undefined,
+    preAggregateValues: unknown[] | undefined,
+): boolean => {
+    if (!queryValues || queryValues.length === 0) {
+        return false;
+    }
+    if (!preAggregateValues || preAggregateValues.length === 0) {
+        return false;
+    }
+
+    return queryValues.every((queryValue) =>
+        preAggregateValues.some((preAggregateValue) =>
+            Object.is(queryValue, preAggregateValue),
+        ),
+    );
+};
+
+const hasFilterValues = (values: unknown[] | undefined): values is unknown[] =>
+    Array.isArray(values) && values.length > 0;
+
+type Range = {
+    lower?: { value: number; inclusive: boolean };
+    upper?: { value: number; inclusive: boolean };
+};
+
+const getRangeForFilter = (
+    filter: FilterRule<FilterOperator, unknown>,
+    toComparableValue: (value: unknown) => number | null,
+): Range | null => {
+    switch (filter.operator) {
+        case FilterOperator.GREATER_THAN: {
+            const value = toComparableValue(filter.values?.[0]);
+            return value === null
+                ? null
+                : { lower: { value, inclusive: false } };
+        }
+        case FilterOperator.GREATER_THAN_OR_EQUAL: {
+            const value = toComparableValue(filter.values?.[0]);
+            return value === null
+                ? null
+                : { lower: { value, inclusive: true } };
+        }
+        case FilterOperator.LESS_THAN: {
+            const value = toComparableValue(filter.values?.[0]);
+            return value === null
+                ? null
+                : { upper: { value, inclusive: false } };
+        }
+        case FilterOperator.LESS_THAN_OR_EQUAL: {
+            const value = toComparableValue(filter.values?.[0]);
+            return value === null
+                ? null
+                : { upper: { value, inclusive: true } };
+        }
+        case FilterOperator.IN_BETWEEN: {
+            const lower = toComparableValue(filter.values?.[0]);
+            const upper = toComparableValue(filter.values?.[1]);
+            return lower === null || upper === null
+                ? null
+                : {
+                      lower: { value: lower, inclusive: true },
+                      upper: { value: upper, inclusive: true },
+                  };
+        }
+        default:
+            return null;
+    }
+};
+
+const isLowerBoundNarrowerOrEqual = (
+    query: Range['lower'],
+    preAggregate: Range['lower'],
+): boolean => {
+    if (!preAggregate) {
+        return true;
+    }
+    if (!query) {
+        return false;
+    }
+
+    if (query.value > preAggregate.value) {
+        return true;
+    }
+    if (query.value < preAggregate.value) {
+        return false;
+    }
+
+    return preAggregate.inclusive || !query.inclusive;
+};
+
+const isUpperBoundNarrowerOrEqual = (
+    query: Range['upper'],
+    preAggregate: Range['upper'],
+): boolean => {
+    if (!preAggregate) {
+        return true;
+    }
+    if (!query) {
+        return false;
+    }
+
+    if (query.value < preAggregate.value) {
+        return true;
+    }
+    if (query.value > preAggregate.value) {
+        return false;
+    }
+
+    return preAggregate.inclusive || !query.inclusive;
+};
+
+const isRangeSubset = (
+    queryRange: Range | null,
+    preAggregateRange: Range | null,
+): boolean =>
+    !!queryRange &&
+    !!preAggregateRange &&
+    isLowerBoundNarrowerOrEqual(queryRange.lower, preAggregateRange.lower) &&
+    isUpperBoundNarrowerOrEqual(queryRange.upper, preAggregateRange.upper);
+
+const containsComparableValue = (range: Range, value: number): boolean => {
+    let satisfiesLower = true;
+    if (range.lower) {
+        satisfiesLower = range.lower.inclusive
+            ? value >= range.lower.value
+            : value > range.lower.value;
+    }
+
+    let satisfiesUpper = true;
+    if (range.upper) {
+        satisfiesUpper = range.upper.inclusive
+            ? value <= range.upper.value
+            : value < range.upper.value;
+    }
+
+    return satisfiesLower && satisfiesUpper;
+};
+
+const getUnitOrder = (unit: UnitOfTime): number =>
+    [
+        UnitOfTime.milliseconds,
+        UnitOfTime.seconds,
+        UnitOfTime.minutes,
+        UnitOfTime.hours,
+        UnitOfTime.days,
+        UnitOfTime.weeks,
+        UnitOfTime.months,
+        UnitOfTime.quarters,
+        UnitOfTime.years,
+    ].indexOf(unit);
+
+const getDateFilterSettings = (
+    filterRule: FilterRule | MetricFilterRule,
+): DateFilterSettings | undefined =>
+    filterRule.settings as DateFilterSettings | undefined;
+
+const getDateFilterUnitOfTime = (
+    filterRule: FilterRule | MetricFilterRule,
+): UnitOfTime =>
+    getDateFilterSettings(filterRule)?.unitOfTime || UnitOfTime.days;
+
+const isCompletedDateFilter = (
+    filterRule: FilterRule | MetricFilterRule,
+): boolean => !!getDateFilterSettings(filterRule)?.completed;
+
+const isRelativeDateFilterEquivalentOrNarrower = (
+    queryFilterRule: FilterRule,
+    preAggregateFilter: MetricFilterRule,
+): boolean => {
+    if (queryFilterRule.operator !== preAggregateFilter.operator) {
+        return false;
+    }
+
+    switch (preAggregateFilter.operator) {
+        case FilterOperator.IN_THE_PAST:
+        case FilterOperator.IN_THE_NEXT: {
+            const preAggregateUnit =
+                getDateFilterUnitOfTime(preAggregateFilter);
+            const queryUnit = getDateFilterUnitOfTime(queryFilterRule);
+            const preAggregateCompleted =
+                isCompletedDateFilter(preAggregateFilter);
+            const queryCompleted = isCompletedDateFilter(queryFilterRule);
+            const preAggregateValue = Number(preAggregateFilter.values?.[0]);
+            const queryValue = Number(queryFilterRule.values?.[0]);
+
+            return (
+                preAggregateUnit === queryUnit &&
+                preAggregateCompleted === queryCompleted &&
+                Number.isFinite(preAggregateValue) &&
+                Number.isFinite(queryValue) &&
+                queryValue <= preAggregateValue
+            );
+        }
+        case FilterOperator.IN_THE_CURRENT:
+        case FilterOperator.NOT_IN_THE_CURRENT: {
+            const preAggregateUnit =
+                getDateFilterUnitOfTime(preAggregateFilter);
+            const queryUnit = getDateFilterUnitOfTime(queryFilterRule);
+            const preAggregateUnitOrder = getUnitOrder(preAggregateUnit);
+            const queryUnitOrder = getUnitOrder(queryUnit);
+
+            if (preAggregateUnitOrder === -1 || queryUnitOrder === -1) {
+                return false;
+            }
+
+            return preAggregateFilter.operator === FilterOperator.IN_THE_CURRENT
+                ? queryUnitOrder <= preAggregateUnitOrder
+                : queryUnitOrder >= preAggregateUnitOrder;
+        }
+        case FilterOperator.NOT_IN_THE_PAST:
+            return (
+                getDateFilterUnitOfTime(queryFilterRule) ===
+                    getDateFilterUnitOfTime(preAggregateFilter) &&
+                isCompletedDateFilter(queryFilterRule) ===
+                    isCompletedDateFilter(preAggregateFilter) &&
+                isValueSubset(queryFilterRule.values, preAggregateFilter.values)
+            );
+        default:
+            return false;
+    }
+};
+
+const isStringFilterEquivalentOrNarrower = (
+    queryFilterRule: FilterRule,
+    preAggregateFilter: MetricFilterRule,
+): boolean => {
+    const preAggregateValue = String(preAggregateFilter.values?.[0] ?? '');
+
+    switch (preAggregateFilter.operator) {
+        case FilterOperator.EQUALS:
+            return (
+                queryFilterRule.operator === FilterOperator.EQUALS &&
+                isValueSubset(queryFilterRule.values, preAggregateFilter.values)
+            );
+        case FilterOperator.INCLUDE:
+            switch (queryFilterRule.operator) {
+                case FilterOperator.EQUALS:
+                    return (
+                        hasFilterValues(queryFilterRule.values) &&
+                        queryFilterRule.values.every((value) =>
+                            String(value).includes(preAggregateValue),
+                        )
+                    );
+                case FilterOperator.INCLUDE:
+                case FilterOperator.STARTS_WITH:
+                case FilterOperator.ENDS_WITH:
+                    return String(queryFilterRule.values?.[0] ?? '').includes(
+                        preAggregateValue,
+                    );
+                default:
+                    return false;
+            }
+        case FilterOperator.STARTS_WITH:
+            switch (queryFilterRule.operator) {
+                case FilterOperator.EQUALS:
+                    return (
+                        hasFilterValues(queryFilterRule.values) &&
+                        queryFilterRule.values.every((value) =>
+                            String(value).startsWith(preAggregateValue),
+                        )
+                    );
+                case FilterOperator.STARTS_WITH:
+                    return String(queryFilterRule.values?.[0] ?? '').startsWith(
+                        preAggregateValue,
+                    );
+                default:
+                    return false;
+            }
+        case FilterOperator.ENDS_WITH:
+            switch (queryFilterRule.operator) {
+                case FilterOperator.EQUALS:
+                    return (
+                        hasFilterValues(queryFilterRule.values) &&
+                        queryFilterRule.values.every((value) =>
+                            String(value).endsWith(preAggregateValue),
+                        )
+                    );
+                case FilterOperator.ENDS_WITH:
+                    return String(queryFilterRule.values?.[0] ?? '').endsWith(
+                        preAggregateValue,
+                    );
+                default:
+                    return false;
+            }
+        case FilterOperator.NULL:
+        case FilterOperator.NOT_NULL:
+            return queryFilterRule.operator === preAggregateFilter.operator;
+        case FilterOperator.NOT_EQUALS:
+        case FilterOperator.NOT_INCLUDE:
+            return (
+                queryFilterRule.operator === preAggregateFilter.operator &&
+                isValueSubset(queryFilterRule.values, preAggregateFilter.values)
+            );
+        default:
+            return false;
+    }
+};
+
+const isNumberFilterEquivalentOrNarrower = (
+    queryFilterRule: FilterRule,
+    preAggregateFilter: MetricFilterRule,
+): boolean => {
+    if (preAggregateFilter.operator === FilterOperator.EQUALS) {
+        return (
+            queryFilterRule.operator === FilterOperator.EQUALS &&
+            isValueSubset(queryFilterRule.values, preAggregateFilter.values)
+        );
+    }
+
+    if (
+        preAggregateFilter.operator === FilterOperator.NULL ||
+        preAggregateFilter.operator === FilterOperator.NOT_NULL
+    ) {
+        return queryFilterRule.operator === preAggregateFilter.operator;
+    }
+
+    if (
+        preAggregateFilter.operator === FilterOperator.NOT_EQUALS ||
+        preAggregateFilter.operator === FilterOperator.NOT_IN_BETWEEN
+    ) {
+        return (
+            queryFilterRule.operator === preAggregateFilter.operator &&
+            isValueSubset(queryFilterRule.values, preAggregateFilter.values)
+        );
+    }
+
+    const toComparableValue = (value: unknown): number | null => {
+        const comparableValue = Number(value);
+        return Number.isFinite(comparableValue) ? comparableValue : null;
+    };
+
+    const preAggregateRange = getRangeForFilter(
+        preAggregateFilter,
+        toComparableValue,
+    );
+    if (!preAggregateRange) {
+        return false;
+    }
+
+    if (queryFilterRule.operator === FilterOperator.EQUALS) {
+        return (
+            hasFilterValues(queryFilterRule.values) &&
+            queryFilterRule.values.every((value) => {
+                const comparableValue = toComparableValue(value);
+                return (
+                    comparableValue !== null &&
+                    containsComparableValue(preAggregateRange, comparableValue)
+                );
+            })
+        );
+    }
+
+    return isRangeSubset(
+        getRangeForFilter(queryFilterRule, toComparableValue),
+        preAggregateRange,
+    );
+};
+
+const isDateFilterEquivalentOrNarrower = (
+    queryFilterRule: FilterRule,
+    preAggregateFilter: MetricFilterRule,
+): boolean => {
+    if (
+        preAggregateFilter.operator === FilterOperator.IN_THE_PAST ||
+        preAggregateFilter.operator === FilterOperator.NOT_IN_THE_PAST ||
+        preAggregateFilter.operator === FilterOperator.IN_THE_NEXT ||
+        preAggregateFilter.operator === FilterOperator.IN_THE_CURRENT ||
+        preAggregateFilter.operator === FilterOperator.NOT_IN_THE_CURRENT
+    ) {
+        return isRelativeDateFilterEquivalentOrNarrower(
+            queryFilterRule,
+            preAggregateFilter,
+        );
+    }
+
+    if (preAggregateFilter.operator === FilterOperator.EQUALS) {
+        return (
+            queryFilterRule.operator === FilterOperator.EQUALS &&
+            isValueSubset(queryFilterRule.values, preAggregateFilter.values)
+        );
+    }
+
+    if (
+        preAggregateFilter.operator === FilterOperator.NULL ||
+        preAggregateFilter.operator === FilterOperator.NOT_NULL
+    ) {
+        return queryFilterRule.operator === preAggregateFilter.operator;
+    }
+
+    if (
+        preAggregateFilter.operator === FilterOperator.NOT_EQUALS ||
+        preAggregateFilter.operator === FilterOperator.NOT_IN_BETWEEN
+    ) {
+        return (
+            queryFilterRule.operator === preAggregateFilter.operator &&
+            isValueSubset(queryFilterRule.values, preAggregateFilter.values)
+        );
+    }
+
+    const toComparableValue = (value: unknown): number | null => {
+        if (value === undefined || value === null) {
+            return null;
+        }
+        const comparableValue = new Date(String(value)).getTime();
+        return Number.isFinite(comparableValue) ? comparableValue : null;
+    };
+
+    const preAggregateRange = getRangeForFilter(
+        preAggregateFilter,
+        toComparableValue,
+    );
+    if (!preAggregateRange) {
+        return false;
+    }
+
+    if (queryFilterRule.operator === FilterOperator.EQUALS) {
+        return (
+            hasFilterValues(queryFilterRule.values) &&
+            queryFilterRule.values.every((value) => {
+                const comparableValue = toComparableValue(value);
+                return (
+                    comparableValue !== null &&
+                    containsComparableValue(preAggregateRange, comparableValue)
+                );
+            })
+        );
+    }
+
+    return isRangeSubset(
+        getRangeForFilter(queryFilterRule, toComparableValue),
+        preAggregateRange,
+    );
+};
+
+const isBooleanFilterEquivalentOrNarrower = (
+    queryFilterRule: FilterRule,
+    preAggregateFilter: MetricFilterRule,
+): boolean => {
+    if (
+        preAggregateFilter.operator === FilterOperator.NULL ||
+        preAggregateFilter.operator === FilterOperator.NOT_NULL
+    ) {
+        return queryFilterRule.operator === preAggregateFilter.operator;
+    }
+
+    return (
+        queryFilterRule.operator === preAggregateFilter.operator &&
+        isValueSubset(queryFilterRule.values, preAggregateFilter.values)
+    );
+};
+
+const isFilterRuleEquivalentOrNarrower = ({
+    queryFilterRule,
+    preAggregateFilter,
+    explore,
+    dimensionsByFieldId,
+}: {
+    queryFilterRule: FilterRule;
+    preAggregateFilter: MetricFilterRule;
+    explore: Explore;
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >;
+}): boolean => {
+    if (queryFilterRule.disabled) {
+        return false;
+    }
+    if (
+        !matchesPreAggregateFilterTarget({
+            queryFilterRule,
+            preAggregateFilter,
+            explore,
+            dimensionsByFieldId,
+        })
+    ) {
+        return false;
+    }
+
+    const queryDimension = dimensionsByFieldId.get(
+        queryFilterRule.target.fieldId,
+    );
+    if (!queryDimension) {
+        return false;
+    }
+
+    switch (queryDimension.type) {
+        case 'string':
+            return isStringFilterEquivalentOrNarrower(
+                queryFilterRule,
+                preAggregateFilter,
+            );
+        case 'number':
+            return isNumberFilterEquivalentOrNarrower(
+                queryFilterRule,
+                preAggregateFilter,
+            );
+        case 'date':
+        case 'timestamp':
+            return isDateFilterEquivalentOrNarrower(
+                queryFilterRule,
+                preAggregateFilter,
+            );
+        case 'boolean':
+            return isBooleanFilterEquivalentOrNarrower(
+                queryFilterRule,
+                preAggregateFilter,
+            );
+        default:
+            return false;
+    }
+};
+
+const filterGroupImpliesPreAggregateFilter = ({
+    filterGroup,
+    preAggregateFilter,
+    explore,
+    dimensionsByFieldId,
+}: {
+    filterGroup: FilterGroup | undefined;
+    preAggregateFilter: MetricFilterRule;
+    explore: Explore;
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >;
+}): boolean => {
+    if (!filterGroup) {
+        return false;
+    }
+
+    const groupItems: FilterGroupItem[] = isAndFilterGroup(filterGroup)
+        ? filterGroup.and
+        : filterGroup.or;
+
+    if (groupItems.length === 0) {
+        return false;
+    }
+
+    if (isAndFilterGroup(filterGroup)) {
+        return groupItems.some((item) =>
+            isFilterGroup(item)
+                ? filterGroupImpliesPreAggregateFilter({
+                      filterGroup: item,
+                      preAggregateFilter,
+                      explore,
+                      dimensionsByFieldId,
+                  })
+                : isFilterRuleEquivalentOrNarrower({
+                      queryFilterRule: item,
+                      preAggregateFilter,
+                      explore,
+                      dimensionsByFieldId,
+                  }),
+        );
+    }
+
+    return groupItems.every((item) =>
+        isFilterGroup(item)
+            ? filterGroupImpliesPreAggregateFilter({
+                  filterGroup: item,
+                  preAggregateFilter,
+                  explore,
+                  dimensionsByFieldId,
+              })
+            : isFilterRuleEquivalentOrNarrower({
+                  queryFilterRule: item,
+                  preAggregateFilter,
+                  explore,
+                  dimensionsByFieldId,
+              }),
+    );
+};
+
+const getUnsatisfiedPreAggregateFilterMiss = ({
+    metricQuery,
+    explore,
+    preAggregateDef,
+    dimensionsByFieldId,
+}: {
+    metricQuery: MetricQuery;
+    explore: Explore;
+    preAggregateDef: PreAggregateDef;
+    dimensionsByFieldId: Map<
+        FieldId,
+        Explore['tables'][string]['dimensions'][string]
+    >;
+}): Extract<
+    PreAggregateMatchMiss,
+    { reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED }
+> | null => {
+    const preAggregateFilters = preAggregateDef.filters || [];
+    const unsatisfiedFilter = preAggregateFilters.find(
+        (preAggregateFilter) =>
+            !filterGroupImpliesPreAggregateFilter({
+                filterGroup: metricQuery.filters.dimensions,
+                preAggregateFilter,
+                explore,
+                dimensionsByFieldId,
+            }),
+    );
+
+    if (!unsatisfiedFilter) {
+        return null;
+    }
+
+    return {
+        reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED,
+        fieldId: convertFieldRefToFieldId(
+            unsatisfiedFilter.target.fieldRef,
+            explore.baseTable,
+        ),
+    };
+};
+
 const getGranularityMissForDef = (
     metricQuery: MetricQuery,
     explore: Explore,
@@ -148,8 +823,6 @@ const getMissForDef = ({
     >;
     metricsByFieldId: ReturnType<typeof getMetricsMapFromTables>;
 }): PreAggregateMatchMiss | null => {
-    // TODO: pre-aggregate filters are ignored for matching in this PR.
-    // Follow-up work should require the query filter set to be equivalent or narrower.
     const defMetrics = new Set(preAggregateDef.metrics);
     for (const metricFieldId of metricQuery.metrics) {
         const metric = metricsByFieldId[metricFieldId];
@@ -225,6 +898,17 @@ const getMissForDef = ({
             reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE,
             fieldId: missingFilterDimensionFieldId,
         };
+    }
+
+    const unsatisfiedPreAggregateFilterMiss =
+        getUnsatisfiedPreAggregateFilterMiss({
+            metricQuery,
+            explore,
+            preAggregateDef,
+            dimensionsByFieldId,
+        });
+    if (unsatisfiedPreAggregateFilterMiss) {
+        return unsatisfiedPreAggregateFilterMiss;
     }
 
     const granularityMiss = getGranularityMissForDef(

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -62,6 +62,7 @@ export enum PreAggregateMissReason {
     NON_ADDITIVE_METRIC = 'non_additive_metric',
     CUSTOM_SQL_METRIC = 'custom_sql_metric',
     FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE = 'filter_dimension_not_in_pre_aggregate',
+    PRE_AGGREGATE_FILTER_NOT_SATISFIED = 'pre_aggregate_filter_not_satisfied',
     GRANULARITY_TOO_FINE = 'granularity_too_fine',
     CUSTOM_DIMENSION_PRESENT = 'custom_dimension_present',
     CUSTOM_METRIC_PRESENT = 'custom_metric_present',
@@ -92,6 +93,10 @@ export type PreAggregateMatchMiss =
       }
     | {
           reason: PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE;
+          fieldId: FieldId;
+      }
+    | {
+          reason: PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED;
           fieldId: FieldId;
       }
     | {
@@ -176,6 +181,8 @@ export const preAggregateMissReasonLabels: Record<
     [PreAggregateMissReason.CUSTOM_SQL_METRIC]: 'Custom SQL metric',
     [PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE]:
         'Filter dimension not in pre-aggregate',
+    [PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED]:
+        'Pre-aggregate filter not satisfied',
     [PreAggregateMissReason.GRANULARITY_TOO_FINE]: 'Granularity too fine',
     [PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT]:
         'Custom dimension present',


### PR DESCRIPTION
### Description:

This PR enhances the pre-aggregate matching logic to properly handle filter validation. Previously, pre-aggregate filters were ignored during matching, but now the system validates that query filters are equivalent to or narrower than the pre-aggregate filters.

**Key changes:**

- Added comprehensive filter comparison logic that supports string, number, date, and boolean filters
- Implemented range-based validation for numeric and date filters to determine if query filters are subsets of pre-aggregate filters
- Added support for relative date filter validation (IN_THE_PAST, IN_THE_NEXT, etc.) with proper unit and value comparisons
- Enhanced filter group handling to properly evaluate AND/OR logic when matching against pre-aggregate constraints
- Added new miss reason `PRE_AGGREGATE_FILTER_NOT_SATISFIED` when queries don't satisfy required pre-aggregate filters
- Added `filters` field to the `PreAggregateDef` type and updated API schemas accordingly

The matching now ensures that:
- Query filters with equivalent values to pre-aggregate filters are matched
- Query filters that are narrower subsets (e.g., filtering for 'completed' when pre-aggregate filters for ['completed', 'shipped']) are matched
- Query filters that are broader than pre-aggregate filters are rejected
- Missing required pre-aggregate filters cause match failures
- OR filter groups that broaden beyond pre-aggregate constraints are properly rejected