### PR TITLE
feat: add materialization role display to pre-aggregate details

### DIFF
--- a/packages/backend/src/ee/models/PreAggregateModel.ts
+++ b/packages/backend/src/ee/models/PreAggregateModel.ts
@@ -600,6 +600,9 @@ export class PreAggregateModel {
                     preAggregateName: row.pre_aggregate_definition.name,
                     preAggExploreName: row.pre_agg_explore_name,
                     sourceExploreName: row.source_explore_name,
+                    materializationRole:
+                        row.pre_aggregate_definition.materializationRole ??
+                        null,
                     dimensions: row.pre_aggregate_definition.dimensions ?? [],
                     metrics: row.pre_aggregate_definition.metrics ?? [],
                     timeDimension:

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -23,6 +23,7 @@ import {
     ExpiredQueryError,
     Explore,
     ExploreCompiler,
+    ExploreType,
     FeatureFlags,
     FieldType,
     ForbiddenError,
@@ -151,6 +152,10 @@ import {
     getNextAndPreviousPage,
     validatePagination,
 } from '../ProjectService/resultsPagination';
+import {
+    exploreHasFilteredAttribute,
+    getFilteredExplore,
+} from '../UserAttributesService/UserAttributeUtils';
 import { getPivotedColumns } from './getPivotedColumns';
 import { getUnpivotedColumns } from './getUnpivotedColumns';
 import {
@@ -345,6 +350,70 @@ export class AsyncQueryService extends ProjectService {
                 ? this.preAggregateStrategy.getResultsStorageClient()
                 : undefined;
         return strategyClient ?? this.resultsStorageClient;
+    }
+
+    private async getExploreForMetricQueryExecution({
+        account,
+        projectUuid,
+        exploreName,
+        organizationUuid,
+        materializationRole,
+    }: {
+        account: Account;
+        projectUuid: string;
+        exploreName: string;
+        organizationUuid: string;
+        materializationRole?: UserAccessControls;
+    }): Promise<Explore> {
+        const ability = this.createAuditedAbility(account);
+        const isForbidden =
+            ability.cannot(
+                'view',
+                subject('Project', { organizationUuid, projectUuid }),
+            ) &&
+            ability.cannot(
+                'view',
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid,
+                    exploreNames: [exploreName],
+                }),
+            );
+
+        if (isForbidden) {
+            throw new ForbiddenError();
+        }
+
+        const explore = await this.projectModel.getExploreFromCache(
+            projectUuid,
+            exploreName,
+        );
+
+        if (isExploreError(explore)) {
+            throw new NotFoundError(`Explore "${exploreName}" has an error.`);
+        }
+
+        if (
+            explore.type === ExploreType.PRE_AGGREGATE &&
+            ability.cannot(
+                'manage',
+                subject('PreAggregation', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new NotFoundError(`Explore "${exploreName}" does not exist.`);
+        }
+
+        if (!exploreHasFilteredAttribute(explore)) {
+            return explore;
+        }
+
+        const { userAttributes } =
+            materializationRole ?? (await this.getUserAttributes({ account }));
+
+        return getFilteredExplore(explore, userAttributes);
     }
 
     public getCacheExpiresAt(baseDate: Date) {
@@ -3264,12 +3333,16 @@ export class AsyncQueryService extends ProjectService {
 
         const metricQueryStart = Date.now();
 
-        const explore = await this.getExplore(
+        const explore = await this.getExploreForMetricQueryExecution({
             account,
             projectUuid,
-            metricQuery.exploreName,
+            exploreName: metricQuery.exploreName,
             organizationUuid,
-        );
+            materializationRole:
+                context === QueryExecutionContext.PRE_AGGREGATE_MATERIALIZATION
+                    ? materializationRole
+                    : undefined,
+        });
         const getExploreMs = Date.now() - metricQueryStart;
 
         const whCredStart = Date.now();

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -245,6 +245,7 @@ export type PreAggregateMaterializationSummary = {
     preAggregateName: string;
     preAggExploreName: string;
     sourceExploreName: string;
+    materializationRole: PreAggregateMaterializationRole | null;
     dimensions: string[];
     metrics: string[];
     timeDimension: string | null;

--- a/packages/frontend/src/components/PreAggregateMaterializations/MaterializationDetailDrawer.tsx
+++ b/packages/frontend/src/components/PreAggregateMaterializations/MaterializationDetailDrawer.tsx
@@ -1,4 +1,5 @@
 import {
+    type PreAggregateMaterializationRole,
     type PreAggregateMaterializationSummary,
     type PreAggregateMaterializationWarning,
 } from '@lightdash/common';
@@ -107,6 +108,61 @@ const ColumnsSection: FC<{
     );
 };
 
+const MaterializationRoleSection: FC<{
+    materializationRole: PreAggregateMaterializationRole;
+}> = ({ materializationRole }) => {
+    const attributeEntries = Object.entries(materializationRole.attributes);
+
+    return (
+        <Box>
+            <DetailLabel>Materialization role</DetailLabel>
+            <Stack gap="sm" mt={4}>
+                <Box>
+                    <DetailLabel>Email</DetailLabel>
+                    <DetailValue mono>{materializationRole.email}</DetailValue>
+                </Box>
+
+                <Box>
+                    <DetailLabel>Attributes</DetailLabel>
+                    <Stack gap={6} mt={4}>
+                        {attributeEntries.map(([attributeName, values]) => (
+                            <Box
+                                key={attributeName}
+                                px="xs"
+                                py={6}
+                                style={{
+                                    borderRadius: 'var(--mantine-radius-sm)',
+                                    backgroundColor:
+                                        'var(--mantine-color-ldGray-0)',
+                                }}
+                            >
+                                <Stack gap={6}>
+                                    <Text fz="xs" ff="monospace">
+                                        {attributeName}
+                                    </Text>
+                                    <Group gap={4}>
+                                        {values.map((value) => (
+                                            <Badge
+                                                key={`${attributeName}-${value}`}
+                                                variant="outline"
+                                                color="gray"
+                                                size="xs"
+                                                ff="monospace"
+                                            >
+                                                {value}
+                                            </Badge>
+                                        ))}
+                                    </Group>
+                                </Stack>
+                            </Box>
+                        ))}
+                    </Stack>
+                </Box>
+            </Stack>
+        </Box>
+    );
+};
+
 type Props = {
     summary: PreAggregateMaterializationSummary | null;
     opened: boolean;
@@ -150,6 +206,12 @@ const MaterializationDetailDrawer: FC<Props> = ({
                     <DetailLabel>Source explore</DetailLabel>
                     <DetailValue mono>{summary.sourceExploreName}</DetailValue>
                 </Box>
+
+                {summary.materializationRole && (
+                    <MaterializationRoleSection
+                        materializationRole={summary.materializationRole}
+                    />
+                )}
 
                 <Box>
                     <DetailLabel>Metrics</DetailLabel>


### PR DESCRIPTION
### Description:

Added materialization role display to the pre-aggregate materialization detail drawer. The `materializationRole` field is now included in the `PreAggregateMaterializationSummary` type and populated from the backend model. 

When a materialization role is configured, the drawer displays the role's email and attributes in a dedicated section. Attributes are shown with their names and values formatted as badges. The section is conditionally rendered and only appears when a materialization role exists.

Added comprehensive tests to verify the materialization role section renders correctly when present and is hidden when no role is configured.