### PR TITLE
feat: add DuckDB execution for pre-aggregate totals calculation

### DIFF
--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -11,6 +11,7 @@ import {
     type Explore,
     type PossibleAbilities,
 } from '@lightdash/common';
+import { DuckdbWarehouseClient } from '@lightdash/warehouses';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
@@ -122,6 +123,7 @@ jest.mock('@lightdash/warehouses', () => ({
         connect: jest.fn(() => warehouseClientMock.credentials),
         disconnect: jest.fn(),
     })),
+    DuckdbWarehouseClient: jest.fn(() => warehouseClientMock),
 }));
 
 const projectModel = {
@@ -151,6 +153,15 @@ const preAggregateModel = {
     upsertPreAggregateDefinitions: jest.fn(),
     getPreAggregateDefinitionsForProject: jest.fn(async () => []),
     getPreAggregateDefinitionByDefinitionName: jest.fn(async () => undefined),
+    getActiveMaterialization: jest.fn(async () => ({
+        materializationUuid: 'mat-1',
+        queryUuid: 'mat-query-1',
+        materializationUri: 's3://mock_preagg_bucket/abc123.jsonl',
+        format: 'jsonl' as const,
+        columns: null,
+        materializedAt: new Date('2024-01-01T00:00:00.000Z'),
+        totalBytes: 987654,
+    })),
 };
 const onboardingModel = {
     getByOrganizationUuid: jest.fn(async () => ({
@@ -259,6 +270,7 @@ describe('ProjectService', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        jest.restoreAllMocks();
     });
     test('should run sql query', async () => {
         jest.spyOn(analyticsMock, 'track');
@@ -277,6 +289,70 @@ describe('ProjectService', () => {
 
         expect(results).toEqual(expectedCatalog);
     });
+    describe('calculateTotalFromQuery', () => {
+        test('should execute explicit pre-aggregate totals against DuckDB materializations', async () => {
+            const getExploreSpy = jest
+                .spyOn(service, 'getExplore')
+                .mockResolvedValue(preAggregateExplore);
+            let executedQuery: string | undefined;
+            const runQueryMock = jest.fn(async (query: string) => {
+                executedQuery = query;
+                return resultsWith1Row;
+            });
+            const mockedDuckdbWarehouseClient = jest.mocked(
+                DuckdbWarehouseClient,
+            );
+
+            mockedDuckdbWarehouseClient.mockReturnValue({
+                ...warehouseClientMock,
+                runQuery: runQueryMock,
+            } as unknown as InstanceType<typeof DuckdbWarehouseClient>);
+
+            await service.calculateTotalFromQuery(
+                developerAccount,
+                projectUuid,
+                {
+                    explore: preAggregateExplore.name,
+                    metricQuery: metricQueryMock,
+                },
+            );
+
+            expect(getExploreSpy).toHaveBeenCalledWith(
+                developerAccount,
+                projectUuid,
+                preAggregateExplore.name,
+                projectSummary.organizationUuid,
+            );
+            expect(
+                preAggregateModel.getActiveMaterialization,
+            ).toHaveBeenCalledWith(projectUuid, preAggregateExplore.name);
+            expect(mockedDuckdbWarehouseClient).toHaveBeenCalledTimes(1);
+            const [credentialsArg, optionsArg] =
+                mockedDuckdbWarehouseClient.mock.calls[0] ?? [];
+            expect(credentialsArg).toMatchObject({
+                type: 'duckdb_s3',
+            });
+            expect(
+                (credentialsArg as { s3Config?: unknown } | undefined)
+                    ?.s3Config,
+            ).toMatchObject(
+                expect.objectContaining({
+                    endpoint: lightdashConfigMock.preAggregates.s3!.endpoint,
+                    region: lightdashConfigMock.preAggregates.s3!.region,
+                }),
+            );
+            expect(optionsArg).toEqual(
+                expect.objectContaining({
+                    logger: expect.anything(),
+                }),
+            );
+            expect(runQueryMock).toHaveBeenCalledTimes(1);
+            expect(executedQuery).toContain(
+                "read_json_auto('s3://mock_preagg_bucket/abc123.jsonl')",
+            );
+            expect(executedQuery).not.toContain('${materialized_table}');
+        });
+    });
     test('should get tables configuration', async () => {
         const result = await service.getTablesConfiguration(
             account,
@@ -285,12 +361,12 @@ describe('ProjectService', () => {
         expect(result).toEqual(tablesConfiguration);
     });
     test('should update tables configuration', async () => {
+        jest.spyOn(analyticsMock, 'track');
         await service.updateTablesConfiguration(
             user,
             projectUuid,
             tablesConfigurationWithNames,
         );
-        jest.spyOn(analyticsMock, 'track');
         expect(projectModel.updateTablesConfiguration).toHaveBeenCalledTimes(1);
         expect(analyticsMock.track).toHaveBeenCalledTimes(1);
         expect(analyticsMock.track).toHaveBeenCalledWith(
@@ -1001,6 +1077,15 @@ describe('ProjectService', () => {
         beforeEach(() => {
             // Clear the warehouse clients cache
             service.warehouseClients = {};
+            (
+                projectModel.getWarehouseCredentialsForProject as jest.Mock
+            ).mockImplementation(async () => warehouseClientMock.credentials);
+            (
+                projectModel.getWarehouseClientFromCredentials as jest.Mock
+            ).mockImplementation(() => ({
+                ...warehouseClientMock,
+                runQuery: jest.fn(async () => resultsWith1Row),
+            }));
         });
 
         afterEach(() => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -184,6 +184,7 @@ import {
 import {
     BigqueryWarehouseClient,
     DATABRICKS_DEFAULT_OAUTH_CLIENT_ID,
+    DuckdbWarehouseClient,
     exchangeDatabricksOAuthCredentials,
     refreshDatabricksOAuthToken,
     SshTunnel,
@@ -215,7 +216,12 @@ import { type DbPreAggregateDefinitionIn } from '../../ee/database/entities/preA
 import { PreAggregateModel } from '../../ee/models/PreAggregateModel';
 import { enhanceExploresForPreAggregates } from '../../ee/preAggregates/enhanceExploresForPreAggregates';
 import { preAggregatePostProcessor } from '../../ee/preAggregates/postProcessor';
+import { getDuckdbRuntimeConfig } from '../../ee/services/AsyncQueryService/getDuckdbRuntimeConfig';
 import { buildMaterializationMetricQuery } from '../../ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery';
+import {
+    getDuckdbPreAggregateSqlTable,
+    getPreAggregateDuckdbLocator,
+} from '../../ee/services/PreAggregateMaterializationService/getDuckdbPreAggregateSqlTable';
 import { errorHandler } from '../../errors';
 import Logger from '../../logging/logger';
 import { measureTime } from '../../logging/measureTime';
@@ -6826,26 +6832,26 @@ export class ProjectService extends BaseService {
         organizationUuid: string,
         parameters?: ParametersValuesMap,
     ) {
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
+        const warehouseCredentials = await this.getWarehouseCredentials({
             projectUuid,
-            await this.getWarehouseCredentials({
-                projectUuid,
-                userId: account.user.id,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-            }),
-            {
-                snowflakeVirtualWarehouse: explore.warehouse,
-                databricksCompute: explore.databricksCompute,
-            },
-        );
+            userId: account.user.id,
+            isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
+        });
+        const executionTarget = await this.getTotalExecutionTarget({
+            projectUuid,
+            explore,
+            warehouseCredentials,
+        });
+        const { warehouseClient } = executionTarget;
+        const executionExplore = executionTarget.explore;
 
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes({ account });
 
         const availableParameterDefinitions = await this.getAvailableParameters(
             projectUuid,
-            explore,
+            executionExplore,
         );
 
         const projectTimezone =
@@ -6857,7 +6863,7 @@ export class ProjectService extends BaseService {
                 timezone,
                 userAttributes,
                 intrinsicUserAttributes,
-                explore,
+                executionExplore,
                 metricQuery,
                 warehouseClient,
                 availableParameterDefinitions,
@@ -6873,7 +6879,7 @@ export class ProjectService extends BaseService {
             };
 
             const { rows } = await warehouseClient.runQuery(query, queryTags);
-            await sshTunnel.disconnect();
+            await executionTarget.disconnect();
             return { row: rows[0] };
         } catch (e) {
             if (e instanceof NotSupportedError) {
@@ -6899,21 +6905,20 @@ export class ProjectService extends BaseService {
             isRegisteredUser: account.isRegisteredUser(),
             isServiceAccount: account.isServiceAccount(),
         });
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
+        const executionTarget = await this.getTotalExecutionTarget({
             projectUuid,
+            explore,
             warehouseCredentials,
-            {
-                snowflakeVirtualWarehouse: explore.warehouse,
-                databricksCompute: explore.databricksCompute,
-            },
-        );
+        });
+        const { warehouseClient } = executionTarget;
+        const executionExplore = executionTarget.explore;
 
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes({ account });
 
         const availableParameterDefinitions = await this.getAvailableParameters(
             projectUuid,
-            explore,
+            executionExplore,
         );
 
         const projectTimezone =
@@ -6926,7 +6931,7 @@ export class ProjectService extends BaseService {
                     timezone,
                     userAttributes,
                     intrinsicUserAttributes,
-                    explore,
+                    executionExplore,
                     metricQuery,
                     warehouseClient,
                     availableParameterDefinitions,
@@ -6955,7 +6960,7 @@ export class ProjectService extends BaseService {
                     queryTags,
                     invalidateCache,
                 });
-            await sshTunnel.disconnect();
+            await executionTarget.disconnect();
             return { row: rows[0], cacheMetadata };
         } catch (e) {
             if (e instanceof NotSupportedError) {
@@ -6964,6 +6969,96 @@ export class ProjectService extends BaseService {
             }
             throw e;
         }
+    }
+
+    private async getTotalExecutionTarget({
+        projectUuid,
+        explore,
+        warehouseCredentials,
+    }: {
+        projectUuid: string;
+        explore: Explore;
+        warehouseCredentials: CreateWarehouseCredentials;
+    }): Promise<{
+        warehouseClient: WarehouseClient;
+        disconnect: () => Promise<void>;
+        explore: Explore;
+    }> {
+        if (
+            explore.type === ExploreType.PRE_AGGREGATE &&
+            explore.preAggregateSource
+        ) {
+            const duckdbRuntimeConfig = getDuckdbRuntimeConfig(
+                this.lightdashConfig.preAggregates.s3,
+            );
+            if (!duckdbRuntimeConfig) {
+                throw new UnexpectedServerError(
+                    'Pre-aggregate DuckDB runtime is not configured',
+                );
+            }
+
+            const activeMaterialization =
+                await this.preAggregateModel.getActiveMaterialization(
+                    projectUuid,
+                    explore.name,
+                );
+
+            if (!activeMaterialization) {
+                throw new NotFoundError(
+                    `No active materialization found for pre-aggregate explore "${explore.name}"`,
+                );
+            }
+
+            const sqlTable = getDuckdbPreAggregateSqlTable(
+                getPreAggregateDuckdbLocator({
+                    uri: activeMaterialization.materializationUri,
+                    format: activeMaterialization.format,
+                }),
+                activeMaterialization.columns,
+            );
+
+            return {
+                warehouseClient: new DuckdbWarehouseClient(
+                    {
+                        type: 'duckdb_s3',
+                        s3Config: duckdbRuntimeConfig,
+                    },
+                    {
+                        logger: this.logger,
+                    },
+                ),
+                disconnect: async () => {},
+                explore: {
+                    ...explore,
+                    tables: Object.fromEntries(
+                        Object.entries(explore.tables).map(
+                            ([tableName, table]) => [
+                                tableName,
+                                {
+                                    ...table,
+                                    sqlTable,
+                                },
+                            ],
+                        ),
+                    ),
+                },
+            };
+        }
+
+        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
+            projectUuid,
+            warehouseCredentials,
+            {
+                snowflakeVirtualWarehouse: explore.warehouse,
+                databricksCompute: explore.databricksCompute,
+            },
+        );
+
+        return {
+            warehouseClient,
+            disconnect: () => sshTunnel.disconnect(),
+            explore,
+        };
     }
 
     async calculateTotalFromSavedChart(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds support for executing total calculations against DuckDB materializations for pre-aggregate explores. 

The changes introduce a new `getTotalExecutionTarget` method that determines whether to use DuckDB or the original warehouse client based on the explore type. For pre-aggregate explores, it:

- Creates a DuckDB warehouse client with S3 configuration
- Retrieves the active materialization for the explore
- Generates the appropriate SQL table reference using the materialization URI
- Modifies the explore's table definitions to use the DuckDB SQL table

For regular explores, it maintains the existing behavior using the original warehouse client and SSH tunnel.

The implementation also updates both `calculateTotalFromQuery` and `calculateTotalFromSavedChart` methods to use this new execution target approach, ensuring consistent behavior across different total calculation entry points.

Test coverage includes verification that DuckDB clients are properly instantiated with correct S3 credentials and that generated queries reference the materialized data sources.