### PR TITLE
feat: add dbt version detection and display installed versions in UI

### DIFF
--- a/packages/backend/src/dbt/dbtCliClient.ts
+++ b/packages/backend/src/dbt/dbtCliClient.ts
@@ -84,6 +84,32 @@ enum DbtCommands {
     DBT_1_11 = 'dbt1.11',
 }
 
+export function getDbtExecName(version: SupportedDbtVersions): string {
+    switch (version) {
+        case SupportedDbtVersions.V1_4:
+            return DbtCommands.DBT_1_4;
+        case SupportedDbtVersions.V1_5:
+            return DbtCommands.DBT_1_5;
+        case SupportedDbtVersions.V1_6:
+            return DbtCommands.DBT_1_6;
+        case SupportedDbtVersions.V1_7:
+            return DbtCommands.DBT_1_7;
+        case SupportedDbtVersions.V1_8:
+            return DbtCommands.DBT_1_8;
+        case SupportedDbtVersions.V1_9:
+            return DbtCommands.DBT_1_9;
+        case SupportedDbtVersions.V1_10:
+            return DbtCommands.DBT_1_10;
+        case SupportedDbtVersions.V1_11:
+            return DbtCommands.DBT_1_11;
+        default:
+            return assertUnreachable(
+                version,
+                'Missing dbt version command mapping',
+            );
+    }
+}
+
 export class DbtCliClient implements DbtClient {
     dbtProjectDirectory: string;
 
@@ -149,29 +175,7 @@ export class DbtCliClient implements DbtClient {
     }
 
     getDbtExec(): string {
-        switch (this.dbtVersion) {
-            case SupportedDbtVersions.V1_4:
-                return DbtCommands.DBT_1_4;
-            case SupportedDbtVersions.V1_5:
-                return DbtCommands.DBT_1_5;
-            case SupportedDbtVersions.V1_6:
-                return DbtCommands.DBT_1_6;
-            case SupportedDbtVersions.V1_7:
-                return DbtCommands.DBT_1_7;
-            case SupportedDbtVersions.V1_8:
-                return DbtCommands.DBT_1_8;
-            case SupportedDbtVersions.V1_9:
-                return DbtCommands.DBT_1_9;
-            case SupportedDbtVersions.V1_10:
-                return DbtCommands.DBT_1_10;
-            case SupportedDbtVersions.V1_11:
-                return DbtCommands.DBT_1_11;
-            default:
-                return assertUnreachable(
-                    this.dbtVersion,
-                    'Missing dbt version command mapping',
-                );
-        }
+        return getDbtExecName(this.dbtVersion);
     }
 
     private async _runDbtCommand(...command: string[]): Promise<{

--- a/packages/backend/src/dbt/dbtVersions.ts
+++ b/packages/backend/src/dbt/dbtVersions.ts
@@ -1,0 +1,96 @@
+import { SupportedDbtVersions } from '@lightdash/common';
+import * as fs from 'fs/promises';
+import * as path from 'path';
+import Logger from '../logging/logger';
+import { getDbtExecName } from './dbtCliClient';
+
+/**
+ * Find the venv path for a dbt executable by searching PATH and resolving symlinks.
+ * e.g. dbt1.11 → /usr/local/bin/dbt1.11 → /usr/local/dbt1.11/bin/dbt → venv: /usr/local/dbt1.11
+ */
+async function findVenvPath(exec: string): Promise<string | null> {
+    const pathDirs = (process.env.PATH || '').split(':');
+    const results = await Promise.all(
+        pathDirs.map(async (dir) => {
+            try {
+                const realPath = await fs.realpath(path.join(dir, exec));
+                // realPath is like /usr/local/dbt1.11/bin/dbt — venv is two levels up
+                return path.dirname(path.dirname(realPath));
+            } catch {
+                return null;
+            }
+        }),
+    );
+    return results.find((r) => r !== null) ?? null;
+}
+
+/**
+ * Read the dbt-core version from a venv's installed package metadata.
+ * Looks for a dbt_core-<version>.dist-info directory in site-packages.
+ */
+async function readDbtCoreVersion(venvPath: string): Promise<string | null> {
+    try {
+        const libDir = path.join(venvPath, 'lib');
+        const pythonDirs = await fs.readdir(libDir);
+        const pythonDir = pythonDirs.find((d) => d.startsWith('python3'));
+        if (!pythonDir) return null;
+
+        const sitePackages = path.join(libDir, pythonDir, 'site-packages');
+        const entries = await fs.readdir(sitePackages);
+        // pip 21.3+ normalizes to dbt_core-, older pip uses dbt-core-
+        const distInfo = entries.find(
+            (e) =>
+                (e.startsWith('dbt_core-') || e.startsWith('dbt-core-')) &&
+                e.endsWith('.dist-info'),
+        );
+        if (!distInfo) return null;
+
+        const match = distInfo.match(/^dbt[_-]core-([\d.]+)\.dist-info$/);
+        return match ? match[1] : null;
+    } catch {
+        return null;
+    }
+}
+
+async function detectDbtPatchVersion(
+    version: SupportedDbtVersions,
+): Promise<string | null> {
+    const exec = getDbtExecName(version);
+    const venvPath = await findVenvPath(exec);
+    if (!venvPath) return null;
+    return readDbtCoreVersion(venvPath);
+}
+
+// Cached for process lifetime — dbt versions are fixed in the Docker image
+let cachedPromise: Promise<
+    Partial<Record<SupportedDbtVersions, string>>
+> | null = null;
+
+export async function getInstalledDbtVersions(): Promise<
+    Partial<Record<SupportedDbtVersions, string>>
+> {
+    if (!cachedPromise) {
+        cachedPromise = (async () => {
+            const versions = Object.values(SupportedDbtVersions);
+            const results = await Promise.all(
+                versions.map(async (version) => {
+                    const patchVersion = await detectDbtPatchVersion(version);
+                    return [version, patchVersion] as const;
+                }),
+            );
+
+            const installed: Partial<Record<SupportedDbtVersions, string>> = {};
+            for (const [version, patchVersion] of results) {
+                if (patchVersion) {
+                    installed[version] = patchVersion;
+                }
+            }
+
+            Logger.debug(
+                `Detected installed dbt versions: ${JSON.stringify(installed)}`,
+            );
+            return installed;
+        })();
+    }
+    return cachedPromise;
+}

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -20,6 +20,7 @@ import {
     getDatabricksOidcEndpointsFromHost,
     getDatabricksStrategyName,
 } from '../controllers/authentication/strategies/databricksStrategy';
+import { getInstalledDbtVersions } from '../dbt/dbtVersions';
 import { AiAgentService } from '../ee/services/AiAgentService/AiAgentService';
 import Logger from '../logging/logger';
 import { UserModel } from '../models/UserModel';
@@ -205,6 +206,17 @@ apiV1Router.get('/health', async (req, res, next) => {
             res.json({
                 status: 'ok',
                 results: state,
+            }),
+        )
+        .catch(next);
+});
+
+apiV1Router.get('/dbt/installed-versions', async (req, res, next) => {
+    getInstalledDbtVersions()
+        .then((results) =>
+            res.json({
+                status: 'ok',
+                results,
             }),
         )
         .catch(next);

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -165,6 +165,7 @@ import {
     type CreateWarehouseCredentials,
     type DbtProjectConfig,
     type Project,
+    type SupportedDbtVersions,
     type WarehouseCredentials,
 } from './projects';
 import { type ApiPromotionChangesResponse } from './promotion';
@@ -794,6 +795,9 @@ export type PasswordReset = {
 };
 
 export type ApiHealthResults = HealthState;
+export type ApiInstalledDbtVersionsResults = Partial<
+    Record<SupportedDbtVersions, string>
+>;
 export type InviteLink = {
     expiresAt: Date;
     inviteCode: string;
@@ -827,6 +831,7 @@ type ApiResults =
     | ApiRefreshResults
     | ApiCreatePreviewResults
     | ApiHealthResults
+    | ApiInstalledDbtVersionsResults
     | Organization
     | LightdashUser
     | LoginOptions

--- a/packages/frontend/src/components/ProjectConnection/Inputs/DbtVersion.tsx
+++ b/packages/frontend/src/components/ProjectConnection/Inputs/DbtVersion.tsx
@@ -6,6 +6,7 @@ import {
 } from '@lightdash/common';
 import { Select } from '@mantine/core';
 import React, { type FC } from 'react';
+import useInstalledDbtVersions from '../../../hooks/dbt/useInstalledDbtVersions';
 import { useFormContext } from '../formContext';
 
 const DbtVersionSelect: FC<{
@@ -13,6 +14,21 @@ const DbtVersionSelect: FC<{
 }> = ({ disabled }) => {
     const form = useFormContext();
     const field = form.getInputProps('dbtVersion');
+    const { data: installedVersions } = useInstalledDbtVersions();
+
+    const getVersionLabel = (version: SupportedDbtVersions): string => {
+        const patchVersion = installedVersions?.[version];
+        if (patchVersion) {
+            return `${version} (running ${patchVersion})`;
+        }
+        return version;
+    };
+
+    const latestVersion = getLatestSupportDbtVersion();
+    const latestPatchVersion = installedVersions?.[latestVersion];
+    const latestLabel = latestPatchVersion
+        ? `latest (running ${latestPatchVersion})`
+        : `latest (${latestVersion})`;
 
     return (
         <Select
@@ -22,13 +38,13 @@ const DbtVersionSelect: FC<{
             data={[
                 {
                     value: DbtVersionOptionLatest.LATEST,
-                    label: `latest (${getLatestSupportDbtVersion()})`,
+                    label: latestLabel,
                 },
                 ...Object.values(SupportedDbtVersions)
                     .reverse()
                     .map((version) => ({
                         value: version,
-                        label: version,
+                        label: getVersionLabel(version),
                     })),
             ]}
             value={field.value}

--- a/packages/frontend/src/hooks/dbt/useInstalledDbtVersions.ts
+++ b/packages/frontend/src/hooks/dbt/useInstalledDbtVersions.ts
@@ -1,0 +1,21 @@
+import {
+    type ApiError,
+    type ApiInstalledDbtVersionsResults,
+} from '@lightdash/common';
+import { useQuery } from '@tanstack/react-query';
+import { lightdashApi } from '../../api';
+
+const getInstalledDbtVersions = async () =>
+    lightdashApi<ApiInstalledDbtVersionsResults>({
+        url: `/dbt/installed-versions`,
+        method: 'GET',
+        body: undefined,
+    });
+
+const useInstalledDbtVersions = () =>
+    useQuery<ApiInstalledDbtVersionsResults, ApiError>({
+        queryKey: ['dbt', 'installed-versions'],
+        queryFn: getInstalledDbtVersions,
+    });
+
+export default useInstalledDbtVersions;


### PR DESCRIPTION
### Description:

Added functionality to detect and display installed dbt patch versions in the project connection form. The system now automatically discovers which dbt versions are available in the environment by scanning PATH for dbt executables and reading their corresponding virtual environment metadata.

Key changes include:

- Created `getDbtExecName()` function to map dbt versions to executable names and extracted existing switch logic from `DbtCliClient`
- Added `getInstalledDbtVersions()` function that detects installed dbt versions by finding virtual environment paths and reading package metadata from site-packages directories
- Implemented new API endpoint `/api/v1/dbt/installed-versions` that returns detected dbt versions with caching for performance
- Enhanced the dbt version selector in the frontend to show actual installed patch versions (e.g., "v1.11 (running 1.11.2)") alongside the base version numbers
- Added React hook `useInstalledDbtVersions` to fetch and cache the installed version data

The version detection works by resolving symlinks in PATH to find the actual dbt installation directories, then parsing the `dbt_core-*.dist-info` metadata to extract precise version numbers. This provides users with better visibility into which dbt versions are actually available in their environment.