### PR TITLE
feat: support dbt seeds as join targets

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/data/raw_order_statuses.csv
+++ b/examples/full-jaffle-shop-demo/dbt/data/raw_order_statuses.csv
@@ -1,0 +1,6 @@
+status,status_label,status_priority,is_active
+placed,Order Placed,1,true
+shipped,Shipped,2,true
+completed,Completed,3,false
+return_pending,Return Pending,4,true
+returned,Returned,5,false

--- a/examples/full-jaffle-shop-demo/dbt/data/seeds.yml
+++ b/examples/full-jaffle-shop-demo/dbt/data/seeds.yml
@@ -91,6 +91,40 @@ seeds:
     config:
       column_types:
         metadata: "{{ 'variant' if target.type == 'snowflake' else ('varchar' if target.type in ['athena', 'trino', 'duckdb', 'clickhouse'] else 'jsonb') }}"
+  - name: raw_order_statuses
+    description: "Order status lookup table — labels and priority for each status"
+    config:
+      meta:
+        joins: []
+      column_types:
+        status_priority: integer
+        is_active: boolean
+    columns:
+      - name: status
+        description: "Order status code"
+        config:
+          meta:
+            dimension:
+              type: string
+              hidden: true
+      - name: status_label
+        description: "Human-readable status label"
+        config:
+          meta:
+            dimension:
+              type: string
+      - name: status_priority
+        description: "Sort priority (1 = earliest stage)"
+        config:
+          meta:
+            dimension:
+              type: number
+      - name: is_active
+        description: "Whether the order is still active in this status"
+        config:
+          meta:
+            dimension:
+              type: boolean
   - name: raw_buildings
     config:
       column_types:

--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -40,6 +40,10 @@ models:
             relationship: many-to-one
             label: Order Customer
             description: The customer who placed this order (many orders can belong to one customer)
+          - join: raw_order_statuses
+            label: Order Status
+            sql_on: ${orders.status} = ${raw_order_statuses.status}
+            relationship: many-to-one
         metrics:
           completion_percentage:
             spotlight:

--- a/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
+++ b/packages/backend/src/projectAdapters/dbtBaseProjectAdapter.ts
@@ -188,7 +188,8 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                 Logger.info(`Compiled models ${compiledModels.length}`);
                 const filtered = compiledModels.filter(
                     (node: AnyType) =>
-                        node.resource_type === 'model' && node.meta,
+                        ['model', 'seed'].includes(node.resource_type) &&
+                        node.meta,
                 ) as DbtRawModelNode[];
                 const elapsed = Date.now() - startTime;
                 Logger.info(
@@ -365,6 +366,11 @@ export class DbtBaseProjectAdapter implements ProjectAdapter {
                     };
                 }
                 if (error) {
+                    // Seeds that fail validation are silently skipped —
+                    // they're only used as join targets, not standalone explores.
+                    if (model.resource_type === 'seed') {
+                        return [validModels, invalidModels];
+                    }
                     const exploreError: ExploreError = {
                         name: model.name,
                         label: model.meta.label || friendlyName(model.name),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -8144,7 +8144,8 @@ export class ProjectService extends BaseService {
         Logger.info(`Manifest models ${nodes.length}`);
         // todo: does it error if they use a selector in the job? check logic in dbtBaseProjectAdapter.compileAllExplores
         const models = nodes.filter(
-            (node: AnyType) => node.resource_type === 'model' && node.meta, // check that node.meta exists
+            (node: AnyType) =>
+                ['model', 'seed'].includes(node.resource_type) && node.meta,
         ) as DbtRawModelNode[];
 
         const { warehouseClient } = await this._getWarehouseClient(

--- a/packages/cli/src/dbt/validation.ts
+++ b/packages/cli/src/dbt/validation.ts
@@ -46,6 +46,11 @@ export const validateDbtModel = async (
                 };
             }
             if (error) {
+                // Seeds that fail validation are silently skipped —
+                // they're only used as join targets, not standalone explores.
+                if (model.resource_type === 'seed') {
+                    return acc;
+                }
                 const exploreError: ExploreError = {
                     name: model.name,
                     label: model.meta.label || friendlyName(model.name),

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1155,7 +1155,11 @@ export const convertExplores = async (
         {},
     );
     const validModels = models.filter(
-        (model) => tableLookup[model.name] !== undefined,
+        (model) =>
+            tableLookup[model.name] !== undefined &&
+            // Seeds are compiled as tables (for join resolution) but should
+            // not generate standalone explores — they're join targets only.
+            model.resource_type !== 'seed',
     );
 
     const exploreCompiler = new ExploreCompiler(warehouseSqlBuilder, {

--- a/packages/common/src/dbt/validation.ts
+++ b/packages/common/src/dbt/validation.ts
@@ -87,6 +87,12 @@ export class ManifestValidator {
     isModelValid = (
         model: DbtRawModelNode,
     ): [true, undefined] | [false, string] => {
+        // Seeds are only used as join targets and don't need full model
+        // schema validation (which enforces resource_type: "model").
+        // They just need valid Lightdash metadata and columns.
+        if (model.resource_type === 'seed') {
+            return [true, undefined];
+        }
         const validator = ManifestValidator.getValidator<DbtModelNode>(
             `${this.lightdashSchemaId}#/definitions/LightdashCompiledModelNode`,
         );

--- a/packages/common/src/types/dbt.test.ts
+++ b/packages/common/src/types/dbt.test.ts
@@ -164,6 +164,29 @@ describe('getModelsFromManifest', () => {
             'model.test.view_model',
         ]);
     });
+
+    it('should include seed nodes alongside models', () => {
+        const manifest = makeManifest({
+            'model.test.my_model': {
+                ...baseModel,
+                unique_id: 'model.test.my_model',
+                name: 'my_model',
+                config: { materialized: 'table' },
+            },
+            'seed.test.raw_plan': {
+                ...baseModel,
+                unique_id: 'seed.test.raw_plan',
+                name: 'raw_plan',
+                resource_type: 'seed',
+                config: { materialized: 'seed' },
+            },
+        });
+
+        const models = getModelsFromManifest(manifest);
+        expect(models).toHaveLength(2);
+        const ids = models.map((m) => m.unique_id).sort();
+        expect(ids).toEqual(['model.test.my_model', 'seed.test.raw_plan']);
+    });
 });
 
 describe('patchPathParts', () => {

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -50,7 +50,13 @@ export type DbtNode = {
     resource_type: string;
     config?: DbtNodeConfig;
 };
-export type DbtRawModelNode = CompiledModelNode & {
+export type DbtRawModelNode = Omit<
+    CompiledModelNode,
+    'resource_type' | 'compiled' | 'language'
+> & {
+    resource_type: 'model' | 'seed';
+    compiled?: boolean;
+    language?: string;
     columns: { [name: string]: DbtModelColumn };
     config?: CompiledModelNode['config'] & { meta?: DbtModelMetadata };
     meta: DbtModelMetadata;
@@ -791,7 +797,7 @@ export const getModelsFromManifest = (
 ): DbtModelNode[] => {
     const models = Object.values(manifest.nodes).filter(
         (node) =>
-            node.resource_type === 'model' &&
+            ['model', 'seed'].includes(node.resource_type) &&
             node.config?.materialized !== 'ephemeral',
     ) as DbtRawModelNode[];
 
@@ -812,6 +818,10 @@ export function getCompiledModels(
     const isAnyModelCompiled = manifestModels.some((model) => model.compiled);
 
     return manifestModels.filter((model) => {
+        // Seeds are always included — they don't appear in dbt ls output
+        // and don't have a compiled field.
+        if (model.resource_type === 'seed') return true;
+
         if (compiledModelIds) {
             return compiledModelIds.includes(model.unique_id);
         }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-6187/joins-with-dbt-seedssources-silently-fail



### Description:
Seeds are now included in the compilation pipeline so they can be used as join targets from models, eliminating the need for wrapper models that just `SELECT * FROM {{ ref('seed') }}`. Seeds are compiled as tables for join resolution but do not create standalone explores.

<img width="1476" height="1518" alt="Screenshot 2026-04-07 at 16 50 08" src="https://github.com/user-attachments/assets/e0ddaba0-0a8c-45de-8d83-65b31349bccb" />