### PR TITLE
feat: add SQL filter transpilation for pre-aggregates

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -71,6 +71,7 @@
         "@octokit/request": "8.4.1",
         "@octokit/rest": "20.1.1",
         "@openrouter/ai-sdk-provider": "1.5.4",
+        "@polyglot-sql/sdk": "0.3.1",
         "@rudderstack/rudder-sdk-node": "2.1.1",
         "@sentry/core": "9.31.0",
         "@sentry/node": "9.46.0",

--- a/packages/backend/src/ee/preAggregates/sqlFilters.test.ts
+++ b/packages/backend/src/ee/preAggregates/sqlFilters.test.ts
@@ -1,0 +1,246 @@
+import {
+    DimensionType,
+    ExploreType,
+    FieldType,
+    SupportedDbtAdapter,
+    type Explore,
+} from '@lightdash/common';
+import { warehouseSqlBuilderFromType } from '@lightdash/warehouses';
+import { rebuildAndTranspilePreAggregateSqlFilters } from './sqlFilters';
+
+const makeDimension = ({
+    name,
+    table,
+    sql,
+    compiledSql,
+}: {
+    name: string;
+    table: string;
+    sql: string;
+    compiledSql: string;
+}) => ({
+    index: 0,
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql,
+    hidden: false,
+    compiledSql,
+    tablesReferences: [table],
+});
+
+const getSourceExplore = (
+    targetDatabase: SupportedDbtAdapter = SupportedDbtAdapter.POSTGRES,
+): Explore =>
+    ({
+        name: 'orders',
+        label: 'Orders',
+        tags: [],
+        baseTable: 'orders',
+        joinedTables: [
+            {
+                table: 'customers',
+                sqlOn: '${orders.customer_id} = ${customers.customer_id}',
+                compiledSqlOn: '"orders".customer_id = "customers".customer_id',
+            },
+        ],
+        targetDatabase,
+        tables: {
+            orders: {
+                name: 'orders',
+                label: 'Orders',
+                database: 'db',
+                schema: 'public',
+                sqlTable: 'orders',
+                dimensions: {
+                    status: makeDimension({
+                        name: 'status',
+                        table: 'orders',
+                        sql: '${TABLE}.status',
+                        compiledSql: '"orders".status',
+                    }),
+                    customer_id: makeDimension({
+                        name: 'customer_id',
+                        table: 'orders',
+                        sql: '${TABLE}.customer_id',
+                        compiledSql: '"orders".customer_id',
+                    }),
+                    order_date: makeDimension({
+                        name: 'order_date',
+                        table: 'orders',
+                        sql: '${TABLE}.order_date',
+                        compiledSql: '"orders".order_date',
+                    }),
+                },
+                metrics: {},
+                lineageGraph: {},
+                uncompiledSqlWhere:
+                    "${TABLE}.status != 'returned' AND customer_id = ${ld.parameters.customer_id} AND customers.segment != 'Enterprise'",
+            },
+            customers: {
+                name: 'customers',
+                label: 'Customers',
+                database: 'db',
+                schema: 'public',
+                sqlTable: 'customers',
+                dimensions: {
+                    customer_id: makeDimension({
+                        name: 'customer_id',
+                        table: 'customers',
+                        sql: '${TABLE}.customer_id',
+                        compiledSql: '"customers".customer_id',
+                    }),
+                    segment: makeDimension({
+                        name: 'segment',
+                        table: 'customers',
+                        sql: '${TABLE}.segment',
+                        compiledSql: '"customers".segment',
+                    }),
+                },
+                metrics: {},
+                lineageGraph: {},
+            },
+        },
+    }) as Explore;
+
+const getPreAggregateExplore = (
+    targetDatabase: SupportedDbtAdapter = SupportedDbtAdapter.POSTGRES,
+): Explore =>
+    ({
+        ...getSourceExplore(targetDatabase),
+        name: '__preagg__orders__orders_rollup',
+        type: ExploreType.PRE_AGGREGATE,
+        preAggregateSource: {
+            sourceExploreName: 'orders',
+            preAggregateName: 'orders_rollup',
+        },
+        tables: {
+            orders: {
+                ...getSourceExplore(targetDatabase).tables.orders,
+                dimensions: {
+                    status: makeDimension({
+                        name: 'status',
+                        table: 'orders',
+                        sql: 'orders.orders_status',
+                        compiledSql: 'orders.orders_status',
+                    }),
+                    customer_id: makeDimension({
+                        name: 'customer_id',
+                        table: 'orders',
+                        sql: 'orders.orders_customer_id',
+                        compiledSql: 'orders.orders_customer_id',
+                    }),
+                    order_date: makeDimension({
+                        name: 'order_date',
+                        table: 'orders',
+                        sql: 'CAST(orders.orders_order_date_day AS TIMESTAMP)',
+                        compiledSql:
+                            'CAST(orders.orders_order_date_day AS TIMESTAMP)',
+                    }),
+                },
+            },
+            customers: {
+                ...getSourceExplore(targetDatabase).tables.customers,
+                dimensions: {
+                    customer_id: makeDimension({
+                        name: 'customer_id',
+                        table: 'customers',
+                        sql: 'orders.customers_customer_id',
+                        compiledSql: 'orders.customers_customer_id',
+                    }),
+                    segment: makeDimension({
+                        name: 'segment',
+                        table: 'customers',
+                        sql: 'orders.customers_segment',
+                        compiledSql: 'orders.customers_segment',
+                    }),
+                },
+            },
+        },
+    }) as Explore;
+
+describe('rebuildAndTranspilePreAggregateSqlFilters', () => {
+    test('rebuilds sqlWhere against the pre-aggregate explore and preserves placeholders', async () => {
+        const sourceExplore = getSourceExplore();
+        const preAggExplore = getPreAggregateExplore();
+
+        const result = await rebuildAndTranspilePreAggregateSqlFilters({
+            sourceExplore,
+            preAggExplore,
+            warehouseSqlBuilder: warehouseSqlBuilderFromType(
+                sourceExplore.targetDatabase,
+            ),
+        });
+
+        expect(result.orders.sqlWhere).toContain('orders.orders_status');
+        expect(result.orders.sqlWhere).toContain('orders.orders_customer_id');
+        expect(result.orders.sqlWhere).toContain('orders.customers_segment');
+        expect(result.orders.sqlWhere).toContain(
+            '${ld.parameters.customer_id}',
+        );
+        expect(result.orders.sqlWhere).not.toContain('"orders".status');
+        expect(result.orders.sqlWhere).not.toContain('"orders".customer_id');
+    });
+
+    test('transpiles source-dialect sql to DuckDB after rebuilding', async () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.uncompiledSqlWhere =
+            "${order_date}::date >= NOW() - INTERVAL '7 days'";
+        const preAggExplore = getPreAggregateExplore();
+
+        const result = await rebuildAndTranspilePreAggregateSqlFilters({
+            sourceExplore,
+            preAggExplore,
+            warehouseSqlBuilder: warehouseSqlBuilderFromType(
+                sourceExplore.targetDatabase,
+            ),
+        });
+
+        expect(result.orders.sqlWhere).toContain(
+            'CAST(orders.orders_order_date_day AS TIMESTAMP)',
+        );
+        expect(result.orders.sqlWhere).not.toContain('::date');
+    });
+
+    test('still rewrites raw columns when the source dialect is already DuckDB', async () => {
+        const sourceExplore = getSourceExplore(SupportedDbtAdapter.DUCKDB);
+        const preAggExplore = getPreAggregateExplore(
+            SupportedDbtAdapter.DUCKDB,
+        );
+
+        const result = await rebuildAndTranspilePreAggregateSqlFilters({
+            sourceExplore,
+            preAggExplore,
+            warehouseSqlBuilder: warehouseSqlBuilderFromType(
+                sourceExplore.targetDatabase,
+            ),
+        });
+
+        expect(result.orders.sqlWhere).toContain('orders.orders_status');
+        expect(result.orders.sqlWhere).toContain('orders.orders_customer_id');
+        expect(result.orders.sqlWhere).not.toContain('.status');
+    });
+
+    test('rewrites raw bare and qualified references without throwing', async () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.uncompiledSqlWhere =
+            "customer_id = 1 AND customers.segment != 'Enterprise'";
+        const preAggExplore = getPreAggregateExplore();
+
+        const result = await rebuildAndTranspilePreAggregateSqlFilters({
+            sourceExplore,
+            preAggExplore,
+            warehouseSqlBuilder: warehouseSqlBuilderFromType(
+                sourceExplore.targetDatabase,
+            ),
+        });
+
+        expect(result.orders.sqlWhere).toContain('orders.orders_customer_id');
+        expect(result.orders.sqlWhere).toContain('orders.customers_segment');
+        expect(result.orders.sqlWhere).not.toContain('customer_id = 1');
+        expect(result.orders.sqlWhere).not.toContain('customers.segment');
+    });
+});

--- a/packages/backend/src/ee/preAggregates/sqlFilters.ts
+++ b/packages/backend/src/ee/preAggregates/sqlFilters.ts
@@ -1,0 +1,368 @@
+import {
+    assertUnreachable,
+    ExploreCompiler,
+    getErrorMessage,
+    lightdashVariablePattern,
+    preAggregateUtils,
+    type AnyType,
+    type Explore,
+    type SupportedDbtAdapter,
+    type WarehouseSqlBuilder,
+} from '@lightdash/common';
+import {
+    Dialect,
+    init,
+    isInitialized,
+    tokenize,
+    transpile,
+} from '@polyglot-sql/sdk';
+
+const PLACEHOLDER_PATTERN =
+    /\$\{(?:lightdash|ld)\.(?:attributes?|attr|user|parameters)\.[^}]+\}|\{%(?:[\s\S]*?)%\}/g;
+
+const getDialect = (adapter: SupportedDbtAdapter): Dialect => {
+    switch (adapter) {
+        case 'postgres':
+            return Dialect.PostgreSQL;
+        case 'bigquery':
+            return Dialect.BigQuery;
+        case 'snowflake':
+            return Dialect.Snowflake;
+        case 'databricks':
+            return Dialect.Databricks;
+        case 'redshift':
+            return Dialect.Redshift;
+        case 'trino':
+            return Dialect.Trino;
+        case 'athena':
+            return Dialect.Athena;
+        case 'duckdb':
+            return Dialect.DuckDB;
+        case 'clickhouse':
+            return Dialect.ClickHouse;
+        default:
+            return assertUnreachable(
+                adapter,
+                `Unsupported dbt adapter "${adapter}" for sql filter transpilation`,
+            );
+    }
+};
+
+const ensurePolyglotInitialized = async (): Promise<void> => {
+    if (!isInitialized()) {
+        await init();
+    }
+};
+
+const getTokenType = (token: unknown): string | undefined =>
+    token != null
+        ? ((token as AnyType).token_type ?? (token as AnyType).tokenType)
+        : undefined;
+
+const isIdentifierToken = (token: unknown): boolean => {
+    const tokenType = getTokenType(token);
+    return tokenType === 'VAR' || tokenType === 'QUOTED_IDENTIFIER';
+};
+
+const isDotToken = (token: unknown): boolean =>
+    getTokenType(token) === 'DOT' ||
+    (token as AnyType | undefined)?.text === '.';
+
+const isOpenParenToken = (token: unknown): boolean =>
+    getTokenType(token) === 'L_PAREN' ||
+    (token as AnyType | undefined)?.text === '(';
+
+const normalizeIdentifier = (value: string): string => {
+    if (
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith('`') && value.endsWith('`'))
+    ) {
+        return value.slice(1, -1);
+    }
+    return value;
+};
+
+const isNonEmptyString = (value: string | undefined): value is string =>
+    !!value;
+
+const protectPlaceholders = (sql: string) => {
+    const placeholders = new Map<string, string>();
+    let index = 0;
+
+    const protectedSql = sql.replace(PLACEHOLDER_PATTERN, (match) => {
+        const sentinel = `__ld_placeholder_${index}__`;
+        index += 1;
+        placeholders.set(sentinel, match);
+        return sentinel;
+    });
+
+    return {
+        protectedSql,
+        restore: (value: string) => {
+            let restored = value;
+            placeholders.forEach((original, sentinel) => {
+                restored = restored.replaceAll(sentinel, original);
+            });
+            return restored;
+        },
+    };
+};
+
+const compileSqlFilterAgainstPreAggregateExplore = ({
+    sql,
+    tableName,
+    preAggExplore,
+    warehouseSqlBuilder,
+}: {
+    sql: string;
+    tableName: string;
+    preAggExplore: Explore;
+    warehouseSqlBuilder: WarehouseSqlBuilder;
+}): string => {
+    const compiler = new ExploreCompiler(warehouseSqlBuilder);
+
+    return sql.replace(
+        lightdashVariablePattern,
+        (_, reference) =>
+            compiler.compileDimensionReference(
+                reference,
+                preAggExplore.tables,
+                tableName,
+                {
+                    fieldType: 'sql_where',
+                    fieldName: tableName,
+                },
+            ).sql,
+    );
+};
+
+const getColumnReplacementMaps = ({
+    sourceExplore,
+    preAggExplore,
+}: {
+    sourceExplore: Explore;
+    preAggExplore: Explore;
+}): Map<string, Map<string, string>> =>
+    Object.entries(sourceExplore.tables).reduce<
+        Map<string, Map<string, string>>
+    >((tableMaps, [tableName, sourceTable]) => {
+        const targetTable = preAggExplore.tables[tableName];
+        if (!targetTable) {
+            return tableMaps;
+        }
+
+        const replacementMap = new Map<string, string>();
+
+        Object.values(sourceTable.dimensions).forEach((sourceDimension) => {
+            const simpleColumnName =
+                preAggregateUtils.getSimpleSqlColumnName(sourceDimension);
+            const targetDimension =
+                targetTable.dimensions[sourceDimension.name];
+
+            if (!simpleColumnName || !targetDimension) {
+                return;
+            }
+
+            replacementMap.set(simpleColumnName, targetDimension.compiledSql);
+        });
+
+        [sourceTable.name, sourceTable.originalName]
+            .filter(isNonEmptyString)
+            .forEach((alias) => {
+                tableMaps.set(alias, replacementMap);
+            });
+
+        return tableMaps;
+    }, new Map<string, Map<string, string>>());
+
+const rewriteRawColumnReferences = async ({
+    sql,
+    currentTableName,
+    columnReplacementMaps,
+}: {
+    sql: string;
+    currentTableName: string;
+    columnReplacementMaps: Map<string, Map<string, string>>;
+}): Promise<string> => {
+    await ensurePolyglotInitialized();
+    const tokenResult = tokenize(sql, Dialect.DuckDB);
+    if (!tokenResult.success || !tokenResult.tokens) {
+        return sql;
+    }
+    const { tokens } = tokenResult;
+
+    const currentTableColumns = columnReplacementMaps.get(currentTableName);
+    let result = '';
+    let lastEnd = 0;
+
+    for (let index = 0; index < tokens.length; index += 1) {
+        const token = tokens[index];
+        const nextToken = tokens[index + 1];
+        const columnToken = tokens[index + 2];
+        let didRewriteQualifiedReference = false;
+
+        if (
+            isIdentifierToken(token) &&
+            isDotToken(nextToken) &&
+            isIdentifierToken(columnToken)
+        ) {
+            const qualifier = normalizeIdentifier(token.text);
+            const column = normalizeIdentifier(columnToken.text);
+            const replacement = columnReplacementMaps
+                .get(qualifier)
+                ?.get(column);
+
+            if (replacement) {
+                result += sql.substring(lastEnd, token.span.start);
+                result += `(${replacement})`;
+                lastEnd = columnToken.span.end;
+                index += 2;
+                didRewriteQualifiedReference = true;
+            }
+        }
+
+        if (!didRewriteQualifiedReference && isIdentifierToken(token)) {
+            const previousToken = tokens[index - 1];
+            const replacement =
+                !isDotToken(previousToken) &&
+                !isDotToken(nextToken) &&
+                !isOpenParenToken(nextToken)
+                    ? currentTableColumns?.get(normalizeIdentifier(token.text))
+                    : undefined;
+
+            if (replacement) {
+                result += sql.substring(lastEnd, token.span.start);
+                result += `(${replacement})`;
+                lastEnd = token.span.end;
+            }
+        }
+    }
+
+    result += sql.substring(lastEnd);
+    return result;
+};
+
+const transpileSqlFilterToDuckDb = async ({
+    sql,
+    sourceAdapter,
+}: {
+    sql: string;
+    sourceAdapter: SupportedDbtAdapter;
+}): Promise<string> => {
+    if (sourceAdapter === 'duckdb') {
+        return sql;
+    }
+
+    await ensurePolyglotInitialized();
+
+    const { protectedSql, restore } = protectPlaceholders(
+        `SELECT 1 WHERE ${sql}`,
+    );
+    const transpiled = transpile(
+        protectedSql,
+        getDialect(sourceAdapter),
+        Dialect.DuckDB,
+    );
+
+    if (!transpiled.success || !transpiled.sql || transpiled.sql.length === 0) {
+        throw new Error(
+            `Failed to transpile sql_filter: ${transpiled.error ?? 'unknown error'}`,
+        );
+    }
+
+    const restoredSql = restore(transpiled.sql[0]);
+    const whereMatch = restoredSql.match(/WHERE\s+([\s\S]+)$/i);
+    if (!whereMatch) {
+        throw new Error(
+            `Failed to extract sql_filter WHERE clause from transpiled SQL: ${restoredSql}`,
+        );
+    }
+
+    return whereMatch[1].trim();
+};
+
+const getPreAggregateTablesWithSourceSqlFilters = ({
+    sourceExplore,
+    preAggExplore,
+}: {
+    sourceExplore: Explore;
+    preAggExplore: Explore;
+}): Explore['tables'] =>
+    Object.fromEntries(
+        Object.entries(preAggExplore.tables).map(([tableName, table]) => {
+            const sourceTable = sourceExplore.tables[tableName];
+            const rawSqlFilter =
+                sourceTable?.uncompiledSqlWhere ??
+                sourceTable?.sqlWhere ??
+                table.uncompiledSqlWhere ??
+                table.sqlWhere;
+
+            return [
+                tableName,
+                {
+                    ...table,
+                    ...(rawSqlFilter
+                        ? { uncompiledSqlWhere: rawSqlFilter }
+                        : {}),
+                },
+            ];
+        }),
+    );
+
+export const rebuildAndTranspilePreAggregateSqlFilters = async ({
+    sourceExplore,
+    preAggExplore,
+    warehouseSqlBuilder,
+}: {
+    sourceExplore: Explore;
+    preAggExplore: Explore;
+    warehouseSqlBuilder: WarehouseSqlBuilder;
+}): Promise<Explore['tables']> => {
+    const rebuiltTables = getPreAggregateTablesWithSourceSqlFilters({
+        sourceExplore,
+        preAggExplore,
+    });
+    const columnReplacementMaps = getColumnReplacementMaps({
+        sourceExplore,
+        preAggExplore,
+    });
+
+    return Object.fromEntries(
+        await Promise.all(
+            Object.entries(rebuiltTables).map(async ([tableName, table]) => {
+                const rawSqlFilter = table.uncompiledSqlWhere ?? table.sqlWhere;
+                if (!rawSqlFilter) {
+                    return [tableName, table] as const;
+                }
+
+                const compiledSqlWhere =
+                    compileSqlFilterAgainstPreAggregateExplore({
+                        sql: rawSqlFilter,
+                        tableName,
+                        preAggExplore,
+                        warehouseSqlBuilder,
+                    });
+                const transpiledSqlWhere = await transpileSqlFilterToDuckDb({
+                    sql: compiledSqlWhere,
+                    sourceAdapter: sourceExplore.targetDatabase,
+                });
+                const rewrittenSqlWhere = await rewriteRawColumnReferences({
+                    sql: transpiledSqlWhere,
+                    currentTableName: tableName,
+                    columnReplacementMaps,
+                });
+
+                return [
+                    tableName,
+                    {
+                        ...table,
+                        sqlWhere: rewrittenSqlWhere,
+                    },
+                ] as const;
+            }),
+        ),
+    );
+};
+
+export const getSqlFilterRebuildError = (error: unknown): string =>
+    `Failed to rebuild pre-aggregate sql_filter: ${getErrorMessage(error)}`;

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -31,6 +31,7 @@ import { ProjectService } from '../../../services/ProjectService/ProjectService'
 import { wrapSentryTransaction } from '../../../utils';
 import { PivotQueryBuilder } from '../../../utils/QueryBuilder/PivotQueryBuilder';
 import { type PreAggregateModel } from '../../models/PreAggregateModel';
+import { rebuildAndTranspilePreAggregateSqlFilters } from '../../preAggregates/sqlFilters';
 import {
     getDuckdbPreAggregateSqlTable,
     getPreAggregateDuckdbLocator,
@@ -326,18 +327,48 @@ export class PreAggregationDuckDbClient {
             );
         }
 
+        const sourceExplore = await Sentry.startSpan(
+            {
+                op: 'cache.read',
+                name: 'preagg.getSourceExploreFromCache',
+                attributes: {
+                    'lightdash.projectUuid': args.projectUuid,
+                    'lightdash.sourceExploreName':
+                        args.preAggregationRoute.sourceExploreName,
+                },
+            },
+            () =>
+                this.projectModel.getExploreFromCache(
+                    args.projectUuid,
+                    args.preAggregationRoute.sourceExploreName,
+                ),
+        );
+        if (isExploreError(sourceExplore)) {
+            throw new Error(
+                `Source explore ${args.preAggregationRoute.sourceExploreName} is not queryable`,
+            );
+        }
+
+        const sourceWarehouseSqlBuilder = warehouseSqlBuilderFromType(
+            sourceExplore.targetDatabase,
+            args.startOfWeek,
+        );
+        const rebuiltTables = await rebuildAndTranspilePreAggregateSqlFilters({
+            sourceExplore,
+            preAggExplore,
+            warehouseSqlBuilder: sourceWarehouseSqlBuilder,
+        });
+
         const patchedPreAggExplore = {
             ...preAggExplore,
             tables: Object.fromEntries(
-                Object.entries(preAggExplore.tables).map(
-                    ([tableName, table]) => [
-                        tableName,
-                        {
-                            ...table,
-                            sqlTable,
-                        },
-                    ],
-                ),
+                Object.entries(rebuiltTables).map(([tableName, table]) => [
+                    tableName,
+                    {
+                        ...table,
+                        sqlTable,
+                    },
+                ]),
             ),
         };
 

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -39,6 +39,18 @@ const getSourceExplore = (): Explore =>
                         compiledSql: '"orders".status',
                         tablesReferences: ['orders'],
                     },
+                    customer_id: {
+                        fieldType: FieldType.DIMENSION,
+                        type: DimensionType.NUMBER,
+                        name: 'customer_id',
+                        label: 'Customer id',
+                        table: 'orders',
+                        tableLabel: 'Orders',
+                        sql: '${TABLE}.customer_id',
+                        hidden: false,
+                        compiledSql: '"orders".customer_id',
+                        tablesReferences: ['orders'],
+                    },
                     order_date: {
                         fieldType: FieldType.DIMENSION,
                         type: DimensionType.DATE,
@@ -120,7 +132,7 @@ const getSourceExplore = (): Explore =>
     }) as Explore;
 
 describe('buildMaterializationMetricQuery', () => {
-    it('includes the time dimension with the configured granularity when omitted from dimensions', () => {
+    it('includes the time dimension with the configured granularity when omitted from dimensions', async () => {
         const preAggregateDef: PreAggregateDef = {
             name: 'orders_rollup',
             dimensions: ['status'],
@@ -129,7 +141,7 @@ describe('buildMaterializationMetricQuery', () => {
             granularity: TimeFrames.DAY,
         };
 
-        const result = buildMaterializationMetricQuery({
+        const result = await buildMaterializationMetricQuery({
             sourceExplore: getSourceExplore(),
             preAggregateDef,
             materializationConfig: { maxRows: null },
@@ -142,7 +154,7 @@ describe('buildMaterializationMetricQuery', () => {
         expect(result.timeDimensionFieldId).toEqual('orders_order_date_day');
     });
 
-    it('does not duplicate the time dimension when it is already part of the definition', () => {
+    it('does not duplicate the time dimension when it is already part of the definition', async () => {
         const preAggregateDef: PreAggregateDef = {
             name: 'orders_rollup',
             dimensions: ['status', 'order_date'],
@@ -151,7 +163,7 @@ describe('buildMaterializationMetricQuery', () => {
             granularity: TimeFrames.DAY,
         };
 
-        const result = buildMaterializationMetricQuery({
+        const result = await buildMaterializationMetricQuery({
             sourceExplore: getSourceExplore(),
             preAggregateDef,
             materializationConfig: { maxRows: null },
@@ -168,14 +180,14 @@ describe('buildMaterializationMetricQuery', () => {
 
     it.each(['order_count', 'orders.order_count'])(
         'resolves metric reference "%s" to field IDs',
-        (metricReference) => {
+        async (metricReference) => {
             const preAggregateDef: PreAggregateDef = {
                 name: 'orders_rollup',
                 dimensions: ['status'],
                 metrics: [metricReference],
             };
 
-            const result = buildMaterializationMetricQuery({
+            const result = await buildMaterializationMetricQuery({
                 sourceExplore: getSourceExplore(),
                 preAggregateDef,
                 materializationConfig: { maxRows: null },
@@ -194,14 +206,14 @@ describe('buildMaterializationMetricQuery', () => {
         },
     );
 
-    it('decomposes average metrics into hidden sum and count component metrics', () => {
+    it('decomposes average metrics into hidden sum and count component metrics', async () => {
         const preAggregateDef: PreAggregateDef = {
             name: 'orders_rollup',
             dimensions: ['status'],
             metrics: ['avg_order_amount'],
         };
 
-        const result = buildMaterializationMetricQuery({
+        const result = await buildMaterializationMetricQuery({
             sourceExplore: getSourceExplore(),
             preAggregateDef,
             materializationConfig: { maxRows: null },
@@ -262,7 +274,7 @@ describe('buildMaterializationMetricQuery', () => {
         expect(result.timeDimensionFieldId).toBeNull();
     });
 
-    it('emits pre-aggregate filters into materialization dimension filters', () => {
+    it('emits pre-aggregate filters into materialization dimension filters', async () => {
         const preAggregateDef: PreAggregateDef = {
             name: 'orders_rollup',
             dimensions: ['status'],
@@ -290,7 +302,7 @@ describe('buildMaterializationMetricQuery', () => {
             ],
         };
 
-        const result = buildMaterializationMetricQuery({
+        const result = await buildMaterializationMetricQuery({
             sourceExplore: getSourceExplore(),
             preAggregateDef,
             materializationConfig: { maxRows: null },
@@ -322,8 +334,8 @@ describe('buildMaterializationMetricQuery', () => {
         });
     });
 
-    it('throws when generated average metric component field IDs collide with selected metrics', () => {
-        expect(() =>
+    it('throws when generated average metric component field IDs collide with selected metrics', async () => {
+        await expect(
             buildMaterializationMetricQuery({
                 sourceExplore: getSourceExplore(),
                 preAggregateDef: {
@@ -333,8 +345,28 @@ describe('buildMaterializationMetricQuery', () => {
                 },
                 materializationConfig: { maxRows: null },
             }),
-        ).toThrow(
+        ).rejects.toThrow(
             'Pre-aggregate "orders_rollup" generates duplicate materialization metric field ID "orders_avg_order_amount__sum"',
+        );
+    });
+
+    it('throws when inherited sql_filter requires an unmaterialized dimension', async () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.uncompiledSqlWhere =
+            '${TABLE}.customer_id = ${ld.parameters.customer_id}';
+
+        await expect(
+            buildMaterializationMetricQuery({
+                sourceExplore,
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['orders_order_count'],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).rejects.toThrow(
+            'Pre-aggregate "orders_rollup" cannot support sql_filter because table "orders" requires "customer_id" (orders_customer_id), which is not materialized by the pre-aggregate',
         );
     });
 });

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -189,7 +189,7 @@ const getPreAggregateDimensionFilters = ({
     };
 };
 
-export const buildMaterializationMetricQuery = ({
+export const buildMaterializationMetricQuery = async ({
     sourceExplore,
     preAggregateDef,
     materializationConfig,
@@ -197,7 +197,21 @@ export const buildMaterializationMetricQuery = ({
     sourceExplore: Explore;
     preAggregateDef: PreAggregateDef;
     materializationConfig: MaterializationConfig;
-}): MaterializationMetricQueryPayload => {
+}): Promise<MaterializationMetricQueryPayload> => {
+    const sqlFilterCompatibility =
+        await preAggregateUtils.getPreAggregateSqlFilterCompatibility({
+            explore: sourceExplore,
+            preAggregateDef,
+        });
+    if (!sqlFilterCompatibility.supported) {
+        throw new Error(
+            preAggregateUtils.formatPreAggregateSqlFilterCompatibilityError({
+                preAggregateName: preAggregateDef.name,
+                compatibility: sqlFilterCompatibility,
+            }),
+        );
+    }
+
     const metricsByReference = preAggregateUtils.getMetricsByReference({
         tables: sourceExplore.tables,
         baseTable: sourceExplore.baseTable,

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -6,11 +6,11 @@ import {
     NotFoundError,
     OrganizationMemberRole,
     ParameterError,
+    preAggregateUtils,
     SessionUser,
     WarehouseTypes,
-    type Explore,
-    type PossibleAbilities,
 } from '@lightdash/common';
+import type { Explore, PossibleAbilities } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
@@ -18,6 +18,7 @@ import { type FileStorageClient } from '../../clients/FileStorage/FileStorageCli
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { type LightdashConfig } from '../../config/parseConfig';
 import { PreAggregateModel } from '../../ee/models/PreAggregateModel';
+import * as preAggregateSqlFilters from '../../ee/preAggregates/sqlFilters';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import type { CatalogModel } from '../../models/CatalogModel/CatalogModel';
 import { ContentModel } from '../../models/ContentModel/ContentModel';
@@ -122,6 +123,7 @@ jest.mock('@lightdash/warehouses', () => ({
         connect: jest.fn(() => warehouseClientMock.credentials),
         disconnect: jest.fn(),
     })),
+    warehouseSqlBuilderFromType: jest.fn(() => warehouseClientMock),
 }));
 
 const projectModel = {
@@ -259,6 +261,7 @@ describe('ProjectService', () => {
 
     afterEach(() => {
         jest.clearAllMocks();
+        jest.restoreAllMocks();
     });
     test('should run sql query', async () => {
         jest.spyOn(analyticsMock, 'track');
@@ -277,6 +280,35 @@ describe('ProjectService', () => {
 
         expect(results).toEqual(expectedCatalog);
     });
+    describe('calculateTotalFromQuery', () => {
+        test('should return empty totals for explicit pre-aggregate explores', async () => {
+            const getExploreSpy = jest
+                .spyOn(service, 'getExplore')
+                .mockResolvedValue(preAggregateExplore);
+            const getWarehouseClientFromCredentialsSpy = jest.spyOn(
+                projectModel,
+                'getWarehouseClientFromCredentials',
+            );
+
+            const result = await service.calculateTotalFromQuery(
+                developerAccount,
+                projectUuid,
+                {
+                    explore: preAggregateExplore.name,
+                    metricQuery: metricQueryMock,
+                },
+            );
+
+            expect(getExploreSpy).toHaveBeenCalledWith(
+                developerAccount,
+                projectUuid,
+                preAggregateExplore.name,
+                projectSummary.organizationUuid,
+            );
+            expect(result).toEqual({});
+            expect(getWarehouseClientFromCredentialsSpy).not.toHaveBeenCalled();
+        });
+    });
     test('should get tables configuration', async () => {
         const result = await service.getTablesConfiguration(
             account,
@@ -285,12 +317,12 @@ describe('ProjectService', () => {
         expect(result).toEqual(tablesConfiguration);
     });
     test('should update tables configuration', async () => {
+        jest.spyOn(analyticsMock, 'track');
         await service.updateTablesConfiguration(
             user,
             projectUuid,
             tablesConfigurationWithNames,
         );
-        jest.spyOn(analyticsMock, 'track');
         expect(projectModel.updateTablesConfiguration).toHaveBeenCalledTimes(1);
         expect(analyticsMock.track).toHaveBeenCalledTimes(1);
         expect(analyticsMock.track).toHaveBeenCalledWith(
@@ -393,6 +425,72 @@ describe('ProjectService', () => {
 
             // Query should still execute successfully with user credentials
             expect(result).toEqual(expectedApiQueryResultsWith1Row);
+        });
+    });
+
+    describe('calculateTotalFromQuery', () => {
+        test('should resolve pre-aggregate explore for totals and return no totals', async () => {
+            const serviceWithPreAggregatesEnabled = getMockedProjectService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+
+            const getExploreSpy = jest
+                .spyOn(serviceWithPreAggregatesEnabled, 'getExplore')
+                .mockResolvedValueOnce(validExplore)
+                .mockResolvedValueOnce(preAggregateExplore);
+            const findMatchSpy = jest
+                .spyOn(preAggregateUtils, 'findMatch')
+                .mockReturnValue({
+                    hit: true,
+                    preAggregateName:
+                        preAggregateExplore.preAggregateSource!
+                            .preAggregateName,
+                    miss: null,
+                });
+            const rebuildSpy = jest
+                .spyOn(
+                    preAggregateSqlFilters,
+                    'rebuildAndTranspilePreAggregateSqlFilters',
+                )
+                .mockResolvedValue(preAggregateExplore.tables);
+            const getWarehouseClientFromCredentialsSpy = jest.spyOn(
+                projectModel,
+                'getWarehouseClientFromCredentials',
+            );
+
+            serviceWithPreAggregatesEnabled.warehouseClients = {};
+
+            const result =
+                await serviceWithPreAggregatesEnabled.calculateTotalFromQuery(
+                    account,
+                    projectUuid,
+                    {
+                        explore: validExplore.name,
+                        metricQuery: metricQueryMock,
+                    },
+                );
+
+            expect(findMatchSpy).toHaveBeenCalledWith(
+                metricQueryMock,
+                validExplore,
+            );
+            expect(getExploreSpy).toHaveBeenNthCalledWith(
+                2,
+                account,
+                projectUuid,
+                preAggregateExplore.name,
+            );
+            expect(rebuildSpy).toHaveBeenCalledWith({
+                sourceExplore: validExplore,
+                preAggExplore: preAggregateExplore,
+                warehouseSqlBuilder: expect.anything(),
+            });
+            expect(result).toEqual({});
+            expect(getWarehouseClientFromCredentialsSpy).not.toHaveBeenCalled();
         });
     });
 
@@ -1001,6 +1099,15 @@ describe('ProjectService', () => {
         beforeEach(() => {
             // Clear the warehouse clients cache
             service.warehouseClients = {};
+            (
+                projectModel.getWarehouseCredentialsForProject as jest.Mock
+            ).mockImplementation(async () => warehouseClientMock.credentials);
+            (
+                projectModel.getWarehouseClientFromCredentials as jest.Mock
+            ).mockImplementation(() => ({
+                ...warehouseClientMock,
+                runQuery: jest.fn(async () => resultsWith1Row),
+            }));
         });
 
         afterEach(() => {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -215,6 +215,7 @@ import { type DbPreAggregateDefinitionIn } from '../../ee/database/entities/preA
 import { PreAggregateModel } from '../../ee/models/PreAggregateModel';
 import { enhanceExploresForPreAggregates } from '../../ee/preAggregates/enhanceExploresForPreAggregates';
 import { preAggregatePostProcessor } from '../../ee/preAggregates/postProcessor';
+import { rebuildAndTranspilePreAggregateSqlFilters } from '../../ee/preAggregates/sqlFilters';
 import { buildMaterializationMetricQuery } from '../../ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery';
 import { errorHandler } from '../../errors';
 import Logger from '../../logging/logger';
@@ -1467,70 +1468,83 @@ export class ProjectService extends BaseService {
         );
 
         const definitionRows: DbPreAggregateDefinitionIn[] = [];
+        const resolvedDefinitionRows = await Promise.all(
+            Object.entries(exploresByUuid).flatMap(
+                ([sourceCachedExploreUuid, sourceExplore]) => {
+                    if (
+                        isExploreError(sourceExplore) ||
+                        !sourceExplore.preAggregates ||
+                        sourceExplore.preAggregates.length === 0
+                    ) {
+                        return [];
+                    }
 
-        Object.entries(exploresByUuid).forEach(
-            ([sourceCachedExploreUuid, sourceExplore]) => {
-                if (
-                    isExploreError(sourceExplore) ||
-                    !sourceExplore.preAggregates ||
-                    sourceExplore.preAggregates.length === 0
-                ) {
-                    return;
-                }
+                    return sourceExplore.preAggregates.map(
+                        async (
+                            preAggregateDefinition,
+                        ): Promise<DbPreAggregateDefinitionIn | null> => {
+                            const preAggregateExploreName =
+                                getPreAggregateExploreName(
+                                    sourceExplore.name,
+                                    preAggregateDefinition.name,
+                                );
+                            const preAggCachedExploreUuid =
+                                preAggregateExploreUuidByName.get(
+                                    preAggregateExploreName,
+                                );
 
-                sourceExplore.preAggregates.forEach(
-                    (preAggregateDefinition) => {
-                        const preAggregateExploreName =
-                            getPreAggregateExploreName(
-                                sourceExplore.name,
-                                preAggregateDefinition.name,
-                            );
-                        const preAggCachedExploreUuid =
-                            preAggregateExploreUuidByName.get(
-                                preAggregateExploreName,
-                            );
+                            if (!preAggCachedExploreUuid) {
+                                this.logger.warn(
+                                    `Skipping pre-aggregate definition "${preAggregateDefinition.name}" for source explore "${sourceExplore.name}" in project ${projectUuid}: generated pre-aggregate explore "${preAggregateExploreName}" not found in cache`,
+                                );
+                                return null;
+                            }
 
-                        if (!preAggCachedExploreUuid) {
-                            this.logger.warn(
-                                `Skipping pre-aggregate definition "${preAggregateDefinition.name}" for source explore "${sourceExplore.name}" in project ${projectUuid}: generated pre-aggregate explore "${preAggregateExploreName}" not found in cache`,
-                            );
-                            return;
-                        }
+                            let materializationMetricQuery = null;
+                            let materializationQueryError = null;
 
-                        let materializationMetricQuery = null;
-                        let materializationQueryError = null;
+                            try {
+                                materializationMetricQuery =
+                                    await buildMaterializationMetricQuery({
+                                        sourceExplore,
+                                        preAggregateDef: preAggregateDefinition,
+                                        materializationConfig: {
+                                            maxRows:
+                                                this.lightdashConfig
+                                                    .preAggregates
+                                                    .materializationMaxRows,
+                                        },
+                                    });
+                            } catch (error) {
+                                materializationQueryError =
+                                    getErrorMessage(error);
+                            }
 
-                        try {
-                            materializationMetricQuery =
-                                buildMaterializationMetricQuery({
-                                    sourceExplore,
-                                    preAggregateDef: preAggregateDefinition,
-                                    materializationConfig: {
-                                        maxRows:
-                                            this.lightdashConfig.preAggregates
-                                                .materializationMaxRows,
-                                    },
-                                });
-                        } catch (error) {
-                            materializationQueryError = getErrorMessage(error);
-                        }
-
-                        definitionRows.push({
-                            project_uuid: projectUuid,
-                            source_cached_explore_uuid: sourceCachedExploreUuid,
-                            pre_agg_cached_explore_uuid:
-                                preAggCachedExploreUuid,
-                            pre_aggregate_definition: preAggregateDefinition,
-                            materialization_metric_query:
-                                materializationMetricQuery,
-                            materialization_query_error:
-                                materializationQueryError,
-                            refresh_cron:
-                                preAggregateDefinition.refresh?.cron ?? null,
-                        });
-                    },
-                );
-            },
+                            return {
+                                project_uuid: projectUuid,
+                                source_cached_explore_uuid:
+                                    sourceCachedExploreUuid,
+                                pre_agg_cached_explore_uuid:
+                                    preAggCachedExploreUuid,
+                                pre_aggregate_definition:
+                                    preAggregateDefinition,
+                                materialization_metric_query:
+                                    materializationMetricQuery,
+                                materialization_query_error:
+                                    materializationQueryError,
+                                refresh_cron:
+                                    preAggregateDefinition.refresh?.cron ??
+                                    null,
+                            };
+                        },
+                    );
+                },
+            ),
+        );
+        definitionRows.push(
+            ...resolvedDefinitionRows.filter(
+                (row): row is DbPreAggregateDefinitionIn => row !== null,
+            ),
         );
 
         await this.preAggregateModel.upsertPreAggregateDefinitions(
@@ -3059,6 +3073,80 @@ export class ProjectService extends BaseService {
         return getAvailableParameterDefinitions(projectParameters, explore);
     }
 
+    private async resolveExploreForQuery({
+        account,
+        projectUuid,
+        sourceExplore,
+        metricQuery,
+        warehouseSqlBuilder,
+        usePreAggregateCache = true,
+    }: {
+        account: Account;
+        projectUuid: string;
+        sourceExplore: Explore;
+        metricQuery: MetricQuery;
+        warehouseSqlBuilder: WarehouseSqlBuilder;
+        usePreAggregateCache?: boolean;
+    }): Promise<Explore> {
+        let explore = sourceExplore;
+
+        if (usePreAggregateCache) {
+            const matchResult = preAggregateUtils.findMatch(
+                metricQuery,
+                sourceExplore,
+            );
+            if (matchResult.hit) {
+                const preAggExploreName = getPreAggregateExploreName(
+                    sourceExplore.name,
+                    matchResult.preAggregateName,
+                );
+                try {
+                    explore = await this.getExplore(
+                        account,
+                        projectUuid,
+                        preAggExploreName,
+                    );
+                } catch {
+                    this.logger.warn(
+                        `Pre-aggregate explore "${preAggExploreName}" not found, falling back to source explore`,
+                    );
+                }
+            }
+        }
+
+        if (
+            explore.type === ExploreType.PRE_AGGREGATE &&
+            explore.preAggregateSource
+        ) {
+            try {
+                const rebuiltTables =
+                    await rebuildAndTranspilePreAggregateSqlFilters({
+                        sourceExplore,
+                        preAggExplore: explore,
+                        warehouseSqlBuilder,
+                    });
+
+                explore = {
+                    ...explore,
+                    tables: rebuiltTables,
+                };
+            } catch (error) {
+                this.logger.warn(
+                    `Failed to rebuild sql_filter for pre-aggregate explore "${explore.name}", falling back to source explore`,
+                    {
+                        projectUuid,
+                        sourceExploreName: sourceExplore.name,
+                        preAggExploreName: explore.name,
+                        error: getErrorMessage(error),
+                    },
+                );
+                explore = sourceExplore;
+            }
+        }
+
+        return explore;
+    }
+
     async compileQuery(
         args: {
             account: Account;
@@ -3109,32 +3197,6 @@ export class ProjectService extends BaseService {
                 ? args.explore
                 : await this.getExplore(account, projectUuid, args.exploreName);
 
-        // Pre-aggregate routing: compile against the pre-agg explore when cache is enabled and there's a match
-        let explore = sourceExplore;
-        if (args.usePreAggregateCache !== false) {
-            const matchResult = preAggregateUtils.findMatch(
-                metricQuery,
-                sourceExplore,
-            );
-            if (matchResult.hit) {
-                const preAggExploreName = getPreAggregateExploreName(
-                    sourceExplore.name,
-                    matchResult.preAggregateName,
-                );
-                try {
-                    explore = await this.getExplore(
-                        account,
-                        projectUuid,
-                        preAggExploreName,
-                    );
-                } catch {
-                    this.logger.warn(
-                        `Pre-aggregate explore "${preAggExploreName}" not found, falling back to source explore`,
-                    );
-                }
-            }
-        }
-
         // Get warehouse credentials to build the SQL builder (no full connection needed for compilation)
         const warehouseCredentials =
             await this.projectModel.getWarehouseCredentialsForProject(
@@ -3145,6 +3207,15 @@ export class ProjectService extends BaseService {
             warehouseCredentials.type,
             warehouseCredentials.startOfWeek,
         );
+
+        const explore = await this.resolveExploreForQuery({
+            account,
+            projectUuid,
+            sourceExplore,
+            metricQuery,
+            warehouseSqlBuilder,
+            usePreAggregateCache: args.usePreAggregateCache !== false,
+        });
 
         const { userAttributes, intrinsicUserAttributes } =
             await this.getUserAttributes({ account });
@@ -6826,14 +6897,28 @@ export class ProjectService extends BaseService {
         organizationUuid: string,
         parameters?: ParametersValuesMap,
     ) {
+        if (
+            explore.type === ExploreType.PRE_AGGREGATE &&
+            explore.preAggregateSource
+        ) {
+            // TODO: Falling back to empty totals here regresses totals for source explores
+            // that resolve onto pre-aggregates; route totals through DuckDB or fall back
+            // to the source explore/warehouse until pre-aggregate totals are supported.
+            this.logger.warn(
+                `Skipping totals for pre-aggregate explore "${explore.name}" until totals run through async DuckDB execution`,
+            );
+            return { row: {} };
+        }
+
+        const warehouseCredentials = await this.getWarehouseCredentials({
+            projectUuid,
+            userId: account.user.id,
+            isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
+        });
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
             projectUuid,
-            await this.getWarehouseCredentials({
-                projectUuid,
-                userId: account.user.id,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-            }),
+            warehouseCredentials,
             {
                 snowflakeVirtualWarehouse: explore.warehouse,
                 databricksCompute: explore.databricksCompute,
@@ -6893,6 +6978,19 @@ export class ProjectService extends BaseService {
         organizationUuid: string,
         parameters?: ParametersValuesMap,
     ) {
+        if (
+            explore.type === ExploreType.PRE_AGGREGATE &&
+            explore.preAggregateSource
+        ) {
+            // TODO: Falling back to empty totals here regresses totals for source explores
+            // that resolve onto pre-aggregates; route totals through DuckDB or fall back
+            // to the source explore/warehouse until pre-aggregate totals are supported.
+            this.logger.warn(
+                `Skipping cached totals for pre-aggregate explore "${explore.name}" until totals run through async DuckDB execution`,
+            );
+            return { row: {}, cacheMetadata: { cacheHit: false } };
+        }
+
         const warehouseCredentials = await this.getWarehouseCredentials({
             projectUuid,
             userId: account.user.id,
@@ -7042,9 +7140,25 @@ export class ProjectService extends BaseService {
             throw new ForbiddenError();
         }
 
+        const warehouseCredentials =
+            await this.projectModel.getWarehouseCredentialsForProject(
+                projectUuid,
+            );
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            warehouseCredentials.type,
+            warehouseCredentials.startOfWeek,
+        );
+        const resolvedExplore = await this.resolveExploreForQuery({
+            account,
+            projectUuid,
+            sourceExplore: explore,
+            metricQuery,
+            warehouseSqlBuilder,
+        });
+
         const combinedParameters = await this.combineParameters(
             projectUuid,
-            explore,
+            resolvedExplore,
             parameters,
             savedChart.parameters,
         );
@@ -7052,7 +7166,7 @@ export class ProjectService extends BaseService {
         const results = await this._calculateTotalFromCacheOrWarehouse(
             account,
             projectUuid,
-            explore,
+            resolvedExplore,
             metricQuery,
             invalidateCache,
             savedChart.organizationUuid,
@@ -7097,16 +7211,32 @@ export class ProjectService extends BaseService {
             organizationUuid,
         );
 
+        const warehouseCredentials =
+            await this.projectModel.getWarehouseCredentialsForProject(
+                projectUuid,
+            );
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            warehouseCredentials.type,
+            warehouseCredentials.startOfWeek,
+        );
+        const resolvedExplore = await this.resolveExploreForQuery({
+            account,
+            projectUuid,
+            sourceExplore: explore,
+            metricQuery: data.metricQuery,
+            warehouseSqlBuilder,
+        });
+
         const combinedParameters = await this.combineParameters(
             projectUuid,
-            explore,
+            resolvedExplore,
             data.parameters,
         );
 
         const results = await this._calculateTotal(
             account,
             projectUuid,
-            explore,
+            resolvedExplore,
             data.metricQuery,
             organizationUuid,
             combinedParameters,

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -30,6 +30,7 @@
   },
   "dependencies": {
     "@casl/ability": "6.8.0",
+    "@polyglot-sql/sdk": "0.3.1",
     "@types/lodash": "4.14.202",
     "ajv": "8.18.0",
     "ajv-errors": "3.0.0",

--- a/packages/common/src/ee/preAggregates/references.ts
+++ b/packages/common/src/ee/preAggregates/references.ts
@@ -5,12 +5,22 @@ import type {
 } from '../../types/field';
 import { getItemId } from '../../utils/item';
 
+const SIMPLE_TABLE_COLUMN_SQL_PATTERN =
+    /^\$\{TABLE\}\.(?:"([^"]+)"|`([^`]+)`|([a-zA-Z_][a-zA-Z0-9_$]*))$/;
+
 export const getDimensionBaseName = (
     dimension: Pick<
         CompiledDimension,
         'name' | 'timeIntervalBaseDimensionName'
     >,
 ): string => dimension.timeIntervalBaseDimensionName ?? dimension.name;
+
+export const getSimpleSqlColumnName = (
+    dimension: Pick<CompiledDimension, 'sql'>,
+): string | null => {
+    const match = dimension.sql.match(SIMPLE_TABLE_COLUMN_SQL_PATTERN);
+    return match ? (match[1] ?? match[2] ?? match[3] ?? null) : null;
+};
 
 export const getDimensionReferences = ({
     dimension,
@@ -52,6 +62,40 @@ export type PreAggregateMetricReferenceLookup = {
     fieldId: FieldId;
     metric: CompiledMetric;
 };
+
+export type PreAggregateDimensionReferenceLookup = {
+    fieldId: FieldId;
+    dimension: CompiledDimension;
+};
+
+export const getDimensionsByReference = ({
+    tables,
+    baseTable,
+}: {
+    tables: Record<string, { dimensions: Record<string, CompiledDimension> }>;
+    baseTable: string;
+}): Map<string, PreAggregateDimensionReferenceLookup[]> =>
+    Object.values(tables).reduce<
+        Map<string, PreAggregateDimensionReferenceLookup[]>
+    >((acc, table) => {
+        Object.values(table.dimensions).forEach((dimension) => {
+            const fieldId = getItemId(dimension);
+            new Set([
+                fieldId,
+                ...getDimensionReferences({
+                    dimension,
+                    baseTable,
+                }),
+            ]).forEach((reference) => {
+                const existingReferences = acc.get(reference) ?? [];
+                acc.set(reference, [
+                    ...existingReferences,
+                    { fieldId, dimension },
+                ]);
+            });
+        });
+        return acc;
+    }, new Map<string, PreAggregateDimensionReferenceLookup[]>());
 
 export const getMetricsByReference = ({
     tables,

--- a/packages/common/src/ee/preAggregates/sqlFilters.test.ts
+++ b/packages/common/src/ee/preAggregates/sqlFilters.test.ts
@@ -1,0 +1,261 @@
+import { SupportedDbtAdapter } from '../../types/dbt';
+import { type Explore } from '../../types/explore';
+import { DimensionType, FieldType } from '../../types/field';
+import { TimeFrames } from '../../types/timeFrames';
+import {
+    getPreAggregateSqlFilterCompatibility,
+    getSqlFilterDependencies,
+} from './sqlFilters';
+
+const makeDimension = ({
+    name,
+    table,
+    sql,
+    timeInterval,
+    timeIntervalBaseDimensionName,
+}: {
+    name: string;
+    table: string;
+    sql?: string;
+    timeInterval?: TimeFrames;
+    timeIntervalBaseDimensionName?: string;
+}) => ({
+    index: 0,
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql: sql ?? `\${TABLE}.${name}`,
+    hidden: false,
+    compiledSql: `"${table}".${name}`,
+    tablesReferences: [table],
+    ...(timeInterval ? { timeInterval } : {}),
+    ...(timeIntervalBaseDimensionName ? { timeIntervalBaseDimensionName } : {}),
+});
+
+const getExplore = (): Explore =>
+    ({
+        name: 'orders',
+        label: 'Orders',
+        tags: [],
+        baseTable: 'orders',
+        joinedTables: [
+            {
+                table: 'customers',
+                compiledSqlOn: '"orders".customer_id = "customers".customer_id',
+                sqlOn: '${orders.customer_id} = ${customers.customer_id}',
+            },
+        ],
+        targetDatabase: SupportedDbtAdapter.POSTGRES,
+        tables: {
+            orders: {
+                name: 'orders',
+                label: 'Orders',
+                database: 'db',
+                schema: 'public',
+                sqlTable: 'orders',
+                dimensions: {
+                    status: makeDimension({ name: 'status', table: 'orders' }),
+                    customer_id: makeDimension({
+                        name: 'customer_id',
+                        table: 'orders',
+                    }),
+                    order_date: makeDimension({
+                        name: 'order_date',
+                        table: 'orders',
+                    }),
+                    order_date_month: makeDimension({
+                        name: 'order_date_month',
+                        table: 'orders',
+                        sql: "DATE_TRUNC('month', ${TABLE}.order_date)",
+                        timeInterval: TimeFrames.MONTH,
+                        timeIntervalBaseDimensionName: 'order_date',
+                    }),
+                },
+                metrics: {},
+                lineageGraph: {},
+            },
+            customers: {
+                name: 'customers',
+                label: 'Customers',
+                database: 'db',
+                schema: 'public',
+                sqlTable: 'customers',
+                dimensions: {
+                    customer_id: makeDimension({
+                        name: 'customer_id',
+                        table: 'customers',
+                    }),
+                    segment: makeDimension({
+                        name: 'segment',
+                        table: 'customers',
+                    }),
+                },
+                metrics: {},
+                lineageGraph: {},
+            },
+        },
+    }) as Explore;
+
+describe('sqlFilters', () => {
+    test('extracts `${TABLE}.column` dependencies while ignoring attribute placeholders', async () => {
+        const explore = getExplore();
+        explore.tables.orders.uncompiledSqlWhere =
+            "${TABLE}.status != 'returned' AND ${TABLE}.status = ANY(string_to_array(${ld.attributes.statuses}, ','))";
+
+        await expect(getSqlFilterDependencies(explore)).resolves.toEqual([
+            {
+                tableName: 'orders',
+                reference: 'status',
+                fieldId: 'orders_status',
+            },
+        ]);
+    });
+
+    test('extracts bare column dependencies while ignoring parameter placeholders', async () => {
+        const explore = getExplore();
+        explore.tables.orders.uncompiledSqlWhere =
+            'customer_id = ${ld.parameters.customer_id}';
+
+        await expect(getSqlFilterDependencies(explore)).resolves.toEqual([
+            {
+                tableName: 'orders',
+                reference: 'customer_id',
+                fieldId: 'orders_customer_id',
+            },
+        ]);
+    });
+
+    test('extracts joined-table dependencies from mixed raw SQL and Lightdash references', async () => {
+        const explore = getExplore();
+        explore.tables.orders.uncompiledSqlWhere =
+            "customers.segment != 'Enterprise' AND ${customers.customer_id} IS NOT NULL";
+
+        await expect(getSqlFilterDependencies(explore)).resolves.toEqual(
+            expect.arrayContaining([
+                {
+                    tableName: 'customers',
+                    reference: 'segment',
+                    fieldId: 'customers_segment',
+                },
+                {
+                    tableName: 'customers',
+                    reference: '${customers.customer_id}',
+                    fieldId: 'customers_customer_id',
+                },
+            ]),
+        );
+    });
+
+    test('extracts raw column dependencies inside Liquid control blocks', async () => {
+        const explore = getExplore();
+        explore.tables.orders.uncompiledSqlWhere =
+            "{% if ld.parameters.include_customer_filter %} customer_id = 1 AND customers.segment != 'Enterprise' {% endif %}";
+
+        await expect(getSqlFilterDependencies(explore)).resolves.toEqual(
+            expect.arrayContaining([
+                {
+                    tableName: 'orders',
+                    reference: 'customer_id',
+                    fieldId: 'orders_customer_id',
+                },
+                {
+                    tableName: 'customers',
+                    reference: 'segment',
+                    fieldId: 'customers_segment',
+                },
+            ]),
+        );
+    });
+
+    test('supports rolled-up time dimensions through implicit timeDimension coverage', async () => {
+        const explore = getExplore();
+        explore.tables.orders.uncompiledSqlWhere =
+            "${order_date_month} >= DATE_TRUNC('month', CURRENT_DATE)";
+
+        await expect(
+            getPreAggregateSqlFilterCompatibility({
+                explore,
+                preAggregateDef: {
+                    name: 'orders_daily',
+                    dimensions: ['status'],
+                    metrics: [],
+                    timeDimension: 'order_date',
+                    granularity: TimeFrames.DAY,
+                },
+            }),
+        ).resolves.toEqual({
+            supported: true,
+            dependencies: [
+                {
+                    tableName: 'orders',
+                    reference: '${order_date_month}',
+                    fieldId: 'orders_order_date_month',
+                },
+            ],
+        });
+    });
+
+    test('returns unsupported when sql_filter requires an unmaterialized base-table column', async () => {
+        const explore = getExplore();
+        explore.tables.orders.uncompiledSqlWhere =
+            'customer_id = ${ld.parameters.customer_id}';
+
+        await expect(
+            getPreAggregateSqlFilterCompatibility({
+                explore,
+                preAggregateDef: {
+                    name: 'orders_daily',
+                    dimensions: ['status'],
+                    metrics: [],
+                },
+            }),
+        ).resolves.toEqual({
+            supported: false,
+            dependency: {
+                tableName: 'orders',
+                reference: 'customer_id',
+                fieldId: 'orders_customer_id',
+            },
+            dependencies: [
+                {
+                    tableName: 'orders',
+                    reference: 'customer_id',
+                    fieldId: 'orders_customer_id',
+                },
+            ],
+        });
+    });
+
+    test('returns unsupported when sql_filter requires an unmaterialized joined-table column', async () => {
+        const explore = getExplore();
+        explore.tables.orders.uncompiledSqlWhere = "customers.segment != 'SMB'";
+
+        await expect(
+            getPreAggregateSqlFilterCompatibility({
+                explore,
+                preAggregateDef: {
+                    name: 'orders_daily',
+                    dimensions: ['status', 'customer_id'],
+                    metrics: [],
+                },
+            }),
+        ).resolves.toEqual({
+            supported: false,
+            dependency: {
+                tableName: 'customers',
+                reference: 'segment',
+                fieldId: 'customers_segment',
+            },
+            dependencies: [
+                {
+                    tableName: 'customers',
+                    reference: 'segment',
+                    fieldId: 'customers_segment',
+                },
+            ],
+        });
+    });
+});

--- a/packages/common/src/ee/preAggregates/sqlFilters.ts
+++ b/packages/common/src/ee/preAggregates/sqlFilters.ts
@@ -1,0 +1,465 @@
+import {
+    Dialect,
+    init,
+    isInitialized,
+    tokenize,
+    transpile,
+} from '@polyglot-sql/sdk';
+import { parseAllReferences } from '../../compiler/exploreCompiler';
+import { SupportedDbtAdapter } from '../../types/dbt';
+import { type Explore } from '../../types/explore';
+import { type PreAggregateDef } from '../../types/preAggregate';
+import assertUnreachable from '../../utils/assertUnreachable';
+import { getItemId } from '../../utils/item';
+import {
+    getDimensionReferences,
+    getSimpleSqlColumnName,
+    type PreAggregateDimensionReferenceLookup,
+} from './references';
+
+export type PreAggregateSqlFilterDependency = {
+    tableName: string;
+    reference: string;
+    fieldId: string;
+};
+
+export type PreAggregateSqlFilterCompatibilityResult =
+    | {
+          supported: true;
+          dependencies: PreAggregateSqlFilterDependency[];
+      }
+    | {
+          supported: false;
+          dependency: PreAggregateSqlFilterDependency;
+          dependencies: PreAggregateSqlFilterDependency[];
+      };
+
+const SQL_FILTER_PLACEHOLDER_PATTERN = /\$\{[^}]+\}/g;
+const LIQUID_TAG_PATTERN = /\{%(?:[\s\S]*?)%\}/g;
+
+type SqlToken = {
+    text?: string;
+    token_type?: string;
+    tokenType?: string;
+};
+
+const getReferencedTable = (
+    refTable: string,
+    tables: Explore['tables'],
+): Explore['tables'][string] | undefined =>
+    tables[refTable] ??
+    Object.values(tables).find(
+        (table) => table.name === refTable || table.originalName === refTable,
+    );
+
+const isNonEmptyString = (value: string | undefined): value is string =>
+    !!value;
+
+const getTableAliases = (table: Explore['tables'][string]): Set<string> =>
+    new Set([table.name, table.originalName].filter(isNonEmptyString));
+
+const getDialect = (adapter: SupportedDbtAdapter): Dialect => {
+    switch (adapter) {
+        case SupportedDbtAdapter.POSTGRES:
+            return Dialect.PostgreSQL;
+        case SupportedDbtAdapter.BIGQUERY:
+            return Dialect.BigQuery;
+        case SupportedDbtAdapter.SNOWFLAKE:
+            return Dialect.Snowflake;
+        case SupportedDbtAdapter.DATABRICKS:
+            return Dialect.Databricks;
+        case SupportedDbtAdapter.REDSHIFT:
+            return Dialect.Redshift;
+        case SupportedDbtAdapter.TRINO:
+            return Dialect.Trino;
+        case SupportedDbtAdapter.ATHENA:
+            return Dialect.Athena;
+        case SupportedDbtAdapter.DUCKDB:
+            return Dialect.DuckDB;
+        case SupportedDbtAdapter.CLICKHOUSE:
+            return Dialect.ClickHouse;
+        default:
+            return assertUnreachable(
+                adapter,
+                `Unsupported dbt adapter "${adapter}" for sql filter analysis`,
+            );
+    }
+};
+
+const ensurePolyglotInitialized = async (): Promise<void> => {
+    if (!isInitialized()) {
+        await init();
+    }
+};
+
+const getSqlToken = (token: unknown): SqlToken | undefined =>
+    typeof token === 'object' && token !== null
+        ? (token as SqlToken)
+        : undefined;
+
+const getTokenType = (token: unknown): string | undefined =>
+    getSqlToken(token)?.token_type ?? getSqlToken(token)?.tokenType;
+
+const isIdentifierToken = (token: unknown): boolean => {
+    const tokenType = getTokenType(token);
+    return tokenType === 'VAR' || tokenType === 'QUOTED_IDENTIFIER';
+};
+
+const isDotToken = (token: unknown): boolean =>
+    getTokenType(token) === 'DOT' || getSqlToken(token)?.text === '.';
+
+const isOpenParenToken = (token: unknown): boolean =>
+    getTokenType(token) === 'L_PAREN' || getSqlToken(token)?.text === '(';
+
+const normalizeIdentifier = (value: string): string => {
+    const normalizedValue =
+        (value.startsWith('"') && value.endsWith('"')) ||
+        (value.startsWith('`') && value.endsWith('`'))
+            ? value.slice(1, -1)
+            : value;
+
+    return normalizedValue.toLowerCase();
+};
+
+const normalizeSqlFilterForTokenizing = ({
+    sql,
+    currentTableName,
+}: {
+    sql: string;
+    currentTableName: string;
+}): string =>
+    sql
+        .replace(LIQUID_TAG_PATTERN, ' ')
+        .replace(SQL_FILTER_PLACEHOLDER_PATTERN, (match) =>
+            match === '${TABLE}' ? currentTableName : 'NULL',
+        );
+
+const getDimensionsBySimpleSqlColumn = (
+    explore: Explore,
+): Map<string, Map<string, PreAggregateDimensionReferenceLookup[]>> =>
+    Object.values(explore.tables).reduce<
+        Map<string, Map<string, PreAggregateDimensionReferenceLookup[]>>
+    >((tablesLookup, table) => {
+        const tableLookup =
+            tablesLookup.get(table.name) ??
+            new Map<string, PreAggregateDimensionReferenceLookup[]>();
+        Object.values(table.dimensions).forEach((dimension) => {
+            const columnName = getSimpleSqlColumnName(dimension);
+            if (!columnName) {
+                return;
+            }
+
+            const lookup = {
+                fieldId: getItemId(dimension),
+                dimension,
+            };
+
+            const existingLookups: PreAggregateDimensionReferenceLookup[] =
+                tableLookup.get(columnName) ?? [];
+            tableLookup.set(columnName, [...existingLookups, lookup]);
+            tablesLookup.set(table.name, tableLookup);
+        });
+
+        return tablesLookup;
+    }, new Map());
+
+const getRawSqlColumnReferences = async ({
+    sql,
+    currentTableName,
+    sourceAdapter,
+}: {
+    sql: string;
+    currentTableName: string;
+    sourceAdapter: SupportedDbtAdapter;
+}): Promise<{
+    qualified: Set<string>;
+    unqualified: Set<string>;
+}> => {
+    await ensurePolyglotInitialized();
+
+    const wrappedSql = `SELECT 1 WHERE ${normalizeSqlFilterForTokenizing({
+        sql,
+        currentTableName,
+    })}`;
+    const sourceDialect = getDialect(sourceAdapter);
+    const transpiled = transpile(wrappedSql, sourceDialect, Dialect.DuckDB);
+    const sqlToTokenize =
+        transpiled.success && transpiled.sql && transpiled.sql.length > 0
+            ? transpiled.sql[0]
+            : wrappedSql;
+    const tokenDialect =
+        transpiled.success && transpiled.sql && transpiled.sql.length > 0
+            ? Dialect.DuckDB
+            : sourceDialect;
+    const tokenResult = tokenize(sqlToTokenize, tokenDialect);
+    const qualified = new Set<string>();
+    const unqualified = new Set<string>();
+
+    if (!tokenResult.success || !tokenResult.tokens) {
+        return { qualified, unqualified };
+    }
+
+    const { tokens } = tokenResult;
+
+    for (let index = 0; index < tokens.length; index += 1) {
+        const token = tokens[index];
+        const previousToken = tokens[index - 1];
+        const nextToken = tokens[index + 1];
+        const columnToken = tokens[index + 2];
+        const tokenText = getSqlToken(token)?.text;
+        const columnTokenText = getSqlToken(columnToken)?.text;
+
+        if (
+            isIdentifierToken(token) &&
+            isDotToken(nextToken) &&
+            isIdentifierToken(columnToken) &&
+            tokenText &&
+            columnTokenText
+        ) {
+            qualified.add(
+                `${normalizeIdentifier(tokenText)}.${normalizeIdentifier(
+                    columnTokenText,
+                )}`,
+            );
+            index += 2;
+        } else if (
+            isIdentifierToken(token) &&
+            tokenText &&
+            !isDotToken(previousToken) &&
+            !isDotToken(nextToken) &&
+            !isOpenParenToken(nextToken)
+        ) {
+            unqualified.add(normalizeIdentifier(tokenText));
+        }
+    }
+
+    return { qualified, unqualified };
+};
+
+const matchesQualifiedColumnReference = ({
+    qualifiedReferences,
+    tableAliases,
+    columnName,
+}: {
+    qualifiedReferences: Set<string>;
+    tableAliases: string[];
+    columnName: string;
+}): boolean =>
+    tableAliases.some((alias) =>
+        qualifiedReferences.has(
+            `${alias.toLowerCase()}.${columnName.toLowerCase()}`,
+        ),
+    );
+
+const matchesCurrentTableColumnReference = ({
+    qualifiedReferences,
+    unqualifiedReferences,
+    tableAliases,
+    columnName,
+}: {
+    qualifiedReferences: Set<string>;
+    unqualifiedReferences: Set<string>;
+    tableAliases: string[];
+    columnName: string;
+}): boolean =>
+    unqualifiedReferences.has(columnName.toLowerCase()) ||
+    matchesQualifiedColumnReference({
+        qualifiedReferences,
+        tableAliases,
+        columnName,
+    });
+
+const addDependency = ({
+    dependencies,
+    seenFieldIds,
+    tableName,
+    reference,
+    lookup,
+}: {
+    dependencies: PreAggregateSqlFilterDependency[];
+    seenFieldIds: Set<string>;
+    tableName: string;
+    reference: string;
+    lookup: PreAggregateDimensionReferenceLookup;
+}) => {
+    if (seenFieldIds.has(lookup.fieldId)) {
+        return;
+    }
+
+    seenFieldIds.add(lookup.fieldId);
+    dependencies.push({
+        tableName,
+        reference,
+        fieldId: lookup.fieldId,
+    });
+};
+
+export const getSqlFilterDependencies = async (
+    explore: Explore,
+): Promise<PreAggregateSqlFilterDependency[]> => {
+    const dependencies: PreAggregateSqlFilterDependency[] = [];
+    const seenFieldIds = new Set<string>();
+    const simpleSqlColumns = getDimensionsBySimpleSqlColumn(explore);
+
+    const sqlFiltersByTable = await Promise.all(
+        Object.values(explore.tables).map(async (table) => {
+            const rawSqlFilter = table.uncompiledSqlWhere ?? table.sqlWhere;
+            return {
+                table,
+                rawSqlFilter,
+                rawSqlColumnReferences: rawSqlFilter
+                    ? await getRawSqlColumnReferences({
+                          sql: rawSqlFilter,
+                          currentTableName: table.name,
+                          sourceAdapter: explore.targetDatabase,
+                      })
+                    : null,
+            };
+        }),
+    );
+
+    sqlFiltersByTable.forEach(
+        ({ table, rawSqlFilter, rawSqlColumnReferences }) => {
+            if (rawSqlFilter && rawSqlColumnReferences) {
+                parseAllReferences(rawSqlFilter, table.name)
+                    .filter((reference) => reference.refName !== 'TABLE')
+                    .forEach((reference) => {
+                        const referencedTable = getReferencedTable(
+                            reference.refTable,
+                            explore.tables,
+                        );
+                        const referencedDimension =
+                            referencedTable?.dimensions[reference.refName];
+
+                        if (referencedTable && referencedDimension) {
+                            addDependency({
+                                dependencies,
+                                seenFieldIds,
+                                tableName: referencedTable.name,
+                                reference:
+                                    reference.refTable === table.name
+                                        ? `\${${reference.refName}}`
+                                        : `\${${reference.refTable}.${reference.refName}}`,
+                                lookup: {
+                                    fieldId: getItemId(referencedDimension),
+                                    dimension: referencedDimension,
+                                },
+                            });
+                        }
+                    });
+
+                Object.values(explore.tables).forEach((targetTable) => {
+                    const tableAliases = Array.from(
+                        getTableAliases(targetTable),
+                    );
+                    const columnLookups =
+                        simpleSqlColumns.get(targetTable.name) ??
+                        new Map<
+                            string,
+                            PreAggregateDimensionReferenceLookup[]
+                        >();
+
+                    columnLookups.forEach((lookups, columnName) => {
+                        const hasReference =
+                            targetTable.name === table.name
+                                ? matchesCurrentTableColumnReference({
+                                      qualifiedReferences:
+                                          rawSqlColumnReferences.qualified,
+                                      unqualifiedReferences:
+                                          rawSqlColumnReferences.unqualified,
+                                      tableAliases,
+                                      columnName,
+                                  })
+                                : matchesQualifiedColumnReference({
+                                      qualifiedReferences:
+                                          rawSqlColumnReferences.qualified,
+                                      tableAliases,
+                                      columnName,
+                                  });
+
+                        if (!hasReference) {
+                            return;
+                        }
+
+                        lookups.forEach((lookup) =>
+                            addDependency({
+                                dependencies,
+                                seenFieldIds,
+                                tableName: targetTable.name,
+                                reference: columnName,
+                                lookup,
+                            }),
+                        );
+                    });
+                });
+            }
+        },
+    );
+
+    return dependencies;
+};
+
+export const getPreAggregateSqlFilterCompatibility = async ({
+    explore,
+    preAggregateDef,
+}: {
+    explore: Explore;
+    preAggregateDef: PreAggregateDef;
+}): Promise<PreAggregateSqlFilterCompatibilityResult> => {
+    const effectiveDimensionReferences = new Set(preAggregateDef.dimensions);
+    const dimensionsByFieldId = Object.values(explore.tables).reduce<
+        Map<string, Explore['tables'][string]['dimensions'][string]>
+    >((acc, table) => {
+        Object.values(table.dimensions).forEach((dimension) => {
+            acc.set(getItemId(dimension), dimension);
+        });
+        return acc;
+    }, new Map());
+
+    if (
+        preAggregateDef.timeDimension &&
+        preAggregateDef.granularity &&
+        !effectiveDimensionReferences.has(preAggregateDef.timeDimension)
+    ) {
+        effectiveDimensionReferences.add(preAggregateDef.timeDimension);
+    }
+
+    const dependencies = await getSqlFilterDependencies(explore);
+    const firstUnsupportedDependency = dependencies.find((dependency) => {
+        const dimension = dimensionsByFieldId.get(dependency.fieldId);
+
+        if (!dimension) {
+            return true;
+        }
+
+        return !getDimensionReferences({
+            dimension,
+            baseTable: explore.baseTable,
+        }).some((reference) => effectiveDimensionReferences.has(reference));
+    });
+
+    if (firstUnsupportedDependency) {
+        return {
+            supported: false,
+            dependency: firstUnsupportedDependency,
+            dependencies,
+        };
+    }
+
+    return {
+        supported: true,
+        dependencies,
+    };
+};
+
+export const formatPreAggregateSqlFilterCompatibilityError = ({
+    preAggregateName,
+    compatibility,
+}: {
+    preAggregateName: string;
+    compatibility: Extract<
+        PreAggregateSqlFilterCompatibilityResult,
+        { supported: false }
+    >;
+}): string =>
+    `Pre-aggregate "${preAggregateName}" cannot support sql_filter because table "${compatibility.dependency.tableName}" requires "${compatibility.dependency.reference}" (${compatibility.dependency.fieldId}), which is not materialized by the pre-aggregate`;

--- a/packages/common/src/ee/preAggregates/types.ts
+++ b/packages/common/src/ee/preAggregates/types.ts
@@ -15,3 +15,7 @@ export {
     type PreAggregateSupportedMetricType,
 } from './metricRepresentation';
 export { type PreAggregateMetricReferenceLookup } from './references';
+export {
+    type PreAggregateSqlFilterCompatibilityResult,
+    type PreAggregateSqlFilterDependency,
+} from './sqlFilters';

--- a/packages/common/src/ee/preAggregates/utils.ts
+++ b/packages/common/src/ee/preAggregates/utils.ts
@@ -7,7 +7,14 @@ export {
 } from './metricRepresentation';
 export {
     getDimensionBaseName,
+    getDimensionsByReference,
     getDimensionReferences,
     getMetricReferences,
     getMetricsByReference,
+    getSimpleSqlColumnName,
 } from './references';
+export {
+    formatPreAggregateSqlFilterCompatibilityError,
+    getPreAggregateSqlFilterCompatibility,
+    getSqlFilterDependencies,
+} from './sqlFilters';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -227,6 +227,9 @@ importers:
       '@openrouter/ai-sdk-provider':
         specifier: 1.5.4
         version: 1.5.4(ai@6.0.71(zod@3.25.55))(zod@3.25.55)
+      '@polyglot-sql/sdk':
+        specifier: 0.3.1
+        version: 0.3.1
       '@rudderstack/rudder-sdk-node':
         specifier: 2.1.1
         version: 2.1.1(tslib@2.8.1)
@@ -724,6 +727,9 @@ importers:
       '@casl/ability':
         specifier: 6.8.0
         version: 6.8.0
+      '@polyglot-sql/sdk':
+        specifier: 0.3.1
+        version: 0.3.1
       '@types/lodash':
         specifier: 4.14.202
         version: 4.14.202
@@ -4214,6 +4220,10 @@ packages:
 
   '@pm2/pm2-version-check@1.0.4':
     resolution: {integrity: sha512-SXsM27SGH3yTWKc2fKR4SYNxsmnvuBQ9dd6QHtEWmiZ/VqaOYPAIlS8+vMcn27YLtAEBGvNRSh3TPNvtjZgfqA==}
+
+  '@polyglot-sql/sdk@0.3.1':
+    resolution: {integrity: sha512-MAdIo1bQGpwnDDPv+kjqu8CoucAQ/jKWgr/N2SkQyDv3NdlFTRGyD2LjvqlNx5P5aGSmwMvCc4DijMLjeM424A==}
+    engines: {node: '>=22', pnpm: '>=10'}
 
   '@popperjs/core@2.11.8':
     resolution: {integrity: sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==}
@@ -12329,7 +12339,6 @@ packages:
     engines: {node: '>=0.6.0', teleport: '>=0.2.0'}
     deprecated: |-
       You or someone you depend on is using Q, the JavaScript Promise library that gave JavaScript developers strong feelings about promises. They can almost certainly migrate to the native JavaScript promise now. Thank you literally everyone for joining me in this bet against the odds. Be excellent to each other.
-
       (For a CapTP with native promises, see @endo/eventual-send and @endo/captp)
 
   qs@6.14.1:
@@ -18623,6 +18632,8 @@ snapshots:
       debug: 4.4.3(supports-color@9.1.0)
     transitivePeerDependencies:
       - supports-color
+
+  '@polyglot-sql/sdk@0.3.1': {}
 
   '@popperjs/core@2.11.8': {}
 


### PR DESCRIPTION
### Description:

This PR adds SQL filter support for pre-aggregates by implementing a comprehensive system to rebuild and transpile SQL filters from source explores to work with pre-aggregate explores.

**Key Changes:**

- **Added `@polyglot-sql/sdk` dependency** to enable SQL transpilation between different database dialects
- **Implemented SQL filter rebuilding logic** in `sqlFilters.ts` that:
  - Parses SQL filters to identify column dependencies
  - Maps source explore column references to pre-aggregate column references  
  - Transpiles SQL from source database dialect to DuckDB for pre-aggregate execution
  - Preserves Lightdash parameter placeholders during transpilation
- **Added SQL filter compatibility validation** to ensure pre-aggregates only materialize when all required dimensions are available
- **Enhanced pre-aggregate query resolution** in `ProjectService` to automatically rebuild SQL filters when using pre-aggregate explores
- **Updated materialization validation** to check SQL filter compatibility during pre-aggregate creation
- **Added comprehensive test coverage** for SQL parsing, dependency detection, and transpilation logic

The implementation handles complex scenarios including:
- Raw column references (both bare and qualified)
- Lightdash dimension references (`${table.dimension}`)
- Time dimension rollups through implicit coverage
- Cross-database SQL dialect differences
- Parameter and attribute placeholder preservation

This enables pre-aggregates to inherit and properly execute SQL filters from their source explores, significantly expanding their applicability while maintaining query correctness.