### PR TITLE
fix: upgrade jspdf 4.2.0 → 4.2.1 (security)

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -91,7 +91,7 @@
         "html2canvas-pro": "1.5.13",
         "immer": "10.1.1",
         "js-yaml": "4.1.1",
-        "jspdf": "4.2.0",
+        "jspdf": "4.2.1",
         "leaflet": "1.9.4",
         "leaflet.heat": "0.2.0",
         "lodash": "4.17.23",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1052,8 +1052,8 @@ importers:
         specifier: 4.1.1
         version: 4.1.1
       jspdf:
-        specifier: 4.2.0
-        version: 4.2.0
+        specifier: 4.2.1
+        version: 4.2.1
       leaflet:
         specifier: 1.9.4
         version: 1.9.4
@@ -10172,8 +10172,8 @@ packages:
     resolution: {integrity: sha512-MT/xP0CrubFRNLNKvxJ2BYfy53Zkm++5bX9dtuPbqAeQpTVe0MQTFhao8+Cp//EmJp244xt6Drw/GVEGCUj40g==}
     engines: {node: '>=12', npm: '>=6'}
 
-  jspdf@4.2.0:
-    resolution: {integrity: sha512-hR/hnRevAXXlrjeqU5oahOE+Ln9ORJUB5brLHHqH67A+RBQZuFr5GkbI9XQI8OUFSEezKegsi45QRpc4bGj75Q==}
+  jspdf@4.2.1:
+    resolution: {integrity: sha512-YyAXyvnmjTbR4bHQRLzex3CuINCDlQnBqoSYyjJwTP2x9jDLuKDzy7aKUl0hgx3uhcl7xzg32agn5vlie6HIlQ==}
 
   jsprim@2.0.2:
     resolution: {integrity: sha512-gqXddjPqQ6G40VdnI6T6yObEC+pDNvyP95wdQhkWkg7crHH3km5qP1FsOXEkzEQwnz6gz5qGTn1c2Y52wP3OyQ==}
@@ -25957,7 +25957,7 @@ snapshots:
       ms: 2.1.3
       semver: 7.7.3
 
-  jspdf@4.2.0:
+  jspdf@4.2.1:
     dependencies:
       '@babel/runtime': 7.28.6
       fast-png: 6.4.0


### PR DESCRIPTION
## Summary

Patches two jsPDF security advisories:

- **PROD-6008** — jsPDF HTML Injection in New Window paths (**critical**)
- **PROD-6006** — jsPDF PDF Object Injection via FreeText color (**high**)

Both fixed in jspdf 4.2.1.

Linear: https://linear.app/lightdash/issue/PROD-6008/ / https://linear.app/lightdash/issue/PROD-6006/

## Risk

🟢 **No risk.** Patch version bump (4.2.0 → 4.2.1). Our only usage is `new JsPDF(...)` + `.save()` in `chartDownloadUtils.ts:88-92` — we don't call the vulnerable `output('pdfjsnewwindow'|'pdfobjectnewwindow'|'dataurlnewwindow')` overloads or `createAnnotation({type:'freetext', color})`, so the bump is purely defense-in-depth.

## Test plan

- [ ] CI green
- [ ] Verify chart "Download as PDF" still works in dashboard view

test-frontend test-backend test-cli

🤖 Generated with [Claude Code](https://claude.com/claude-code)