### PR TITLE
feat: remember preferences for experimental dbt cloud cli

### DIFF
--- a/packages/cli/src/config.ts
+++ b/packages/cli/src/config.ts
@@ -30,6 +30,7 @@ export type Config = {
     answers?: {
         permissionToStoreWarehouseCredentials?: boolean;
         metadataFileGitignoreNoticeShown?: boolean;
+        useExperimentalDbtCloudCLI?: boolean;
     };
 };
 

--- a/packages/cli/src/globalState.ts
+++ b/packages/cli/src/globalState.ts
@@ -5,7 +5,6 @@ import * as styles from './styles';
 
 type PromptAnswer = {
     useFallbackDbtVersion?: boolean;
-    useExperimentalDbtCloudCLI?: boolean;
 };
 
 class GlobalState {

--- a/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.test.ts
@@ -5,6 +5,7 @@ import {
 } from '@lightdash/common';
 import execa from 'execa';
 import inquirer from 'inquirer';
+import * as config from '../../config';
 import GlobalState from '../../globalState';
 import { getDbtVersion } from './getDbtVersion';
 import { cliMocks } from './getDbtVersion.mocks';
@@ -14,7 +15,12 @@ const execaMock = execa as unknown as jest.Mock;
 jest.mock('inquirer', () => ({
     prompt: jest.fn(),
 }));
+jest.mock('../../config', () => ({
+    getConfig: jest.fn().mockResolvedValue({ answers: {} }),
+    setAnswer: jest.fn().mockResolvedValue(undefined),
+}));
 const promptMock = inquirer.prompt as unknown as jest.Mock;
+const getConfigMock = config.getConfig as jest.Mock;
 const consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
 
 describe('Get dbt version', () => {
@@ -26,6 +32,7 @@ describe('Get dbt version', () => {
         process.env = { ...env };
         execaMock.mockImplementation(async () => cliMocks.dbt1_4);
         promptMock.mockImplementation(async () => ({ isConfirm: true }));
+        getConfigMock.mockResolvedValue({ answers: {} });
         GlobalState.clearPromptAnswer();
     });
 

--- a/packages/cli/src/handlers/dbt/getDbtVersion.ts
+++ b/packages/cli/src/handlers/dbt/getDbtVersion.ts
@@ -8,6 +8,7 @@ import {
 } from '@lightdash/common';
 import execa from 'execa';
 import inquirer from 'inquirer';
+import { getConfig, setAnswer } from '../../config';
 import GlobalState from '../../globalState';
 import * as styles from '../../styles';
 
@@ -121,9 +122,10 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
         GlobalState.savePromptAnswer('useFallbackDbtVersion', true);
     }
 
+    const config = await getConfig();
     if (
         isDbtCloudCLI(verboseVersion) &&
-        !GlobalState.getSavedPromptAnswer('useExperimentalDbtCloudCLI')
+        !config.answers?.useExperimentalDbtCloudCLI
     ) {
         const message = `Support for dbt Cloud CLI is still experimental and might not work as expected.`;
         const spinner = GlobalState.getActiveSpinner();
@@ -150,7 +152,7 @@ export const getDbtVersion = async (): Promise<DbtVersion> => {
             }
         }
         spinner?.start();
-        GlobalState.savePromptAnswer('useExperimentalDbtCloudCLI', true);
+        await setAnswer({ useExperimentalDbtCloudCLI: true });
     }
 
     return {


### PR DESCRIPTION
## Summary
- Persist the user's acceptance of the dbt Cloud CLI experimental warning to `~/.config/lightdash/config.yaml` instead of only storing it in-memory for the session
- Uses the same `setAnswer`/`getConfig` pattern already used by `permissionToStoreWarehouseCredentials` and `metadataFileGitignoreNoticeShown`
- Users are now only prompted once — subsequent CLI runs skip the warning

## Test plan
- [x] Built the CLI and ran `lightdash compile` with a fake dbt Cloud CLI binary
- [x] First run: warning shown, `useExperimentalDbtCloudCLI: true` written to config file
- [x] Second run: warning skipped