### PR TITLE
docs: add --include-charts flag to skills documentation

### DIFF
--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -181,7 +181,7 @@ tiles:
 2. **Edit** the YAML file in `lightdash/` directory
 3. **Verify filter values**: If you added or changed filters, use `lightdash sql` to check actual column values (see [Common Mistakes](#common-mistakes))
 4. **Lint**: `lightdash lint` to validate before uploading
-5. **Upload**: `lightdash upload --dashboards dashboard-slug`
+5. **Upload**: `lightdash upload --dashboards dashboard-slug --include-charts` (uploads the dashboard and all charts it references)
 
 ### Creating New Content
 
@@ -209,6 +209,7 @@ lightdash stop-preview --name "my-feature"
 |---------|---------|
 | `lightdash deploy` | Sync semantic layer (metrics, dimensions) |
 | `lightdash upload` | Upload charts/dashboards |
+| `lightdash upload --dashboards ... --include-charts` | Upload dashboard with all its referenced charts |
 | `lightdash download` | Download charts/dashboards as YAML |
 | `lightdash lint` | Validate YAML locally |
 | `lightdash preview` | Create temporary test project |

--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -181,7 +181,7 @@ tiles:
 2. **Edit** the YAML file in `lightdash/` directory
 3. **Verify filter values**: If you added or changed filters, use `lightdash sql` to check actual column values (see [Common Mistakes](#common-mistakes))
 4. **Lint**: `lightdash lint` to validate before uploading
-5. **Upload**: `lightdash upload --dashboards dashboard-slug --include-charts` (uploads the dashboard and all charts it references)
+5. **Upload**: `lightdash upload --dashboards dashboard-slug`
 
 ### Creating New Content
 
@@ -209,7 +209,6 @@ lightdash stop-preview --name "my-feature"
 |---------|---------|
 | `lightdash deploy` | Sync semantic layer (metrics, dimensions) |
 | `lightdash upload` | Upload charts/dashboards |
-| `lightdash upload --dashboards ... --include-charts` | Upload dashboard with all its referenced charts |
 | `lightdash download` | Download charts/dashboards as YAML |
 | `lightdash lint` | Validate YAML locally |
 | `lightdash preview` | Create temporary test project |

--- a/skills/developing-in-lightdash/resources/cli-reference.md
+++ b/skills/developing-in-lightdash/resources/cli-reference.md
@@ -103,6 +103,9 @@ lightdash upload --force
 
 # Upload specific items
 lightdash upload --charts my-chart --dashboards my-dashboard
+
+# Upload dashboard with all its referenced charts
+lightdash upload --dashboards my-dashboard --include-charts
 ```
 
 ## Delete Content


### PR DESCRIPTION
The agent was manually listing charts instead of using --include-charts when uploading dashboards. Added documentation for this flag in both SKILL.md and cli-reference.md to make it more discoverable.

https://claude.ai/code/session_01SzC8AJvCQNyck4PtDQqTDr

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
