### PR TITLE
fix: disable HSTS on /minimal/* routes for headless browser

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -495,6 +495,16 @@ export default class App {
 
         expressApp.use('/embed/*', helmet(helmetConfigForEmbeds));
 
+        // Disable HSTS on /minimal/* routes used by the headless browser.
+        // When INTERNAL_LIGHTDASH_HOST uses HTTP, the HSTS header causes
+        // Chromium to upgrade subresource requests to HTTPS, breaking
+        // scheduled deliveries (Slack, email) in Kubernetes deployments.
+        const helmetConfigForMinimal = produce(helmetConfig, (draft) => {
+            // eslint-disable-next-line no-param-reassign
+            draft.strictTransportSecurity = false;
+        });
+        expressApp.use('/minimal/*', helmet(helmetConfigForMinimal));
+
         expressApp.use('/api/v1/file/*', (_req, res, next) => {
             res.setHeader('Cross-Origin-Resource-Policy', 'cross-origin');
             next();


### PR DESCRIPTION
## What does this PR do?

Fixes #21494

Scheduled deliveries (Slack, email, PDF exports) break in Kubernetes deployments where `SECURE_COOKIES=true` is used with an HTTP `INTERNAL_LIGHTDASH_HOST`.

## Root cause

Helmet sends `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload` on **all** HTTP responses, including those served to the headless browser on `/minimal/*` routes.

Per RFC 6797, browsers should ignore HSTS over HTTP. However, some Chromium versions in `browserless-chrome` containers process the header anyway and upgrade subsequent subresource requests (CSS, JS) to HTTPS:

```
Initial page load:  http://lightdash:8080/minimal/projects/...  → 200 OK (with HSTS header)
Asset request:      https://lightdash:8080/assets/uiw-xxx.css   → ERR_SSL_PROTOCOL_ERROR
```

The headless browser receives the initial HTML but can't load styles/scripts, resulting in blank or broken screenshots.

## Fix

Added a separate Helmet config for `/minimal/*` routes with `strictTransportSecurity: false`, following the exact same pattern already used for `/embed/*` routes (line 488-496 in `App.ts`):

```typescript
const helmetConfigForMinimal = produce(helmetConfig, (draft) => {
    draft.strictTransportSecurity = false;
});
expressApp.use('/minimal/*', helmet(helmetConfigForMinimal));
```

All other security headers (CSP, X-Frame-Options, etc.) remain unchanged on `/minimal/*` routes. Only HSTS is disabled since these routes are exclusively accessed by the internal headless browser over HTTP.

## Why this is safe

- `/minimal/*` routes are **never** accessed by end users — they're internal-only routes used by the headless browser for screenshot/PDF generation
- The headless browser connects via `INTERNAL_LIGHTDASH_HOST` which is typically a Kubernetes service DNS name
- Removing HSTS from these internal routes has no security impact since the traffic never leaves the cluster
- All user-facing routes retain full HSTS protection