### PR TITLE
feat: timezone-aware DATE_TRUNC for all warehouses

### DIFF
--- a/packages/api-tests/helpers/timezone-test.ts
+++ b/packages/api-tests/helpers/timezone-test.ts
@@ -1,0 +1,129 @@
+import { SEED_PROJECT } from '@lightdash/common';
+import { expect } from 'vitest';
+import { ApiClient, Body } from './api-client';
+
+const apiUrl = '/api/v2';
+const projectUuid = SEED_PROJECT.project_uuid;
+
+export async function getProjectConfig(client: ApiClient): Promise<{
+    dbtConnection: Record<string, unknown>;
+    warehouseConnection: Record<string, unknown>;
+}> {
+    const resp = await client.request<
+        Body<{
+            dbtConnection: Record<string, unknown>;
+            warehouseConnection: Record<string, unknown>;
+        }>
+    >(`/api/v1/projects/${projectUuid}`);
+    expect(resp.status).toBe(200);
+    return {
+        dbtConnection: resp.body.results.dbtConnection,
+        warehouseConnection: resp.body.results.warehouseConnection,
+    };
+}
+
+export async function updateDataTimezone(
+    client: ApiClient,
+    dataTimezone?: string,
+): Promise<void> {
+    const { dbtConnection, warehouseConnection } =
+        await getProjectConfig(client);
+    const resp = await client.request(`/api/v1/projects/${projectUuid}`, {
+        method: 'PATCH',
+        body: {
+            dbtConnection,
+            warehouseConnection: {
+                ...warehouseConnection,
+                dataTimezone: dataTimezone ?? null,
+            },
+        },
+    });
+    expect(resp.status).toBe(200);
+}
+
+export async function runTimezoneTestQuery(
+    client: ApiClient,
+    options: {
+        dimensions: string[];
+        metrics: string[];
+        filters?: Record<string, unknown>;
+        sorts?: Array<{ fieldId: string; descending: boolean }>;
+        timezone?: string;
+    },
+): Promise<
+    Array<Record<string, { value: { raw: string; formatted: string } }>>
+> {
+    const startResp = await client.request<Body<{ queryUuid: string }>>(
+        `${apiUrl}/projects/${projectUuid}/query/metric-query`,
+        {
+            method: 'POST',
+            body: {
+                query: {
+                    exploreName: 'timezone_test',
+                    dimensions: options.dimensions,
+                    metrics: options.metrics,
+                    filters: options.filters ?? {},
+                    sorts: options.sorts ?? [
+                        {
+                            fieldId: options.dimensions[0],
+                            descending: false,
+                        },
+                    ],
+                    limit: 500,
+                    tableCalculations: [],
+                    timezone: options.timezone,
+                },
+            },
+        },
+    );
+    expect(startResp.status).toBe(200);
+    const { queryUuid } = startResp.body.results;
+
+    let attempts = 0;
+    while (attempts < 30) {
+        const pollResp = await client.request<
+            Body<{ status: string; rows: Array<Record<string, unknown>> }>
+        >(
+            `${apiUrl}/projects/${projectUuid}/query/${queryUuid}?page=1&pageSize=500`,
+        );
+        expect(pollResp.status).toBe(200);
+
+        if (pollResp.body.results.status === 'ready') {
+            return pollResp.body.results.rows as Array<
+                Record<string, { value: { raw: string; formatted: string } }>
+            >;
+        }
+        if (pollResp.body.results.status === 'error') {
+            const errorDetails = JSON.stringify(pollResp.body.results, null, 2);
+            throw new Error(`Query failed: ${errorDetails}`);
+        }
+        await new Promise((resolve) => setTimeout(resolve, 500));
+        attempts++;
+    }
+    throw new Error('Query timed out');
+}
+
+type TimezoneTestRow = Record<
+    string,
+    { value: { raw: string; formatted: string } }
+>;
+
+export function getRowCount(
+    rows: TimezoneTestRow[],
+    dayFormatted: string,
+): number {
+    const row = rows.find(
+        (r) =>
+            r.timezone_test_event_timestamp_day?.value?.formatted ===
+            dayFormatted,
+    );
+    return row ? parseInt(row.timezone_test_count?.value?.raw ?? '0', 10) : 0;
+}
+
+export function getTotalCount(rows: TimezoneTestRow[]): number {
+    return rows.reduce(
+        (sum, r) =>
+            sum + parseInt(r.timezone_test_count?.value?.raw ?? '0', 10),
+        0,
+    );
+}

--- a/packages/api-tests/helpers/timezone-test.ts
+++ b/packages/api-tests/helpers/timezone-test.ts
@@ -111,19 +111,21 @@ type TimezoneTestRow = Record<
 export function getRowCount(
     rows: TimezoneTestRow[],
     dayFormatted: string,
+    dimensionKey: string,
+    metricKey: string,
 ): number {
     const row = rows.find(
-        (r) =>
-            r.timezone_test_event_timestamp_day?.value?.formatted ===
-            dayFormatted,
+        (r) => r[dimensionKey]?.value?.formatted === dayFormatted,
     );
-    return row ? parseInt(row.timezone_test_count?.value?.raw ?? '0', 10) : 0;
+    return row ? parseInt(row[metricKey]?.value?.raw ?? '0', 10) : 0;
 }
 
-export function getTotalCount(rows: TimezoneTestRow[]): number {
+export function getTotalCount(
+    rows: TimezoneTestRow[],
+    metricKey: string,
+): number {
     return rows.reduce(
-        (sum, r) =>
-            sum + parseInt(r.timezone_test_count?.value?.raw ?? '0', 10),
+        (sum, r) => sum + parseInt(r[metricKey]?.value?.raw ?? '0', 10),
         0,
     );
 }

--- a/packages/api-tests/tests/dataTimezone.test.ts
+++ b/packages/api-tests/tests/dataTimezone.test.ts
@@ -33,8 +33,10 @@ import {
 
 let admin: ApiClient;
 
-const DIMENSIONS = ['timezone_test_event_timestamp_day'];
-const METRICS = ['timezone_test_count'];
+const DIMENSION_KEY = 'timezone_test_event_timestamp_day';
+const METRIC_KEY = 'timezone_test_count';
+const DIMENSIONS = [DIMENSION_KEY];
+const METRICS = [METRIC_KEY];
 
 describe('Data timezone', () => {
     beforeAll(async () => {
@@ -52,8 +54,12 @@ describe('Data timezone', () => {
                 metrics: METRICS,
             });
             expect(rows).toHaveLength(2);
-            expect(getRowCount(rows, '2024-01-15')).toBe(6);
-            expect(getRowCount(rows, '2024-01-16')).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(6);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
         });
 
         it('should filter by UTC day for equals filter', async () => {
@@ -77,7 +83,7 @@ describe('Data timezone', () => {
                     },
                 },
             });
-            expect(getTotalCount(rows)).toBe(6);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(6);
         });
 
         it('should filter by UTC day for greaterThan filter', async () => {
@@ -101,7 +107,7 @@ describe('Data timezone', () => {
                     },
                 },
             });
-            expect(getTotalCount(rows)).toBe(4);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(4);
         });
     });
 
@@ -118,8 +124,12 @@ describe('Data timezone', () => {
             // With timezone-aware DATE_TRUNC, grouping follows queryTimezone (UTC),
             // not dataTimezone (Pago_Pago). The session TZ only affects NTZ interpretation.
             expect(rows).toHaveLength(2);
-            expect(getRowCount(rows, '2024-01-15')).toBe(6);
-            expect(getRowCount(rows, '2024-01-16')).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(6);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
         });
 
         it('should filter by UTC day for equals filter (queryTimezone defaults to UTC)', async () => {
@@ -144,7 +154,7 @@ describe('Data timezone', () => {
                 },
             });
             // Filters also use queryTimezone (UTC), not dataTimezone
-            expect(getTotalCount(rows)).toBe(6);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(6);
         });
 
         it('should filter by UTC day for greaterThan filter (queryTimezone defaults to UTC)', async () => {
@@ -169,7 +179,7 @@ describe('Data timezone', () => {
                 },
             });
             // Filters use queryTimezone (UTC): only Jan 16 events (4)
-            expect(getTotalCount(rows)).toBe(4);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(4);
         });
     });
 
@@ -186,8 +196,12 @@ describe('Data timezone', () => {
                 timezone: 'UTC',
             });
             expect(rows).toHaveLength(2);
-            expect(getRowCount(rows, '2024-01-15')).toBe(6);
-            expect(getRowCount(rows, '2024-01-16')).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(6);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
         });
 
         it('dataTz=Pago_Pago, queryTz=Pago_Pago: skip optimization, groups by Pago_Pago', async () => {
@@ -199,9 +213,15 @@ describe('Data timezone', () => {
                 timezone: 'Pacific/Pago_Pago',
             });
             expect(rows).toHaveLength(3);
-            expect(getRowCount(rows, '2024-01-14')).toBe(4);
-            expect(getRowCount(rows, '2024-01-15')).toBe(4);
-            expect(getRowCount(rows, '2024-01-16')).toBe(2);
+            expect(
+                getRowCount(rows, '2024-01-14', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(2);
         });
 
         it('dataTz=Pago_Pago, queryTz=Pago_Pago: filter day=Jan15 returns 4 events', async () => {
@@ -227,7 +247,7 @@ describe('Data timezone', () => {
                 },
             });
             expect(rows).toHaveLength(1);
-            expect(getTotalCount(rows)).toBe(4);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(4);
         });
 
         afterAll(async () => {

--- a/packages/api-tests/tests/dataTimezone.test.ts
+++ b/packages/api-tests/tests/dataTimezone.test.ts
@@ -1,151 +1,40 @@
-import { SEED_PROJECT } from '@lightdash/common';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
-import { ApiClient, Body } from '../helpers/api-client';
+import { ApiClient } from '../helpers/api-client';
 import { login } from '../helpers/auth';
-
-const apiUrl = '/api/v2';
-const projectUuid = SEED_PROJECT.project_uuid;
+import {
+    getRowCount,
+    getTotalCount,
+    runTimezoneTestQuery,
+    updateDataTimezone,
+} from '../helpers/timezone-test';
 
 /**
  * Data timezone tests.
  *
  * Uses the `timezone_test` model which has 10 events with timestamptz values
- * at specific UTC times. When the warehouse session timezone changes (via
- * dataTimezone on credentials), DATE_TRUNC day boundaries shift, producing
- * different per-day counts.
+ * at specific UTC times. Tests that `dataTimezone` sets the warehouse session
+ * timezone correctly.
  *
- * Expected counts by day (no filter):
- *   UTC (default):              Jan 15 = 6, Jan 16 = 4
- *   Pacific/Pago_Pago (UTC-11): Jan 14 = 4, Jan 15 = 4, Jan 16 = 2
+ * With timezone-aware DATE_TRUNC enabled, grouping is controlled by
+ * `queryTimezone` (project timezone), NOT `dataTimezone` (session timezone).
+ * Since these tests don't set `queryTimezone`, it defaults to UTC, so
+ * grouping is always by UTC day boundaries regardless of `dataTimezone`.
  *
- * Expected counts with "equals Jan 15" filter:
- *   UTC: 6
- *   Pacific/Pago_Pago: 4
+ * The `dataTimezone` setting controls how the warehouse interprets NTZ
+ * (no-timezone) columns, not how timestamptz grouping works. For timestamptz
+ * columns (which this test uses), `dataTimezone` only affects display
+ * formatting, not grouping when timezone-aware DATE_TRUNC is active.
+ *
+ * Expected counts by day (queryTimezone = UTC, all cases):
+ *   Jan 15 = 6, Jan 16 = 4
  *
  * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment.
  */
 
 let admin: ApiClient;
 
-async function getProjectConfig(client: ApiClient): Promise<{
-    dbtConnection: Record<string, unknown>;
-    warehouseConnection: Record<string, unknown>;
-}> {
-    const resp = await client.request<
-        Body<{
-            dbtConnection: Record<string, unknown>;
-            warehouseConnection: Record<string, unknown>;
-        }>
-    >(`/api/v1/projects/${projectUuid}`);
-    expect(resp.status).toBe(200);
-    return {
-        dbtConnection: resp.body.results.dbtConnection,
-        warehouseConnection: resp.body.results.warehouseConnection,
-    };
-}
-
-async function updateDataTimezone(
-    client: ApiClient,
-    dataTimezone?: string,
-): Promise<void> {
-    const { dbtConnection, warehouseConnection } =
-        await getProjectConfig(client);
-    const resp = await client.request(`/api/v1/projects/${projectUuid}`, {
-        method: 'PATCH',
-        body: {
-            dbtConnection,
-            warehouseConnection: {
-                ...warehouseConnection,
-                dataTimezone: dataTimezone ?? null,
-            },
-        },
-    });
-    expect(resp.status).toBe(200);
-}
-
-async function runAsyncQuery(
-    client: ApiClient,
-    options: {
-        dimensions: string[];
-        metrics: string[];
-        filters?: Record<string, unknown>;
-        sorts?: Array<{ fieldId: string; descending: boolean }>;
-    },
-): Promise<
-    Array<Record<string, { value: { raw: string; formatted: string } }>>
-> {
-    // Start the query
-    const startResp = await client.request<Body<{ queryUuid: string }>>(
-        `${apiUrl}/projects/${projectUuid}/query/metric-query`,
-        {
-            method: 'POST',
-            body: {
-                query: {
-                    exploreName: 'timezone_test',
-                    dimensions: options.dimensions,
-                    metrics: options.metrics,
-                    filters: options.filters ?? {},
-                    sorts: options.sorts ?? [
-                        {
-                            fieldId: options.dimensions[0],
-                            descending: false,
-                        },
-                    ],
-                    limit: 500,
-                    tableCalculations: [],
-                },
-            },
-        },
-    );
-    expect(startResp.status).toBe(200);
-    const { queryUuid } = startResp.body.results;
-
-    // Poll for results
-    let attempts = 0;
-    while (attempts < 30) {
-        const pollResp = await client.request<
-            Body<{ status: string; rows: Array<Record<string, unknown>> }>
-        >(
-            `${apiUrl}/projects/${projectUuid}/query/${queryUuid}?page=1&pageSize=500`,
-        );
-        expect(pollResp.status).toBe(200);
-
-        if (pollResp.body.results.status === 'ready') {
-            return pollResp.body.results.rows as Array<
-                Record<string, { value: { raw: string; formatted: string } }>
-            >;
-        }
-        if (pollResp.body.results.status === 'error') {
-            const errorDetails = JSON.stringify(pollResp.body.results, null, 2);
-            throw new Error(`Query failed: ${errorDetails}`);
-        }
-        await new Promise((resolve) => setTimeout(resolve, 500));
-        attempts++;
-    }
-    throw new Error('Query timed out');
-}
-
-function getRowCount(
-    rows: Array<Record<string, { value: { raw: string; formatted: string } }>>,
-    dayFormatted: string,
-): number {
-    const row = rows.find(
-        (r) =>
-            r.timezone_test_event_timestamp_day?.value?.formatted ===
-            dayFormatted,
-    );
-    return row ? parseInt(row.timezone_test_count?.value?.raw ?? '0', 10) : 0;
-}
-
-function getTotalCount(
-    rows: Array<Record<string, { value: { raw: string; formatted: string } }>>,
-): number {
-    return rows.reduce(
-        (sum, r) =>
-            sum + parseInt(r.timezone_test_count?.value?.raw ?? '0', 10),
-        0,
-    );
-}
+const DIMENSIONS = ['timezone_test_event_timestamp_day'];
+const METRICS = ['timezone_test_count'];
 
 describe('Data timezone', () => {
     beforeAll(async () => {
@@ -158,20 +47,19 @@ describe('Data timezone', () => {
         });
 
         it('should group events by UTC day boundaries', async () => {
-            const rows = await runAsyncQuery(admin, {
-                dimensions: ['timezone_test_event_timestamp_day'],
-                metrics: ['timezone_test_count'],
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
             });
-
             expect(rows).toHaveLength(2);
             expect(getRowCount(rows, '2024-01-15')).toBe(6);
             expect(getRowCount(rows, '2024-01-16')).toBe(4);
         });
 
         it('should filter by UTC day for equals filter', async () => {
-            const rows = await runAsyncQuery(admin, {
-                dimensions: ['timezone_test_event_timestamp_day'],
-                metrics: ['timezone_test_count'],
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
                 filters: {
                     dimensions: {
                         id: 'tz-test',
@@ -189,14 +77,13 @@ describe('Data timezone', () => {
                     },
                 },
             });
-
             expect(getTotalCount(rows)).toBe(6);
         });
 
         it('should filter by UTC day for greaterThan filter', async () => {
-            const rows = await runAsyncQuery(admin, {
-                dimensions: ['timezone_test_event_timestamp_day'],
-                metrics: ['timezone_test_count'],
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
                 filters: {
                     dimensions: {
                         id: 'tz-test',
@@ -214,8 +101,6 @@ describe('Data timezone', () => {
                     },
                 },
             });
-
-            // Only Jan 16 events (4)
             expect(getTotalCount(rows)).toBe(4);
         });
     });
@@ -225,22 +110,22 @@ describe('Data timezone', () => {
             await updateDataTimezone(admin, 'Pacific/Pago_Pago');
         });
 
-        it('should group events by Pago Pago day boundaries', async () => {
-            const rows = await runAsyncQuery(admin, {
-                dimensions: ['timezone_test_event_timestamp_day'],
-                metrics: ['timezone_test_count'],
+        it('should still group by UTC day boundaries (queryTimezone defaults to UTC)', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
             });
-
-            expect(rows).toHaveLength(3);
-            expect(getRowCount(rows, '2024-01-14')).toBe(4);
-            expect(getRowCount(rows, '2024-01-15')).toBe(4);
-            expect(getRowCount(rows, '2024-01-16')).toBe(2);
+            // With timezone-aware DATE_TRUNC, grouping follows queryTimezone (UTC),
+            // not dataTimezone (Pago_Pago). The session TZ only affects NTZ interpretation.
+            expect(rows).toHaveLength(2);
+            expect(getRowCount(rows, '2024-01-15')).toBe(6);
+            expect(getRowCount(rows, '2024-01-16')).toBe(4);
         });
 
-        it('should filter by Pago Pago day for equals filter', async () => {
-            const rows = await runAsyncQuery(admin, {
-                dimensions: ['timezone_test_event_timestamp_day'],
-                metrics: ['timezone_test_count'],
+        it('should filter by UTC day for equals filter (queryTimezone defaults to UTC)', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
                 filters: {
                     dimensions: {
                         id: 'tz-test',
@@ -258,14 +143,14 @@ describe('Data timezone', () => {
                     },
                 },
             });
-
-            expect(getTotalCount(rows)).toBe(4);
+            // Filters also use queryTimezone (UTC), not dataTimezone
+            expect(getTotalCount(rows)).toBe(6);
         });
 
-        it('should filter by Pago Pago day for greaterThan filter', async () => {
-            const rows = await runAsyncQuery(admin, {
-                dimensions: ['timezone_test_event_timestamp_day'],
-                metrics: ['timezone_test_count'],
+        it('should filter by UTC day for greaterThan filter (queryTimezone defaults to UTC)', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
                 filters: {
                     dimensions: {
                         id: 'tz-test',
@@ -283,9 +168,70 @@ describe('Data timezone', () => {
                     },
                 },
             });
+            // Filters use queryTimezone (UTC): only Jan 16 events (4)
+            expect(getTotalCount(rows)).toBe(4);
+        });
+    });
 
-            // Only Jan 16 events in Pago Pago (2)
-            expect(getTotalCount(rows)).toBe(2);
+    describe('dataTimezone + queryTimezone interaction', () => {
+        beforeAll(async () => {
+            await updateDataTimezone(admin, 'Pacific/Pago_Pago');
+        });
+
+        it('dataTz=Pago_Pago, queryTz=UTC: groups by UTC despite non-UTC session', async () => {
+            // queryTimezone controls grouping, not dataTimezone
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'UTC',
+            });
+            expect(rows).toHaveLength(2);
+            expect(getRowCount(rows, '2024-01-15')).toBe(6);
+            expect(getRowCount(rows, '2024-01-16')).toBe(4);
+        });
+
+        it('dataTz=Pago_Pago, queryTz=Pago_Pago: skip optimization, groups by Pago_Pago', async () => {
+            // When dataTimezone === queryTimezone, bare DATE_TRUNC is used
+            // (session TZ already produces correct grouping)
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Pacific/Pago_Pago',
+            });
+            expect(rows).toHaveLength(3);
+            expect(getRowCount(rows, '2024-01-14')).toBe(4);
+            expect(getRowCount(rows, '2024-01-15')).toBe(4);
+            expect(getRowCount(rows, '2024-01-16')).toBe(2);
+        });
+
+        it('dataTz=Pago_Pago, queryTz=Pago_Pago: filter day=Jan15 returns 4 events', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Pacific/Pago_Pago',
+                filters: {
+                    dimensions: {
+                        id: 'tz-test',
+                        and: [
+                            {
+                                id: 'tz-equals',
+                                target: {
+                                    fieldId:
+                                        'timezone_test_event_timestamp_day',
+                                },
+                                operator: 'equals',
+                                values: ['2024-01-15'],
+                            },
+                        ],
+                    },
+                },
+            });
+            expect(rows).toHaveLength(1);
+            expect(getTotalCount(rows)).toBe(4);
+        });
+
+        afterAll(async () => {
+            await updateDataTimezone(admin, undefined);
         });
     });
 

--- a/packages/api-tests/tests/queryTimezone.test.ts
+++ b/packages/api-tests/tests/queryTimezone.test.ts
@@ -39,8 +39,10 @@ import {
 
 let admin: ApiClient;
 
-const DIMENSIONS = ['timezone_test_event_timestamp_day'];
-const METRICS = ['timezone_test_count'];
+const DIMENSION_KEY = 'timezone_test_event_timestamp_day';
+const METRIC_KEY = 'timezone_test_count';
+const DIMENSIONS = [DIMENSION_KEY];
+const METRICS = [METRIC_KEY];
 
 const EQUALS_FILTER = (day: string) => ({
     dimensions: {
@@ -99,8 +101,12 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 metrics: METRICS,
             });
             expect(rows).toHaveLength(2);
-            expect(getRowCount(rows, '2024-01-15')).toBe(6);
-            expect(getRowCount(rows, '2024-01-16')).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(6);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
         });
 
         it('Pacific/Pago_Pago: Jan 14=4, Jan 15=4, Jan 16=2', async () => {
@@ -110,9 +116,15 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'Pacific/Pago_Pago',
             });
             expect(rows).toHaveLength(3);
-            expect(getRowCount(rows, '2024-01-14')).toBe(4);
-            expect(getRowCount(rows, '2024-01-15')).toBe(4);
-            expect(getRowCount(rows, '2024-01-16')).toBe(2);
+            expect(
+                getRowCount(rows, '2024-01-14', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(2);
         });
 
         it('America/New_York: Jan 14=1, Jan 15=6, Jan 16=3', async () => {
@@ -122,9 +134,15 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'America/New_York',
             });
             expect(rows).toHaveLength(3);
-            expect(getRowCount(rows, '2024-01-14')).toBe(1);
-            expect(getRowCount(rows, '2024-01-15')).toBe(6);
-            expect(getRowCount(rows, '2024-01-16')).toBe(3);
+            expect(
+                getRowCount(rows, '2024-01-14', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(1);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(6);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(3);
         });
 
         it('America/Chicago: Jan 14=2, Jan 15=5, Jan 16=3', async () => {
@@ -134,9 +152,15 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'America/Chicago',
             });
             expect(rows).toHaveLength(3);
-            expect(getRowCount(rows, '2024-01-14')).toBe(2);
-            expect(getRowCount(rows, '2024-01-15')).toBe(5);
-            expect(getRowCount(rows, '2024-01-16')).toBe(3);
+            expect(
+                getRowCount(rows, '2024-01-14', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(2);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(5);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(3);
         });
 
         it('Asia/Tokyo: Jan 15=5, Jan 16=4, Jan 17=1', async () => {
@@ -146,9 +170,15 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'Asia/Tokyo',
             });
             expect(rows).toHaveLength(3);
-            expect(getRowCount(rows, '2024-01-15')).toBe(5);
-            expect(getRowCount(rows, '2024-01-16')).toBe(4);
-            expect(getRowCount(rows, '2024-01-17')).toBe(1);
+            expect(
+                getRowCount(rows, '2024-01-15', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(5);
+            expect(
+                getRowCount(rows, '2024-01-16', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(4);
+            expect(
+                getRowCount(rows, '2024-01-17', DIMENSION_KEY, METRIC_KEY),
+            ).toBe(1);
         });
     });
 
@@ -162,7 +192,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 filters: EQUALS_FILTER('2024-01-15'),
             });
             expect(rows).toHaveLength(1);
-            expect(getTotalCount(rows)).toBe(6);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(6);
         });
 
         it('Pacific/Pago_Pago: 4 events on Jan 15', async () => {
@@ -173,7 +203,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 filters: EQUALS_FILTER('2024-01-15'),
             });
             expect(rows).toHaveLength(1);
-            expect(getTotalCount(rows)).toBe(4);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(4);
         });
 
         it('America/New_York: 6 events on Jan 15', async () => {
@@ -184,7 +214,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 filters: EQUALS_FILTER('2024-01-15'),
             });
             expect(rows).toHaveLength(1);
-            expect(getTotalCount(rows)).toBe(6);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(6);
         });
 
         it('America/Chicago: 5 events on Jan 15', async () => {
@@ -195,7 +225,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 filters: EQUALS_FILTER('2024-01-15'),
             });
             expect(rows).toHaveLength(1);
-            expect(getTotalCount(rows)).toBe(5);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(5);
         });
 
         it('Asia/Tokyo: 5 events on Jan 15', async () => {
@@ -206,7 +236,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 filters: EQUALS_FILTER('2024-01-15'),
             });
             expect(rows).toHaveLength(1);
-            expect(getTotalCount(rows)).toBe(5);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(5);
         });
     });
 
@@ -221,7 +251,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 metrics: METRICS,
                 filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(6);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(6);
         });
 
         it('America/New_York: 7 events in Jan 14–15', async () => {
@@ -231,7 +261,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'America/New_York',
                 filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(7);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(7);
         });
 
         it('America/Chicago: 7 events in Jan 14–15', async () => {
@@ -241,7 +271,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'America/Chicago',
                 filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(7);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(7);
         });
 
         it('Asia/Tokyo: 5 events in Jan 14–15', async () => {
@@ -251,7 +281,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'Asia/Tokyo',
                 filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(5);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(5);
         });
 
         it('Pacific/Pago_Pago: 8 events in Jan 14–15', async () => {
@@ -261,7 +291,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'Pacific/Pago_Pago',
                 filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(8);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(8);
         });
 
         // Single-day inBetween — same as equals, catches off-by-one boundary shifts
@@ -272,7 +302,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'America/New_York',
                 filters: IN_BETWEEN_FILTER('2024-01-15', '2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(6);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(6);
         });
     });
 
@@ -285,7 +315,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 metrics: METRICS,
                 filters: GREATER_THAN_FILTER('2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(4);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(4);
         });
 
         it('Pacific/Pago_Pago: 2 events after Jan 15', async () => {
@@ -295,7 +325,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'Pacific/Pago_Pago',
                 filters: GREATER_THAN_FILTER('2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(2);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(2);
         });
 
         it('America/New_York: 3 events after Jan 15', async () => {
@@ -305,7 +335,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'America/New_York',
                 filters: GREATER_THAN_FILTER('2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(3);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(3);
         });
 
         it('America/Chicago: 3 events after Jan 15', async () => {
@@ -315,7 +345,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'America/Chicago',
                 filters: GREATER_THAN_FILTER('2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(3);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(3);
         });
 
         it('Asia/Tokyo: 5 events after Jan 15', async () => {
@@ -325,7 +355,7 @@ describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
                 timezone: 'Asia/Tokyo',
                 filters: GREATER_THAN_FILTER('2024-01-15'),
             });
-            expect(getTotalCount(rows)).toBe(5);
+            expect(getTotalCount(rows, METRIC_KEY)).toBe(5);
         });
     });
 

--- a/packages/api-tests/tests/queryTimezone.test.ts
+++ b/packages/api-tests/tests/queryTimezone.test.ts
@@ -1,0 +1,335 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { ApiClient } from '../helpers/api-client';
+import { login } from '../helpers/auth';
+import {
+    getRowCount,
+    getTotalCount,
+    runTimezoneTestQuery,
+    updateDataTimezone,
+} from '../helpers/timezone-test';
+
+/**
+ * Query timezone (project timezone) tests.
+ *
+ * Verifies that timezone-aware DATE_TRUNC groups and filters data by the
+ * query timezone (metricQuery.timezone), not the warehouse session timezone.
+ *
+ * Uses the `timezone_test` model with 10 events at specific UTC times:
+ *   #1  2024-01-15 02:00 UTC    #6  2024-01-15 18:00 UTC
+ *   #2  2024-01-15 05:00 UTC    #7  2024-01-16 03:00 UTC
+ *   #3  2024-01-15 08:00 UTC    #8  2024-01-16 08:00 UTC
+ *   #4  2024-01-15 10:00 UTC    #9  2024-01-16 12:00 UTC
+ *   #5  2024-01-15 12:00 UTC    #10 2024-01-16 18:00 UTC
+ *
+ * Expected GROUP BY DAY counts per timezone:
+ *   UTC (+0):                Jan 15 = 6, Jan 16 = 4
+ *   America/New_York (-5):   Jan 14 = 1, Jan 15 = 6, Jan 16 = 3
+ *   America/Chicago (-6):    Jan 14 = 2, Jan 15 = 5, Jan 16 = 3
+ *   Asia/Tokyo (+9):         Jan 15 = 5, Jan 16 = 4, Jan 17 = 1
+ *   Pacific/Pago_Pago (-11): Jan 14 = 4, Jan 15 = 4, Jan 16 = 2
+ *
+ * Expected FILTER day = Jan 15 counts:
+ *   UTC: 6 | New_York: 6 | Chicago: 5 | Tokyo: 5 | Pago_Pago: 4
+ *
+ * Expected FILTER day > Jan 15 counts:
+ *   UTC: 4 | New_York: 3 | Chicago: 3 | Tokyo: 5 | Pago_Pago: 2
+ *
+ * Requires LIGHTDASH_ENABLE_TIMEZONE_SUPPORT=true in the environment.
+ */
+
+let admin: ApiClient;
+
+const DIMENSIONS = ['timezone_test_event_timestamp_day'];
+const METRICS = ['timezone_test_count'];
+
+const EQUALS_FILTER = (day: string) => ({
+    dimensions: {
+        id: 'tz-test',
+        and: [
+            {
+                id: 'tz-eq',
+                target: { fieldId: 'timezone_test_event_timestamp_day' },
+                operator: 'equals',
+                values: [day],
+            },
+        ],
+    },
+});
+
+const IN_BETWEEN_FILTER = (from: string, to: string) => ({
+    dimensions: {
+        id: 'tz-test',
+        and: [
+            {
+                id: 'tz-between',
+                target: { fieldId: 'timezone_test_event_timestamp_day' },
+                operator: 'inBetween',
+                values: [from, to],
+            },
+        ],
+    },
+});
+
+const GREATER_THAN_FILTER = (day: string) => ({
+    dimensions: {
+        id: 'tz-test',
+        and: [
+            {
+                id: 'tz-gt',
+                target: { fieldId: 'timezone_test_event_timestamp_day' },
+                operator: 'greaterThan',
+                values: [day],
+            },
+        ],
+    },
+});
+
+describe('Query timezone (timezone-aware DATE_TRUNC)', () => {
+    beforeAll(async () => {
+        admin = await login();
+        await updateDataTimezone(admin, undefined);
+    });
+
+    // ── Grouping ──────────────────────────────────────────────────────
+
+    describe('grouping by query timezone', () => {
+        it('UTC (default): Jan 15=6, Jan 16=4', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+            });
+            expect(rows).toHaveLength(2);
+            expect(getRowCount(rows, '2024-01-15')).toBe(6);
+            expect(getRowCount(rows, '2024-01-16')).toBe(4);
+        });
+
+        it('Pacific/Pago_Pago: Jan 14=4, Jan 15=4, Jan 16=2', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Pacific/Pago_Pago',
+            });
+            expect(rows).toHaveLength(3);
+            expect(getRowCount(rows, '2024-01-14')).toBe(4);
+            expect(getRowCount(rows, '2024-01-15')).toBe(4);
+            expect(getRowCount(rows, '2024-01-16')).toBe(2);
+        });
+
+        it('America/New_York: Jan 14=1, Jan 15=6, Jan 16=3', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/New_York',
+            });
+            expect(rows).toHaveLength(3);
+            expect(getRowCount(rows, '2024-01-14')).toBe(1);
+            expect(getRowCount(rows, '2024-01-15')).toBe(6);
+            expect(getRowCount(rows, '2024-01-16')).toBe(3);
+        });
+
+        it('America/Chicago: Jan 14=2, Jan 15=5, Jan 16=3', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/Chicago',
+            });
+            expect(rows).toHaveLength(3);
+            expect(getRowCount(rows, '2024-01-14')).toBe(2);
+            expect(getRowCount(rows, '2024-01-15')).toBe(5);
+            expect(getRowCount(rows, '2024-01-16')).toBe(3);
+        });
+
+        it('Asia/Tokyo: Jan 15=5, Jan 16=4, Jan 17=1', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Asia/Tokyo',
+            });
+            expect(rows).toHaveLength(3);
+            expect(getRowCount(rows, '2024-01-15')).toBe(5);
+            expect(getRowCount(rows, '2024-01-16')).toBe(4);
+            expect(getRowCount(rows, '2024-01-17')).toBe(1);
+        });
+    });
+
+    // ── Filter alignment: equals ──────────────────────────────────────
+
+    describe('filter alignment — equals day = Jan 15', () => {
+        it('UTC: 6 events on Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                filters: EQUALS_FILTER('2024-01-15'),
+            });
+            expect(rows).toHaveLength(1);
+            expect(getTotalCount(rows)).toBe(6);
+        });
+
+        it('Pacific/Pago_Pago: 4 events on Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Pacific/Pago_Pago',
+                filters: EQUALS_FILTER('2024-01-15'),
+            });
+            expect(rows).toHaveLength(1);
+            expect(getTotalCount(rows)).toBe(4);
+        });
+
+        it('America/New_York: 6 events on Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/New_York',
+                filters: EQUALS_FILTER('2024-01-15'),
+            });
+            expect(rows).toHaveLength(1);
+            expect(getTotalCount(rows)).toBe(6);
+        });
+
+        it('America/Chicago: 5 events on Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/Chicago',
+                filters: EQUALS_FILTER('2024-01-15'),
+            });
+            expect(rows).toHaveLength(1);
+            expect(getTotalCount(rows)).toBe(5);
+        });
+
+        it('Asia/Tokyo: 5 events on Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Asia/Tokyo',
+                filters: EQUALS_FILTER('2024-01-15'),
+            });
+            expect(rows).toHaveLength(1);
+            expect(getTotalCount(rows)).toBe(5);
+        });
+    });
+
+    // ── Filter alignment: inBetween ────────────────────────────────────
+    // Jan 14–15 inclusive. Expected totals per timezone:
+    //   UTC: 0+6=6 | New_York: 1+6=7 | Chicago: 2+5=7 | Tokyo: 0+5=5 | Pago_Pago: 4+4=8
+
+    describe('filter alignment — inBetween Jan 14 to Jan 15', () => {
+        it('UTC: 6 events in Jan 14–15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(6);
+        });
+
+        it('America/New_York: 7 events in Jan 14–15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/New_York',
+                filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(7);
+        });
+
+        it('America/Chicago: 7 events in Jan 14–15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/Chicago',
+                filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(7);
+        });
+
+        it('Asia/Tokyo: 5 events in Jan 14–15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Asia/Tokyo',
+                filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(5);
+        });
+
+        it('Pacific/Pago_Pago: 8 events in Jan 14–15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Pacific/Pago_Pago',
+                filters: IN_BETWEEN_FILTER('2024-01-14', '2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(8);
+        });
+
+        // Single-day inBetween — same as equals, catches off-by-one boundary shifts
+        it('America/New_York: 6 events in Jan 15–15 (single day)', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/New_York',
+                filters: IN_BETWEEN_FILTER('2024-01-15', '2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(6);
+        });
+    });
+
+    // ── Filter alignment: greaterThan ─────────────────────────────────
+
+    describe('filter alignment — greaterThan day > Jan 15', () => {
+        it('UTC: 4 events after Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                filters: GREATER_THAN_FILTER('2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(4);
+        });
+
+        it('Pacific/Pago_Pago: 2 events after Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Pacific/Pago_Pago',
+                filters: GREATER_THAN_FILTER('2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(2);
+        });
+
+        it('America/New_York: 3 events after Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/New_York',
+                filters: GREATER_THAN_FILTER('2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(3);
+        });
+
+        it('America/Chicago: 3 events after Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'America/Chicago',
+                filters: GREATER_THAN_FILTER('2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(3);
+        });
+
+        it('Asia/Tokyo: 5 events after Jan 15', async () => {
+            const rows = await runTimezoneTestQuery(admin, {
+                dimensions: DIMENSIONS,
+                metrics: METRICS,
+                timezone: 'Asia/Tokyo',
+                filters: GREATER_THAN_FILTER('2024-01-15'),
+            });
+            expect(getTotalCount(rows)).toBe(5);
+        });
+    });
+
+    afterAll(async () => {
+        await updateDataTimezone(admin, undefined);
+    });
+});

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -159,6 +159,7 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
             userAccessControls: resolveArgs.userAccessControls!,
             availableParameterDefinitions:
                 resolveArgs.availableParameterDefinitions!,
+            useTimezoneAwareDateTrunc: resolveArgs.useTimezoneAwareDateTrunc,
         });
 
         if (resolution.resolved) {

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregationDuckDbClient.ts
@@ -66,6 +66,7 @@ export type ResolvePreAggregationDuckDbArgs = {
     startOfWeek: CreateWarehouseCredentials['startOfWeek'];
     userAccessControls: UserAccessControls;
     availableParameterDefinitions: ParameterDefinitions;
+    useTimezoneAwareDateTrunc?: boolean;
 };
 
 export type PreAggregationDuckDbResolution =
@@ -365,6 +366,7 @@ export class PreAggregationDuckDbClient {
                     availableParameterDefinitions:
                         args.availableParameterDefinitions,
                     pivotConfiguration: args.pivotConfiguration,
+                    useTimezoneAwareDateTrunc: args.useTimezoneAwareDateTrunc,
                 }),
         );
 

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -864,7 +864,10 @@ export class EmbedService extends BaseService {
         );
 
         const useTimezoneAwareDateTrunc =
-            await this.projectService.isTimezoneAwareDateTruncEnabled();
+            await this.projectService.isTimezoneSupportEnabled({
+                userUuid: account.user.id,
+                organizationUuid: account.organization.organizationUuid,
+            });
 
         const compiledQuery = await ProjectService._compileQuery({
             metricQuery,
@@ -1389,7 +1392,10 @@ export class EmbedService extends BaseService {
             await this.projectService.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
         const useTimezoneAwareDateTrunc =
-            await this.projectService.isTimezoneAwareDateTruncEnabled();
+            await this.projectService.isTimezoneSupportEnabled({
+                userUuid: account.user.id,
+                organizationUuid: account.organization.organizationUuid,
+            });
 
         try {
             const { totalQuery: totalMetricQuery } =
@@ -1653,7 +1659,10 @@ export class EmbedService extends BaseService {
             projectTimezone,
         );
         const useTimezoneAwareDateTrunc =
-            await this.projectService.isTimezoneAwareDateTruncEnabled();
+            await this.projectService.isTimezoneSupportEnabled({
+                userUuid: account.user.id,
+                organizationUuid: account.organization.organizationUuid,
+            });
 
         try {
             const { totalQuery: totalMetricQuery } =

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -863,6 +863,9 @@ export class EmbedService extends BaseService {
             filteredExplore,
         );
 
+        const useTimezoneAwareDateTrunc =
+            await this.projectService.isTimezoneAwareDateTruncEnabled();
+
         const compiledQuery = await ProjectService._compileQuery({
             metricQuery,
             explore: filteredExplore,
@@ -877,6 +880,8 @@ export class EmbedService extends BaseService {
                 : undefined,
             parameters: combinedParameters,
             availableParameterDefinitions,
+            useTimezoneAwareDateTrunc,
+            dataTimezone: warehouseClient.credentials.dataTimezone,
         });
 
         const results =
@@ -1383,6 +1388,8 @@ export class EmbedService extends BaseService {
         const projectTimezone =
             await this.projectService.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
+        const useTimezoneAwareDateTrunc =
+            await this.projectService.isTimezoneAwareDateTruncEnabled();
 
         try {
             const { totalQuery: totalMetricQuery } =
@@ -1395,6 +1402,8 @@ export class EmbedService extends BaseService {
                     warehouseClient,
                     availableParameterDefinitions,
                     combinedParameters,
+                    useTimezoneAwareDateTrunc,
+                    warehouseClient.credentials.dataTimezone,
                 );
 
             const { rows } = await this._runEmbedQuery({
@@ -1643,6 +1652,8 @@ export class EmbedService extends BaseService {
             data.metricQuery,
             projectTimezone,
         );
+        const useTimezoneAwareDateTrunc =
+            await this.projectService.isTimezoneAwareDateTruncEnabled();
 
         try {
             const { totalQuery: totalMetricQuery } =
@@ -1655,6 +1666,8 @@ export class EmbedService extends BaseService {
                     warehouseClient,
                     availableParameterDefinitions,
                     combinedParameters,
+                    useTimezoneAwareDateTrunc,
+                    warehouseClient.credentials.dataTimezone,
                 );
 
             const { rows } = await this._runEmbedQuery({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1655,6 +1655,7 @@ export class AsyncQueryService extends ProjectService {
         userAccessControls,
         availableParameterDefinitions,
         queryUuid,
+        useTimezoneAwareDateTrunc,
     }: {
         projectUuid: string;
         warehouseQuery: string;
@@ -1670,6 +1671,7 @@ export class AsyncQueryService extends ProjectService {
         userAccessControls?: UserAccessControls;
         availableParameterDefinitions?: ParameterDefinitions;
         queryUuid: string;
+        useTimezoneAwareDateTrunc?: boolean;
     }): Promise<AsyncQueryExecutionPlan> {
         if (routingTarget === 'materialization') {
             return { target: 'materialization', warehouseQuery };
@@ -1694,6 +1696,7 @@ export class AsyncQueryService extends ProjectService {
                 startOfWeek,
                 userAccessControls,
                 availableParameterDefinitions,
+                useTimezoneAwareDateTrunc,
             },
         });
 
@@ -2635,6 +2638,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration,
         userAttributeOverrides,
         materializationRole,
+        dataTimezone,
     }: Pick<
         ExecuteAsyncMetricQueryArgs,
         | 'account'
@@ -2648,6 +2652,7 @@ export class AsyncQueryService extends ProjectService {
         warehouseSqlBuilder: WarehouseSqlBuilder;
         explore: Explore;
         pivotConfiguration?: PivotConfiguration;
+        dataTimezone?: string;
     }) {
         assertIsAccountWithOrg(account);
 
@@ -2672,6 +2677,9 @@ export class AsyncQueryService extends ProjectService {
             projectTimezone,
         );
 
+        const useTimezoneAwareDateTrunc =
+            await this.isTimezoneAwareDateTruncEnabled();
+
         const fullQuery = await ProjectService._compileQuery({
             metricQuery,
             explore,
@@ -2685,6 +2693,8 @@ export class AsyncQueryService extends ProjectService {
             availableParameterDefinitions,
             pivotConfiguration,
             pivotDimensions: metricQuery.pivotDimensions,
+            useTimezoneAwareDateTrunc,
+            dataTimezone,
         });
 
         const fieldsWithOverrides: ItemsMap = Object.fromEntries(
@@ -3041,6 +3051,9 @@ export class AsyncQueryService extends ProjectService {
                         } satisfies ExecuteAsyncQueryReturn;
                     }
 
+                    const useTimezoneAwareDateTrunc =
+                        await this.isTimezoneAwareDateTruncEnabled();
+
                     const resolveStart = Date.now();
                     const executionPlan =
                         await this.resolveAsyncQueryExecutionPlan({
@@ -3058,6 +3071,7 @@ export class AsyncQueryService extends ProjectService {
                             userAccessControls,
                             availableParameterDefinitions,
                             queryUuid: queryHistoryUuid,
+                            useTimezoneAwareDateTrunc,
                         });
                     const resolveMs = Date.now() - resolveStart;
 
@@ -3409,6 +3423,7 @@ export class AsyncQueryService extends ProjectService {
             pivotConfiguration,
             userAttributeOverrides,
             materializationRole,
+            dataTimezone: warehouseCredentials.dataTimezone,
         });
         const prepareMs = Date.now() - prepareStart;
 
@@ -3654,6 +3669,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             pivotConfiguration,
+            dataTimezone: warehouseCredentials.dataTimezone,
         });
 
         const routingDecision = this.getPreAggregationRoutingDecision({
@@ -3969,6 +3985,7 @@ export class AsyncQueryService extends ProjectService {
             parameters: combinedParameters,
             projectUuid,
             pivotConfiguration,
+            dataTimezone: warehouseCredentials.dataTimezone,
         });
 
         const routingDecision = this.getPreAggregationRoutingDecision({
@@ -4273,6 +4290,7 @@ export class AsyncQueryService extends ProjectService {
             warehouseSqlBuilder,
             parameters: combinedParameters,
             projectUuid,
+            dataTimezone: warehouseCredentials.dataTimezone,
         });
 
         const { queryUuid: underlyingDataQueryUuid, cacheMetadata } =

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -24,7 +24,6 @@ import {
     Explore,
     ExploreCompiler,
     ExploreType,
-    FeatureFlags,
     FieldType,
     ForbiddenError,
     formatItemValue,
@@ -1994,10 +1993,10 @@ export class AsyncQueryService extends ProjectService {
                 sshTunnel = warehouseConnection.sshTunnel;
             }
 
-            const { enabled: isTimezoneSupportEnabled } =
-                await this.featureFlagModel.get({
-                    featureFlagId: FeatureFlags.EnableTimezoneSupport,
-                    user: { userUuid, organizationUuid },
+            const isTimezoneSupportEnabled =
+                await this.isTimezoneSupportEnabled({
+                    userUuid,
+                    organizationUuid,
                 });
             const resolvedDataTimezone = isTimezoneSupportEnabled
                 ? warehouseClient.credentials.dataTimezone
@@ -2677,8 +2676,10 @@ export class AsyncQueryService extends ProjectService {
             projectTimezone,
         );
 
-        const useTimezoneAwareDateTrunc =
-            await this.isTimezoneAwareDateTruncEnabled();
+        const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+        });
 
         const fullQuery = await ProjectService._compileQuery({
             metricQuery,
@@ -3052,7 +3053,11 @@ export class AsyncQueryService extends ProjectService {
                     }
 
                     const useTimezoneAwareDateTrunc =
-                        await this.isTimezoneAwareDateTruncEnabled();
+                        await this.isTimezoneSupportEnabled({
+                            userUuid: account.user.id,
+                            organizationUuid:
+                                account.organization.organizationUuid,
+                        });
 
                     const resolveStart = Date.now();
                     const executionPlan =

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -86,6 +86,7 @@ export type ResolveExecutionArgs = {
     startOfWeek: CreateWarehouseCredentials['startOfWeek'];
     userAccessControls?: UserAccessControls;
     availableParameterDefinitions?: ParameterDefinitions;
+    useTimezoneAwareDateTrunc?: boolean;
 };
 
 export type PreAggregateExecutionResolution =

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3171,8 +3171,10 @@ export class ProjectService extends BaseService {
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
-        const useTimezoneAwareDateTrunc =
-            await this.isTimezoneAwareDateTruncEnabled();
+        const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+        });
 
         const compiledQuery = await ProjectService._compileQuery({
             metricQuery,
@@ -4132,7 +4134,11 @@ export class ProjectService extends BaseService {
                         projectTimezone,
                     );
                     const useTimezoneAwareDateTrunc =
-                        await this.isTimezoneAwareDateTruncEnabled();
+                        await this.isTimezoneSupportEnabled({
+                            userUuid: account.user.id,
+                            organizationUuid:
+                                account.organization.organizationUuid,
+                        });
 
                     const fullQuery = await ProjectService._compileQuery({
                         metricQuery: metricQueryWithLimit,
@@ -4772,7 +4778,7 @@ export class ProjectService extends BaseService {
             await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
         const useTimezoneAwareDateTrunc =
-            await this.isTimezoneAwareDateTruncEnabled();
+            await this.isTimezoneSupportEnabled(user);
 
         const { query } = await ProjectService._compileQuery({
             metricQuery,
@@ -6948,8 +6954,10 @@ export class ProjectService extends BaseService {
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
-        const useTimezoneAwareDateTrunc =
-            await this.isTimezoneAwareDateTruncEnabled();
+        const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+        });
 
         try {
             const { query } = await ProjectService._getCalculateTotalQuery(
@@ -7020,8 +7028,10 @@ export class ProjectService extends BaseService {
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
-        const useTimezoneAwareDateTrunc =
-            await this.isTimezoneAwareDateTruncEnabled();
+        const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+        });
 
         try {
             const { query, totalQuery } =
@@ -7812,10 +7822,15 @@ export class ProjectService extends BaseService {
         });
     }
 
-    async isTimezoneAwareDateTruncEnabled(): Promise<boolean> {
+    async isTimezoneSupportEnabled(user: {
+        userUuid: string;
+        organizationUuid?: string;
+    }): Promise<boolean> {
         const { enabled } = await this.featureFlagModel.get({
             featureFlagId: FeatureFlags.EnableTimezoneSupport,
+            user,
         });
+
         return enabled;
     }
 

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -2992,6 +2992,8 @@ export class ProjectService extends BaseService {
         pivotConfiguration,
         pivotDimensions,
         continueOnError,
+        useTimezoneAwareDateTrunc,
+        dataTimezone,
     }: {
         metricQuery: MetricQuery;
         explore: Explore;
@@ -3005,6 +3007,8 @@ export class ProjectService extends BaseService {
         pivotConfiguration?: PivotConfiguration;
         pivotDimensions?: string[];
         continueOnError?: boolean;
+        useTimezoneAwareDateTrunc?: boolean;
+        dataTimezone?: string;
     }): Promise<CompiledQuery> {
         const availableParameters = Object.keys(availableParameterDefinitions);
 
@@ -3037,6 +3041,8 @@ export class ProjectService extends BaseService {
             pivotDimensions,
             continueOnError,
             originalExplore: dateZoom ? explore : undefined,
+            useTimezoneAwareDateTrunc,
+            dataTimezone,
         });
 
         return wrapSentryTransactionSync('QueryBuilder.buildQuery', {}, () =>
@@ -3165,6 +3171,8 @@ export class ProjectService extends BaseService {
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
+        const useTimezoneAwareDateTrunc =
+            await this.isTimezoneAwareDateTruncEnabled();
 
         const compiledQuery = await ProjectService._compileQuery({
             metricQuery,
@@ -3178,6 +3186,8 @@ export class ProjectService extends BaseService {
             pivotConfiguration,
             pivotDimensions,
             continueOnError: true, // Return SQL even with compilation errors for debugging
+            useTimezoneAwareDateTrunc,
+            dataTimezone: warehouseCredentials.dataTimezone,
         });
 
         // Generate pivot query if pivot configuration is provided
@@ -4121,6 +4131,8 @@ export class ProjectService extends BaseService {
                         metricQueryWithLimit,
                         projectTimezone,
                     );
+                    const useTimezoneAwareDateTrunc =
+                        await this.isTimezoneAwareDateTruncEnabled();
 
                     const fullQuery = await ProjectService._compileQuery({
                         metricQuery: metricQueryWithLimit,
@@ -4133,6 +4145,8 @@ export class ProjectService extends BaseService {
                         parameters,
                         availableParameterDefinitions,
                         pivotDimensions: metricQueryWithLimit.pivotDimensions,
+                        useTimezoneAwareDateTrunc,
+                        dataTimezone: warehouseClient.credentials.dataTimezone,
                     });
 
                     const { query } = fullQuery;
@@ -4757,6 +4771,8 @@ export class ProjectService extends BaseService {
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
+        const useTimezoneAwareDateTrunc =
+            await this.isTimezoneAwareDateTruncEnabled();
 
         const { query } = await ProjectService._compileQuery({
             metricQuery,
@@ -4767,6 +4783,8 @@ export class ProjectService extends BaseService {
             timezone,
             parameters: combinedParameters,
             availableParameterDefinitions,
+            useTimezoneAwareDateTrunc,
+            dataTimezone: warehouseClient.credentials.dataTimezone,
         });
 
         const cacheKey = metricQuery.timezone
@@ -6854,6 +6872,8 @@ export class ProjectService extends BaseService {
         warehouseClient: WarehouseClient,
         availableParameterDefinitions: ParameterDefinitions,
         parameters?: ParametersValuesMap,
+        useTimezoneAwareDateTrunc?: boolean,
+        dataTimezone?: string,
     ) {
         const totalQuery: MetricQuery = {
             ...metricQuery,
@@ -6888,6 +6908,8 @@ export class ProjectService extends BaseService {
             timezone,
             parameters,
             availableParameterDefinitions,
+            useTimezoneAwareDateTrunc,
+            dataTimezone,
         });
 
         return { query, totalQuery };
@@ -6926,6 +6948,8 @@ export class ProjectService extends BaseService {
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
+        const useTimezoneAwareDateTrunc =
+            await this.isTimezoneAwareDateTruncEnabled();
 
         try {
             const { query } = await ProjectService._getCalculateTotalQuery(
@@ -6937,6 +6961,8 @@ export class ProjectService extends BaseService {
                 warehouseClient,
                 availableParameterDefinitions,
                 parameters,
+                useTimezoneAwareDateTrunc,
+                warehouseClient.credentials.dataTimezone,
             );
 
             const queryTags: RunQueryTags = {
@@ -6994,6 +7020,8 @@ export class ProjectService extends BaseService {
         const projectTimezone =
             await this.getQueryTimezoneForProject(projectUuid);
         const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
+        const useTimezoneAwareDateTrunc =
+            await this.isTimezoneAwareDateTruncEnabled();
 
         try {
             const { query, totalQuery } =
@@ -7006,6 +7034,8 @@ export class ProjectService extends BaseService {
                     warehouseClient,
                     availableParameterDefinitions,
                     parameters,
+                    useTimezoneAwareDateTrunc,
+                    warehouseClient.credentials.dataTimezone,
                 );
 
             const queryTags: RunQueryTags = {
@@ -7780,6 +7810,13 @@ export class ProjectService extends BaseService {
                         : null,
             },
         });
+    }
+
+    async isTimezoneAwareDateTruncEnabled(): Promise<boolean> {
+        const { enabled } = await this.featureFlagModel.get({
+            featureFlagId: FeatureFlags.EnableTimezoneSupport,
+        });
+        return enabled;
     }
 
     async getQueryTimezoneForProject(projectUuid: string): Promise<string> {

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -131,17 +131,9 @@ export type BuildQueryProps = {
      * this explore for dimension field lookups instead of the zoomed explore.
      */
     originalExplore?: Explore;
-    /**
-     * When true, DATE_TRUNC on timestamp dimensions is wrapped with
-     * timezone conversion to group by day/week/month in the project
-     * timezone instead of UTC. Gated behind EnableTimezoneSupport.
-     */
+    /** Wrap DATE_TRUNC with timezone conversion. Gated behind EnableTimezoneSupport. */
     useTimezoneAwareDateTrunc?: boolean;
-    /**
-     * The warehouse data timezone from credentials. Used to skip
-     * timezone-aware DATE_TRUNC wrapping when the session timezone
-     * already matches the query timezone (no conversion needed).
-     */
+    /** Warehouse session timezone — used to skip wrapping when it matches queryTimezone. */
     dataTimezone?: string;
 };
 
@@ -318,14 +310,7 @@ export class MetricQueryBuilder {
         CompiledDimension
     > = {};
 
-    /**
-     * Returns the query timezone when timezone-aware DATE_TRUNC is needed,
-     * undefined otherwise. Used to pass timezone to getDimensionFromId and
-     * getSqlForTruncatedDate.
-     *
-     * Skips wrapping when the warehouse session timezone already matches
-     * the query timezone, since bare DATE_TRUNC already groups correctly.
-     */
+    /** Query timezone when timezone-aware DATE_TRUNC is active, undefined otherwise. */
     private get timezoneForDateTrunc(): string | undefined {
         if (!this.args.useTimezoneAwareDateTrunc) return undefined;
         if (this.shouldSkipTimezoneConversion()) return undefined;
@@ -333,21 +318,9 @@ export class MetricQueryBuilder {
     }
 
     /**
-     * Whether timezone conversion can be skipped because the warehouse
-     * input is already in the query timezone.
-     *
-     * Each warehouse's DATE_TRUNC input has an "effective input timezone"
-     * that determines what bare DATE_TRUNC operates on:
-     *
-     * - Snowflake: convertTimezone() in translator.ts normalizes all
-     *   timestamp compiledSql to UTC at compile time, so the effective
-     *   input TZ is always UTC regardless of the session/data timezone.
-     *
-     * - All others: compiledSql is the raw column, interpreted via the
-     *   warehouse session timezone (= dataTimezone, defaulting to UTC).
-     *
-     * When the effective input TZ matches the query TZ, bare DATE_TRUNC
-     * already truncates in the correct timezone — no wrapping needed.
+     * Skip timezone conversion when the effective input TZ matches the query TZ.
+     * Snowflake's effective input is always UTC (convertTimezone normalizes at
+     * compile time); all others use dataTimezone (defaulting to UTC).
      */
     private shouldSkipTimezoneConversion(): boolean {
         const adapterType = this.args.warehouseSqlBuilder.getAdapterType();
@@ -608,12 +581,7 @@ export class MetricQueryBuilder {
         );
     }
 
-    /**
-     * Returns timezone-aware dimension SQL when the dimension has a time
-     * interval and the feature is enabled. Looks up the base dimension's
-     * compiledSql (before DATE_TRUNC) and regenerates the DATE_TRUNC
-     * with timezone conversion via getSqlForTruncatedDate.
-     */
+    /** Regenerates DATE_TRUNC with timezone conversion for truncatable timestamp dimensions. */
     private getTimezoneAwareDimensionSql(
         dimension: CompiledDimension,
         adapterType: SupportedDbtAdapter,
@@ -621,10 +589,8 @@ export class MetricQueryBuilder {
     ): string {
         const { timezone, useTimezoneAwareDateTrunc } = this.args;
 
-        // Only apply timezone-aware DATE_TRUNC when the feature is enabled
-        // and the dimension uses a truncatable time interval (DAY, WEEK, etc.).
-        // Non-truncatable intervals (DAY_OF_WEEK_INDEX, MONTH_NUM, etc.) use
-        // EXTRACT/DATE_PART and must not be passed to getSqlForTruncatedDate.
+        // Skip non-truncatable intervals (DAY_OF_WEEK_INDEX, MONTH_NUM, etc.)
+        // which use EXTRACT/DATE_PART, not DATE_TRUNC.
         if (
             !useTimezoneAwareDateTrunc ||
             !dimension.timeInterval ||
@@ -633,8 +599,7 @@ export class MetricQueryBuilder {
             return dimension.compiledSql;
         }
 
-        // Look up the base dimension (without time interval) to check
-        // if it's a timestamp and get its compiledSql before DATE_TRUNC
+        // Get base dimension's compiledSql (before DATE_TRUNC)
         const baseDimensionId = dimension.timeIntervalBaseDimensionName
             ? `${dimension.table}_${dimension.timeIntervalBaseDimensionName}`
             : undefined;
@@ -1387,10 +1352,7 @@ export class MetricQueryBuilder {
             throw new FieldReferenceError(errorMessage);
         }
 
-        // When timezone-aware DATE_TRUNC is active, override the filter
-        // dimension's compiledSql to match the SELECT clause. Without this,
-        // filters on time-interval dimensions (e.g., event_timestamp_day = '2024-01-16')
-        // would use UTC DATE_TRUNC while the SELECT groups by project timezone.
+        // Override filter dimension SQL to match the timezone-aware SELECT clause
         const filterField = isDimension(field)
             ? {
                   ...field,

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -26,6 +26,7 @@ import {
     getMetricsMapFromTables,
     getParsedReference,
     getPopComparisonConfigKey,
+    getSqlForTruncatedDate,
     hashPopComparisonConfigKeyToSuffix,
     hasPivotFunctions,
     hasRowFunctions,
@@ -34,6 +35,7 @@ import {
     isAndFilterGroup,
     isCompiledCustomSqlDimension,
     isCustomBinDimension,
+    isDimension,
     isFilterGroup,
     isFilterRuleInQuery,
     isJoinModelRequiredFilter,
@@ -57,11 +59,13 @@ import {
     SupportedDbtAdapter,
     TableCalculationFunctionCompiler,
     TimeFrames,
+    truncatableTimeFrames,
     UserAttributeValueMap,
     type FieldsContext,
     type ParameterDefinitions,
     type ParametersValuesMap,
     type WarehouseSqlBuilder,
+    type WeekDay,
 } from '@lightdash/common';
 import Logger from '../../logging/logger';
 import { compilePostCalculationMetric } from '../../queryCompiler';
@@ -127,6 +131,18 @@ export type BuildQueryProps = {
      * this explore for dimension field lookups instead of the zoomed explore.
      */
     originalExplore?: Explore;
+    /**
+     * When true, DATE_TRUNC on timestamp dimensions is wrapped with
+     * timezone conversion to group by day/week/month in the project
+     * timezone instead of UTC. Gated behind EnableTimezoneSupport.
+     */
+    useTimezoneAwareDateTrunc?: boolean;
+    /**
+     * The warehouse data timezone from credentials. Used to skip
+     * timezone-aware DATE_TRUNC wrapping when the session timezone
+     * already matches the query timezone (no conversion needed).
+     */
+    dataTimezone?: string;
 };
 
 /**
@@ -302,6 +318,48 @@ export class MetricQueryBuilder {
         CompiledDimension
     > = {};
 
+    /**
+     * Returns the query timezone when timezone-aware DATE_TRUNC is needed,
+     * undefined otherwise. Used to pass timezone to getDimensionFromId and
+     * getSqlForTruncatedDate.
+     *
+     * Skips wrapping when the warehouse session timezone already matches
+     * the query timezone, since bare DATE_TRUNC already groups correctly.
+     */
+    private get timezoneForDateTrunc(): string | undefined {
+        if (!this.args.useTimezoneAwareDateTrunc) return undefined;
+        if (this.shouldSkipTimezoneConversion()) return undefined;
+        return this.args.timezone;
+    }
+
+    /**
+     * Whether timezone conversion can be skipped because the warehouse
+     * input is already in the query timezone.
+     *
+     * Each warehouse's DATE_TRUNC input has an "effective input timezone"
+     * that determines what bare DATE_TRUNC operates on:
+     *
+     * - Snowflake: convertTimezone() in translator.ts normalizes all
+     *   timestamp compiledSql to UTC at compile time, so the effective
+     *   input TZ is always UTC regardless of the session/data timezone.
+     *
+     * - All others: compiledSql is the raw column, interpreted via the
+     *   warehouse session timezone (= dataTimezone, defaulting to UTC).
+     *
+     * When the effective input TZ matches the query TZ, bare DATE_TRUNC
+     * already truncates in the correct timezone — no wrapping needed.
+     */
+    private shouldSkipTimezoneConversion(): boolean {
+        const adapterType = this.args.warehouseSqlBuilder.getAdapterType();
+
+        const effectiveInputTz =
+            adapterType === SupportedDbtAdapter.SNOWFLAKE
+                ? 'UTC'
+                : (this.args.dataTimezone ?? 'UTC');
+
+        return effectiveInputTz === this.args.timezone;
+    }
+
     // Contains the metrics from the Explore and the custom metrics from the metric query
     private readonly availableMetrics: Record<string, CompiledMetric> = {};
 
@@ -447,6 +505,7 @@ export class MetricQueryBuilder {
             dimensionsWithoutAccess: this.exploreDimensionsWithoutAccess,
             adapterType,
             startOfWeek,
+            timezone: this.timezoneForDateTrunc,
         });
         const popDimensionBaseId = `${popDimension.table}_${
             popDimension.timeIntervalBaseDimensionName ?? popDimension.name
@@ -549,6 +608,58 @@ export class MetricQueryBuilder {
         );
     }
 
+    /**
+     * Returns timezone-aware dimension SQL when the dimension has a time
+     * interval and the feature is enabled. Looks up the base dimension's
+     * compiledSql (before DATE_TRUNC) and regenerates the DATE_TRUNC
+     * with timezone conversion via getSqlForTruncatedDate.
+     */
+    private getTimezoneAwareDimensionSql(
+        dimension: CompiledDimension,
+        adapterType: SupportedDbtAdapter,
+        startOfWeek: WeekDay | null | undefined,
+    ): string {
+        const { timezone, useTimezoneAwareDateTrunc } = this.args;
+
+        // Only apply timezone-aware DATE_TRUNC when the feature is enabled
+        // and the dimension uses a truncatable time interval (DAY, WEEK, etc.).
+        // Non-truncatable intervals (DAY_OF_WEEK_INDEX, MONTH_NUM, etc.) use
+        // EXTRACT/DATE_PART and must not be passed to getSqlForTruncatedDate.
+        if (
+            !useTimezoneAwareDateTrunc ||
+            !dimension.timeInterval ||
+            !truncatableTimeFrames.has(dimension.timeInterval)
+        ) {
+            return dimension.compiledSql;
+        }
+
+        // Look up the base dimension (without time interval) to check
+        // if it's a timestamp and get its compiledSql before DATE_TRUNC
+        const baseDimensionId = dimension.timeIntervalBaseDimensionName
+            ? `${dimension.table}_${dimension.timeIntervalBaseDimensionName}`
+            : undefined;
+
+        const baseDimension = baseDimensionId
+            ? this.exploreDimensions[baseDimensionId]
+            : undefined;
+
+        if (
+            !baseDimension?.compiledSql ||
+            baseDimension.type !== DimensionType.TIMESTAMP
+        ) {
+            return dimension.compiledSql;
+        }
+
+        return getSqlForTruncatedDate(
+            adapterType,
+            dimension.timeInterval,
+            baseDimension.compiledSql,
+            baseDimension.type,
+            startOfWeek,
+            timezone,
+        );
+    }
+
     private buildDimensionsWhereClause(
         dimensionsFilterGroup?: FilterGroup,
     ): string | undefined {
@@ -632,6 +743,7 @@ export class MetricQueryBuilder {
                             this.exploreDimensionsWithoutAccess,
                         adapterType,
                         startOfWeek,
+                        timezone: this.timezoneForDateTrunc,
                     });
 
                     assertValidDimensionRequiredAttribute(
@@ -731,7 +843,12 @@ export class MetricQueryBuilder {
         dimensionsObjects.forEach((dimension) => {
             const id = getItemId(dimension);
             const quotedAlias = `${fieldQuoteChar}${id}${fieldQuoteChar}`;
-            selects[id] = `  ${dimension.compiledSql} AS ${quotedAlias}`;
+            const sql = this.getTimezoneAwareDimensionSql(
+                dimension,
+                adapterType,
+                startOfWeek,
+            );
+            selects[id] = `  ${sql} AS ${quotedAlias}`;
         });
 
         if (customBinDimensionSql?.selects) {
@@ -918,6 +1035,7 @@ export class MetricQueryBuilder {
                         this.exploreDimensionsWithoutAccess,
                     adapterType,
                     startOfWeek,
+                    timezone: this.timezoneForDateTrunc,
                 });
 
                 assertValidDimensionRequiredAttribute(
@@ -1269,6 +1387,21 @@ export class MetricQueryBuilder {
             throw new FieldReferenceError(errorMessage);
         }
 
+        // When timezone-aware DATE_TRUNC is active, override the filter
+        // dimension's compiledSql to match the SELECT clause. Without this,
+        // filters on time-interval dimensions (e.g., event_timestamp_day = '2024-01-16')
+        // would use UTC DATE_TRUNC while the SELECT groups by project timezone.
+        const filterField = isDimension(field)
+            ? {
+                  ...field,
+                  compiledSql: this.getTimezoneAwareDimensionSql(
+                      field,
+                      adapterType,
+                      startOfWeek,
+                  ),
+              }
+            : field;
+
         // For period-to-date filters on truncated dimensions, resolve the
         // base (raw) dimension SQL so EXTRACT operates on the actual date
         let baseDimensionSql: string | undefined;
@@ -1294,7 +1427,7 @@ export class MetricQueryBuilder {
         return renderWithErrorHandling(() =>
             renderFilterRuleSqlFromField(
                 filterRuleWithParamReplacedValues,
-                field,
+                filterField,
                 fieldQuoteChar,
                 stringQuoteChar,
                 escapeString,
@@ -1303,6 +1436,7 @@ export class MetricQueryBuilder {
                 timezone,
                 this.args.explore.caseSensitive ?? true,
                 baseDimensionSql,
+                this.args.useTimezoneAwareDateTrunc,
             ),
         );
     }
@@ -2028,6 +2162,7 @@ export class MetricQueryBuilder {
                                 this.exploreDimensionsWithoutAccess,
                             adapterType,
                             startOfWeek,
+                            timezone: this.timezoneForDateTrunc,
                         });
                         const popDimensionFilters =
                             this.getPopDimensionsFilterSQL(popFieldId);
@@ -2233,6 +2368,7 @@ export class MetricQueryBuilder {
                             this.exploreDimensionsWithoutAccess,
                         adapterType,
                         startOfWeek,
+                        timezone: this.timezoneForDateTrunc,
                     });
                     const popDimensionFilters =
                         this.getPopDimensionsFilterSQL(popFieldId);
@@ -3779,6 +3915,7 @@ export class MetricQueryBuilder {
                         this.exploreDimensionsWithoutAccess,
                     adapterType,
                     startOfWeek,
+                    timezone: this.timezoneForDateTrunc,
                 });
                 const popDimensionFilters =
                     this.getPopDimensionsFilterSQL(popFieldId);

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -43,12 +43,14 @@ export const getDimensionFromId = ({
     dimensionsWithoutAccess,
     adapterType,
     startOfWeek,
+    timezone,
 }: {
     dimId: FieldId;
     dimensions: Record<string, CompiledDimension>;
     dimensionsWithoutAccess?: Record<string, CompiledDimension>;
     adapterType: SupportedDbtAdapter;
     startOfWeek: WeekDay | null | undefined;
+    timezone?: string;
 }): CompiledDimension => {
     const dimension = dimensions[dimId];
 
@@ -62,6 +64,7 @@ export const getDimensionFromId = ({
                 dimensionsWithoutAccess,
                 adapterType,
                 startOfWeek,
+                timezone,
             });
             if (baseField && newTimeFrame)
                 return {
@@ -72,6 +75,7 @@ export const getDimensionFromId = ({
                         baseField.compiledSql,
                         baseField.type,
                         startOfWeek,
+                        timezone,
                     ),
                     timeInterval: newTimeFrame,
                 };

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -62,6 +62,7 @@ type WarehouseConfig = {
         originalSql: string,
         type: DimensionType,
         startOfWeek?: WeekDay | null,
+        timezone?: string,
     ) => string;
     getSqlForDatePart: (
         timeFrame: TimeFrames,
@@ -76,6 +77,66 @@ type WarehouseConfig = {
     ) => string;
 };
 
+/**
+ * Per-warehouse SQL for converting timestamps to the project timezone
+ * before DATE_TRUNC. The truncated result stays in local time (NTZ) —
+ * no conversion back to UTC is needed because DATE_TRUNC is lossy
+ * (always produces midnight, no meaningful time component).
+ *
+ * BigQuery uses no-ops because TIMESTAMP_TRUNC has native timezone
+ * support — the timezone parameter is passed directly inside the
+ * function call, not as input wrapping.
+ */
+type DateTruncTimezoneConversion = {
+    toProjectTz: (sql: string, tz: string) => string;
+};
+
+const dateTruncTimezoneConversions: Record<
+    SupportedDbtAdapter,
+    DateTruncTimezoneConversion
+> = {
+    // BigQuery: no-op — TIMESTAMP_TRUNC handles timezone natively as a parameter
+    [SupportedDbtAdapter.BIGQUERY]: {
+        toProjectTz: (sql) => sql,
+    },
+    // Snowflake: CONVERT_TIMEZONE from UTC to project TZ
+    [SupportedDbtAdapter.SNOWFLAKE]: {
+        toProjectTz: (sql, tz) => `CONVERT_TIMEZONE('UTC', '${tz}', ${sql})`,
+    },
+    // Postgres: ::timestamptz interprets NTZ via session TZ (data timezone),
+    // then AT TIME ZONE converts to project TZ (produces NTZ in local time)
+    [SupportedDbtAdapter.POSTGRES]: {
+        toProjectTz: (sql, tz) => `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+    },
+    [SupportedDbtAdapter.REDSHIFT]: {
+        toProjectTz: (sql, tz) => `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+    },
+    [SupportedDbtAdapter.DUCKDB]: {
+        toProjectTz: (sql, tz) => `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
+    },
+    // Databricks: normalize to UTC via session TZ, then to project TZ
+    [SupportedDbtAdapter.DATABRICKS]: {
+        toProjectTz: (sql, tz) =>
+            `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
+    },
+    // Trino/Athena: CAST to timestamptz interprets NTZ via session TZ,
+    // then AT TIME ZONE changes the timezone. Unlike Postgres, Trino's
+    // AT TIME ZONE on timestamptz produces another timestamptz (not NTZ).
+    // The outer CAST to timestamp strips the timezone to get NTZ local time.
+    [SupportedDbtAdapter.TRINO]: {
+        toProjectTz: (sql, tz) =>
+            `CAST(CAST(${sql} AS timestamp with time zone) AT TIME ZONE '${tz}' AS timestamp)`,
+    },
+    [SupportedDbtAdapter.ATHENA]: {
+        toProjectTz: (sql, tz) =>
+            `CAST(CAST(${sql} AS timestamp with time zone) AT TIME ZONE '${tz}' AS timestamp)`,
+    },
+    // ClickHouse: toTimeZone changes the display timezone
+    [SupportedDbtAdapter.CLICKHOUSE]: {
+        toProjectTz: (sql, tz) => `toTimeZone(${sql}, '${tz}')`,
+    },
+};
+
 const bigqueryStartOfWeekMap: Record<WeekDay, string> = {
     [WeekDay.MONDAY]: 'MONDAY',
     [WeekDay.TUESDAY]: 'TUESDAY',
@@ -87,12 +148,27 @@ const bigqueryStartOfWeekMap: Record<WeekDay, string> = {
 };
 
 const bigqueryConfig: WarehouseConfig = {
-    getSqlForTruncatedDate: (timeFrame, originalSql, type, startOfWeek) => {
+    // BigQuery TIMESTAMP_TRUNC has native timezone support — timezone is
+    // passed as a parameter, not via input/output wrapping. The
+    // dateTruncTimezoneConversions for BigQuery are no-ops for this reason.
+    getSqlForTruncatedDate: (
+        timeFrame,
+        originalSql,
+        type,
+        startOfWeek,
+        timezone,
+    ) => {
         const datePart =
             timeFrame === TimeFrames.WEEK && isWeekDay(startOfWeek)
                 ? `${timeFrame}(${bigqueryStartOfWeekMap[startOfWeek]})`
                 : timeFrame;
         if (type === DimensionType.TIMESTAMP) {
+            if (timezone) {
+                // TIMESTAMP_TRUNC returns a UTC TIMESTAMP. Wrap with
+                // DATETIME to convert to local time so the result matches
+                // date literals in filters (e.g., '2024-01-15').
+                return `DATETIME(TIMESTAMP_TRUNC(${originalSql}, ${datePart}, '${timezone}'), '${timezone}')`;
+            }
             return `TIMESTAMP_TRUNC(${originalSql}, ${datePart})`;
         }
         return `DATE_TRUNC(${originalSql}, ${datePart})`;
@@ -452,19 +528,47 @@ const warehouseConfigs: Record<SupportedDbtAdapter, WarehouseConfig> = {
     [SupportedDbtAdapter.CLICKHOUSE]: clickhouseConfig,
 };
 
-export const getSqlForTruncatedDate: TimeFrameConfig['getSql'] = (
-    adapterType,
-    timeFrame,
-    originalSql,
-    type,
-    startOfWeek,
-) =>
-    warehouseConfigs[adapterType].getSqlForTruncatedDate(
+/**
+ * Generates DATE_TRUNC SQL, optionally with timezone conversion.
+ *
+ * When timezone is provided, the flow is:
+ *   1. Convert input to project timezone (dateTruncTimezoneConversions.toProjectTz)
+ *   2. Apply DATE_TRUNC (warehouseConfigs.getSqlForTruncatedDate)
+ *      — BigQuery uses timezone natively inside TIMESTAMP_TRUNC; others ignore it
+ *
+ * The result stays in the project timezone (NTZ). DATE_TRUNC is lossy —
+ * it always produces midnight with no meaningful time component — so
+ * converting back to UTC is unnecessary and would break filter comparisons
+ * (e.g., `= '2024-01-15'` wouldn't match midnight-local expressed as UTC).
+ */
+export const getSqlForTruncatedDate = (
+    adapterType: SupportedDbtAdapter,
+    timeFrame: TimeFrames,
+    originalSql: string,
+    type: DimensionType,
+    startOfWeek?: WeekDay | null,
+    timezone?: string,
+): string => {
+    if (!timezone) {
+        return warehouseConfigs[adapterType].getSqlForTruncatedDate(
+            timeFrame,
+            originalSql,
+            type,
+            startOfWeek,
+        );
+    }
+
+    const { toProjectTz } = dateTruncTimezoneConversions[adapterType];
+    const input = toProjectTz(originalSql, timezone);
+    return warehouseConfigs[adapterType].getSqlForTruncatedDate(
         timeFrame,
-        originalSql,
+        input,
         type,
         startOfWeek,
+        timezone,
     );
+};
+
 const getSqlForDatePart: TimeFrameConfig['getSql'] = (
     adapterType,
     timeFrame,
@@ -683,6 +787,23 @@ export const getDefaultTimeFrames = (type: DimensionType) =>
               TimeFrames.QUARTER,
               TimeFrames.YEAR,
           ];
+
+/**
+ * Time frames that use DATE_TRUNC (truncation to a calendar boundary).
+ * Non-truncatable time frames (DAY_OF_WEEK_INDEX, MONTH_NUM, etc.) use
+ * EXTRACT/DATE_PART instead and should not be passed to getSqlForTruncatedDate.
+ */
+export const truncatableTimeFrames: ReadonlySet<TimeFrames> = new Set([
+    TimeFrames.MILLISECOND,
+    TimeFrames.SECOND,
+    TimeFrames.MINUTE,
+    TimeFrames.HOUR,
+    TimeFrames.DAY,
+    TimeFrames.WEEK,
+    TimeFrames.MONTH,
+    TimeFrames.QUARTER,
+    TimeFrames.YEAR,
+]);
 
 export const isTimeInterval = (value: string): value is TimeFrames =>
     Object.keys(timeFrameConfigs).includes(value);

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -57,6 +57,8 @@ const timeFrameToDatePartMap: Record<TimeFrames, string | null> = {
 };
 
 type WarehouseConfig = {
+    // `timezone` is only used by BigQuery (native TIMESTAMP_TRUNC support);
+    // other warehouses convert via dateTruncTimezoneConversions instead.
     getSqlForTruncatedDate: (
         timeFrame: TimeFrames,
         originalSql: string,

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -79,16 +79,8 @@ type WarehouseConfig = {
     ) => string;
 };
 
-/**
- * Per-warehouse SQL for converting timestamps to the project timezone
- * before DATE_TRUNC. The truncated result stays in local time (NTZ) —
- * no conversion back to UTC is needed because DATE_TRUNC is lossy
- * (always produces midnight, no meaningful time component).
- *
- * BigQuery uses no-ops because TIMESTAMP_TRUNC has native timezone
- * support — the timezone parameter is passed directly inside the
- * function call, not as input wrapping.
- */
+/** Per-warehouse SQL to convert timestamps to the project timezone before DATE_TRUNC.
+ *  BigQuery is a no-op — TIMESTAMP_TRUNC accepts timezone natively. */
 type DateTruncTimezoneConversion = {
     toProjectTz: (sql: string, tz: string) => string;
 };
@@ -97,7 +89,7 @@ const dateTruncTimezoneConversions: Record<
     SupportedDbtAdapter,
     DateTruncTimezoneConversion
 > = {
-    // BigQuery: no-op — TIMESTAMP_TRUNC handles timezone natively as a parameter
+    // BigQuery: no-op — TIMESTAMP_TRUNC accepts timezone natively
     [SupportedDbtAdapter.BIGQUERY]: {
         toProjectTz: (sql) => sql,
     },
@@ -105,8 +97,7 @@ const dateTruncTimezoneConversions: Record<
     [SupportedDbtAdapter.SNOWFLAKE]: {
         toProjectTz: (sql, tz) => `CONVERT_TIMEZONE('UTC', '${tz}', ${sql})`,
     },
-    // Postgres: ::timestamptz interprets NTZ via session TZ (data timezone),
-    // then AT TIME ZONE converts to project TZ (produces NTZ in local time)
+    // Postgres: cast to timestamptz (session TZ), then AT TIME ZONE to project TZ
     [SupportedDbtAdapter.POSTGRES]: {
         toProjectTz: (sql, tz) => `(${sql})::timestamptz AT TIME ZONE '${tz}'`,
     },
@@ -121,10 +112,7 @@ const dateTruncTimezoneConversions: Record<
         toProjectTz: (sql, tz) =>
             `from_utc_timestamp(to_utc_timestamp(${sql}, current_timezone()), '${tz}')`,
     },
-    // Trino/Athena: CAST to timestamptz interprets NTZ via session TZ,
-    // then AT TIME ZONE changes the timezone. Unlike Postgres, Trino's
-    // AT TIME ZONE on timestamptz produces another timestamptz (not NTZ).
-    // The outer CAST to timestamp strips the timezone to get NTZ local time.
+    // Trino/Athena: cast to timestamptz, AT TIME ZONE, then cast back to NTZ
     [SupportedDbtAdapter.TRINO]: {
         toProjectTz: (sql, tz) =>
             `CAST(CAST(${sql} AS timestamp with time zone) AT TIME ZONE '${tz}' AS timestamp)`,
@@ -150,9 +138,7 @@ const bigqueryStartOfWeekMap: Record<WeekDay, string> = {
 };
 
 const bigqueryConfig: WarehouseConfig = {
-    // BigQuery TIMESTAMP_TRUNC has native timezone support — timezone is
-    // passed as a parameter, not via input/output wrapping. The
-    // dateTruncTimezoneConversions for BigQuery are no-ops for this reason.
+    // BigQuery: timezone passed natively to TIMESTAMP_TRUNC (no input wrapping needed)
     getSqlForTruncatedDate: (
         timeFrame,
         originalSql,
@@ -166,9 +152,7 @@ const bigqueryConfig: WarehouseConfig = {
                 : timeFrame;
         if (type === DimensionType.TIMESTAMP) {
             if (timezone) {
-                // TIMESTAMP_TRUNC returns a UTC TIMESTAMP. Wrap with
-                // DATETIME to convert to local time so the result matches
-                // date literals in filters (e.g., '2024-01-15').
+                // Wrap with DATETIME to convert UTC result to local time
                 return `DATETIME(TIMESTAMP_TRUNC(${originalSql}, ${datePart}, '${timezone}'), '${timezone}')`;
             }
             return `TIMESTAMP_TRUNC(${originalSql}, ${datePart})`;
@@ -532,16 +516,8 @@ const warehouseConfigs: Record<SupportedDbtAdapter, WarehouseConfig> = {
 
 /**
  * Generates DATE_TRUNC SQL, optionally with timezone conversion.
- *
- * When timezone is provided, the flow is:
- *   1. Convert input to project timezone (dateTruncTimezoneConversions.toProjectTz)
- *   2. Apply DATE_TRUNC (warehouseConfigs.getSqlForTruncatedDate)
- *      — BigQuery uses timezone natively inside TIMESTAMP_TRUNC; others ignore it
- *
- * The result stays in the project timezone (NTZ). DATE_TRUNC is lossy —
- * it always produces midnight with no meaningful time component — so
- * converting back to UTC is unnecessary and would break filter comparisons
- * (e.g., `= '2024-01-15'` wouldn't match midnight-local expressed as UTC).
+ * When timezone is provided: convert to project TZ, then DATE_TRUNC.
+ * Result stays in project TZ (NTZ) — no back-conversion to UTC.
  */
 export const getSqlForTruncatedDate = (
     adapterType: SupportedDbtAdapter,
@@ -790,11 +766,7 @@ export const getDefaultTimeFrames = (type: DimensionType) =>
               TimeFrames.YEAR,
           ];
 
-/**
- * Time frames that use DATE_TRUNC (truncation to a calendar boundary).
- * Non-truncatable time frames (DAY_OF_WEEK_INDEX, MONTH_NUM, etc.) use
- * EXTRACT/DATE_PART instead and should not be passed to getSqlForTruncatedDate.
- */
+/** Time frames that use DATE_TRUNC (not EXTRACT/DATE_PART). */
 export const truncatableTimeFrames: ReadonlySet<TimeFrames> = new Set([
     TimeFrames.MILLISECOND,
     TimeFrames.SECOND,


### PR DESCRIPTION
## Summary

Timezone-aware DATE_TRUNC for all warehouses, gated behind `EnableTimezoneSupport`. Timestamp dimensions grouped by day/week/month now truncate in the query timezone instead of UTC.

- Per-warehouse timezone conversion in `getSqlForTruncatedDate` via a `dateTruncTimezoneConversions` map
- `MetricQueryBuilder` regenerates DATE_TRUNC from the base dimension's raw column SQL with timezone conversion, applied to both SELECT and WHERE clauses
- Skips wrapping when warehouse session timezone already matches query timezone
- Service plumbing threads `useTimezoneAwareDateTrunc` and `dataTimezone` through all query compilation paths (ProjectService, AsyncQueryService, EmbedService)

### Per-warehouse DATE_TRUNC SQL (DAY, America/New_York)

| Warehouse | SQL |
|---|---|
| Postgres/Redshift/DuckDB | `DATE_TRUNC('DAY', (col)::timestamptz AT TIME ZONE 'America/New_York')` |
| Snowflake | `DATE_TRUNC('DAY', CONVERT_TIMEZONE('UTC', 'America/New_York', col))` |
| BigQuery | `DATETIME(TIMESTAMP_TRUNC(col, DAY, 'America/New_York'), 'America/New_York')` |
| Databricks | `DATE_TRUNC('DAY', from_utc_timestamp(to_utc_timestamp(col, current_timezone()), 'America/New_York'))` |
| Trino/Athena | `DATE_TRUNC('DAY', CAST(CAST(col AS timestamp with time zone) AT TIME ZONE 'America/New_York' AS timestamp))` |
| ClickHouse | `toStartOfDay(toTimeZone(col, 'America/New_York'))` |

Closes: https://linear.app/lightdash/issue/GLITCH-290/add-timezone-aware-date-trunc-for-all-supported-warehouses