### PR TITLE
feat: thread resolved timezone through formatting paths

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -23,6 +23,7 @@ import {
     ExecuteAsyncDashboardChartRequestParams,
     Explore,
     ExploreError,
+    FeatureFlags,
     FieldValueSearchResult,
     FilterableDimension,
     ForbiddenError,
@@ -1209,6 +1210,12 @@ export class EmbedService extends BaseService {
             combinedParameters,
         });
 
+        const { enabled: isTimezoneSupportEnabled } =
+            await this.featureFlagModel.get({
+                featureFlagId: FeatureFlags.EnableTimezoneSupport,
+            });
+        const displayTimezone = isTimezoneSupportEnabled ? timezone : undefined;
+
         return {
             appliedDashboardFilters: undefined,
             chart: {
@@ -1217,7 +1224,13 @@ export class EmbedService extends BaseService {
                 access: [],
             },
             explore,
-            rows: formatRows(rows, fields),
+            rows: formatRows(
+                rows,
+                fields,
+                undefined,
+                undefined,
+                displayTimezone,
+            ),
             cacheMetadata,
             metricQuery: metricQueryWithDashboardOverrides,
             fields,

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2203,6 +2203,7 @@ export default class SchedulerTask {
             if (payload.pivotConfig) {
                 // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                 // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
+                // TODO(GLITCH-293): resolve and pass timezone for scheduled deliveries
                 const formattedRows = formatRows(rows, itemMap);
 
                 const pivotedResults = pivotResultsAsCsv({
@@ -2811,6 +2812,7 @@ export default class SchedulerTask {
                 ) {
                     // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                     // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
+                    // TODO(GLITCH-293): resolve and pass timezone for scheduled deliveries
                     const formattedRows = formatRows(rows, itemMap);
 
                     const pivotedResults = pivotResultsAsCsv({
@@ -2963,6 +2965,7 @@ export default class SchedulerTask {
                         ) {
                             // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                             // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
+                            // TODO(GLITCH-293): resolve and pass timezone for scheduled deliveries
                             const formattedRows = formatRows(rows, itemMap);
 
                             const pivotedResults = pivotResultsAsCsv({

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2203,7 +2203,6 @@ export default class SchedulerTask {
             if (payload.pivotConfig) {
                 // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                 // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
-                // TODO(GLITCH-293): resolve and pass timezone for scheduled deliveries
                 const formattedRows = formatRows(rows, itemMap);
 
                 const pivotedResults = pivotResultsAsCsv({
@@ -2812,7 +2811,6 @@ export default class SchedulerTask {
                 ) {
                     // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                     // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
-                    // TODO(GLITCH-293): resolve and pass timezone for scheduled deliveries
                     const formattedRows = formatRows(rows, itemMap);
 
                     const pivotedResults = pivotResultsAsCsv({
@@ -2965,7 +2963,6 @@ export default class SchedulerTask {
                         ) {
                             // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                             // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
-                            // TODO(GLITCH-293): resolve and pass timezone for scheduled deliveries
                             const formattedRows = formatRows(rows, itemMap);
 
                             const pivotedResults = pivotResultsAsCsv({

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -746,11 +746,25 @@ export class AsyncQueryService extends ProjectService {
             totalRowCount,
         });
 
+        // Resolve display timezone for result formatting (gated by feature flag)
+        const { enabled: isTimezoneSupportEnabled } =
+            await this.featureFlagModel.get({
+                featureFlagId: FeatureFlags.EnableTimezoneSupport,
+            });
+        const displayTimezone = isTimezoneSupportEnabled
+            ? resolveQueryTimezone(
+                  queryHistory.metricQuery,
+                  await this.getQueryTimezoneForProject(projectUuid),
+              )
+            : undefined;
+
         const formatter = (row: Record<string, unknown>) =>
             formatRow(
                 row,
                 queryHistory.fields,
                 queryHistory.pivotValuesColumns,
+                undefined, // parameters
+                displayTimezone,
             );
 
         const {
@@ -1427,6 +1441,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration,
         itemsMap,
         dataTimezone,
+        displayTimezone,
     }: {
         warehouseClient: WarehouseClient;
         query: string;
@@ -1435,6 +1450,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration?: PivotConfiguration;
         itemsMap: ItemsMap;
         dataTimezone?: string;
+        displayTimezone?: string;
     }): Promise<{
         columns: ResultColumns;
         warehouseResults: WarehouseExecuteAsyncQuery;
@@ -1539,7 +1555,7 @@ export class AsyncQueryService extends ProjectService {
                                   ? formatItemValue(
                                         field,
                                         row[c.reference],
-                                        undefined,
+                                        displayTimezone,
                                     )
                                   : String(rawValue);
                               return {
@@ -1926,6 +1942,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration,
         originalColumns,
         queryCreatedAt,
+        timezone: resolvedTimezone,
         warehouseClientOverride,
         warehouseCredentialsTypeOverride,
     }: RunAsyncWarehouseQueryArgs & {
@@ -2004,6 +2021,9 @@ export class AsyncQueryService extends ProjectService {
                 });
             const resolvedDataTimezone = isTimezoneSupportEnabled
                 ? warehouseClient.credentials.dataTimezone
+                : undefined;
+            const displayTimezone = isTimezoneSupportEnabled
+                ? resolvedTimezone
                 : undefined;
 
             const t0 = Date.now();
@@ -2107,6 +2127,7 @@ export class AsyncQueryService extends ProjectService {
                         pivotConfiguration,
                         itemsMap: fieldsMap,
                         dataTimezone: resolvedDataTimezone,
+                        displayTimezone,
                     }),
             );
 
@@ -3151,6 +3172,7 @@ export class AsyncQueryService extends ProjectService {
                         cacheKey,
                         originalColumns,
                         queryCreatedAt,
+                        timezone,
                     };
 
                     if (executionPlan.target === 'pre_aggregate') {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -747,10 +747,10 @@ export class AsyncQueryService extends ProjectService {
         });
 
         // Resolve display timezone for result formatting (gated by feature flag)
-        const { enabled: isTimezoneSupportEnabled } =
-            await this.featureFlagModel.get({
-                featureFlagId: FeatureFlags.EnableTimezoneSupport,
-            });
+        const isTimezoneSupportEnabled = await this.isTimezoneSupportEnabled({
+            userUuid: account.user.id,
+            organizationUuid: account.organization.organizationUuid,
+        });
         const displayTimezone = isTimezoneSupportEnabled
             ? resolveQueryTimezone(
                   queryHistory.metricQuery,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -201,6 +201,7 @@ export type RunAsyncWarehouseQueryArgs = {
     originalColumns?: ResultColumns;
     query: string;
     queryCreatedAt: Date;
+    timezone?: string;
 };
 
 export type RunAsyncPreAggregateQueryArgs = Omit<

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -119,6 +119,7 @@ export class ExcelService {
         maxColumnLimit,
         pivotDetails,
         enableImprovedExcelDates = false,
+        timezone,
     }: {
         rows: Record<string, AnyType>[];
         itemMap: ItemsMap;
@@ -129,8 +130,15 @@ export class ExcelService {
         maxColumnLimit: number;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
         enableImprovedExcelDates?: boolean;
+        timezone?: string;
     }): Promise<Excel.Buffer> {
-        const formattedRows = formatRows(rows, itemMap);
+        const formattedRows = formatRows(
+            rows,
+            itemMap,
+            undefined,
+            undefined,
+            timezone,
+        );
 
         if (!enableImprovedExcelDates) {
             return ExcelService.downloadPivotTableXlsxLegacy({

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -200,6 +200,7 @@ export class PivotTableService extends BaseService {
         organizationUuid,
         createdByUserUuid,
         expirationSecondsOverride,
+        timezone,
     }: {
         name?: string;
         projectUuid: string;
@@ -216,6 +217,7 @@ export class PivotTableService extends BaseService {
         organizationUuid: string;
         createdByUserUuid: string | null;
         expirationSecondsOverride?: number;
+        timezone?: string;
     }): Promise<AttachmentUrl> {
         // PivotDetails.valuesColumns is just an array objects, we need to convert it to a map so we can format the pivoted results
         // See AsyncQueryService.ts line 1126 for more details on why we're using pivotColumnName as the key
@@ -228,7 +230,13 @@ export class PivotTableService extends BaseService {
 
         // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
         // TODO: refactor pivotQueryResults to accept a Record<string, any>[] simple row type for performance
-        const formattedRows = formatRows(rows, itemMap, pivotValuesColumnsMap);
+        const formattedRows = formatRows(
+            rows,
+            itemMap,
+            pivotValuesColumnsMap,
+            undefined,
+            timezone,
+        );
         const csvResults = pivotResultsAsCsv({
             pivotConfig,
             rows: formattedRows,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3821,6 +3821,18 @@ export class ProjectService extends BaseService {
                     span.setAttribute('warehouse', warehouseConnection?.type);
                 }
 
+                // Resolve display timezone for formatting (gated by feature flag)
+                const { enabled: isTimezoneSupportEnabled } =
+                    await this.featureFlagModel.get({
+                        featureFlagId: FeatureFlags.EnableTimezoneSupport,
+                    });
+                const displayTimezone = isTimezoneSupportEnabled
+                    ? resolveQueryTimezone(
+                          metricQuery,
+                          await this.getQueryTimezoneForProject(projectUuid),
+                      )
+                    : undefined;
+
                 // If there are more than 500 rows, we need to format them in a background job
                 const formattedRows = await wrapSentryTransaction<ResultRow[]>(
                     'ProjectService.runQueryAndFormatRows.formatRows',
@@ -3846,11 +3858,18 @@ export class ProjectService extends BaseService {
                                                   workerData: {
                                                       rows,
                                                       itemMap: fields,
+                                                      timezone: displayTimezone,
                                                   },
                                               },
                                           ),
                                       )
-                                    : formatRows(rows, fields);
+                                    : formatRows(
+                                          rows,
+                                          fields,
+                                          undefined,
+                                          undefined,
+                                          displayTimezone,
+                                      );
                             },
                             'formatRows',
                             this.logger,

--- a/packages/backend/src/services/ProjectService/formatRows.ts
+++ b/packages/backend/src/services/ProjectService/formatRows.ts
@@ -4,11 +4,18 @@ import { parentPort, workerData } from 'worker_threads';
 type Args = {
     rows: Record<string, AnyType>[];
     itemMap: ItemsMap;
+    timezone?: string;
 };
 
 function run() {
-    const { rows, itemMap }: Args = workerData;
-    const formattedRows = formatRows(rows, itemMap);
+    const { rows, itemMap, timezone }: Args = workerData;
+    const formattedRows = formatRows(
+        rows,
+        itemMap,
+        undefined,
+        undefined,
+        timezone,
+    );
     if (parentPort) parentPort.postMessage(formattedRows);
 }
 

--- a/packages/common/src/index.test.ts
+++ b/packages/common/src/index.test.ts
@@ -1,9 +1,12 @@
 import moment from 'moment';
 import {
+    DimensionType,
+    formatRawValue,
     getDateGroupLabel,
     getFilterRuleFromFieldWithDefaultValue,
     getPasswordSchema,
     isValidEmailAddress,
+    MetricType,
 } from '.';
 import {
     dateDayDimension,
@@ -175,6 +178,48 @@ describe('getDateGroupLabel', () => {
                 label: 'day date (day)',
             }),
         ).toEqual('Day date day'); // doesn't recognize (day) as a valid time frame
+    });
+});
+
+describe('formatRawValue', () => {
+    test('DATE field: normalizes timezone offset to midnight UTC', () => {
+        expect(formatRawValue(dateDayDimension, '2024-01-15T11:00:00Z')).toBe(
+            '2024-01-15T00:00:00Z',
+        );
+    });
+
+    test('DATE field: midnight UTC is preserved', () => {
+        expect(formatRawValue(dateDayDimension, '2024-01-15T00:00:00Z')).toBe(
+            '2024-01-15T00:00:00Z',
+        );
+    });
+
+    test('TIMESTAMP field: time component is preserved', () => {
+        const timestampDim = {
+            ...dateDayDimension,
+            type: DimensionType.TIMESTAMP,
+        };
+        expect(formatRawValue(timestampDim, '2024-01-15T11:00:00Z')).toBe(
+            '2024-01-15T11:00:00Z',
+        );
+    });
+
+    test('DATE metric: normalized like DATE dimension', () => {
+        const dateMetric = {
+            ...dateDayDimension,
+            type: MetricType.DATE,
+        };
+        expect(formatRawValue(dateMetric, '2024-01-15T05:00:00Z')).toBe(
+            '2024-01-15T00:00:00Z',
+        );
+    });
+
+    test('null value returns null', () => {
+        expect(formatRawValue(dateDayDimension, null)).toBeNull();
+    });
+
+    test('non-date field returns raw value', () => {
+        expect(formatRawValue(stringDimension, 'hello')).toBe('hello');
     });
 });
 

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -715,8 +715,15 @@ export function formatRawValue(
             field.type === DimensionType.TIMESTAMP);
 
     if (isTimestamp && value !== null) {
-        // We want to return the datetime in UTC to avoid timezone issues in the frontend like in chart tooltips
-        return dayjs(value).utc(true).format();
+        const d = dayjs(value).utc(true);
+        // For DATE types, the time component is a timezone offset artifact from
+        // timezone-aware DATE_TRUNC (e.g. 11:00 UTC = midnight in UTC-11).
+        // Normalize to midnight UTC so echarts, pivot keys, and category axes
+        // all work without per-consumer timezone workarounds.
+        if (isField(field) && field.type === DimensionType.DATE) {
+            return d.startOf('day').format();
+        }
+        return d.format();
     }
 
     return value;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -715,15 +715,17 @@ export function formatRawValue(
             field.type === DimensionType.TIMESTAMP);
 
     if (isTimestamp && value !== null) {
-        const d = dayjs(value).utc(true);
-        // For DATE types, the time component is a timezone offset artifact from
-        // timezone-aware DATE_TRUNC (e.g. 11:00 UTC = midnight in UTC-11).
-        // Normalize to midnight UTC so echarts, pivot keys, and category axes
-        // all work without per-consumer timezone workarounds.
+        // DATE values from timezone-aware DATE_TRUNC are `timestamp without tz`
+        // in the warehouse. The PG client parses them in server-local time, so
+        // JSON.stringify shifts them by the server's UTC offset. Use utc(true)
+        // to reinterpret the local representation as UTC, recovering the
+        // intended date, then normalize to midnight.
         if (isField(field) && field.type === DimensionType.DATE) {
-            return d.startOf('day').format();
+            return dayjs(value).utc(true).startOf('day').format();
         }
-        return d.format();
+        // TIMESTAMP values come from `timestamptz` columns — the PG client
+        // already returns the correct UTC. Just normalize to a clean ISO string.
+        return dayjs.utc(value).format();
     }
 
     return value;
@@ -764,10 +766,23 @@ export function formatRow(
         const pivotValuesColumn = pivotValuesColumns?.[columnName];
         const item = itemsMap[pivotValuesColumn?.referenceField ?? columnName];
 
+        const raw = formatRawValue(item, value);
+        // For DATE types, use the normalized raw value for formatting.
+        // formatRawValue recovers the intended date from the S3-serialized
+        // value (PG parses `timestamp without tz` in server-local time,
+        // shifting the UTC representation). The normalized value is midnight
+        // UTC, which moment.utc() in formatDate reads correctly.
+        // For all other types, use the original value.
+        const isDateType = isField(item) && item.type === DimensionType.DATE;
         resultRow[columnName] = {
             value: {
-                raw: formatRawValue(item, value),
-                formatted: formatItemValue(item, value, timezone, parameters),
+                raw,
+                formatted: formatItemValue(
+                    item,
+                    isDateType ? raw : value,
+                    timezone,
+                    parameters,
+                ),
             },
         };
     }

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1763,14 +1763,16 @@ describe('Formatting', () => {
                 );
             });
 
-            test('formats in specified timezone', () => {
+            test('formats as UTC when timezone is specified (DATE values are pre-normalized to midnight UTC)', () => {
+                // DATE values are normalized to midnight UTC by formatRawValue.
+                // formatDate uses moment.utc() so the timezone doesn't shift the date.
                 expect(
                     formatDate(
-                        utcTimestamp,
+                        '2020-04-04T00:00:00.000Z',
                         TimeFrames.DAY,
                         'America/New_York',
                     ),
-                ).toBe('2020-04-03');
+                ).toBe('2020-04-04');
             });
 
             test('formats in process timezone when no timezone provided (flag off)', () => {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -137,9 +137,9 @@ export function formatDate(
     timezone?: string,
 ): string {
     // DATE values are already the correct date — timezone-aware DATE_TRUNC
-    // truncated in the project timezone at the SQL level, and formatRawValue
-    // normalized to midnight UTC. Just format as UTC to avoid browser timezone
-    // shifts. (TIMESTAMP values use formatTimestamp which does the tz conversion.)
+    // truncated in the project timezone at the SQL level, and formatRow
+    // passes the normalized raw value (midnight UTC) to formatItemValue.
+    // Format as UTC to avoid browser timezone shifts.
     const momentDate = timezone ? moment.utc(date) : moment(date);
 
     if (!momentDate.isValid()) {

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -136,7 +136,11 @@ export function formatDate(
     timeInterval: TimeFrames = TimeFrames.DAY,
     timezone?: string,
 ): string {
-    const momentDate = timezone ? moment.utc(date).tz(timezone) : moment(date);
+    // DATE values are already the correct date — timezone-aware DATE_TRUNC
+    // truncated in the project timezone at the SQL level, and formatRawValue
+    // normalized to midnight UTC. Just format as UTC to avoid browser timezone
+    // shifts. (TIMESTAMP values use formatTimestamp which does the tz conversion.)
+    const momentDate = timezone ? moment.utc(date) : moment(date);
 
     if (!momentDate.isValid()) {
         return 'NaT';

--- a/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
+++ b/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
@@ -27,6 +27,7 @@ export const getCartesianAxisFormatterConfig = ({
     defaultNameGap,
     show,
     parameters,
+    timezone,
 }: {
     axisItem: ItemsMap[string] | undefined;
     longestLabelWidth?: number;
@@ -34,6 +35,7 @@ export const getCartesianAxisFormatterConfig = ({
     defaultNameGap?: number;
     show?: boolean;
     parameters?: Record<string, unknown>;
+    timezone?: string;
 }) => {
     // Remove axis labels, lines, and ticks if the axis is not shown
     // This is done to prevent the grid from disappearing when the axis is not shown
@@ -72,7 +74,7 @@ export const getCartesianAxisFormatterConfig = ({
     if (axisItem && (hasFormattingConfig || axisMinInterval)) {
         axisConfig.axisLabel = {
             formatter: (value: AnyType) =>
-                formatItemValue(axisItem, value, 'UTC', parameters),
+                formatItemValue(axisItem, value, timezone ?? 'UTC', parameters),
         };
         axisConfig.axisPointer = {
             label: {
@@ -84,7 +86,7 @@ export const getCartesianAxisFormatterConfig = ({
                         ? formatItemValue(
                               axisItem,
                               value.value,
-                              'UTC',
+                              timezone ?? 'UTC',
                               parameters,
                           )
                         : undefined,
@@ -109,7 +111,7 @@ export const getCartesianAxisFormatterConfig = ({
                         ? formatItemValue(
                               axisItem,
                               value.value,
-                              'UTC',
+                              timezone ?? 'UTC',
                               parameters,
                           )
                         : undefined,
@@ -153,7 +155,12 @@ export const getCartesianAxisFormatterConfig = ({
             case TimeFrames.WEEK:
                 axisConfig.axisLabel = {
                     formatter: (value: AnyType) =>
-                        formatItemValue(axisItem, value, 'UTC', parameters),
+                        formatItemValue(
+                            axisItem,
+                            value,
+                            timezone ?? 'UTC',
+                            parameters,
+                        ),
                 };
 
                 axisConfig.axisPointer = {

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -345,6 +345,7 @@ const getHeader = (
     params: (TooltipFormatterParams | TooltipParam)[],
     itemsMap?: ItemsMap,
     xFieldId?: string,
+    timezone?: string,
 ): string => {
     const firstParam = params[0];
 
@@ -362,7 +363,12 @@ const getHeader = (
     const rawAxisValue = firstParam?.axisValue;
     if (rawAxisValue !== undefined && rawAxisValue !== null) {
         if (itemsMap && xFieldId) {
-            return getFormattedValue(rawAxisValue, xFieldId, itemsMap, 'UTC');
+            return getFormattedValue(
+                rawAxisValue,
+                xFieldId,
+                itemsMap,
+                timezone ?? 'UTC',
+            );
         }
         return String(rawAxisValue);
     }
@@ -374,7 +380,12 @@ const getHeader = (
         if (xValue !== undefined && xValue !== null) {
             // Use getFormattedValue for consistent formatting with axis labels
             if (itemsMap && xFieldId) {
-                return getFormattedValue(xValue, xFieldId, itemsMap, 'UTC');
+                return getFormattedValue(
+                    xValue,
+                    xFieldId,
+                    itemsMap,
+                    timezone ?? 'UTC',
+                );
             }
             return String(xValue);
         }
@@ -496,6 +507,7 @@ export function createStack100TooltipFormatter(
     xAxisField: string,
     itemsMap?: ItemsMap,
     xAxisDateFormat?: string,
+    timezone?: string,
 ) {
     return (params: TooltipParams) => {
         if (!Array.isArray(params)) return '';
@@ -514,9 +526,9 @@ export function createStack100TooltipFormatter(
                           rawValue as string | number,
                           xAxisDateFormat,
                       )
-                    : getHeader(params, itemsMap, xAxisField);
+                    : getHeader(params, itemsMap, xAxisField, timezone);
         } else {
-            header = getHeader(params, itemsMap, xAxisField);
+            header = getHeader(params, itemsMap, xAxisField, timezone);
         }
 
         const rowsHtml = params
@@ -843,6 +855,7 @@ export const buildCartesianTooltipFormatter =
         pivotValuesColumnsMap,
         parameters,
         rows,
+        timezone,
     }: {
         itemsMap?: ItemsMap;
         stackValue: string | boolean | undefined;
@@ -857,6 +870,7 @@ export const buildCartesianTooltipFormatter =
         pivotValuesColumnsMap?: Record<string, PivotValuesColumn>;
         parameters?: ParametersValuesMap;
         rows?: (ResultRow | Record<string, unknown>)[];
+        timezone?: string;
     }): TooltipComponentFormatterCallback<
         TooltipFormatterParams | TooltipFormatterParams[]
     > =>
@@ -882,10 +896,12 @@ export const buildCartesianTooltipFormatter =
                 },
                 xFieldId,
                 itemsMap,
+                undefined, // xAxisDateFormat
+                timezone,
             )(params as TooltipParam[]);
         }
 
-        const header = getHeader(params, itemsMap, xFieldId);
+        const header = getHeader(params, itemsMap, xFieldId, timezone);
 
         const sortedParams = sortTooltipParams(
             params,

--- a/packages/common/src/visualizations/helpers/valueFormatter.ts
+++ b/packages/common/src/visualizations/helpers/valueFormatter.ts
@@ -23,13 +23,14 @@ export const valueFormatter =
         itemsMap: ItemsMap,
         pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
         parameters?: ParametersValuesMap,
+        timezone?: string,
     ) =>
     (rawValue: AnyType) =>
         getFormattedValue(
             rawValue,
             yFieldId,
             itemsMap,
-            undefined,
+            timezone,
             pivotValuesColumnsMap,
             parameters,
         );

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -401,6 +401,10 @@ const ValidDashboardChartTile: FC<{
                 containerHeight={containerHeight}
                 isDashboard
                 dateZoom={{ granularity: dateZoomGranularity }}
+                resolvedTimezone={
+                    dashboardChartReadyQuery.executeQueryResponse
+                        .resolvedTimezone
+                }
             >
                 <LightdashVisualization
                     ref={measureRef}
@@ -546,6 +550,9 @@ const ValidDashboardChartTileMinimal: FC<{
             containerHeight={containerHeight}
             isDashboard
             dateZoom={{ granularity: dateZoomGranularity }}
+            resolvedTimezone={
+                dashboardChartReadyQuery.executeQueryResponse.resolvedTimezone
+            }
         >
             <LightdashVisualization
                 ref={measureRef}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -292,6 +292,7 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                 containerHeight={containerHeight}
                 isDashboard={false}
                 isEditMode={isEditMode}
+                resolvedTimezone={query.data?.resolvedTimezone ?? null}
             >
                 <CollapsableCard
                     title="Chart"

--- a/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
+++ b/packages/frontend/src/components/LightdashVisualization/VisualizationProvider.tsx
@@ -88,6 +88,7 @@ export type VisualizationProviderProps = {
     isDashboard?: boolean;
     isEditMode?: boolean;
     dateZoom?: DateZoom;
+    resolvedTimezone?: string | null;
 };
 
 const VisualizationProvider: FC<
@@ -120,6 +121,7 @@ const VisualizationProvider: FC<
     isDashboard,
     isEditMode,
     dateZoom,
+    resolvedTimezone = null,
 }) => {
     const itemsMap = useMemo(() => {
         return resultsData?.fields;
@@ -364,6 +366,7 @@ const VisualizationProvider: FC<
         isDashboard,
         isEditMode,
         isTouchDevice,
+        resolvedTimezone,
     };
 
     switch (chartConfig.type) {

--- a/packages/frontend/src/components/LightdashVisualization/context.ts
+++ b/packages/frontend/src/components/LightdashVisualization/context.ts
@@ -56,6 +56,8 @@ type VisualizationContext = {
     isEditMode?: boolean;
     // Touch device detection for tooltip positioning
     isTouchDevice: boolean;
+    // Resolved display timezone from execution response (null when flag is off or SQL queries)
+    resolvedTimezone: string | null;
 };
 
 const Context = createContext<VisualizationContext | undefined>(undefined);

--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -140,6 +140,7 @@ const SimpleChart: FC<SimpleChartProps> = memo(
             onSeriesContextMenu,
             itemsMap,
             resultsData,
+            resolvedTimezone,
         } = useVisualizationContext();
 
         const isLargeChartPerformanceEnabled = useClientFeatureFlag(
@@ -385,7 +386,8 @@ const SimpleChart: FC<SimpleChartProps> = memo(
                                                           axisValue,
                                                           dim,
                                                           itemsMap,
-                                                          'UTC',
+                                                          resolvedTimezone ??
+                                                              'UTC',
                                                       )
                                                     : axisValue;
 
@@ -417,7 +419,7 @@ const SimpleChart: FC<SimpleChartProps> = memo(
                     }, 100);
                 }
             },
-            [chartRef, eChartsOptions?.tooltip, itemsMap],
+            [chartRef, eChartsOptions?.tooltip, itemsMap, resolvedTimezone],
         );
 
         const handleOnMouseOut = useCallback(() => {

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -23,6 +23,7 @@ import { Box, Checkbox, Group, Select, Stack, Switch } from '@mantine/core';
 import React, { useCallback, type FC } from 'react';
 import { createPortal } from 'react-dom';
 import type useCartesianChartConfig from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
+import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../../common/Config';
 import { GrabIcon } from '../../common/GrabIcon';
 import { ChartTypeSelect } from './ChartTypeSelect';
@@ -51,9 +52,10 @@ const getFormatterValue = (
     value: any,
     key: string,
     items: Array<Field | TableCalculation | CustomDimension>,
+    timezone?: string,
 ) => {
     const item = items.find((i) => getItemId(i) === key);
-    return formatItemValue(item, value, 'UTC');
+    return formatItemValue(item, value, timezone);
 };
 
 type DraggablePortalHandlerProps = {
@@ -94,6 +96,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     updateSeries,
     series,
 }) => {
+    const { resolvedTimezone } = useVisualizationContext();
     const [openSeriesId, setOpenSeriesId] = React.useState<
         string | undefined
     >();
@@ -308,6 +311,8 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                                                             value,
                                                             field,
                                                             items,
+                                                            resolvedTimezone ??
+                                                                undefined,
                                                         );
                                                     return acc
                                                         ? `${acc} - ${formattedValue}`

--- a/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/ChatElements/AiVisualizationRenderer.tsx
@@ -210,6 +210,9 @@ export const AiVisualizationRenderer: FC<Props> = ({
                 }}
                 onChartConfigChange={handleChartConfigChange}
                 unsavedMetricQuery={metricQuery}
+                resolvedTimezone={
+                    queryExecutionHandle.data.query.resolvedTimezone
+                }
             >
                 <Stack gap="md" h="100%">
                     {headerContent && headerContent}

--- a/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
+++ b/packages/frontend/src/ee/features/embed/EmbedChart/components/EmbedChart.tsx
@@ -51,6 +51,7 @@ const MinimalChartContent = memo(() => {
             savedChartUuid={savedChart.uuid}
             colorPalette={savedChart.colorPalette}
             parameters={query.data?.usedParametersValues}
+            resolvedTimezone={query.data?.resolvedTimezone ?? null}
         >
             <Box mih="inherit" h="100%">
                 <LightdashVisualization

--- a/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricExploreModal/MetricExploreModal.tsx
@@ -589,6 +589,7 @@ export const MetricExploreModal: FC<Props> = ({ opened, onClose, metrics }) => {
                                             onSeriesContextMenu={undefined}
                                             pivotTableMaxColumnLimit={60}
                                             computedSeries={computedSeries}
+                                            resolvedTimezone={null}
                                         >
                                             <LightdashVisualization />
                                         </VisualizationProvider>

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -227,6 +227,9 @@ const getAxisType = ({
 
     // For coarse time intervals (week, month, quarter, year), use category axis to prevent
     // ECharts from generating misleading intermediate ticks (e.g., daily ticks for weekly data).
+    // When a non-UTC timezone is set, DAY also uses category axis because the raw UTC
+    // values sit at a non-midnight offset (e.g. 11:00 UTC for UTC-11), which causes
+    // ECharts to position bars off-center on a continuous time axis.
     // Exception: keep 'time' axis if there's a reference line (needs continuous positioning)
     const inferAxisType = (axisId?: string, isXAxis: boolean = false) => {
         const field = axisId ? itemsMap[axisId] : undefined;
@@ -670,6 +673,7 @@ type GetPivotSeriesArg = {
     pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null;
     parameters?: ParametersValuesMap;
     isStack100?: boolean;
+    timezone?: string;
 };
 
 const seriesValueFormatter = (
@@ -878,6 +882,7 @@ const getPivotSeries = ({
     pivotValuesColumnsMap,
     parameters,
     isStack100,
+    timezone,
 }: GetPivotSeriesArg): EChartsSeries => {
     const pivotLabel = pivotReference.pivotValues.reduce(
         (acc, { field, value }) => {
@@ -885,7 +890,7 @@ const getPivotSeries = ({
                 value,
                 field,
                 itemsMap,
-                undefined,
+                timezone,
                 pivotValuesColumnsMap,
                 parameters,
             );
@@ -940,6 +945,7 @@ const getPivotSeries = ({
                 itemsMap,
                 pivotValuesColumnsMap,
                 parameters,
+                timezone,
             ),
         },
         showSymbol: series.showSymbol ?? true,
@@ -1076,6 +1082,7 @@ type GetSimpleSeriesArg = {
     parameters?: ParametersValuesMap;
     isStack100?: boolean;
     backgroundColor?: string;
+    timezone?: string;
 };
 
 const getSimpleSeries = ({
@@ -1089,6 +1096,7 @@ const getSimpleSeries = ({
     parameters,
     isStack100,
     backgroundColor,
+    timezone,
 }: GetSimpleSeriesArg) => ({
     ...series,
     xAxisIndex: flipAxes ? series.yAxisIndex : undefined,
@@ -1125,6 +1133,7 @@ const getSimpleSeries = ({
             itemsMap,
             pivotValuesColumnsMap,
             parameters,
+            timezone,
         ),
     },
     ...getSimpleSeriesSymbolConfig(series),
@@ -1201,6 +1210,7 @@ const getEchartsSeriesFromPivotedData = (
     pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
     parameters?: ParametersValuesMap,
     backgroundColor?: string,
+    timezone?: string,
 ): EChartsSeries[] => {
     // Check if 100% stacking is enabled
     const isStack100 = cartesianChart.layout.stack === StackType.PERCENT;
@@ -1266,6 +1276,7 @@ const getEchartsSeriesFromPivotedData = (
                     pivotValuesColumnsMap,
                     parameters,
                     isStack100,
+                    timezone,
                 });
             }
 
@@ -1281,6 +1292,7 @@ const getEchartsSeriesFromPivotedData = (
                 parameters,
                 isStack100,
                 backgroundColor,
+                timezone,
             });
         });
 
@@ -2313,6 +2325,7 @@ const getStackTotalSeries = (
     selectedLegendNames: LegendValues,
     isStack100: boolean,
     connectNulls: boolean | undefined = true,
+    timezone?: string,
 ) => {
     const seriesGroupedByStack = groupBy(seriesWithStack, 'stack');
     return Object.entries(seriesGroupedByStack).reduce<EChartsSeries[]>(
@@ -2341,6 +2354,7 @@ const getStackTotalSeries = (
                                 stackTotal,
                                 fieldId,
                                 itemsMap,
+                                timezone,
                             );
                         }
                         return '';
@@ -2440,7 +2454,11 @@ const useEchartsCartesianConfig = (
 
     const { rows: allRows, rowKeyMap } = useMemo(() => {
         if (resultsData?.pivotDetails) {
-            return getPivotedDataFromPivotDetails(resultsData, undefined);
+            return getPivotedDataFromPivotDetails(
+                resultsData,
+                undefined,
+                resolvedTimezone ?? undefined,
+            );
         }
 
         // Legacy implementation - comment out when fully migrated
@@ -2450,7 +2468,13 @@ const useEchartsCartesianConfig = (
             pivotedKeys,
             nonPivotedKeys,
         );
-    }, [resultsData, pivotDimensions, pivotedKeys, nonPivotedKeys]);
+    }, [
+        resultsData,
+        pivotDimensions,
+        pivotedKeys,
+        nonPivotedKeys,
+        resolvedTimezone,
+    ]);
 
     const rows = useMemo(
         () =>
@@ -2493,6 +2517,8 @@ const useEchartsCartesianConfig = (
                 rowKeyMap,
                 pivotValuesColumnsMap,
                 parameters,
+                undefined,
+                resolvedTimezone ?? undefined,
             );
         } else {
             // Legacy implementation
@@ -2520,6 +2546,7 @@ const useEchartsCartesianConfig = (
         parameters,
         resultsAndMinsAndMaxes.results,
         isShowHideRowsEnabled,
+        resolvedTimezone,
     ]);
 
     const axes = useMemo(() => {
@@ -2747,6 +2774,7 @@ const useEchartsCartesianConfig = (
                 validCartesianConfigLegend,
                 isStack100,
                 validCartesianConfig?.layout.connectNulls,
+                resolvedTimezone ?? undefined,
             ),
         ];
     }, [
@@ -2765,6 +2793,7 @@ const useEchartsCartesianConfig = (
         getSeriesColor,
         colorPalette,
         theme.colors.background,
+        resolvedTimezone,
     ]);
     const sortedResults = useMemo(() => {
         const results =
@@ -3178,6 +3207,7 @@ const useEchartsCartesianConfig = (
                         total,
                         fieldId,
                         itemsMap,
+                        resolvedTimezone ?? undefined,
                     );
                     maxCharCount = Math.max(maxCharCount, formatted.length);
                 });
@@ -3199,6 +3229,7 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.stack,
         validCartesianConfig?.layout?.flipAxes,
         validCartesianConfigLegend,
+        resolvedTimezone,
     ]);
 
     const currentGrid = useMemo(() => {

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1566,6 +1566,7 @@ const getEchartAxes = ({
     displayedRows,
     minsAndMaxes,
     parameters,
+    timezone,
 }: {
     validCartesianConfig: CartesianChart;
     itemsMap: ItemsMap;
@@ -1574,6 +1575,7 @@ const getEchartAxes = ({
     displayedRows?: ResultRow[];
     minsAndMaxes: ReturnType<typeof getResultValueArray>['minsAndMaxes'];
     parameters?: ParametersValuesMap;
+    timezone?: string;
 }) => {
     const xAxisItemId = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.layout?.yField?.[0]
@@ -1785,6 +1787,7 @@ const getEchartAxes = ({
         defaultNameGap: 30,
         show: showXAxis,
         parameters,
+        timezone,
     });
     const bottomAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -1805,6 +1808,7 @@ const getEchartAxes = ({
         defaultNameGap: 30,
         show: showXAxis,
         parameters,
+        timezone,
     });
     const topAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -1824,6 +1828,7 @@ const getEchartAxes = ({
         defaultNameGap: leftYaxisGap + defaultAxisLabelGap,
         show: showLeftYAxis,
         parameters,
+        timezone,
     });
     const leftAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -1843,6 +1848,7 @@ const getEchartAxes = ({
         defaultNameGap: rightYaxisGap + defaultAxisLabelGap,
         show: showRightYAxis,
         parameters,
+        timezone,
     });
     const rightAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -2375,6 +2381,7 @@ const useEchartsCartesianConfig = (
         parameters,
         isTouchDevice,
         colorPalette,
+        resolvedTimezone,
     } = useVisualizationContext();
 
     const theme = useMantineTheme();
@@ -2535,6 +2542,7 @@ const useEchartsCartesianConfig = (
                     : undefined,
             minsAndMaxes: resultsAndMinsAndMaxes.minsAndMaxes,
             parameters,
+            timezone: resolvedTimezone ?? undefined,
         });
     }, [
         itemsMap,
@@ -2545,6 +2553,7 @@ const useEchartsCartesianConfig = (
         isShowHideRowsEnabled,
         resultsAndMinsAndMaxes.minsAndMaxes,
         parameters,
+        resolvedTimezone,
     ]);
 
     const stackedSeriesWithColorAssignments = useMemo(() => {
@@ -3104,6 +3113,7 @@ const useEchartsCartesianConfig = (
                 pivotValuesColumnsMap,
                 parameters,
                 rows: dataToRender,
+                timezone: resolvedTimezone ?? undefined,
             }),
         };
     }, [
@@ -3120,6 +3130,7 @@ const useEchartsCartesianConfig = (
         hiddenSeriesPivotRefs,
         dataToRender,
         isTouchDevice,
+        resolvedTimezone,
     ]);
 
     // Calculate max stack label padding for 100% stacking grid

--- a/packages/frontend/src/hooks/plottedData/getPlottedData.ts
+++ b/packages/frontend/src/hooks/plottedData/getPlottedData.ts
@@ -106,6 +106,7 @@ export const getPlottedData = (
 export const getPivotedDataFromPivotDetails = (
     resultsData: InfiniteQueryResults | undefined,
     itemsMap: ItemsMap | undefined,
+    timezone?: string,
 ): {
     pivotValuesMap: PivotValueMap;
     rowKeyMap: RowKeyMap;
@@ -137,7 +138,11 @@ export const getPivotedDataFromPivotDetails = (
                     ...acc[value.referenceField],
                     [String(value.value)]: {
                         raw: value.value,
-                        formatted: formatItemValue(field, value.value),
+                        formatted: formatItemValue(
+                            field,
+                            value.value,
+                            timezone,
+                        ),
                     },
                 };
             });

--- a/packages/frontend/src/pages/MinimalSavedExplorer.tsx
+++ b/packages/frontend/src/pages/MinimalSavedExplorer.tsx
@@ -113,6 +113,7 @@ const MinimalExplorerContent = memo(() => {
                 savedChartUuid={savedChart.uuid}
                 colorPalette={savedChart.colorPalette}
                 parameters={query.data?.usedParametersValues}
+                resolvedTimezone={query.data?.resolvedTimezone ?? null}
                 containerWidth={containerWidth}
                 containerHeight={containerHeight}
             >


### PR DESCRIPTION
closes: https://linear.app/lightdash/issue/GLITCH-291/update-result-formatting-to-use-resolved-project-timezone

### Problem

Timezone-aware DATE_TRUNC creates a display mismatch. With project timezone `America/New_York (UTC -4:00)`, a raw timestamp showing `2024-01-15, 02:00 (+00:00)` gets grouped under `2024-01-14` — because it was still January 14th in New York. The user sees two different dates for the same row with no explanation.

### Summary

Threads the resolved project timezone through all formatting paths so timestamps display in the correct timezone. 100% gated behind `EnableTimezoneSupport`.

- **Backend:** resolve display timezone in AsyncQueryService, ProjectService, EmbedService; pass to `formatRows`/`formatRow`
- **Frontend:** add `resolvedTimezone` to VisualizationProvider context; pass to axis labels, tooltips, series labels, stack totals, and pivot display values
- **DATE normalization:** strip the time component from DATE values to midnight UTC in `formatRawValue`, so echarts positioning and pivot keys work correctly