### PR TITLE
feat: auto-detect CJK language for correct font rendering in screenshots

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1251,6 +1251,46 @@ export class UnfurlService extends BaseService {
                         'Screenshot ready indicator found - page is ready',
                     );
 
+                    // Auto-detect CJK language from page content and set
+                    // <html lang="..."> so CSS :lang() rules select the
+                    // correct Noto Sans CJK font variant for screenshots.
+                    const detectedLang = await page.evaluate(() => {
+                        const text = document.body.innerText;
+                        if (/[\u3040-\u309F\u30A0-\u30FF]/.test(text))
+                            return 'ja';
+                        if (/[\uAC00-\uD7AF\u1100-\u11FF]/.test(text))
+                            return 'ko';
+                        if (/[\u4E00-\u9FFF]/.test(text)) {
+                            // Distinguish Simplified vs Traditional Chinese
+                            // by checking for script-specific character variants
+                            const simplified = (
+                                text.match(
+                                    /[\u4EEC\u56FD\u5B66\u5BF9\u8FD9\u8BA9\u8BF4\u4E1C\u7ECF\u5F00]/g,
+                                ) ?? []
+                            ).length;
+                            const traditional = (
+                                text.match(
+                                    /[\u5011\u570B\u5B78\u5C0D\u9019\u8B93\u8AAA\u6771\u7D93\u958B]/g,
+                                ) ?? []
+                            ).length;
+                            return traditional > simplified ? 'zh-TW' : 'zh-CN';
+                        }
+                        return null;
+                    });
+                    if (detectedLang) {
+                        await page.evaluate(
+                            (lang) =>
+                                document.documentElement.setAttribute(
+                                    'lang',
+                                    lang,
+                                ),
+                            detectedLang,
+                        );
+                        this.logger.info(
+                            `Auto-detected CJK language: ${detectedLang}`,
+                        );
+                    }
+
                     const path = `/tmp/${imageId}.png`;
 
                     let finalSelector = selector;

--- a/packages/frontend/src/mantineTheme.ts
+++ b/packages/frontend/src/mantineTheme.ts
@@ -376,6 +376,22 @@ export const getMantineThemeOverride = (
             '.wmde-markdown img': {
                 backgroundColor: 'transparent',
             },
+            // CJK font selection for headless browser screenshots/PDFs.
+            // Chromium on Linux ignores fontconfig, so we use :lang() CSS
+            // selectors to explicitly pick the correct Noto Sans CJK variant.
+            ':lang(ja)': {
+                fontFamily: `'Noto Sans CJK JP', ${theme.fontFamily}`,
+            },
+            ':lang(zh-CN), :lang(zh-Hans)': {
+                fontFamily: `'Noto Sans CJK SC', ${theme.fontFamily}`,
+            },
+            ':lang(zh-TW), :lang(zh-Hant)': {
+                fontFamily: `'Noto Sans CJK TC', ${theme.fontFamily}`,
+            },
+            ':lang(ko)': {
+                fontFamily: `'Noto Sans CJK KR', ${theme.fontFamily}`,
+            },
+
             '@keyframes fadeIn': {
                 from: { opacity: 0 },
                 to: { opacity: 1 },


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21499

### Description:
Chromium on Linux ignores fontconfig for CJK font fallback, rendering all CJK text with Chinese-style glyphs. Instead of requiring a manual project-level language setting, auto-detect the language from page content using Unicode script ranges (hiragana/katakana → Japanese, hangul → Korean, character frequency heuristics → SC/TC Chinese) and set the html lang attribute so CSS :lang() rules select the correct Noto Sans CJK font variant.

### Testing:
Used the following example inputs in a Markdown tile:
```
Japanese:
直接売上の骨格 — 今月の角度分析レポート

Korean:
직접 매출 골격 — 이번 달 각도 분석 보고서

Simplified Chinese:
直接销售的骨架 — 这个月的角度分析报告

Traditional Chinese:
直接銷售的骨架 — 這個月的角度分析報告
```

Each was correctly detected, validated via logs.


#### Example with Japanese:

Before:
<img width="708" height="289" alt="japanese-before" src="https://github.com/user-attachments/assets/c59a6aa1-c717-4c35-93b9-0dedb3354193" />

After:
<img width="708" height="289" alt="japanese-after" src="https://github.com/user-attachments/assets/5c41ddb0-990d-4d5d-9783-de8d23b21b50" />

