### PR TITLE
fix: return disabled state for unknown feature flags instead of throwing error (GLITCH-331)

### DIFF
--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -3,7 +3,6 @@ import {
     FeatureFlags,
     isFeatureFlags,
     LightdashUser,
-    NotFoundError,
 } from '@lightdash/common';
 import { Knex } from 'knex';
 import { LightdashConfig } from '../../config/parseConfig';
@@ -99,7 +98,10 @@ export class FeatureFlagModel {
                 args.featureFlagId,
             );
         }
-        throw new NotFoundError(`Feature flag ${args.featureFlagId} not found`);
+
+        // Unknown flags default to disabled.
+        // See: GLITCH-331
+        return { id: args.featureFlagId, enabled: false };
     }
 
     static async getPosthogFeatureFlag(


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: GLITCH-331

### Description:
Changed feature flag behavior to return disabled state for unknown flags instead of throwing a NotFoundError. Unknown feature flags now default to `{ id: featureFlagId, enabled: false }` rather than causing the application to error.