### PR TITLE
feat: add formula package to build-published-packages script

### DIFF
--- a/package.json
+++ b/package.json
@@ -144,7 +144,7 @@
         "test": "turbo run test --filter=@lightdash/common --filter=@lightdash/warehouses --filter=backend --filter=@lightdash/frontend --filter=e2e --filter=@lightdash/cli --filter=api-tests",
         "dev": "pnpm -r --stream --parallel -F common -F warehouses -F backend -F frontend run dev",
         "build": "turbo run build --filter=@lightdash/common --filter=@lightdash/warehouses --filter=backend --filter=@lightdash/frontend",
-        "build-published-packages": "pnpm -r --stream --sequential -F common -F warehouses -F query-sdk -F cli build && pnpm frontend-build-sdk",
+        "build-published-packages": "pnpm -r --stream --sequential -F common -F warehouses -F query-sdk -F cli -F formula build && pnpm frontend-build-sdk",
         "release-packages": "pnpm -r --stream --sequential -F common -F warehouses -F query-sdk -F cli -F frontend release",
         "start": "pnpm run backend-start",
         "prepare": "husky || true",


### PR DESCRIPTION
### Description:

Added the `formula` package to the `build-published-packages` script to include it in the build process for published packages. Needed because frontend now reads from `@lightdash/formula` 