### PR TITLE
fix: upgrade @octokit/rest 20.1.1 → 20.1.2 (security)

### DIFF
--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -70,7 +70,7 @@
         "@octokit/auth-token": "4.0.0",
         "@octokit/core": "5.2.0",
         "@octokit/request": "8.4.1",
-        "@octokit/rest": "20.1.1",
+        "@octokit/rest": "20.1.2",
         "@openrouter/ai-sdk-provider": "1.5.4",
         "@rudderstack/rudder-sdk-node": "2.1.1",
         "@sentry/core": "9.31.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -228,8 +228,8 @@ importers:
         specifier: 8.4.1
         version: 8.4.1
       '@octokit/rest':
-        specifier: 20.1.1
-        version: 20.1.1
+        specifier: 20.1.2
+        version: 20.1.2
       '@openrouter/ai-sdk-provider':
         specifier: 1.5.4
         version: 1.5.4(ai@6.0.71(zod@3.25.55))(zod@3.25.55)
@@ -3484,8 +3484,8 @@ packages:
     peerDependencies:
       '@octokit/core': '>=5'
 
-  '@octokit/plugin-paginate-rest@11.3.1':
-    resolution: {integrity: sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==}
+  '@octokit/plugin-paginate-rest@11.4.4-cjs.2':
+    resolution: {integrity: sha512-2dK6z8fhs8lla5PaOTgqfCGBxgAv/le+EhPs27KklPhm1bKObpu6lXzwfUEQ16ajXzqNrKMujsFyo9K2eaoISw==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@octokit/core': '5'
@@ -3508,8 +3508,8 @@ packages:
     peerDependencies:
       '@octokit/core': '>=5'
 
-  '@octokit/plugin-rest-endpoint-methods@13.2.2':
-    resolution: {integrity: sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==}
+  '@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1':
+    resolution: {integrity: sha512-VUjIjOOvF2oELQmiFpWA1aOPdawpyaCUqcEBc/UOUnj3Xp6DJGrJ1+bjUIIDzdHjnFNO6q57ODMfdEZnoBkCwQ==}
     engines: {node: '>= 18'}
     peerDependencies:
       '@octokit/core': ^5
@@ -3534,8 +3534,8 @@ packages:
     resolution: {integrity: sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==}
     engines: {node: '>= 18'}
 
-  '@octokit/rest@20.1.1':
-    resolution: {integrity: sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==}
+  '@octokit/rest@20.1.2':
+    resolution: {integrity: sha512-GmYiltypkHHtihFwPRxlaorG5R9VAHuk/vbszVoRTGXnAsY60wYLkh/E2XiFmdZmqrisw+9FaazS1i5SbdWYgA==}
     engines: {node: '>= 18'}
 
   '@octokit/types@12.4.0':
@@ -17886,7 +17886,7 @@ snapshots:
     dependencies:
       '@octokit/core': 5.2.0
 
-  '@octokit/plugin-paginate-rest@11.3.1(@octokit/core@5.2.0)':
+  '@octokit/plugin-paginate-rest@11.4.4-cjs.2(@octokit/core@5.2.0)':
     dependencies:
       '@octokit/core': 5.2.0
       '@octokit/types': 13.8.0
@@ -17905,7 +17905,7 @@ snapshots:
       '@octokit/core': 5.2.0
       '@octokit/types': 12.4.0
 
-  '@octokit/plugin-rest-endpoint-methods@13.2.2(@octokit/core@5.2.0)':
+  '@octokit/plugin-rest-endpoint-methods@13.3.2-cjs.1(@octokit/core@5.2.0)':
     dependencies:
       '@octokit/core': 5.2.0
       '@octokit/types': 13.8.0
@@ -17936,12 +17936,12 @@ snapshots:
       '@octokit/types': 13.8.0
       universal-user-agent: 6.0.1
 
-  '@octokit/rest@20.1.1':
+  '@octokit/rest@20.1.2':
     dependencies:
       '@octokit/core': 5.2.0
-      '@octokit/plugin-paginate-rest': 11.3.1(@octokit/core@5.2.0)
+      '@octokit/plugin-paginate-rest': 11.4.4-cjs.2(@octokit/core@5.2.0)
       '@octokit/plugin-request-log': 4.0.0(@octokit/core@5.2.0)
-      '@octokit/plugin-rest-endpoint-methods': 13.2.2(@octokit/core@5.2.0)
+      '@octokit/plugin-rest-endpoint-methods': 13.3.2-cjs.1(@octokit/core@5.2.0)
 
   '@octokit/types@12.4.0':
     dependencies:


### PR DESCRIPTION
## Summary

Fixes the ReDoS vulnerability in Octokit dependencies (replaces Snyk PR #21609 which was closed).

## Why not v21?

Snyk's auto-PR (#21609) proposed `@octokit/rest@21.0.0`, but **v21 is ESM-only** ([release notes](https://github.com/octokit/rest.js/releases/tag/v21.0.0)). Our backend is CommonJS (`"type": "module"` is not set), so importing an ESM-only package would break at runtime. See [analysis comment](https://github.com/lightdash/lightdash/pull/21609#issuecomment-4221737833).

**v20.1.2** ([release notes](https://github.com/octokit/rest.js/releases/tag/v20.1.2)) patches the same ReDoS by bumping internal Octokit deps to CJS-compatible builds — no module system change, no API changes.

## Changelog review (20.1.1 → 20.1.2)

Single commit: "bump Octokit dependencies to address ReDos vulnerabilities, bump devDependencies". Transitive deps bumped to \`*-cjs.*\` variants:

- \`@octokit/plugin-paginate-rest\` 11.3.1 → 11.4.4-cjs.2
- \`@octokit/plugin-rest-endpoint-methods\` 13.2.2 → 13.3.2-cjs.1

No API surface change. No breaking changes.

## Risk

🟢 **No risk.** Patch bump within the 20.x CJS line. Lockfile shows single \`@octokit/rest@20.1.2\`, no stale references.

## Test plan

- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)