### PR TITLE
fix: handle series sorting for pivoted bar charts with no x-axis dimension

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2876,6 +2876,16 @@ const useEchartsCartesianConfig = (
         const xFieldId = validCartesianConfig?.layout?.xField;
         const xAxisConfig = validCartesianConfig?.eChartsConfig.xAxis?.[0];
 
+        // When xField is EMPTY_X_AXIS (no x-axis dimension, bars are pivoted series),
+        // row-based sorting is meaningless (single row) and produces undefined category values.
+        // Series-level sorting for this case is handled separately in sortedSeriesForChart.
+        if (xFieldId === EMPTY_X_AXIS) {
+            return {
+                xAxisSortedResults: sortedResults,
+                xAxisSortedCategoryValues: undefined,
+            };
+        }
+
         // Handle bar totals sorting
         if (
             xFieldId &&
@@ -3375,6 +3385,77 @@ const useEchartsCartesianConfig = (
         validCartesianConfig?.layout?.flipAxes,
     ]);
 
+    // When xField is EMPTY_X_AXIS (pivoted bars with no x-axis dimension),
+    // sorting must reorder the series array since bars are series, not categories.
+    const sortedSeriesForChart = useMemo(() => {
+        if (!stackedSeriesWithColorAssignments?.length) {
+            return stackedSeriesWithColorAssignments;
+        }
+
+        const xFieldId = validCartesianConfig?.layout?.xField;
+        if (xFieldId !== EMPTY_X_AXIS) {
+            return stackedSeriesWithColorAssignments;
+        }
+
+        const xAxisConfig = validCartesianConfig?.eChartsConfig.xAxis?.[0];
+        const sortType = xAxisConfig?.sortType ?? XAxisSortType.DEFAULT;
+        const isInverse = xAxisConfig?.inverse ?? false;
+
+        if (sortType === XAxisSortType.DEFAULT && !isInverse) {
+            return stackedSeriesWithColorAssignments;
+        }
+
+        const sorted = [...stackedSeriesWithColorAssignments];
+
+        if (sortType === XAxisSortType.CATEGORY) {
+            // Sort by series name (pivot value label) alphabetically
+            sorted.sort((a, b) => {
+                const nameA = String(a.name ?? '');
+                const nameB = String(b.name ?? '');
+                return nameA.localeCompare(nameB);
+            });
+        } else if (sortType === XAxisSortType.BAR_TOTALS) {
+            // Sort by metric value from the dataset row
+            const row = xAxisSortedResults[0];
+            if (row) {
+                sorted.sort((a, b) => {
+                    const yKeyA = a.encode?.y;
+                    const yKeyB = b.encode?.y;
+                    const rawA = yKeyA
+                        ? (row as Record<string, unknown>)[yKeyA]
+                        : undefined;
+                    const rawB = yKeyB
+                        ? (row as Record<string, unknown>)[yKeyB]
+                        : undefined;
+                    const valA = Number(
+                        typeof rawA === 'object' && rawA !== null
+                            ? (rawA as { value: unknown }).value
+                            : (rawA ?? 0),
+                    );
+                    const valB = Number(
+                        typeof rawB === 'object' && rawB !== null
+                            ? (rawB as { value: unknown }).value
+                            : (rawB ?? 0),
+                    );
+                    return valA - valB;
+                });
+            }
+        }
+
+        // For DEFAULT with inverse, or CATEGORY/BAR_TOTALS with inverse (descending),
+        // reverse the sorted order
+        if (isInverse) {
+            sorted.reverse();
+        }
+
+        return sorted;
+    }, [
+        stackedSeriesWithColorAssignments,
+        validCartesianConfig?.layout?.xField,
+        validCartesianConfig?.eChartsConfig.xAxis,
+        xAxisSortedResults,
+    ]);
+
     const eChartsOptions = useMemo(() => {
         const enableDataZoom =
             validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.enableDataZoom;
@@ -3384,7 +3465,7 @@ const useEchartsCartesianConfig = (
             xAxis: sortedAxes.xAxis,
             yAxis: sortedAxes.yAxis,
             useUTC: true,
-            series: stackedSeriesWithColorAssignments,
+            series: sortedSeriesForChart,
             animation: !(isInDashboard || minimal),
             legend: legendConfigWithInstructionsTooltip,
             dataset: {
@@ -3425,7 +3506,7 @@ const useEchartsCartesianConfig = (
         };
     }, [
         sortedAxes,
-        stackedSeriesWithColorAssignments,
+        sortedSeriesForChart,
         isInDashboard,
         minimal,
         legendConfigWithInstructionsTooltip,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: https://linear.app/lightdash/issue/PROD-2998/sorting-does-not-apply-to-bar-charts-when-grouping-by-parameterized

Before
<img width="1664" height="827" alt="CleanShot 2026-04-10 at 10 28 51" src="https://github.com/user-attachments/assets/b0e65304-bc01-4799-b5c7-51a74cdb578a" />

After

<img width="1661" height="836" alt="CleanShot 2026-04-10 at 10 29 30" src="https://github.com/user-attachments/assets/103833d5-a747-4db9-894f-225bb7b0e12f" />


### Description:

This PR fixes sorting behavior for pivoted bar charts that have no x-axis dimension (EMPTY_X_AXIS). 

Previously, when users applied sorting to these charts, the sorting logic attempted to reorder categories on the x-axis, but since bars represent series rather than categories in this configuration, the sorting had no visual effect.

The fix introduces two key changes:

1. **Skip row-based sorting for EMPTY_X_AXIS**: When there's no x-axis dimension, row-based sorting is bypassed since it's meaningless for single-row datasets and can produce undefined category values.

2. **Add series-level sorting**: A new `sortedSeriesForChart` function handles sorting by reordering the series array itself, supporting:
   - Category sorting (alphabetical by series name)
   - Bar totals sorting (by metric values)
   - Inverse/descending order for both sort types

This ensures that sorting controls work correctly for pivoted bar charts, providing users with the expected visual reordering of bars based on their selected sort criteria.

test-frontend test-backend create-preview