### PR TITLE
fix(cli): support dbt-fusion patch_path format in generate

### DIFF
--- a/packages/cli/src/dbt/models.ts
+++ b/packages/cli/src/dbt/models.ts
@@ -185,9 +185,12 @@ export const findAndUpdateModelYaml = async ({
     if (patchPath) {
         const { project: expectedYamlProject, path: expectedYamlSubPath } =
             patchPathParts(patchPath);
+        // dbt-fusion omits the project prefix from patch_path — fall back to the
+        // model's packageName, which carries the same information.
+        const resolvedProject = expectedYamlProject ?? packageName;
         const projectSubpath =
-            expectedYamlProject !== projectName
-                ? path.join('dbt_packages', expectedYamlProject)
+            resolvedProject !== projectName
+                ? path.join('dbt_packages', resolvedProject)
                 : '.';
         const expectedYamlPath = path.join(
             projectDir,

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -7,6 +7,7 @@ import {
     convertToAiHints,
     convertToGroups,
     isV9MetricRef,
+    patchPathParts,
     SupportedDbtAdapter,
     type DbtColumnLightdashDimension,
     type DbtColumnMetadata,
@@ -1289,7 +1290,9 @@ export const convertExplores = async (
                     targetDatabase: adapterType,
                     warehouse: model.config?.snowflake_warehouse,
                     databricksCompute: model.config?.databricks_compute,
-                    ymlPath: model.patch_path?.split('://')?.[1],
+                    ymlPath: model.patch_path
+                        ? patchPathParts(model.patch_path).path
+                        : undefined,
                     sqlPath: model.path,
                     spotlightConfig: lightdashProjectConfig.spotlight,
                     ...(meta.ai_hint

--- a/packages/common/src/types/dbt.test.ts
+++ b/packages/common/src/types/dbt.test.ts
@@ -1,4 +1,4 @@
-import { getModelsFromManifest, type DbtManifest } from './dbt';
+import { getModelsFromManifest, patchPathParts, type DbtManifest } from './dbt';
 
 const makeManifest = (nodes: Record<string, object>): DbtManifest =>
     ({
@@ -163,5 +163,50 @@ describe('getModelsFromManifest', () => {
             'model.test.table_model',
             'model.test.view_model',
         ]);
+    });
+});
+
+describe('patchPathParts', () => {
+    it('parses the dbt-core format with project prefix', () => {
+        expect(
+            patchPathParts('dbt_artifacts://models/dim_current_models.yml'),
+        ).toEqual({
+            project: 'dbt_artifacts',
+            path: 'models/dim_current_models.yml',
+        });
+    });
+
+    it('parses dbt-core paths with nested directories', () => {
+        expect(
+            patchPathParts('my_project://models/sources/exposures.yml'),
+        ).toEqual({
+            project: 'my_project',
+            path: 'models/sources/exposures.yml',
+        });
+    });
+
+    it('parses the dbt-fusion format (no project prefix)', () => {
+        expect(patchPathParts('models/dim_current_models.yml')).toEqual({
+            project: null,
+            path: 'models/dim_current_models.yml',
+        });
+    });
+
+    it('normalizes Windows backslashes from dbt-fusion on Windows', () => {
+        expect(patchPathParts('models\\dim_current_models.yml')).toEqual({
+            project: null,
+            path: 'models/dim_current_models.yml',
+        });
+        expect(patchPathParts('models\\sources\\exposures.yml')).toEqual({
+            project: null,
+            path: 'models/sources/exposures.yml',
+        });
+    });
+
+    it('preserves additional :// occurrences after the project separator', () => {
+        expect(patchPathParts('my_project://models/weird://name.yml')).toEqual({
+            project: 'my_project',
+            path: 'models/weird://name.yml',
+        });
     });
 });

--- a/packages/common/src/types/dbt.ts
+++ b/packages/common/src/types/dbt.ts
@@ -11,7 +11,7 @@ import {
     type CompiledModelNode,
     type ParsedMetric,
 } from './dbtFromSchema';
-import { DbtError, ParseError } from './errors';
+import { ParseError } from './errors';
 import { type JoinRelationship } from './explore';
 import {
     FieldType,
@@ -309,16 +309,22 @@ export const normaliseModelDatabase = (
             );
     }
 };
-export const patchPathParts = (patchPath: string) => {
-    const [project, ...rest] = patchPath.split('://');
-    if (rest.length === 0) {
-        throw new DbtError(
-            'Could not parse dbt manifest. It looks like you might be using an old version of dbt. You must be using dbt version 0.20.0 or above.',
-        );
+export const patchPathParts = (
+    patchPath: string,
+): { project: string | null; path: string } => {
+    // dbt-core format: `project://path/to/file.yml`
+    // dbt-fusion format: raw path with no project prefix, may contain Windows backslashes
+    const normalized = patchPath.replace(/\\/g, '/');
+    const separatorIndex = normalized.indexOf('://');
+    if (separatorIndex === -1) {
+        return {
+            project: null,
+            path: normalized,
+        };
     }
     return {
-        project,
-        path: rest.join('://'),
+        project: normalized.slice(0, separatorIndex),
+        path: normalized.slice(separatorIndex + '://'.length),
     };
 };
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-6913/cli-dbt-fusion-patch-path-format-causes-misleading-old-version-of-dbt

### Description:
dbt-fusion manifests write `patch_path` as a raw path (e.g. `models\dim.yml`) rather than dbt-core's `project://models/dim.yml` format, which caused `patchPathParts` to throw a misleading "old version of dbt" error during `lightdash generate` / `lightdash dbt run`.

`patchPathParts` now accepts both formats, normalizes Windows backslashes to forward slashes, and returns `project: null` for the fusion format so callers can fall back to `model.packageName` when resolving the existing YAML file. `translator.ts` also switches to `patchPathParts` so `explore.ymlPath` populates correctly for fusion.


### Testing:
Used the F1 demo project which I recently migrated to dbt fusion

Before:
<img width="1374" height="165" alt="before" src="https://github.com/user-attachments/assets/78e736f9-8bc6-4b0e-b8e1-38238802ac87" />


After:
<img width="1374" height="394" alt="after" src="https://github.com/user-attachments/assets/2b70f7c8-b925-4a23-a933-151e6f434253" />
