### PR TITLE
feat(docker-dev): auto-monitor PM2 logs after start

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -466,6 +466,44 @@ Then start:
 pnpm pm2:start
 ```
 
+### Monitor Logs with Monitor Tool
+
+After PM2 is running, start **two persistent Monitor watchers** to stream backend and frontend errors in real-time. These run for the lifetime of the session — you'll be notified whenever an error or warning appears without needing to poll logs.
+
+**Backend monitor** (API + scheduler errors/warnings):
+
+Use the **Monitor tool** with:
+- description: `Backend errors (API + scheduler)`
+- persistent: `true`
+- command:
+```bash
+pm2 logs "${LD_INSTANCE_ID}-api" "${LD_INSTANCE_ID}-scheduler" --raw 2>/dev/null | grep --line-buffered -E '(\[31m| error: |ERR!|unhandled|ECONNREFUSED|EADDRINUSE|crash|fatal|Cannot find module|TypeError:|ReferenceError:|SyntaxError:|DatabaseError)' | grep --line-buffered -v -E '(last [0-9]+ lines|TAILING|^$)'
+```
+
+**Filter design notes:**
+- `\[31m` matches ANSI red (error-level log lines in raw pm2 output)
+- ` error: ` (with spaces) matches the log-level field without catching `"0 errors"` in info messages
+- `DatabaseError` catches migration/connection issues specifically
+- The `-v` pipeline excludes pm2 metadata lines (TAILING headers, blank lines)
+
+**Frontend monitor** (Vite build errors and warnings):
+
+Use the **Monitor tool** with:
+- description: `Frontend errors (Vite)`
+- persistent: `true`
+- command:
+```bash
+pm2 logs "${LD_INSTANCE_ID}-frontend" --raw 2>/dev/null | grep --line-buffered -E '(ERROR|ELIFECYCLE|✘|Build failed|Could not resolve|Failed to)' | grep --line-buffered -v '(last [0-9]+ lines|^$)'
+```
+
+**Launch both monitors in parallel** (two Monitor tool calls in a single message). They filter for actionable signals only — not raw log streams — so you won't be overwhelmed.
+
+If a monitor fires, investigate the error. Common responses:
+- **EADDRINUSE**: Port conflict — run `./scripts/dev-ports.sh gc` then restart the process
+- **Cannot find module**: Missing build — run `pnpm -F common build`
+- **ECONNREFUSED on 5432**: PostgreSQL container down — restart with `docker compose -p "$LD_COMPOSE_PROJECT" -f docker/docker-compose.dev.instance.yml up -d`
+- **TypeErrors/build failures**: Code issue — read the full log with `pm2 logs ${LD_INSTANCE_ID}-api --lines 50 --nostream`
+
 **Instance-specific PM2 commands:**
 
 | Command | Description |

--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -493,7 +493,7 @@ Use the **Monitor tool** with:
 - persistent: `true`
 - command:
 ```bash
-pm2 logs "${LD_INSTANCE_ID}-frontend" --raw 2>/dev/null | grep --line-buffered -E '(ERROR|ELIFECYCLE|✘|Build failed|Could not resolve|Failed to)' | grep --line-buffered -v '(last [0-9]+ lines|^$)'
+pm2 logs "${LD_INSTANCE_ID}-frontend" --raw 2>/dev/null | grep --line-buffered -E '(ERROR|ELIFECYCLE|✘|Build failed|Could not resolve|Failed to)' | grep --line-buffered -v -E '(last [0-9]+ lines|TAILING|^$)'
 ```
 
 **Launch both monitors in parallel** (two Monitor tool calls in a single message). They filter for actionable signals only — not raw log streams — so you won't be overwhelmed.


### PR DESCRIPTION
## Summary
- After `pnpm pm2:start`, the docker-dev command now automatically launches two persistent Monitor tool watchers that stream errors in real-time
- **Backend monitor**: tails API + scheduler logs, filters for error-level lines (`\[31m` ANSI red, ` error: ` log level), crashes, `DatabaseError` (catches unmigrated DB), missing modules
- **Frontend monitor**: tails Vite output, filters for build failures, unresolved imports

## Details
The grep filters were iterated on to avoid noise:
- Uses ANSI color code `\[31m` + ` error: ` (with spaces) to match error-level log lines without catching info lines like `"0 errors (>1 hour)"`
- Two-stage pipeline (`grep | grep -v`) excludes pm2 metadata (TAILING headers)
- Includes troubleshooting guide for common error patterns (EADDRINUSE, missing modules, DB connection refused)

## Test plan
- [ ] Run `/docker-dev start` on a fresh worktree and verify both monitors launch after PM2 starts
- [ ] Verify monitors stay quiet during normal operation (no false positives from scheduler info logs)
- [ ] Stop the PostgreSQL container and verify the backend monitor fires with ECONNREFUSED
- [ ] Introduce a syntax error in backend code, restart API, verify monitor catches it

🤖 Generated with [Claude Code](https://claude.com/claude-code)