### PR TITLE
fix: cross-model type:number referencing sum_distinct metrics

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -53,6 +53,17 @@ models:
             drivers:
               - total_order_amount
               - total_completed_order_amount
+          # PROD-6869: Cross-model type:number referencing sum_distinct
+          # This metric references customers.total_order_amount_deduped (sum_distinct)
+          # from the joined customers model. Before the fix, this would fail
+          # with "invalid identifier" because the sum_distinct's deduplication
+          # CTE metadata was lost during cross-model reference compilation.
+          deduped_revenue_per_order:
+            type: number
+            sql: ${customers.total_order_amount_deduped} / NULLIF(${unique_order_count}, 0)
+            description: "Average deduped revenue per order. References a cross-model sum_distinct metric to test PROD-6869."
+            format: usd
+            round: 2
         default_time_dimension:
           field: order_date
           interval: MONTH

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -3017,3 +3017,258 @@ export const METRIC_QUERY_NESTED_AGG_MIXED_RAW_NO_DIMS: CompiledMetricQuery = {
     compiledAdditionalMetrics: [],
     compiledCustomDimensions: [],
 };
+
+// --- cross-model type:number referencing sum_distinct fixtures ---
+
+export const EXPLORE_WITH_CROSS_MODEL_SUM_DISTINCT: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'customers',
+    label: 'customers',
+    baseTable: 'customers',
+    tags: [],
+    tables: {
+        customers: {
+            name: 'customers',
+            label: 'customers',
+            database: 'mydb',
+            schema: 'public',
+            sqlTable: 'customers',
+            primaryKey: ['customer_id'],
+            lineageGraph: {},
+            dimensions: {
+                customer_id: {
+                    type: DimensionType.STRING,
+                    name: 'customer_id',
+                    label: 'Customer ID',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.customer_id',
+                    compiledSql: '"customers".customer_id',
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                adjusted_revenue: {
+                    type: MetricType.NUMBER,
+                    name: 'adjusted_revenue',
+                    label: 'Adjusted Revenue',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${orders.total_revenue} * 1.1',
+                    // BUG: compileMetricReference inlines the sum_distinct
+                    // fallback SQL instead of preserving distinct metadata
+                    compiledSql: '(SUM("orders".amount)) * 1.1',
+                    tablesReferences: ['customers', 'orders'],
+                    hidden: false,
+                },
+            },
+        },
+        orders: {
+            name: 'orders',
+            label: 'orders',
+            database: 'mydb',
+            schema: 'public',
+            sqlTable: 'orders',
+            primaryKey: ['order_id'],
+            lineageGraph: {},
+            dimensions: {
+                order_id: {
+                    type: DimensionType.STRING,
+                    name: 'order_id',
+                    label: 'Order ID',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_id',
+                    compiledSql: '"orders".order_id',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                line_item_id: {
+                    type: DimensionType.STRING,
+                    name: 'line_item_id',
+                    label: 'Line Item ID',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.line_item_id',
+                    compiledSql: '"orders".line_item_id',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_revenue: {
+                    type: MetricType.SUM_DISTINCT,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    name: 'total_revenue',
+                    label: 'Total Revenue',
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("orders".amount)',
+                    compiledValueSql: '"orders".amount',
+                    compiledDistinctKeys: ['"orders".line_item_id'],
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+        },
+    },
+    joinedTables: [
+        {
+            table: 'orders',
+            sqlOn: '${customers.customer_id} = ${orders.customer_id}',
+            compiledSqlOn: '("customers".customer_id) = ("orders".customer_id)',
+            type: 'left',
+            relationship: JoinRelationship.ONE_TO_MANY,
+            tablesReferences: ['customers', 'orders'],
+        },
+    ],
+};
+
+export const METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT: CompiledMetricQuery = {
+    exploreName: 'customers',
+    dimensions: ['customers_customer_id'],
+    metrics: ['customers_adjusted_revenue'],
+    filters: {},
+    sorts: [{ fieldId: 'customers_adjusted_revenue', descending: true }],
+    limit: 10,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};
+
+// Same-model: type:number referencing sum_distinct + regular aggregate
+// Tests that references like ${order_count} resolve to dd_base."orders_order_count"
+// instead of being recompiled as raw SQL (which breaks in the outer SELECT context).
+export const EXPLORE_WITH_SAME_MODEL_NUMBER_AND_SUM_DISTINCT: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'orders',
+    label: 'orders',
+    baseTable: 'orders',
+    tags: [],
+    joinedTables: [],
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'orders',
+            database: 'db',
+            schema: 'schema',
+            sqlTable: '"db"."schema"."orders"',
+            primaryKey: ['order_id'],
+            lineageGraph: {},
+            dimensions: {
+                order_id: {
+                    type: DimensionType.STRING,
+                    name: 'order_id',
+                    label: 'Order ID',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_id',
+                    compiledSql: '"orders".order_id',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                line_item_id: {
+                    type: DimensionType.STRING,
+                    name: 'line_item_id',
+                    label: 'Line Item ID',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.line_item_id',
+                    compiledSql: '"orders".line_item_id',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                status: {
+                    type: DimensionType.STRING,
+                    name: 'status',
+                    label: 'Status',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.status',
+                    compiledSql: '"orders".status',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_revenue: {
+                    type: MetricType.SUM_DISTINCT,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    name: 'total_revenue',
+                    label: 'Total Revenue',
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("orders".amount)',
+                    compiledValueSql: '"orders".amount',
+                    compiledDistinctKeys: ['"orders".line_item_id'],
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                order_count: {
+                    type: MetricType.COUNT,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    name: 'order_count',
+                    label: 'Order Count',
+                    sql: '${TABLE}.order_id',
+                    compiledSql: 'COUNT("orders".order_id)',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                avg_deduped_revenue: {
+                    type: MetricType.NUMBER,
+                    fieldType: FieldType.METRIC,
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    name: 'avg_deduped_revenue',
+                    label: 'Avg Deduped Revenue',
+                    sql: '${total_revenue} / NULLIF(${order_count}, 0)',
+                    compiledSql:
+                        '(SUM("orders".amount)) / NULLIF(COUNT("orders".order_id), 0)',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+        },
+    },
+};
+
+export const METRIC_QUERY_SAME_MODEL_NUMBER_WITH_SUM_DISTINCT: CompiledMetricQuery =
+    {
+        exploreName: 'orders',
+        dimensions: ['orders_status'],
+        metrics: ['orders_avg_deduped_revenue'],
+        filters: {},
+        sorts: [{ fieldId: 'orders_avg_deduped_revenue', descending: true }],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };
+
+export const METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT_NO_DIMS: CompiledMetricQuery =
+    {
+        exploreName: 'customers',
+        dimensions: [],
+        metrics: ['customers_adjusted_revenue'],
+        filters: {},
+        sorts: [{ fieldId: 'customers_adjusted_revenue', descending: true }],
+        limit: 10,
+        tableCalculations: [],
+        compiledTableCalculations: [],
+        compiledAdditionalMetrics: [],
+        compiledCustomDimensions: [],
+    };

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -27,10 +27,12 @@ import {
     bigqueryClientMock,
     EXPLORE,
     EXPLORE_WITH_AVERAGE_DISTINCT,
+    EXPLORE_WITH_CROSS_MODEL_SUM_DISTINCT,
     EXPLORE_WITH_CROSS_TABLE_METRICS,
     EXPLORE_WITH_DATE_DIMENSION,
     EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
     EXPLORE_WITH_NESTED_AGG,
+    EXPLORE_WITH_SAME_MODEL_NUMBER_AND_SUM_DISTINCT,
     EXPLORE_WITH_SQL_FILTER,
     EXPLORE_WITH_SUM_DISTINCT,
     EXPLORE_WITHOUT_JOIN_RELATIONSHIPS,
@@ -39,6 +41,8 @@ import {
     METRIC_QUERY,
     METRIC_QUERY_AVERAGE_DISTINCT_NO_DIMS,
     METRIC_QUERY_AVERAGE_DISTINCT_WITH_DIMS,
+    METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT,
+    METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_CROSS_TABLE,
     METRIC_QUERY_NESTED_AGG_COMPLEX,
     METRIC_QUERY_NESTED_AGG_CONDITIONAL,
@@ -54,6 +58,7 @@ import {
     METRIC_QUERY_NESTED_AGG_TRANSITIVE_MIXED,
     METRIC_QUERY_NESTED_AGG_WINDOW_TABLE_REF,
     METRIC_QUERY_NESTED_AGG_WITH_DIMS,
+    METRIC_QUERY_SAME_MODEL_NUMBER_WITH_SUM_DISTINCT,
     METRIC_QUERY_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_SUM_DISTINCT_WITH_DIMS,
     METRIC_QUERY_TWO_TABLES,
@@ -2266,6 +2271,82 @@ LIMIT 10`;
             );
             expect(result.query).toContain('GROUP BY');
             expect(result.query).toContain('dd_orders_avg_shipping_cost');
+        });
+
+        test('type:number metric referencing cross-model sum_distinct should use CTE', () => {
+            const result = buildQuery({
+                explore: EXPLORE_WITH_CROSS_MODEL_SUM_DISTINCT,
+                compiledMetricQuery: METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            // The sum_distinct metric should get a deduplication CTE
+            expect(result.query).toContain('dd_orders_total_revenue');
+            // The CTE should use ROW_NUMBER for deduplication
+            expect(result.query).toContain('ROW_NUMBER() OVER');
+            // The type:number metric should reference the CTE alias,
+            // NOT inline the raw SUM("orders".amount)
+            expect(result.query).toContain(
+                'dd_orders_total_revenue."orders_total_revenue"',
+            );
+            // The inlined fallback SUM should NOT appear in the final SELECT
+            // (it's OK inside the CTE, but not in the outer query)
+            const outerSelect =
+                result.query.split('FROM')[
+                    result.query.split('FROM').length - 1
+                ];
+            // Check the final SELECT doesn't use the raw inlined SQL
+            expect(result.query).not.toMatch(
+                /SELECT[\s\S]*\(SUM\("orders"\.amount\)\) \* 1\.1[\s\S]*FROM(?![\s\S]*AS \()/,
+            );
+        });
+
+        test('same-model type:number referencing sum_distinct + regular aggregate should not break', () => {
+            const result = buildQuery({
+                explore: EXPLORE_WITH_SAME_MODEL_NUMBER_AND_SUM_DISTINCT,
+                compiledMetricQuery:
+                    METRIC_QUERY_SAME_MODEL_NUMBER_WITH_SUM_DISTINCT,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            // The dd CTE should exist for the sum_distinct metric
+            expect(result.query).toContain('dd_orders_total_revenue');
+            // The type:number metric should reference the dd CTE for sum_distinct
+            expect(result.query).toContain(
+                'dd_orders_total_revenue."orders_total_revenue"',
+            );
+            // The non-dd metric (order_count) should reference dd_base, not raw SQL
+            expect(result.query).toContain('dd_base."orders_order_count"');
+            // The outer SELECT after dd_base should use the CTE alias, not
+            // recompile to raw COUNT("orders".order_id)
+            const outerSelect = result.query
+                .split('FROM dd_base')[0]
+                .split('SELECT')
+                .pop();
+            expect(outerSelect).not.toContain('COUNT("orders".order_id)');
+        });
+
+        test('type:number referencing cross-model sum_distinct works without dimensions', () => {
+            const result = buildQuery({
+                explore: EXPLORE_WITH_CROSS_MODEL_SUM_DISTINCT,
+                compiledMetricQuery:
+                    METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT_NO_DIMS,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            // Should still have CTE-based deduplication
+            expect(result.query).toContain('dd_orders_total_revenue');
+            expect(result.query).toContain('ROW_NUMBER() OVER');
+            // Should reference CTE, not inlined SQL
+            expect(result.query).toContain(
+                'dd_orders_total_revenue."orders_total_revenue"',
+            );
         });
     });
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -884,6 +884,54 @@ export class MetricQueryBuilder {
         });
     }
 
+    /**
+     * Returns the set of non-aggregate metric IDs whose SQL templates
+     * reference at least one sum_distinct / average_distinct metric.
+     * These metrics must be excluded from the regular SELECT and instead
+     * handled in the dd CTE outer SELECT so their references can be
+     * rewritten to point at the deduplication CTE aliases.
+     */
+    private getNonAggregateMetricsReferencingDistinct(): Set<string> {
+        const allMetricIds = this.getSelectedAndReferencedMetricIds();
+        const ddMetricIds = new Set(
+            allMetricIds.filter((id) => {
+                try {
+                    const m = this.getMetricFromId(id);
+                    return (
+                        m.type === MetricType.SUM_DISTINCT ||
+                        m.type === MetricType.AVERAGE_DISTINCT
+                    );
+                } catch {
+                    return false;
+                }
+            }),
+        );
+        if (ddMetricIds.size === 0) return new Set();
+
+        const result = new Set<string>();
+        for (const metricId of allMetricIds) {
+            try {
+                const metric = this.getMetricFromId(metricId);
+                if (isNonAggregateMetric(metric)) {
+                    const refs = parseAllReferences(metric.sql, metric.table);
+                    for (const ref of refs) {
+                        const refId = getItemId({
+                            table: ref.refTable,
+                            name: ref.refName,
+                        });
+                        if (ddMetricIds.has(refId)) {
+                            result.add(metricId);
+                            break;
+                        }
+                    }
+                }
+            } catch {
+                // skip
+            }
+        }
+        return result;
+    }
+
     private getMetricsSQL(): {
         tables: string[];
         selects: string[];
@@ -947,6 +995,12 @@ export class MetricQueryBuilder {
                 }
             }
         }
+        // Non-aggregate metrics that reference sum_distinct/average_distinct
+        // metrics are handled in the dd CTE outer SELECT so their references
+        // can be rewritten to point at the deduplication CTE aliases.
+        const nonAggReferencingDd =
+            this.getNonAggregateMetricsReferencingDistinct();
+
         metrics.forEach((field) => {
             try {
                 const alias = field;
@@ -964,6 +1018,14 @@ export class MetricQueryBuilder {
                 }
                 // Metrics with nested aggregate dependencies are handled via CTE
                 if (nestedAggOuterIds.has(field) || innerDepIds.has(field)) {
+                    (metric.tablesReferences || [metric.table]).forEach(
+                        (table) => tables.add(table),
+                    );
+                    return;
+                }
+                // Non-aggregate metrics referencing distinct metrics are
+                // handled in the dd CTE outer SELECT
+                if (nonAggReferencingDd.has(field)) {
                     (metric.tablesReferences || [metric.table]).forEach(
                         (table) => tables.add(table),
                     );
@@ -3913,7 +3975,48 @@ export class MetricQueryBuilder {
             });
             ctes.push(...ddCtes);
 
-            if (hasNonDdSelects) {
+            // Build selects for non-aggregate metrics that reference dd metrics.
+            // Their SQL templates are recompiled so ${ref} expressions pointing
+            // at sum_distinct/average_distinct metrics resolve to the dd CTE
+            // aliases instead of the inlined fallback SUM/AVG SQL.
+            const nonAggDdMetricIds =
+                this.getNonAggregateMetricsReferencingDistinct();
+            const nonAggDdSelects: string[] = [];
+
+            // Build CTE map for replaceMetricReferencesWithCteReferences.
+            // dd_base must come first (its name is used for dimension resolution).
+            // Include all non-dd metrics that land in dd_base so that references
+            // like ${unique_customer_count} resolve to dd_base."metric_id"
+            // instead of being recompiled as raw SQL (which would reference
+            // tables not available in the outer SELECT).
+            const ddMetricIdSet = new Set(ddMetricIds);
+            const metricsInDdBase =
+                this.getSelectedAndReferencedMetricIds().filter(
+                    (id) =>
+                        !ddMetricIdSet.has(id) && !nonAggDdMetricIds.has(id),
+                );
+            const ddCteMap: Array<{ name: string; metrics: string[] }> = [
+                { name: ddBaseCteName, metrics: metricsInDdBase },
+                ...ddMetricIds.map((id) => ({
+                    name: `dd_${snakeCaseName(id)}`,
+                    metrics: [id],
+                })),
+            ];
+            const ddFieldQuoteChar =
+                this.args.warehouseSqlBuilder.getFieldQuoteChar();
+            for (const metricId of nonAggDdMetricIds) {
+                const metric = this.getMetricFromId(metricId);
+                const rewrittenSql =
+                    this.replaceMetricReferencesWithCteReferences(
+                        metric,
+                        ddCteMap,
+                    );
+                nonAggDdSelects.push(
+                    `  ${rewrittenSql} AS ${ddFieldQuoteChar}${metricId}${ddFieldQuoteChar}`,
+                );
+            }
+
+            if (hasNonDdSelects || nonAggDdSelects.length > 0) {
                 ctes.push(
                     MetricQueryBuilder.wrapAsCte(
                         ddBaseCteName,
@@ -3923,7 +4026,11 @@ export class MetricQueryBuilder {
 
                 finalSelectParts = [
                     `SELECT`,
-                    [`  ${ddBaseCteName}.*`, ...ddMetricSelects].join(',\n'),
+                    [
+                        `  ${ddBaseCteName}.*`,
+                        ...ddMetricSelects,
+                        ...nonAggDdSelects,
+                    ].join(',\n'),
                     `FROM ${ddBaseCteName}`,
                     ...ddJoins,
                 ];


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: PROD-6869

<img width="1268" height="762" alt="CleanShot 2026-04-10 at 11 57 56" src="https://github.com/user-attachments/assets/825b0926-2569-47c7-bd60-0488005c2b90" />



### Description:

Fixes cross-model type:number metrics that reference sum_distinct metrics. Previously, when a type:number metric referenced a sum_distinct metric from a joined model, the query would fail with "invalid identifier" because the sum_distinct's deduplication CTE metadata was lost during cross-model reference compilation.

The fix identifies non-aggregate metrics that reference sum_distinct/average_distinct metrics and handles them in the deduplication CTE's outer SELECT instead of the regular SELECT. This allows their SQL templates to be recompiled so that metric references resolve to the correct CTE aliases rather than inlined fallback SQL.

Added comprehensive test coverage including:
- Cross-model type:number referencing sum_distinct with and without dimensions
- Same-model type:number referencing both sum_distinct and regular aggregates
- New test fixture `deduped_revenue_per_order` in the jaffle shop demo that references `customers.total_order_amount_deduped` to validate the fix