### PR TITLE
feat: enable timezone flag per-org via database overrides

### DIFF
--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -411,17 +411,16 @@ export class FeatureFlagModel {
         };
     }
 
-    // Config-only (no PostHog) to avoid needing a user context — this flag
-    // is checked in the query execution path where only userUuid is available,
-    // and loading the full user would add an extra DB query on every query.
-    // It also needs to work for embed users who don't have a user record.
-    private async getEnableTimezoneSupportEnabled({
-        featureFlagId,
-    }: FeatureFlagLogicArgs) {
-        return {
-            id: featureFlagId,
-            enabled: this.lightdashConfig.query.enableTimezoneSupport ?? false,
-        };
+    // No PostHog — checked in the query execution path where adding
+    // latency is not acceptable.
+    private async getEnableTimezoneSupportEnabled(
+        args: FeatureFlagLogicArgs,
+    ): Promise<FeatureFlag> {
+        if (this.lightdashConfig.query.enableTimezoneSupport) {
+            return { id: args.featureFlagId, enabled: true };
+        }
+        const dbResult = await this.getFromDatabase(args);
+        return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 
     private async getEnableDataAppsEnabled(

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1759,6 +1759,8 @@ describe('AsyncQueryService', () => {
 
                 const runAsyncArgs: RunAsyncWarehouseQueryArgs = {
                     userUuid: sessionAccount.user.id,
+                    organizationUuid:
+                        sessionAccount.organization.organizationUuid!,
                     isRegisteredUser: true,
                     projectUuid,
                     query: 'SELECT * FROM test',
@@ -1854,6 +1856,7 @@ describe('AsyncQueryService', () => {
 
             const runAsyncArgs: RunAsyncWarehouseQueryArgs = {
                 userUuid: sessionAccount.user.id,
+                organizationUuid: sessionAccount.organization.organizationUuid!,
                 isRegisteredUser: true,
                 projectUuid,
                 query: 'SELECT * FROM test_table',

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1904,6 +1904,7 @@ export class AsyncQueryService extends ProjectService {
      */
     public async runAsyncWarehouseQuery({
         userUuid,
+        organizationUuid,
         isRegisteredUser,
         isServiceAccount,
         projectUuid,
@@ -1990,6 +1991,7 @@ export class AsyncQueryService extends ProjectService {
             const { enabled: isTimezoneSupportEnabled } =
                 await this.featureFlagModel.get({
                     featureFlagId: FeatureFlags.EnableTimezoneSupport,
+                    user: { userUuid, organizationUuid },
                 });
             const resolvedDataTimezone = isTimezoneSupportEnabled
                 ? warehouseClient.credentials.dataTimezone
@@ -2308,6 +2310,7 @@ export class AsyncQueryService extends ProjectService {
         return {
             projectUuid: query.projectUuid ?? '',
             userUuid: actor.userUuid,
+            organizationUuid: query.organizationUuid,
             queryUuid: query.queryUuid,
             isRegisteredUser: actor.isRegisteredUser,
             isServiceAccount: actor.isServiceAccount,
@@ -2341,6 +2344,7 @@ export class AsyncQueryService extends ProjectService {
         return {
             projectUuid: query.projectUuid ?? '',
             userUuid: actor.userUuid,
+            organizationUuid: query.organizationUuid,
             queryUuid: query.queryUuid,
             isRegisteredUser: actor.isRegisteredUser,
             isServiceAccount: actor.isServiceAccount,
@@ -3108,6 +3112,7 @@ export class AsyncQueryService extends ProjectService {
 
                     const warehouseArgs: RunAsyncWarehouseQueryArgs = {
                         userUuid: account.user.id,
+                        organizationUuid,
                         isRegisteredUser: account.isRegisteredUser(),
                         isServiceAccount: account.isServiceAccount(),
                         projectUuid,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1731,6 +1731,7 @@ export class AsyncQueryService extends ProjectService {
 
     public async runAsyncPreAggregateQuery({
         userUuid,
+        organizationUuid,
         isRegisteredUser,
         isServiceAccount,
         projectUuid,
@@ -1751,6 +1752,7 @@ export class AsyncQueryService extends ProjectService {
 
             await this.runAsyncWarehouseQuery({
                 userUuid,
+                organizationUuid,
                 isRegisteredUser,
                 isServiceAccount,
                 projectUuid,
@@ -1786,6 +1788,7 @@ export class AsyncQueryService extends ProjectService {
             );
             await this.runAsyncWarehouseQuery({
                 userUuid,
+                organizationUuid,
                 isRegisteredUser,
                 isServiceAccount,
                 projectUuid,

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -176,7 +176,7 @@ export const SCHEDULER_POLLING_OPTIONS: PollingOptions = {
 export type RunAsyncWarehouseQueryArgs = {
     projectUuid: string;
     userUuid: string;
-    organizationUuid?: string;
+    organizationUuid: string;
     queryUuid: string;
     isRegisteredUser: boolean;
     isServiceAccount?: boolean;

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -176,6 +176,7 @@ export const SCHEDULER_POLLING_OPTIONS: PollingOptions = {
 export type RunAsyncWarehouseQueryArgs = {
     projectUuid: string;
     userUuid: string;
+    organizationUuid?: string;
     queryUuid: string;
     isRegisteredUser: boolean;
     isServiceAccount?: boolean;


### PR DESCRIPTION
## Summary

- Changed `EnableTimezoneSupport` flag handler to check the database for user/org overrides before falling back to the config env var
- Threaded `organizationUuid` through `RunAsyncWarehouseQueryArgs` so the flag check can resolve org-level overrides
- Avoids PostHog to prevent adding latency in the query execution path

Closes: GLITCH-329