### PR TITLE
fix: inherit font size in ExploreNavLink highlight component

### DIFF
--- a/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreSideBar/ExploreNavLink.tsx
@@ -112,6 +112,7 @@ const ExploreNavLink: React.FC<ExploreNavLinkProps> = ({
                         component={Text}
                         highlight={query ?? ''}
                         truncate
+                        fz="inherit"
                     >
                         {displayLabel}
                     </Highlight>


### PR DESCRIPTION
### Description:
Added `fz="inherit"` property to the Highlight component in ExploreNavLink to ensure the font size is inherited from the parent element rather than using a default size.