### PR TITLE
fix: inherit font size and line height in menu item text spans

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/CellContextMenu.tsx
@@ -176,12 +176,12 @@ const CellContextMenu: FC<
                         leftSection={<MantineIcon icon={IconFilter} />}
                         onClick={handleFilterByValue}
                     >
-                        <Text fz="sm">
+                        <>
                             Filter by{' '}
-                            <Text span fz="sm" fw="bold">
+                            <Text span fz="inherit" lh="inherit" fw="bold">
                                 {value.formatted}
                             </Text>
-                        </Text>
+                        </>
                     </Menu.Item>
                 )}
 

--- a/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
+++ b/packages/frontend/src/components/MetricQueryData/DrillDownMenuItem.tsx
@@ -83,10 +83,12 @@ const DrillDownMenuItem: FC<DrillDownMenuItemProps> = ({
                 leftSection={<MantineIcon icon={IconArrowBarToDown} />}
                 onClick={handleDrillInto}
             >
-                Drill into{' '}
-                <Text span fz="sm" fw="bold">
-                    {value}
-                </Text>
+                <>
+                    Drill into{' '}
+                    <Text span fz="inherit" lh="inherit" fw="bold">
+                        {value}
+                    </Text>
+                </>
             </Menu.Item>
         );
     }

--- a/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
+++ b/packages/frontend/src/components/common/PivotTable/ValueCellMenu.tsx
@@ -198,10 +198,12 @@ const ValueCellMenuDropdownContent: FC<{
                     }
                     onClick={handleOpenDrillIntoModal}
                 >
-                    Drill into{' '}
-                    <Text span fw={500}>
-                        {value.formatted}
-                    </Text>
+                    <>
+                        Drill into{' '}
+                        <Text span fz="inherit" lh="inherit" fw={500}>
+                            {value.formatted}
+                        </Text>
+                    </>
                 </Menu.Item>
             )}
             {isDashboardPage && filters.length > 0 && (


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:
Fixed text styling inheritance issues in menu items by replacing wrapping `Text` components with React fragments and updating nested `Text` components to use `fz="inherit"` and `lh="inherit"` properties. This ensures proper font size and line height inheritance in context menus for filtering, drilling down, and pivot table interactions.