### PR TITLE
fix: inherit font size and line height in table cell header menu item text spans

### DIFF
--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderContextMenu.tsx
@@ -142,7 +142,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             }}
                         >
                             Filter by{' '}
-                            <Text span fz="sm">
+                            <Text span fz="inherit" lh="inherit">
                                 "{getItemLabelWithoutTableName(item)}"
                             </Text>
                         </Menu.Item>
@@ -240,7 +240,7 @@ const ContextMenu: FC<ContextMenuProps> = ({
                             }}
                         >
                             Filter by{' '}
-                            <Text span fw={500}>
+                            <Text span fz="inherit" lh="inherit" fw={500}>
                                 {getItemLabelWithoutTableName(item)}
                             </Text>
                         </Menu.Item>

--- a/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
+++ b/packages/frontend/src/components/Explorer/ResultsCard/ColumnHeaderSortMenuOptions.tsx
@@ -71,7 +71,7 @@ const ColumnHeaderSortMenuOptions: FC<Props> = ({ item, sort }) => {
                         onClick={() => handleSortClick(sortDirection)}
                     >
                         Sort{' '}
-                        <Text span fz="sm" fw="bold">
+                        <Text span fz="inherit" lh="inherit" fw="bold">
                             {getSortLabel(item, sortDirection)}
                         </Text>
                     </Menu.Item>

--- a/packages/frontend/src/components/SimpleTable/DashboardHeaderContextMenu.tsx
+++ b/packages/frontend/src/components/SimpleTable/DashboardHeaderContextMenu.tsx
@@ -61,7 +61,7 @@ const ColumnHeaderSortMenuOptions: FC<Props> = ({ item, tileUuid }) => {
                         }}
                     >
                         Sort{' '}
-                        <Text span fw={500}>
+                        <Text span fz="inherit" lh="inherit" fw={500}>
                             {getSortLabel(item, sortDirection)}
                         </Text>
                     </Menu.Item>


### PR DESCRIPTION
### Description:
Fix text styling inconsistencies in menu items by standardizing font size and line height inheritance. Updates Text components in column header context menus and sort options to use `fz="inherit"` and `lh="inherit"` instead of fixed font sizes, ensuring consistent typography across menu items in the Explorer results card and dashboard table components.