### PR TITLE
fix: include userUuid in filter autocomplete cache key

### DIFF
--- a/packages/backend/src/clients/Aws/S3CacheClient.ts
+++ b/packages/backend/src/clients/Aws/S3CacheClient.ts
@@ -146,6 +146,26 @@ export class S3CacheClient extends S3BaseClient {
         );
     }
 
+    async getIfFresh(
+        key: string,
+        ttlSeconds: number,
+    ): Promise<string | undefined> {
+        const metadata = await this.getResultsMetadata(key).catch(
+            () => undefined,
+        );
+
+        if (
+            !metadata?.LastModified ||
+            new Date().getTime() - metadata.LastModified.getTime() >=
+                ttlSeconds * 1000
+        ) {
+            return undefined;
+        }
+
+        const entry = await this.getResults(key);
+        return entry.Body?.transformToString();
+    }
+
     async getResults(key: string, extension: string = 'json') {
         return wrapSentryTransaction('s3.getResults', { key }, async (span) => {
             if (!this.configuration || !this.s3) {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1095,7 +1095,6 @@ describe('ProjectService', () => {
         });
 
         test('should use different cache keys for users with per-user warehouse credentials', async () => {
-            // Two users with different userUuids who have per-user warehouse credentials
             const userA: SessionUser = {
                 ...user,
                 userUuid: 'user-aaaa-1111',
@@ -1127,7 +1126,6 @@ describe('ProjectService', () => {
             }));
 
             // Mock getWarehouseCredentials to simulate per-user credentials
-            // Each user gets credentials with a userWarehouseCredentialsUuid
             jest.spyOn(
                 // eslint-disable-next-line @typescript-eslint/no-explicit-any
                 serviceWithCache as any,
@@ -1191,6 +1189,95 @@ describe('ProjectService', () => {
 
             // Each user should query the warehouse independently
             expect(runQueryMock).toHaveBeenCalledTimes(2);
+        });
+
+        test('should share cache key when users have shared warehouse credentials', async () => {
+            const userA: SessionUser = {
+                ...user,
+                userUuid: 'user-aaaa-1111',
+            };
+
+            const userB: SessionUser = {
+                ...user,
+                userUuid: 'user-bbbb-2222',
+            };
+
+            const serviceWithCache = getMockedProjectService({
+                ...lightdashConfigMock,
+                results: {
+                    ...lightdashConfigMock.results,
+                    autocompleteEnabled: true,
+                },
+            });
+            serviceWithCache.warehouseClients = {};
+
+            const runQueryMock = jest.fn(
+                async (_sql: string) => resultsWith1Row,
+            );
+            (
+                projectModel.getWarehouseClientFromCredentials as jest.Mock
+            ).mockImplementation(() => ({
+                ...warehouseClientMock,
+                runQuery: runQueryMock,
+            }));
+
+            // No userWarehouseCredentialsUuid — shared project credentials
+            jest.spyOn(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                serviceWithCache as any,
+                'getWarehouseCredentials',
+            ).mockImplementation(async () => ({
+                ...warehouseClientMock.credentials,
+            }));
+
+            const cacheKeyLookups: string[] = [];
+            const cachedResults = new Map<string, string>();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (serviceWithCache as any).s3CacheClient = {
+                getResultsMetadata: jest.fn(async (key: string) => {
+                    cacheKeyLookups.push(key);
+                    return cachedResults.has(key)
+                        ? { LastModified: new Date() }
+                        : undefined;
+                }),
+                getResults: jest.fn(async (key: string) => ({
+                    Body: {
+                        transformToString: async () => cachedResults.get(key),
+                    },
+                })),
+                uploadResults: jest.fn(async (key: string, buffer: Buffer) => {
+                    cachedResults.set(key, buffer.toString());
+                }),
+            };
+
+            await serviceWithCache.searchFieldUniqueValues(
+                userA,
+                projectUuid,
+                'a',
+                'a_dim1',
+                'test',
+                10,
+                undefined,
+                false,
+            );
+
+            await serviceWithCache.searchFieldUniqueValues(
+                userB,
+                projectUuid,
+                'a',
+                'a_dim1',
+                'test',
+                10,
+                undefined,
+                false,
+            );
+
+            // Cache keys must be the same — shared credentials, no per-user scoping
+            expect(cacheKeyLookups[0]).toEqual(cacheKeyLookups[1]);
+
+            // Warehouse should only be queried once — second call hits the cache
+            expect(runQueryMock).toHaveBeenCalledTimes(1);
         });
     });
 

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1111,6 +1111,7 @@ describe('ProjectService', () => {
                 results: {
                     ...lightdashConfigMock.results,
                     autocompleteEnabled: true,
+                    cacheStateTimeSeconds: 86400,
                 },
             });
             serviceWithCache.warehouseClients = {};
@@ -1207,6 +1208,7 @@ describe('ProjectService', () => {
                 results: {
                     ...lightdashConfigMock.results,
                     autocompleteEnabled: true,
+                    cacheStateTimeSeconds: 86400,
                 },
             });
             serviceWithCache.warehouseClients = {};

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -1093,6 +1093,105 @@ describe('ProjectService', () => {
                                         LIMIT 10`),
             );
         });
+
+        test('should use different cache keys for users with per-user warehouse credentials', async () => {
+            // Two users with different userUuids who have per-user warehouse credentials
+            const userA: SessionUser = {
+                ...user,
+                userUuid: 'user-aaaa-1111',
+            };
+
+            const userB: SessionUser = {
+                ...user,
+                userUuid: 'user-bbbb-2222',
+            };
+
+            // Enable autocomplete caching
+            const serviceWithCache = getMockedProjectService({
+                ...lightdashConfigMock,
+                results: {
+                    ...lightdashConfigMock.results,
+                    autocompleteEnabled: true,
+                },
+            });
+            serviceWithCache.warehouseClients = {};
+
+            const runQueryMock = jest.fn(
+                async (_sql: string) => resultsWith1Row,
+            );
+            (
+                projectModel.getWarehouseClientFromCredentials as jest.Mock
+            ).mockImplementation(() => ({
+                ...warehouseClientMock,
+                runQuery: runQueryMock,
+            }));
+
+            // Mock getWarehouseCredentials to simulate per-user credentials
+            // Each user gets credentials with a userWarehouseCredentialsUuid
+            jest.spyOn(
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                serviceWithCache as any,
+                'getWarehouseCredentials',
+            ).mockImplementation(async (...args: unknown[]) => {
+                const { userId } = args[0] as { userId: string };
+                return {
+                    ...warehouseClientMock.credentials,
+                    userWarehouseCredentialsUuid: `cred-${userId}`,
+                };
+            });
+
+            // Mock S3 cache: track all cache key lookups
+            const cacheKeyLookups: string[] = [];
+            const cachedResults = new Map<string, string>();
+
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            (serviceWithCache as any).s3CacheClient = {
+                getResultsMetadata: jest.fn(async (key: string) => {
+                    cacheKeyLookups.push(key);
+                    return cachedResults.has(key)
+                        ? { LastModified: new Date() }
+                        : undefined;
+                }),
+                getResults: jest.fn(async (key: string) => ({
+                    Body: {
+                        transformToString: async () => cachedResults.get(key),
+                    },
+                })),
+                uploadResults: jest.fn(async (key: string, buffer: Buffer) => {
+                    cachedResults.set(key, buffer.toString());
+                }),
+            };
+
+            // User A queries — populates the cache
+            await serviceWithCache.searchFieldUniqueValues(
+                userA,
+                projectUuid,
+                'a',
+                'a_dim1',
+                'test',
+                10,
+                undefined,
+                false,
+            );
+
+            // User B queries the same field
+            await serviceWithCache.searchFieldUniqueValues(
+                userB,
+                projectUuid,
+                'a',
+                'a_dim1',
+                'test',
+                10,
+                undefined,
+                false,
+            );
+
+            // Cache keys must differ when users have per-user warehouse credentials
+            expect(cacheKeyLookups[0]).not.toEqual(cacheKeyLookups[1]);
+
+            // Each user should query the warehouse independently
+            expect(runQueryMock).toHaveBeenCalledTimes(2);
+        });
     });
 
     describe('updateDefaultUserSpaces', () => {

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -998,6 +998,19 @@ describe('ProjectService', () => {
         const replaceWhitespace = (str: string) =>
             str.replace(/\s+/g, ' ').trim();
 
+        const buildS3CacheMock = (
+            lookups: string[],
+            store: Map<string, string>,
+        ) => ({
+            getIfFresh: jest.fn(async (key: string) => {
+                lookups.push(key);
+                return store.get(key);
+            }),
+            uploadResults: jest.fn(async (key: string, buffer: Buffer) => {
+                store.set(key, buffer.toString());
+            }),
+        });
+
         beforeEach(() => {
             // Clear the warehouse clients cache
             service.warehouseClients = {};
@@ -1144,22 +1157,10 @@ describe('ProjectService', () => {
             const cachedResults = new Map<string, string>();
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (serviceWithCache as any).s3CacheClient = {
-                getResultsMetadata: jest.fn(async (key: string) => {
-                    cacheKeyLookups.push(key);
-                    return cachedResults.has(key)
-                        ? { LastModified: new Date() }
-                        : undefined;
-                }),
-                getResults: jest.fn(async (key: string) => ({
-                    Body: {
-                        transformToString: async () => cachedResults.get(key),
-                    },
-                })),
-                uploadResults: jest.fn(async (key: string, buffer: Buffer) => {
-                    cachedResults.set(key, buffer.toString());
-                }),
-            };
+            (serviceWithCache as any).s3CacheClient = buildS3CacheMock(
+                cacheKeyLookups,
+                cachedResults,
+            );
 
             // User A queries — populates the cache
             await serviceWithCache.searchFieldUniqueValues(
@@ -1236,22 +1237,10 @@ describe('ProjectService', () => {
             const cachedResults = new Map<string, string>();
 
             // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            (serviceWithCache as any).s3CacheClient = {
-                getResultsMetadata: jest.fn(async (key: string) => {
-                    cacheKeyLookups.push(key);
-                    return cachedResults.has(key)
-                        ? { LastModified: new Date() }
-                        : undefined;
-                }),
-                getResults: jest.fn(async (key: string) => ({
-                    Body: {
-                        transformToString: async () => cachedResults.get(key),
-                    },
-                })),
-                uploadResults: jest.fn(async (key: string, buffer: Buffer) => {
-                    cachedResults.set(key, buffer.toString());
-                }),
-            };
+            (serviceWithCache as any).s3CacheClient = buildS3CacheMock(
+                cacheKeyLookups,
+                cachedResults,
+            );
 
             await serviceWithCache.searchFieldUniqueValues(
                 userA,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4788,10 +4788,16 @@ export class ProjectService extends BaseService {
         }
 
         if (!forceRefresh && isCacheEnabled && queryHash) {
-            const isCached =
-                await this.s3CacheClient.getResultsMetadata(queryHash);
+            const cacheEntryMetadata = await this.s3CacheClient
+                .getResultsMetadata(queryHash)
+                .catch(() => undefined);
 
-            if (isCached !== undefined) {
+            if (
+                cacheEntryMetadata?.LastModified &&
+                new Date().getTime() -
+                    cacheEntryMetadata.LastModified.getTime() <
+                    this.lightdashConfig.results.cacheStateTimeSeconds * 1000
+            ) {
                 const cacheEntry =
                     await this.s3CacheClient.getResults(queryHash);
                 const stringResults =

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3865,6 +3865,22 @@ export class ProjectService extends BaseService {
         );
     }
 
+    private static getCacheUserUuid(
+        warehouseCredentials: { userWarehouseCredentialsUuid?: string },
+        userId: string,
+    ): string | null {
+        return warehouseCredentials.userWarehouseCredentialsUuid
+            ? userId
+            : null;
+    }
+
+    private static buildCacheHash(parts: (string | null)[]): string {
+        return crypto
+            .createHash('sha256')
+            .update(parts.join('.'))
+            .digest('hex');
+    }
+
     async getResultsFromCacheOrWarehouse({
         projectUuid,
         userUuid,
@@ -3891,14 +3907,9 @@ export class ProjectService extends BaseService {
             'ProjectService.getResultsFromCacheOrWarehouse',
             {},
             async (span) => {
-                // TODO: put this hash function in a util somewhere
-                const queryHashKey = metricQuery.timezone
-                    ? `${projectUuid}.${userUuid}.${query}.${metricQuery.timezone}`
-                    : `${projectUuid}.${userUuid}.${query}`;
-                const queryHash = crypto
-                    .createHash('sha256')
-                    .update(queryHashKey)
-                    .digest('hex');
+                const hashParts = [projectUuid, userUuid, query];
+                if (metricQuery.timezone) hashParts.push(metricQuery.timezone);
+                const queryHash = ProjectService.buildCacheHash(hashParts);
 
                 span.setAttribute('queryHash', queryHash);
                 span.setAttribute('cacheHit', false);
@@ -4197,10 +4208,10 @@ export class ProjectService extends BaseService {
                         'warehouse.type',
                         warehouseClient.credentials.type,
                     );
-                    const userUuid =
-                        warehouseCredentials.userWarehouseCredentialsUuid
-                            ? account.user.id
-                            : null;
+                    const userUuid = ProjectService.getCacheUserUuid(
+                        warehouseCredentials,
+                        account.user.id,
+                    );
                     const { rows, cacheMetadata } =
                         await this.getResultsFromCacheOrWarehouse({
                             projectUuid,
@@ -4772,46 +4783,31 @@ export class ProjectService extends BaseService {
 
         const isCacheEnabled = this.lightdashConfig.results.autocompleteEnabled;
 
-        const userUuid = warehouseCredentials.userWarehouseCredentialsUuid
-            ? user.userUuid
-            : null;
+        const userUuid = ProjectService.getCacheUserUuid(
+            warehouseCredentials,
+            user.userUuid,
+        );
 
-        let queryHash: string | undefined;
-        if (isCacheEnabled) {
-            const cacheKey = metricQuery.timezone
-                ? `${projectUuid}.${userUuid}.cache_autocomplete.${query}.${metricQuery.timezone}`
-                : `${projectUuid}.${userUuid}.cache_autocomplete.${query}`;
-            queryHash = crypto
-                .createHash('sha256')
-                .update(cacheKey)
-                .digest('hex');
-        }
+        const hashParts = [projectUuid, userUuid, 'cache_autocomplete', query];
+        if (metricQuery.timezone) hashParts.push(metricQuery.timezone);
+        const queryHash = ProjectService.buildCacheHash(hashParts);
 
-        if (!forceRefresh && isCacheEnabled && queryHash) {
-            const cacheEntryMetadata = await this.s3CacheClient
-                .getResultsMetadata(queryHash)
+        if (!forceRefresh && isCacheEnabled) {
+            const stringResults = await this.s3CacheClient
+                .getIfFresh(
+                    queryHash,
+                    this.lightdashConfig.results.cacheStateTimeSeconds,
+                )
                 .catch(() => undefined);
-
-            if (
-                cacheEntryMetadata?.LastModified &&
-                new Date().getTime() -
-                    cacheEntryMetadata.LastModified.getTime() <
-                    this.lightdashConfig.results.cacheStateTimeSeconds * 1000
-            ) {
-                const cacheEntry =
-                    await this.s3CacheClient.getResults(queryHash);
-                const stringResults =
-                    await cacheEntry.Body?.transformToString();
-                if (stringResults) {
-                    try {
-                        await sshTunnel.disconnect();
-                        return JSON.parse(stringResults);
-                    } catch (e) {
-                        this.logger.error(
-                            'Error parsing autocomplete cache results:',
-                            e,
-                        );
-                    }
+            if (stringResults) {
+                try {
+                    await sshTunnel.disconnect();
+                    return JSON.parse(stringResults);
+                } catch (e) {
+                    this.logger.error(
+                        'Error parsing autocomplete cache results:',
+                        e,
+                    );
                 }
             }
         }
@@ -4833,7 +4829,7 @@ export class ProjectService extends BaseService {
             }
         }
 
-        if (isCacheEnabled && queryHash) {
+        if (isCacheEnabled) {
             const searchResults = {
                 search,
                 results: Array.from(allResults),
@@ -7030,9 +7026,10 @@ export class ProjectService extends BaseService {
                 query_context: QueryExecutionContext.CALCULATE_TOTAL,
             };
 
-            const userUuid = warehouseCredentials.userWarehouseCredentialsUuid
-                ? account.user.id
-                : null;
+            const userUuid = ProjectService.getCacheUserUuid(
+                warehouseCredentials,
+                account.user.id,
+            );
             const { rows, cacheMetadata } =
                 await this.getResultsFromCacheOrWarehouse({
                     projectUuid,

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4770,14 +4770,17 @@ export class ProjectService extends BaseService {
             availableParameterDefinitions,
         });
 
-        const isCacheEnabled =
-            this.lightdashConfig.results.autocompleteEnabled && !!user.userUuid;
+        const isCacheEnabled = this.lightdashConfig.results.autocompleteEnabled;
+
+        const userUuid = warehouseCredentials.userWarehouseCredentialsUuid
+            ? user.userUuid
+            : null;
 
         let queryHash: string | undefined;
         if (isCacheEnabled) {
             const cacheKey = metricQuery.timezone
-                ? `${projectUuid}.${user.userUuid}.cache_autocomplete.${query}.${metricQuery.timezone}`
-                : `${projectUuid}.${user.userUuid}.cache_autocomplete.${query}`;
+                ? `${projectUuid}.${userUuid}.cache_autocomplete.${query}.${metricQuery.timezone}`
+                : `${projectUuid}.${userUuid}.cache_autocomplete.${query}`;
             queryHash = crypto
                 .createHash('sha256')
                 .update(cacheKey)

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4765,7 +4765,8 @@ export class ProjectService extends BaseService {
             availableParameterDefinitions,
         });
 
-        const isCacheEnabled = this.lightdashConfig.results.autocompleteEnabled;
+        const isUserCacheEnabled =
+            this.lightdashConfig.results.autocompleteEnabled && !!user.userUuid;
 
         const userUuid = getCacheUserUuid(warehouseCredentials, user.userUuid);
 
@@ -4773,7 +4774,7 @@ export class ProjectService extends BaseService {
         if (metricQuery.timezone) hashParts.push(metricQuery.timezone);
         const queryHash = buildCacheHash(hashParts);
 
-        if (!forceRefresh && isCacheEnabled) {
+        if (!forceRefresh && isUserCacheEnabled) {
             const stringResults = await this.s3CacheClient
                 .getIfFresh(
                     queryHash,
@@ -4810,7 +4811,7 @@ export class ProjectService extends BaseService {
             }
         }
 
-        if (isCacheEnabled) {
+        if (isUserCacheEnabled) {
             const searchResults = {
                 search,
                 results: Array.from(allResults),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4770,20 +4770,21 @@ export class ProjectService extends BaseService {
             availableParameterDefinitions,
         });
 
-        const userUuid = warehouseCredentials.userWarehouseCredentialsUuid
-            ? user.userUuid
-            : null;
-        const cacheKey = metricQuery.timezone
-            ? `${projectUuid}.${userUuid}.cache_autocomplete.${query}.${metricQuery.timezone}`
-            : `${projectUuid}.${userUuid}.cache_autocomplete.${query}`;
-        const queryHash = crypto
-            .createHash('sha256')
-            .update(cacheKey)
-            .digest('hex');
+        const isCacheEnabled =
+            this.lightdashConfig.results.autocompleteEnabled && !!user.userUuid;
 
-        const isCacheEnabled = this.lightdashConfig.results.autocompleteEnabled;
+        let queryHash: string | undefined;
+        if (isCacheEnabled) {
+            const cacheKey = metricQuery.timezone
+                ? `${projectUuid}.${user.userUuid}.cache_autocomplete.${query}.${metricQuery.timezone}`
+                : `${projectUuid}.${user.userUuid}.cache_autocomplete.${query}`;
+            queryHash = crypto
+                .createHash('sha256')
+                .update(cacheKey)
+                .digest('hex');
+        }
 
-        if (!forceRefresh && isCacheEnabled) {
+        if (!forceRefresh && isCacheEnabled && queryHash) {
             const isCached =
                 await this.s3CacheClient.getResultsMetadata(queryHash);
 
@@ -4823,7 +4824,7 @@ export class ProjectService extends BaseService {
             }
         }
 
-        if (isCacheEnabled) {
+        if (isCacheEnabled && queryHash) {
             const searchResults = {
                 search,
                 results: Array.from(allResults),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -191,7 +191,6 @@ import {
     warehouseSqlBuilderFromType,
 } from '@lightdash/warehouses';
 import * as Sentry from '@sentry/node';
-import * as crypto from 'crypto';
 import * as fs from 'fs';
 import * as yaml from 'js-yaml';
 import { uniq } from 'lodash';
@@ -254,6 +253,7 @@ import {
     wrapSentryTransaction,
     wrapSentryTransactionSync,
 } from '../../utils';
+import { buildCacheHash, getCacheUserUuid } from '../../utils/cacheUtils';
 import { metricQueryWithLimit as applyMetricQueryLimit } from '../../utils/csvLimitUtils';
 import { EncryptionUtil } from '../../utils/EncryptionUtil/EncryptionUtil';
 import {
@@ -3865,22 +3865,6 @@ export class ProjectService extends BaseService {
         );
     }
 
-    private static getCacheUserUuid(
-        warehouseCredentials: { userWarehouseCredentialsUuid?: string },
-        userId: string,
-    ): string | null {
-        return warehouseCredentials.userWarehouseCredentialsUuid
-            ? userId
-            : null;
-    }
-
-    private static buildCacheHash(parts: (string | null)[]): string {
-        return crypto
-            .createHash('sha256')
-            .update(parts.join('.'))
-            .digest('hex');
-    }
-
     async getResultsFromCacheOrWarehouse({
         projectUuid,
         userUuid,
@@ -3909,7 +3893,7 @@ export class ProjectService extends BaseService {
             async (span) => {
                 const hashParts = [projectUuid, userUuid, query];
                 if (metricQuery.timezone) hashParts.push(metricQuery.timezone);
-                const queryHash = ProjectService.buildCacheHash(hashParts);
+                const queryHash = buildCacheHash(hashParts);
 
                 span.setAttribute('queryHash', queryHash);
                 span.setAttribute('cacheHit', false);
@@ -4208,7 +4192,7 @@ export class ProjectService extends BaseService {
                         'warehouse.type',
                         warehouseClient.credentials.type,
                     );
-                    const userUuid = ProjectService.getCacheUserUuid(
+                    const userUuid = getCacheUserUuid(
                         warehouseCredentials,
                         account.user.id,
                     );
@@ -4783,14 +4767,11 @@ export class ProjectService extends BaseService {
 
         const isCacheEnabled = this.lightdashConfig.results.autocompleteEnabled;
 
-        const userUuid = ProjectService.getCacheUserUuid(
-            warehouseCredentials,
-            user.userUuid,
-        );
+        const userUuid = getCacheUserUuid(warehouseCredentials, user.userUuid);
 
         const hashParts = [projectUuid, userUuid, 'cache_autocomplete', query];
         if (metricQuery.timezone) hashParts.push(metricQuery.timezone);
-        const queryHash = ProjectService.buildCacheHash(hashParts);
+        const queryHash = buildCacheHash(hashParts);
 
         if (!forceRefresh && isCacheEnabled) {
             const stringResults = await this.s3CacheClient
@@ -7026,7 +7007,7 @@ export class ProjectService extends BaseService {
                 query_context: QueryExecutionContext.CALCULATE_TOTAL,
             };
 
-            const userUuid = ProjectService.getCacheUserUuid(
+            const userUuid = getCacheUserUuid(
                 warehouseCredentials,
                 account.user.id,
             );

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -4720,13 +4720,14 @@ export class ProjectService extends BaseService {
                 filters,
             });
 
+        const warehouseCredentials = await this.getWarehouseCredentials({
+            projectUuid,
+            userId: user.userUuid,
+            isRegisteredUser: true,
+        });
         const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
             projectUuid,
-            await this.getWarehouseCredentials({
-                projectUuid,
-                userId: user.userUuid,
-                isRegisteredUser: true,
-            }),
+            warehouseCredentials,
             {
                 snowflakeVirtualWarehouse: explore.warehouse,
                 databricksCompute: explore.databricksCompute,
@@ -4769,9 +4770,12 @@ export class ProjectService extends BaseService {
             availableParameterDefinitions,
         });
 
+        const userUuid = warehouseCredentials.userWarehouseCredentialsUuid
+            ? user.userUuid
+            : null;
         const cacheKey = metricQuery.timezone
-            ? `${projectUuid}.cache_autocomplete.${query}.${metricQuery.timezone}`
-            : `${projectUuid}.cache_autocomplete.${query}`;
+            ? `${projectUuid}.${userUuid}.cache_autocomplete.${query}.${metricQuery.timezone}`
+            : `${projectUuid}.${userUuid}.cache_autocomplete.${query}`;
         const queryHash = crypto
             .createHash('sha256')
             .update(cacheKey)

--- a/packages/backend/src/utils/cacheUtils.ts
+++ b/packages/backend/src/utils/cacheUtils.ts
@@ -1,0 +1,12 @@
+import * as crypto from 'crypto';
+
+export function getCacheUserUuid(
+    warehouseCredentials: { userWarehouseCredentialsUuid?: string },
+    userId: string,
+): string | null {
+    return warehouseCredentials.userWarehouseCredentialsUuid ? userId : null;
+}
+
+export function buildCacheHash(parts: (string | null)[]): string {
+    return crypto.createHash('sha256').update(parts.join('.')).digest('hex');
+}


### PR DESCRIPTION
## Summary

- Adds `userUuid` to the `searchFieldUniqueValues` autocomplete cache key when per-user warehouse credentials are configured, preventing cross-user cache poisoning for deployments with warehouse-level RLS
- Adds TTL checking to the autocomplete cache (was missing — entries never expired, unlike the main results cache)
- Extracts repeated cache patterns into reusable helpers (`getCacheUserUuid`, `buildCacheHash`, `S3CacheClient.getIfFresh`)

## Details

**Cache key fix:** The cache key for filter autocomplete was missing user scoping:
```
${projectUuid}.cache_autocomplete.${query}.${timezone}
```

Now conditionally includes `userUuid` when per-user warehouse credentials exist (matching the pattern in `getResultsFromCacheOrWarehouse`):
```
${projectUuid}.${userUuid}.cache_autocomplete.${query}.${timezone}
```

When `userUuid` is `null` (shared project credentials), all users share the cache — correct, since they connect to the same warehouse with the same credentials.

**TTL fix:** The autocomplete cache previously used entries regardless of age. Now checks `cacheStateTimeSeconds` (default 86400s / 1 day) before serving cached results, via the new `S3CacheClient.getIfFresh()` method.

**Refactor:** Extracted three repeated patterns into shared utilities:
- `getCacheUserUuid()` (`utils/cacheUtils.ts`) — derives user scoping from warehouse credentials (was duplicated at 3 call sites)
- `buildCacheHash()` (`utils/cacheUtils.ts`) — builds and SHA-256 hashes dotted cache key parts (addresses existing TODO)
- `S3CacheClient.getIfFresh()` — TTL-checked cache read combining metadata check + age validation + result fetch

## Test plan

- [x] Regression test: two users with per-user credentials get different cache keys and independent warehouse queries
- [x] Regression test: two users with shared credentials share the same cache key (warehouse queried once)
- [x] All 39 ProjectService tests pass
- [x] Lint and typecheck pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)