### PR TITLE
chore: add formula package reference to frontend tsconfig

### DIFF
--- a/packages/frontend/tsconfig.json
+++ b/packages/frontend/tsconfig.json
@@ -23,14 +23,13 @@
         "noUncheckedIndexedAccess": false, // TODO fix errors, then enable
         "tsBuildInfoFile": "dist/.tsbuildinfo"
     },
-    "include": [
-        "./src",
-        "./sdk/index.tsx",
-        "./vite-env.d.ts"
-    ],
+    "include": ["./src", "./sdk/index.tsx", "./vite-env.d.ts"],
     "references": [
         {
             "path": "../common"
+        },
+        {
+            "path": "../formula"
         },
         {
             "path": "./tsconfig.node.json"


### PR DESCRIPTION
### Description:

This PR adds a TypeScript project reference to the `formula` package in the frontend's `tsconfig.json` configuration. The change enables proper type checking and build dependencies between the frontend and formula packages. Additionally, the `include` array formatting has been condensed to a single line for consistency.