### PR TITLE
fix: disable code splitting in SDK build configuration

### DIFF
--- a/packages/frontend/vite.config.sdk.ts
+++ b/packages/frontend/vite.config.sdk.ts
@@ -18,7 +18,11 @@ export default defineConfig({
         __APP_VERSION__: JSON.stringify(process.env.npm_package_version),
         __SDK_VERSION__: JSON.stringify(sdkPackageJson.version),
     },
-    plugins: [svgrPlugin(), dts({ rollupTypes: true }), cssInjectedByJsPlugin()],
+    plugins: [
+        svgrPlugin(),
+        dts({ rollupTypes: true }),
+        cssInjectedByJsPlugin(),
+    ],
     build: {
         outDir: 'sdk/dist',
         emptyOutDir: true,
@@ -44,6 +48,7 @@ export default defineConfig({
                     react: 'React',
                     'react-dom': 'ReactDOM',
                 },
+                codeSplitting: false,
             },
         },
     },


### PR DESCRIPTION
### Description:
This pull request disables code splitting for the SDK build configuration by setting `codeSplitting: false` in the Vite rollup options. Additionally, the plugins array has been reformatted for better readability with each plugin on its own line.