### PR TITLE
fix: date filter boundaries no longer depend on server timezone

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -1,11 +1,14 @@
+import momentTz from 'moment-timezone';
 import moment from 'moment/moment';
 import { SupportedDbtAdapter } from '../types/dbt';
+import { DimensionType } from '../types/field';
 import { FilterOperator, UnitOfTime, type FilterRule } from '../types/filter';
 import { WeekDay } from '../utils/timeFrames';
 import {
     createBoundaryDateFormatter,
     renderBooleanFilterSql,
     renderDateFilterSql,
+    renderFilterRuleSql,
     renderFilterRuleSqlFromField,
     renderNumberFilterSql,
     renderStringFilterSql,
@@ -2378,4 +2381,93 @@ describe('Number Filter SQL Injection Prevention', () => {
             },
         );
     });
+});
+
+describe('DATE dimension filters are server-timezone-independent', () => {
+    // Regression: the default boundaryFormatter (formatDate) used moment(date)
+    // which formats in the server's local timezone. On a server with a positive
+    // UTC offset, endOf('day') in UTC (23:59 UTC) gets shifted to the next
+    // calendar day, producing a 2-day filter range instead of 1.
+    const systemTime = new Date('10 Apr 2026 14:00:00 GMT');
+
+    beforeEach(() => {
+        jest.setSystemTime(systemTime.getTime());
+    });
+
+    afterEach(() => {
+        // Reset moment default timezone so other tests are unaffected
+        momentTz.tz.setDefault();
+    });
+
+    test.each([
+        ['UTC', 'UTC'],
+        ['Europe/Moscow', 'UTC'],
+        ['Asia/Tokyo', 'UTC'],
+        ['America/New_York', 'UTC'],
+        ['Pacific/Auckland', 'UTC'],
+    ])(
+        'inTheCurrent day for DATE dimension produces single-day range regardless of server TZ=%s',
+        (serverTz, projectTz) => {
+            // Simulate a server running in a non-UTC timezone
+            momentTz.tz.setDefault(serverTz);
+
+            const sql = renderFilterRuleSql(
+                {
+                    id: 'id',
+                    target: { fieldId: 'fieldId' },
+                    operator: FilterOperator.IN_THE_CURRENT,
+                    values: [1],
+                    settings: { unitOfTime: UnitOfTime.days },
+                },
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.POSTGRES,
+                projectTz,
+            );
+
+            // Both boundaries must be the same UTC date — no 2-day range
+            expect(sql).toBe(
+                `((${DimensionSqlMock}) >= ('2026-04-10') AND (${DimensionSqlMock}) <= ('2026-04-10'))`,
+            );
+        },
+    );
+
+    test.each([
+        ['Europe/Moscow', 'UTC'],
+        ['Asia/Tokyo', 'UTC'],
+        ['America/New_York', 'UTC'],
+    ])(
+        'inThePast 1 completed day for DATE dimension is server-TZ-independent (server TZ=%s)',
+        (serverTz, projectTz) => {
+            momentTz.tz.setDefault(serverTz);
+
+            const sql = renderFilterRuleSql(
+                {
+                    id: 'id',
+                    target: { fieldId: 'fieldId' },
+                    operator: FilterOperator.IN_THE_PAST,
+                    values: [1],
+                    settings: {
+                        unitOfTime: UnitOfTime.days,
+                        completed: true,
+                    },
+                },
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.POSTGRES,
+                projectTz,
+            );
+
+            // Yesterday in UTC: April 9
+            expect(sql).toBe(
+                `((${DimensionSqlMock}) >= ('2026-04-09') AND (${DimensionSqlMock}) < ('2026-04-10'))`,
+            );
+        },
+    );
 });

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -556,26 +556,40 @@ const renderDateOrTimestampFilterSql = (
     }
 };
 
-/** Renders filter SQL for DATE-type dimensions. Uses boundaryDateFormatter for computed boundaries. */
+/**
+ * Renders filter SQL for DATE-type dimensions.
+ *
+ * When no explicit boundaryDateFormatter is provided, both boundary
+ * computation and formatting default to UTC.  This matches the warehouse's
+ * UTC-based DATE_TRUNC and removes any dependency on the server's local
+ * timezone.  Callers that enable timezone-aware DATE_TRUNC should pass
+ * createBoundaryDateFormatter(timezone) so both sides use the project
+ * timezone instead.
+ */
 export const renderDateFilterSql = (
     dimensionSql: string,
     filter: DateFilterRule,
     adapterType: SupportedDbtAdapter,
     timezone: string,
-    boundaryDateFormatter: (date: Date) => string = formatDate,
+    boundaryDateFormatter?: (date: Date) => string,
     startOfWeek: WeekDay | null | undefined = undefined,
     baseDimensionSql?: string,
-): string =>
-    renderDateOrTimestampFilterSql(
+): string => {
+    const effectiveTimezone = boundaryDateFormatter ? timezone : 'UTC';
+    const effectiveFormatter =
+        boundaryDateFormatter ?? createBoundaryDateFormatter('UTC');
+
+    return renderDateOrTimestampFilterSql(
         dimensionSql,
         filter,
         adapterType,
-        timezone,
+        effectiveTimezone,
         formatDate,
-        boundaryDateFormatter,
+        effectiveFormatter,
         startOfWeek,
         baseDimensionSql,
     );
+};
 
 /** Renders filter SQL for TIMESTAMP-type dimensions. Both literals and boundaries use the same UTC formatter. */
 export const renderTimestampFilterSql = (


### PR DESCRIPTION
## Summary

DATE dimension filters (`in the current day`, `in the past N days`, etc.) used `moment(date)` to format boundary dates, which formats in the **server's local timezone**. On servers with a non-UTC timezone, `endOf('day')` at 23:59 UTC gets shifted to the next calendar day, producing a 2-day filter range instead of 1.

**Fix:** When timezone-aware `DATE_TRUNC` is off, force boundary computation and formatting to UTC — matching the warehouse's UTC-based `DATE_TRUNC`. When the flag is on, both use the project timezone.

**Before**
<img width="1808" height="785" alt="CleanShot 2026-04-10 at 16 11 01" src="https://github.com/user-attachments/assets/81e51ada-31a0-45e3-9f12-f3decc5b82ea" />

**After**
<img width="1801" height="789" alt="CleanShot 2026-04-10 at 16 09 28" src="https://github.com/user-attachments/assets/234c6a41-8043-4589-9e4e-1a3712d7fa6c" />

## Context

**Before timezone work:** All filters used `timezone = 'UTC'`. Boundaries computed in UTC, formatted with `formatDate` (server-local time). Worked because servers run in UTC and the timezone was always UTC.

**PR #21637:** Made all relative date operators consistently use `.tz(timezone)`. Once non-UTC project timezones started flowing through, `formatDate` (which formats in server-local time) became a problem for DATE dimensions. The boundary dates could land on different calendar days depending on the server's timezone.

**This PR:** When no explicit boundary formatter is provided, `renderDateFilterSql` now defaults both boundary computation and formatting to UTC. This restores the original UTC-based behavior, makes it server-timezone-independent, and keeps filter boundaries aligned with the warehouse's UTC-based `DATE_TRUNC`. When timezone-aware `DATE_TRUNC` is enabled #21874 , callers pass an explicit formatter and both sides use the project timezone instead.

## Test plan

- [x] Added tests that simulate non-UTC server timezones via `moment.tz.setDefault()` and verify single-day boundaries
- [x] Verified tests fail without the fix (5 failures on positive-offset server TZs)
- [ ] Manual: set project timezone to non-UTC, apply `in the current day` filter on a date dimension, verify SQL shows single-day range