### PR TITLE
fix: prevent hidden dimensions in required/default filters

### DIFF
--- a/packages/common/.eslintrc.js
+++ b/packages/common/.eslintrc.js
@@ -23,6 +23,7 @@ module.exports = {
             },
         ],
         '@typescript-eslint/only-throw-error': 'warn',
+        '@typescript-eslint/no-throw-literal': 'warn',
         '@typescript-eslint/no-unused-vars': [
             'error',
             {

--- a/packages/common/src/compiler/exploreCompiler.mock.ts
+++ b/packages/common/src/compiler/exploreCompiler.mock.ts
@@ -180,6 +180,46 @@ export const exploreOneEmptyTableCompiled: Explore = {
     },
 };
 
+export const createExploreWithRequiredFilters = (
+    requiredFilters: UncompiledExplore['tables'][string]['requiredFilters'],
+): UncompiledExplore => ({
+    ...exploreOneEmptyTable,
+    name: 'orders',
+    label: 'Orders',
+    baseTable: 'orders',
+    tables: {
+        orders: {
+            ...exploreOneEmptyTable.tables.a,
+            name: 'orders',
+            label: 'Orders',
+            dimensions: {
+                credit_card_amount: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.NUMBER,
+                    name: 'credit_card_amount',
+                    label: 'Credit card amount',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.credit_card_amount',
+                    hidden: true,
+                },
+                has_credit_card_payment: {
+                    fieldType: FieldType.DIMENSION,
+                    type: DimensionType.BOOLEAN,
+                    name: 'has_credit_card_payment',
+                    label: 'Has credit card payment',
+                    table: 'orders',
+                    tableLabel: 'Orders',
+                    sql: '${TABLE}.credit_card_amount > 0',
+                    hidden: false,
+                    isAdditionalDimension: true,
+                },
+            },
+            requiredFilters,
+        },
+    },
+});
+
 export const exploreMissingBaseTable: UncompiledExplore = {
     ...exploreBase,
     spotlightConfig: DEFAULT_SPOTLIGHT_CONFIG,

--- a/packages/common/src/compiler/exploreCompiler.test.ts
+++ b/packages/common/src/compiler/exploreCompiler.test.ts
@@ -1,6 +1,7 @@
 import { SupportedDbtAdapter } from '../types/dbt';
 import { CompileError } from '../types/errors';
 import { DimensionType, FieldType, friendlyName } from '../types/field';
+import { FilterOperator } from '../types/filter';
 import {
     ExploreCompiler,
     parseAllReferences,
@@ -23,6 +24,7 @@ import {
     compiledSimpleJoinedExplore,
     compiledSimpleJoinedExploreWithAlwaysTrue,
     compiledSimpleJoinedExploreWithBaseTableDescription,
+    createExploreWithRequiredFilters,
     customSqlDimensionWithNoReferences,
     customSqlDimensionWithReferences,
     expectedCompiledCustomSqlDimensionWithNoReferences,
@@ -73,6 +75,60 @@ import {
 } from './exploreCompiler.mock';
 
 const compiler = new ExploreCompiler(warehouseClientMock);
+
+test('Should throw when required/default filters reference a hidden dimension', () => {
+    const exploreWithHiddenRequiredFilter = createExploreWithRequiredFilters([
+        {
+            id: 'hidden-filter',
+            target: { fieldRef: 'credit_card_amount' },
+            operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+            values: [0],
+            required: true,
+        },
+        {
+            id: 'visible-filter',
+            target: { fieldRef: 'has_credit_card_payment' },
+            operator: FilterOperator.EQUALS,
+            values: ['true'],
+            required: true,
+        },
+    ]);
+
+    const compileExplore = () =>
+        compiler.compileExplore(exploreWithHiddenRequiredFilter);
+
+    expect(compileExplore).toThrowError(
+        /Hidden fields can't be used in default_filters or required_filters/,
+    );
+    expect(compileExplore).toThrowError(/credit_card_amount/);
+});
+
+test('Should allow required/default filters on visible additional dimensions', () => {
+    const exploreWithVisibleAdditionalRequiredFilter =
+        createExploreWithRequiredFilters([
+            {
+                id: 'visible-filter',
+                target: { fieldRef: 'has_credit_card_payment' },
+                operator: FilterOperator.EQUALS,
+                values: ['true'],
+                required: true,
+            },
+        ]);
+
+    const compiledExplore = compiler.compileExplore(
+        exploreWithVisibleAdditionalRequiredFilter,
+    );
+
+    expect(compiledExplore.tables.orders.requiredFilters).toEqual(
+        expect.arrayContaining([
+            expect.objectContaining({
+                target: expect.objectContaining({
+                    fieldRef: 'has_credit_card_payment',
+                }),
+            }),
+        ]),
+    );
+});
 
 test('Should compile empty table', () => {
     expect(compiler.compileExplore(exploreOneEmptyTable)).toStrictEqual(

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -25,6 +25,7 @@ import {
     type FieldCompilationError,
     type Metric,
 } from '../types/field';
+import { type ModelRequiredFilterRule } from '../types/filter';
 import { type LightdashProjectConfig } from '../types/lightdashProjectConfig';
 import { type PreAggregateDef } from '../types/preAggregate';
 import {
@@ -180,6 +181,59 @@ export const getParsedReference = (
     return { refTable, refName };
 };
 
+const getDimensionFromRequiredFilter = ({
+    requiredFilter,
+    baseTable,
+    tables,
+}: {
+    requiredFilter: ModelRequiredFilterRule;
+    baseTable: string;
+    tables: Record<string, Table>;
+}): Dimension | undefined => {
+    const { refTable, refName } = getParsedReference(
+        requiredFilter.target.fieldRef,
+        baseTable,
+    );
+    const table = tables[refTable];
+
+    if (!table) {
+        return undefined;
+    }
+
+    // Keep required/default filter reference matching case-insensitive,
+    // consistent with metric filter dimension matching in this compiler.
+    const dimensionRefName = Object.keys(table.dimensions).find(
+        (key) => key.toLowerCase() === refName.toLowerCase(),
+    );
+
+    return dimensionRefName ? table.dimensions[dimensionRefName] : undefined;
+};
+
+const getHiddenRequiredFilterRefs = ({
+    requiredFilters,
+    baseTable,
+    tables,
+}: {
+    requiredFilters: ModelRequiredFilterRule[] | undefined;
+    baseTable: string;
+    tables: Record<string, Table>;
+}): string[] => {
+    if (!requiredFilters || requiredFilters.length === 0) {
+        return [];
+    }
+
+    return requiredFilters
+        .filter((requiredFilter) => {
+            const dimension = getDimensionFromRequiredFilter({
+                requiredFilter,
+                baseTable,
+                tables,
+            });
+            return dimension?.hidden === true;
+        })
+        .map((requiredFilter) => requiredFilter.target.fieldRef);
+};
+
 export const getAllReferences = (raw: string): string[] =>
     (raw.match(lightdashVariablePattern) || []).map(
         (value) => value.slice(2, value.length - 1), // value without brackets
@@ -277,6 +331,21 @@ export class ExploreCompiler {
         if (!tables[baseTable]) {
             throw new CompileError(
                 `Failed to compile explore "${name}". Tried to find base table but cannot find table with name "${baseTable}"`,
+                {},
+            );
+        }
+
+        const hiddenRequiredFilterRefs = getHiddenRequiredFilterRefs({
+            requiredFilters: tables[baseTable].requiredFilters,
+            baseTable,
+            tables,
+        });
+
+        if (hiddenRequiredFilterRefs.length > 0) {
+            throw new CompileError(
+                `Failed to compile explore "${name}". Hidden fields can't be used in default_filters or required_filters: ${hiddenRequiredFilterRefs.join(
+                    ', ',
+                )}.`,
                 {},
             );
         }

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -1278,6 +1278,108 @@ describe('explore-scoped additional dimensions', () => {
     });
 });
 
+describe('required/default filters on hidden dimensions', () => {
+    const createOrdersModel = (
+        defaultFilters: Array<Record<string, unknown>>,
+    ): DbtModelNode => ({
+        ...model,
+        name: 'orders',
+        alias: 'orders',
+        relation_name: 'orders',
+        columns: {
+            status: {
+                name: 'status',
+                data_type: DimensionType.STRING,
+                meta: {
+                    dimension: {
+                        type: DimensionType.STRING,
+                    },
+                },
+            },
+            credit_card_amount: {
+                name: 'credit_card_amount',
+                data_type: DimensionType.NUMBER,
+                meta: {
+                    dimension: {
+                        type: DimensionType.NUMBER,
+                        hidden: true,
+                    },
+                    additional_dimensions: {
+                        has_credit_card_payment: {
+                            type: DimensionType.BOOLEAN,
+                            label: 'Has credit card payment',
+                            sql: '${TABLE}.credit_card_amount > 0',
+                        },
+                    },
+                },
+            },
+        },
+        meta: {
+            default_filters:
+                defaultFilters as DbtModelNode['meta']['default_filters'],
+        },
+    });
+
+    it('should fail only the explore with hidden-dimension default filters and keep base explore valid', async () => {
+        const modelWithExploreScopedFilters: DbtModelNode = {
+            ...createOrdersModel([]),
+            meta: {
+                explores: {
+                    orders_news_portal: {
+                        label: 'Orders News Portal',
+                        default_filters: [
+                            {
+                                credit_card_amount: '>= 0',
+                                required: true,
+                            },
+                            {
+                                has_credit_card_payment: 'true',
+                                required: true,
+                            },
+                        ] as DbtModelNode['meta']['default_filters'],
+                    },
+                },
+            },
+        };
+
+        const explores = await convertExplores(
+            [modelWithExploreScopedFilters],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            [],
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+        );
+
+        const baseExplore = explores.find((e) => e.name === 'orders');
+        const exploreWithHiddenFilterError = explores.find(
+            (e) => e.name === 'orders_news_portal',
+        );
+
+        expect(baseExplore).toBeDefined();
+        expect(baseExplore && 'errors' in baseExplore).toBe(false);
+        expect(exploreWithHiddenFilterError).toBeDefined();
+        expect(
+            exploreWithHiddenFilterError &&
+                'errors' in exploreWithHiddenFilterError,
+        ).toBe(true);
+
+        if (
+            exploreWithHiddenFilterError &&
+            'errors' in exploreWithHiddenFilterError
+        ) {
+            expect(exploreWithHiddenFilterError.errors[0].message).toContain(
+                'credit_card_amount',
+            );
+            expect(exploreWithHiddenFilterError.errors[0].type).toBe(
+                InlineErrorType.METADATA_PARSE_ERROR,
+            );
+        }
+    });
+});
+
 describe('custom granularities', () => {
     const customGranularities = {
         slt_week: {


### PR DESCRIPTION
closes: https://github.com/lightdash/lightdash/issues/21924  
closes: [PROD-6920](https://linear.app/lightdash/issue/PROD-6920/default-filters-on-hidden-dimensions-show-unknown-id-in-ui-but-still)  
  
docs: https://github.com/lightdash/mintlify-docs/pull/537  
  
Description:

This PR adds validation to prevent hidden dimensions from being used in required/default filters. The explore compiler now throws a `CompileError` when hidden dimensions are referenced in `default_filters` or `required_filters`, suggesting the use of visible additional dimensions instead.