### PR TITLE
fix: scope custom HTTP headers to internal requests only to prevent CORS failures

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -887,14 +887,28 @@ export class UnfurlService extends BaseService {
                                       ...viewport,
                                       width: gridWidth ?? viewport.width,
                                   },
-                        extraHTTPHeaders: {
-                            [LightdashRequestMethodHeader]:
-                                RequestMethod.HEADLESS_BROWSER,
-                            'Lightdash-Headless-Browser-Context': context,
-                            'Lightdash-Headless-Browser-Context-Id': contextId
-                                ? contextId.toString()
-                                : 'undefined',
-                        },
+                    });
+
+                    // Add custom headers only to internal Lightdash API requests.
+                    // Using extraHTTPHeaders on newPage() would add these headers to ALL requests
+                    // including cross-origin ones (e.g. Google Fonts), causing CORS preflight failures.
+                    // See: https://github.com/lightdash/lightdash/issues/17452
+                    const internalHost =
+                        this.lightdashConfig.headlessBrowser
+                            .internalLightdashHost;
+                    await page.route(`${internalHost}/**`, async (route) => {
+                        await route.continue({
+                            headers: {
+                                ...route.request().headers(),
+                                [LightdashRequestMethodHeader]:
+                                    RequestMethod.HEADLESS_BROWSER,
+                                'Lightdash-Headless-Browser-Context': context,
+                                'Lightdash-Headless-Browser-Context-Id':
+                                    contextId
+                                        ? contextId.toString()
+                                        : 'undefined',
+                            },
+                        });
                     });
 
                     // Polyfill crypto.randomUUID (needed for Loom iframes)

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1085,26 +1085,31 @@ export class UnfurlService extends BaseService {
                                 .internalLightdashHostIgnoreHttpsErrors,
                     });
 
-                    // Add custom headers only to internal Lightdash API requests.
-                    // Using extraHTTPHeaders on newPage() would add these headers to ALL requests
-                    // including cross-origin ones (e.g. Google Fonts), causing CORS preflight failures.
-                    // See: https://github.com/lightdash/lightdash/issues/17452
+                    // Scope custom headers to internal requests only — setting them
+                    // on every request (e.g. Google Fonts) triggers CORS preflight failures.
                     const internalHost =
-                        this.lightdashConfig.headlessBrowser
-                            .internalLightdashHost;
+                        this.lightdashConfig.headlessBrowser.internalLightdashHost.replace(
+                            /\/+$/,
+                            '',
+                        );
                     await page.route(`${internalHost}/**`, async (route) => {
-                        await route.continue({
-                            headers: {
-                                ...route.request().headers(),
-                                [LightdashRequestMethodHeader]:
-                                    RequestMethod.HEADLESS_BROWSER,
-                                'Lightdash-Headless-Browser-Context': context,
-                                'Lightdash-Headless-Browser-Context-Id':
-                                    contextId
-                                        ? contextId.toString()
-                                        : 'undefined',
-                            },
-                        });
+                        try {
+                            await route.continue({
+                                headers: {
+                                    ...route.request().headers(),
+                                    [LightdashRequestMethodHeader]:
+                                        RequestMethod.HEADLESS_BROWSER,
+                                    'Lightdash-Headless-Browser-Context':
+                                        context,
+                                    'Lightdash-Headless-Browser-Context-Id':
+                                        contextId
+                                            ? contextId.toString()
+                                            : 'undefined',
+                                },
+                            });
+                        } catch {
+                            await route.fallback().catch(() => {});
+                        }
                     });
 
                     if (lightdashPage === LightdashPage.APP) {

--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1075,14 +1075,6 @@ export class UnfurlService extends BaseService {
 
                     page = await browser.newPage({
                         viewport: initialViewport,
-                        extraHTTPHeaders: {
-                            [LightdashRequestMethodHeader]:
-                                RequestMethod.HEADLESS_BROWSER,
-                            'Lightdash-Headless-Browser-Context': context,
-                            'Lightdash-Headless-Browser-Context-Id': contextId
-                                ? contextId.toString()
-                                : 'undefined',
-                        },
                         // Allow self-signed / untrusted certs when the
                         // internal Lightdash host is reached through an
                         // HTTPS ingress whose cert isn't in the browserless
@@ -1091,6 +1083,28 @@ export class UnfurlService extends BaseService {
                         ignoreHTTPSErrors:
                             this.lightdashConfig.headlessBrowser
                                 .internalLightdashHostIgnoreHttpsErrors,
+                    });
+
+                    // Add custom headers only to internal Lightdash API requests.
+                    // Using extraHTTPHeaders on newPage() would add these headers to ALL requests
+                    // including cross-origin ones (e.g. Google Fonts), causing CORS preflight failures.
+                    // See: https://github.com/lightdash/lightdash/issues/17452
+                    const internalHost =
+                        this.lightdashConfig.headlessBrowser
+                            .internalLightdashHost;
+                    await page.route(`${internalHost}/**`, async (route) => {
+                        await route.continue({
+                            headers: {
+                                ...route.request().headers(),
+                                [LightdashRequestMethodHeader]:
+                                    RequestMethod.HEADLESS_BROWSER,
+                                'Lightdash-Headless-Browser-Context': context,
+                                'Lightdash-Headless-Browser-Context-Id':
+                                    contextId
+                                        ? contextId.toString()
+                                        : 'undefined',
+                            },
+                        });
                     });
 
                     if (lightdashPage === LightdashPage.APP) {


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/17452

## Problem

The `extraHTTPHeaders` set on `browser.newPage()` in `UnfurlService.saveScreenshot()` are added to **all** HTTP requests from the page, including cross-origin ones to external services.

This causes CORS preflight failures because the custom headers (`Lightdash-Headless-Browser-Context`, `Lightdash-Request-Method`, etc.) are not listed in the `Access-Control-Allow-Headers` of external servers.

## Solution

Replace `extraHTTPHeaders` on `newPage()` with `page.route()` that adds custom headers **only** to requests matching the internal Lightdash host (`INTERNAL_LIGHTDASH_HOST`). External requests are left unmodified.

This preserves the existing functionality of identifying headless browser requests in the backend while avoiding CORS issues with external resources.

## Testing

- Verified that the route pattern `${internalHost}/**` correctly matches internal API requests
