### PR TITLE
fix: prevent $ref pointers in MCP schema generation

### DIFF
--- a/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.test.ts
+++ b/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.test.ts
@@ -541,6 +541,31 @@ describe('McpSchemaCompatLayer', () => {
         });
     });
 
+    describe('JSON Schema $ref generation', () => {
+        // Regression test: zodToJsonSchema must not produce $ref pointers in
+        // the run_metric_query schema. The MCP Gateway cannot resolve them and
+        // returns 500 ERR_INVALID_URL when filters are present.
+        test('toolRunMetricQueryArgsSchema should not produce $ref pointers', () => {
+            // Use the same zodToJsonSchema that the MCP SDK uses internally
+            // eslint-disable-next-line @typescript-eslint/no-var-requires, global-require
+            const { zodToJsonSchema } = require('zod-to-json-schema') as {
+                zodToJsonSchema: (
+                    schema: z.ZodSchema,
+                    opts?: Record<string, unknown>,
+                ) => Record<string, unknown>;
+            };
+            const processed = mcpSchemaCompatLayer.processZodType(
+                toolRunMetricQueryArgsSchema,
+            );
+            const jsonSchema = zodToJsonSchema(processed, {
+                strictUnions: true,
+                pipeStrategy: 'input',
+            });
+            const serialized = JSON.stringify(jsonSchema);
+            expect(serialized).not.toContain('"$ref"');
+        });
+    });
+
     describe('pagination schema', () => {
         const schema = toolFindFieldsArgsSchema;
         const schemaTransformed = toolFindFieldsArgsSchemaTransformed;

--- a/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.ts
+++ b/packages/backend/src/ee/services/McpService/McpSchemaCompatLayer.ts
@@ -10,10 +10,31 @@ import {
     SchemaCompatLayer,
     type AllZodType,
 } from '@mastra/schema-compat';
-import { z, ZodDefault, ZodNullable, ZodType, type ZodTypeAny } from 'zod';
+import {
+    z,
+    ZodDefault,
+    ZodDiscriminatedUnion,
+    ZodNullable,
+    type ZodTypeAny,
+} from 'zod';
 
 const isNullable = (v: ZodTypeAny): v is ZodNullable<AnyType> =>
     v._def.typeName === 'ZodNullable';
+
+const isDiscriminatedUnion = (
+    v: ZodTypeAny,
+): v is ZodDiscriminatedUnion<string, AnyType> =>
+    v._def.typeName === 'ZodDiscriminatedUnion';
+
+/**
+ * Create a new Zod schema instance with the same _def but a distinct object
+ * identity. zodToJsonSchema uses reference equality to detect shared schemas
+ * and emits $ref pointers for them. The MCP Gateway cannot resolve those
+ * pointers and returns 500 ERR_INVALID_URL. By cloning every node during
+ * processZodType, we guarantee all output instances are unique.
+ */
+const cloneZodInstance = (v: AnyType): AnyType =>
+    new (v.constructor as new (def: AnyType) => AnyType)({ ...v._def });
 
 export class McpSchemaCompatLayer extends SchemaCompatLayer {
     constructor() {
@@ -35,9 +56,14 @@ export class McpSchemaCompatLayer extends SchemaCompatLayer {
     }
 
     processZodType(value: AnyType): AnyType {
+        // Clone the node so every processed schema has a unique identity.
+        // This prevents zodToJsonSchema from generating $ref pointers when
+        // the MCP SDK converts the schema for tool listing.
+        const v = cloneZodInstance(value);
+
         // Handle nullable types (e.g., z.string().nullable()) map them to optional but default to null
-        if (isNullable(value)) {
-            let innerType = this.processZodType(value._def.innerType);
+        if (isNullable(v)) {
+            let innerType = this.processZodType(v._def.innerType);
 
             // fix for `.default(...).nullable()`
             if (!(innerType instanceof ZodDefault)) {
@@ -47,20 +73,20 @@ export class McpSchemaCompatLayer extends SchemaCompatLayer {
             return innerType
                 .describe(
                     [
-                        value.description ?? '',
-                        value._def.innerType.description ?? '',
+                        v.description ?? '',
+                        v._def.innerType.description ?? '',
                     ].join(', '),
                 )
                 .transform((val: AnyType) => (val === undefined ? null : val));
         }
 
         // always coerce numbers
-        if (isNumber(value)) {
-            return z.preprocess((val) => Number(val), value);
+        if (isNumber(v)) {
+            return z.preprocess((val) => Number(val), v);
         }
 
         // Identical to packages/backend/node_modules/@mastra/schema-compat/src/provider-compats/anthropic.ts
-        if (isOptional(value)) {
+        if (isOptional(v)) {
             const handleTypes: AllZodType[] = [
                 'ZodObject',
                 'ZodArray',
@@ -69,22 +95,35 @@ export class McpSchemaCompatLayer extends SchemaCompatLayer {
                 'ZodUndefined',
                 'ZodTuple',
             ];
-            return this.defaultZodOptionalHandler(value, handleTypes);
+            return this.defaultZodOptionalHandler(v, handleTypes);
         }
-        if (isObj(value)) {
-            return this.defaultZodObjectHandler(value);
+        if (isObj(v)) {
+            return this.defaultZodObjectHandler(v);
         }
-        if (isArr(value)) {
-            return this.defaultZodArrayHandler(value, []);
+        if (isArr(v)) {
+            return this.defaultZodArrayHandler(v, []);
         }
-        if (isUnion(value)) {
-            return this.defaultZodUnionHandler(value);
+        if (isUnion(v)) {
+            return this.defaultZodUnionHandler(v);
         }
-        if (isString(value)) {
-            return value;
+        // ZodDiscriminatedUnion is not recognized by isUnion() from
+        // @mastra/schema-compat, so handle it explicitly by converting to a
+        // regular union. This ensures its variants are recursively processed
+        // (and therefore cloned) to prevent $ref generation.
+        if (isDiscriminatedUnion(v)) {
+            return this.defaultZodUnionHandler(
+                z.union(
+                    v._def.options.map((opt: AnyType) =>
+                        this.processZodType(opt),
+                    ),
+                ),
+            );
+        }
+        if (isString(v)) {
+            return v;
         }
 
-        return this.defaultUnsupportedZodTypeHandler(value, [
+        return this.defaultUnsupportedZodTypeHandler(v, [
             'ZodNever',
             'ZodTuple',
             'ZodUndefined',


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Fixed MCP Gateway 500 ERR_INVALID_URL errors by preventing `$ref` pointer generation in JSON schemas. The issue occurred because `zodToJsonSchema` uses reference equality to detect shared schemas and emits `$ref` pointers for them, which the MCP Gateway cannot resolve.

The fix introduces schema cloning during processing to ensure all Zod instances have unique identities. Added explicit handling for `ZodDiscriminatedUnion` types by converting them to regular unions, and implemented a `cloneZodInstance` function that creates new instances with the same definitions but distinct object identities.

Includes a regression test that verifies `toolRunMetricQueryArgsSchema` does not produce `$ref` pointers when converted to JSON schema.