### PR TITLE
feat: add drag-and-drop reordering for dashboard parameters

### DIFF
--- a/packages/common/src/types/dashboard.ts
+++ b/packages/common/src/types/dashboard.ts
@@ -177,6 +177,7 @@ export type DashboardConfig = {
     isDateZoomDisabled: boolean;
     isAddFilterDisabled?: boolean;
     pinnedParameters?: string[];
+    parameterOrder?: string[];
     dateZoomGranularities?: (DateGranularity | string)[];
     defaultDateZoomGranularity?: DateGranularity | string;
 };

--- a/packages/frontend/src/components/PinnedParameters.tsx
+++ b/packages/frontend/src/components/PinnedParameters.tsx
@@ -3,8 +3,6 @@ import {
     DragOverlay,
     MouseSensor,
     TouchSensor,
-    useDraggable,
-    useDroppable,
     useSensor,
     useSensors,
     type DragEndEvent,
@@ -21,66 +19,13 @@ import {
     Group,
     Popover,
     Text,
-    useMantineTheme,
 } from '@mantine-8/core';
 import { IconGripVertical } from '@tabler/icons-react';
-import { useCallback, useMemo, type FC, type ReactNode } from 'react';
+import { useCallback, useMemo, type FC } from 'react';
 import { ParameterInput } from '../features/parameters/components/ParameterInput';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
+import { DraggableItem, DroppableArea } from './common/DndHelpers';
 import MantineIcon from './common/MantineIcon';
-
-const DraggableItem: FC<{
-    id: string;
-    children: ReactNode;
-    disabled?: boolean;
-}> = ({ id, children, disabled }) => {
-    const { attributes, listeners, setNodeRef, transform } = useDraggable({
-        id,
-        disabled,
-    });
-
-    const style = transform
-        ? ({
-              position: 'relative',
-              zIndex: 1,
-              transform: `translate(${transform.x}px, ${transform.y}px)`,
-              opacity: 0.8,
-          } as const)
-        : undefined;
-
-    return (
-        <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
-            {children}
-        </div>
-    );
-};
-
-const DroppableArea: FC<{
-    id: string;
-    children: ReactNode;
-    pinnedKeys: string[];
-}> = ({ id, children, pinnedKeys }) => {
-    const { active, isOver, over, setNodeRef } = useDroppable({ id });
-    const { colors } = useMantineTheme();
-
-    const placeholderStyle = useMemo(() => {
-        if (isOver && active && over && active.id !== over.id) {
-            const oldIndex = pinnedKeys.indexOf(String(active.id));
-            const newIndex = pinnedKeys.indexOf(String(over.id));
-            if (newIndex < oldIndex) {
-                return { boxShadow: `-8px 0px ${colors.blue[4]}` };
-            } else if (newIndex > oldIndex) {
-                return { boxShadow: `8px 0px ${colors.blue[4]}` };
-            }
-        }
-    }, [isOver, active, over, pinnedKeys, colors]);
-
-    return (
-        <div ref={setNodeRef} style={placeholderStyle}>
-            {children}
-        </div>
-    );
-};
 
 interface PinnedParameterProps {
     parameterKey: string;
@@ -280,7 +225,7 @@ const PinnedParameters: FC<PinnedParametersProps> = ({ isEditMode }) => {
                     <DroppableArea
                         key={key}
                         id={key}
-                        pinnedKeys={pinnedParameterKeys}
+                        orderedKeys={pinnedParameterKeys}
                     >
                         <DraggableItem id={key} disabled={!isEditMode}>
                             <PinnedParameter

--- a/packages/frontend/src/components/PinnedParameters.tsx
+++ b/packages/frontend/src/components/PinnedParameters.tsx
@@ -1,12 +1,4 @@
-import {
-    DndContext,
-    DragOverlay,
-    MouseSensor,
-    TouchSensor,
-    useSensor,
-    useSensors,
-    type DragEndEvent,
-} from '@dnd-kit/core';
+import { DndContext, DragOverlay, type DragEndEvent } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 import {
     type LightdashProjectParameter,
@@ -23,6 +15,7 @@ import {
 import { IconGripVertical } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import { ParameterInput } from '../features/parameters/components/ParameterInput';
+import { useDndSensors } from '../hooks/useDndSensors';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
 import { DraggableItem, DroppableArea } from './common/DndHelpers';
 import MantineIcon from './common/MantineIcon';
@@ -169,13 +162,7 @@ const PinnedParameters: FC<PinnedParametersProps> = ({ isEditMode }) => {
 
     const pinnedParameterKeys = useDashboardContext((c) => c.pinnedParameters);
 
-    const mouseSensor = useSensor(MouseSensor, {
-        activationConstraint: { distance: 10 },
-    });
-    const touchSensor = useSensor(TouchSensor, {
-        activationConstraint: { delay: 250, tolerance: 5 },
-    });
-    const dragSensors = useSensors(mouseSensor, touchSensor);
+    const dragSensors = useDndSensors();
 
     const handleParameterChange = useCallback(
         (key: string, value: ParameterValue | null) => {

--- a/packages/frontend/src/components/PinnedParameters.tsx
+++ b/packages/frontend/src/components/PinnedParameters.tsx
@@ -1,4 +1,16 @@
 import {
+    DndContext,
+    DragOverlay,
+    MouseSensor,
+    TouchSensor,
+    useDraggable,
+    useDroppable,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+} from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
+import {
     type LightdashProjectParameter,
     type ParameterValue,
 } from '@lightdash/common';
@@ -9,10 +21,66 @@ import {
     Group,
     Popover,
     Text,
+    useMantineTheme,
 } from '@mantine-8/core';
-import { useCallback, useMemo, type FC } from 'react';
+import { IconGripVertical } from '@tabler/icons-react';
+import { useCallback, useMemo, type FC, type ReactNode } from 'react';
 import { ParameterInput } from '../features/parameters/components/ParameterInput';
 import useDashboardContext from '../providers/Dashboard/useDashboardContext';
+import MantineIcon from './common/MantineIcon';
+
+const DraggableItem: FC<{
+    id: string;
+    children: ReactNode;
+    disabled?: boolean;
+}> = ({ id, children, disabled }) => {
+    const { attributes, listeners, setNodeRef, transform } = useDraggable({
+        id,
+        disabled,
+    });
+
+    const style = transform
+        ? ({
+              position: 'relative',
+              zIndex: 1,
+              transform: `translate(${transform.x}px, ${transform.y}px)`,
+              opacity: 0.8,
+          } as const)
+        : undefined;
+
+    return (
+        <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
+            {children}
+        </div>
+    );
+};
+
+const DroppableArea: FC<{
+    id: string;
+    children: ReactNode;
+    pinnedKeys: string[];
+}> = ({ id, children, pinnedKeys }) => {
+    const { active, isOver, over, setNodeRef } = useDroppable({ id });
+    const { colors } = useMantineTheme();
+
+    const placeholderStyle = useMemo(() => {
+        if (isOver && active && over && active.id !== over.id) {
+            const oldIndex = pinnedKeys.indexOf(String(active.id));
+            const newIndex = pinnedKeys.indexOf(String(over.id));
+            if (newIndex < oldIndex) {
+                return { boxShadow: `-8px 0px ${colors.blue[4]}` };
+            } else if (newIndex > oldIndex) {
+                return { boxShadow: `8px 0px ${colors.blue[4]}` };
+            }
+        }
+    }, [isOver, active, over, pinnedKeys, colors]);
+
+    return (
+        <div ref={setNodeRef} style={placeholderStyle}>
+            {children}
+        </div>
+    );
+};
 
 interface PinnedParameterProps {
     parameterKey: string;
@@ -21,6 +89,7 @@ interface PinnedParameterProps {
     onChange: (key: string, value: ParameterValue | null) => void;
     onUnpin: (key: string) => void;
     isEditMode: boolean;
+    isDraggable?: boolean;
     projectUuid?: string;
 }
 
@@ -31,6 +100,7 @@ const PinnedParameter: FC<PinnedParameterProps> = ({
     onChange,
     onUnpin,
     isEditMode,
+    isDraggable = false,
     projectUuid,
 }) => {
     const parameterValues = useDashboardContext((c) => c.parameterValues);
@@ -67,17 +137,15 @@ const PinnedParameter: FC<PinnedParameterProps> = ({
                 <Button
                     size="xs"
                     variant="default"
-                    styles={{
-                        inner: {
-                            color: 'foreground',
-                        },
-                        label: {
-                            maxWidth: '300px',
-                            whiteSpace: 'nowrap',
-                            overflow: 'hidden',
-                            textOverflow: 'ellipsis',
-                        },
-                    }}
+                    leftSection={
+                        isDraggable && (
+                            <MantineIcon
+                                icon={IconGripVertical}
+                                cursor="grab"
+                                size="sm"
+                            />
+                        )
+                    }
                     rightSection={
                         isEditMode ? (
                             <CloseButton
@@ -139,8 +207,19 @@ const PinnedParameters: FC<PinnedParametersProps> = ({ isEditMode }) => {
         (c) => c.parameterDefinitions,
     );
     const toggleParameterPin = useDashboardContext((c) => c.toggleParameterPin);
+    const setPinnedParameters = useDashboardContext(
+        (c) => c.setPinnedParameters,
+    );
 
     const pinnedParameterKeys = useDashboardContext((c) => c.pinnedParameters);
+
+    const mouseSensor = useSensor(MouseSensor, {
+        activationConstraint: { distance: 10 },
+    });
+    const touchSensor = useSensor(TouchSensor, {
+        activationConstraint: { delay: 250, tolerance: 5 },
+    });
+    const dragSensors = useSensors(mouseSensor, touchSensor);
 
     const handleParameterChange = useCallback(
         (key: string, value: ParameterValue | null) => {
@@ -154,6 +233,18 @@ const PinnedParameters: FC<PinnedParametersProps> = ({ isEditMode }) => {
             toggleParameterPin(key);
         },
         [toggleParameterPin],
+    );
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            const { active, over } = event;
+            if (!active || !over || active.id === over.id) return;
+            const oldIndex = pinnedParameterKeys.indexOf(String(active.id));
+            const newIndex = pinnedParameterKeys.indexOf(String(over.id));
+            const newOrder = arrayMove(pinnedParameterKeys, oldIndex, newIndex);
+            setPinnedParameters(newOrder);
+        },
+        [pinnedParameterKeys, setPinnedParameters],
     );
 
     if (!pinnedParameterKeys.length || !parameterDefinitions) {
@@ -172,20 +263,31 @@ const PinnedParameters: FC<PinnedParametersProps> = ({ isEditMode }) => {
     }
 
     return (
-        <Group gap="xs">
-            {pinnedParametersList.map(({ key, parameter }) => (
-                <PinnedParameter
-                    key={key}
-                    parameterKey={key}
-                    parameter={parameter}
-                    value={parameterValues[key] ?? null}
-                    onChange={handleParameterChange}
-                    onUnpin={handleUnpin}
-                    isEditMode={isEditMode}
-                    projectUuid={dashboard?.projectUuid}
-                />
-            ))}
-        </Group>
+        <DndContext sensors={dragSensors} onDragEnd={handleDragEnd}>
+            <Group gap="xs">
+                {pinnedParametersList.map(({ key, parameter }) => (
+                    <DroppableArea
+                        key={key}
+                        id={key}
+                        pinnedKeys={pinnedParameterKeys}
+                    >
+                        <DraggableItem id={key} disabled={!isEditMode}>
+                            <PinnedParameter
+                                parameterKey={key}
+                                parameter={parameter}
+                                value={parameterValues[key] ?? null}
+                                onChange={handleParameterChange}
+                                onUnpin={handleUnpin}
+                                isEditMode={isEditMode}
+                                isDraggable={isEditMode}
+                                projectUuid={dashboard?.projectUuid}
+                            />
+                        </DraggableItem>
+                    </DroppableArea>
+                ))}
+            </Group>
+            <DragOverlay />
+        </DndContext>
     );
 };
 

--- a/packages/frontend/src/components/PinnedParameters.tsx
+++ b/packages/frontend/src/components/PinnedParameters.tsx
@@ -137,6 +137,17 @@ const PinnedParameter: FC<PinnedParameterProps> = ({
                 <Button
                     size="xs"
                     variant="default"
+                    styles={{
+                        inner: {
+                            color: 'foreground',
+                        },
+                        label: {
+                            maxWidth: '300px',
+                            whiteSpace: 'nowrap',
+                            overflow: 'hidden',
+                            textOverflow: 'ellipsis',
+                        },
+                    }}
                     leftSection={
                         isDraggable && (
                             <MantineIcon

--- a/packages/frontend/src/components/common/DndHelpers.tsx
+++ b/packages/frontend/src/components/common/DndHelpers.tsx
@@ -1,0 +1,56 @@
+import { useDraggable, useDroppable } from '@dnd-kit/core';
+import { Box, useMantineTheme } from '@mantine-8/core';
+import { useMemo, type FC, type ReactNode } from 'react';
+
+export const DraggableItem: FC<{
+    id: string;
+    children: ReactNode;
+    disabled?: boolean;
+}> = ({ id, children, disabled }) => {
+    const { attributes, listeners, setNodeRef, transform } = useDraggable({
+        id,
+        disabled,
+    });
+
+    const style = transform
+        ? ({
+              position: 'relative',
+              zIndex: 1,
+              transform: `translate(${transform.x}px, ${transform.y}px)`,
+              opacity: 0.8,
+          } as const)
+        : undefined;
+
+    return (
+        <Box ref={setNodeRef} style={style} {...listeners} {...attributes}>
+            {children}
+        </Box>
+    );
+};
+
+export const DroppableArea: FC<{
+    id: string;
+    children: ReactNode;
+    orderedKeys: string[];
+}> = ({ id, children, orderedKeys }) => {
+    const { active, isOver, over, setNodeRef } = useDroppable({ id });
+    const { colors } = useMantineTheme();
+
+    const placeholderStyle = useMemo(() => {
+        if (isOver && active && over && active.id !== over.id) {
+            const oldIndex = orderedKeys.indexOf(String(active.id));
+            const newIndex = orderedKeys.indexOf(String(over.id));
+            if (newIndex < oldIndex) {
+                return { boxShadow: `-8px 0px ${colors.blue[4]}` };
+            } else if (newIndex > oldIndex) {
+                return { boxShadow: `8px 0px ${colors.blue[4]}` };
+            }
+        }
+    }, [isOver, active, over, orderedKeys, colors]);
+
+    return (
+        <Box ref={setNodeRef} style={placeholderStyle}>
+            {children}
+        </Box>
+    );
+};

--- a/packages/frontend/src/features/dashboardFilters/DashboardFiltersBar.tsx
+++ b/packages/frontend/src/features/dashboardFilters/DashboardFiltersBar.tsx
@@ -32,6 +32,8 @@ type Props = {
     missingRequiredParameters: string[];
     pinnedParameters: string[];
     onParameterPin: (parameterKey: string) => void;
+    parameterOrder: string[];
+    onParameterReorder: (order: string[]) => void;
     isDateZoomDisabled: boolean;
     onCollapse: () => void;
 };
@@ -49,6 +51,8 @@ export const DashboardFiltersBar: FC<Props> = ({
     missingRequiredParameters,
     pinnedParameters,
     onParameterPin,
+    parameterOrder,
+    onParameterReorder,
     isDateZoomDisabled,
     onCollapse,
 }) => {
@@ -133,6 +137,8 @@ export const DashboardFiltersBar: FC<Props> = ({
                                         }
                                         pinnedParameters={pinnedParameters}
                                         onParameterPin={onParameterPin}
+                                        parameterOrder={parameterOrder}
+                                        onParameterReorder={onParameterReorder}
                                         separator={parametersSeparator}
                                     />
                                     <PinnedParameters isEditMode={isEditMode} />

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -208,6 +208,8 @@ type DashboardTabsProps = {
     onParameterChange: (key: string, value: ParameterValue | null) => void;
     onParameterClearAll: () => void;
     onParameterPin: (parameterKey: string) => void;
+    parameterOrder: string[];
+    onParameterReorder: (order: string[]) => void;
 };
 
 const DashboardTabs: FC<DashboardTabsProps> = ({
@@ -232,6 +234,8 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
     onParameterChange,
     onParameterClearAll,
     onParameterPin,
+    parameterOrder,
+    onParameterReorder,
 }) => {
     const gridProps = useMemo(() => getResponsiveGridLayoutProps(), []);
     const [currentCols, setCurrentCols] = useState(gridProps.cols.lg);
@@ -1007,6 +1011,12 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                     }
                                                     onParameterPin={
                                                         onParameterPin
+                                                    }
+                                                    parameterOrder={
+                                                        parameterOrder
+                                                    }
+                                                    onParameterReorder={
+                                                        onParameterReorder
                                                     }
                                                     isDateZoomDisabled={
                                                         isDateZoomDisabled

--- a/packages/frontend/src/features/parameters/components/Parameter.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameter.tsx
@@ -15,7 +15,7 @@ import {
     Tooltip,
 } from '@mantine-8/core';
 import { useId } from '@mantine-8/hooks';
-import { IconX } from '@tabler/icons-react';
+import { IconGripVertical, IconX } from '@tabler/icons-react';
 import { useCallback, useMemo, type FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
 import styles from './Parameter.module.css';
@@ -33,6 +33,7 @@ type Props = {
     projectUuid?: string;
     isRequired?: boolean;
     isEditMode?: boolean;
+    isDraggable?: boolean;
 };
 
 const Parameter: FC<Props> = ({
@@ -46,6 +47,7 @@ const Parameter: FC<Props> = ({
     onParameterChange,
     projectUuid,
     isRequired = false,
+    isDraggable = false,
 }) => {
     const popoverId = useId();
     const isPopoverOpen = openPopoverId === popoverId;
@@ -140,6 +142,15 @@ const Parameter: FC<Props> = ({
                             hasUnsetRequiredParameter
                                 ? styles.unsetRequired
                                 : ''
+                        }
+                        leftSection={
+                            isDraggable && (
+                                <MantineIcon
+                                    icon={IconGripVertical}
+                                    cursor="grab"
+                                    size="sm"
+                                />
+                            )
                         }
                         rightSection={
                             hasValue && (

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -1,12 +1,4 @@
-import {
-    DndContext,
-    DragOverlay,
-    MouseSensor,
-    TouchSensor,
-    useSensor,
-    useSensors,
-    type DragEndEvent,
-} from '@dnd-kit/core';
+import { DndContext, DragOverlay, type DragEndEvent } from '@dnd-kit/core';
 import { arrayMove } from '@dnd-kit/sortable';
 import {
     type ParameterDefinitions,
@@ -20,6 +12,7 @@ import {
     DraggableItem,
     DroppableArea,
 } from '../../../components/common/DndHelpers';
+import { useDndSensors } from '../../../hooks/useDndSensors';
 import Parameter from './Parameter';
 
 type Props = {
@@ -61,13 +54,7 @@ export const Parameters: FC<Props> = ({
         setOpenPopoverId(undefined);
     }, []);
 
-    const mouseSensor = useSensor(MouseSensor, {
-        activationConstraint: { distance: 10 },
-    });
-    const touchSensor = useSensor(TouchSensor, {
-        activationConstraint: { delay: 250, tolerance: 5 },
-    });
-    const dragSensors = useSensors(mouseSensor, touchSensor);
+    const dragSensors = useDndSensors();
 
     // Sort parameter entries by parameterOrder, with unordered params appended at the end
     const sortedParamEntries = useMemo(() => {

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -1,12 +1,77 @@
 import {
+    DndContext,
+    DragOverlay,
+    MouseSensor,
+    TouchSensor,
+    useDraggable,
+    useDroppable,
+    useSensor,
+    useSensors,
+    type DragEndEvent,
+} from '@dnd-kit/core';
+import { arrayMove } from '@dnd-kit/sortable';
+import {
     type ParameterDefinitions,
     type ParametersValuesMap,
     type ParameterValue,
 } from '@lightdash/common';
-import { Group, Skeleton } from '@mantine-8/core';
-import { useCallback, useState, type FC, type ReactNode } from 'react';
+import { Group, Skeleton, useMantineTheme } from '@mantine-8/core';
+import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
 import { useParams } from 'react-router';
 import Parameter from './Parameter';
+
+const DraggableItem: FC<{
+    id: string;
+    children: ReactNode;
+    disabled?: boolean;
+}> = ({ id, children, disabled }) => {
+    const { attributes, listeners, setNodeRef, transform } = useDraggable({
+        id,
+        disabled,
+    });
+
+    const style = transform
+        ? ({
+              position: 'relative',
+              zIndex: 1,
+              transform: `translate(${transform.x}px, ${transform.y}px)`,
+              opacity: 0.8,
+          } as const)
+        : undefined;
+
+    return (
+        <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
+            {children}
+        </div>
+    );
+};
+
+const DroppableArea: FC<{
+    id: string;
+    children: ReactNode;
+    orderedKeys: string[];
+}> = ({ id, children, orderedKeys }) => {
+    const { active, isOver, over, setNodeRef } = useDroppable({ id });
+    const { colors } = useMantineTheme();
+
+    const placeholderStyle = useMemo(() => {
+        if (isOver && active && over && active.id !== over.id) {
+            const oldIndex = orderedKeys.indexOf(String(active.id));
+            const newIndex = orderedKeys.indexOf(String(over.id));
+            if (newIndex < oldIndex) {
+                return { boxShadow: `-8px 0px ${colors.blue[4]}` };
+            } else if (newIndex > oldIndex) {
+                return { boxShadow: `8px 0px ${colors.blue[4]}` };
+            }
+        }
+    }, [isOver, active, over, orderedKeys, colors]);
+
+    return (
+        <div ref={setNodeRef} style={placeholderStyle}>
+            {children}
+        </div>
+    );
+};
 
 type Props = {
     isEditMode: boolean;
@@ -19,6 +84,8 @@ type Props = {
     onParameterPin?: (paramKey: string) => void;
     isLoading?: boolean;
     isError?: boolean;
+    parameterOrder?: string[];
+    onParameterReorder?: (order: string[]) => void;
     /** Separator element to render with the first parameter (so they wrap together) */
     separator?: ReactNode;
 };
@@ -31,6 +98,8 @@ export const Parameters: FC<Props> = ({
     isLoading,
     missingRequiredParameters = [],
     separator,
+    parameterOrder = [],
+    onParameterReorder,
 }) => {
     const { projectUuid } = useParams<{ projectUuid: string }>();
     const [openPopoverId, setOpenPopoverId] = useState<string | undefined>();
@@ -42,6 +111,53 @@ export const Parameters: FC<Props> = ({
     const handlePopoverClose = useCallback(() => {
         setOpenPopoverId(undefined);
     }, []);
+
+    const mouseSensor = useSensor(MouseSensor, {
+        activationConstraint: { distance: 10 },
+    });
+    const touchSensor = useSensor(TouchSensor, {
+        activationConstraint: { delay: 250, tolerance: 5 },
+    });
+    const dragSensors = useSensors(mouseSensor, touchSensor);
+
+    // Sort parameter entries by parameterOrder, with unordered params appended at the end
+    const sortedParamEntries = useMemo(() => {
+        if (!parameters) return [];
+        const allKeys = Object.keys(parameters);
+        if (parameterOrder.length === 0) {
+            return allKeys.map((key) => [key, parameters[key]] as const);
+        }
+        const orderedKeys = parameterOrder.filter((key) =>
+            allKeys.includes(key),
+        );
+        const unorderedKeys = allKeys.filter(
+            (key) => !parameterOrder.includes(key),
+        );
+        return [...orderedKeys, ...unorderedKeys].map(
+            (key) => [key, parameters[key]] as const,
+        );
+    }, [parameters, parameterOrder]);
+
+    const orderedKeys = useMemo(
+        () => sortedParamEntries.map(([key]) => key),
+        [sortedParamEntries],
+    );
+
+    const handleDragEnd = useCallback(
+        (event: DragEndEvent) => {
+            const { active, over } = event;
+            if (!active || !over || active.id === over.id) return;
+            const oldIndex = orderedKeys.indexOf(String(active.id));
+            const newIndex = orderedKeys.indexOf(String(over.id));
+            const newOrder = arrayMove(orderedKeys, oldIndex, newIndex);
+            onParameterReorder?.(newOrder);
+        },
+        [orderedKeys, onParameterReorder],
+    );
+
+    const handleDragStart = useCallback(() => {
+        handlePopoverClose();
+    }, [handlePopoverClose]);
 
     if (!parameters || Object.keys(parameters).length === 0) {
         return null;
@@ -57,28 +173,41 @@ export const Parameters: FC<Props> = ({
         );
     }
 
-    const paramEntries = Object.entries(parameters);
-
     return (
-        <>
-            {paramEntries.map(([paramKey, parameter], index) => {
+        <DndContext
+            sensors={dragSensors}
+            onDragStart={handleDragStart}
+            onDragEnd={handleDragEnd}
+        >
+            {sortedParamEntries.map(([paramKey, parameter], index) => {
                 const paramComponent = (
-                    <Parameter
+                    <DroppableArea
                         key={paramKey}
-                        paramKey={paramKey}
-                        parameter={parameter}
-                        value={parameterValues[paramKey] ?? null}
-                        parameterValues={parameterValues}
-                        openPopoverId={openPopoverId}
-                        onPopoverOpen={handlePopoverOpen}
-                        onPopoverClose={handlePopoverClose}
-                        onParameterChange={onParameterChange}
-                        projectUuid={projectUuid}
-                        isRequired={missingRequiredParameters.includes(
-                            paramKey,
-                        )}
-                        isEditMode={isEditMode}
-                    />
+                        id={paramKey}
+                        orderedKeys={orderedKeys}
+                    >
+                        <DraggableItem
+                            id={paramKey}
+                            disabled={!isEditMode || !!openPopoverId}
+                        >
+                            <Parameter
+                                paramKey={paramKey}
+                                parameter={parameter}
+                                value={parameterValues[paramKey] ?? null}
+                                parameterValues={parameterValues}
+                                openPopoverId={openPopoverId}
+                                onPopoverOpen={handlePopoverOpen}
+                                onPopoverClose={handlePopoverClose}
+                                onParameterChange={onParameterChange}
+                                projectUuid={projectUuid}
+                                isRequired={missingRequiredParameters.includes(
+                                    paramKey,
+                                )}
+                                isEditMode={isEditMode}
+                                isDraggable={isEditMode}
+                            />
+                        </DraggableItem>
+                    </DroppableArea>
                 );
 
                 // Group separator with first parameter so they wrap together
@@ -93,6 +222,7 @@ export const Parameters: FC<Props> = ({
 
                 return paramComponent;
             })}
-        </>
+            <DragOverlay />
+        </DndContext>
     );
 };

--- a/packages/frontend/src/features/parameters/components/Parameters.tsx
+++ b/packages/frontend/src/features/parameters/components/Parameters.tsx
@@ -3,8 +3,6 @@ import {
     DragOverlay,
     MouseSensor,
     TouchSensor,
-    useDraggable,
-    useDroppable,
     useSensor,
     useSensors,
     type DragEndEvent,
@@ -15,63 +13,14 @@ import {
     type ParametersValuesMap,
     type ParameterValue,
 } from '@lightdash/common';
-import { Group, Skeleton, useMantineTheme } from '@mantine-8/core';
+import { Group, Skeleton } from '@mantine-8/core';
 import { useCallback, useMemo, useState, type FC, type ReactNode } from 'react';
 import { useParams } from 'react-router';
+import {
+    DraggableItem,
+    DroppableArea,
+} from '../../../components/common/DndHelpers';
 import Parameter from './Parameter';
-
-const DraggableItem: FC<{
-    id: string;
-    children: ReactNode;
-    disabled?: boolean;
-}> = ({ id, children, disabled }) => {
-    const { attributes, listeners, setNodeRef, transform } = useDraggable({
-        id,
-        disabled,
-    });
-
-    const style = transform
-        ? ({
-              position: 'relative',
-              zIndex: 1,
-              transform: `translate(${transform.x}px, ${transform.y}px)`,
-              opacity: 0.8,
-          } as const)
-        : undefined;
-
-    return (
-        <div ref={setNodeRef} style={style} {...listeners} {...attributes}>
-            {children}
-        </div>
-    );
-};
-
-const DroppableArea: FC<{
-    id: string;
-    children: ReactNode;
-    orderedKeys: string[];
-}> = ({ id, children, orderedKeys }) => {
-    const { active, isOver, over, setNodeRef } = useDroppable({ id });
-    const { colors } = useMantineTheme();
-
-    const placeholderStyle = useMemo(() => {
-        if (isOver && active && over && active.id !== over.id) {
-            const oldIndex = orderedKeys.indexOf(String(active.id));
-            const newIndex = orderedKeys.indexOf(String(over.id));
-            if (newIndex < oldIndex) {
-                return { boxShadow: `-8px 0px ${colors.blue[4]}` };
-            } else if (newIndex > oldIndex) {
-                return { boxShadow: `8px 0px ${colors.blue[4]}` };
-            }
-        }
-    }, [isOver, active, over, orderedKeys, colors]);
-
-    return (
-        <div ref={setNodeRef} style={placeholderStyle}>
-            {children}
-        </div>
-    );
-};
 
 type Props = {
     isEditMode: boolean;

--- a/packages/frontend/src/hooks/useDndSensors.ts
+++ b/packages/frontend/src/hooks/useDndSensors.ts
@@ -1,0 +1,11 @@
+import { MouseSensor, TouchSensor, useSensor, useSensors } from '@dnd-kit/core';
+
+export const useDndSensors = () => {
+    const mouseSensor = useSensor(MouseSensor, {
+        activationConstraint: { distance: 10 },
+    });
+    const touchSensor = useSensor(TouchSensor, {
+        activationConstraint: { delay: 250, tolerance: 5 },
+    });
+    return useSensors(mouseSensor, touchSensor);
+};

--- a/packages/frontend/src/pages/Dashboard.tsx
+++ b/packages/frontend/src/pages/Dashboard.tsx
@@ -137,6 +137,14 @@ const Dashboard: FC = () => {
     const setPinnedParameters = useDashboardContext(
         (c) => c.setPinnedParameters,
     );
+    const parameterOrder = useDashboardContext((c) => c.parameterOrder);
+    const setParameterOrder = useDashboardContext((c) => c.setParameterOrder);
+    const hasParameterOrderChanged = useDashboardContext(
+        (c) => c.hasParameterOrderChanged,
+    );
+    const setHasParameterOrderChanged = useDashboardContext(
+        (c) => c.setHasParameterOrderChanged,
+    );
     const dateZoomGranularities = useDashboardContext(
         (c) => c.dateZoomGranularities,
     );
@@ -497,6 +505,7 @@ const Dashboard: FC = () => {
         setSavedParameters(dashboard.parameters ?? {});
         setPinnedParameters(dashboard.config?.pinnedParameters ?? []);
         setHavePinnedParametersChanged(false);
+        setHasParameterOrderChanged(false);
         setDateZoomGranularities(
             dashboard.config?.dateZoomGranularities ??
                 Object.values(DateGranularity),
@@ -538,6 +547,7 @@ const Dashboard: FC = () => {
         setHaveDateZoomGranularitiesChanged,
         setDefaultDateZoomGranularity,
         setHasDefaultDateZoomGranularityChanged,
+        setHasParameterOrderChanged,
     ]);
 
     const handleMoveDashboardToSpace = useCallback(
@@ -676,6 +686,9 @@ const Dashboard: FC = () => {
                 isDateZoomDisabled,
                 isAddFilterDisabled,
                 pinnedParameters,
+                parameterOrder: hasParameterOrderChanged
+                    ? parameterOrder
+                    : dashboard.config?.parameterOrder,
                 dateZoomGranularities: haveDateZoomGranularitiesChanged
                     ? dateZoomGranularities
                     : dashboard.config?.dateZoomGranularities,
@@ -710,6 +723,7 @@ const Dashboard: FC = () => {
             hasAddFilterDisabledChanged ||
             parametersHaveChanged ||
             havePinnedParametersChanged ||
+            hasParameterOrderChanged ||
             haveDateZoomGranularitiesChanged ||
             hasDefaultDateZoomGranularityChanged,
         onAddTiles: handleAddTiles,
@@ -777,6 +791,8 @@ const Dashboard: FC = () => {
                         missingRequiredParameters={missingRequiredParameters}
                         pinnedParameters={pinnedParameters}
                         onParameterPin={toggleParameterPin}
+                        parameterOrder={parameterOrder}
+                        onParameterReorder={setParameterOrder}
                         // tabs
                         activeTab={activeTab}
                         addingTab={addingTab}

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -247,6 +247,11 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
     const [havePinnedParametersChanged, setHavePinnedParametersChanged] =
         useState<boolean>(false);
 
+    // Parameter order state
+    const [parameterOrder, setParameterOrderState] = useState<string[]>([]);
+    const [hasParameterOrderChanged, setHasParameterOrderChanged] =
+        useState<boolean>(false);
+
     // Date zoom granularities state
     const allStandardGranularities = useMemo(
         () => Object.values(DateGranularity),
@@ -284,6 +289,15 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             setPinnedParametersState([]);
         }
     }, [dashboard?.config?.pinnedParameters, dashboard?.config]);
+
+    // Set parameter order when dashboard is loaded
+    useEffect(() => {
+        if (dashboard?.config?.parameterOrder !== undefined) {
+            setParameterOrderState(dashboard.config.parameterOrder);
+        } else if (dashboard?.config !== undefined) {
+            setParameterOrderState([]);
+        }
+    }, [dashboard?.config?.parameterOrder, dashboard?.config]);
 
     // Sync date zoom granularities from dashboard config
     // Note: Custom granularities from explores are added by DashboardGranularitySync
@@ -383,6 +397,11 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             return newPinnedParams;
         });
         setHavePinnedParametersChanged(true);
+    }, []);
+
+    const setParameterOrder = useCallback((order: string[]) => {
+        setParameterOrderState(order);
+        setHasParameterOrderChanged(true);
     }, []);
 
     const setDateZoomGranularities = useCallback(
@@ -1401,6 +1420,10 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         toggleParameterPin,
         havePinnedParametersChanged,
         setHavePinnedParametersChanged,
+        parameterOrder,
+        setParameterOrder,
+        hasParameterOrderChanged,
+        setHasParameterOrderChanged,
         dateZoomGranularities,
         setDateZoomGranularities,
         haveDateZoomGranularitiesChanged,

--- a/packages/frontend/src/providers/Dashboard/types.ts
+++ b/packages/frontend/src/providers/Dashboard/types.ts
@@ -132,6 +132,10 @@ export type DashboardContextType = {
     toggleParameterPin: (parameterKey: string) => void;
     havePinnedParametersChanged: boolean;
     setHavePinnedParametersChanged: Dispatch<SetStateAction<boolean>>;
+    parameterOrder: string[];
+    setParameterOrder: (order: string[]) => void;
+    hasParameterOrderChanged: boolean;
+    setHasParameterOrderChanged: Dispatch<SetStateAction<boolean>>;
     dateZoomGranularities: (DateGranularity | string)[];
     setDateZoomGranularities: (
         granularities: (DateGranularity | string)[],


### PR DESCRIPTION
## Summary
- Adds drag-and-drop reordering for dashboard parameters in edit mode, matching the existing filter reordering UX
- Both parameter pills (in the filter bar) and pinned parameters support drag-and-drop with grip handles
- Parameter order is persisted in the dashboard config JSON (`parameterOrder` field) — no migrations needed
- Uses the same `@dnd-kit/core` library and patterns as the existing filter DnD

Closes https://linear.app/lightdash/issue/PROD-6944
Closes #21955