### PR TITLE
refactor: migrate CatalogService to audited ability checks

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -100,6 +100,7 @@ module.exports = {
         {
             // Error on direct ability checks in fully migrated services
             files: [
+                'src/services/CatalogService/**/*.ts',
                 'src/services/ContentService/**/*.ts',
                 'src/services/DashboardService/**/*.ts',
                 'src/services/SavedChartsService/**/*.ts',

--- a/packages/backend/src/services/CatalogService/CatalogService.test.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.test.ts
@@ -1,0 +1,279 @@
+import { Ability } from '@casl/ability';
+import {
+    ForbiddenError,
+    LightdashMode,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    SessionUser,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { LightdashConfig } from '../../config/parseConfig';
+import { CatalogModel } from '../../models/CatalogModel/CatalogModel';
+import { ChangesetModel } from '../../models/ChangesetModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedChartModel } from '../../models/SavedChartModel';
+import { SpaceModel } from '../../models/SpaceModel';
+import type { TagsModel } from '../../models/TagsModel';
+import { UserAttributesModel } from '../../models/UserAttributesModel';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { CatalogService } from './CatalogService';
+
+const PROJECT_UUID = 'project-uuid';
+const ORG_UUID = 'org-uuid';
+const TREE_UUID = 'tree-uuid';
+
+const buildUser = (canManageMetricsTree: boolean): SessionUser => ({
+    userUuid: 'user-uuid',
+    email: 'user@example.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid: ORG_UUID,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    userId: 0,
+    role: OrganizationMemberRole.ADMIN,
+    ability: new Ability<PossibleAbilities>(
+        canManageMetricsTree
+            ? [
+                  {
+                      subject: 'MetricsTree',
+                      action: ['manage', 'view'],
+                      conditions: { projectUuid: PROJECT_UUID },
+                  },
+              ]
+            : [],
+    ),
+    isActive: true,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+});
+
+const buildService = (overrides?: { catalogModel?: Partial<CatalogModel> }) => {
+    const projectModel = {
+        getSummary: jest.fn(async () => ({
+            organizationUuid: ORG_UUID,
+            name: 'Test Project',
+        })),
+    } as unknown as ProjectModel;
+
+    const catalogModel = {
+        acquireTreeLock: jest.fn(async () => ({
+            metricsTreeUuid: TREE_UUID,
+            lockedByUserUuid: 'user-uuid',
+            expiresAt: new Date(Date.now() + 60_000),
+        })),
+        refreshTreeLockHeartbeat: jest.fn(async () => true),
+        releaseTreeLock: jest.fn(async () => undefined),
+        getTreeLock: jest.fn(async () => null),
+        updateMetricsTree: jest.fn(async () => ({})),
+        deleteMetricsTree: jest.fn(async () => undefined),
+        ...overrides?.catalogModel,
+    } as unknown as CatalogModel;
+
+    const service = new CatalogService({
+        lightdashConfig: { mode: LightdashMode.DEFAULT } as LightdashConfig,
+        analytics: analyticsMock,
+        projectModel,
+        catalogModel,
+        userAttributesModel: {} as UserAttributesModel,
+        savedChartModel: {} as SavedChartModel,
+        spaceModel: {} as SpaceModel,
+        tagsModel: {} as TagsModel,
+        changesetModel: {} as ChangesetModel,
+        spacePermissionService: {} as SpacePermissionService,
+    });
+
+    return { service, projectModel, catalogModel };
+};
+
+describe('CatalogService tree-lock ability checks', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    describe('acquireTreeLock', () => {
+        it('acquires when ability allows', async () => {
+            const { service, catalogModel } = buildService();
+            await service.acquireTreeLock(
+                buildUser(true),
+                PROJECT_UUID,
+                TREE_UUID,
+            );
+            expect(catalogModel.acquireTreeLock).toHaveBeenCalledWith(
+                TREE_UUID,
+                'user-uuid',
+            );
+        });
+
+        it('throws ForbiddenError when ability denies and does not touch the lock', async () => {
+            const { service, catalogModel } = buildService();
+            await expect(
+                service.acquireTreeLock(
+                    buildUser(false),
+                    PROJECT_UUID,
+                    TREE_UUID,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(catalogModel.acquireTreeLock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('refreshTreeLockHeartbeat', () => {
+        it('refreshes when ability allows', async () => {
+            const { service, catalogModel } = buildService();
+            await service.refreshTreeLockHeartbeat(
+                buildUser(true),
+                PROJECT_UUID,
+                TREE_UUID,
+            );
+            expect(catalogModel.refreshTreeLockHeartbeat).toHaveBeenCalledWith(
+                TREE_UUID,
+                'user-uuid',
+            );
+        });
+
+        it('throws ForbiddenError when ability denies', async () => {
+            const { service, catalogModel } = buildService();
+            await expect(
+                service.refreshTreeLockHeartbeat(
+                    buildUser(false),
+                    PROJECT_UUID,
+                    TREE_UUID,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(
+                catalogModel.refreshTreeLockHeartbeat,
+            ).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('releaseTreeLock', () => {
+        it('releases when ability allows', async () => {
+            const { service, catalogModel } = buildService();
+            await service.releaseTreeLock(
+                buildUser(true),
+                PROJECT_UUID,
+                TREE_UUID,
+            );
+            expect(catalogModel.releaseTreeLock).toHaveBeenCalledWith(
+                TREE_UUID,
+                'user-uuid',
+            );
+        });
+
+        it('throws ForbiddenError when ability denies', async () => {
+            const { service, catalogModel } = buildService();
+            await expect(
+                service.releaseTreeLock(
+                    buildUser(false),
+                    PROJECT_UUID,
+                    TREE_UUID,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(catalogModel.releaseTreeLock).not.toHaveBeenCalled();
+        });
+    });
+
+    describe('updateMetricsTree', () => {
+        it('throws ForbiddenError on ability deny before inspecting the lock', async () => {
+            const { service, catalogModel } = buildService();
+            await expect(
+                service.updateMetricsTree(
+                    buildUser(false),
+                    PROJECT_UUID,
+                    TREE_UUID,
+                    {
+                        name: 'Tree',
+                        description: undefined,
+                        nodes: [],
+                        edges: [],
+                        expectedGeneration: 0,
+                    },
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(catalogModel.getTreeLock).not.toHaveBeenCalled();
+            expect(catalogModel.updateMetricsTree).not.toHaveBeenCalled();
+        });
+
+        it('throws when user does not hold the lock', async () => {
+            const { service } = buildService({
+                catalogModel: {
+                    getTreeLock: jest.fn(async () => ({
+                        metricsTreeUuid: TREE_UUID,
+                        lockedByUserUuid: 'someone-else',
+                        lockedByUserName: 'Someone Else',
+                        acquiredAt: new Date(),
+                        expiresAt: new Date(Date.now() + 60_000),
+                    })),
+                } as unknown as Partial<CatalogModel>,
+            });
+            await expect(
+                service.updateMetricsTree(
+                    buildUser(true),
+                    PROJECT_UUID,
+                    TREE_UUID,
+                    {
+                        name: 'Tree',
+                        description: undefined,
+                        nodes: [],
+                        edges: [],
+                        expectedGeneration: 0,
+                    },
+                ),
+            ).rejects.toThrow(ForbiddenError);
+        });
+    });
+
+    describe('deleteMetricsTree', () => {
+        it('deletes when ability allows and no lock is held', async () => {
+            const { service, catalogModel } = buildService();
+            await service.deleteMetricsTree(
+                buildUser(true),
+                PROJECT_UUID,
+                TREE_UUID,
+            );
+            expect(catalogModel.deleteMetricsTree).toHaveBeenCalledWith(
+                PROJECT_UUID,
+                TREE_UUID,
+            );
+        });
+
+        it('throws ForbiddenError on ability deny', async () => {
+            const { service, catalogModel } = buildService();
+            await expect(
+                service.deleteMetricsTree(
+                    buildUser(false),
+                    PROJECT_UUID,
+                    TREE_UUID,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(catalogModel.deleteMetricsTree).not.toHaveBeenCalled();
+        });
+
+        it('throws when a foreign lock is held', async () => {
+            const { service, catalogModel } = buildService({
+                catalogModel: {
+                    getTreeLock: jest.fn(async () => ({
+                        metricsTreeUuid: TREE_UUID,
+                        lockedByUserUuid: 'someone-else',
+                        lockedByUserName: 'Someone Else',
+                        acquiredAt: new Date(),
+                        expiresAt: new Date(Date.now() + 60_000),
+                    })),
+                } as unknown as Partial<CatalogModel>,
+            });
+            await expect(
+                service.deleteMetricsTree(
+                    buildUser(true),
+                    PROJECT_UUID,
+                    TREE_UUID,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(catalogModel.deleteMetricsTree).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -693,12 +693,18 @@ export class CatalogService<
         catalogSearch: ApiCatalogSearch,
         context: CatalogSearchContext,
     ): Promise<KnexPaginatedData<(CatalogField | CatalogTable)[]>> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -749,12 +755,18 @@ export class CatalogService<
         // Right now we return the full cached explore based on name
         // We could extract some data to only return what we need instead
         // to make this request more lightweight
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -830,12 +842,18 @@ export class CatalogService<
         projectUuid: string,
         table: string,
     ): Promise<CatalogAnalytics> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -870,11 +888,18 @@ export class CatalogService<
         projectUuid: string,
         fieldId: string,
     ): Promise<CatalogAnalytics> {
-        const { organizationUuid } = user;
+        const { organizationUuid, name: projectName } =
+            await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -916,13 +941,19 @@ export class CatalogService<
         }: ApiCatalogSearch = {},
         sortArgs?: ApiSort,
     ): Promise<KnexPaginatedData<CatalogField[]>> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1026,13 +1057,16 @@ export class CatalogService<
 
         const { organizationUuid: tagOrganizationUuid } =
             await this.projectModel.getSummary(tag.projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Tags', {
                     projectUuid: tag.projectUuid,
                     organizationUuid: tagOrganizationUuid,
+                    uuid: tag.tagUuid,
+                    name: tag.name,
                 }),
             )
         ) {
@@ -1071,13 +1105,16 @@ export class CatalogService<
 
         const { organizationUuid: tagOrganizationUuid } =
             await this.projectModel.getSummary(tag.projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Tags', {
                     projectUuid: tag.projectUuid,
                     organizationUuid: tagOrganizationUuid,
+                    uuid: tag.tagUuid,
+                    name: tag.name,
                 }),
             )
         ) {
@@ -1095,9 +1132,10 @@ export class CatalogService<
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 // NOTE: being able to manage tags that the user can customise catalog items
                 subject('Tags', {
@@ -1133,13 +1171,19 @@ export class CatalogService<
         userAttributes?: UserAttributeValueMap;
         addDefaultTimeDimension?: boolean;
     }): Promise<MetricWithAssociatedTimeDimension[]> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1275,11 +1319,15 @@ export class CatalogService<
     ) {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1291,11 +1339,15 @@ export class CatalogService<
     async getAllMetricsTreeEdges(user: SessionUser, projectUuid: string) {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1357,11 +1409,15 @@ export class CatalogService<
     ) {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1387,12 +1443,18 @@ export class CatalogService<
         context: CatalogSearchContext,
         tableName?: string,
     ): Promise<MetricWithAssociatedTimeDimension[]> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1446,12 +1508,18 @@ export class CatalogService<
         categoryNames?: string[],
         tags?: string[],
     ): Promise<KnexPaginatedData<CatalogField[]>> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1513,13 +1581,19 @@ export class CatalogService<
         tableName: string,
         context: CatalogSearchContext,
     ): Promise<CompiledDimension[]> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1563,13 +1637,19 @@ export class CatalogService<
         tableName: string,
         context: CatalogSearchContext,
     ): Promise<CompiledDimension[]> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1614,11 +1694,15 @@ export class CatalogService<
     ) {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1639,13 +1723,19 @@ export class CatalogService<
         user: SessionUser,
         projectUuid: string,
     ): Promise<boolean> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1659,13 +1749,19 @@ export class CatalogService<
         user: SessionUser,
         projectUuid: string,
     ): Promise<CatalogOwner[]> {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    uuid: projectUuid,
+                    name: projectName,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1683,11 +1779,15 @@ export class CatalogService<
     ): Promise<KnexPaginatedData<MetricsTreeSummary[]>> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1703,11 +1803,16 @@ export class CatalogService<
     ): Promise<MetricsTreeWithDetails> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: metricsTreeUuidOrSlug,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1728,11 +1833,15 @@ export class CatalogService<
     ): Promise<MetricsTree> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1764,11 +1873,16 @@ export class CatalogService<
     ): Promise<MetricsTreeLockInfo> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: metricsTreeUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1789,11 +1903,16 @@ export class CatalogService<
     ): Promise<boolean> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: metricsTreeUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1812,11 +1931,16 @@ export class CatalogService<
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: metricsTreeUuid,
+                }),
             )
         ) {
             throw new ForbiddenError();
@@ -1833,11 +1957,16 @@ export class CatalogService<
     ): Promise<MetricsTreeWithDetails> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: metricsTreeUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1877,11 +2006,16 @@ export class CatalogService<
     ): Promise<void> {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('MetricsTree', { projectUuid, organizationUuid }),
+                subject('MetricsTree', {
+                    projectUuid,
+                    organizationUuid,
+                    uuid: metricsTreeUuid,
+                }),
             )
         ) {
             throw new ForbiddenError(


### PR DESCRIPTION
## Summary

- Migrates all 27 `user.ability.cannot()` call sites in `CatalogService` to `this.createAuditedAbility()` for ITGC-compliant audit logging (SPK-338).
- Enriches CASL subjects with the correct resource identifiers: Project subjects get `projectUuid` + `name`, Tags subjects get `tag.tagUuid` + `tag.name`, tree-specific MetricsTree subjects get `metricsTreeUuid`.
- Adds `CatalogService.test.ts` covering the 5 stateful tree-lock methods (11 tests) — asserts ability denial short-circuits before any lock mutation.
- Promotes `no-direct-ability-check` ESLint rule from `warn` → `error` for `CatalogService`, matching the pattern used for the 6 already-migrated services.

## Behavior change — please read

**`getFieldAnalytics` now correctly resolves the project's `organizationUuid`.** Previously it used the caller's session `organizationUuid`, which meant a user with a multi-org PAT could call this endpoint against a project in a different org and receive a 200. It now returns 403 in that scenario (fix bundled with the refactor because the audit wrapper would otherwise log misleading cross-org events).

No other functional changes — the `uuid`/`name` subject enrichment is inert for CASL rule matching (rules condition only on `projectUuid`/`organizationUuid`) and only affects audit event metadata.

## Test plan

- [x] `pnpm -F backend typecheck` clean
- [x] `pnpm -F backend lint` — 0 errors on CatalogService (rule is now `error`-level)
- [x] `pnpm -F backend exec jest CatalogService.test.ts` — 11/11 tree-lock tests pass, audit events visible in test output
- [ ] Manual smoke: load catalog sidebar, tag/untag a field, update an icon, create/edit/delete a metrics tree, acquire/refresh/release a tree lock — confirm audit events in PM2 logs for each
- [ ] Manual smoke: cross-org PAT call to `getFieldAnalytics` returns 403 (line 875 fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)