### PR TITLE
feat(backend): add debug logging to create project endpoint

### DIFF
--- a/packages/backend/src/controllers/organizationController.ts
+++ b/packages/backend/src/controllers/organizationController.ts
@@ -49,6 +49,7 @@ import {
     Tags,
 } from '@tsoa/runtime';
 import express from 'express';
+import Logger from '../logging/logger';
 import {
     allowApiKeyAuthentication,
     isAuthenticated,
@@ -619,14 +620,30 @@ export class OrganizationController extends BaseController {
         @Request() req: express.Request,
         @Body() body: CreateProjectOptionalCredentials,
     ): Promise<ApiSuccess<ApiCreateProjectResults>> {
-        const results = await this.services
-            .getProjectService()
-            .createWithoutCompile(
-                req.user!,
-                body,
-                getRequestMethod(req.header(LightdashRequestMethodHeader)),
+        Logger.debug(
+            `createProject request received: name=${body.name}, type=${body.type}`,
+        );
+        let results: ApiCreateProjectResults;
+        try {
+            Logger.debug(
+                'createProject: calling projectService.createWithoutCompile',
             );
-
+            results = await this.services
+                .getProjectService()
+                .createWithoutCompile(
+                    req.user!,
+                    body,
+                    getRequestMethod(req.header(LightdashRequestMethodHeader)),
+                );
+        } catch (e) {
+            Logger.debug(
+                `createProject: error creating project: ${e instanceof Error ? e.message : String(e)}`,
+            );
+            throw e;
+        }
+        Logger.debug(
+            `createProject: project created successfully, uuid=${results.project.projectUuid}`,
+        );
         return {
             status: 'ok',
             results,


### PR DESCRIPTION
## Summary

- Imports `Logger` from `../logging/logger` in `organizationController.ts`
- Adds `Logger.debug` calls to `POST /api/v1/org/projects` (`createProject` handler):
  - **Entry**: logs request body shape (`name`, `type`)
  - **Pre-service**: logs that `projectService.createWithoutCompile` is being called
  - **Success**: logs the newly created project UUID (`results.project.projectUuid`)
  - **Error**: logs the error message before re-throwing

## Test plan

- [ ] Create a project via the UI or API while `LOG_LEVEL=debug` and verify the four debug lines appear in backend logs
- [ ] Verify error path by triggering a creation failure (e.g. duplicate name) and confirming the error log appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)