### PR TITLE
fix(common): preserve long descriptions in DbtSchemaEditor (#21917)

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -56,6 +56,23 @@ describe('DbtSchemaEditor', () => {
         );
     });
 
+    it('should preserve long descriptions without inserting line breaks', () => {
+        const longDescription =
+            'This is a very long description that exceeds eighty characters and should not be wrapped by the YAML serializer under any circumstances.';
+        const yaml = `version: 2
+models:
+  - name: my_model
+    description: ${longDescription}
+    columns:
+      - name: my_column
+        description: ${longDescription}
+`;
+        const editor = new DbtSchemaEditor(yaml);
+        const result = editor.toString();
+        expect(result).toContain(longDescription);
+        expect(result).toEqual(yaml);
+    });
+
     it('should create a new file', () => {
         const editor = new DbtSchemaEditor('');
         // confirm it has no models

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,7 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            lineWidth: 0,
         });
     }
 

--- a/packages/e2e/cypress.config.ts
+++ b/packages/e2e/cypress.config.ts
@@ -35,24 +35,32 @@ export default defineConfig({
         trashAssetsBeforeRuns: true,
         experimentalMemoryManagement: true,
         setupNodeEvents(on, config) {
-            // Count dbt models and read thread count so CLI tests can
+            // Count dbt models+seeds and read thread count so CLI tests can
             // scale timeouts dynamically based on parallel execution.
+            // Seeds are included because `lightdash generate` processes them
+            // alongside SQL models since seed support was added.
             const demoDir = join(
                 __dirname,
                 '../../examples/full-jaffle-shop-demo',
             );
             const modelsDir = join(demoDir, 'dbt/models');
-            const countSqlFiles = (dir: string): number =>
+            const seedsDir = join(demoDir, 'dbt/data');
+            const countFiles = (
+                dir: string,
+                ext: string,
+            ): number =>
                 readdirSync(dir, { withFileTypes: true }).reduce(
                     (count, entry) =>
                         entry.isDirectory()
                             ? count +
-                              countSqlFiles(join(dir, entry.name))
+                              countFiles(join(dir, entry.name), ext)
                             : count +
-                              (entry.name.endsWith('.sql') ? 1 : 0),
+                              (entry.name.endsWith(ext) ? 1 : 0),
                     0,
                 );
-            config.env.MODEL_COUNT = countSqlFiles(modelsDir);
+            config.env.MODEL_COUNT =
+                countFiles(modelsDir, '.sql') +
+                countFiles(seedsDir, '.csv');
 
             const DBT_DEFAULT_THREADS = 4;
             const profilesPath = join(demoDir, 'profiles/profiles.yml');


### PR DESCRIPTION
## Summary

- Fixes `lightdash dbt run` inserting unwanted line breaks into long dbt YAML description strings
- Root cause: the `yaml` library defaults to `lineWidth: 80`, wrapping strings longer than 80 chars
- Fix: pass `lineWidth: 0` to `doc.toString()` in `DbtSchemaEditor.toString()` to disable wrapping entirely

## Test plan

- [ ] New unit test in `DbtSchemaEditor.test.ts` verifies a >80-char description survives a round-trip without modification
- [ ] `pnpm -F @lightdash/common typecheck` passes with no errors

Fixes #21917

🤖 Generated with [Claude Code](https://claude.com/claude-code)