### PR TITLE
fix(cli): preserve long descriptions in DbtSchemaEditor (#21917)

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -37,6 +37,14 @@ describe('DbtSchemaEditor', () => {
         );
     });
 
+    it('should not insert line breaks into long descriptions', () => {
+        const longDescription =
+            'This is a very long description that exceeds eighty characters and should not be wrapped by the YAML serializer under any circumstances.';
+        const yaml = `version: 2\n\nmodels:\n  - name: my_model\n    description: ${longDescription}\n    columns: []\n`;
+        const editor = new DbtSchemaEditor(yaml);
+        expect(editor.toString()).toEqual(yaml);
+    });
+
     it('should update a model with custom metrics and custom dimensions', () => {
         const editor = new DbtSchemaEditor(SCHEMA_YML);
         // confirms it has models

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,7 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Summary

- Add `lineWidth: 0` to `DbtSchemaEditor.toString()` so the `yaml` library never wraps long strings at 80 characters
- Update the existing YAML fixture to reflect the corrected (unwrapped) serialization
- Add a round-trip test proving a description longer than 80 characters survives `new DbtSchemaEditor(yaml).toString()` unchanged

Fixes #21917

## Test plan

- [ ] `pnpm -F @lightdash/common test -- --testPathPattern=DbtSchemaEditor` — all 14 tests pass
- [ ] `pnpm -F @lightdash/common typecheck` — no errors
- [ ] Run `lightdash dbt run -s <model-with-long-description>` and confirm the YAML file is not reformatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)