### PR TITLE
fix(common): preserve long descriptions in DbtSchemaEditor (#21917)

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -69,6 +69,24 @@ describe('DbtSchemaEditor', () => {
     });
 });
 
+describe('long description preservation', () => {
+    it('should not insert line breaks into long descriptions on round-trip', () => {
+        const longDescription =
+            'This is a very long description that exceeds eighty characters and should not be reformatted with line breaks when the schema is serialized back to YAML by DbtSchemaEditor';
+        const schema = `version: 2
+models:
+  - name: my_model
+    columns:
+      - name: my_column
+        description: "${longDescription}"
+`;
+        const editor = new DbtSchemaEditor(schema);
+        const output = editor.toString();
+        expect(output).toContain(longDescription);
+        expect(output).not.toMatch(/description:.*\n\s+/);
+    });
+});
+
 describe('case-insensitive column matching', () => {
     const MIXED_CASE_SCHEMA = `version: 2
 models:

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,7 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Summary
- Set `lineWidth: 0` in `DbtSchemaEditor.toString()` to prevent the `yaml` library from inserting line breaks into long strings (default was 80 characters)
- Added a round-trip test confirming long descriptions survive serialization without reformatting

Fixes #21917

## Test plan
- [x] `pnpm -F @lightdash/common typecheck` passes
- [x] All `DbtSchemaEditor` tests pass (14/14), including the new long-description preservation test

🤖 Generated with [Claude Code](https://claude.com/claude-code)