### PR TITLE
fix(common): preserve long descriptions in DbtSchemaEditor (#21917)

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -69,6 +69,18 @@ describe('DbtSchemaEditor', () => {
     });
 });
 
+describe('long description preservation', () => {
+    it('should not insert line breaks into long description strings', () => {
+        const longDesc =
+            'This is a very long description that exceeds eighty characters and should not be reformatted with line breaks by the YAML serializer when round-tripping through DbtSchemaEditor';
+        const schema = `version: 2\nmodels:\n  - name: my_model\n    description: "${longDesc}"\n    columns:\n      - name: col_a\n        description: A column\n`;
+        const editor = new DbtSchemaEditor(schema);
+        const output = editor.toString();
+        expect(output).toContain(`description: "${longDesc}"`);
+        expect(output).not.toMatch(/description: ".*\n\s+.*"/);
+    });
+});
+
 describe('case-insensitive column matching', () => {
     const MIXED_CASE_SCHEMA = `version: 2
 models:

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -432,16 +432,9 @@ export default class DbtSchemaEditor {
     // Returns the updated schema as a string(YAML)
     toString(options?: { quoteChar?: `'` | `"` }): string {
         return this.doc.toString({
-            /**
-             * Use 'single quote' rather than "double quote" where applicable.
-             * Set to `false` to disable single quotes completely.
-             * Set to `null` to keep the original quotes.
-             *
-             * Once we allow the user to set the quote char in the UI, we can enforce the quote char for the entire file.
-             * Until then, we try to keep the original quotes by defaulting to null.
-             */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Summary
- Set `lineWidth: 0` in `DbtSchemaEditor.toString()` to prevent the `yaml` library from inserting line breaks at 80 characters
- `lightdash dbt run` now only adds missing columns without reformatting existing long description strings
- Added a round-trip test proving long descriptions survive without line breaks being inserted

Fixes #21917

## Test plan
- [x] Existing `DbtSchemaEditor` tests updated and passing (14/14)
- [x] Full `@lightdash/common` test suite passing (1775 tests)
- [x] TypeScript typecheck passing
- [ ] Manual: run `lightdash dbt run -s <model>` against a model with a long description and verify no line breaks are added

🤖 Generated with [Claude Code](https://claude.com/claude-code)