### PR TITLE
fix: parse date strings as UTC in formatDate/formatTimestamp to prevent 1-day offset in stacked bar tooltip

### DIFF
--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -137,11 +137,14 @@ export function formatDate(
     convertToUTC: boolean = false,
     timezone?: string,
 ): string {
+    // moment.utc(date) parses date-only strings as UTC. moment(date).utc()
+    // parses in the local timezone first, shifting the date back a day
+    // in UTC+ browsers (e.g. JST).
     let momentDate;
     if (timezone) {
         momentDate = moment.utc(date).tz(timezone);
     } else if (convertToUTC) {
-        momentDate = moment(date).utc();
+        momentDate = moment.utc(date);
     } else {
         momentDate = moment(date);
     }
@@ -163,7 +166,7 @@ export function formatTimestamp(
     if (timezone) {
         momentDate = moment.utc(value).tz(timezone);
     } else if (convertToUTC) {
-        momentDate = moment(value).utc();
+        momentDate = moment.utc(value);
     } else {
         momentDate = moment(value);
     }


### PR DESCRIPTION
Relates to: https://github.com/lightdash/lightdash/issues/21962

### Description:

**Bug**: In stacked bar charts, the individual group hover tooltip showed dates 1 day behind the correct date (e.g. showed "2026-03-13" when the correct date was "2026-03-14"). The X-axis and the cumulative tooltip were both correct; only the per-series item-mode tooltip was wrong. The bug only appeared in UTC+ timezones (e.g. JST/UTC+9).

**Root cause**: When `convertToUTC=true`, `formatDate` and `formatTimestamp` used `moment(date).utc()`. For date-only strings like `"2026-03-14"`:

1. `moment("2026-03-14")` parses as **local midnight** (in JST: `2026-03-14T00:00:00+09:00`)
2. `.utc()` switches to UTC view → `2026-03-13T15:00:00Z`
3. Formats as `"2026-03-13"` — 1 day behind

ECharts with `useUTC: true` treats `"2026-03-14"` as UTC midnight (JavaScript's `new Date("2026-03-14")` parses ISO date-only strings as UTC), so the axis and cumulative tooltip showed the correct date.

**Fix**: Change `moment(date).utc()` → `moment.utc(date)` in both `formatDate` and `formatTimestamp`. `moment.utc(date)` parses the string **as UTC** from the start, matching ECharts' `useUTC: true` behaviour.

The cumulative tooltip was unaffected because ECharts provides a numeric timestamp via `axisPointer.label.formatter`, and `moment(numericTimestamp).utc()` always gives the correct UTC date regardless of local timezone.