### PR TITLE
fix: validate dashboard filter table existence (closes #21130)

### DIFF
--- a/packages/backend/src/services/ValidationService/ValidationService.test.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.test.ts
@@ -363,6 +363,82 @@ describe('validation', () => {
         );
     });
 
+    it('Should validate dashboard filters when referenced table no longer exists', async () => {
+        (
+            dashboardModel.findDashboardsForValidation as jest.Mock
+        ).mockImplementationOnce(async () => [
+            {
+                ...dashboardForValidation,
+                filters: {
+                    dimensions: [
+                        {
+                            id: 'filter-uuid',
+                            target: {
+                                fieldId: 'deleted_table_dimension',
+                                tableName: 'deleted_table',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: [],
+                        },
+                    ],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.DASHBOARDS]),
+        );
+
+        expect(errors.map((error) => error.error)).toContain(
+            "Table 'deleted_table' no longer exists",
+        );
+    });
+
+    it('Should validate dashboard tile targets when referenced table no longer exists', async () => {
+        (
+            dashboardModel.findDashboardsForValidation as jest.Mock
+        ).mockImplementationOnce(async () => [
+            {
+                ...dashboardForValidation,
+                filters: {
+                    dimensions: [
+                        {
+                            id: 'filter-uuid',
+                            target: {
+                                fieldId: 'table_dimension',
+                                tableName: 'table',
+                            },
+                            operator: FilterOperator.EQUALS,
+                            values: [],
+                            tileTargets: {
+                                'tile-uuid': {
+                                    fieldId: 'deleted_table_dimension',
+                                    tableName: 'deleted_table',
+                                },
+                            },
+                        },
+                    ],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            },
+        ]);
+
+        const errors = await validationService.generateValidation(
+            'projectUuid',
+            undefined,
+            new Set([ValidationTarget.DASHBOARDS]),
+        );
+
+        expect(errors.map((error) => error.error)).toContain(
+            "Table 'deleted_table' no longer exists",
+        );
+    });
+
     it('Should validate only tables and charts in project', async () => {
         (
             projectModel.findExploresFromCache as jest.Mock

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -603,6 +603,7 @@ export class ValidationService extends BaseService {
         dashboardUuid?: string,
     ): Promise<CreateDashboardValidation[]> {
         const existingFieldIds = existingFields.map(getItemId);
+        const existingTableNames = new Set(existingFields.map((f) => f.table));
 
         // Pre-build Map for O(1) broken chart lookup instead of O(n) array.find()
         const brokenChartMap = new Map(
@@ -653,6 +654,21 @@ export class ValidationService extends BaseService {
                         return acc;
                     };
 
+                    const checkTableExists = (
+                        fieldId: string,
+                        tableName: string | undefined,
+                    ): CreateDashboardValidation | undefined => {
+                        if (tableName && !existingTableNames.has(tableName)) {
+                            return {
+                                ...commonValidation,
+                                errorType: ValidationErrorType.Filter,
+                                error: `Table '${tableName}' no longer exists`,
+                                fieldName: fieldId,
+                            };
+                        }
+                        return undefined;
+                    };
+
                     const checkTableFieldConsistency = (
                         fieldId: string,
                         tableName: string | undefined,
@@ -689,6 +705,14 @@ export class ValidationService extends BaseService {
                             )
                                 ? filter.target.tableName
                                 : undefined;
+
+                            const tableExistsError = checkTableExists(
+                                fieldId,
+                                tableName,
+                            );
+                            if (tableExistsError) {
+                                return [...acc, tableExistsError];
+                            }
 
                             const consistencyError = checkTableFieldConsistency(
                                 fieldId,
@@ -737,6 +761,14 @@ export class ValidationService extends BaseService {
                                 !tileTarget.isSqlColumn // Skip SQL column targets
                             ) {
                                 const { fieldId, tableName } = tileTarget;
+
+                                const tableExistsError = checkTableExists(
+                                    fieldId,
+                                    tableName,
+                                );
+                                if (tableExistsError) {
+                                    return [...acc, tableExistsError];
+                                }
 
                                 const consistencyError =
                                     checkTableFieldConsistency(


### PR DESCRIPTION
## Bug
When a dbt model is deleted and the project is recompiled, dashboard filter validation does not generate `TableDoesNotExist` errors. The `DashboardFilterValidationErrorType.TableDoesNotExist` enum, the `parseDashboardFilterError` parser, and the frontend `FixDashboardFilterModal` handler are all fully implemented — but `validateDashboards()` never generates this error type.

Instead, deleted tables are caught by the less-specific field existence check, which emits `"the field 'X' on table 'Y' no longer exists"` (a `FieldDoesNotExist` error) rather than `"Table 'Y' no longer exists"` (a `TableDoesNotExist` error). This means the frontend cannot show the correct fix action for deleted tables.

Closes #21130

## Expected
When a dashboard filter references a `tableName` that no longer exists in any compiled explore, validation should emit a `"Table 'X' no longer exists"` error so the validation bell and fix modal show the appropriate error type and remediation.

## Reproduction
Two failing tests added to `ValidationService.test.ts`:
1. **Filter target**: Dashboard filter with `tableName: 'deleted_table'` — expects `TableDoesNotExist` error, gets `FieldDoesNotExist`
2. **Tile target**: Dashboard tile target with `tableName: 'deleted_table'` — same issue

## Evidence (before)
- Failing tests: `packages/backend/src/services/ValidationService/ValidationService.test.ts` — see CI run
- Current error: `"Filter error: the field 'deleted_table_dimension' on table 'deleted_table' no longer exists"`
- Expected error: `"Table 'deleted_table' no longer exists"`

## Fix
**Root cause**: `validateDashboards()` in `ValidationService.ts` checks field existence (`existingFieldIds.includes(fieldId)`) and field-table prefix consistency, but never checks whether the `tableName` itself corresponds to a table that exists in any non-error compiled explore. The `TableDoesNotExist` enum value, parser regex, and frontend handler were all implemented but the actual check was never wired in.

**Change**: Added a `checkTableExists` helper that builds a `Set<string>` of valid table names from `existingFields` (each `CompiledField` has a `table` property) and checks the filter's `tableName` against it. This check runs before the prefix consistency and field existence checks, so the most specific error is emitted first. Applied to both filter targets and per-tile targets.

## Evidence (after)
- Tests now passing: `packages/backend/src/services/ValidationService/ValidationService.test.ts`
- All 23 tests pass (21 existing + 2 new)
- typecheck / lint: ✅

## Note on full reproduction
A previous engineer (almeidabbm, PROD-5931) could not reproduce the full user-reported symptom (dimensions appearing in filter dropdown after model deletion) via the standard steps. The filter dropdown is powered by `getAvailableFiltersForSavedQueries` which reads from `cached_explores` — if the cache is correctly refreshed, deleted explores are removed. The root cause of the dropdown symptom may be a cache timing issue separate from this validation gap. This PR fixes the validation side: ensuring the validation bell correctly flags dashboard filters referencing deleted tables with the specific `TableDoesNotExist` error type.