### PR TITLE
chore: add automated QA workflow with Claude agent for release testing

### DIFF
--- a/.github/workflows/release-qa.yml
+++ b/.github/workflows/release-qa.yml
@@ -1,0 +1,212 @@
+name: Release QA Agent
+
+# Spins up an Okteto preview built from a released Lightdash tag, sends the
+# changelog to the Claude QA agent for a smoke test, then tears the preview down.
+# The agent posts results to #aqa-team in Slack via its own MCP integration.
+#
+# Trigger modes:
+#   - release:published  → tests the tag just released (github.event.release.tag_name)
+#   - workflow_dispatch  → manual; pass image_tag to test a specific version
+
+on:
+    release:
+        types: [published]
+
+    workflow_dispatch:
+        inputs:
+            image_tag:
+                description: 'Docker image tag to test (e.g. 0.2754.0). Leave empty to use results.latest.version.'
+                required: false
+                type: string
+
+permissions:
+    deployments: write
+    contents: read
+    pull-requests: write
+
+concurrency:
+    # The namespace is qa-<version>, so serialize by tag. For dispatch without an explicit
+    # tag the version is resolved at runtime, so fall back to run id to avoid collisions.
+    group: release-qa-${{ github.event.release.tag_name || inputs.image_tag || github.run_id }}
+    cancel-in-progress: false
+
+jobs:
+    qa:
+        name: Test released image with Claude agent
+        runs-on: ubuntu-latest
+        timeout-minutes: 30
+        steps:
+            - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+              with:
+                  fetch-depth: 0  # need full history + tags to compute changelog
+
+            - name: Resolve image tag and preview name
+              id: resolve
+              run: |
+                  set -e
+                  if [[ "${{ github.event_name }}" == "release" ]]; then
+                    TAG="${{ github.event.release.tag_name }}"
+                  elif [[ "${{ github.event_name }}" == "workflow_dispatch" && -n "${{ inputs.image_tag }}" ]]; then
+                    TAG="${{ inputs.image_tag }}"
+                  else
+                    # Manual dispatch without an image_tag input: fall back to the last published image.
+                    TAG=$(curl -sS https://analytics.lightdash.cloud/api/v1/health | python3 -c 'import sys,json; print(json.load(sys.stdin)["results"]["latest"]["version"])')
+                  fi
+                  NAME="qa-${TAG//./-}"
+
+                  if [[ -z "$TAG" || "$TAG" == "null" ]]; then
+                    echo "Could not resolve image tag"; exit 1
+                  fi
+
+                  # We reuse the existing okteto.preview.yaml + docker-compose.preview.yml,
+                  # whose service is named 'lightdash-preview'. Okteto endpoint format is
+                  # <service>-<namespace>.<okteto-domain>.
+                  URL="https://lightdash-preview-${NAME}.lightdash.okteto.dev"
+                  echo "tag=$TAG" >> $GITHUB_OUTPUT
+                  echo "name=$NAME" >> $GITHUB_OUTPUT
+                  echo "url=$URL" >> $GITHUB_OUTPUT
+                  echo "Testing image lightdash/lightdash:$TAG at $URL"
+
+            - name: Generate changelog
+              id: changelog
+              run: |
+                  set -e
+                  TAG="${{ steps.resolve.outputs.tag }}"
+
+                  # Find the previous tag (sorted by semver, the one immediately before TAG)
+                  PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${TAG}$" | tail -n1 || true)
+                  if [[ -z "$PREVIOUS_TAG" || "$PREVIOUS_TAG" == "$TAG" ]]; then
+                    echo "Could not find previous tag for $TAG; falling back to no-changelog"
+                    echo "No commit list available between previous version and ${TAG}." > changelog.txt
+                  else
+                    echo "Changelog ${PREVIOUS_TAG} -> ${TAG}:" > changelog.txt
+                    # Up to 20 non-bot commits, formatted for Slack
+                    git log --pretty=format:"%H|%an|%s" "${PREVIOUS_TAG}".."${TAG}" \
+                      | awk -F'|' '$2 != "semantic-release-bot" {print "• *" $2 "*: _" $3 "_"}' \
+                      | head -20 >> changelog.txt
+                  fi
+
+                  echo "previous_tag=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+                  echo "--- changelog.txt ---"
+                  cat changelog.txt
+
+            - name: Okteto context
+              uses: okteto/context@bff593401ac86e181bab973c61b35816bd52587a # latest
+              with:
+                  url: ${{ secrets.OKTETO_CONTEXT }}
+                  token: ${{ secrets.OKTETO_TOKEN }}
+
+            - name: Deploy preview at released tag
+              # Uses the existing PR-preview compose (docker-compose.preview.yml via okteto.preview.yaml).
+              # The `branch` input tells Okteto to clone the released tag instead of this workflow's
+              # branch — that way the preview is built from the released source, including the
+              # jaffle-shop dbt files in `examples/full-jaffle-shop-demo/` that seed the demo project.
+              uses: okteto/deploy-preview@ec76bb82c13aa0f748fc687ee622c96282890150 # latest
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+              with:
+                  name: ${{ steps.resolve.outputs.name }}
+                  timeout: 15m
+                  file: okteto.preview.yaml
+                  branch: ${{ steps.resolve.outputs.tag }}
+                  variables: |
+                      SITE_URL=${{ steps.resolve.outputs.url }}
+
+            - name: Wait for preview to be healthy
+              run: |
+                  URL="${{ steps.resolve.outputs.url }}"
+                  for i in $(seq 1 60); do
+                    if curl -fsS "$URL/api/v1/health" >/dev/null 2>&1; then
+                      echo "Healthy after ${i} attempts"; exit 0
+                    fi
+                    sleep 10
+                  done
+                  echo "Preview never became healthy"; exit 1
+
+            - name: Run Claude QA agent against preview
+              env:
+                  ANTHROPIC_API_KEY: ${{ secrets.QA_ANTHROPIC_API_KEY }}
+                  AGENT_ID: agent_011Ca1uNqZRFtFFJZMJGJw4K
+                  PREVIEW_URL: ${{ steps.resolve.outputs.url }}
+                  IMAGE_TAG: ${{ steps.resolve.outputs.tag }}
+              run: |
+                  set -e
+
+                  SESSION_RESPONSE=$(curl -sS \
+                    "https://api.anthropic.com/v1/sessions" \
+                    -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+                    -H "anthropic-version: 2023-06-01" \
+                    -H "anthropic-beta: managed-agents-2026-04-01" \
+                    -H "content-type: application/json" \
+                    -d "{\"agent\": \"${AGENT_ID}\", \"environment_id\": \"env_01Bq7t2WKXRZGD7ATqF12dig\", \"vault_ids\": [\"vlt_011Ca3AgrQGBFgVeLSb6FAXD\"]}")
+
+                  SESSION_ID=$(echo "$SESSION_RESPONSE" | jq -r '.id')
+                  if [[ -z "$SESSION_ID" || "$SESSION_ID" == "null" ]]; then
+                    echo "Failed to create session: $SESSION_RESPONSE"; exit 1
+                  fi
+                  echo "Created session: $SESSION_ID"
+
+                  MESSAGE_JSON=$(PREVIEW_URL="$PREVIEW_URL" IMAGE_TAG="$IMAGE_TAG" python3 <<'PY'
+                  import json, os
+                  url = os.environ['PREVIEW_URL']
+                  tag = os.environ['IMAGE_TAG']
+                  with open('changelog.txt') as f:
+                      changelog = f.read().strip()
+                  msg = (
+                      f"Lightdash {tag} pre-release smoke test on a fresh Okteto preview.\n\n"
+                      f"Target URL: {url}\n"
+                      f"Login: demo@lightdash.com / demo_password!\n"
+                      f"Project UUID (seeded jaffle-shop): 3675b69e-8324-4110-bdca-059031aa8da3\n\n"
+                      f"{changelog}\n\n"
+                      f"Test the happy path of the changes above. Report PASS/FAIL to #aqa-team, "
+                      f"noting this is a *pre-release* run for version {tag}."
+                  )
+                  print(json.dumps(msg))
+                  PY
+                  )
+
+                  curl -sS --fail-with-body \
+                    "https://api.anthropic.com/v1/sessions/${SESSION_ID}/events" \
+                    -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+                    -H "anthropic-version: 2023-06-01" \
+                    -H "anthropic-beta: managed-agents-2026-04-01" \
+                    -H "content-type: application/json" \
+                    -d "{\"events\":[{\"type\":\"user.message\",\"content\":[{\"type\":\"text\",\"text\":${MESSAGE_JSON}}]}]}"
+
+                  echo "SESSION_ID=$SESSION_ID" >> $GITHUB_ENV
+
+            - name: Poll session until idle
+              env:
+                  ANTHROPIC_API_KEY: ${{ secrets.QA_ANTHROPIC_API_KEY }}
+              run: |
+                  # Wait for the agent to finish so we can tear the preview down afterwards.
+                  # The session is briefly "idle" right after creation (before the agent picks
+                  # up the message), so only treat "idle" as terminal AFTER we've seen the
+                  # session go into a working state at least once.
+                  seen_working=false
+                  for i in $(seq 1 80); do
+                    STATUS=$(curl -sS \
+                      "https://api.anthropic.com/v1/sessions/${SESSION_ID}" \
+                      -H "x-api-key: ${ANTHROPIC_API_KEY}" \
+                      -H "anthropic-version: 2023-06-01" \
+                      -H "anthropic-beta: managed-agents-2026-04-01" \
+                      | jq -r '.status // "unknown"')
+                    echo "[$i] session status: $STATUS (seen_working=$seen_working)"
+                    if [[ "$STATUS" == "error" || "$STATUS" == "stopped" ]]; then
+                      exit 0
+                    fi
+                    if [[ "$STATUS" != "idle" && "$STATUS" != "created" && "$STATUS" != "unknown" ]]; then
+                      seen_working=true
+                    fi
+                    if [[ "$seen_working" == "true" && "$STATUS" == "idle" ]]; then
+                      exit 0
+                    fi
+                    sleep 15
+                  done
+                  echo "Session did not finish within 20 minutes; tearing down anyway"
+
+            - name: Destroy preview
+              if: always()
+              uses: okteto/destroy-preview@b3b2db89ea11724de3edddf8d4591173fbede9c7 # latest
+              with:
+                  name: ${{ steps.resolve.outputs.name }}


### PR DESCRIPTION
### Description:

This PR introduces automated QA testing for Lightdash releases using a Claude AI agent. The workflow spins up an Okteto preview environment with a pre-built Lightdash Docker image, runs automated testing through the Claude QA agent, and then tears down the environment.

The workflow supports three trigger modes:
- **Release published**: Tests the newly released image using the release tag
- **Pull request**: Tests the latest published image when changes are made to the workflow files
- **Manual dispatch**: Allows testing of a specific image tag via workflow_dispatch

Key components added:
- GitHub Actions workflow (`.github/workflows/release-qa.yml`) that orchestrates the entire QA process
- Docker Compose configuration (`docker/docker-compose.release-test.yml`) for the test environment using pre-built images
- Okteto deployment configuration (`okteto.release-test.yaml`) for preview environment management

The workflow creates a temporary preview environment with seeded demo data, waits for it to become healthy, instructs the Claude agent to perform smoke testing of core functionality (login, charts, dashboards), and automatically cleans up the environment afterward. The agent reports results to the #aqa-team channel, providing automated pre-release validation.