### PR TITLE
feat: add QA blast radius generation to post-release workflow

### DIFF
--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -144,8 +144,13 @@ jobs:
           CURRENT_TAG="${{ github.event.release.tag_name }}"
           PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${CURRENT_TAG}$" | tail -1)
           if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$CURRENT_TAG" ]; then
-            echo "No previous tag found, diffing against HEAD~20"
-            echo "base=HEAD~20" >> $GITHUB_OUTPUT
+            echo "No previous tag found, checking commit count for safe fallback"
+            COMMIT_COUNT=$(git rev-list --count HEAD)
+            if [ "$COMMIT_COUNT" -lt 20 ]; then
+              echo "base=HEAD~$((COMMIT_COUNT-1))" >> $GITHUB_OUTPUT
+            else
+              echo "base=HEAD~20" >> $GITHUB_OUTPUT
+            fi
           else
             echo "Diffing $CURRENT_TAG against $PREVIOUS_TAG"
             echo "base=$PREVIOUS_TAG" >> $GITHUB_OUTPUT

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -125,6 +125,7 @@ jobs:
   qa-blast-radius:
     name: Generate QA Blast Radius
     runs-on: ubuntu-latest
+    continue-on-error: true
     permissions:
       contents: write
     steps:
@@ -152,7 +153,7 @@ jobs:
 
       - name: Build code graph and detect changes
         run: |
-          pip install code-review-graph
+          pip install code-review-graph==2.3.1
           code-review-graph build --skip-postprocess
           code-review-graph detect-changes --base ${{ steps.prev-tag.outputs.base }} > blast-radius.json
 

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -120,7 +120,52 @@ jobs:
             SENTRY_ENVIRONMENT=cloud_beta
 
   # ============================================================================
-  # Job 2: CLI Release Binaries
+  # Job 2: QA Blast Radius
+  # ============================================================================
+  qa-blast-radius:
+    name: Generate QA Blast Radius
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.release.tag_name }}
+
+      - uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5
+        with:
+          python-version: '3.12'
+
+      - name: Find previous release tag
+        id: prev-tag
+        run: |
+          CURRENT_TAG="${{ github.event.release.tag_name }}"
+          PREVIOUS_TAG=$(git tag --sort=-version:refname | grep -A1 "^${CURRENT_TAG}$" | tail -1)
+          if [ -z "$PREVIOUS_TAG" ] || [ "$PREVIOUS_TAG" = "$CURRENT_TAG" ]; then
+            echo "No previous tag found, diffing against HEAD~20"
+            echo "base=HEAD~20" >> $GITHUB_OUTPUT
+          else
+            echo "Diffing $CURRENT_TAG against $PREVIOUS_TAG"
+            echo "base=$PREVIOUS_TAG" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Build code graph and detect changes
+        run: |
+          pip install code-review-graph
+          code-review-graph build --skip-postprocess
+          code-review-graph detect-changes --base ${{ steps.prev-tag.outputs.base }} > blast-radius.json
+
+      - name: Upload blast radius to release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            blast-radius.json \
+            --clobber
+
+  # ============================================================================
+  # Job 3: CLI Release Binaries
   # ============================================================================
   check-cli-changes:
     name: Check if CLI files changed


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:

This PR adds a new QA blast radius job to the post-release workflow that automatically generates change impact analysis for each release. The job:

- Runs on Ubuntu with Python 3.12 after a release is published
- Finds the previous release tag by sorting tags in version order, falling back to HEAD~20 if no previous tag exists
- Uses the `code-review-graph` tool to build a code dependency graph and detect changes between the current and previous release
- Uploads the generated `blast-radius.json` file as an asset to the GitHub release

This enables QA teams to understand the scope and impact of changes in each release for more targeted testing.