### PR TITLE
feat(ee): Slack notifications + CronDate bugfix for managed agent

### DIFF
--- a/packages/backend/src/database/migrations/20260413160747_create_managed_agent_tables.ts
+++ b/packages/backend/src/database/migrations/20260413160747_create_managed_agent_tables.ts
@@ -27,8 +27,6 @@ export const up = async (knex: Knex): Promise<void> => {
         // duplicate environments and vaults on every service restart.
         table.text('anthropic_environment_id').nullable();
         table.text('anthropic_vault_id').nullable();
-        // Slack channel ID for posting heartbeat summaries
-        table.text('slack_channel_id').nullable();
         table
             .timestamp('created_at', { useTz: false })
             .notNullable()

--- a/packages/backend/src/database/migrations/20260413160747_create_managed_agent_tables.ts
+++ b/packages/backend/src/database/migrations/20260413160747_create_managed_agent_tables.ts
@@ -27,6 +27,8 @@ export const up = async (knex: Knex): Promise<void> => {
         // duplicate environments and vaults on every service restart.
         table.text('anthropic_environment_id').nullable();
         table.text('anthropic_vault_id').nullable();
+        // Slack channel ID for posting heartbeat summaries
+        table.text('slack_channel_id').nullable();
         table
             .timestamp('created_at', { useTz: false })
             .notNullable()

--- a/packages/backend/src/database/migrations/20260414145236_add_slack_channel_to_managed_agent.ts
+++ b/packages/backend/src/database/migrations/20260414145236_add_slack_channel_to_managed_agent.ts
@@ -1,0 +1,15 @@
+import { type Knex } from 'knex';
+
+const ManagedAgentSettingsTableName = 'managed_agent_settings';
+
+export const up = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable(ManagedAgentSettingsTableName, (table) => {
+        table.text('slack_channel_id').nullable();
+    });
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable(ManagedAgentSettingsTableName, (table) => {
+        table.dropColumn('slack_channel_id');
+    });
+};

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -1,4 +1,5 @@
 import Anthropic from '@anthropic-ai/sdk';
+import { AnyType } from '@lightdash/common';
 import Logger from '../../logging/logger';
 import { CUSTOM_TOOL_DEFINITIONS } from '../services/ManagedAgentService/managedAgentTools';
 
@@ -77,8 +78,7 @@ export class ManagedAgentClient {
             };
         }
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const betaAny = this.client.beta as any;
+        const betaAny = this.client.beta as AnyType;
 
         // Reuse existing environment if one exists, otherwise create
         const environment = await this.findOrCreateEnvironment(betaAny);
@@ -104,9 +104,9 @@ export class ManagedAgentClient {
         };
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any, class-methods-use-this
+    // eslint-disable-next-line class-methods-use-this
     private async findOrCreateEnvironment(
-        betaAny: any,
+        betaAny: AnyType,
     ): Promise<{ id: string }> {
         const ENV_NAME = 'lightdash-agent-env';
         try {
@@ -136,8 +136,7 @@ export class ManagedAgentClient {
         });
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    private async findOrCreateVault(betaAny: any): Promise<{ id: string }> {
+    private async findOrCreateVault(betaAny: AnyType): Promise<{ id: string }> {
         const VAULT_NAME = 'Lightdash MCP Auth';
         try {
             const list = await betaAny.vaults.list();
@@ -180,8 +179,7 @@ export class ManagedAgentClient {
         const { agentId, environmentId, vaultId } =
             await this.ensureAgentAndEnvironment();
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const betaAny = this.client.beta as any;
+        const betaAny = this.client.beta as AnyType;
 
         const session = await betaAny.sessions.create({
             agent: agentId,

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -80,33 +80,17 @@ export class ManagedAgentClient {
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
         const betaAny = this.client.beta as any;
 
-        const environment = await betaAny.environments.create({
-            name: 'lightdash-agent-env',
-            config: {
-                type: 'cloud',
-                networking: { type: 'limited', allow_mcp_servers: true },
-            },
-        });
+        // Reuse existing environment if one exists, otherwise create
+        const environment = await this.findOrCreateEnvironment(betaAny);
 
-        // Create a vault and add a static bearer credential for MCP auth
-        const vault = await betaAny.vaults.create({
-            display_name: 'Lightdash MCP Auth',
-        });
-
-        await betaAny.vaults.credentials.create(vault.id, {
-            display_name: 'Lightdash PAT',
-            auth: {
-                type: 'static_bearer',
-                mcp_server_url: `${this.config.siteUrl}/api/v1/mcp`,
-                token: this.config.serviceAccountPat,
-            },
-        });
+        // Reuse existing vault if one exists, otherwise create with credentials
+        const vault = await this.findOrCreateVault(betaAny);
 
         this.agentId = configAgentId;
         this.environmentId = environment.id;
         this.vaultId = vault.id;
 
-        // Persist the new IDs so they survive service restarts
+        // Persist the IDs so they survive service restarts
         await this.config.onResourcesCreated(environment.id, vault.id);
 
         Logger.info(
@@ -118,6 +102,75 @@ export class ManagedAgentClient {
             environmentId: environment.id,
             vaultId: vault.id,
         };
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, class-methods-use-this
+    private async findOrCreateEnvironment(
+        betaAny: any,
+    ): Promise<{ id: string }> {
+        const ENV_NAME = 'lightdash-agent-env';
+        try {
+            const list = await betaAny.environments.list();
+            const existing = list?.data?.find(
+                (e: { name: string }) => e.name === ENV_NAME,
+            );
+            if (existing) {
+                Logger.info(
+                    `[ManagedAgent] Reusing existing environment: ${existing.id}`,
+                );
+                return existing;
+            }
+        } catch (error) {
+            Logger.warn(
+                `[ManagedAgent] Could not list environments, creating new: ${error instanceof Error ? error.message : 'Unknown'}`,
+            );
+        }
+
+        Logger.info('[ManagedAgent] Creating new environment');
+        return betaAny.environments.create({
+            name: ENV_NAME,
+            config: {
+                type: 'cloud',
+                networking: { type: 'limited', allow_mcp_servers: true },
+            },
+        });
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    private async findOrCreateVault(betaAny: any): Promise<{ id: string }> {
+        const VAULT_NAME = 'Lightdash MCP Auth';
+        try {
+            const list = await betaAny.vaults.list();
+            const existing = list?.data?.find(
+                (v: { display_name: string }) => v.display_name === VAULT_NAME,
+            );
+            if (existing) {
+                Logger.info(
+                    `[ManagedAgent] Reusing existing vault: ${existing.id}`,
+                );
+                return existing;
+            }
+        } catch (error) {
+            Logger.warn(
+                `[ManagedAgent] Could not list vaults, creating new: ${error instanceof Error ? error.message : 'Unknown'}`,
+            );
+        }
+
+        Logger.info('[ManagedAgent] Creating new vault');
+        const vault = await betaAny.vaults.create({
+            display_name: VAULT_NAME,
+        });
+
+        await betaAny.vaults.credentials.create(vault.id, {
+            display_name: 'Lightdash PAT',
+            auth: {
+                type: 'static_bearer',
+                mcp_server_url: `${this.config.siteUrl}/api/v1/mcp`,
+                token: this.config.serviceAccountPat,
+            },
+        });
+
+        return vault;
     }
 
     async runSession(

--- a/packages/backend/src/ee/database/entities/managedAgent.ts
+++ b/packages/backend/src/ee/database/entities/managedAgent.ts
@@ -11,6 +11,7 @@ export type DbManagedAgentSettings = {
     service_account_token: Buffer | null;
     anthropic_environment_id: string | null;
     anthropic_vault_id: string | null;
+    slack_channel_id: string | null;
     created_at: Date;
     updated_at: Date;
 };
@@ -28,6 +29,7 @@ export type DbManagedAgentSettingsCreate = Pick<
             | 'service_account_token'
             | 'anthropic_environment_id'
             | 'anthropic_vault_id'
+            | 'slack_channel_id'
         >
     >;
 
@@ -40,6 +42,7 @@ export type DbManagedAgentSettingsUpdate = Partial<
         | 'service_account_token'
         | 'anthropic_environment_id'
         | 'anthropic_vault_id'
+        | 'slack_channel_id'
         | 'updated_at'
     >
 >;

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -404,6 +404,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     personalAccessTokenModel:
                         models.getPersonalAccessTokenModel(),
                     schedulerClient: clients.getSchedulerClient(),
+                    slackClient: clients.getSlackClient(),
                 }),
             deployService: ({ models, clients, repository, context }) =>
                 new DeployService({

--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -38,6 +38,7 @@ export class ManagedAgentModel {
             enabled: row.enabled,
             scheduleCron: row.schedule_cron,
             enabledByUserUuid: row.enabled_by_user_uuid,
+            slackChannelId: row.slack_channel_id,
             createdAt: row.created_at,
             updatedAt: row.updated_at,
         };
@@ -110,6 +111,7 @@ export class ManagedAgentModel {
                 enabled: update.enabled ?? false,
                 schedule_cron: update.scheduleCron ?? '*/30 * * * *',
                 enabled_by_user_uuid: update.enabled ? userUuid : null,
+                slack_channel_id: update.slackChannelId ?? null,
                 updated_at: new Date(),
             })
             .onConflict('project_uuid')
@@ -117,6 +119,9 @@ export class ManagedAgentModel {
                 enabled: update.enabled,
                 ...(update.scheduleCron !== undefined && {
                     schedule_cron: update.scheduleCron,
+                }),
+                ...(update.slackChannelId !== undefined && {
+                    slack_channel_id: update.slackChannelId,
                 }),
                 enabled_by_user_uuid: update.enabled ? userUuid : undefined,
                 updated_at: new Date(),

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -15,6 +15,7 @@ import {
     type UpdateManagedAgentSettings,
     type ValidationResponse,
 } from '@lightdash/common';
+import type { SlackClient } from '../../../clients/Slack/SlackClient';
 import type { LightdashConfig } from '../../../config/parseConfig';
 import type { AnalyticsModel } from '../../../models/AnalyticsModel';
 import type { DashboardModel } from '../../../models/DashboardModel/DashboardModel';
@@ -41,6 +42,7 @@ type ManagedAgentServiceDependencies = {
     userModel: UserModel;
     personalAccessTokenModel: PersonalAccessTokenModel;
     schedulerClient: SchedulerClient;
+    slackClient: SlackClient;
 };
 
 export class ManagedAgentService extends BaseService {
@@ -66,6 +68,8 @@ export class ManagedAgentService extends BaseService {
 
     private readonly schedulerClient: SchedulerClient;
 
+    private readonly slackClient: SlackClient;
+
     private client: ManagedAgentClient | null = null;
 
     constructor(deps: ManagedAgentServiceDependencies) {
@@ -81,6 +85,7 @@ export class ManagedAgentService extends BaseService {
         this.userModel = deps.userModel;
         this.personalAccessTokenModel = deps.personalAccessTokenModel;
         this.schedulerClient = deps.schedulerClient;
+        this.slackClient = deps.slackClient;
     }
 
     // --- Validation helpers ---
@@ -388,6 +393,160 @@ export class ManagedAgentService extends BaseService {
         sessionId = await client.runSession(projectUuid, onToolCall);
 
         this.logger.info(`Heartbeat complete for project: ${projectUuid}`);
+
+        // Post summary to Slack if configured
+        if (settings.slackChannelId && sessionId) {
+            await this.postHeartbeatSummaryToSlack(
+                projectUuid,
+                sessionId,
+                settings.slackChannelId,
+            );
+        }
+    }
+
+    private async postHeartbeatSummaryToSlack(
+        projectUuid: string,
+        sessionId: string,
+        slackChannelId: string,
+    ): Promise<void> {
+        try {
+            const actions = await this.managedAgentModel.getActions(
+                projectUuid,
+                { sessionId },
+            );
+
+            if (actions.length === 0) {
+                return; // Nothing to report
+            }
+
+            const { organizationUuid } =
+                await this.projectModel.getSummary(projectUuid);
+            const { siteUrl } = this.lightdashConfig;
+            const activityUrl = `${siteUrl}/projects/${projectUuid}/improve`;
+
+            // Build action summary counts
+            const counts: Record<string, number> = {};
+            for (const a of actions) {
+                counts[a.actionType] = (counts[a.actionType] || 0) + 1;
+            }
+
+            const summaryParts: string[] = [];
+            if (counts.fixed_broken)
+                summaryParts.push(
+                    `*${counts.fixed_broken}* chart${counts.fixed_broken > 1 ? 's' : ''} fixed`,
+                );
+            if (counts.created_content)
+                summaryParts.push(
+                    `*${counts.created_content}* chart${counts.created_content > 1 ? 's' : ''} created`,
+                );
+            if (counts.flagged_stale)
+                summaryParts.push(
+                    `*${counts.flagged_stale}* item${counts.flagged_stale > 1 ? 's' : ''} flagged as stale`,
+                );
+            if (counts.flagged_broken)
+                summaryParts.push(
+                    `*${counts.flagged_broken}* item${counts.flagged_broken > 1 ? 's' : ''} flagged as broken`,
+                );
+            if (counts.soft_deleted)
+                summaryParts.push(
+                    `*${counts.soft_deleted}* item${counts.soft_deleted > 1 ? 's' : ''} cleaned up`,
+                );
+            if (counts.insight)
+                summaryParts.push(
+                    `*${counts.insight}* insight${counts.insight > 1 ? 's' : ''}`,
+                );
+
+            const ACTION_ICONS: Record<string, string> = {
+                [ManagedAgentActionType.FIXED_BROKEN]: ':wrench:',
+                [ManagedAgentActionType.CREATED_CONTENT]: ':sparkles:',
+                [ManagedAgentActionType.FLAGGED_STALE]: ':warning:',
+                [ManagedAgentActionType.FLAGGED_BROKEN]: ':x:',
+                [ManagedAgentActionType.SOFT_DELETED]: ':wastebasket:',
+                [ManagedAgentActionType.INSIGHT]: ':bulb:',
+            };
+
+            const RESOURCE_URL_PATTERNS: Record<string, string> = {
+                [ManagedAgentTargetType.CHART]: 'saved',
+                [ManagedAgentTargetType.DASHBOARD]: 'dashboards',
+            };
+
+            // Build per-action detail lines with links
+            const detailLines = actions.slice(0, 10).map((a) => {
+                const urlSegment = RESOURCE_URL_PATTERNS[a.targetType];
+                const resourceUrl = urlSegment
+                    ? `${siteUrl}/projects/${projectUuid}/${urlSegment}/${a.targetUuid}`
+                    : null;
+
+                const icon = ACTION_ICONS[a.actionType] || ':bulb:';
+
+                const nameLink = resourceUrl
+                    ? `<${resourceUrl}|${a.targetName}>`
+                    : a.targetName;
+
+                return `${icon} ${nameLink} — ${a.description}`;
+            });
+
+            const moreCount = actions.length - 10;
+            if (moreCount > 0) {
+                detailLines.push(
+                    `_...and ${moreCount} more action${moreCount > 1 ? 's' : ''}_`,
+                );
+            }
+
+            const blocks = [
+                {
+                    type: 'header' as const,
+                    text: {
+                        type: 'plain_text' as const,
+                        text: ':zap: Improve agent completed a run',
+                        emoji: true,
+                    },
+                },
+                {
+                    type: 'section' as const,
+                    text: {
+                        type: 'mrkdwn' as const,
+                        text: summaryParts.join('  ·  '),
+                    },
+                },
+                {
+                    type: 'section' as const,
+                    text: {
+                        type: 'mrkdwn' as const,
+                        text: detailLines.join('\n'),
+                    },
+                },
+                {
+                    type: 'actions' as const,
+                    elements: [
+                        {
+                            type: 'button' as const,
+                            text: {
+                                type: 'plain_text' as const,
+                                text: 'View all activity',
+                                emoji: true,
+                            },
+                            url: activityUrl,
+                        },
+                    ],
+                },
+            ];
+
+            await this.slackClient.postMessage({
+                organizationUuid,
+                channel: slackChannelId,
+                text: `Improve agent: ${summaryParts.join(', ')}`,
+                blocks,
+            });
+
+            this.logger.info(
+                `Posted heartbeat summary to Slack channel ${slackChannelId}`,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `Failed to post heartbeat summary to Slack: ${error instanceof Error ? error.message : 'Unknown error'}`,
+            );
+        }
     }
 
     // --- Tool Handlers ---

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1568,7 +1568,7 @@ export class SchedulerClient {
 
         const arr = stringToArray(cronPattern);
         const schedule = getSchedule(arr, new Date(), 'UTC');
-        const nextRun = schedule.next();
+        const nextRun = schedule.next().toJSDate();
 
         await graphileClient.addJob(
             SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT,

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -19,6 +19,7 @@ export type ManagedAgentSettings = {
     enabled: boolean;
     scheduleCron: string;
     enabledByUserUuid: string | null;
+    slackChannelId: string | null;
     createdAt: Date;
     updatedAt: Date;
 };
@@ -41,6 +42,7 @@ export type ManagedAgentAction = {
 export type UpdateManagedAgentSettings = {
     enabled?: boolean;
     scheduleCron?: string;
+    slackChannelId?: string | null;
 };
 
 export type CreateManagedAgentAction = {

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.module.css
@@ -344,6 +344,13 @@
     word-break: break-all;
 }
 
+.slackBadge {
+    border-radius: 8px;
+    border: 1px solid
+        light-dark(var(--mantine-color-gray-3), var(--mantine-color-dark-4));
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.06);
+}
+
 /* Page header */
 .headerDivider {
     height: 1px;

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -24,7 +24,7 @@ import { lightdashApi } from '../../../api';
 import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
 import { SlackChannelSelect } from '../../../components/common/SlackChannelSelect';
 import TruncatedText from '../../../components/common/TruncatedText';
-import useHealth from '../../../hooks/health/useHealth';
+import { useGetSlack } from '../../../hooks/slack/useSlack';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentActivityPage.module.css';
@@ -67,8 +67,8 @@ const SetupSection: FC<{
     isLoading,
 }) => {
     const queryClient = useQueryClient();
-    const { data: health } = useHealth();
-    const hasSlack = health?.hasSlack ?? false;
+    const { data: slackInstallation } = useGetSlack();
+    const organizationHasSlack = !!slackInstallation?.organizationUuid;
 
     const mutation = useMutation({
         mutationFn: (body: Parameters<typeof updateSettings>[1]) =>
@@ -111,10 +111,10 @@ const SetupSection: FC<{
                     )}
                 </Group>
                 <Group gap="md" align="center">
-                    {hasSlack && enabled && (
-                        <Box w={240}>
+                    {organizationHasSlack && enabled && (
+                        <Box w={220}>
                             <SlackChannelSelect
-                                placeholder="Post summaries to..."
+                                placeholder="Slack channel..."
                                 size="xs"
                                 value={initialSlackChannelId}
                                 onChange={handleSlackChannelChange}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1,6 +1,5 @@
 import {
     ActionIcon,
-    Badge,
     Box,
     Group,
     Loader,
@@ -141,24 +140,26 @@ const SetupSection: FC<{
                     {organizationHasSlack && enabled && (
                         <>
                             {initialSlackChannelId ? (
-                                <Badge
-                                    variant="light"
-                                    color="gray"
-                                    size="lg"
-                                    leftSection={<IconBrandSlack size={14} />}
-                                    rightSection={
-                                        <ActionIcon
-                                            variant="transparent"
-                                            size="xs"
-                                            color="gray"
-                                            onClick={handleClearSlack}
-                                        >
-                                            <IconX size={12} />
-                                        </ActionIcon>
-                                    }
+                                <Group
+                                    gap={6}
+                                    px="sm"
+                                    py={4}
+                                    bg="white"
+                                    className={classes.slackBadge}
                                 >
-                                    #{slackChannelName}
-                                </Badge>
+                                    <IconBrandSlack size={14} />
+                                    <Text fz="xs" fw={500}>
+                                        {slackChannelName}
+                                    </Text>
+                                    <ActionIcon
+                                        variant="transparent"
+                                        size="xs"
+                                        color="gray"
+                                        onClick={handleClearSlack}
+                                    >
+                                        <IconX size={12} />
+                                    </ActionIcon>
+                                </Group>
                             ) : (
                                 <Popover
                                     opened={slackPopoverOpen}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -1,7 +1,10 @@
 import {
+    ActionIcon,
+    Badge,
     Box,
     Group,
     Loader,
+    Popover,
     Stack,
     Switch,
     Table,
@@ -11,20 +14,21 @@ import {
 } from '@mantine-8/core';
 import {
     IconBolt,
+    IconBrandSlack,
     IconChartBar,
     IconExternalLink,
     IconLayoutDashboard,
     IconX,
 } from '@tabler/icons-react';
 import { useMutation, useQueryClient } from '@tanstack/react-query';
-import { type FC, useState } from 'react';
+import { useCallback, type FC, useState } from 'react';
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
 import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
 import { SlackChannelSelect } from '../../../components/common/SlackChannelSelect';
 import TruncatedText from '../../../components/common/TruncatedText';
-import { useGetSlack } from '../../../hooks/slack/useSlack';
+import { useGetSlack, useSlackChannels } from '../../../hooks/slack/useSlack';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentActivityPage.module.css';
@@ -70,6 +74,19 @@ const SetupSection: FC<{
     const { data: slackInstallation } = useGetSlack();
     const organizationHasSlack = !!slackInstallation?.organizationUuid;
 
+    const { data: resolvedChannels } = useSlackChannels(
+        '',
+        {
+            includeChannelIds: initialSlackChannelId
+                ? [initialSlackChannelId]
+                : undefined,
+        },
+        { enabled: !!initialSlackChannelId && organizationHasSlack },
+    );
+    const slackChannelName =
+        resolvedChannels?.find((c) => c.id === initialSlackChannelId)?.name ??
+        initialSlackChannelId;
+
     const mutation = useMutation({
         mutationFn: (body: Parameters<typeof updateSettings>[1]) =>
             updateSettings(projectUuid, body),
@@ -84,9 +101,19 @@ const SetupSection: FC<{
         mutation.mutate({ enabled: val });
     };
 
-    const handleSlackChannelChange = (channelId: string | null) => {
-        mutation.mutate({ slackChannelId: channelId });
-    };
+    const [slackPopoverOpen, setSlackPopoverOpen] = useState(false);
+
+    const handleSlackChannelChange = useCallback(
+        (channelId: string | null) => {
+            mutation.mutate({ slackChannelId: channelId });
+            setSlackPopoverOpen(false);
+        },
+        [mutation],
+    );
+
+    const handleClearSlack = useCallback(() => {
+        mutation.mutate({ slackChannelId: null });
+    }, [mutation]);
 
     const scheduleLabel =
         SCHEDULE_OPTIONS.find(
@@ -110,17 +137,62 @@ const SetupSection: FC<{
                         </Box>
                     )}
                 </Group>
-                <Group gap="md" align="center">
+                <Group gap="sm" align="center">
                     {organizationHasSlack && enabled && (
-                        <Box w={220}>
-                            <SlackChannelSelect
-                                placeholder="Slack channel..."
-                                size="xs"
-                                value={initialSlackChannelId}
-                                onChange={handleSlackChannelChange}
-                                disabled={isLoading || mutation.isLoading}
-                            />
-                        </Box>
+                        <>
+                            {initialSlackChannelId ? (
+                                <Badge
+                                    variant="light"
+                                    color="gray"
+                                    size="lg"
+                                    leftSection={<IconBrandSlack size={14} />}
+                                    rightSection={
+                                        <ActionIcon
+                                            variant="transparent"
+                                            size="xs"
+                                            color="gray"
+                                            onClick={handleClearSlack}
+                                        >
+                                            <IconX size={12} />
+                                        </ActionIcon>
+                                    }
+                                >
+                                    #{slackChannelName}
+                                </Badge>
+                            ) : (
+                                <Popover
+                                    opened={slackPopoverOpen}
+                                    onChange={setSlackPopoverOpen}
+                                    position="bottom-end"
+                                    width={280}
+                                    shadow="md"
+                                >
+                                    <Popover.Target>
+                                        <ActionIcon
+                                            variant="subtle"
+                                            color="gray"
+                                            size="md"
+                                            onClick={() =>
+                                                setSlackPopoverOpen((o) => !o)
+                                            }
+                                        >
+                                            <IconBrandSlack size={18} />
+                                        </ActionIcon>
+                                    </Popover.Target>
+                                    <Popover.Dropdown>
+                                        <Text fz="xs" fw={500} mb="xs">
+                                            Post summaries to Slack
+                                        </Text>
+                                        <SlackChannelSelect
+                                            placeholder="Search channels..."
+                                            size="xs"
+                                            value={null}
+                                            onChange={handleSlackChannelChange}
+                                        />
+                                    </Popover.Dropdown>
+                                </Popover>
+                            )}
+                        </>
                     )}
                     <Switch
                         checked={enabled}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -22,7 +22,9 @@ import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { useParams } from 'react-router';
 import { lightdashApi } from '../../../api';
 import { NAVBAR_HEIGHT } from '../../../components/common/Page/constants';
+import { SlackChannelSelect } from '../../../components/common/SlackChannelSelect';
 import TruncatedText from '../../../components/common/TruncatedText';
+import useHealth from '../../../hooks/health/useHealth';
 import { useManagedAgentActions } from './hooks/useManagedAgentActions';
 import { useManagedAgentSettings } from './hooks/useManagedAgentSettings';
 import classes from './ManagedAgentActivityPage.module.css';
@@ -30,7 +32,11 @@ import type { ManagedAgentAction } from './types';
 
 const updateSettings = async (
     projectUuid: string,
-    body: { enabled?: boolean; scheduleCron?: string },
+    body: {
+        enabled?: boolean;
+        scheduleCron?: string;
+        slackChannelId?: string | null;
+    },
 ) =>
     lightdashApi({
         url: `/projects/${projectUuid}/managed-agent/settings`,
@@ -51,12 +57,21 @@ const SetupSection: FC<{
     projectUuid: string;
     enabled: boolean;
     schedule: string;
+    slackChannelId: string | null;
     isLoading: boolean;
-}> = ({ projectUuid, enabled, schedule: initialSchedule, isLoading }) => {
+}> = ({
+    projectUuid,
+    enabled,
+    schedule: initialSchedule,
+    slackChannelId: initialSlackChannelId,
+    isLoading,
+}) => {
     const queryClient = useQueryClient();
+    const { data: health } = useHealth();
+    const hasSlack = health?.hasSlack ?? false;
 
     const mutation = useMutation({
-        mutationFn: (body: { enabled?: boolean }) =>
+        mutationFn: (body: Parameters<typeof updateSettings>[1]) =>
             updateSettings(projectUuid, body),
         onSuccess: () => {
             void queryClient.invalidateQueries({
@@ -67,6 +82,10 @@ const SetupSection: FC<{
 
     const handleToggle = (val: boolean) => {
         mutation.mutate({ enabled: val });
+    };
+
+    const handleSlackChannelChange = (channelId: string | null) => {
+        mutation.mutate({ slackChannelId: channelId });
     };
 
     const scheduleLabel =
@@ -91,13 +110,26 @@ const SetupSection: FC<{
                         </Box>
                     )}
                 </Group>
-                <Switch
-                    checked={enabled}
-                    onChange={(e) => handleToggle(e.currentTarget.checked)}
-                    disabled={isLoading || mutation.isLoading}
-                    size="sm"
-                    color="dark"
-                />
+                <Group gap="md" align="center">
+                    {hasSlack && enabled && (
+                        <Box w={240}>
+                            <SlackChannelSelect
+                                placeholder="Post summaries to..."
+                                size="xs"
+                                value={initialSlackChannelId}
+                                onChange={handleSlackChannelChange}
+                                disabled={isLoading || mutation.isLoading}
+                            />
+                        </Box>
+                    )}
+                    <Switch
+                        checked={enabled}
+                        onChange={(e) => handleToggle(e.currentTarget.checked)}
+                        disabled={isLoading || mutation.isLoading}
+                        size="sm"
+                        color="dark"
+                    />
+                </Group>
             </Group>
             <Box className={classes.headerDivider} />
         </Stack>
@@ -308,6 +340,9 @@ export const ManagedAgentActivityPage: FC = () => {
                                 enabled={settings?.enabled ?? false}
                                 schedule={
                                     settings?.scheduleCron ?? '*/30 * * * *'
+                                }
+                                slackChannelId={
+                                    settings?.slackChannelId ?? null
                                 }
                                 isLoading={settingsLoading}
                             />

--- a/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
+++ b/packages/frontend/src/ee/features/managedAgent/hooks/useManagedAgentSettings.ts
@@ -7,6 +7,7 @@ type ManagedAgentSettings = {
     enabled: boolean;
     scheduleCron: string;
     enabledByUserUuid: string | null;
+    slackChannelId: string | null;
     createdAt: string;
     updatedAt: string;
 };


### PR DESCRIPTION
## Summary

Adds Slack notification support to the managed agent and fixes a CronDate bug that caused 500 errors when enabling the agent.

### Slack Notifications

After each heartbeat run, the agent posts a formatted summary to a configured Slack channel:

```
⚡ Improve agent completed a run
─────────────────────────────────
*2* charts fixed  ·  *1* chart created  ·  *3* items flagged as stale

🔧 <link|Revenue by Region> — Fixed invalid dimension reference
✨ <link|Top Customers Q1> — Created from orders explore gap
⚠️ <link|Old Sales Report> — No views in 4 months

[ View all activity ]
```

- Action counts with bold formatting
- Per-action detail lines with clickable links to charts/dashboards
- "View all activity" button linking to the activity page
- Non-blocking — failures are logged as warnings, never block the heartbeat

### Channel Configuration UI

- When no channel is set: Slack icon button opens a popover with channel search
- When a channel is set: compact pill with Slack icon, channel name (resolved from ID), and X to clear
- Only visible when Slack is installed and the agent is enabled

### CronDate Bugfix

`getSchedule().next()` returns a cron-converter `CronDate`, not a native `Date`. Graphile Worker's `addJob` calls `.toISOString()` which doesn't exist on `CronDate`. Fixed with `.toJSDate()`.

This was causing a 500 on `PATCH /managed-agent/settings` when enabling the agent.

## Changes

| File | Change |
|------|--------|
| `common/ee/types/managedAgent.ts` | Add `slackChannelId` to `ManagedAgentSettings` and `UpdateManagedAgentSettings` |
| `ee/database/entities/managedAgent.ts` | Add `slack_channel_id` to DB entity types |
| `migrations/20260414145236` | New migration: `ALTER TABLE managed_agent_settings ADD slack_channel_id` |
| `ee/models/ManagedAgentModel.ts` | Map and persist `slackChannelId` in `mapDbSettings` / `upsertSettings` |
| `ee/services/ManagedAgentService.ts` | Add `SlackClient` dependency, `postHeartbeatSummaryToSlack()` method |
| `ee/index.ts` | Wire `slackClient` into `ManagedAgentService` |
| `scheduler/SchedulerClient.ts` | Fix `.next()` → `.next().toJSDate()` |
| `ManagedAgentActivityPage.tsx` | Slack pill badge + popover channel picker in header |
| `ManagedAgentActivityPage.module.css` | `.slackBadge` styles |
| `useManagedAgentSettings.ts` | Add `slackChannelId` to frontend type |

## Test plan

- [ ] Enable agent with Slack channel set → verify formatted message posted after heartbeat
- [ ] Set Slack channel → verify pill badge shows resolved channel name
- [ ] Clear Slack channel → verify Slack icon button returns
- [ ] Enable agent (the CronDate fix) → verify no 500 error
- [ ] Heartbeat without Slack channel → verify no Slack message, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)