### PR TITLE
fix: ClickHouse Date Zoom week truncation off by one

### DIFF
--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -77,6 +77,47 @@ describe('TimeFrames', () => {
                 "DATE_TRUNC('WEEK', ${TABLE}.created)", // start of week is set in the session
             );
         });
+
+        test('ClickHouse week truncation should use Monday-based toStartOfWeek', () => {
+            // Monday (0): toStartOfWeek with mode 1 returns Monday, no shift needed
+            expect(
+                timeFrameConfigs[TimeFrames.WEEK].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.WEEK,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(
+                'addDays(toStartOfWeek(addDays(${TABLE}.created, -0), 1), 0)',
+            );
+
+            // Wednesday (2): shift back 2 days, truncate to Monday-week, shift forward 2
+            expect(
+                timeFrameConfigs[TimeFrames.WEEK].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.WEEK,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    WeekDay.WEDNESDAY,
+                ),
+            ).toEqual(
+                'addDays(toStartOfWeek(addDays(${TABLE}.created, -2), 1), 2)',
+            );
+
+            // Sunday (6): shift back 6 days, truncate to Monday-week, shift forward 6
+            expect(
+                timeFrameConfigs[TimeFrames.WEEK].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.WEEK,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    WeekDay.SUNDAY,
+                ),
+            ).toEqual(
+                'addDays(toStartOfWeek(addDays(${TABLE}.created, -6), 1), 6)',
+            );
+        });
     });
 
     describe('getSqlForDatePart - DAY_OF_WEEK_INDEX with startOfWeek', () => {

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -422,14 +422,14 @@ const clickhouseConfig: WarehouseConfig = {
     getSqlForTruncatedDate: (timeFrame, originalSql, _, startOfWeek) => {
         if (timeFrame === TimeFrames.WEEK && isWeekDay(startOfWeek)) {
             const intervalDiff = startOfWeek;
-            return `addDays(toStartOfWeek(addDays(${originalSql}, -${intervalDiff})), ${intervalDiff})`;
+            return `addDays(toStartOfWeek(addDays(${originalSql}, -${intervalDiff}), 1), ${intervalDiff})`;
         }
 
         switch (timeFrame) {
             case TimeFrames.DAY:
                 return `toStartOfDay(${originalSql})`;
             case TimeFrames.WEEK:
-                return `toStartOfWeek(${originalSql})`;
+                return `toStartOfWeek(${originalSql}, 1)`;
             case TimeFrames.MONTH:
                 return `toStartOfMonth(${originalSql})`;
             case TimeFrames.QUARTER:


### PR DESCRIPTION
## Bug
ClickHouse Date Zoom week boundaries are shifted by one day. Setting start of week to Monday (0) produces Sunday-start weeks; setting Tuesday (1) produces Monday weeks.

## Expected
Week boundaries should respect the configured start of week for ClickHouse, matching other warehouses.

## Reproduction
Failing test in `packages/common/src/utils/timeFrames.test.ts` — "ClickHouse week truncation should use Monday-based toStartOfWeek"

## Evidence (before)
- Test output shows `toStartOfWeek(...)` without mode parameter, defaulting to Sunday in ClickHouse
- Expected: `addDays(toStartOfWeek(addDays(..., -0), 1), 0)` (with mode 1 = Monday)
- Received: `addDays(toStartOfWeek(addDays(..., -0)), 0)` (no mode = Sunday default)

## Fix
**Root cause:** ClickHouse's `toStartOfWeek()` defaults to mode 0 (Sunday), but the week shift formula in `timeFrames.ts` assumed it returns Monday (like Postgres's `DATE_TRUNC('week')`).

**Change:** Pass mode `1` to `toStartOfWeek()` in both the configured start-of-week path (line 425) and the default WEEK case (line 432). Mode 1 tells ClickHouse to use Monday as the first day of the week, making the shift arithmetic correct.

## Evidence (after)
- Test now passing: `packages/common/src/utils/timeFrames.test.ts` — all 9 tests pass
- typecheck / lint / test: ✅

Closes #21930