### PR TITLE
feat(cli): include Lightdash YAML schema references in install-skills

### DIFF
--- a/skills/developing-in-lightdash/SKILL.md
+++ b/skills/developing-in-lightdash/SKILL.md
@@ -115,6 +115,19 @@ dimensions:
     type: string
 ```
 
+### YAML Schema References
+
+Use these JSON schemas to validate Lightdash YAML files. The schema you need depends on the project type and content type:
+
+| Schema | Use For | Path |
+|--------|---------|------|
+| [lightdash-dbt-2.0.json](./resources/schemas/lightdash-dbt-2.0.json) | dbt model YAML with Lightdash metadata (`meta:` properties) | `resources/schemas/lightdash-dbt-2.0.json` |
+| [model-as-code-1.0.json](./resources/schemas/model-as-code-1.0.json) | Pure Lightdash model YAML (no dbt, top-level properties) | `resources/schemas/model-as-code-1.0.json` |
+| [chart-as-code-1.0.json](./resources/schemas/chart-as-code-1.0.json) | Chart YAML files | `resources/schemas/chart-as-code-1.0.json` |
+| [dashboard-as-code-1.0.json](./resources/schemas/dashboard-as-code-1.0.json) | Dashboard YAML files | `resources/schemas/dashboard-as-code-1.0.json` |
+
+When editing or creating Lightdash YAML files, validate the structure against the appropriate schema. These schemas define all valid properties, types, and enums for each content type.
+
 ## Setting Up Warehouse Connection
 
 If the project needs a different warehouse connection (e.g., switching from Postgres to BigQuery), update it from your profiles.yml:

--- a/skills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/skills/developing-in-lightdash/resources/dashboard-reference.md
@@ -2,6 +2,8 @@
 
 Dashboards combine multiple charts, KPIs, and content tiles into a cohesive view for analysis and monitoring.
 
+> **Schema Reference**: For the complete schema definition, see [dashboard-as-code-1.0.json](schemas/dashboard-as-code-1.0.json).
+
 ## Dashboard Structure
 
 ```yaml

--- a/skills/developing-in-lightdash/resources/dimensions-reference.md
+++ b/skills/developing-in-lightdash/resources/dimensions-reference.md
@@ -2,6 +2,8 @@
 
 Dimensions are attributes used to segment and filter data. They describe the "who", "what", "where", and "when" of your data.
 
+> **Schema Reference**: For dbt projects, see [lightdash-dbt-2.0.json](schemas/lightdash-dbt-2.0.json). For pure Lightdash projects, see [model-as-code-1.0.json](schemas/model-as-code-1.0.json).
+
 ## Basic Configuration
 
 ```yaml

--- a/skills/developing-in-lightdash/resources/metrics-reference.md
+++ b/skills/developing-in-lightdash/resources/metrics-reference.md
@@ -2,6 +2,8 @@
 
 Metrics are aggregated calculations performed on your data. They answer questions like "how much?", "how many?", and "what's the average?".
 
+> **Schema Reference**: For dbt projects, see [lightdash-dbt-2.0.json](schemas/lightdash-dbt-2.0.json). For pure Lightdash projects, see [model-as-code-1.0.json](schemas/model-as-code-1.0.json).
+
 ## Metric Locations
 
 Metrics can be defined in two places:

--- a/skills/developing-in-lightdash/resources/schemas/lightdash-dbt-2.0.json
+++ b/skills/developing-in-lightdash/resources/schemas/lightdash-dbt-2.0.json
@@ -1,0 +1,1 @@
+../../../../packages/common/src/schemas/json/lightdash-dbt-2.0.json


### PR DESCRIPTION
## Summary
- Adds a **YAML Schema References** section to the `developing-in-lightdash` skill (`SKILL.md`) with a table mapping each schema to its use case (dbt models, pure Lightdash models, charts, dashboards)
- Adds schema reference callouts to the **metrics**, **dimensions**, and **dashboard** reference docs — matching the pattern already used by chart type references
- Adds the missing `lightdash-dbt-2.0.json` symlink to `resources/schemas/` so dbt project validation is covered alongside the existing `model-as-code-1.0.json`

## Context
Closes #21909 / PROD-6914

The `install-skills` command already bundled `model-as-code-1.0.json` in `resources/schemas/` but never referenced it from the skill content, so copilots didn't know the schema existed for YAML validation.

## Test plan
- [ ] Run `lightdash install-skills` and verify the installed `SKILL.md` contains the YAML Schema References section
- [ ] Verify `resources/schemas/` contains all four schema files (chart, dashboard, model-as-code, lightdash-dbt-2.0)
- [ ] Open a Lightdash YAML file with a copilot and confirm it references the schema for validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)