### PR TITLE
fix: support metric sorting on pivot tables without row dimensions (Databricks)

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1218,6 +1218,50 @@ SELECT * FROM group_by_query LIMIT 50`);
                 'dense_rank() over (order by g."event_type" asc) as "column_index"',
             );
         });
+
+        test('Metric sort without index columns: should use precomputed column_ranking CTE (Databricks compatibility)', () => {
+            const pivotConfiguration = {
+                indexColumn: [],
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Should create column_ranking CTE even without index columns
+            expect(result).toContain('column_ranking AS (');
+
+            // pivot_query should JOIN with precomputed column_ranking
+            expect(replaceWhitespace(result)).toContain(
+                'LEFT JOIN column_ranking cr ON g."category" = cr."category"',
+            );
+
+            // pivot_query should use precomputed col_idx, not inline DENSE_RANK for column_index
+            expect(replaceWhitespace(result)).toContain(
+                'cr."col_idx" AS "column_index"',
+            );
+
+            // row_index should be constant 1 (no index columns)
+            expect(replaceWhitespace(result)).toContain('1 AS "row_index"');
+
+            // Should NOT have row_ranking or row_anchor CTEs (no index columns)
+            expect(result).not.toContain('row_ranking AS (');
+            expect(result).not.toContain('_row_anchor');
+        });
     });
 
     describe('Warehouse type compatibility', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -896,14 +896,10 @@ export class PivotQueryBuilder {
             ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
         );
 
-        // Check if we need row anchor CTEs (only when sorting by a metric value AND have index columns)
-        // When sorting by a metric, we need additional CTEs to identify the "first pivot column"
-        // and compute row anchor values from that specific column only.
-        // When there are no index columns, row sorting is not needed (all rows have row_index = 1)
+        // Check if any sort references a value column (metric sort)
         const hasMetricSort = valuesColumns?.some((valCol) =>
             sortBy?.some((sort) => sort.reference === valCol.reference),
         );
-        const needsRowAnchor = hasMetricSort && indexColumns.length > 0;
 
         let columnRankingCTE: string | null = null;
         let anchorColumnCTE: string | null = null;
@@ -911,8 +907,11 @@ export class PivotQueryBuilder {
         let rowAnchorQueries: Record<string, { cteName: string; sql: string }> =
             {};
 
-        if (needsRowAnchor) {
-            // Generate column_ranking CTE
+        if (hasMetricSort) {
+            // Generate column_ranking CTE whenever metric sorting is active.
+            // This isolates the DENSE_RANK + column anchor references in a
+            // self-contained CTE so Databricks/Spark can resolve them even
+            // when there are no index columns.
             const columnRankingSQL = this.getColumnRankingSQL(
                 groupByColumns,
                 valuesColumns,
@@ -921,23 +920,27 @@ export class PivotQueryBuilder {
             );
             columnRankingCTE = `column_ranking AS (${columnRankingSQL})`;
 
-            // Generate anchor_column CTE
-            const anchorColumnSQL = this.getAnchorColumnSQL(
-                groupByColumns,
-                sortBy,
-            );
-            anchorColumnCTE = `anchor_column AS (${anchorColumnSQL})`;
+            // Row anchor CTEs are only needed when there are index columns —
+            // without them all rows have row_index = 1 and no row sorting is needed.
+            if (indexColumns.length > 0) {
+                // Generate anchor_column CTE
+                const anchorColumnSQL = this.getAnchorColumnSQL(
+                    groupByColumns,
+                    sortBy,
+                );
+                anchorColumnCTE = `anchor_column AS (${anchorColumnSQL})`;
 
-            // Generate row anchor CTEs using anchor_column
-            rowAnchorQueries = this.getRowAnchorCTEs(
-                indexColumns,
-                valuesColumns,
-                groupByColumns,
-                sortBy,
-            );
-            rowAnchorCTEs = Object.values(rowAnchorQueries).map(
-                ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
-            );
+                // Generate row anchor CTEs using anchor_column
+                rowAnchorQueries = this.getRowAnchorCTEs(
+                    indexColumns,
+                    valuesColumns,
+                    groupByColumns,
+                    sortBy,
+                );
+                rowAnchorCTEs = Object.values(rowAnchorQueries).map(
+                    ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
+                );
+            }
         }
 
         // Combine all queries for the metricFirstValueQueries map (used by getPivotQuerySQL)
@@ -1294,15 +1297,14 @@ export class PivotQueryBuilder {
             sortBy,
         );
 
-        // When metric sorting with index columns is active (needsRowAnchor),
-        // compute rankings in separate CTEs instead of inline Window functions.
-        // This prevents Databricks/Spark from failing when it inlines CTEs and
-        // can't resolve anchor column references in Window ORDER BY clauses.
-        const needsPrecomputedRankings =
-            columnRankingCTE !== null && indexColumns.length > 0;
+        // When metric sorting is active, compute rankings in separate CTEs
+        // instead of inline Window functions. This prevents Databricks/Spark
+        // from failing when it inlines CTEs and can't resolve anchor column
+        // references in Window ORDER BY clauses.
+        const needsPrecomputedRankings = columnRankingCTE !== null;
 
         let rowRankingCTE: string | null = null;
-        if (needsPrecomputedRankings) {
+        if (needsPrecomputedRankings && indexColumns.length > 0) {
             // Extract only row anchor queries for the row_ranking CTE
             const rowAnchorQueries = Object.fromEntries(
                 Object.entries(metricFirstValueQueries).filter(([key]) =>


### PR DESCRIPTION
## Bug
Pivot charts with metric-based sorting and no row dimensions fail on Databricks with `Cannot find column index for attribute '..._column_anchor_value'`. The `columnRankingCTE` is only generated when `indexColumns.length > 0`, so the inline DENSE_RANK path references column anchor CTE values that Databricks can't resolve due to CTE inlining.

## Expected
Pivot tables with metric sorting and no row dimensions should work on all warehouses including Databricks.

## Reproduction
Failing test: `packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts` — "Metric sort without index columns: should use precomputed column_ranking CTE (Databricks compatibility)"

## Evidence (before)
- Failing test confirms `column_ranking AS (` CTE is missing when metric sort is active with no index columns
- Inline DENSE_RANK in `pivot_query` references `"revenue_column_anchor"."revenue_column_anchor_value"` which Databricks can't resolve

## Fix
The `hasMetricSort` condition in `getMetricAnchorCTEs` was gated on `indexColumns.length > 0`, which bundled column ranking (needed for column ordering on all warehouses) with row ranking (only needed when row dimensions exist). Split the conditions: `column_ranking` CTE is now generated whenever metric sorting is active, while `anchor_column`, `row_anchor`, and `row_ranking` CTEs still require index columns. The `needsPrecomputedRankings` flag in `getFullPivotSQL` was also ungated from `indexColumns.length > 0`.

## Evidence (after)
- Test now passing: `PivotQueryBuilder.test.ts` — all 97 tests pass
- typecheck: ✅
- lint: ✅

Closes #21193