### PR TITLE
fix: support metric sorting on pivot tables without row dimensions on Databricks

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -1218,6 +1218,49 @@ SELECT * FROM group_by_query LIMIT 50`);
                 'dense_rank() over (order by g."event_type" asc) as "column_index"',
             );
         });
+
+        test('Should use precomputed column_ranking CTE when sorting by metric without row dimensions', () => {
+            const pivotConfiguration = {
+                indexColumn: undefined,
+                valuesColumns: [
+                    {
+                        reference: 'revenue',
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: 'revenue', direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+            const result = builder.toSql();
+
+            // column_ranking CTE should be generated for metric sorting even without index columns
+            expect(result).toContain('column_ranking AS (');
+            expect(replaceWhitespace(result)).toContain(
+                'LEFT JOIN column_ranking cr ON g."category" = cr."category"',
+            );
+
+            // Row index should be constant (no row dimensions)
+            expect(result).toContain('1 AS "row_index"');
+
+            // Column index should come from precomputed column_ranking, not inline DENSE_RANK
+            expect(replaceWhitespace(result)).toContain(
+                'cr."col_idx" AS "column_index"',
+            );
+
+            // Should NOT have row_ranking CTE (no index columns to rank)
+            expect(result).not.toContain('row_ranking AS (');
+            // Should NOT have anchor_column or row_anchor CTEs
+            expect(result).not.toContain('anchor_column AS (');
+            expect(result).not.toContain('"revenue_row_anchor" AS (');
+        });
     });
 
     describe('Warehouse type compatibility', () => {

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -896,13 +896,11 @@ export class PivotQueryBuilder {
             ({ cteName, sql }) => `${q}${cteName}${q} AS (${sql})`,
         );
 
-        // Check if we need row anchor CTEs (only when sorting by a metric value AND have index columns)
-        // When sorting by a metric, we need additional CTEs to identify the "first pivot column"
-        // and compute row anchor values from that specific column only.
-        // When there are no index columns, row sorting is not needed (all rows have row_index = 1)
         const hasMetricSort = valuesColumns?.some((valCol) =>
             sortBy?.some((sort) => sort.reference === valCol.reference),
         );
+        // Row anchor CTEs are only needed when sorting by a metric AND there are index columns.
+        // When there are no index columns, row sorting is not needed (all rows have row_index = 1).
         const needsRowAnchor = hasMetricSort && indexColumns.length > 0;
 
         let columnRankingCTE: string | null = null;
@@ -911,8 +909,11 @@ export class PivotQueryBuilder {
         let rowAnchorQueries: Record<string, { cteName: string; sql: string }> =
             {};
 
-        if (needsRowAnchor) {
-            // Generate column_ranking CTE
+        // Generate column_ranking CTE whenever metric sorting is active, even without
+        // index columns. This ensures column ordering uses a precomputed CTE instead of
+        // inline Window functions that reference column anchor CTE values — which
+        // Databricks/Spark can't resolve due to CTE inlining.
+        if (hasMetricSort) {
             const columnRankingSQL = this.getColumnRankingSQL(
                 groupByColumns,
                 valuesColumns,
@@ -920,7 +921,9 @@ export class PivotQueryBuilder {
                 columnAnchorQueries,
             );
             columnRankingCTE = `column_ranking AS (${columnRankingSQL})`;
+        }
 
+        if (needsRowAnchor) {
             // Generate anchor_column CTE
             const anchorColumnSQL = this.getAnchorColumnSQL(
                 groupByColumns,
@@ -1294,15 +1297,14 @@ export class PivotQueryBuilder {
             sortBy,
         );
 
-        // When metric sorting with index columns is active (needsRowAnchor),
-        // compute rankings in separate CTEs instead of inline Window functions.
-        // This prevents Databricks/Spark from failing when it inlines CTEs and
-        // can't resolve anchor column references in Window ORDER BY clauses.
-        const needsPrecomputedRankings =
-            columnRankingCTE !== null && indexColumns.length > 0;
+        // When metric sorting is active, compute rankings in separate CTEs instead
+        // of inline Window functions. This prevents Databricks/Spark from failing
+        // when it inlines CTEs and can't resolve anchor column references in
+        // Window ORDER BY clauses.
+        const needsPrecomputedRankings = columnRankingCTE !== null;
 
         let rowRankingCTE: string | null = null;
-        if (needsPrecomputedRankings) {
+        if (needsPrecomputedRankings && indexColumns.length > 0) {
             // Extract only row anchor queries for the row_ranking CTE
             const rowAnchorQueries = Object.fromEntries(
                 Object.entries(metricFirstValueQueries).filter(([key]) =>


### PR DESCRIPTION
## Bug
Pivot charts with metric-based sorting and no row dimensions fail on Databricks with:
```
Cannot find column index for attribute '..._column_anchor_value'
```

## Expected
Pivot tables with metric sorting and no row dimensions should work correctly on all warehouses including Databricks.

## Reproduction
Failing test: `packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts` — "Should use precomputed column_ranking CTE when sorting by metric without row dimensions"

The test shows that when there are no index columns (row dimensions) but metric sorting is active, the code falls through to the inline DENSE_RANK path which references column anchor CTE values directly in Window functions. Databricks inlines CTEs and can't resolve these cross-CTE references.

## Evidence (before)
- Failing test confirms `column_ranking AS (` is NOT present in generated SQL
- Instead, inline `DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC, ...)` is used in pivot_query

## Fix
**Root cause**: `getMetricAnchorCTEs()` only generated the `columnRankingCTE` when `hasMetricSort && indexColumns.length > 0`. Without row dimensions, the precomputed column ranking was skipped entirely.

**Change**: Generate `columnRankingCTE` whenever metric sorting is active (`hasMetricSort`), not just when row dimensions are present. Row-specific CTEs (`anchor_column`, `row_anchor`, `row_ranking`) remain gated on `indexColumns.length > 0` since `row_index` is constant at 1 without row dimensions. Updated `needsPrecomputedRankings` to `columnRankingCTE !== null` (removed `indexColumns.length > 0` guard).

## Evidence (after)
- Test now passing: `packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts` (97/97 pass)
- typecheck / lint: ✅

Closes #21193