### PR TITLE
fix: stacked bar chart dates shifted by 1 day during DST transitions

### DIFF
--- a/packages/common/src/pivot/pivotQueryResults.mock.ts
+++ b/packages/common/src/pivot/pivotQueryResults.mock.ts
@@ -4,10 +4,12 @@ import {
     DimensionType,
     FieldType,
     MetricType,
+    type Dimension,
 } from '../types/field';
 import { type MetricQuery } from '../types/metricQuery';
 import { type PivotData } from '../types/pivot';
 import { type ResultRow } from '../types/results';
+import { TimeFrames } from '../types/timeFrames';
 import {
     SortByDirection,
     VizAggregationOptions,
@@ -135,6 +137,19 @@ export const getFieldMock = (fieldId: string): ItemsMap[string] | undefined => {
             sql: '${TABLE}.order_date_year',
             hidden: false,
         };
+    }
+    if (fieldId === 'orders_order_date_day') {
+        return {
+            fieldType: FieldType.DIMENSION,
+            type: DimensionType.DATE,
+            name: 'order_date_day',
+            label: 'Order Date Day',
+            table: 'orders',
+            tableLabel: 'Orders',
+            sql: '${TABLE}.order_date_day',
+            hidden: false,
+            timeInterval: TimeFrames.DAY,
+        } satisfies Dimension as Dimension;
     }
     if (fieldId === 'payments_total_revenue') {
         return {

--- a/packages/common/src/pivot/pivotQueryResults.test.ts
+++ b/packages/common/src/pivot/pivotQueryResults.test.ts
@@ -1,3 +1,6 @@
+import type { ReadyQueryResultsPage } from '../index';
+import type { ResultRow } from '../types/results';
+import { VizAggregationOptions, VizIndexType } from '../visualizations/types';
 import {
     convertSqlPivotedRowsToPivotData,
     pivotQueryResults,
@@ -1465,6 +1468,91 @@ describe('convertSqlPivotedRowsToPivotData', () => {
         });
 
         expect(largeResult).toStrictEqual(fullResult);
+    });
+
+    it('should not shift date dimensions during DST transitions (convertToUTC consistency)', () => {
+        const origTZ = process.env.TZ;
+        process.env.TZ = 'Europe/London';
+
+        try {
+            // Simulate a stacked bar chart where a date dimension (day-truncated)
+            // is the groupBy (pivot) column, with timestamps during BST (UTC+1).
+            // The raw value '2026-03-29T00:30:00.000+01:00' is 00:30 BST on March 29.
+            // With convertToUTC: true, moment converts to UTC → 23:30 on March 28 → wrong day.
+            // With convertToUTC: false (correct), moment keeps local time → March 29.
+            const dstPivotRows: ResultRow[] = [
+                {
+                    payments_payment_method: {
+                        value: { raw: 'credit_card', formatted: 'credit_card' },
+                    },
+                    payments_total_revenue_any_2026_03_29: {
+                        value: { raw: 100, formatted: '100.00' },
+                    },
+                },
+            ];
+
+            const dstPivotDetails: NonNullable<
+                ReadyQueryResultsPage['pivotDetails']
+            > = {
+                totalColumnCount: 1,
+                valuesColumns: [
+                    {
+                        aggregation: VizAggregationOptions.ANY,
+                        pivotValues: [
+                            {
+                                value: '2026-03-29T00:30:00.000+01:00',
+                                referenceField: 'orders_order_date_day',
+                            },
+                        ],
+                        referenceField: 'payments_total_revenue',
+                        pivotColumnName:
+                            'payments_total_revenue_any_2026_03_29',
+                    },
+                ],
+                indexColumn: [
+                    {
+                        type: VizIndexType.CATEGORY,
+                        reference: 'payments_payment_method',
+                    },
+                ],
+                groupByColumns: [
+                    {
+                        reference: 'orders_order_date_day',
+                    },
+                ],
+                sortBy: [],
+                originalColumns: {},
+            };
+
+            const result = convertSqlPivotedRowsToPivotData({
+                rows: dstPivotRows,
+                pivotDetails: dstPivotDetails,
+                pivotConfig: {
+                    rowTotals: false,
+                    columnTotals: false,
+                    metricsAsRows: false,
+                    columnOrder: [
+                        'orders_order_date_day',
+                        'payments_payment_method',
+                        'payments_total_revenue',
+                    ],
+                },
+                getField: getFieldMock,
+                getFieldLabel: (fieldId) => fieldId,
+                groupedSubtotals: undefined,
+            });
+
+            // The header should format the date as March 29, not March 28.
+            // Before the fix, convertToUTC: true shifts this to March 28.
+            const headerValue = result.headerValues[0]?.[0];
+            expect(headerValue).toBeDefined();
+            expect(headerValue?.type).toBe('value');
+            if (headerValue?.type === 'value') {
+                expect(headerValue.value.formatted).toBe('2026-03-29');
+            }
+        } finally {
+            process.env.TZ = origTZ;
+        }
     });
 });
 

--- a/packages/common/src/pivot/pivotQueryResults.ts
+++ b/packages/common/src/pivot/pivotQueryResults.ts
@@ -1024,7 +1024,7 @@ export const convertSqlPivotedRowsToPivotData = ({
                         ? formatItemValue(
                               field,
                               pivotValue.value,
-                              true,
+                              false,
                               undefined,
                           )
                         : String(pivotValue.value));


### PR DESCRIPTION
## Bug
In stacked bar charts, date values in pivot segments are shifted by 1 day compared to totals during DST transitions. The `convertSqlPivotedRowsToPivotData` function calls `formatItemValue` with `convertToUTC: true` for pivot/groupBy header values, but `false` for row totals and no conversion for index values. During DST, the UTC conversion pushes dates across the midnight boundary.

## Expected
Dates should be consistent between stacked segments and totals regardless of DST.

## Reproduction
- Failing test: `packages/common/src/pivot/pivotQueryResults.test.ts` — "should not shift date dimensions during DST transitions"
- Uses `TZ=Europe/London` with a BST timestamp (`2026-03-29T00:30:00.000+01:00`) as a pivot groupBy value
- Header value incorrectly shows `2026-03-28` instead of `2026-03-29`

## Evidence (before)
- Failing test asserts `headerValue.value.formatted` equals `'2026-03-29'` but receives `'2026-03-28'`

## Fix
Changed `convertToUTC` from `true` to `false` in the `formatItemValue` call for pivot header values (`packages/common/src/pivot/pivotQueryResults.ts:1027`). This makes the parameter consistent with row totals (same function, line 1405) and the non-SQL pivot path (lines 262, 277) which all use `false`.

Root cause: `moment(date).utc()` shifts timestamps to UTC, causing dates near midnight in DST-affected timezones to cross day boundaries (e.g. `2026-03-29T00:30:00+01:00` → `2026-03-28T23:30:00Z` → formatted as March 28 instead of March 29).

## Evidence (after)
- Test now passing: `packages/common/src/pivot/pivotQueryResults.test.ts`
- typecheck / lint / test: ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code)