### PR TITLE
chore: added OR filtering instructions for non-overalpping time periods to AI agent

### DIFF
--- a/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
+++ b/packages/backend/src/ee/services/ai/prompts/systemV2Template.ts
@@ -216,6 +216,10 @@ ${EXPLORE_SELECTION_AMBIGUITY_CHECKER}
       - Use filters property with appropriate operators:
         - "inThePast": For relative time windows (e.g., inThePast 1 year, inThePast 90 days)
         - Other time operators as appropriate for the query
+      - **Comparing two or more separate date ranges (OR logic):**
+        - When the user asks to compare data across two or more separate, non-contiguous date ranges (e.g., "compare Mar 1-6 vs Apr 1-6", "sales in Q1 vs Q3"), set the filters type to "or" and add one dimension filter entry per range, each targeting the same date fieldId with operator "inBetween" and the range's start/end values.
+        - A single date cannot belong to two non-overlapping ranges simultaneously, so AND logic will return zero results. You MUST use OR.
+        - Include the date dimension at an appropriate granularity (e.g., day, week, month) in the query's dimensions so the two ranges are visually distinguishable in the result.
       - Implementation details:
         - Add a filter entry targeting the relevant date dimension (fieldId) with the operator and values the user requested
         - The date dimension can come from the base table OR any joined table - both work identically


### PR DESCRIPTION
Closes: #21987

### Description:
The AI agent struggled to compare non-contiguous date periods e.g. user wants to compare 1-15th March to 1-15th April. The initial bug report indicated that the AND filter is used and this fultered out all results, but I have seen some examples that worked during my testing, including this one, where the AI agent created custom metrics for each date range: 
<img width="1152" height="564" alt="CleanShot 2026-04-28 at 11 49 50" src="https://github.com/user-attachments/assets/cca57721-e6e1-420b-86c2-1491ccab7b39" />

The above is not the most efficient way to do things, so in this PR, I added instructions on how to use the OR filter for non-contiguous date ranges. You can see this in action in dev here: 
<img width="800" height="508" alt="CleanShot 2026-04-28 at 11 39 53" src="https://github.com/user-attachments/assets/259cf1a9-84d2-4f2e-8d46-20e102de4fa8" />

_Note that the `inPeriodToDate` operator (identifies current date position in the current period and filters all periods to this include days for this position and before) could work for this but currently this only works with the current date so we need to be careful with adding this as an instruction for this use case._