### PR TITLE
fix: take screenshot before page.pdf() in PDF-only path to ensure canvas rendering

### DIFF
--- a/packages/backend/src/services/UnfurlService/UnfurlService.ts
+++ b/packages/backend/src/services/UnfurlService/UnfurlService.ts
@@ -1374,7 +1374,27 @@ export class UnfurlService extends BaseService {
                     };
 
                     // PDF-only output
+                    // Take a screenshot first to force the browser to fully
+                    // paint all canvas elements (e.g. ECharts).  page.pdf()
+                    // alone unreliably captures canvas content.  This matches
+                    // the IMAGE+withPdf path where screenshot precedes PDF.
                     if (outputFormat === 'pdf') {
+                        if (
+                            lightdashPage === LightdashPage.DASHBOARD ||
+                            lightdashPage === LightdashPage.EXPLORE
+                        ) {
+                            await page
+                                .locator(finalSelector)
+                                .screenshot({
+                                    animations: 'disabled',
+                                    timeout: RESPONSE_TIMEOUT_MS,
+                                });
+                        } else {
+                            await page.screenshot({
+                                fullPage: true,
+                                animations: 'disabled',
+                            });
+                        }
                         const pdfBuffer = await generatePdf();
                         return { pdfBuffer };
                     }


### PR DESCRIPTION
## Summary

- Take a screenshot before calling `page.pdf()` in the PDF-only path to force the browser to fully paint all canvas elements (e.g. ECharts)
- This aligns the PDF-only path with the IMAGE+PDF path, which already takes a screenshot before generating the PDF and works reliably

## Context

`page.pdf()` alone unreliably captures HTML5 Canvas content, resulting in intermittently blank chart areas in the generated PDF. The IMAGE+PDF path works because `page.screenshot()` is called first — this forces the browser to composite and paint all layers including canvas elements.

See #21950 for the full root cause analysis.

## Test plan

- [ ] Create a scheduled delivery with PDF format for a dashboard containing ECharts-based charts
- [ ] Send the delivery (both Send Now and scheduled)
- [ ] Verify charts are rendered in the received PDF
- [ ] Verify IMAGE+PDF format still works correctly (no regression)