### PR TITLE
fix(e2e): bump dbt CLI cypress timeouts

### DIFF
--- a/packages/e2e/cypress/cli/dbt/cli.cy.ts
+++ b/packages/e2e/cypress/cli/dbt/cli.cy.ts
@@ -6,8 +6,8 @@ describe('CLI', () => {
     // Scale timeout based on the number of models and thread count (both
     // read dynamically in cypress.config.ts). dbt runs models in parallel,
     // so we estimate batches rather than sequential model count.
-    const TIMEOUT_PER_BATCH_MS = 3000;
-    const BASE_TIMEOUT_MS = 30000;
+    const TIMEOUT_PER_BATCH_MS = 8000;
+    const BASE_TIMEOUT_MS = 60000;
     const modelCount = Number(Cypress.env('MODEL_COUNT')) || 50;
     const dbtThreads = Number(Cypress.env('DBT_THREADS')) || 4;
     const batches = Math.ceil(modelCount / dbtThreads);


### PR DESCRIPTION
## Summary
- Raise `BASE_TIMEOUT_MS` from 30s → 60s and `TIMEOUT_PER_BATCH_MS` from 3s → 8s in `packages/e2e/cypress/cli/dbt/cli.cy.ts` to reduce flakiness in the dbt CLI e2e tests.
- Extracted from #21985 so the timeout bump can land independently of the YAML line-width fix.

## Test plan
- [ ] Cypress CLI dbt suite passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)