### PR TITLE
fix: disable ECharts animations in minimal mode for funnel, treemap, and gauge charts

### DIFF
--- a/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsFunnelConfig.ts
@@ -61,6 +61,7 @@ const useEchartsFunnelConfig = (
         colorPalette,
         parameters,
         isTouchDevice,
+        minimal,
     } = useVisualizationContext();
 
     const theme = useMantineTheme();
@@ -244,7 +245,7 @@ const useEchartsFunnelConfig = (
                 trigger: 'item' as const,
             },
             series: [funnelSeriesOptions],
-            animation: !isInDashboard,
+            animation: !(isInDashboard || minimal),
         };
 
         return {
@@ -256,6 +257,7 @@ const useEchartsFunnelConfig = (
         funnelSeriesOptions,
         seriesData,
         isInDashboard,
+        minimal,
         theme,
         legendConfigWithTooltip,
         isTouchDevice,

--- a/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsGaugeConfig.ts
@@ -78,7 +78,7 @@ const useEchartsGaugeConfig = ({
     lineSize,
     radius,
 }: Args) => {
-    const { visualizationConfig, itemsMap, resultsData, parameters } =
+    const { visualizationConfig, itemsMap, resultsData, parameters, minimal } =
         useVisualizationContext();
     const theme = useMantineTheme();
 
@@ -411,9 +411,9 @@ const useEchartsGaugeConfig = ({
                 ),
             },
             series: gaugeSeries,
-            animation: !isInDashboard,
+            animation: !(isInDashboard || minimal),
         };
-    }, [chartConfig, gaugeSeries, isInDashboard, theme?.other?.chartFont]);
+    }, [chartConfig, gaugeSeries, isInDashboard, minimal, theme?.other?.chartFont]);
 
     if (!itemsMap) return;
     if (!eChartsOption) return;

--- a/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsTreemapConfig.ts
@@ -26,6 +26,7 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
         colorPalette,
         parameters,
         isTouchDevice,
+        minimal,
     } = useVisualizationContext();
     const theme = useMantineTheme();
 
@@ -206,12 +207,13 @@ const useEchartsTreemapConfig = (isInDashboard: boolean) => {
                 trigger: 'item' as const, //Even though this is the default, tooltips will not show up if this is not set.
             },
             series: [treemapSeriesOption],
-            animation: !isInDashboard,
+            animation: !(isInDashboard || minimal),
         };
     }, [
         chartConfig,
         treemapSeriesOption,
         isInDashboard,
+        minimal,
         theme?.other?.chartFont,
         isTouchDevice,
     ]);


### PR DESCRIPTION
## Summary

- Disable ECharts animations in minimal/headless browser mode for funnel, treemap, and gauge chart types
- These chart types were only checking `isInDashboard` but not `minimal`, unlike cartesian, pie, and sankey which already use `!(isInDashboard || minimal)`

## Context

When ECharts animations are still running at the time a screenshot or PDF is captured, charts may appear partially rendered or blank. This was previously fixed for sankey charts in #20987. Funnel, treemap, and gauge were missed.

## Changes

| File | Change |
|---|---|
| `useEchartsFunnelConfig.ts` | Add `minimal` to context destructuring, update animation logic and deps |
| `useEchartsTreemapConfig.ts` | Add `minimal` to context destructuring, update animation logic and deps |
| `useEchartsGaugeConfig.ts` | Add `minimal` to context destructuring, update animation logic and deps |

## Test plan

- [ ] Create a dashboard with funnel, treemap, and/or gauge charts
- [ ] Take a screenshot via scheduled delivery or Slack unfurl
- [ ] Verify charts are fully rendered (no partial animation state)
- [ ] Verify animations still work in normal (non-minimal) dashboard view