### PR TITLE
fix: prevent CLI from reformatting long YAML descriptions with line breaks

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -130,6 +130,24 @@ models:
     });
 });
 
+describe('toString lineWidth', () => {
+    it('should not insert line breaks into long descriptions', () => {
+        const longDescription =
+            'This is a very long description that exceeds eighty characters and should not be reformatted with line breaks by the YAML serializer';
+        const schema = `version: 2
+models:
+  - name: my_model
+    columns:
+      - name: my_column
+        description: ${longDescription}`;
+
+        const editor = new DbtSchemaEditor(schema);
+        const output = editor.toString();
+        expect(output).toContain(`description: ${longDescription}`);
+        expect(output).not.toMatch(/description:[\s\S]*\n\s+/m);
+    });
+});
+
 describe('dbt v1.10+ compatibility', () => {
     it('should add custom metrics under config.meta for dbt v1.10', () => {
         const editor = new DbtSchemaEditor(

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,7 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Bug
`lightdash dbt run` inserts line breaks at 80 characters into long description strings in YAML files, because the `yaml` library (v2.x) used in `DbtSchemaEditor.toString()` defaults to a `lineWidth` of 80.

## Expected
Existing descriptions should be preserved as-is. The CLI should only add missing columns, not reformat existing content.

## Reproduction
Failing test in `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — a schema with a description >80 chars is round-tripped through `DbtSchemaEditor` and the output wraps the description onto a new line.

## Evidence (before)
- Failing test: `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — see CI run

## Fix
Root cause: `DbtSchemaEditor.toString()` calls `this.doc.toString()` without setting `lineWidth`. The `yaml` library v2.x defaults `lineWidth` to 80, causing any scalar string longer than 80 characters to be folded with line breaks.

Fix: Added `lineWidth: 0` to the `this.doc.toString()` options to disable line wrapping entirely.

## Evidence (after)
- Test now passing: `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts`
- typecheck / lint / test: ✅