### PR TITLE
fix: field value search 500s on missing table or malformed filters

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -3,6 +3,7 @@ import {
     NotFoundError,
     ParameterError,
     type Explore,
+    type FilterGroupItem,
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
 import { validExplore } from './ProjectService.mock';
@@ -176,5 +177,58 @@ describe('getFieldValuesMetricQuery', () => {
                 exploreResolver: mockExploreResolver,
             }),
         ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is undefined', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('handles filters object with missing .and property gracefully', async () => {
+        const filtersWithoutAnd = { id: 'filter-group' } as unknown as {
+            id: string;
+            and: FilterGroupItem[];
+        };
+
+        const result = await getFieldValuesMetricQuery({
+            projectUuid: 'project-uuid',
+            table: 'a',
+            initialFieldId: 'a_dim1',
+            search: '',
+            limit: 50,
+            maxLimit: 5000,
+            filters: filtersWithoutAnd,
+            exploreResolver: mockExploreResolver,
+        });
+
+        const dims = result.metricQuery.filters?.dimensions;
+        const filterRules = dims && 'and' in dims ? dims.and : [];
+        // Only the 2 autocomplete filters, no crash
+        expect(filterRules).toHaveLength(2);
     });
 });

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -51,6 +51,12 @@ export async function getFieldValuesMetricQuery({
     field: Dimension;
     fieldId: string;
 }> {
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table"',
+        );
+    }
+
     if (limit > maxLimit) {
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
     }
@@ -106,7 +112,7 @@ export async function getFieldValuesMetricQuery({
             values: [],
         },
     ];
-    if (filters) {
+    if (filters?.and) {
         const filtersCompatibleWithExplore = filters.and.filter(
             (filter) =>
                 isFilterRule(filter) &&


### PR DESCRIPTION
## Bug
`POST /api/v1/projects/:projectUuid/field/:fieldId/search` returns **500 UnexpectedServerError** when request body is missing `table` (Knex undefined binding) or has a `filters` object without `.and` property (TypeError).

Sentry: LIGHTDASH-BACKEND-CF9, LIGHTDASH-BACKEND-CF8

## Expected
Both cases should return 4xx validation errors, not 500.

## Reproduction
Failing tests in `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`:
1. `throws ParameterError when table is undefined`
2. `throws ParameterError when table is empty string`
3. `handles filters object with missing .and property gracefully`

## Evidence (before)
- `table is undefined`: resolves instead of rejecting (would hit Knex undefined binding in prod → 500)
- `table is empty string`: resolves instead of rejecting (same)
- `filters without .and`: `TypeError: Cannot read properties of undefined (reading 'filter')` at line 110 → 500

## Fix
**Root cause**: `getFieldValuesMetricQuery` in `fieldValuesQueryBuilder.ts` has two input validation gaps:
1. No check for missing/empty `table` before passing it to `exploreResolver.findExploreByTableName()`, which forwards it to a Knex query that crashes on undefined bindings
2. `filters.and.filter(...)` at line 110 assumes `filters.and` exists whenever `filters` is truthy

**Changes** (`packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts`):
1. Added early `if (!table)` check that throws `ParameterError` with message `'Field value search requires a non-empty "table"'`
2. Changed `if (filters)` to `if (filters?.and)` to safely skip malformed filter objects

## Evidence (after)
- All 10 tests passing including 3 new regression tests
- typecheck: ✅
- lint: ✅