### PR TITLE
fix: DbtSchemaEditor.toString() wraps long descriptions at 80 chars

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -130,6 +130,21 @@ models:
     });
 });
 
+describe('lineWidth preservation', () => {
+    const LONG_DESC_SCHEMA = `version: 2
+models:
+  - name: my_model
+    columns:
+      - name: my_column
+        description: This is a very long description that exceeds eighty characters and should not be wrapped onto multiple lines by the YAML serializer`;
+
+    it('should not insert line breaks into long descriptions', () => {
+        const editor = new DbtSchemaEditor(LONG_DESC_SCHEMA);
+        const output = editor.toString();
+        expect(output).toEqual(`${LONG_DESC_SCHEMA}\n`);
+    });
+});
+
 describe('dbt v1.10+ compatibility', () => {
     it('should add custom metrics under config.meta for dbt v1.10', () => {
         const editor = new DbtSchemaEditor(

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,7 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Bug
`lightdash dbt run` reformats existing YAML description strings by inserting line breaks at 80 characters. The `yaml` v2 library used in `DbtSchemaEditor.toString()` defaults to `lineWidth: 80`, wrapping any string that exceeds that length.

## Expected
Existing descriptions should be preserved as-is without inserted line breaks.

## Reproduction
Failing test in `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — creates a YAML doc with a description >80 chars and asserts `toString()` preserves it verbatim.

## Evidence (before)
- Failing test: `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — "should not insert line breaks into long descriptions"
- The yaml library wraps the description onto two lines at the 80-char boundary

## Fix
**Root cause**: `DbtSchemaEditor.toString()` at `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts:434` calls `this.doc.toString()` without setting `lineWidth`. The yaml v2 library defaults `lineWidth` to 80, folding any scalar string longer than 80 characters.

**Change**: Added `lineWidth: 0` to the `this.doc.toString()` options to disable line wrapping entirely. Updated the existing test mock to reflect the now-unwrapped output.

## Evidence (after)
- Test now passing: `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — all 14 tests pass
- typecheck / lint / test: ✅

Closes #21917

🤖 Generated with [Claude Code](https://claude.com/claude-code)