### PR TITLE
fix: validate table and filters in field value search

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -2,6 +2,7 @@ import {
     FilterOperator,
     NotFoundError,
     ParameterError,
+    type AndFilterGroup,
     type Explore,
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
@@ -176,5 +177,56 @@ describe('getFieldValuesMetricQuery', () => {
                 exploreResolver: mockExploreResolver,
             }),
         ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is undefined', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('handles filters object missing .and property gracefully', async () => {
+        const filtersWithoutAnd = {
+            id: 'filter-group',
+        } as unknown as AndFilterGroup;
+
+        const result = await getFieldValuesMetricQuery({
+            projectUuid: 'project-uuid',
+            table: 'a',
+            initialFieldId: 'a_dim1',
+            search: 'test',
+            limit: 10,
+            maxLimit: 5000,
+            filters: filtersWithoutAnd,
+            exploreResolver: mockExploreResolver,
+        });
+
+        const dims = result.metricQuery.filters?.dimensions;
+        const filterRules = dims && 'and' in dims ? dims.and : [];
+        expect(filterRules).toHaveLength(2);
     });
 });

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -51,6 +51,12 @@ export async function getFieldValuesMetricQuery({
     field: Dimension;
     fieldId: string;
 }> {
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table"',
+        );
+    }
+
     if (limit > maxLimit) {
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
     }
@@ -106,7 +112,7 @@ export async function getFieldValuesMetricQuery({
             values: [],
         },
     ];
-    if (filters) {
+    if (filters && Array.isArray(filters.and)) {
         const filtersCompatibleWithExplore = filters.and.filter(
             (filter) =>
                 isFilterRule(filter) &&


### PR DESCRIPTION
## Bug
`POST /api/v1/projects/:projectUuid/field/:fieldId/search` returns 500 UnexpectedServerError when:
1. Request body is missing `table` → Knex undefined binding error
2. Request body has `filters` object without `.and` property → TypeError

Both should return 4xx validation errors instead. Same code path is reachable from the v2 endpoint via `AsyncQueryService.executeAsyncFieldValueSearch`.

## Expected
- Missing/empty `table` → 400 ParameterError
- Malformed `filters` (no `.and`) → handled gracefully (ignored)

## Reproduction
Failing tests in `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`:
- `throws ParameterError when table is empty string`
- `throws ParameterError when table is undefined`
- `handles filters object missing .and property gracefully`

## Evidence (before)
- Failing test: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts` — see CI run

## Fix
**Root cause:** `fieldValuesQueryBuilder.ts` passed `table` directly to `exploreResolver.findExploreByTableName()` without validating it's non-empty — `undefined`/`""` reaches Knex as an undefined binding. Separately, `filters.and.filter(...)` at line 110 assumed `.and` exists whenever `filters` is truthy.

**Changes:**
- Added early `!table` guard that throws `ParameterError` with message `'Field value search requires a non-empty "table"'`
- Changed `if (filters)` to `if (filters && Array.isArray(filters.and))` so malformed filter objects are safely skipped

Both v1 and v2 endpoints are hardened because they share `getFieldValuesMetricQuery`.

## Evidence (after)
- All 10 tests passing: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`
- typecheck / lint / test: ✅