### PR TITLE
fix: validate table and filters in field value search to prevent 500 errors

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -2,6 +2,7 @@ import {
     FilterOperator,
     NotFoundError,
     ParameterError,
+    type AndFilterGroup,
     type Explore,
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
@@ -176,5 +177,53 @@ describe('getFieldValuesMetricQuery', () => {
                 exploreResolver: mockExploreResolver,
             }),
         ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is undefined', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('handles filters object without .and property gracefully', async () => {
+        const result = await getFieldValuesMetricQuery({
+            projectUuid: 'project-uuid',
+            table: 'a',
+            initialFieldId: 'a_dim1',
+            search: 'test',
+            limit: 10,
+            maxLimit: 5000,
+            filters: { id: 'filter-group' } as unknown as AndFilterGroup,
+            exploreResolver: mockExploreResolver,
+        });
+
+        const dims = result.metricQuery.filters?.dimensions;
+        const filterRules = dims && 'and' in dims ? dims.and : [];
+        // Only the 2 autocomplete filters, malformed filters object is ignored
+        expect(filterRules).toHaveLength(2);
     });
 });

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -51,6 +51,12 @@ export async function getFieldValuesMetricQuery({
     field: Dimension;
     fieldId: string;
 }> {
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table"',
+        );
+    }
+
     if (limit > maxLimit) {
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
     }
@@ -106,7 +112,7 @@ export async function getFieldValuesMetricQuery({
             values: [],
         },
     ];
-    if (filters) {
+    if (filters?.and) {
         const filtersCompatibleWithExplore = filters.and.filter(
             (filter) =>
                 isFilterRule(filter) &&


### PR DESCRIPTION
## Bug
`POST /api/v1/projects/:projectUuid/field/:fieldId/search` returns 500 UnexpectedServerError when:
1. Request body is missing `table` — causes Knex undefined binding error
2. Request body has `filters` object without `.and` property — causes TypeError

Sentry: LIGHTDASH-BACKEND-CF9, LIGHTDASH-BACKEND-CF8

## Expected
Both cases should return 4xx validation errors, not 500.

## Reproduction
Failing tests in `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`:
- `throws ParameterError when table is undefined`
- `throws ParameterError when table is empty string`
- `handles filters object without .and property gracefully`

## Evidence (before)
- `table: undefined` → unhandled Knex error (`Undefined binding(s) detected when compiling SELECT`)
- `table: ''` → silently resolves instead of rejecting (hits Knex downstream)
- `filters` without `.and` → `TypeError: Cannot read properties of undefined (reading 'filter')` at `fieldValuesQueryBuilder.ts:110`

## Fix
**Root cause:** `getFieldValuesMetricQuery` in `fieldValuesQueryBuilder.ts` did not validate that `table` is a non-empty string before passing it to `exploreResolver.findExploreByTableName()`, and accessed `filters.and` without checking `.and` exists.

**Changes:**
- Added early `!table` check that throws `ParameterError` with message `"Field value search requires a non-empty "table""` (line 54)
- Changed `if (filters)` to `if (filters?.and)` so a `filters` object missing `.and` is silently skipped instead of crashing (line 113)

Both v1 (`projectRouter`) and v2 (`AsyncQueryService.executeAsyncFieldValueSearch`) code paths use the same `getFieldValuesMetricQuery` helper, so both are hardened by this fix.

## Evidence (after)
- All 10 tests passing in `fieldValuesQueryBuilder.test.ts` — including 3 new regression tests
- typecheck / lint / test: ✅