### PR TITLE
fix: validate table and filters in field value search to prevent 500 errors

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -2,6 +2,7 @@ import {
     FilterOperator,
     NotFoundError,
     ParameterError,
+    type AndFilterGroup,
     type Explore,
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
@@ -173,6 +174,51 @@ describe('getFieldValuesMetricQuery', () => {
                 limit: 10000,
                 maxLimit: 5000,
                 filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is undefined', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when filters is truthy but missing .and', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: { id: 'filter-group' } as unknown as AndFilterGroup,
                 exploreResolver: mockExploreResolver,
             }),
         ).rejects.toThrow(ParameterError);

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -51,8 +51,20 @@ export async function getFieldValuesMetricQuery({
     field: Dimension;
     fieldId: string;
 }> {
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table"',
+        );
+    }
+
     if (limit > maxLimit) {
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
+    }
+
+    if (filters && !Array.isArray(filters.and)) {
+        throw new ParameterError(
+            'Field value search "filters" must include an "and" array',
+        );
     }
 
     let explore = await exploreResolver.findExploreByTableName(


### PR DESCRIPTION
## Bug
`POST /api/v1/projects/:projectUuid/field/:fieldId/search` returns 500 UnexpectedServerError when the request body is missing `table` (Knex undefined binding) or has a `filters` object without `.and` (TypeError). Both should return 4xx validation errors.

Sentry: LIGHTDASH-BACKEND-CF9, LIGHTDASH-BACKEND-CF8

## Expected
Requests missing `table` should return a 400 ParameterError. Requests with malformed `filters` (missing `.and`) should return a 400 ParameterError.

## Reproduction
Failing tests in `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`:
- `throws ParameterError when table is undefined`
- `throws ParameterError when table is empty string`
- `throws ParameterError when filters is truthy but missing .and`

## Evidence (before)
- Failing test: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts` — see CI run

## Fix
`getFieldValuesMetricQuery` in `fieldValuesQueryBuilder.ts` did not validate inputs before use:
- `table` was passed directly to `exploreResolver.findExploreByTableName()`, which feeds it to a Knex query — `undefined` caused `Undefined binding(s)` 500 error
- `filters.and.filter(...)` was called without checking `.and` exists — a truthy `filters` without `.and` caused `TypeError: Cannot read properties of undefined` 500 error

Added two early validation checks that throw `ParameterError` (400):
1. `table` must be a non-empty string
2. If `filters` is provided, `filters.and` must be an array

Both v1 and v2 endpoints share the same `getFieldValuesMetricQuery` function, so both are fixed.

## Evidence (after)
- All 10 tests passing including 3 new regression tests
- typecheck / lint: ✅