### PR TITLE
fix(ee): managed agent — vault refresh, session ID, Slack reliability

### DIFF
--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -191,37 +191,39 @@ export class ManagedAgentClient {
         credPayload: Record<string, unknown>,
     ): Promise<void> {
         try {
-            // List credentials and delete all existing ones, then recreate
-            const creds = await betaAny.vaults.credentials.list(vaultId);
-            const credList = creds?.data ?? [];
-            Logger.debug(
-                `[ManagedAgent] Vault ${vaultId} has ${credList.length} credentials`,
+            // Create new credential first — if this fails, the old one still works
+            const newCred = await betaAny.vaults.credentials.create(
+                vaultId,
+                credPayload,
             );
-            // Delete all existing credentials in parallel
-            const deletePromises = credList.map(
+            const newCredId =
+                newCred?.credential_id ??
+                newCred?.id ??
+                newCred?.credential_uuid;
+            Logger.info(
+                `[ManagedAgent] Created new vault credential ${newCredId} in ${vaultId}`,
+            );
+
+            // Then clean up old credentials, keeping only the one we just created
+            const creds = await betaAny.vaults.credentials.list(vaultId);
+            const oldCreds = (creds?.data ?? []).filter(
                 (cred: Record<string, unknown>) => {
                     const credId =
                         cred.credential_id ?? cred.id ?? cred.credential_uuid;
-                    if (credId) {
-                        Logger.debug(
-                            `[ManagedAgent] Deleting credential ${credId} from vault ${vaultId}`,
-                        );
-                        return betaAny.vaults.credentials.delete(
-                            vaultId,
-                            credId,
-                        );
-                    }
-                    Logger.warn(
-                        `[ManagedAgent] Credential has no recognizable ID field: ${JSON.stringify(Object.keys(cred))}`,
+                    return credId && credId !== newCredId;
+                },
+            );
+            const deletePromises = oldCreds.map(
+                (cred: Record<string, unknown>) => {
+                    const credId =
+                        cred.credential_id ?? cred.id ?? cred.credential_uuid;
+                    Logger.debug(
+                        `[ManagedAgent] Deleting old credential ${credId} from vault ${vaultId}`,
                     );
-                    return Promise.resolve();
+                    return betaAny.vaults.credentials.delete(vaultId, credId);
                 },
             );
             await Promise.all(deletePromises);
-            await betaAny.vaults.credentials.create(vaultId, credPayload);
-            Logger.info(
-                `[ManagedAgent] Refreshed vault credential in ${vaultId}`,
-            );
         } catch (error) {
             Logger.warn(
                 `[ManagedAgent] Could not refresh vault credential: ${error instanceof Error ? error.message : 'Unknown'}`,

--- a/packages/backend/src/ee/clients/ManagedAgentClient.ts
+++ b/packages/backend/src/ee/clients/ManagedAgentClient.ts
@@ -138,6 +138,16 @@ export class ManagedAgentClient {
 
     private async findOrCreateVault(betaAny: AnyType): Promise<{ id: string }> {
         const VAULT_NAME = 'Lightdash MCP Auth';
+        const CRED_NAME = 'Lightdash PAT';
+        const credPayload = {
+            display_name: CRED_NAME,
+            auth: {
+                type: 'static_bearer',
+                mcp_server_url: `${this.config.siteUrl}/api/v1/mcp`,
+                token: this.config.serviceAccountPat,
+            },
+        };
+
         try {
             const list = await betaAny.vaults.list();
             const existing = list?.data?.find(
@@ -146,6 +156,14 @@ export class ManagedAgentClient {
             if (existing) {
                 Logger.info(
                     `[ManagedAgent] Reusing existing vault: ${existing.id}`,
+                );
+                // Refresh the credential so the PAT stays in sync.
+                // Delete existing credentials and recreate with current PAT.
+                await this.refreshVaultCredential(
+                    betaAny,
+                    existing.id,
+                    CRED_NAME,
+                    credPayload,
                 );
                 return existing;
             }
@@ -160,21 +178,61 @@ export class ManagedAgentClient {
             display_name: VAULT_NAME,
         });
 
-        await betaAny.vaults.credentials.create(vault.id, {
-            display_name: 'Lightdash PAT',
-            auth: {
-                type: 'static_bearer',
-                mcp_server_url: `${this.config.siteUrl}/api/v1/mcp`,
-                token: this.config.serviceAccountPat,
-            },
-        });
+        await betaAny.vaults.credentials.create(vault.id, credPayload);
 
         return vault;
+    }
+
+    // eslint-disable-next-line class-methods-use-this
+    private async refreshVaultCredential(
+        betaAny: AnyType,
+        vaultId: string,
+        credName: string,
+        credPayload: Record<string, unknown>,
+    ): Promise<void> {
+        try {
+            // List credentials and delete all existing ones, then recreate
+            const creds = await betaAny.vaults.credentials.list(vaultId);
+            const credList = creds?.data ?? [];
+            Logger.debug(
+                `[ManagedAgent] Vault ${vaultId} has ${credList.length} credentials`,
+            );
+            // Delete all existing credentials in parallel
+            const deletePromises = credList.map(
+                (cred: Record<string, unknown>) => {
+                    const credId =
+                        cred.credential_id ?? cred.id ?? cred.credential_uuid;
+                    if (credId) {
+                        Logger.debug(
+                            `[ManagedAgent] Deleting credential ${credId} from vault ${vaultId}`,
+                        );
+                        return betaAny.vaults.credentials.delete(
+                            vaultId,
+                            credId,
+                        );
+                    }
+                    Logger.warn(
+                        `[ManagedAgent] Credential has no recognizable ID field: ${JSON.stringify(Object.keys(cred))}`,
+                    );
+                    return Promise.resolve();
+                },
+            );
+            await Promise.all(deletePromises);
+            await betaAny.vaults.credentials.create(vaultId, credPayload);
+            Logger.info(
+                `[ManagedAgent] Refreshed vault credential in ${vaultId}`,
+            );
+        } catch (error) {
+            Logger.warn(
+                `[ManagedAgent] Could not refresh vault credential: ${error instanceof Error ? error.message : 'Unknown'}`,
+            );
+        }
     }
 
     async runSession(
         projectName: string,
         onCustomToolUse: CustomToolHandler,
+        onSessionCreated?: (sessionId: string) => void,
     ): Promise<string> {
         const { agentId, environmentId, vaultId } =
             await this.ensureAgentAndEnvironment();
@@ -189,6 +247,7 @@ export class ManagedAgentClient {
         });
 
         Logger.info(`[ManagedAgent] Session created: ${session.id}`);
+        onSessionCreated?.(session.id);
 
         const stream = await betaAny.sessions.events.stream(session.id);
 
@@ -297,7 +356,15 @@ export class ManagedAgentClient {
             }
         };
 
-        await Promise.race([eventLoop(), timeoutPromise]);
+        try {
+            await Promise.race([eventLoop(), timeoutPromise]);
+        } catch (error) {
+            // Always return the session ID even on timeout so the caller
+            // can still look up actions recorded before the error.
+            Logger.error(
+                `[ManagedAgent] Session ${session.id} error: ${error instanceof Error ? error.message : 'Unknown'}`,
+            );
+        }
 
         return session.id;
     }

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -390,17 +390,34 @@ export class ManagedAgentService extends BaseService {
         ): Promise<string> =>
             this.handleToolCall(projectUuid, sessionId, toolName, input);
 
-        sessionId = await client.runSession(projectUuid, onToolCall);
+        const onSessionCreated = (id: string) => {
+            sessionId = id;
+        };
 
-        this.logger.info(`Heartbeat complete for project: ${projectUuid}`);
-
-        // Post summary to Slack if configured
-        if (settings.slackChannelId && sessionId) {
-            await this.postHeartbeatSummaryToSlack(
+        try {
+            sessionId = await client.runSession(
                 projectUuid,
-                sessionId,
-                settings.slackChannelId,
+                onToolCall,
+                onSessionCreated,
             );
+            this.logger.info(`Heartbeat complete for project: ${projectUuid}`);
+        } catch (error) {
+            this.logger.error(
+                `Heartbeat session error for project ${projectUuid}: ${error instanceof Error ? error.message : 'Unknown'}`,
+            );
+        } finally {
+            // Post summary to Slack even if the session errored — actions
+            // recorded via custom tools before the crash are still valuable.
+            this.logger.info(
+                `Slack notification check: slackChannelId=${settings.slackChannelId ?? 'null'}, sessionId=${sessionId || 'empty'}`,
+            );
+            if (settings.slackChannelId && sessionId) {
+                await this.postHeartbeatSummaryToSlack(
+                    projectUuid,
+                    sessionId,
+                    settings.slackChannelId,
+                );
+            }
         }
     }
 
@@ -409,14 +426,22 @@ export class ManagedAgentService extends BaseService {
         sessionId: string,
         slackChannelId: string,
     ): Promise<void> {
+        this.logger.info(
+            `Posting Slack summary: project=${projectUuid}, session=${sessionId}, channel=${slackChannelId}`,
+        );
         try {
             const actions = await this.managedAgentModel.getActions(
                 projectUuid,
                 { sessionId },
             );
 
+            this.logger.info(
+                `Found ${actions.length} actions for session ${sessionId}`,
+            );
+
             if (actions.length === 0) {
-                return; // Nothing to report
+                this.logger.info('No actions to report, skipping Slack');
+                return;
             }
 
             const { organizationUuid } =
@@ -470,8 +495,8 @@ export class ManagedAgentService extends BaseService {
                 [ManagedAgentTargetType.DASHBOARD]: 'dashboards',
             };
 
-            // Build per-action detail lines with links
-            const detailLines = actions.slice(0, 10).map((a) => {
+            // Build per-action detail lines with links (max 5 to stay under Slack's 3000 char limit)
+            const detailLines = actions.slice(0, 5).map((a) => {
                 const urlSegment = RESOURCE_URL_PATTERNS[a.targetType];
                 const resourceUrl = urlSegment
                     ? `${siteUrl}/projects/${projectUuid}/${urlSegment}/${a.targetUuid}`
@@ -483,10 +508,14 @@ export class ManagedAgentService extends BaseService {
                     ? `<${resourceUrl}|${a.targetName}>`
                     : a.targetName;
 
-                return `${icon} ${nameLink} — ${a.description}`;
+                const desc =
+                    a.description.length > 120
+                        ? `${a.description.slice(0, 117)}...`
+                        : a.description;
+                return `${icon} ${nameLink} — ${desc}`;
             });
 
-            const moreCount = actions.length - 10;
+            const moreCount = actions.length - 5;
             if (moreCount > 0) {
                 detailLines.push(
                     `_...and ${moreCount} more action${moreCount > 1 ? 's' : ''}_`,


### PR DESCRIPTION
## Summary

Bugfixes for the managed agent discovered during local testing. Fixes MCP 401 errors, empty session IDs, and Slack notification failures.

## Fixes

| Bug | Root Cause | Fix |
|-----|-----------|-----|
| MCP returns 401 | Vault credential has stale PAT after agent is re-enabled | Refresh vault credential (delete + recreate) on each heartbeat |
| Duplicate environments/vaults on Anthropic | DB persistence failed on prior runs (CronDate bug) | List existing by name before creating; find-or-create pattern |
| Slack notification never fires | `runSession` throws on timeout before returning session ID | Catch timeout inside `runSession`, always return session ID |
| Actions stored with empty `session_id` | `sessionId` variable set after `runSession` returns, but tool calls execute during it | `onSessionCreated` callback sets `sessionId` before event loop starts |
| Slack `invalid_blocks` error | Detail block exceeds Slack's 3000 char limit with 10 actions | Cap to 5 actions, truncate descriptions at 120 chars |
| Slack skipped when session errors | `finally` block had `sessionId=''` | Session ID now always available via callback + catch pattern |

## Test plan

- [ ] Enable agent, wait for heartbeat → verify vault credential refreshed (no MCP 401)
- [ ] Check logs for `Refreshed vault credential in` message
- [ ] Verify actions have real session IDs (not empty strings)
- [ ] Verify Slack notification posts after heartbeat with actions
- [ ] Verify Slack message fits (no `invalid_blocks` error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)