### PR TITLE
fix: DbtSchemaEditor.toString() wraps long descriptions at 80 chars

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -67,6 +67,23 @@ describe('DbtSchemaEditor', () => {
         expect(editor.toJS()).toEqual(EXPECTED_SCHEMA_JSON_WITH_NEW_MODEL);
         expect(editor.toString()).toEqual(EXPECTED_SCHEMA_YML_WITH_NEW_MODEL);
     });
+
+    it('should preserve long descriptions without inserting line breaks', () => {
+        const longDescription =
+            'This is a very long description that exceeds eighty characters and should not be wrapped or reformatted by the YAML serializer in any way';
+        const schema = `version: 2
+models:
+  - name: my_model
+    columns:
+      - name: my_column
+        description: ${longDescription}
+`;
+        const editor = new DbtSchemaEditor(schema);
+        const result = editor.toString();
+        expect(result).toContain(`description: ${longDescription}`);
+        expect(result).not.toContain('\n        ');
+        expect(result).toEqual(schema);
+    });
 });
 
 describe('case-insensitive column matching', () => {

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -81,7 +81,6 @@ models:
         const editor = new DbtSchemaEditor(schema);
         const result = editor.toString();
         expect(result).toContain(`description: ${longDescription}`);
-        expect(result).not.toContain('\n        ');
         expect(result).toEqual(schema);
     });
 });

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,7 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Bug
`lightdash dbt run` reformats existing YAML description strings by inserting line breaks at 80 characters, because the yaml v2 library's default `lineWidth` is 80.

## Expected
Existing descriptions should be preserved as-is. The CLI should only add missing columns, not reformat existing content.

## Reproduction
1. Create a dbt model YAML file with a description longer than 80 characters
2. Run `lightdash dbt run -s <model>`
3. Description now has line breaks inserted at 80-char boundaries

Failing test: `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — "should preserve long descriptions without inserting line breaks"

## Fix
**Root cause**: `DbtSchemaEditor.toString()` calls `this.doc.toString()` (yaml v2) without specifying `lineWidth`. The library defaults to `lineWidth: 80`, folding any string exceeding 80 characters with line breaks.

**Change**: Added `lineWidth: 0` to the `toString()` options in `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts` to disable automatic line wrapping.

## Evidence (after)
- All 14 DbtSchemaEditor tests passing (including new regression test)
- Updated mock expectations to reflect unwrapped output
- typecheck / lint / test: ✅

Closes #21917