### PR TITLE
feat(ee): rename to Dash — project health agent copy + modal fix

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -527,7 +527,7 @@ export class ManagedAgentService extends BaseService {
                     type: 'header' as const,
                     text: {
                         type: 'plain_text' as const,
-                        text: ':zap: Improve agent completed a run',
+                        text: ':zap: Dash completed a health check',
                         emoji: true,
                     },
                 },
@@ -564,7 +564,7 @@ export class ManagedAgentService extends BaseService {
             await this.slackClient.postMessage({
                 organizationUuid,
                 channel: slackChannelId,
-                text: `Improve agent: ${summaryParts.join(', ')}`,
+                text: `Dash: ${summaryParts.join(', ')}`,
                 blocks,
             });
 

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -133,25 +133,25 @@ const SetupSection: FC<{
     return (
         <Stack gap={0}>
             <Group justify="space-between" align="center" pb="md">
-                <Group gap="sm" align="center">
-                    <Box className={classes.setupOrb}>
-                        <IconBolt size={16} />
-                    </Box>
-                    <Stack gap={0}>
+                <Stack gap={0}>
+                    <Group gap="sm" align="center">
+                        <Box className={classes.setupOrb}>
+                            <IconBolt size={16} />
+                        </Box>
                         <Title order={4} fw={700}>
                             Dash
                         </Title>
-                        <Text fz="xs" c="dimmed">
-                            Project health agent
-                        </Text>
-                    </Stack>
-                    {enabled && (
-                        <Box className={classes.activeBadge}>
-                            <Box className={classes.activeDotInline} />
-                            Active &middot; {scheduleLabel}
-                        </Box>
-                    )}
-                </Group>
+                        {enabled && (
+                            <Box className={classes.activeBadge}>
+                                <Box className={classes.activeDotInline} />
+                                Active &middot; {scheduleLabel}
+                            </Box>
+                        )}
+                    </Group>
+                    <Text fz="xs" c="dimmed" ml={46}>
+                        Project health agent
+                    </Text>
+                </Stack>
                 <Group gap="sm" align="center">
                     {organizationHasSlack && enabled && (
                         <>

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -137,9 +137,14 @@ const SetupSection: FC<{
                     <Box className={classes.setupOrb}>
                         <IconBolt size={16} />
                     </Box>
-                    <Title order={4} fw={700}>
-                        Project health
-                    </Title>
+                    <Stack gap={0}>
+                        <Title order={4} fw={700}>
+                            Dash
+                        </Title>
+                        <Text fz="xs" c="dimmed">
+                            Project health agent
+                        </Text>
+                    </Stack>
                     {enabled && (
                         <Box className={classes.activeBadge}>
                             <Box className={classes.activeDotInline} />

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -138,7 +138,7 @@ const SetupSection: FC<{
                         <IconBolt size={16} />
                     </Box>
                     <Title order={4} fw={700}>
-                        Improve
+                        Project health
                     </Title>
                     {enabled && (
                         <Box className={classes.activeBadge}>

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -162,7 +162,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                         <Stack gap={4}>
                             <Group gap={8} align="center">
                                 <Text fz="lg" fw={700}>
-                                    Improve
+                                    Project health
                                 </Text>
                                 <Box className={classes.activePill}>
                                     <Box className={classes.activeDotSmall} />
@@ -171,8 +171,8 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                             </Group>
                             <Text fz="sm" c="dimmed" fw={500}>
                                 {actionCount > 0
-                                    ? `${actionCount} actions — ${actionSummary}`
-                                    : 'Monitoring your project'}
+                                    ? `Dash took ${actionCount} actions — ${actionSummary}`
+                                    : 'Dash is monitoring your project'}
                                 {lastActionAt &&
                                     ` · last run ${formatRelative(lastActionAt)}`}
                             </Text>
@@ -206,7 +206,7 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                     </Box>
                     <Stack gap={4}>
                         <Text fz="lg" fw={700}>
-                            Self-improving agent
+                            Project health agent
                         </Text>
                         <Group
                             gap={6}

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentHomeCard.tsx
@@ -197,45 +197,47 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
     const currentFeature = FEATURES[featureIdx];
 
     return (
-        <UnstyledButton onClick={handleClick} className={classes.card}>
-            <PixelGrid />
-            <Stack gap="md">
-                <Group gap="md" align="center">
-                    <Box className={classes.orb}>
-                        <IconBolt size={18} />
-                    </Box>
-                    <Stack gap={4}>
-                        <Text fz="lg" fw={700}>
-                            Project health agent
-                        </Text>
-                        <Group
-                            gap={6}
-                            wrap="nowrap"
-                            key={featureIdx}
-                            className={classes.featureCarousel}
-                        >
-                            <currentFeature.icon
-                                size={15}
-                                color="var(--mantine-color-violet-4)"
-                            />
-                            <Text fz="sm" fw={500} c="dimmed">
-                                {currentFeature.label}
+        <>
+            <UnstyledButton onClick={handleClick} className={classes.card}>
+                <PixelGrid />
+                <Stack gap="md">
+                    <Group gap="md" align="center">
+                        <Box className={classes.orb}>
+                            <IconBolt size={18} />
+                        </Box>
+                        <Stack gap={4}>
+                            <Text fz="lg" fw={700}>
+                                Project health agent
                             </Text>
-                        </Group>
-                    </Stack>
-                </Group>
+                            <Group
+                                gap={6}
+                                wrap="nowrap"
+                                key={featureIdx}
+                                className={classes.featureCarousel}
+                            >
+                                <currentFeature.icon
+                                    size={15}
+                                    color="var(--mantine-color-violet-4)"
+                                />
+                                <Text fz="sm" fw={500} c="dimmed">
+                                    {currentFeature.label}
+                                </Text>
+                            </Group>
+                        </Stack>
+                    </Group>
 
-                <Box ml={52}>
-                    <Button
-                        variant="filled"
-                        color="dark"
-                        size="sm"
-                        rightSection={<IconArrowRight size={14} />}
-                    >
-                        Get started
-                    </Button>
-                </Box>
-            </Stack>
+                    <Box ml={52}>
+                        <Button
+                            variant="filled"
+                            color="dark"
+                            size="sm"
+                            rightSection={<IconArrowRight size={14} />}
+                        >
+                            Get started
+                        </Button>
+                    </Box>
+                </Stack>
+            </UnstyledButton>
             <ManagedAgentSetupModal
                 projectUuid={projectUuid}
                 opened={setupOpen}
@@ -245,6 +247,6 @@ export const ManagedAgentHomeCard: FC<{ projectUuid: string }> = ({
                     void navigate(`/projects/${projectUuid}/improve`);
                 }}
             />
-        </UnstyledButton>
+        </>
     );
 };

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentSetupModal.tsx
@@ -85,17 +85,18 @@ export const ManagedAgentSetupModal: FC<{
         <MantineModal
             opened={opened}
             onClose={onClose}
-            title="Enable self-improving agent"
+            title="Enable project health agent"
             icon={IconBolt}
             size="lg"
             onConfirm={() => mutation.mutate()}
-            confirmLabel="Enable agent"
+            confirmLabel="Enable Dash"
         >
             <Stack gap="xl">
                 {/* Description */}
                 <Text fz="sm" c="dimmed">
-                    An AI agent that monitors and improves your project
-                    automatically. All actions are logged and reversible.
+                    Dash monitors your project&apos;s health automatically —
+                    cleaning up stale content, fixing broken charts, and
+                    surfacing insights. All actions are logged and reversible.
                 </Text>
 
                 {/* Capabilities */}
@@ -145,8 +146,8 @@ export const ManagedAgentSetupModal: FC<{
                         size="sm"
                     />
                     <Text fz="xs" c="dimmed" mt={6}>
-                        All actions are reversible. Created content goes to an
-                        &quot;Agent Suggestions&quot; space for review.
+                        All actions are logged and reversible. Created charts go
+                        to a &quot;Dash Suggestions&quot; space for review.
                     </Text>
                 </Box>
             </Stack>


### PR DESCRIPTION
## Summary

Updates all user-facing copy to introduce **Dash** as the project health agent name, and fixes the setup modal not closing.

### Copy changes

| Location | Before | After |
|----------|--------|-------|
| Homepage card (active) | Improve | Project health |
| Homepage card (setup) | Self-improving agent | Project health agent |
| Homepage subtitle | "238 actions — 10 created..." | "Dash took 238 actions — 10 created..." |
| Homepage idle | "Monitoring your project" | "Dash is monitoring your project" |
| Activity page title | Improve | **Dash** with "Project health agent" subtitle |
| Setup modal title | Enable self-improving agent | Enable project health agent |
| Setup modal description | "An AI agent that monitors..." | "Dash monitors your project's health..." |
| Setup modal confirm | Enable agent | Enable Dash |
| Setup modal footer | "Agent Suggestions" space | "Dash Suggestions" space |
| Slack notification header | Improve agent completed a run | Dash completed a health check |
| Slack fallback text | Improve agent: ... | Dash: ... |

### Bug fix

**Setup modal can't close** — the `ManagedAgentSetupModal` was rendered inside the card's `<UnstyledButton onClick={handleClick}>`. Clicking Cancel or X bubbled up to the button, which called `setSetupOpen(true)` and reopened the modal instantly. Fixed by moving the modal outside the button as a sibling wrapped in a fragment.

## Test plan

- [ ] Click "Get started" on homepage → modal opens
- [ ] Click Cancel → modal closes (was broken before)
- [ ] Click X → modal closes
- [ ] Click outside modal → modal closes
- [ ] Enable Dash → verify activity page shows "Dash" / "Project health agent"
- [ ] Wait for heartbeat → verify Slack says "Dash completed a health check"

🤖 Generated with [Claude Code](https://claude.com/claude-code)