### PR TITLE
fix: validate table and filters in field value search to prevent 500s

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -2,6 +2,7 @@ import {
     FilterOperator,
     NotFoundError,
     ParameterError,
+    type AndFilterGroup,
     type Explore,
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
@@ -173,6 +174,51 @@ describe('getFieldValuesMetricQuery', () => {
                 limit: 10000,
                 maxLimit: 5000,
                 filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is undefined', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when filters is truthy but missing .and', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: { id: 'bad-filter' } as unknown as AndFilterGroup,
                 exploreResolver: mockExploreResolver,
             }),
         ).rejects.toThrow(ParameterError);

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -51,6 +51,18 @@ export async function getFieldValuesMetricQuery({
     field: Dimension;
     fieldId: string;
 }> {
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table" parameter',
+        );
+    }
+
+    if (filters && !Array.isArray(filters.and)) {
+        throw new ParameterError(
+            'Field value search "filters" must include an "and" array',
+        );
+    }
+
     if (limit > maxLimit) {
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
     }


### PR DESCRIPTION
## Bug
POST `/api/v1/projects/:projectUuid/field/:fieldId/search` and `POST /api/v2/projects/:projectUuid/query/field-values` return **500 UnexpectedServerError** when:
1. Request body is missing `table` field — Knex throws `Undefined binding(s)` error
2. `filters` object is present but missing `.and` property — TypeError: `Cannot read properties of undefined (reading 'filter')`

Sentry: LIGHTDASH-BACKEND-CF9, LIGHTDASH-BACKEND-CF8

## Expected
Both cases should return 400 ParameterError with a meaningful message.

## Reproduction
Failing tests in `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`:
- `throws ParameterError when table is undefined`
- `throws ParameterError when table is empty string`
- `throws ParameterError when filters is truthy but missing .and`

## Evidence (before)
- Failing tests: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts` — see CI run for repro commit

## Fix
**Root cause**: `getFieldValuesMetricQuery` in `fieldValuesQueryBuilder.ts` had no input validation for `table` or `filters.and`:
- `table` was passed directly to `exploreResolver.findExploreByTableName()` → Knex query with undefined binding → 500
- `filters.and.filter(...)` was called when `filters` was truthy but `.and` was undefined → TypeError → 500

**Change**: Added two early validation guards at the top of `getFieldValuesMetricQuery`:
1. `if (!table)` → throws `ParameterError('Field value search requires a non-empty "table" parameter')`
2. `if (filters && !Array.isArray(filters.and))` → throws `ParameterError('Field value search "filters" must include an "and" array')`

Both v1 and v2 endpoints flow through this shared function, so both are covered.

## Evidence (after)
- All 10 tests passing: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`
- typecheck / lint: ✅