### PR TITLE
fix: field search returns 500 when table is missing or filters.and is undefined

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -177,4 +177,66 @@ describe('getFieldValuesMetricQuery', () => {
             }),
         ).rejects.toThrow(ParameterError);
     });
+
+    test('throws ParameterError when table is undefined', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when filters is truthy but missing .and', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                // @ts-expect-error testing malformed input
+                filters: {},
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when filters.and is not an array', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                // @ts-expect-error testing malformed input
+                filters: { and: 'not-an-array' },
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
 });

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -51,6 +51,12 @@ export async function getFieldValuesMetricQuery({
     field: Dimension;
     fieldId: string;
 }> {
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table"',
+        );
+    }
+
     if (limit > maxLimit) {
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
     }
@@ -107,6 +113,11 @@ export async function getFieldValuesMetricQuery({
         },
     ];
     if (filters) {
+        if (!Array.isArray(filters.and)) {
+            throw new ParameterError(
+                'Field value search "filters" must include an "and" array',
+            );
+        }
         const filtersCompatibleWithExplore = filters.and.filter(
             (filter) =>
                 isFilterRule(filter) &&


### PR DESCRIPTION
## Bug
POST filter autocomplete endpoint (`/api/v1/projects/:projectUuid/field/:fieldId/search` and `/api/v2/.../query/field-values`) returns 500 UnexpectedServerError when:
1. Request body is missing the `table` field → Knex "Undefined binding(s)" error
2. `filters` is present but missing `.and` property → TypeError "Cannot read properties of undefined (reading 'filter')"

## Expected
Both cases should return a clean 4xx validation error (400 ParameterError) with a meaningful message.

## Reproduction
```bash
# Bug 1: missing table
curl -X POST -H 'Content-Type: application/json' \
  -d '{"search":"","limit":50}' \
  "http://localhost:8080/api/v1/projects/$PROJECT_UUID/field/users_last_name/search"

# Bug 2: malformed filters
curl -X POST -H 'Content-Type: application/json' \
  -d '{"search":"","limit":50,"table":"users","filters":{"id":"test"}}' \
  "http://localhost:8080/api/v1/projects/$PROJECT_UUID/field/users_last_name/search"
```

## Evidence (before)
- Failing tests: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts` — 4 new tests fail
- Logs: [before-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-missing-table/before-logs.txt)

Key log excerpt:
```
Error: Undefined binding(s) detected when compiling SELECT. Undefined column(s): [name]
  at fieldValuesQueryBuilder.ts:58

TypeError: Cannot read properties of undefined (reading 'filter')
  at fieldValuesQueryBuilder.ts:110
```

## Fix
`getFieldValuesMetricQuery` in `fieldValuesQueryBuilder.ts` did not validate `table` or `filters.and` before use. Added two validation guards:
1. Check `table` is non-empty before passing to `findExploreByTableName` (prevents Knex undefined binding)
2. Check `filters.and` is an array before calling `.filter()` on it (prevents TypeError)

Both throw `ParameterError` (400) with descriptive messages.

## Evidence (after)
- All 11 tests passing: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`

| Repro | Before | After |
|---|---|---|
| `POST .../field/users_last_name/search` no `table` | 500 `UnexpectedServerError` — Knex `Undefined binding(s)` at `fieldValuesQueryBuilder.ts:58` | 400 `ParameterError` — "Field value search requires a non-empty \"table\"" at `fieldValuesQueryBuilder.ts:55` |
| `POST .../field/users_last_name/search` `filters` w/o `.and` | 500 `UnexpectedServerError` — `TypeError: Cannot read properties of undefined (reading 'filter')` at `fieldValuesQueryBuilder.ts:110` | 400 `ParameterError` — "Field value search \"filters\" must include an \"and\" array" at `fieldValuesQueryBuilder.ts:117` |

Logs: [before-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-missing-table/before-logs.txt) · [after-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-missing-table/after-logs.txt)

- typecheck / lint / test: ✅

Closes #22005