### PR TITLE
fix: field search endpoint 500s on missing table and malformed filters

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -2,6 +2,7 @@ import {
     FilterOperator,
     NotFoundError,
     ParameterError,
+    type AndFilterGroup,
     type Explore,
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
@@ -176,5 +177,53 @@ describe('getFieldValuesMetricQuery', () => {
                 exploreResolver: mockExploreResolver,
             }),
         ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is undefined', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('handles filters without .and property gracefully', async () => {
+        const result = await getFieldValuesMetricQuery({
+            projectUuid: 'project-uuid',
+            table: 'a',
+            initialFieldId: 'a_dim1',
+            search: 'test',
+            limit: 10,
+            maxLimit: 5000,
+            filters: { id: 'f1' } as unknown as AndFilterGroup,
+            exploreResolver: mockExploreResolver,
+        });
+
+        const dims = result.metricQuery.filters?.dimensions;
+        const filterRules = dims && 'and' in dims ? dims.and : [];
+        // Only the 2 autocomplete filters — no crash, malformed filters silently skipped
+        expect(filterRules).toHaveLength(2);
     });
 });

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -55,6 +55,12 @@ export async function getFieldValuesMetricQuery({
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
     }
 
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table"',
+        );
+    }
+
     let explore = await exploreResolver.findExploreByTableName(
         projectUuid,
         table,
@@ -106,7 +112,7 @@ export async function getFieldValuesMetricQuery({
             values: [],
         },
     ];
-    if (filters) {
+    if (filters?.and) {
         const filtersCompatibleWithExplore = filters.and.filter(
             (filter) =>
                 isFilterRule(filter) &&


### PR DESCRIPTION
## Bug
POST \`/api/v1/projects/:projectUuid/field/:fieldId/search\` returns 500 UnexpectedServerError in two cases:
1. Request body missing \`table\` field → Knex \`Undefined binding(s)\` crash
2. Request body has \`filters\` object missing \`.and\` property → \`TypeError: Cannot read properties of undefined (reading 'filter')\`

Both paths share \`getFieldValuesMetricQuery\` in \`fieldValuesQueryBuilder.ts\`.

## Expected
1. Requests without \`table\` should return 400 ParameterError with a meaningful message
2. Requests with malformed \`filters\` (missing \`.and\`) should not crash — the malformed filters should be silently skipped

## Reproduction

```bash
# Bug 1: missing table
curl -b cookies.txt -X POST -H 'Content-Type: application/json' \
  -d '{"search":"","limit":50}' \
  "http://localhost:8120/api/v1/projects/3675b69e.../field/users_last_name/search"
# Returns: 500 UnexpectedServerError

# Bug 2: filters without .and
curl -b cookies.txt -X POST -H 'Content-Type: application/json' \
  -d '{"search":"","limit":50,"table":"users","filters":{"id":"f1"}}' \
  "http://localhost:8120/api/v1/projects/3675b69e.../field/users_last_name/search"
# Returns: 500 UnexpectedServerError
```

Failing tests: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`

## Evidence (before)

**Bug 1** — Knex undefined binding at `fieldValuesQueryBuilder.ts:58`:
```
Error: Undefined binding(s) detected when compiling SELECT. Undefined column(s): [name]
    at async getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:58:19)
    at async ProjectService.searchFieldUniqueValues (ProjectService.ts:4652:13)
```

**Bug 2** — TypeError at `fieldValuesQueryBuilder.ts:110`:
```
TypeError: Cannot read properties of undefined (reading 'filter')
    at getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:110:58)
    at async ProjectService.searchFieldUniqueValues (ProjectService.ts:4652:13)
```

[before-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-validation/before-logs.txt)

## Fix

**Root cause**: `getFieldValuesMetricQuery` had no runtime guard for `table` (undefined passed to Knex's `whereIn` → crash) and accessed `filters.and` without checking if `.and` exists.

**Changes** in `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts`:
1. Added `if (!table) throw new ParameterError(...)` after the `limit > maxLimit` check
2. Changed `if (filters)` to `if (filters?.and)` — silently skips malformed filter objects

## Evidence (after)

Tests now passing: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts` (10/10 ✅)

| Repro | Before | After |
|---|---|---|
| `POST .../field/users_last_name/search` no `table` | 500 `UnexpectedServerError` — Knex `Undefined binding(s)` at `fieldValuesQueryBuilder.ts:58` | 400 `ParameterError` — `Field value search requires a non-empty "table"` at `fieldValuesQueryBuilder.ts:59` |
| `POST .../field/users_last_name/search` `filters` w/o `.and` | 500 `UnexpectedServerError` — `TypeError: Cannot read properties of undefined (reading 'filter')` at `fieldValuesQueryBuilder.ts:110` | 403 `ForbiddenError` — downstream user-attribute check (proves TypeError site no longer reached) |

Logs: [before-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-validation/before-logs.txt) · [after-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-validation/after-logs.txt)

- typecheck / lint / test: ✅