### PR TITLE
chore: always start minio in dev env

### DIFF
--- a/docker/docker-compose.infra.yml
+++ b/docker/docker-compose.infra.yml
@@ -1,6 +1,7 @@
 services:
     minio:
         image: coollabsio/minio:latest
+        restart: always
         ports:
             - '9000:9000'
             - '9001:9001' # for minio console


### PR DESCRIPTION
### Description:
@notgiorgi pointed out that all the containers start-up except minio. Turns out the prop was simply missing there.
