### PR TITLE
fix(ee): reverse_own_action UUID type error

### DIFF
--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -1316,9 +1316,12 @@ chartConfig:
                 break;
         }
 
+        const settings = await this.managedAgentModel.getSettings(projectUuid);
+        const actorUuid = settings?.enabledByUserUuid ?? projectUuid;
+
         const reversed = await this.managedAgentModel.reverseAction(
             actionUuid,
-            'agent', // reversed by the agent itself
+            actorUuid,
         );
 
         this.logger.info(`Agent reversed action ${actionUuid}: ${reason}`);


### PR DESCRIPTION
The `reversed_by_user_uuid` column is UUID type but we were passing the string `'agent'`. Use the `enabledByUserUuid` from settings instead.

Fixes: `invalid input syntax for type uuid: "agent"` on prod.

🤖 Generated with [Claude Code](https://claude.com/claude-code)