### PR TITLE
feat: change Data Apps badge from Beta to Experimental

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -135,7 +135,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                     description="Build an interactive app powered by your data."
                                     to={`/projects/${projectUuid}/apps/generate`}
                                     icon={IconAppWindow}
-                                    isBeta
+                                    isExperimental
                                 />
                             </Can>
                         )}

--- a/packages/frontend/src/components/common/ExperimentalBadge.tsx
+++ b/packages/frontend/src/components/common/ExperimentalBadge.tsx
@@ -1,0 +1,23 @@
+import { Badge, Tooltip } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type Props = {
+    tooltipLabel?: string;
+};
+
+/**
+ * A badge that displays an experimental label and a tooltip when hovered.
+ * @param tooltipLabel - The label to display in the tooltip
+ * @returns A badge that displays an experimental label and a tooltip when hovered.
+ */
+export const ExperimentalBadge: FC<Props> = ({
+    tooltipLabel = 'This feature is experimental. It may change or be removed without notice.',
+}) => {
+    return (
+        <Tooltip label={tooltipLabel}>
+            <Badge color="red" size="xs" radius="sm" fz="xs">
+                Experimental
+            </Badge>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/components/common/LargeMenuItem.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.tsx
@@ -10,6 +10,7 @@ import {
 import { type Icon as TablerIconType } from '@tabler/icons-react';
 import { forwardRef, type ReactNode } from 'react';
 import { BetaBadge } from './BetaBadge';
+import { ExperimentalBadge } from './ExperimentalBadge';
 import MantineIcon, { type MantineIconProps } from './MantineIcon';
 
 interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
@@ -18,13 +19,25 @@ interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
     title: string;
     description: string | ReactNode;
     isBeta?: boolean;
+    isExperimental?: boolean;
 }
 
 const LargeMenuItem: ReturnType<
     typeof createPolymorphicComponent<'button', LargeMenuItemProps>
 > = createPolymorphicComponent<'button', LargeMenuItemProps>(
     forwardRef<HTMLButtonElement, LargeMenuItemProps>(
-        ({ icon, title, description, iconProps, isBeta, ...rest }, ref) => {
+        (
+            {
+                icon,
+                title,
+                description,
+                iconProps,
+                isBeta,
+                isExperimental,
+                ...rest
+            },
+            ref,
+        ) => {
             return (
                 <Menu.Item
                     ref={ref}
@@ -46,6 +59,7 @@ const LargeMenuItem: ReturnType<
                                 {title}
                             </Text>
                             {isBeta && <BetaBadge />}
+                            {isExperimental && <ExperimentalBadge />}
                         </Group>
                         <Text c="ldDark.8" fz="xs">
                             {description}


### PR DESCRIPTION
## Summary
- Replaces the blue "Beta" badge on the Apps item in the "New" menu with a red "Experimental" badge
- Adds a new `ExperimentalBadge` component (`packages/frontend/src/components/common/ExperimentalBadge.tsx`) mirroring the existing `BetaBadge` pattern but with `color="red"` and text "Experimental"
- Adds `isExperimental` prop to `LargeMenuItem` alongside the existing `isBeta` prop
- Other `BetaBadge` consumers (`VisualizationCardOptions`, `ColumnHeaderContextMenu`, `SlackSettingsPanel`) are unaffected

## Linear
PROD-6987

## Test plan
- [ ] Open the app, click "New" in the navbar — the "App" menu item should show a red "Experimental" badge instead of the blue "Beta" badge
- [ ] Hover the badge — tooltip reads "This feature is experimental. It may change or be removed without notice."
- [ ] Other menu items with "Beta" badge remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)