### PR TITLE
fix: Change Apps menu item badge from Beta to Experimental

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -135,7 +135,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                     description="Build an interactive app powered by your data."
                                     to={`/projects/${projectUuid}/apps/generate`}
                                     icon={IconAppWindow}
-                                    isBeta
+                                    isExperimental
                                 />
                             </Can>
                         )}

--- a/packages/frontend/src/components/common/LargeMenuItem.test.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.test.tsx
@@ -1,0 +1,59 @@
+import { Menu } from '@mantine-8/core';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import LargeMenuItem from './LargeMenuItem';
+
+// Mock icon component
+const MockIcon = () => <svg data-testid="mock-icon" />;
+
+// LargeMenuItem uses Menu.Item internally so it requires a Menu context
+const renderInMenu = (ui: React.ReactNode) =>
+    renderWithProviders(
+        <Menu opened>
+            <Menu.Dropdown>{ui}</Menu.Dropdown>
+        </Menu>,
+    );
+
+describe('LargeMenuItem', () => {
+    it('renders no badge when neither isBeta nor isExperimental is set', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="Chart"
+                description="Build queries and save them as charts."
+                icon={MockIcon}
+            />,
+        );
+
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+        expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
+    });
+
+    it('renders a "Beta" badge when isBeta is true', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="Chart"
+                description="Build queries and save them as charts."
+                icon={MockIcon}
+                isBeta
+            />,
+        );
+
+        expect(screen.getByText('Beta')).toBeInTheDocument();
+        expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
+    });
+
+    it('renders an "Experimental" badge when isExperimental is true', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="App"
+                description="Build an interactive app powered by your data."
+                icon={MockIcon}
+                isExperimental
+            />,
+        );
+
+        expect(screen.getByText('Experimental')).toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/LargeMenuItem.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.tsx
@@ -1,10 +1,12 @@
 import {
+    Badge,
     Card,
     createPolymorphicComponent,
     Group,
     Menu,
     Stack,
     Text,
+    Tooltip,
     type MenuItemProps,
 } from '@mantine-8/core';
 import { type Icon as TablerIconType } from '@tabler/icons-react';
@@ -18,13 +20,25 @@ interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
     title: string;
     description: string | ReactNode;
     isBeta?: boolean;
+    isExperimental?: boolean;
 }
 
 const LargeMenuItem: ReturnType<
     typeof createPolymorphicComponent<'button', LargeMenuItemProps>
 > = createPolymorphicComponent<'button', LargeMenuItemProps>(
     forwardRef<HTMLButtonElement, LargeMenuItemProps>(
-        ({ icon, title, description, iconProps, isBeta, ...rest }, ref) => {
+        (
+            {
+                icon,
+                title,
+                description,
+                iconProps,
+                isBeta,
+                isExperimental,
+                ...rest
+            },
+            ref,
+        ) => {
             return (
                 <Menu.Item
                     ref={ref}
@@ -46,6 +60,18 @@ const LargeMenuItem: ReturnType<
                                 {title}
                             </Text>
                             {isBeta && <BetaBadge />}
+                            {isExperimental && (
+                                <Tooltip label="This feature is experimental. It may change or be removed.">
+                                    <Badge
+                                        color="red"
+                                        size="xs"
+                                        radius="sm"
+                                        fz="xs"
+                                    >
+                                        Experimental
+                                    </Badge>
+                                </Tooltip>
+                            )}
                         </Group>
                         <Text c="ldDark.8" fz="xs">
                             {description}


### PR DESCRIPTION
## Bug
The "Apps" item in the "New" navigation menu displays a blue **Beta** badge, but Apps are an experimental feature, not a beta one.

## Expected
The "Apps" item should display a red **Experimental** badge instead.

## Reproduction
- Navigate to any Lightdash project
- Click the **New** button in the nav bar
- Observe the "App" menu item has a blue "Beta" badge

Failing test: `packages/frontend/src/components/common/LargeMenuItem.test.tsx`

## Evidence (before)
- Failing test: `renders an "Experimental" badge when isExperimental is true` — **FAILS** because `isExperimental` prop was not implemented on `LargeMenuItem`
- `renders a "Beta" badge when isBeta is true` — passes (regression baseline)
- `renders no badge when neither is set` — passes

## Fix
**Root cause**: `LargeMenuItem.tsx` only had `isBeta?: boolean` which renders a `<BetaBadge />` (indigo/blue "Beta"). The App menu item in `ExploreMenu.tsx:138` used `isBeta`, so it showed the wrong badge.

**Changes**:
1. `LargeMenuItem.tsx` — Added `isExperimental?: boolean` prop; renders a red `<Badge>Experimental</Badge>` inside a `<Tooltip>` when set
2. `ExploreMenu.tsx:138` — Changed `isBeta` → `isExperimental` on the App menu item

The existing `isBeta` prop is preserved for other consumers (`ColumnHeaderContextMenu`, `VisualizationCardOptions`, `SlackSettingsPanel`).

## Evidence (after)

All 3 tests now pass:
- `renders no badge when neither isBeta nor isExperimental is set` ✅
- `renders a "Beta" badge when isBeta is true` ✅
- `renders an "Experimental" badge when isExperimental is true` ✅

| Check | Result |
|---|---|
| `npx vitest run src/components/common/LargeMenuItem.test.tsx` | ✅ 3/3 passed |
| `pnpm -F frontend typecheck` | ✅ |
| `pnpm -F frontend lint` | ✅ 0 errors |