### PR TITLE
fix: change Data Apps badge from blue Beta to red Experimental

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -135,7 +135,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                     description="Build an interactive app powered by your data."
                                     to={`/projects/${projectUuid}/apps/generate`}
                                     icon={IconAppWindow}
-                                    isBeta
+                                    isExperimental
                                 />
                             </Can>
                         )}

--- a/packages/frontend/src/components/common/LargeMenuItem.test.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.test.tsx
@@ -1,0 +1,43 @@
+import { Menu } from '@mantine-8/core';
+import { IconTable } from '@tabler/icons-react';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import LargeMenuItem from './LargeMenuItem';
+
+// LargeMenuItem renders a Menu.Item which requires a Menu context
+const renderInMenu = (ui: React.ReactNode) =>
+    renderWithProviders(
+        <Menu opened>
+            <Menu.Dropdown>{ui}</Menu.Dropdown>
+        </Menu>,
+    );
+
+describe('LargeMenuItem', () => {
+    it('renders "Experimental" badge (red) when isExperimental is true', () => {
+        renderInMenu(
+            <LargeMenuItem
+                icon={IconTable}
+                title="App"
+                description="Build an interactive app powered by your data."
+                isExperimental
+            />,
+        );
+
+        expect(screen.getByText('Experimental')).toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    });
+
+    it('renders no badge when isExperimental is omitted', () => {
+        renderInMenu(
+            <LargeMenuItem
+                icon={IconTable}
+                title="App"
+                description="Build an interactive app powered by your data."
+            />,
+        );
+
+        expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/LargeMenuItem.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.tsx
@@ -1,4 +1,5 @@
 import {
+    Badge,
     Card,
     createPolymorphicComponent,
     Group,
@@ -9,7 +10,6 @@ import {
 } from '@mantine-8/core';
 import { type Icon as TablerIconType } from '@tabler/icons-react';
 import { forwardRef, type ReactNode } from 'react';
-import { BetaBadge } from './BetaBadge';
 import MantineIcon, { type MantineIconProps } from './MantineIcon';
 
 interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
@@ -17,14 +17,17 @@ interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
     iconProps?: Omit<MantineIconProps, 'icon'>;
     title: string;
     description: string | ReactNode;
-    isBeta?: boolean;
+    isExperimental?: boolean;
 }
 
 const LargeMenuItem: ReturnType<
     typeof createPolymorphicComponent<'button', LargeMenuItemProps>
 > = createPolymorphicComponent<'button', LargeMenuItemProps>(
     forwardRef<HTMLButtonElement, LargeMenuItemProps>(
-        ({ icon, title, description, iconProps, isBeta, ...rest }, ref) => {
+        (
+            { icon, title, description, iconProps, isExperimental, ...rest },
+            ref,
+        ) => {
             return (
                 <Menu.Item
                     ref={ref}
@@ -45,7 +48,16 @@ const LargeMenuItem: ReturnType<
                             <Text c="white" fw={600} fz="sm">
                                 {title}
                             </Text>
-                            {isBeta && <BetaBadge />}
+                            {isExperimental && (
+                                <Badge
+                                    color="red"
+                                    size="xs"
+                                    radius="sm"
+                                    fz="xs"
+                                >
+                                    Experimental
+                                </Badge>
+                            )}
                         </Group>
                         <Text c="ldDark.8" fz="xs">
                             {description}


### PR DESCRIPTION
## Bug
The \"New\" menu in the navbar renders the \"App\" item with a blue \"Beta\" badge. Per PROD-6987 this should be a red badge saying \"Experimental\" instead, reflecting the actual state of the hackathon project.

## Expected
The \"App\" menu item displays a red badge with the text \"Experimental\".

## Reproduction
- `LargeMenuItem.tsx:20` had `isBeta?: boolean` prop rendering `<BetaBadge />` (indigo/blue, text \"Beta\") at line 48
- `ExploreMenu.tsx:138` passed `isBeta` to the App `LargeMenuItem`
- Failing test: `packages/frontend/src/components/common/LargeMenuItem.test.tsx`

## Evidence (before)
- Failing test: `packages/frontend/src/components/common/LargeMenuItem.test.tsx` — `getByText('Experimental')` failed because `isExperimental` prop didn't exist; component rendered a blue \"Beta\" badge instead

## Fix
Renamed `isBeta` → `isExperimental` in `LargeMenuItem`, replaced `<BetaBadge />` with an inline `<Badge color="red" size="xs" radius="sm" fz="xs">Experimental</Badge>`, and updated `ExploreMenu.tsx` to pass `isExperimental`.

- `BetaBadge` component is untouched — still used by other callers
- No tooltip added (ticket doesn't request one; flagged here for reviewer input if desired)
- `isBeta` was only used on the App menu item (confirmed via grep) — rename is safe

## Evidence (after)
- Test now passing: `packages/frontend/src/components/common/LargeMenuItem.test.tsx` ✅

| Test | Before | After |
|---|---|---|
| `renders "Experimental" badge when isExperimental=true` | FAIL — `getByText('Experimental')` not found | PASS ✅ |
| `renders no badge when isExperimental is omitted` | PASS | PASS ✅ |

- typecheck / lint / test: ✅

> **Note on tooltip**: `BetaBadge` includes a tooltip ("This feature is currently in beta…"). The fix does not add a tooltip to the Experimental badge. If one is desired (e.g. "This feature is experimental and subject to change"), it can be added — but the ticket doesn't mention one.