### PR TITLE
fix: Change Apps menu item badge from Beta to Experimental

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -135,7 +135,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                     description="Build an interactive app powered by your data."
                                     to={`/projects/${projectUuid}/apps/generate`}
                                     icon={IconAppWindow}
-                                    isBeta
+                                    isExperimental
                                 />
                             </Can>
                         )}

--- a/packages/frontend/src/components/common/LargeMenuItem.test.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.test.tsx
@@ -1,0 +1,59 @@
+import { Menu } from '@mantine-8/core';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import LargeMenuItem from './LargeMenuItem';
+
+// Mock icon component
+const MockIcon = () => <svg data-testid="mock-icon" />;
+
+// LargeMenuItem uses Menu.Item internally so it requires a Menu context
+const renderInMenu = (ui: React.ReactNode) =>
+    renderWithProviders(
+        <Menu opened>
+            <Menu.Dropdown>{ui}</Menu.Dropdown>
+        </Menu>,
+    );
+
+describe('LargeMenuItem', () => {
+    it('renders no badge when neither isBeta nor isExperimental is set', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="Chart"
+                description="Build queries and save them as charts."
+                icon={MockIcon}
+            />,
+        );
+
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+        expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
+    });
+
+    it('renders a "Beta" badge when isBeta is true', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="Chart"
+                description="Build queries and save them as charts."
+                icon={MockIcon}
+                isBeta
+            />,
+        );
+
+        expect(screen.getByText('Beta')).toBeInTheDocument();
+        expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
+    });
+
+    it('renders an "Experimental" badge when isExperimental is true', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="App"
+                description="Build an interactive app powered by your data."
+                icon={MockIcon}
+                isExperimental
+            />,
+        );
+
+        expect(screen.getByText('Experimental')).toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/LargeMenuItem.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.tsx
@@ -1,10 +1,12 @@
 import {
+    Badge,
     Card,
     createPolymorphicComponent,
     Group,
     Menu,
     Stack,
     Text,
+    Tooltip,
     type MenuItemProps,
 } from '@mantine-8/core';
 import { type Icon as TablerIconType } from '@tabler/icons-react';
@@ -18,13 +20,25 @@ interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
     title: string;
     description: string | ReactNode;
     isBeta?: boolean;
+    isExperimental?: boolean;
 }
 
 const LargeMenuItem: ReturnType<
     typeof createPolymorphicComponent<'button', LargeMenuItemProps>
 > = createPolymorphicComponent<'button', LargeMenuItemProps>(
     forwardRef<HTMLButtonElement, LargeMenuItemProps>(
-        ({ icon, title, description, iconProps, isBeta, ...rest }, ref) => {
+        (
+            {
+                icon,
+                title,
+                description,
+                iconProps,
+                isBeta,
+                isExperimental,
+                ...rest
+            },
+            ref,
+        ) => {
             return (
                 <Menu.Item
                     ref={ref}
@@ -46,6 +60,18 @@ const LargeMenuItem: ReturnType<
                                 {title}
                             </Text>
                             {isBeta && <BetaBadge />}
+                            {isExperimental && (
+                                <Tooltip label="This feature is experimental. It may change or be removed.">
+                                    <Badge
+                                        color="red"
+                                        size="xs"
+                                        radius="sm"
+                                        fz="xs"
+                                    >
+                                        Experimental
+                                    </Badge>
+                                </Tooltip>
+                            )}
                         </Group>
                         <Text c="ldDark.8" fz="xs">
                             {description}


### PR DESCRIPTION
## Bug
The \"New\" menu's \"App\" item shows a blue **\"Beta\"** badge — but the feature is experimental, not beta. Ticket: PROD-6987.

## Expected
The App menu item should show a red **\"Experimental\"** badge.

## Reproduction
Failing test demonstrates that `LargeMenuItem` had no `isExperimental` prop, making it impossible to render anything other than the `BetaBadge` (indigo/blue) on the App menu item.

Test file: `packages/frontend/src/components/common/LargeMenuItem.test.tsx`

Run: `cd packages/frontend && npx vitest run src/components/common/LargeMenuItem.test.tsx`

## Evidence (before)
- Failing test: `LargeMenuItem.test.tsx` — `isExperimental` prop did not exist, test asserting `"Experimental"` text would fail
- ⚠️ Chrome DevTools MCP unavailable in this environment — screenshot evidence could not be captured

## Fix

**Root cause**: `LargeMenuItem` only had an `isBeta?: boolean` prop, which rendered a `<BetaBadge />` (indigo, "Beta" text). The `ExploreMenu` used `isBeta` for the App item, so it always showed a blue "Beta" badge.

**Changes**:
1. Added `isExperimental?: boolean` prop to `LargeMenuItem` — renders an inline red `Badge` with text "Experimental" and a tooltip
2. Switched the App `LargeMenuItem` in `ExploreMenu.tsx` from `isBeta` to `isExperimental`
3. Added `LargeMenuItem.test.tsx` covering no-badge / Beta / Experimental states

`isBeta` is preserved on `LargeMenuItem` — other callers (`SlackSettingsPanel`, `VisualizationCardOptions`, `ColumnHeaderContextMenu`) are unaffected.

## Evidence (after)
- Test now passing: `packages/frontend/src/components/common/LargeMenuItem.test.tsx` — all 3 tests pass
- typecheck / lint / test: ✅