### PR TITLE
feat(ee): slow query detection for project health agent

### DIFF
--- a/packages/backend/src/ee/models/ManagedAgentModel.ts
+++ b/packages/backend/src/ee/models/ManagedAgentModel.ts
@@ -289,4 +289,76 @@ export class ManagedAgentModel {
             .first();
         return row?.created_at ?? null;
     }
+
+    async getSlowQueries(
+        projectUuid: string,
+        thresholdMs: number = 2000,
+        limit: number = 20,
+    ): Promise<
+        Array<{
+            executionTimeMs: number;
+            context: string;
+            chartUuid: string | null;
+            chartName: string | null;
+            dashboardUuid: string | null;
+            dashboardName: string | null;
+            createdAt: Date;
+        }>
+    > {
+        const rows = await this.database('query_history as qh')
+            .leftJoin(
+                'saved_queries as sq',
+                this.database.raw(
+                    `sq.saved_query_uuid = (qh.request_parameters->>'savedChartUuid')::uuid AND sq.deleted_at IS NULL`,
+                ),
+            )
+            .leftJoin(
+                'dashboards as d',
+                this.database.raw(
+                    `d.dashboard_uuid = (qh.request_parameters->>'dashboardUuid')::uuid AND d.deleted_at IS NULL`,
+                ),
+            )
+            .where('qh.project_uuid', projectUuid)
+            .where('qh.warehouse_execution_time_ms', '>=', thresholdMs)
+            .where(
+                'qh.created_at',
+                '>',
+                this.database.raw(`now() - interval '30 days'`),
+            )
+            .select(
+                'qh.warehouse_execution_time_ms as execution_time_ms',
+                'qh.context',
+                this.database.raw(
+                    `qh.request_parameters->>'savedChartUuid' as chart_uuid`,
+                ),
+                'sq.name as chart_name',
+                this.database.raw(
+                    `qh.request_parameters->>'dashboardUuid' as dashboard_uuid`,
+                ),
+                'd.name as dashboard_name',
+                'qh.created_at',
+            )
+            .orderBy('qh.warehouse_execution_time_ms', 'desc')
+            .limit(limit);
+
+        return rows.map(
+            (r: {
+                execution_time_ms: number;
+                context: string;
+                chart_uuid: string | null;
+                chart_name: string | null;
+                dashboard_uuid: string | null;
+                dashboard_name: string | null;
+                created_at: Date;
+            }) => ({
+                executionTimeMs: r.execution_time_ms,
+                context: r.context,
+                chartUuid: r.chart_uuid,
+                chartName: r.chart_name,
+                dashboardUuid: r.dashboard_uuid,
+                dashboardName: r.dashboard_name,
+                createdAt: r.created_at,
+            }),
+        );
+    }
 }

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -595,6 +595,8 @@ export class ManagedAgentService extends BaseService {
                 return this.handleCreateContent(projectUuid, sessionId, input);
             case 'get_user_questions':
                 return this.handleGetUserQuestions(projectUuid, input);
+            case 'get_slow_queries':
+                return this.handleGetSlowQueries(projectUuid, input);
             case 'reverse_own_action':
                 return this.handleReverseOwnAction(projectUuid, input);
             default:
@@ -1051,6 +1053,7 @@ chartConfig:
     private static readonly VALID_FLAG_TYPES = new Set<string>([
         ManagedAgentActionType.FLAGGED_STALE,
         ManagedAgentActionType.FLAGGED_BROKEN,
+        ManagedAgentActionType.FLAGGED_SLOW,
     ]);
 
     private async handleFlagContent(
@@ -1256,6 +1259,33 @@ chartConfig:
                 question: q.prompt,
                 asked_by: q.userName,
                 asked_at: q.createdAt,
+            })),
+        );
+    }
+
+    private async handleGetSlowQueries(
+        projectUuid: string,
+        input: Record<string, unknown>,
+    ): Promise<string> {
+        const thresholdMs = (input.threshold_ms as number) ?? 2000;
+        const limit = (input.limit as number) ?? 20;
+
+        const slowQueries = await this.managedAgentModel.getSlowQueries(
+            projectUuid,
+            thresholdMs,
+            limit,
+        );
+
+        return JSON.stringify(
+            slowQueries.map((q) => ({
+                execution_time_ms: q.executionTimeMs,
+                execution_time_seconds: (q.executionTimeMs / 1000).toFixed(1),
+                context: q.context,
+                chart_uuid: q.chartUuid,
+                chart_name: q.chartName,
+                dashboard_uuid: q.dashboardUuid,
+                dashboard_name: q.dashboardName,
+                ran_at: q.createdAt,
             })),
         );
     }

--- a/packages/backend/src/ee/services/ManagedAgentService/managedAgentTools.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/managedAgentTools.ts
@@ -60,7 +60,14 @@ CRITICAL: chartConfig.type must be "cartesian" (for line/bar/area), "table", "bi
 
 Max 3 charts per run. Skip if nothing warrants creation.
 
-### 5. Insights
+### 5. Slow Queries
+Call get_slow_queries. For each slow chart or dashboard:
+- Flag with flag_content using flag_type "flagged_slow"
+- Include execution time and context in the description
+- Don't re-flag content you've already flagged as slow in a previous run
+- Only flag if the query consistently takes >2 seconds (not a one-off spike)
+
+### 6. Insights
 Call get_popular_content.
 - Surface content that is popular but not pinned
 - Surface content with high views but restricted access (private space)
@@ -162,7 +169,7 @@ export const CUSTOM_TOOL_DEFINITIONS = [
                 },
                 flag_type: {
                     type: 'string',
-                    enum: ['flagged_stale', 'flagged_broken'],
+                    enum: ['flagged_stale', 'flagged_broken', 'flagged_slow'],
                     description: 'Why this content is being flagged',
                 },
                 description: {
@@ -398,6 +405,27 @@ export const CUSTOM_TOOL_DEFINITIONS = [
                 },
             },
             required: ['action_uuid', 'reason'],
+        },
+    },
+    {
+        type: 'custom' as const,
+        name: 'get_slow_queries',
+        description:
+            'Get the slowest warehouse queries in the project from the last 30 days. Returns the chart or dashboard name, execution time in ms, query context, and when it ran. Use this to flag charts or dashboards with consistently slow queries so admins can optimize them.',
+        input_schema: {
+            type: 'object' as const,
+            properties: {
+                threshold_ms: {
+                    type: 'number',
+                    description:
+                        'Minimum execution time in ms to consider slow (default 2000)',
+                },
+                limit: {
+                    type: 'number',
+                    description: 'Max results to return (default 20)',
+                },
+            },
+            required: [] as string[],
         },
     },
 ];

--- a/packages/common/src/ee/types/managedAgent.ts
+++ b/packages/common/src/ee/types/managedAgent.ts
@@ -2,6 +2,7 @@ export enum ManagedAgentActionType {
     FLAGGED_STALE = 'flagged_stale',
     SOFT_DELETED = 'soft_deleted',
     FLAGGED_BROKEN = 'flagged_broken',
+    FLAGGED_SLOW = 'flagged_slow',
     FIXED_BROKEN = 'fixed_broken',
     CREATED_CONTENT = 'created_content',
     INSIGHT = 'insight',

--- a/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
+++ b/packages/frontend/src/ee/features/managedAgent/ManagedAgentActivityPage.tsx
@@ -241,6 +241,10 @@ const ACTION_CONFIG: Record<
         label: 'Broken',
         dotColor: 'var(--mantine-color-red-5)',
     },
+    flagged_slow: {
+        label: 'Slow',
+        dotColor: 'var(--mantine-color-yellow-6)',
+    },
     fixed_broken: {
         label: 'Fixed',
         dotColor: 'var(--mantine-color-teal-5)',

--- a/packages/frontend/src/ee/features/managedAgent/types.ts
+++ b/packages/frontend/src/ee/features/managedAgent/types.ts
@@ -6,6 +6,7 @@ export type ManagedAgentAction = {
         | 'flagged_stale'
         | 'soft_deleted'
         | 'flagged_broken'
+        | 'flagged_slow'
         | 'fixed_broken'
         | 'created_content'
         | 'insight';


### PR DESCRIPTION
## Summary

Adds slow query detection to the managed agent. The agent can now identify charts and dashboards with consistently slow warehouse queries and flag them for admin attention.

### New tool: `get_slow_queries`

Queries the `query_history` table for warehouse queries exceeding a configurable threshold (default 2 seconds). Returns:
- Execution time in ms and seconds
- Chart name and UUID (resolved from `saved_queries`)
- Dashboard name and UUID (resolved from `dashboards`)
- Query context (dashboardView, chartView, etc.)
- When it ran

### New action type: `flagged_slow`

- Yellow dot in the activity feed
- Agent flags charts/dashboards with consistently slow queries
- Only flags if the query appears multiple times above threshold (not one-off spikes)

### Checklist update

New step 5 "Slow Queries" added between broken content and insights.

## Test plan

- [ ] Agent calls `get_slow_queries` and receives results
- [ ] Agent flags a slow chart with `flagged_slow` type
- [ ] Activity feed shows yellow "Slow" badge
- [ ] Sidebar shows execution time in metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)