### PR TITLE
fix: change Data Apps badge from blue Beta to red Experimental

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -135,7 +135,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                     description="Build an interactive app powered by your data."
                                     to={`/projects/${projectUuid}/apps/generate`}
                                     icon={IconAppWindow}
-                                    isBeta
+                                    isExperimental
                                 />
                             </Can>
                         )}

--- a/packages/frontend/src/components/common/ExperimentalBadge.tsx
+++ b/packages/frontend/src/components/common/ExperimentalBadge.tsx
@@ -1,0 +1,23 @@
+import { Badge, Tooltip } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type Props = {
+    tooltipLabel?: string;
+};
+
+/**
+ * A badge that displays an experimental label and a tooltip when hovered.
+ * @param tooltipLabel - The label to display in the tooltip
+ * @returns A badge that displays an experimental label and a tooltip when hovered.
+ */
+export const ExperimentalBadge: FC<Props> = ({
+    tooltipLabel = 'This feature is experimental. It might cause unexpected results and is subject to change.',
+}) => {
+    return (
+        <Tooltip label={tooltipLabel}>
+            <Badge color="red" size="xs" radius="sm" fz="xs">
+                Experimental
+            </Badge>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/components/common/LargeMenuItem.test.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.test.tsx
@@ -1,0 +1,27 @@
+import { Menu } from '@mantine-8/core';
+import { IconAppWindow } from '@tabler/icons-react';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import LargeMenuItem from './LargeMenuItem';
+
+describe('LargeMenuItem', () => {
+    it('renders isExperimental badge with "Experimental" text instead of "Beta"', () => {
+        renderWithProviders(
+            <Menu opened>
+                <Menu.Dropdown>
+                    <LargeMenuItem
+                        title="App"
+                        description="Build an interactive app powered by your data."
+                        icon={IconAppWindow}
+                        isExperimental
+                    />
+                </Menu.Dropdown>
+            </Menu>,
+        );
+
+        // Should show "Experimental" badge, not "Beta"
+        expect(screen.getByText('Experimental')).toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/LargeMenuItem.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.tsx
@@ -10,6 +10,7 @@ import {
 import { type Icon as TablerIconType } from '@tabler/icons-react';
 import { forwardRef, type ReactNode } from 'react';
 import { BetaBadge } from './BetaBadge';
+import { ExperimentalBadge } from './ExperimentalBadge';
 import MantineIcon, { type MantineIconProps } from './MantineIcon';
 
 interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
@@ -18,13 +19,25 @@ interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
     title: string;
     description: string | ReactNode;
     isBeta?: boolean;
+    isExperimental?: boolean;
 }
 
 const LargeMenuItem: ReturnType<
     typeof createPolymorphicComponent<'button', LargeMenuItemProps>
 > = createPolymorphicComponent<'button', LargeMenuItemProps>(
     forwardRef<HTMLButtonElement, LargeMenuItemProps>(
-        ({ icon, title, description, iconProps, isBeta, ...rest }, ref) => {
+        (
+            {
+                icon,
+                title,
+                description,
+                iconProps,
+                isBeta,
+                isExperimental,
+                ...rest
+            },
+            ref,
+        ) => {
             return (
                 <Menu.Item
                     ref={ref}
@@ -46,6 +59,7 @@ const LargeMenuItem: ReturnType<
                                 {title}
                             </Text>
                             {isBeta && <BetaBadge />}
+                            {isExperimental && <ExperimentalBadge />}
                         </Group>
                         <Text c="ldDark.8" fz="xs">
                             {description}


### PR DESCRIPTION
## Bug
The "New" menu in the navbar shows the "App" menu item with a blue **Beta** badge. It should show a red **Experimental** badge instead, reflecting the actual state of Data Apps.

## Expected
The App menu item in the "New" dropdown shows a red badge with the text **Experimental**.

## Reproduction
The `LargeMenuItem` component only supported `isBeta` (renders `BetaBadge` — blue/indigo). There was no `isExperimental` prop or `ExperimentalBadge` component. The App item in `ExploreMenu.tsx:138` passed `isBeta` but should pass `isExperimental`.

See test: `packages/frontend/src/components/common/LargeMenuItem.test.tsx`

## Evidence (before)
- Failing test: `src/components/common/LargeMenuItem.test.tsx` — `Unable to find an element with the text: 'Experimental'`
- Screenshot: ⚠️ Chrome DevTools MCP was unavailable in this environment

## Fix
**Root cause**: `ExploreMenu.tsx:138` passed `isBeta` to `LargeMenuItem`, rendering a blue `BetaBadge`. No `ExperimentalBadge` or `isExperimental` prop existed.

**Changes**:
1. Created `ExperimentalBadge.tsx` — red badge, "Experimental" text, matching tooltip style of `BetaBadge`
2. Added `isExperimental?: boolean` prop to `LargeMenuItem` rendering `ExperimentalBadge`
3. Changed `ExploreMenu.tsx:138` from `isBeta` → `isExperimental`

## Evidence (after)

| Repro | Before | After |
|---|---|---|
| `LargeMenuItem` with `isExperimental` | Test fails: `Unable to find element with text 'Experimental'` | Test passes: "Experimental" text found, "Beta" not found |

- Test now passing: `src/components/common/LargeMenuItem.test.tsx` ✅
- Screenshot: ⚠️ Chrome DevTools MCP unavailable
- typecheck / lint / test: ✅