### PR TITLE
fix: change Data Apps badge from blue Beta to red Experimental

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -135,7 +135,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                     description="Build an interactive app powered by your data."
                                     to={`/projects/${projectUuid}/apps/generate`}
                                     icon={IconAppWindow}
-                                    isBeta
+                                    isExperimental
                                 />
                             </Can>
                         )}

--- a/packages/frontend/src/components/common/LargeMenuItem.test.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.test.tsx
@@ -1,0 +1,43 @@
+import { Menu } from '@mantine-8/core';
+import { IconTable } from '@tabler/icons-react';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import LargeMenuItem from './LargeMenuItem';
+
+// LargeMenuItem renders a Menu.Item which requires a Menu context
+const renderInMenu = (ui: React.ReactNode) =>
+    renderWithProviders(
+        <Menu opened>
+            <Menu.Dropdown>{ui}</Menu.Dropdown>
+        </Menu>,
+    );
+
+describe('LargeMenuItem', () => {
+    it('renders "Experimental" badge (red) when isExperimental is true', () => {
+        renderInMenu(
+            <LargeMenuItem
+                icon={IconTable}
+                title="App"
+                description="Build an interactive app powered by your data."
+                isExperimental
+            />,
+        );
+
+        expect(screen.getByText('Experimental')).toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    });
+
+    it('renders no badge when isExperimental is omitted', () => {
+        renderInMenu(
+            <LargeMenuItem
+                icon={IconTable}
+                title="App"
+                description="Build an interactive app powered by your data."
+            />,
+        );
+
+        expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/LargeMenuItem.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.tsx
@@ -1,4 +1,5 @@
 import {
+    Badge,
     Card,
     createPolymorphicComponent,
     Group,
@@ -9,7 +10,6 @@ import {
 } from '@mantine-8/core';
 import { type Icon as TablerIconType } from '@tabler/icons-react';
 import { forwardRef, type ReactNode } from 'react';
-import { BetaBadge } from './BetaBadge';
 import MantineIcon, { type MantineIconProps } from './MantineIcon';
 
 interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
@@ -17,14 +17,17 @@ interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
     iconProps?: Omit<MantineIconProps, 'icon'>;
     title: string;
     description: string | ReactNode;
-    isBeta?: boolean;
+    isExperimental?: boolean;
 }
 
 const LargeMenuItem: ReturnType<
     typeof createPolymorphicComponent<'button', LargeMenuItemProps>
 > = createPolymorphicComponent<'button', LargeMenuItemProps>(
     forwardRef<HTMLButtonElement, LargeMenuItemProps>(
-        ({ icon, title, description, iconProps, isBeta, ...rest }, ref) => {
+        (
+            { icon, title, description, iconProps, isExperimental, ...rest },
+            ref,
+        ) => {
             return (
                 <Menu.Item
                     ref={ref}
@@ -45,7 +48,16 @@ const LargeMenuItem: ReturnType<
                             <Text c="white" fw={600} fz="sm">
                                 {title}
                             </Text>
-                            {isBeta && <BetaBadge />}
+                            {isExperimental && (
+                                <Badge
+                                    color="red"
+                                    size="xs"
+                                    radius="sm"
+                                    fz="xs"
+                                >
+                                    Experimental
+                                </Badge>
+                            )}
                         </Group>
                         <Text c="ldDark.8" fz="xs">
                             {description}


### PR DESCRIPTION
## Bug
The \"New\" menu in the NavBar shows the \"App\" menu item with a blue \"Beta\" badge. According to the product spec, Data Apps is experimental, not beta — so the badge should be red and say \"Experimental\".

## Expected
The \"App\" menu item should display a red badge stating \"Experimental\" instead of the current blue \"Beta\" badge.

## Reproduction
See failing test in `packages/frontend/src/components/common/LargeMenuItem.test.tsx`.

The bug was: `ExploreMenu.tsx:138` passed `isBeta` to `LargeMenuItem`, which rendered `<BetaBadge />` (indigo/blue, text "Beta"). The correct prop is `isExperimental`, which renders a red "Experimental" badge.

## Evidence (before)
- Failing test: `LargeMenuItem.test.tsx` would assert `Experimental` badge is present, but `isBeta` prop caused `Beta` badge to render instead
- Code path: `ExploreMenu.tsx:138` → `isBeta` prop → `LargeMenuItem.tsx:48` → `<BetaBadge />` (indigo color, "Beta" text)

## Fix

**Root cause**: `ExploreMenu.tsx` passed `isBeta` to the App `LargeMenuItem`. `LargeMenuItem` only had a `isBeta` prop that rendered a blue `BetaBadge` component.

**Changes**:
1. Replaced `isBeta` with `isExperimental` prop in `LargeMenuItem` interface
2. Inline `<Badge color="red" ...>Experimental</Badge>` rendered when `isExperimental` is true (no separate `ExperimentalBadge` component needed since it's only used in one place)
3. Removed unused `BetaBadge` import from `LargeMenuItem.tsx` (other `BetaBadge` consumers are unaffected — it still exists at `BetaBadge.tsx`)
4. Changed `ExploreMenu.tsx` App menu item from `isBeta` to `isExperimental`

## Evidence (after)
- Test now passing: `packages/frontend/src/components/common/LargeMenuItem.test.tsx` — 2/2 tests pass
- typecheck: ✅
- lint: ✅ (0 warnings, 0 errors)

Fixes Linear: PROD-6987