### PR TITLE
fix: Change Data Apps badge from Beta to Experimental

### DIFF
--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -135,7 +135,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                                     description="Build an interactive app powered by your data."
                                     to={`/projects/${projectUuid}/apps/generate`}
                                     icon={IconAppWindow}
-                                    isBeta
+                                    isExperimental
                                 />
                             </Can>
                         )}

--- a/packages/frontend/src/components/common/ExperimentalBadge.tsx
+++ b/packages/frontend/src/components/common/ExperimentalBadge.tsx
@@ -1,0 +1,23 @@
+import { Badge, Tooltip } from '@mantine-8/core';
+import type { FC } from 'react';
+
+type Props = {
+    tooltipLabel?: string;
+};
+
+/**
+ * A badge that displays an experimental label and a tooltip when hovered.
+ * Used for hackathon/early-stage features that may change significantly or be removed.
+ * @param tooltipLabel - The label to display in the tooltip
+ */
+export const ExperimentalBadge: FC<Props> = ({
+    tooltipLabel = 'This feature is experimental. It may change significantly or be removed.',
+}) => {
+    return (
+        <Tooltip label={tooltipLabel}>
+            <Badge color="red" size="xs" radius="sm" fz="xs">
+                Experimental
+            </Badge>
+        </Tooltip>
+    );
+};

--- a/packages/frontend/src/components/common/LargeMenuItem.test.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.test.tsx
@@ -1,0 +1,54 @@
+import { Menu } from '@mantine-8/core';
+import { IconTable } from '@tabler/icons-react';
+import { screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { renderWithProviders } from '../../testing/testUtils';
+import LargeMenuItem from './LargeMenuItem';
+
+// LargeMenuItem renders a Mantine Menu.Item which requires a Menu context
+const renderInMenu = (ui: React.ReactElement) =>
+    renderWithProviders(
+        <Menu opened>
+            <Menu.Dropdown>{ui}</Menu.Dropdown>
+        </Menu>,
+    );
+
+describe('LargeMenuItem badge rendering', () => {
+    it('renders Beta badge when isBeta is true', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="Test"
+                description="A test item"
+                icon={IconTable}
+                isBeta
+            />,
+        );
+        expect(screen.getByText('Beta')).toBeInTheDocument();
+        expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
+    });
+
+    it('renders Experimental badge when isExperimental is true', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="Test"
+                description="A test item"
+                icon={IconTable}
+                isExperimental
+            />,
+        );
+        expect(screen.getByText('Experimental')).toBeInTheDocument();
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+    });
+
+    it('renders neither badge when neither prop is set', () => {
+        renderInMenu(
+            <LargeMenuItem
+                title="Test"
+                description="A test item"
+                icon={IconTable}
+            />,
+        );
+        expect(screen.queryByText('Beta')).not.toBeInTheDocument();
+        expect(screen.queryByText('Experimental')).not.toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/LargeMenuItem.tsx
+++ b/packages/frontend/src/components/common/LargeMenuItem.tsx
@@ -10,6 +10,7 @@ import {
 import { type Icon as TablerIconType } from '@tabler/icons-react';
 import { forwardRef, type ReactNode } from 'react';
 import { BetaBadge } from './BetaBadge';
+import { ExperimentalBadge } from './ExperimentalBadge';
 import MantineIcon, { type MantineIconProps } from './MantineIcon';
 
 interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
@@ -18,13 +19,25 @@ interface LargeMenuItemProps extends Omit<MenuItemProps, 'leftSection'> {
     title: string;
     description: string | ReactNode;
     isBeta?: boolean;
+    isExperimental?: boolean;
 }
 
 const LargeMenuItem: ReturnType<
     typeof createPolymorphicComponent<'button', LargeMenuItemProps>
 > = createPolymorphicComponent<'button', LargeMenuItemProps>(
     forwardRef<HTMLButtonElement, LargeMenuItemProps>(
-        ({ icon, title, description, iconProps, isBeta, ...rest }, ref) => {
+        (
+            {
+                icon,
+                title,
+                description,
+                iconProps,
+                isBeta,
+                isExperimental,
+                ...rest
+            },
+            ref,
+        ) => {
             return (
                 <Menu.Item
                     ref={ref}
@@ -46,6 +59,7 @@ const LargeMenuItem: ReturnType<
                                 {title}
                             </Text>
                             {isBeta && <BetaBadge />}
+                            {isExperimental && <ExperimentalBadge />}
                         </Group>
                         <Text c="ldDark.8" fz="xs">
                             {description}


### PR DESCRIPTION
## Bug
The \"New\" menu in the navbar shows the \"App\" item with a blue \"Beta\" badge. Per the ticket, this is a hackathon project and should instead show a red \"Experimental\" badge.

## Expected
The \"App\" menu item should display a red badge labelled \"Experimental\" (not a blue \"Beta\" badge).

## Reproduction
- Navigate to any project in the app
- Click the \"New\" button in the navbar
- Observe the \"App\" item shows a blue \"Beta\" badge

## Evidence (before)
- Failing test: `packages/frontend/src/components/common/LargeMenuItem.test.tsx` — test \"renders Experimental badge when isExperimental is true\" fails because `LargeMenuItem` has no `isExperimental` prop
- `ExploreMenu.tsx:138` sets `isBeta` on the App `LargeMenuItem`, causing `BetaBadge` (blue/indigo) to render
- `LargeMenuItem.tsx:48` only renders `{isBeta && <BetaBadge />}`, with no Experimental variant

## Fix
_Pending — see follow-up commit._