### PR TITLE
fix: preserve long descriptions in DbtSchemaEditor without line wrapping

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -67,6 +67,23 @@ describe('DbtSchemaEditor', () => {
         expect(editor.toJS()).toEqual(EXPECTED_SCHEMA_JSON_WITH_NEW_MODEL);
         expect(editor.toString()).toEqual(EXPECTED_SCHEMA_YML_WITH_NEW_MODEL);
     });
+
+    it('should preserve long descriptions without adding line breaks', () => {
+        const longDescription =
+            'This is a very long description that exceeds eighty characters and should not be wrapped or reformatted by the YAML serializer under any circumstances';
+        const schema = `version: 2
+models:
+  - name: my_model
+    description: ${longDescription}
+    columns:
+      - name: my_column
+        description: A short description
+`;
+        const editor = new DbtSchemaEditor(schema);
+        const result = editor.toString();
+        expect(result).toEqual(schema);
+        expect(result).toContain(`description: ${longDescription}`);
+    });
 });
 
 describe('case-insensitive column matching', () => {

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,13 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            /**
+             * Disable line wrapping entirely (yaml v2 defaults to lineWidth: 80).
+             * Without this, any plain scalar string exceeding 80 characters gets
+             * re-wrapped with line breaks, reformatting existing descriptions even
+             * when the CLI is only supposed to add missing columns.
+             */
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Bug
\`lightdash dbt run\` reformats long description strings in YAML files by inserting line breaks at 80 characters. This happens because the \`yaml\` library (v2.x) used in \`DbtSchemaEditor.toString()\` defaults to \`lineWidth: 80\`, wrapping any plain scalar string that exceeds that length.

## Expected
Existing descriptions should be preserved as-is. The CLI should only add missing columns, not reformat existing content.

## Reproduction
- Failing test: \`packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts\` — "should preserve long descriptions without adding line breaks"

The test confirmed the wrapping (before fix):
\`\`\`
- Expected: description: This is a very long description that exceeds eighty characters and should not be wrapped...
+ Received: description: This is a very long description that exceeds eighty characters and
+             should not be wrapped or reformatted by the YAML serializer under any
+             circumstances
\`\`\`

## Fix
**Root cause**: `DbtSchemaEditor.toString()` at `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts:434` calls `this.doc.toString()` without `lineWidth: 0`. The yaml v2 library defaults to `lineWidth: 80`, which re-wraps any plain scalar exceeding 80 characters (including indentation) when serializing.

**Change**: Added `lineWidth: 0` to the `this.doc.toString()` options, which disables line wrapping entirely. Also updated `DbtSchemaEditor.mock.ts` to reflect the corrected (unwrapped) output for bin dimension SQL fields.

## Evidence (after)
- Test now passing: `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — 14/14 tests pass

| Check | Result |
|---|---|
| New regression test: "should preserve long descriptions without adding line breaks" | ✅ PASS (was failing before fix) |
| Existing test: "should update a model with custom metrics and custom dimensions" | ✅ PASS (mock updated to match correct output) |
| All 14 DbtSchemaEditor tests | ✅ PASS |
| `pnpm -F common typecheck` | ✅ clean |
| `pnpm -F common lint` | ✅ 0 errors (2 pre-existing warnings in unrelated files) |

Closes #21917