### PR TITLE
fix: use British English spelling "Organise" in Space menu description

### DIFF
--- a/packages/e2e/cypress/e2e/app/space.cy.ts
+++ b/packages/e2e/cypress/e2e/app/space.cy.ts
@@ -26,7 +26,7 @@ describe('Space', () => {
         });
 
         cy.contains('New').click();
-        cy.contains('Organize your saved charts and dashboards.').click();
+        cy.contains('Organise your saved charts and dashboards.').click();
         cy.findByText('Restricted access').click();
         cy.findByPlaceholderText('eg. KPIs')
             .click()

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -149,7 +149,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
                         >
                             <LargeMenuItem
                                 title="Space"
-                                description="Organize your saved charts and dashboards."
+                                description="Organise your saved charts and dashboards."
                                 onClick={() => setIsCreateSpaceOpen(true)}
                                 icon={IconFolder}
                             />


### PR DESCRIPTION
## Bug
The \"New\" menu's Space item description reads \"Organize your saved charts and dashboards.\" — using American English spelling.

## Expected
Should read \"Organise your saved charts and dashboards.\" per British English preference.

## Reproduction
Open the app → click \"New\" in the top nav → observe the Space menu item description.

## Evidence (before)

![before](https://storage.googleapis.com/jarvis-assets/repro-fix/fix-space-menu-description/before-1.png)

The snapshot confirms: `menuitem "Space Organize your saved charts and dashboards."`

## Fix
Changed `"Organize"` → `"Organise"` in `ExploreMenu.tsx:152` and updated the matching Cypress e2e test selector in `space.cy.ts:29`.

Root cause: a single string literal with American English spelling.

## Evidence (after)

![after](https://storage.googleapis.com/jarvis-assets/repro-fix/fix-space-menu-description/after-1.png)

The snapshot now shows: `menuitem "Space Organise your saved charts and dashboards."`

| Check | Result |
|---|---|
| `pnpm -F frontend typecheck` | ✅ |
| `pnpm -F frontend lint` (via pre-commit) | ✅ |
| Cypress e2e test selector updated | ✅ |

Fixes PROD-6987