### PR TITLE
fix(ee): multi-project heartbeat with per-project scheduling

### DIFF
--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -118,45 +118,51 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
 
                 Logger.info('Starting managed agent heartbeat');
 
-                try {
-                    const enabledProjects =
-                        await this.managedAgentService.getEnabledProjects();
+                const enabledProjects =
+                    await this.managedAgentService.getEnabledProjects();
 
-                    if (enabledProjects.length === 0) {
-                        Logger.debug('No projects with managed agent enabled');
-                        return;
-                    }
+                if (enabledProjects.length === 0) {
+                    Logger.debug('No projects with managed agent enabled');
+                    return;
+                }
 
-                    // v1: single project support
-                    const project = enabledProjects[0];
-                    await this.managedAgentService.runHeartbeat(
-                        project.projectUuid,
-                    );
-
-                    Logger.info('Managed agent heartbeat completed');
-                } catch (error) {
-                    Logger.error(
-                        'Error during managed agent heartbeat:',
-                        error,
-                    );
-                    throw error;
-                } finally {
-                    // Self-schedule the next heartbeat if any projects are still enabled.
-                    // This replaces the static cron — disabling all projects stops the loop.
-                    const stillEnabled =
-                        await this.managedAgentService.getEnabledProjects();
-                    if (
-                        stillEnabled.length > 0 &&
-                        this.lightdashConfig.managedAgent.enabled
-                    ) {
+                // Run each project's heartbeat independently.
+                // Errors in one project don't block others.
+                for (const project of enabledProjects) {
+                    try {
+                        Logger.info(
+                            `Running heartbeat for project ${project.projectUuid}`,
+                        );
+                        // eslint-disable-next-line no-await-in-loop
+                        await this.managedAgentService.runHeartbeat(
+                            project.projectUuid,
+                        );
+                        Logger.info(
+                            `Heartbeat completed for project ${project.projectUuid}`,
+                        );
+                    } catch (error) {
+                        Logger.error(
+                            `Error during heartbeat for project ${project.projectUuid}:`,
+                            error,
+                        );
+                        // Continue to next project
+                    } finally {
+                        // Self-schedule the next heartbeat for THIS project
+                        // using its own cron pattern and a per-project job key.
                         const schedule =
-                            stillEnabled[0].scheduleCron ??
+                            project.scheduleCron ??
                             this.lightdashConfig.managedAgent.schedule;
+                        // eslint-disable-next-line no-await-in-loop
                         await this.schedulerClient.scheduleManagedAgentHeartbeat(
                             schedule,
+                            project.projectUuid,
                         );
                     }
                 }
+
+                Logger.info(
+                    `Managed agent heartbeat completed for ${enabledProjects.length} project(s)`,
+                );
             },
             [SCHEDULER_TASKS.DOWNLOAD_ASYNC_QUERY_RESULTS]: async (
                 payload,

--- a/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
+++ b/packages/backend/src/ee/services/ManagedAgentService/ManagedAgentService.ts
@@ -287,10 +287,13 @@ export class ManagedAgentService extends BaseService {
             const schedule =
                 settings.scheduleCron ??
                 this.lightdashConfig.managedAgent.schedule;
-            await this.schedulerClient.scheduleManagedAgentHeartbeat(schedule);
+            await this.schedulerClient.scheduleManagedAgentHeartbeat(
+                schedule,
+                projectUuid,
+            );
         } else if (update.enabled === false) {
-            // Cancel pending heartbeat when disabling
-            await this.schedulerClient.cancelManagedAgentHeartbeat();
+            // Cancel pending heartbeat for this specific project
+            await this.schedulerClient.cancelManagedAgentHeartbeat(projectUuid);
         }
 
         return settings;

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -1557,18 +1557,23 @@ export class SchedulerClient {
 
     // --- Managed Agent Heartbeat (self-scheduling) ---
 
-    private static readonly MANAGED_AGENT_JOB_KEY = 'managed-agent-heartbeat';
-
     /**
-     * Schedule the next managed agent heartbeat at the given cron interval from now.
-     * Uses a stable jobKey so duplicate calls replace the existing pending job.
+     * Schedule the next managed agent heartbeat for a specific project.
+     * Uses a per-project jobKey so each project has its own schedule.
      */
-    async scheduleManagedAgentHeartbeat(cronPattern: string): Promise<void> {
+    async scheduleManagedAgentHeartbeat(
+        cronPattern: string,
+        projectUuid?: string,
+    ): Promise<void> {
         const graphileClient = await this.graphileUtils;
 
         const arr = stringToArray(cronPattern);
         const schedule = getSchedule(arr, new Date(), 'UTC');
         const nextRun = schedule.next().toJSDate();
+
+        const jobKey = projectUuid
+            ? `managed-agent-heartbeat:${projectUuid}`
+            : 'managed-agent-heartbeat';
 
         await graphileClient.addJob(
             SCHEDULER_TASKS.MANAGED_AGENT_HEARTBEAT,
@@ -1577,27 +1582,38 @@ export class SchedulerClient {
                 runAt: nextRun,
                 maxAttempts: 1,
                 priority: JobPriority.LOW,
-                jobKey: SchedulerClient.MANAGED_AGENT_JOB_KEY,
+                jobKey,
             },
         );
 
         Logger.info(
-            `Scheduled managed agent heartbeat at ${nextRun.toISOString()}`,
+            `Scheduled managed agent heartbeat for ${projectUuid ?? 'default'} at ${nextRun.toISOString()}`,
         );
     }
 
     /**
-     * Cancel any pending managed agent heartbeat job.
+     * Cancel pending managed agent heartbeat job(s).
+     * If projectUuid is provided, cancels only that project's job.
+     * Otherwise cancels all managed agent heartbeat jobs.
      */
-    async cancelManagedAgentHeartbeat(): Promise<void> {
+    async cancelManagedAgentHeartbeat(projectUuid?: string): Promise<void> {
         const graphileClient = await this.graphileUtils;
         await graphileClient.withPgClient(async (pgClient) => {
-            await pgClient.query(
-                `DELETE FROM graphile_worker.jobs
-                 WHERE key = $1 AND locked_by IS NULL`,
-                [SchedulerClient.MANAGED_AGENT_JOB_KEY],
-            );
+            if (projectUuid) {
+                await pgClient.query(
+                    `DELETE FROM graphile_worker.jobs
+                     WHERE key = $1 AND locked_by IS NULL`,
+                    [`managed-agent-heartbeat:${projectUuid}`],
+                );
+            } else {
+                await pgClient.query(
+                    `DELETE FROM graphile_worker.jobs
+                     WHERE key LIKE 'managed-agent-heartbeat%' AND locked_by IS NULL`,
+                );
+            }
         });
-        Logger.info('Cancelled pending managed agent heartbeat job');
+        Logger.info(
+            `Cancelled pending managed agent heartbeat job${projectUuid ? ` for ${projectUuid}` : 's'}`,
+        );
     }
 }


### PR DESCRIPTION
## Summary

The heartbeat was only running for the first enabled project. Now runs all of them with per-project job keys.

### Changes

- **All enabled projects** get their heartbeat run (was `enabledProjects[0]` only)
- **Per-project job keys**: `managed-agent-heartbeat:{projectUuid}` — each project schedules independently
- **Error isolation**: try/catch per project, one failure doesn't block others  
- **Per-project cancel**: disabling a project only cancels its job, not all projects

### Scaling

Each project gets its own Graphile Worker job with its own cron pattern. Projects with different schedules (15 min vs hourly) no longer overwrite each other's jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)