### PR TITLE
fix: preserve long descriptions in dbt YAML files (lineWidth:0)

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -37,6 +37,24 @@ describe('DbtSchemaEditor', () => {
         );
     });
 
+    it('should preserve long descriptions without adding line breaks', () => {
+        const longDescription =
+            'This is a very long description that exceeds eighty characters and should not be wrapped to a new line by the yaml serializer';
+        const longColumnDescription =
+            'Another long description that is definitely more than eighty characters long and must be preserved exactly as written';
+        const schema = `version: 2
+models:
+  - name: my_model
+    description: ${longDescription}
+    columns:
+      - name: my_column
+        description: ${longColumnDescription}`;
+        const editor = new DbtSchemaEditor(schema);
+        const result = editor.toString();
+        expect(result).toContain(`description: ${longDescription}`);
+        expect(result).toContain(`description: ${longColumnDescription}`);
+    });
+
     it('should update a model with custom metrics and custom dimensions', () => {
         const editor = new DbtSchemaEditor(SCHEMA_YML);
         // confirms it has models


### PR DESCRIPTION
## Bug

The `lightdash dbt run` CLI command reformats long description strings in YAML files by inserting line breaks at 80 characters. This is caused by `DbtSchemaEditor.toString()` calling `this.doc.toString()` from the yaml v2.7.0 library without specifying `lineWidth`, which defaults to 80.

## Expected

Existing descriptions should be preserved as-is. The CLI should only add missing columns, not reformat existing content.

## Reproduction

Failing test: `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — `should preserve long descriptions without adding line breaks`

## Evidence (before)

- Failing test: `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts` — see CI run
- Test output:
  ```
  Expected substring: "description: This is a very long description that exceeds eighty characters and should not be wrapped to a new line by the yaml serializer"
  Received string:    ...
      description: This is a very long description that exceeds eighty characters and
        should not be wrapped to a new line by the yaml serializer
  ```

The yaml library wraps the description at 80 characters, injecting a line continuation (`should not be wrapped...` appears on the next line with extra indentation).

## Fix

_Pending — see follow-up commit._

Add `lineWidth: 0` to the `this.doc.toString()` options in `packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts` to disable automatic line wrapping. Also update the `EXPECTED_SCHEMA_YML_WITH_NEW_METRICS_AND_DIMENSIONS` test mock whose SQL values were previously wrapped at 80 chars.

Fixes #21917