### PR TITLE
fix: DbtSchemaEditor.toString() wraps long strings at 80 chars (lineWidth default)

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -37,6 +37,23 @@ describe('DbtSchemaEditor', () => {
         );
     });
 
+    it('should preserve long descriptions without adding line breaks', () => {
+        const longDescription =
+            'This is a very long description that exceeds eighty characters and should not be reformatted by the YAML serializer when round-tripping through DbtSchemaEditor';
+        const schema = `version: 2
+models:
+  - name: my_model
+    description: ${longDescription}
+    columns:
+      - name: my_column
+        description: short desc
+`;
+        const editor = new DbtSchemaEditor(schema);
+        const result = editor.toString();
+        expect(result).toEqual(schema);
+        expect(result).toContain(`description: ${longDescription}`);
+    });
+
     it('should update a model with custom metrics and custom dimensions', () => {
         const editor = new DbtSchemaEditor(SCHEMA_YML);
         // confirms it has models

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,13 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            /**
+             * Disable line-folding. The yaml library defaults to lineWidth:80,
+             * which inserts line breaks into plain scalars exceeding 80 chars.
+             * Setting lineWidth:0 preserves existing strings as-is, so the CLI
+             * does not reformat content it did not write.
+             */
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Bug
\`lightdash dbt run\` inserts line breaks into long description strings in YAML files. Any plain scalar string exceeding 80 characters gets folded because the \`yaml\` library (v2.x) defaults \`lineWidth\` to 80.

## Expected
Existing descriptions should be preserved as-is. The CLI should only add missing columns, not reformat existing content.

## Reproduction
Failing test at \`packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts\` — "should preserve long descriptions without adding line breaks"

Steps:
1. Parse a YAML schema with a description > 80 chars
2. Call \`editor.toString()\`
3. The description is now wrapped across multiple lines

## Evidence (before)

Failing test output showed the 160-char description being wrapped across 3 lines:
```
- Expected  - 1
+ Received  + 3

    description: This is a very long description that exceeds eighty characters and
      should not be reformatted by the YAML serializer when round-tripping
      through DbtSchemaEditor
```

## Fix

Root cause: \`DbtSchemaEditor.toString()\` at \`packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts:434\` called \`this.doc.toString()\` without specifying \`lineWidth\`. The yaml v2 library defaults to \`lineWidth:80\`, folding any plain scalar that exceeds 80 characters.

Fix: added \`lineWidth: 0\` to the options object. In yaml v2, \`lineWidth: 0\` disables line-folding entirely. Updated \`EXPECTED_SCHEMA_YML_WITH_NEW_METRICS_AND_DIMENSIONS\` mock to reflect the corrected (non-wrapped) output — the bin dimension SQL strings that were previously folded are now preserved as single lines.

## Evidence (after)

All 14 tests passing:
```
PASS src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
  DbtSchemaEditor
    ✓ should load the yaml schema and convert to JS and YML
    ✓ should throw error with invalid yaml schema
    ✓ should preserve long descriptions without adding line breaks
    ✓ should update a model with custom metrics and custom dimensions
    ✓ should create a new file
  case-insensitive column matching
    ✓ should find columns with case-insensitive name matching
    ✓ should update columns found by case-insensitive matching
    ✓ should prevent adding duplicate columns with different case
    ✓ should remove columns with case-insensitive matching
  dbt v1.10+ compatibility
    ✓ should add custom metrics under config.meta for dbt v1.10
    ✓ should add custom metrics directly under meta for dbt v1.9
    ✓ should add custom dimensions under config.meta for dbt v1.10
    ✓ should add custom dimensions directly under meta for dbt v1.9
    ✓ should handle dbt versions correctly in isDbtVersion110OrHigher

Tests: 14 passed, 14 total
```

This is a pure logic bug in \`packages/common\` — no server involvement, PM2 logs and screenshots not applicable.

- typecheck / lint / test: ✅