### PR TITLE
fix: DbtSchemaEditor.toString() wraps long descriptions at 80 characters

### DIFF
--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.mock.ts
@@ -180,19 +180,15 @@ models:
             fixed_width_id:
               label: Fixed width name
               type: string
-              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10)
-                + 1) * 10 - 1)
+              sql: CONCAT(FLOOR(\${TABLE}.dim_a / 10) * 10, ' - ', (FLOOR(\${TABLE}.dim_a / 10) + 1) * 10 - 1)
             range_id:
               label: Range name
               type: string
-              sql: >-
+              sql: |-
                 CASE
                             WHEN \${TABLE}.dim_a IS NULL THEN NULL
-                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0,
-                '-', 10)
-
-                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN
-                CONCAT(11, '-', 20)
+                WHEN \${TABLE}.dim_a >= 0 AND \${TABLE}.dim_a < 10 THEN CONCAT(0, '-', 10)
+                WHEN \${TABLE}.dim_a >= 11 AND \${TABLE}.dim_a < 20 THEN CONCAT(11, '-', 20)
                             END
   - name: table_b
     description: >-

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts
@@ -235,6 +235,20 @@ describe('dbt v1.10+ compatibility', () => {
         );
     });
 
+    it('should preserve long descriptions without inserting line breaks', () => {
+        // Regression test for: lightdash dbt run reformats long descriptions by adding line breaks
+        // The yaml library defaults lineWidth to 80, which causes strings > 80 chars to wrap
+        // at word boundaries. This test uses a description with spaces to trigger that behavior.
+        const longDesc =
+            'This is a very long description that should definitely exceed eighty characters and trigger the line wrapping behavior in the yaml library default settings for plain scalars';
+        const yamlInput = `version: 2\nmodels:\n  - name: my_model\n    description: ${longDesc}\n    columns:\n      - name: col_a\n        description: Short`;
+        const editor = new DbtSchemaEditor(yamlInput);
+        editor.addColumn('my_model', { name: 'new_col', description: '' });
+        const output = editor.toString();
+        // The long description must remain on a single line, not wrapped across multiple lines
+        expect(output).toContain(`description: ${longDesc}`);
+    });
+
     it('should handle dbt versions correctly in isDbtVersion110OrHigher', () => {
         // Test v1.9 and below
         const editorV19 = new DbtSchemaEditor(

--- a/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
+++ b/packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.ts
@@ -442,6 +442,10 @@ export default class DbtSchemaEditor {
              */
             singleQuote:
                 options?.quoteChar && options.quoteChar === `'` ? true : null,
+            // Disable line wrapping (yaml v2.x defaults to lineWidth: 80, which
+            // inserts line breaks into long descriptions and SQL strings, silently
+            // reformatting YAML files when only column additions were requested).
+            lineWidth: 0,
         });
     }
 


### PR DESCRIPTION
## Bug
\`lightdash dbt run\` (and \`lightdash generate\`) reformats long description strings in YAML files by inserting line breaks at 80 characters. This happens because the \`yaml\` v2.x library defaults \`lineWidth\` to 80, wrapping any plain string with spaces that exceeds that length.

## Expected
Running \`lightdash dbt run\` should only add missing columns without reformatting existing content. Long descriptions should be preserved as-is, without inserted line breaks.

## Reproduction
Failing test in \`packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts\` — "should preserve long descriptions without inserting line breaks".

The test creates a YAML with a description longer than 80 chars, calls \`addColumn()\`, then asserts the description is not wrapped. The yaml library wraps at word boundaries:

```
description: This is a very long description that should definitely exceed
  eighty characters and trigger the line wrapping behavior in the yaml
  library default settings for plain scalars
```

## Evidence (before)
- Failing test: \`packages/common/src/dbt/DbtSchemaEditor/DbtSchemaEditor.test.ts\` — \`should preserve long descriptions without inserting line breaks\`

## Fix
Added \`lineWidth: 0\` to \`this.doc.toString()\` options in \`DbtSchemaEditor.ts:434\`. In yaml v2.x, \`lineWidth: 0\` disables all line wrapping.

Also updated \`EXPECTED_SCHEMA_YML_WITH_NEW_METRICS_AND_DIMENSIONS\` mock to reflect the now-correct unwrapped SQL output:
- \`fixed_width_id.sql\`: single line instead of 2 wrapped lines
- \`range_id.sql\`: changes from \`>-\` (folded scalar, wraps mid-line) to \`|-\` (literal scalar, preserves newlines only) — both produce identical parsed strings

## Evidence (after)
- Test now passing: all 14 tests in \`DbtSchemaEditor.test.ts\` ✅
- typecheck: \`pnpm -F common typecheck\` — clean ✅
- lint: \`pnpm -F common lint\` — 0 errors (2 pre-existing unrelated warnings) ✅

| Repro | Before | After |
|---|---|---|
| \`addColumn()\` on model with 170-char description | Description split across 3 lines at word boundaries | Description preserved on single line |
| SQL with 100-char CONCAT expression | Wrapped to 2 lines with continuation indent | Single-line SQL as authored |
| SQL block scalar (CASE statement) | \`>-\` folded style with mid-line wrapping and blank lines between WHEN clauses | \`|-\` literal style, no mid-line wrapping |

This is a pure library code change — no HTTP endpoint or running server involved. The bug is entirely in the YAML serializer, verified via unit tests.