### PR TITLE
fix: field search 500 on missing table / malformed filters

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -2,6 +2,7 @@ import {
     FilterOperator,
     NotFoundError,
     ParameterError,
+    type AndFilterGroup,
     type Explore,
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
@@ -176,5 +177,41 @@ describe('getFieldValuesMetricQuery', () => {
                 exploreResolver: mockExploreResolver,
             }),
         ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        // Regression test: req.body.table missing → undefined at runtime, cast here as empty string hits the same !table guard
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('handles filters with missing .and gracefully (no crash)', async () => {
+        // Regression test: filters truthy but .and is undefined causes TypeError at line 110
+        const result = await getFieldValuesMetricQuery({
+            projectUuid: 'project-uuid',
+            table: 'a',
+            initialFieldId: 'a_dim1',
+            search: '',
+            limit: 10,
+            maxLimit: 5000,
+            // Cast to bypass TS: simulates a malformed runtime payload where .and is absent
+            filters: { id: 'filter-group' } as unknown as AndFilterGroup,
+            exploreResolver: mockExploreResolver,
+        });
+
+        // Malformed filters should be silently skipped; only the 2 autocomplete filters remain
+        const dims = result.metricQuery.filters?.dimensions;
+        const filterRules = dims && 'and' in dims ? dims.and : [];
+        expect(filterRules).toHaveLength(2);
     });
 });

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -55,6 +55,12 @@ export async function getFieldValuesMetricQuery({
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
     }
 
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table"',
+        );
+    }
+
     let explore = await exploreResolver.findExploreByTableName(
         projectUuid,
         table,
@@ -106,7 +112,7 @@ export async function getFieldValuesMetricQuery({
             values: [],
         },
     ];
-    if (filters) {
+    if (filters?.and) {
         const filtersCompatibleWithExplore = filters.and.filter(
             (filter) =>
                 isFilterRule(filter) &&


### PR DESCRIPTION
## Bug

\`POST /api/v1/projects/:projectUuid/field/:fieldId/search\` returns **500 UnexpectedServerError** in two cases:

1. Request body missing \`table\` → Knex \`Undefined binding(s)\` crash at \`fieldValuesQueryBuilder.ts:58\`
2. Request body has \`filters\` object without \`.and\` property → \`TypeError: Cannot read properties of undefined (reading 'filter')\` at \`fieldValuesQueryBuilder.ts:110\`

Closes #22005

## Expected

1. Missing \`table\` → clean 400 \`ParameterError\`
2. Malformed \`filters\` (missing \`.and\`) → graceful handling (no crash, filter silently skipped)

## Reproduction

```bash
# Bug 1: missing table
curl -b cookies.txt -X POST -H 'Content-Type: application/json' \
  -d '{"search":"","limit":50}' \
  "http://localhost:8080/api/v1/projects/$PROJECT_UUID/field/users_last_name/search"
# Returns: 500 UnexpectedServerError

# Bug 2: filters without .and
curl -b cookies.txt -X POST -H 'Content-Type: application/json' \
  -d '{"search":"","limit":50,"table":"users","filters":{"id":"test"}}' \
  "http://localhost:8080/api/v1/projects/$PROJECT_UUID/field/users_last_name/search"
# Returns: 500 UnexpectedServerError
```

## Evidence (before)

- Failing tests: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`
- [before-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-500/before-logs.txt)

Key log excerpts:
```
Error: Undefined binding(s) detected when compiling SELECT. Undefined column(s): [name]
  at getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:58)

TypeError: Cannot read properties of undefined (reading 'filter')
  at getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:110)
```

## Fix

Two minimal changes to `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts`:

1. **Bug 1** — Added `if (!table) throw new ParameterError(...)` after the limit check (line ~57), before `table` is used in the Knex query. Catches both `undefined` (from missing request body field) and `''`.

2. **Bug 2** — Changed `if (filters)` to `if (filters?.and)` at line 115. A `filters` object without `.and` is treated as having no additional filters, which is the safe and harmless default.

Both v1 (`projectRouter.ts`) and v2 (`AsyncQueryService`) paths funnel through `getFieldValuesMetricQuery`, so the fix covers all callers.

## Evidence (after)

- All 9 tests pass: `packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts`
- [after-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-500/after-logs.txt)

| Repro | Before | After |
|---|---|---|
| `POST …/field/users_last_name/search` no `table` | 500 `UnexpectedServerError` — Knex `Undefined binding(s)` at `fieldValuesQueryBuilder.ts:58` | 400 `ParameterError` — "Field value search requires a non-empty \"table\"" at `fieldValuesQueryBuilder.ts:59` |
| `POST …/field/users_last_name/search` `filters` w/o `.and` | 500 `UnexpectedServerError` — `TypeError: Cannot read properties of undefined (reading 'filter')` at `fieldValuesQueryBuilder.ts:110` | 403 `ForbiddenError` — "Missing user attribute customer_id" (downstream row-level-security check — proves TypeError site no longer reached) |

Logs: [before-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-500/before-logs.txt) · [after-logs.txt](https://storage.googleapis.com/jarvis-assets/repro-fix/field-search-500/after-logs.txt)

- typecheck: ✅
- lint: ✅ (0 errors)
- test: ✅ (9/9 pass)