### PR TITLE
fix: validate table and filters.and in getFieldValuesMetricQuery to return 400 instead of 500

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -2,6 +2,7 @@ import {
     FilterOperator,
     NotFoundError,
     ParameterError,
+    type AndFilterGroup,
     type Explore,
 } from '@lightdash/common';
 import { getFieldValuesMetricQuery } from './fieldValuesQueryBuilder';
@@ -173,6 +174,51 @@ describe('getFieldValuesMetricQuery', () => {
                 limit: 10000,
                 maxLimit: 5000,
                 filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is empty string', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: '',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when table is undefined at runtime', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: undefined as unknown as string,
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: undefined,
+                exploreResolver: mockExploreResolver,
+            }),
+        ).rejects.toThrow(ParameterError);
+    });
+
+    test('throws ParameterError when filters is truthy but missing .and', async () => {
+        await expect(
+            getFieldValuesMetricQuery({
+                projectUuid: 'project-uuid',
+                table: 'a',
+                initialFieldId: 'a_dim1',
+                search: '',
+                limit: 10,
+                maxLimit: 5000,
+                filters: { id: 'bad-filter' } as unknown as AndFilterGroup,
                 exploreResolver: mockExploreResolver,
             }),
         ).rejects.toThrow(ParameterError);

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -55,6 +55,12 @@ export async function getFieldValuesMetricQuery({
         throw new ParameterError(`Query limit can not exceed ${maxLimit}`);
     }
 
+    if (!table) {
+        throw new ParameterError(
+            'Field value search requires a non-empty "table"',
+        );
+    }
+
     let explore = await exploreResolver.findExploreByTableName(
         projectUuid,
         table,
@@ -107,6 +113,11 @@ export async function getFieldValuesMetricQuery({
         },
     ];
     if (filters) {
+        if (!Array.isArray(filters.and)) {
+            throw new ParameterError(
+                'Filters must include an "and" array of filter rules',
+            );
+        }
         const filtersCompatibleWithExplore = filters.and.filter(
             (filter) =>
                 isFilterRule(filter) &&


### PR DESCRIPTION
## Bug
\`POST /api/v1/projects/:projectUuid/field/:fieldId/search\` returns 500 UnexpectedServerError when:
1. Request body is missing \`table\` — causes Knex undefined binding crash
2. Request body has a truthy \`filters\` object without \`.and\` — causes TypeError

Same crash path is reachable via \`POST /api/v2/projects/:projectUuid/query/field-values\` with \`table: ""\` (empty string passes TSOA validation but crashes \`getFieldValuesMetricQuery\`).

## Expected
All inputs that previously crashed with 500 now return 400 ParameterError.

## Reproduction
\`\`\`bash
# Bug 1: missing table (v1)
curl -X POST http://localhost:8080/api/v1/projects/$PROJECT_UUID/field/orders_status/search \
  -H 'Content-Type: application/json' -d '{"search":"","limit":50}'

# Bug 2: malformed filters (v1)
curl -X POST http://localhost:8080/api/v1/projects/$PROJECT_UUID/field/orders_status/search \
  -H 'Content-Type: application/json' \
  -d '{"search":"","limit":50,"table":"orders","filters":{"id":"bad-filter"}}'

# Bug 1 on v2 path (empty string bypasses TSOA, crashes AsyncQueryService)
curl -X POST http://localhost:8080/api/v2/projects/$PROJECT_UUID/query/field-values \
  -H 'Content-Type: application/json' \
  -d '{"fieldId":"orders_status","table":"","search":"","limit":50}'
\`\`\`

## Evidence (before)

[before-logs.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/filter-autocomplete-500/before-logs.txt)

Key excerpts from before-logs.txt (timestamped 2026-04-15T15:53:31):

**Bug 1 — v1, missing table → 500 UnexpectedServerError**
\`\`\`
[Lightdash][fbc7b8faa8f2b9c5c0e33b27f3fbc537] error: Error in wrapped sentry transaction "ProjectModel.findExploresFromCache":
  Error: Undefined binding(s) detected when compiling SELECT. Undefined column(s): [name]
  query: select "explore", "cached_explore_uuid" from "cached_explore" where "project_uuid" = ? and "name" in (?)
  at async ProjectModel.findExploreByTableName (ProjectModel.ts:1281:32)
  at async getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:58:19)
  at async ProjectService.searchFieldUniqueValues (ProjectService.ts:4652:13)
  at async projectRouter.ts:130:29
[Lightdash][fbc7b8faa8f2b9c5c0e33b27f3fbc537] http: POST /api/v1/projects/.../field/orders_status/search 500 - 43 ms
\`\`\`

**Bug 2 — v1, malformed filters → 500 UnexpectedServerError**
\`\`\`
[Lightdash][1301a4c6385ae319a1b0dd151e227f0f] error: TypeError: Cannot read properties of undefined (reading 'filter')
  at getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:110:58)
  at async ProjectService.searchFieldUniqueValues (ProjectService.ts:4652:13)
  at async projectRouter.ts:130:29
[Lightdash][1301a4c6385ae319a1b0dd151e227f0f] http: POST /api/v1/projects/.../field/orders_status/search 500 - 34 ms
\`\`\`

**Bug 1 — v2, empty string table → 404 NotFoundError (no guard, reaches explore resolution)**
\`\`\`
[Lightdash][887292e01cc25208e50a90e325134db9] error: NotFoundError: Explore  does not exist
  at getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:74:15)
  at async AsyncQueryService.executeAsyncFieldValueSearch (AsyncQueryService.ts:3535:13)
  at async QueryController.executeAsyncFieldValueSearch (QueryController.ts:198:25)
  at async QueryController_executeAsyncFieldValueSearch (routes.ts:56445:17)
[Lightdash][887292e01cc25208e50a90e325134db9] http: POST /api/v2/projects/.../query/field-values 404 - 22 ms
\`\`\`

## Fix
Added early `ParameterError` guards in `getFieldValuesMetricQuery` (`fieldValuesQueryBuilder.ts`):
- Line 58–62: throws `ParameterError('Field value search requires a non-empty "table"')` when `table` is falsy — fires before explore resolution (previously crashed Knex or returned wrong 404)
- Line 116–120: throws `ParameterError('Filters must include an "and" array of filter rules')` when `filters` is truthy but `filters.and` is not an array — fires before array destructuring (previously threw TypeError)

## Evidence (after) — branch HEAD e9e62c341f

[after-logs.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/filter-autocomplete-500/after-logs.txt)

Key excerpts from after-logs.txt (timestamped 2026-04-15T15:54:30):

**Bug 1 — v1, missing table → 400 ParameterError (new guard at fieldValuesQueryBuilder.ts:59)**
\`\`\`
[Lightdash][7c92c0b6c558ac9c29b31320e9934a0a] error: Handled error of type ParameterError on
  [POST] /api/v1/projects/.../field/orders_status/search Field value search requires a non-empty "table"
[Lightdash][7c92c0b6c558ac9c29b31320e9934a0a] error: ParameterError: Field value search requires a non-empty "table"
  at getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:59:15)
  at ProjectService._getFieldValuesMetricQuery (ProjectService.ts:4615:16)
  at ProjectService.searchFieldUniqueValues (ProjectService.ts:4652:24)
  at async projectRouter.ts:130:29
[Lightdash][7c92c0b6c558ac9c29b31320e9934a0a] http: POST /api/v1/projects/.../field/orders_status/search 400 - 29 ms
\`\`\`

**Bug 2 — v1, malformed filters → 400 ParameterError (new guard at fieldValuesQueryBuilder.ts:117)**
\`\`\`
[Lightdash][9199cf4a6cd919ed1883b7cb293ceaba] error: Handled error of type ParameterError on
  [POST] /api/v1/projects/.../field/orders_status/search Filters must include an "and" array of filter rules
[Lightdash][9199cf4a6cd919ed1883b7cb293ceaba] error: ParameterError: Filters must include an "and" array of filter rules
  at getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:117:19)
  at async ProjectService.searchFieldUniqueValues (ProjectService.ts:4652:13)
  at async projectRouter.ts:130:29
[Lightdash][9199cf4a6cd919ed1883b7cb293ceaba] http: POST /api/v1/projects/.../field/orders_status/search 400 - 30 ms
\`\`\`

**Bug 1 — v2, empty string table → 400 ParameterError via AsyncQueryService (new guard fires on v2 code path)**
\`\`\`
[Lightdash][8ee5b219441008057f21769874a3c69f] error: Handled error of type ParameterError on
  [POST] /api/v2/projects/.../query/field-values Field value search requires a non-empty "table"
[Lightdash][8ee5b219441008057f21769874a3c69f] error: ParameterError: Field value search requires a non-empty "table"
  at getFieldValuesMetricQuery (fieldValuesQueryBuilder.ts:59:15)
  at AsyncQueryService.executeAsyncFieldValueSearch (AsyncQueryService.ts:3535:19)
  at async QueryController.executeAsyncFieldValueSearch (QueryController.ts:198:25)
  at async QueryController_executeAsyncFieldValueSearch (routes.ts:56445:17)
[Lightdash][8ee5b219441008057f21769874a3c69f] http: POST /api/v2/projects/.../query/field-values 400 - 9 ms
\`\`\`

The v2 stack trace proves the new guard in `getFieldValuesMetricQuery` fires through the full `AsyncQueryService → QueryController` path — not TSOA validation.

### Before/After comparison table

| Repro | Before | After |
|---|---|---|
| `POST .../field/orders_status/search` no `table` | 500 `UnexpectedServerError` — Knex `Undefined binding(s)` at `fieldValuesQueryBuilder.ts:58` | 400 `ParameterError` — `'table' required` at `fieldValuesQueryBuilder.ts:59` |
| `POST .../field/orders_status/search` `filters` w/o `.and` | 500 `UnexpectedServerError` — `TypeError: Cannot read properties of undefined (reading 'filter')` at `fieldValuesQueryBuilder.ts:110` | 400 `ParameterError` — `'and' array required` at `fieldValuesQueryBuilder.ts:117` |
| `POST .../query/field-values` `table: ""` | 404 `NotFoundError: Explore  does not exist` (no guard, reached explore resolution at `fieldValuesQueryBuilder.ts:74` via `AsyncQueryService.ts:3535`) | 400 `ParameterError` — `'table' required` at `fieldValuesQueryBuilder.ts:59` via `AsyncQueryService.ts:3535` — guard fires before explore lookup |

Logs: [before-logs.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/filter-autocomplete-500/before-logs.txt) · [after-logs.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/filter-autocomplete-500/after-logs.txt)

### Unit tests — 10/10 passing on branch HEAD

\`\`\`
PASS src/services/ProjectService/fieldValuesQueryBuilder.test.ts
  getFieldValuesMetricQuery
    ✓ builds a MetricQuery with correct structure (7 ms)
    ✓ includes compatible filters from input (1 ms)
    ✓ falls back to join alias explore when table not found (1 ms)
    ✓ throws NotFoundError when explore not found (13 ms)
    ✓ throws NotFoundError when field not found in explore (1 ms)
    ✓ throws ParameterError when field is a metric (1 ms)
    ✓ throws ParameterError when limit exceeds max (2 ms)
    ✓ throws ParameterError when table is empty string (1 ms)
    ✓ throws ParameterError when table is undefined at runtime
    ✓ throws ParameterError when filters is truthy but missing .and

Tests: 10 passed, 10 total
\`\`\`