### PR TITLE
fix: ClickHouse start-of-week off-by-one in Date Zoom week truncation

### DIFF
--- a/packages/common/src/utils/timeFrames.test.ts
+++ b/packages/common/src/utils/timeFrames.test.ts
@@ -76,6 +76,33 @@ describe('TimeFrames', () => {
             ).toEqual(
                 "DATE_TRUNC('WEEK', ${TABLE}.created)", // start of week is set in the session
             );
+            // ClickHouse: toStartOfWeek(date, 1) uses mode 1 (Monday base), matching Postgres DATE_TRUNC('week')
+            expect(
+                timeFrameConfigs[TimeFrames.WEEK].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.WEEK,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    WeekDay.WEDNESDAY,
+                ),
+            ).toEqual(
+                'addDays(toStartOfWeek(addDays(${TABLE}.created, -2), 1), 2)',
+            );
+        });
+
+        test('should get sql where start of the week is Monday for ClickHouse', () => {
+            // Monday (startOfWeek=0): must pass mode 1 to toStartOfWeek() so it returns Monday not Sunday
+            expect(
+                timeFrameConfigs[TimeFrames.WEEK].getSql(
+                    SupportedDbtAdapter.CLICKHOUSE,
+                    TimeFrames.WEEK,
+                    '${TABLE}.created',
+                    DimensionType.TIMESTAMP,
+                    WeekDay.MONDAY,
+                ),
+            ).toEqual(
+                'addDays(toStartOfWeek(addDays(${TABLE}.created, -0), 1), 0)',
+            );
         });
     });
 

--- a/packages/common/src/utils/timeFrames.ts
+++ b/packages/common/src/utils/timeFrames.ts
@@ -422,7 +422,9 @@ const clickhouseConfig: WarehouseConfig = {
     getSqlForTruncatedDate: (timeFrame, originalSql, _, startOfWeek) => {
         if (timeFrame === TimeFrames.WEEK && isWeekDay(startOfWeek)) {
             const intervalDiff = startOfWeek;
-            return `addDays(toStartOfWeek(addDays(${originalSql}, -${intervalDiff})), ${intervalDiff})`;
+            // Mode 1 makes toStartOfWeek() return Monday (matching Postgres DATE_TRUNC('week')),
+            // so the shift arithmetic is correct for all startOfWeek values.
+            return `addDays(toStartOfWeek(addDays(${originalSql}, -${intervalDiff}), 1), ${intervalDiff})`;
         }
 
         switch (timeFrame) {


### PR DESCRIPTION
## Bug
ClickHouse Date Zoom week truncation is off by one day. When `startOfWeek = 0` (Monday), weeks start on Sunday instead of Monday. Setting Tuesday (1) produces Monday weeks — a consistent off-by-one.

## Expected
Week boundaries for ClickHouse should respect the configured start of week setting, matching behavior of calendar date filters and other warehouses.

## Root cause
`packages/common/src/utils/timeFrames.ts:425` — `toStartOfWeek()` defaults to mode 0 (Sunday base). The shift formula assumes Monday as the base (like Postgres `DATE_TRUNC('week')`), so every configured `startOfWeek` value was off by one. Passing mode `1` makes `toStartOfWeek()` return Monday, aligning ClickHouse with all other warehouses.

**Changed line:**
```typescript
// before
return `addDays(toStartOfWeek(addDays(${originalSql}, -${intervalDiff})), ${intervalDiff})`;
// after
return `addDays(toStartOfWeek(addDays(${originalSql}, -${intervalDiff}), 1), ${intervalDiff})`;
```

## Evidence (before)

### Failing unit tests
[before-test.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/clickhouse-start-of-week/before-test.txt)

Key excerpt:
```
FAIL src/utils/timeFrames.test.ts
  ✕ should get sql where stat of the week is Wednesday
  ✕ should get sql where start of the week is Monday for ClickHouse
  Tests: 2 failed, 7 passed, 9 total

  Expected: "addDays(toStartOfWeek(addDays(${TABLE}.created, -2), 1), 2)"
  Received: "addDays(toStartOfWeek(addDays(${TABLE}.created, -2)), 2)"

  Expected: "addDays(toStartOfWeek(addDays(${TABLE}.created, -0), 1), 0)"
  Received: "addDays(toStartOfWeek(addDays(${TABLE}.created, -0)), 0)"
```

### ClickHouse integration (real DB query, before fix)
[before-clickhouse.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/clickhouse-start-of-week/before-clickhouse.txt)

Key rows — **all dates return the wrong week boundary**:
```
scenario                                         input       week_start  dow  verdict
startOfWeek=MONDAY (intervalDiff=0) - BEFORE     2024-01-08  2024-01-07  7    expected Monday(1) got Sunday(7)
startOfWeek=WEDNESDAY (intervalDiff=2) - BEFORE  2024-01-10  2024-01-09  2    expected Wednesday(3) got Tuesday(2)
```

## Evidence (after)

### Passing unit tests
[after-test.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/clickhouse-start-of-week/after-test.txt)

```
PASS src/utils/timeFrames.test.ts
  ✓ should get sql where stat of the week is Wednesday
  ✓ should get sql where start of the week is Monday for ClickHouse
  Tests: 9 passed, 9 total
```

### ClickHouse integration (real DB query, after fix)
[after-clickhouse.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/clickhouse-start-of-week/after-clickhouse.txt)

Key rows — **all dates return the correct week boundary**:
```
scenario                                        input       week_start  dow  verdict
startOfWeek=MONDAY (intervalDiff=0) - AFTER     2024-01-08  2024-01-08  1    Monday(1) correct
startOfWeek=WEDNESDAY (intervalDiff=2) - AFTER  2024-01-10  2024-01-10  3    Wednesday(3) correct
```

## Before/After summary

| Scenario | Formula | Before fix | After fix |
|---|---|---|---|
| `startOfWeek=MONDAY`, input `2024-01-08` (Mon) | `addDays(toStartOfWeek(addDays(date, -0)[, 1]), 0)` | `2024-01-07` Sunday ❌ | `2024-01-08` Monday ✅ |
| `startOfWeek=WEDNESDAY`, input `2024-01-10` (Wed) | `addDays(toStartOfWeek(addDays(date, -2)[, 1]), 2)` | `2024-01-09` Tuesday ❌ | `2024-01-10` Wednesday ✅ |

Queries run against ClickHouse 24.10.2.80 (via Docker). Logs: [before-clickhouse.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/clickhouse-start-of-week/before-clickhouse.txt) · [after-clickhouse.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/clickhouse-start-of-week/after-clickhouse.txt)

- typecheck / lint / test: ✅