### PR TITLE
fix(auth): gracefully handle missing Okta session state instead of 500

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.test.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.test.ts
@@ -1,0 +1,131 @@
+/// <reference path="../../../@types/express-session.d.ts" />
+import { Request } from 'express';
+import { OpenIDClientOktaStrategy } from './oktaStrategy';
+
+jest.mock('../../../logging/logger', () => ({
+    default: {
+        debug: jest.fn(),
+        info: jest.fn(),
+        warn: jest.fn(),
+        error: jest.fn(),
+    },
+}));
+
+jest.mock('@sentry/node', () => ({
+    captureException: jest.fn(),
+}));
+
+jest.mock('../../../config/lightdashConfig', () => ({
+    lightdashConfig: {
+        auth: {
+            okta: {
+                callbackPath: '/oauth/redirect/okta',
+                oauth2ClientId: 'test-client-id',
+                oauth2ClientSecret: 'test-client-secret',
+                authorizationServerId: undefined,
+                oktaDomain: 'test.okta.com',
+                extraScopes: undefined,
+            },
+        },
+        siteUrl: 'https://example.com',
+    },
+}));
+
+jest.mock('openid-client', () => ({
+    Issuer: {
+        discover: jest.fn(),
+    },
+    generators: {
+        state: jest.fn(() => 'mock-state'),
+        codeVerifier: jest.fn(() => 'mock-code-verifier'),
+        codeChallenge: jest.fn(() => 'mock-code-challenge'),
+    },
+}));
+
+describe('OpenIDClientOktaStrategy', () => {
+    let strategy: OpenIDClientOktaStrategy;
+    let mockCallbackFn: jest.Mock;
+    let mockCallbackParamsFn: jest.Mock;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+
+        mockCallbackFn = jest.fn();
+        mockCallbackParamsFn = jest.fn(() => ({
+            // Simulate Okta returning a state parameter in the redirect URL
+            state: 'okta-state-from-redirect',
+        }));
+
+        const mockClientInstance = {
+            callbackParams: mockCallbackParamsFn,
+            callback: mockCallbackFn,
+            authorizationUrl: jest.fn(),
+            userinfo: jest.fn(),
+        };
+
+        const MockClientConstructor = jest.fn(() => mockClientInstance);
+        const mockIssuer = { Client: MockClientConstructor };
+
+        const { Issuer } = jest.requireMock('openid-client') as {
+            Issuer: { discover: jest.Mock };
+        };
+        Issuer.discover.mockResolvedValue(mockIssuer);
+
+        strategy = new OpenIDClientOktaStrategy();
+        // Set up passport-strategy callback methods (normally set by Passport internals)
+        strategy.fail = jest.fn();
+        strategy.error = jest.fn();
+        strategy.success = jest.fn();
+    });
+
+    describe('authenticate — missing session OAuth state', () => {
+        it('should gracefully fail with 401 when session oauth state is missing', async () => {
+            // Simulate the TypeError that openid-client throws when Okta sends state
+            // in the redirect URL but checks.state is undefined (missing from session)
+            mockCallbackFn.mockRejectedValue(
+                new TypeError('checks.state argument is missing'),
+            );
+
+            const mockReq = {
+                query: {},
+                session: { oauth: { codeVerifier: 'some-verifier' } }, // state is absent
+            } as unknown as Request;
+
+            await strategy.authenticate(mockReq);
+
+            // Should redirect the user gracefully, not throw a 500
+            expect(strategy.fail).toHaveBeenCalledWith(
+                {
+                    message:
+                        'Your login session has expired. Please try logging in again.',
+                },
+                401,
+            );
+            expect(strategy.error).not.toHaveBeenCalled();
+        });
+
+        it('should gracefully fail with 401 when session oauth is undefined', async () => {
+            // Simulate the TypeError that openid-client throws when Okta sends state
+            // in the redirect URL but checks.state is undefined (session lost entirely)
+            mockCallbackFn.mockRejectedValue(
+                new TypeError('checks.state argument is missing'),
+            );
+
+            const mockReq = {
+                query: {},
+                session: {}, // oauth property is absent entirely
+            } as unknown as Request;
+
+            await strategy.authenticate(mockReq);
+
+            expect(strategy.fail).toHaveBeenCalledWith(
+                {
+                    message:
+                        'Your login session has expired. Please try logging in again.',
+                },
+                401,
+            );
+            expect(strategy.error).not.toHaveBeenCalled();
+        });
+    });
+});

--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
@@ -115,10 +115,23 @@ export class OpenIDClientOktaStrategy extends Strategy {
                 lightdashConfig.siteUrl,
             ).href;
 
+            // Guard against expired/lost session: if the OAuth state is missing,
+            // the openid-client library will throw TypeError when Okta's redirect
+            // includes a state parameter. Fail gracefully instead of returning a 500.
+            if (!req.session.oauth?.state) {
+                return this.fail(
+                    {
+                        message:
+                            'Your login session has expired. Please try logging in again.',
+                    },
+                    401,
+                );
+            }
+
             const params = client.callbackParams(req);
             const tokenSet = await client.callback(redirectUri, params, {
                 code_verifier: req.session.oauth?.codeVerifier,
-                state: req.session.oauth?.state,
+                state: req.session.oauth.state,
             });
 
             const userInfo = tokenSet.access_token

--- a/packages/backend/src/database/seeds/development/01_initial_user.ts
+++ b/packages/backend/src/database/seeds/development/01_initial_user.ts
@@ -285,13 +285,38 @@ export async function seed(knex: Knex): Promise<void> {
             explores,
         );
 
+        // Seed spotlight categories and parameters from lightdash project config.
+        // This must happen before indexCatalog so that catalog items are correctly
+        // associated with their yaml_reference tags.
+        const lightdashProjectConfig = await adapter.getLightdashProjectConfig({
+            projectUuid,
+            organizationUuid,
+            userUuid: user.user_uuid,
+        });
+        await new ProjectParametersModel({
+            database: knex,
+        }).replace(projectUuid, lightdashProjectConfig.parameters ?? {});
+
+        const tagsModel = new TagsModel({ database: knex });
+        await tagsModel.replaceYamlTags(
+            projectUuid,
+            Object.entries(
+                lightdashProjectConfig.spotlight?.categories ?? {},
+            ).map(([yamlReference, category]) => ({
+                project_uuid: projectUuid,
+                name: category.label,
+                color: category.color ?? 'gray',
+                yaml_reference: yamlReference,
+                created_by_user_uuid: user.user_uuid,
+            })),
+        );
+
         // Index catalog after saving explores to cache
         // This is needed for catalog_search table to be populated in PR/preview environments
         const catalogModel = new CatalogModel({
             database: knex,
             lightdashConfig,
         });
-        const tagsModel = new TagsModel({ database: knex });
         const projectYamlTags = await tagsModel.getYamlTags(projectUuid);
         const cachedExploresMap = await projectModel.findExploresFromCache(
             projectUuid,
@@ -304,16 +329,6 @@ export async function seed(knex: Knex): Promise<void> {
             projectYamlTags,
             user.user_uuid,
         );
-
-        // Seed parameters
-        const lightdashProjectConfig = await adapter.getLightdashProjectConfig({
-            projectUuid,
-            organizationUuid,
-            userUuid: user.user_uuid,
-        });
-        await new ProjectParametersModel({
-            database: knex,
-        }).replace(projectUuid, lightdashProjectConfig.parameters ?? {});
     } catch (e) {
         console.error(e);
         throw e;


### PR DESCRIPTION
## Bug
When a user's OAuth session has expired or been lost between initiating the Okta login and the callback being received, \`req.session.oauth.state\` is \`undefined\`. The \`openid-client\` library throws \`TypeError: checks.state argument is missing\`, which is caught by the outer catch block and escalated to \`this.error(err)\` — resulting in a 500 Internal Server Error instead of a graceful auth failure redirect.

## Expected
The user should be redirected to the login page with an appropriate flash message (graceful 401 failure) rather than hitting a 500 error.

## Reproduction
Failing tests in \`packages/backend/src/controllers/authentication/strategies/oktaStrategy.test.ts\`.

## Evidence (before)

**Before: `strategy.error` IS called with the TypeError (proves 500 path):**

```
PASS src/controllers/authentication/strategies/oktaBeforeEvidence.test.ts
  BEFORE FIX: TypeError propagates to strategy.error (500 path)
    ✓ strategy.error IS called with the TypeError (proves 500 bug) (15 ms)
```

Full output: [before-error-path-verification.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/okta-missing-session-state/before-error-path-verification.txt)

**Before: regression tests FAIL (strategy.fail never called):**

```
FAIL src/controllers/authentication/strategies/oktaStrategy.test.ts
  ✕ should gracefully fail with 401 when session oauth state is missing
  ✕ should gracefully fail with 401 when session oauth is undefined
  Expected: {"message": "Your login session has expired..."}, 401
  Number of calls: 0
```

Full output: [before-test-output.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/okta-missing-session-state/before-test-output.txt)

## Fix

### Commit 1: Okta session guard (`oktaStrategy.ts`)
Added a guard before `client.callbackParams()` that checks for `req.session.oauth?.state`. When absent (session expired/lost), calls `this.fail()` with a 401 — redirecting the user to the login page — instead of propagating a TypeError to `this.error()`.

### Commit 2: Seed spotlight categories before catalog indexing (`01_initial_user.ts`)
The seed was calling `indexCatalog` with empty `projectYamlTags` because `getLightdashProjectConfig` (and `replaceYamlTags`) ran after indexing. Fixed by moving `getLightdashProjectConfig` and `replaceYamlTags` before `indexCatalog`, so preview environments have spotlight category tags indexed on first deployment. This fixed the `E2E: API (Vitest)` CI failures in `metricsWithTimeDimensions.test.ts`.

## Evidence (after)

**After: tests pass:**

```
PASS src/controllers/authentication/strategies/oktaStrategy.test.ts
  ✓ should gracefully fail with 401 when session oauth state is missing (38 ms)
  ✓ should gracefully fail with 401 when session oauth is undefined (15 ms)
Tests: 2 passed, 2 total
```

Full output: [after-test-output.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/okta-missing-session-state/after-test-output.txt)

| Repro | Before | After |
|---|---|---|
| `authenticate()` with `session.oauth.state` absent | `strategy.error` called with `TypeError: checks.state argument is missing` → 500 | `strategy.fail({ message: 'Your login session has expired...' }, 401)` → redirect to login |
| `authenticate()` with `session.oauth` undefined | `strategy.error` called with `TypeError: checks.state argument is missing` → 500 | `strategy.fail({ message: 'Your login session has expired...' }, 401)` → redirect to login |

Artifacts: [before-error-path-verification.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/okta-missing-session-state/before-error-path-verification.txt) · [before-test-output.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/okta-missing-session-state/before-test-output.txt) · [after-test-output.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/okta-missing-session-state/after-test-output.txt)

- typecheck / lint / test: ✅