### PR TITLE
fix: add CellErrorBoundary to prevent Firefox DOMException from crashing table page

### DIFF
--- a/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/BodyCell.tsx
@@ -24,6 +24,7 @@ import { type CSSProperties } from 'styled-components';
 import useToaster from '../../../../hooks/toaster/useToaster';
 import { Td } from '../Table.styles';
 import { type CellContextMenuProps } from '../types';
+import CellErrorBoundary from './CellErrorBoundary';
 import CellMenu from './CellMenu';
 import CellTooltip from './CellTooltip';
 
@@ -166,7 +167,9 @@ const BodyCell: FC<React.PropsWithChildren<CommonBodyCellProps>> = ({
                         : undefined
                 }
             >
-                <span>{children}</span>
+                <CellErrorBoundary>
+                    <span>{children}</span>
+                </CellErrorBoundary>
             </Td>
 
             {shouldRenderMenu ? (

--- a/packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.domRepro.test.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.domRepro.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * DOM mutation repro — the actual runtime mechanism behind
+ * LIGHTDASH-FRONTEND-45K / PROD-2237.
+ *
+ * Browser translation extensions (Google Translate, Firefox Translate) wrap
+ * table-cell text nodes in <font> elements. On the next React re-render that
+ * removes that specific text child, React calls:
+ *
+ *   parentSpan.removeChild(textNode)
+ *
+ * React's `textContent = ""` shortcut only fires when a host element has
+ * NO element-sibling children. Table cells produced by getFormattedValueCell
+ * often include element children alongside text (e.g. the formatted value
+ * text node next to a bar-display <div>, or a rich-text component wrapping
+ * alongside raw text). When React detects mixed content it falls back to the
+ * explicit `removeChild` per-node deletion path.
+ *
+ * Because textNode is now inside <font> (no longer a direct child of
+ * parentSpan), both Firefox and JSDOM's spec-compliant removeChild throw:
+ *
+ *   Firefox: NotFoundError: "The object can not be found here."
+ *   JSDOM:   NotFoundError: "The node to be removed is not a child of this node."
+ *
+ * This is NOT a synthetic DOMException injection: the error is produced by
+ * JSDOM's Node.removeChild implementation when React's commit phase tries to
+ * delete the moved text node.
+ *
+ * BEFORE FIX: error propagates past BodyCell → reaches page-level boundary →
+ *             page shows crash UI (blank/error screen).
+ * AFTER  FIX: CellErrorBoundary catches it at cell level → cell shows '-',
+ *             page stays intact.
+ */
+import { render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+import CellErrorBoundary from './CellErrorBoundary';
+
+// ---------------------------------------------------------------------------
+// simulateTranslationExtension
+//
+// Wraps the first non-empty text node found inside `container` in a <font>
+// element — exactly what Google Translate and Firefox's built-in translation
+// perform on page content. After this mutation:
+//   - textNode.parentNode === font  (no longer the original span)
+//   - font.parentNode     === originalSpan
+//
+// When React next calls originalSpan.removeChild(textNode) to delete the
+// text fiber, JSDOM/Firefox throws NotFoundError because textNode is no
+// longer a direct child of originalSpan.
+// ---------------------------------------------------------------------------
+function simulateTranslationExtension(container: HTMLElement): boolean {
+    const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT, {
+        acceptNode: (node) =>
+            (node.textContent ?? '').trim().length > 0
+                ? NodeFilter.FILTER_ACCEPT
+                : NodeFilter.FILTER_SKIP,
+    });
+    const textNode = walker.nextNode() as Text | null;
+    if (!textNode || !textNode.parentNode) return false;
+
+    // Google Translate wraps text in <font face="sans-serif">
+    const font = document.createElement('font');
+    font.setAttribute('face', 'sans-serif');
+    textNode.parentNode.insertBefore(font, textNode);
+    font.appendChild(textNode);
+
+    return true;
+}
+
+// ---------------------------------------------------------------------------
+// PageLevelBoundary — stands in for the page-level ErrorBoundary in Page.tsx.
+// If triggered, the page "crashes" (shows blank/error screen).
+// ---------------------------------------------------------------------------
+class PageLevelBoundary extends Component<
+    { children: ReactNode; onCatch?: (e: Error) => void },
+    { hasError: boolean }
+> {
+    constructor(props: { children: ReactNode; onCatch?: (e: Error) => void }) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): { hasError: boolean } {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, _info: ErrorInfo): void {
+        this.props.onCatch?.(error);
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) return <div>page crashed</div>;
+        return this.props.children;
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CellContent — models getFormattedValueCell output for a numeric field.
+//
+// CRITICAL: the span contains BOTH a text node AND an element child (<em>).
+// This is the key structure that prevents React from using its
+// `node.textContent = ""` shortcut (which would silently remove all children).
+// With mixed content React must call span.removeChild(textNode) explicitly,
+// which throws when textNode was moved inside <font> by a translation extension.
+//
+// Real-world analogue: getFormattedValueCell returns a span with formatted
+// text alongside bar-display divs, icon wrappers, or rich-text markup.
+// ---------------------------------------------------------------------------
+const CellContent = ({ showValue }: { showValue: boolean }) => (
+    <span>
+        {/* Text node — targeted and wrapped by translation extension */}
+        {showValue ? '42,000' : null}
+        {/* Element sibling — forces React to use removeChild per-node path */}
+        <em />
+    </span>
+);
+
+// ---------------------------------------------------------------------------
+// PreFixBodyCell — BodyCell structure BEFORE CellErrorBoundary was added.
+// Children are wrapped only in a plain <span>; no error boundary.
+// ---------------------------------------------------------------------------
+const PreFixBodyCell = ({ showValue }: { showValue: boolean }) => (
+    <td>
+        <span>
+            <CellContent showValue={showValue} />
+        </span>
+    </td>
+);
+
+// ---------------------------------------------------------------------------
+// PostFixBodyCell — current BodyCell structure with CellErrorBoundary.
+// ---------------------------------------------------------------------------
+const PostFixBodyCell = ({ showValue }: { showValue: boolean }) => (
+    <td>
+        <CellErrorBoundary>
+            <span>
+                <CellContent showValue={showValue} />
+            </span>
+        </CellErrorBoundary>
+    </td>
+);
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('DOM mutation repro — actual translation-extension mechanism', () => {
+    it('[BEFORE FIX] translation extension wraps text node → React removeChild throws NotFoundError → page-level boundary triggered', async () => {
+        const consoleError = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        const consoleWarn = vi
+            .spyOn(console, 'warn')
+            .mockImplementation(() => {});
+
+        const caught: Error[] = [];
+
+        const { container, rerender } = render(
+            <PageLevelBoundary onCatch={(e) => caught.push(e)}>
+                <table>
+                    <tbody>
+                        <tr>
+                            <PreFixBodyCell showValue={true} />
+                        </tr>
+                    </tbody>
+                </table>
+            </PageLevelBoundary>,
+        );
+
+        // Verify initial render
+        const innerSpan = container.querySelector('td > span > span');
+        expect(innerSpan).not.toBeNull();
+        expect(innerSpan!.textContent).toContain('42,000');
+
+        // Simulate translation extension: wrap text node in <font>
+        const mutated = simulateTranslationExtension(container);
+        expect(mutated).toBe(true);
+
+        // Verify the DOM mutation occurred: first child of inner span is now <font>
+        expect(innerSpan!.childNodes[0].nodeName).toBe('FONT');
+        expect(innerSpan!.querySelector('font')?.textContent).toBe('42,000');
+
+        // Re-render with showValue=false.
+        // React needs to delete the text fiber "42,000" while keeping <em />.
+        // Since the span has mixed content (text + element), React calls:
+        //   innerSpan.removeChild(textNode)
+        // But textNode is inside <font> — NotFoundError is thrown.
+        await act(async () => {
+            rerender(
+                <PageLevelBoundary onCatch={(e) => caught.push(e)}>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <PreFixBodyCell showValue={false} />
+                            </tr>
+                        </tbody>
+                    </table>
+                </PageLevelBoundary>,
+            );
+        });
+
+        // The page-level boundary caught the DOMException — page shows crash UI.
+        // This reproduces the crash path in LIGHTDASH-FRONTEND-45K:
+        //   getFormattedValueCell → BodyCell → page-level React ErrorBoundary
+        expect(caught.length).toBeGreaterThan(0);
+        expect(caught[0].name).toBe('NotFoundError');
+        expect(screen.getByText('page crashed')).toBeInTheDocument();
+
+        // eslint-disable-next-line no-console
+        console.info(
+            '[BEFORE FIX] NotFoundError reached PageLevelBoundary:',
+            caught[0].name,
+            '-',
+            caught[0].message,
+        );
+
+        consoleError.mockRestore();
+        consoleWarn.mockRestore();
+    });
+
+    it('[AFTER FIX] same DOM mutation with CellErrorBoundary → error caught at cell level, page-level boundary NOT triggered', async () => {
+        const consoleError = vi
+            .spyOn(console, 'error')
+            .mockImplementation(() => {});
+        const warnMessages: string[] = [];
+        const consoleWarn = vi
+            .spyOn(console, 'warn')
+            .mockImplementation((...args: unknown[]) => {
+                warnMessages.push(args.map(String).join(' '));
+            });
+
+        const caught: Error[] = [];
+
+        const { container, rerender } = render(
+            <PageLevelBoundary onCatch={(e) => caught.push(e)}>
+                <table>
+                    <tbody>
+                        <tr>
+                            <PostFixBodyCell showValue={true} />
+                        </tr>
+                    </tbody>
+                </table>
+            </PageLevelBoundary>,
+        );
+
+        const innerSpan = container.querySelector('td > span > span');
+        expect(innerSpan).not.toBeNull();
+        expect(innerSpan!.textContent).toContain('42,000');
+
+        // Same translation extension DOM mutation
+        const mutated = simulateTranslationExtension(container);
+        expect(mutated).toBe(true);
+        expect(innerSpan!.childNodes[0].nodeName).toBe('FONT');
+
+        // Same re-render that triggers React's removeChild on the moved text node
+        await act(async () => {
+            rerender(
+                <PageLevelBoundary onCatch={(e) => caught.push(e)}>
+                    <table>
+                        <tbody>
+                            <tr>
+                                <PostFixBodyCell showValue={false} />
+                            </tr>
+                        </tbody>
+                    </table>
+                </PageLevelBoundary>,
+            );
+        });
+
+        // CellErrorBoundary caught the error — page-level boundary NOT triggered.
+        expect(caught).toHaveLength(0);
+        expect(screen.queryByText('page crashed')).not.toBeInTheDocument();
+
+        // The cell shows the '-' fallback (CellErrorBoundary's recovery UI).
+        expect(screen.getByText('-')).toBeInTheDocument();
+
+        // CellErrorBoundary emitted a console.warn (not an application error).
+        const cellBoundaryWarn = warnMessages.find((m) =>
+            m.includes('[CellErrorBoundary]'),
+        );
+        expect(cellBoundaryWarn).toBeDefined();
+
+        // eslint-disable-next-line no-console
+        console.info(
+            '[AFTER FIX] PageLevelBoundary caught:',
+            caught.length,
+            'errors (expected 0)',
+        );
+        // eslint-disable-next-line no-console
+        console.info(
+            '[AFTER FIX] CellErrorBoundary logged at warn level:',
+            cellBoundaryWarn,
+        );
+
+        consoleError.mockRestore();
+        consoleWarn.mockRestore();
+    });
+});

--- a/packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.test.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.test.tsx
@@ -1,4 +1,5 @@
 import { screen } from '@testing-library/react';
+import { Component, type ErrorInfo, type ReactNode } from 'react';
 import { describe, expect, it, vi } from 'vitest';
 import { renderWithProviders } from '../../../../testing/testUtils';
 import CellErrorBoundary from './CellErrorBoundary';
@@ -22,6 +23,33 @@ afterEach(() => {
 const ThrowingChild = ({ error }: { error: Error }) => {
     throw error;
 };
+
+// Simulates the page-level ErrorBoundary in Page.tsx — the outer boundary
+// that would catch unhandled errors from any descendant component.
+class PageLevelBoundary extends Component<
+    { children: ReactNode; onCatch?: (e: Error) => void },
+    { hasError: boolean }
+> {
+    constructor(props: { children: ReactNode; onCatch?: (e: Error) => void }) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): { hasError: boolean } {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, _info: ErrorInfo): void {
+        this.props.onCatch?.(error);
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            return <div>page crashed</div>;
+        }
+        return this.props.children;
+    }
+}
 
 describe('CellErrorBoundary', () => {
     it('renders children normally when no error is thrown', () => {
@@ -78,6 +106,63 @@ describe('CellErrorBoundary', () => {
             </CellErrorBoundary>,
         );
 
+        expect(screen.getByText('-')).toBeInTheDocument();
+    });
+});
+
+describe('CellErrorBoundary — error propagation path', () => {
+    const domException = new DOMException(
+        'The object can not be found here.',
+        'NotFoundError',
+    );
+
+    it('[BEFORE FIX] without CellErrorBoundary, a DOMException propagates to the page-level boundary and crashes the page', () => {
+        // This simulates the pre-fix BodyCell render: children were wrapped in
+        // a plain <span> with no cell-level error boundary. The DOMException
+        // thrown by browser translation extensions would escape all the way to
+        // the page-level ErrorBoundary, showing a blank/error page.
+        const caught: Error[] = [];
+
+        renderWithProviders(
+            // Outer boundary = page-level ErrorBoundary in Page.tsx
+            <PageLevelBoundary onCatch={(e) => caught.push(e)}>
+                {/* Pre-fix BodyCell structure: no CellErrorBoundary */}
+                <span>
+                    <ThrowingChild error={domException} />
+                </span>
+            </PageLevelBoundary>,
+        );
+
+        // The outer boundary DOES catch it → page crashes
+        expect(caught).toHaveLength(1);
+        expect(caught[0].message).toBe('The object can not be found here.');
+        expect(screen.getByText('page crashed')).toBeInTheDocument();
+    });
+
+    it('[AFTER FIX] with CellErrorBoundary, the same DOMException is caught at cell level — the page-level boundary is never triggered', () => {
+        // This simulates the fixed BodyCell render: children are now wrapped
+        // in CellErrorBoundary before being placed in the <span>. The
+        // DOMException is caught at cell level; the outer (page-level) boundary
+        // never sees it.
+        const caught: Error[] = [];
+
+        renderWithProviders(
+            // Outer boundary = page-level ErrorBoundary in Page.tsx
+            <PageLevelBoundary onCatch={(e) => caught.push(e)}>
+                {/* Fixed BodyCell structure: CellErrorBoundary wraps the children */}
+                <CellErrorBoundary>
+                    <span>
+                        <ThrowingChild error={domException} />
+                    </span>
+                </CellErrorBoundary>
+            </PageLevelBoundary>,
+        );
+
+        // The outer boundary was NOT triggered → page does not crash
+        expect(caught).toHaveLength(0);
+        expect(screen.queryByText('page crashed')).not.toBeInTheDocument();
+
+        // The cell shows its graceful '-' fallback instead
         expect(screen.getByText('-')).toBeInTheDocument();
     });
 });

--- a/packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.test.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.test.tsx
@@ -1,0 +1,83 @@
+import { screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+import { renderWithProviders } from '../../../../testing/testUtils';
+import CellErrorBoundary from './CellErrorBoundary';
+
+// Suppress console.error/console.warn output during error boundary tests
+// so vitest output stays clean. We still verify behaviour via assertions.
+const originalError = console.error;
+const originalWarn = console.warn;
+
+beforeEach(() => {
+    console.error = vi.fn();
+    console.warn = vi.fn();
+});
+
+afterEach(() => {
+    console.error = originalError;
+    console.warn = originalWarn;
+});
+
+// A component that throws the given error on render
+const ThrowingChild = ({ error }: { error: Error }) => {
+    throw error;
+};
+
+describe('CellErrorBoundary', () => {
+    it('renders children normally when no error is thrown', () => {
+        renderWithProviders(
+            <CellErrorBoundary>
+                <span>cell value</span>
+            </CellErrorBoundary>,
+        );
+        expect(screen.getByText('cell value')).toBeInTheDocument();
+    });
+
+    it('renders fallback dash when a Firefox DOMException NotFoundError is thrown', () => {
+        // This is the exact error that browser translation extensions cause:
+        // Firefox's DOMException when React can't find a text node it tried to
+        // update (because the extension wrapped it in a <font> element).
+        const domException = new DOMException(
+            'The object can not be found here.',
+            'NotFoundError',
+        );
+
+        renderWithProviders(
+            <CellErrorBoundary>
+                <ThrowingChild error={domException} />
+            </CellErrorBoundary>,
+        );
+
+        // The cell should show a dash fallback instead of crashing
+        expect(screen.getByText('-')).toBeInTheDocument();
+    });
+
+    it('renders fallback dash when an error with name NotFoundError is thrown', () => {
+        // Covers the case where the error is not a DOMException instance but
+        // has the same .name (cross-realm objects, serialised errors, etc.)
+        const err = new Error('The object can not be found here.');
+        err.name = 'NotFoundError';
+
+        renderWithProviders(
+            <CellErrorBoundary>
+                <ThrowingChild error={err} />
+            </CellErrorBoundary>,
+        );
+
+        expect(screen.getByText('-')).toBeInTheDocument();
+    });
+
+    it('renders fallback dash when an unrelated error is thrown (prevents page crash)', () => {
+        // Any error inside a cell should be contained at cell level — it must
+        // not propagate to the page-level ErrorBoundary and crash the whole page.
+        const err = new TypeError('Cannot read properties of undefined');
+
+        renderWithProviders(
+            <CellErrorBoundary>
+                <ThrowingChild error={err} />
+            </CellErrorBoundary>,
+        );
+
+        expect(screen.getByText('-')).toBeInTheDocument();
+    });
+});

--- a/packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.tsx
+++ b/packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.tsx
@@ -1,0 +1,59 @@
+import { Component, type ErrorInfo, type ReactNode } from 'react';
+
+interface Props {
+    children: ReactNode;
+}
+
+interface State {
+    hasError: boolean;
+}
+
+/**
+ * Cell-level error boundary to catch DOMException errors caused by browser
+ * translation extensions (e.g. Google Translate, Grammarly) that modify the
+ * DOM behind React's back, causing React's reconciler to throw a
+ * NotFoundError (Firefox: "The object can not be found here.").
+ *
+ * Without this boundary, a single cell render error propagates to the
+ * page-level ErrorBoundary and crashes the entire page. With it, only the
+ * affected cell shows a '-' fallback, leaving the rest of the table intact.
+ */
+class CellErrorBoundary extends Component<Props, State> {
+    constructor(props: Props) {
+        super(props);
+        this.state = { hasError: false };
+    }
+
+    static getDerivedStateFromError(): State {
+        return { hasError: true };
+    }
+
+    componentDidCatch(error: Error, info: ErrorInfo): void {
+        // DOMException NotFoundError is caused by browser translation
+        // extensions mutating the DOM. Log at warn level — it's not a
+        // Lightdash application error.
+        if (error instanceof DOMException || error.name === 'NotFoundError') {
+            console.warn(
+                '[CellErrorBoundary] DOMException in table cell (likely caused by a browser translation extension):',
+                error.message,
+                info.componentStack,
+            );
+        } else {
+            console.error(
+                '[CellErrorBoundary] Unexpected error in table cell:',
+                error,
+                info.componentStack,
+            );
+        }
+    }
+
+    render(): ReactNode {
+        if (this.state.hasError) {
+            // Graceful fallback: show a dash so the table remains usable
+            return <span>-</span>;
+        }
+        return this.props.children;
+    }
+}
+
+export default CellErrorBoundary;

--- a/packages/frontend/src/components/common/Table/Table.styles.tsx
+++ b/packages/frontend/src/components/common/Table/Table.styles.tsx
@@ -196,7 +196,7 @@ export const Tr = forwardRef<HTMLTableRowElement, TrProps>(
 );
 Tr.displayName = 'Tr';
 
-export const Td = styled.td<{
+export const Td = styled.td.attrs({ translate: 'no' })<{
     $isNaN: boolean;
     $rowIndex: number;
     $isSelected: boolean;


### PR DESCRIPTION
## Bug
In Firefox, table cells on dashboard chart tiles crash the entire page with \`NotFoundError: The object can not be found here.\` The Sentry stack traces through \`getFormattedValueCell → BodyCell → page-level React ErrorBoundary\`.

## Expected
A single cell rendering error must not crash the entire page. The cell should show a graceful \`-\` fallback while the rest of the table stays intact.

## Reproduction
Browser translation extensions (Google Translate, Firefox Translate) wrap table-cell text nodes in \`<font>\` elements. On the next React re-render that removes that text child, React calls \`parentSpan.removeChild(textNode)\`. Because \`textNode\` is now inside \`<font>\` — no longer a direct child of \`parentSpan\` — Firefox throws:

> NotFoundError: "The object can not be found here."

JSDOM (used in our test suite) throws the equivalent:

> NotFoundError: "The node to be removed is not a child of this node."

**Note**: React's \`textContent = ""\` shortcut is only used when a host element has exclusively text children. Table cells produced by \`getFormattedValueCell\` often contain mixed content (formatted text alongside bar-display divs, icon wrappers, or rich-text markup). With mixed content React falls back to the explicit per-node \`removeChild\` path — which is exactly when the translation extension mutation causes the crash.

## Evidence (before)

The DOM mutation repro is in `packages/frontend/src/components/common/Table/ScrollableTable/CellErrorBoundary.domRepro.test.tsx`.

**Mechanism exercised** (not a synthetic throw — actual JSDOM `Node.removeChild`):
1. Render a table cell with mixed content: text node (`"42,000"`) + element sibling (`<em/>`).
   The sibling prevents React's `textContent=""` shortcut; React must call `removeChild(textNode)` individually.
2. `simulateTranslationExtension()` wraps the text node in `<font face="sans-serif">` — the exact DOM mutation translation extensions perform.
3. Re-render with text value removed → React calls `span.removeChild(textNode)`, but `textNode` is inside `<font>` → NotFoundError.

**Runtime stdout** (`[BEFORE FIX]` test):
```
[BEFORE FIX] NotFoundError reached PageLevelBoundary: NotFoundError - The node to be removed is not a child of this node.
```

Assertions:
- `caught.length > 0` ✅ — page-level boundary DID catch the error
- `caught[0].name === 'NotFoundError'` ✅
- `screen.getByText('page crashed')` ✅ — page shows crash UI

[before-logs.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/cell-dom-exception-error-boundary/before-logs.txt)

## Fix
**Root cause**: No cell-level error boundary in `BodyCell`. When a translation extension mutates the DOM, React's `removeChild` commit-phase operation fails with `NotFoundError`, which propagates uncaught to the page-level `ErrorBoundary`.

**Changes**:
1. **`CellErrorBoundary`** (`ScrollableTable/CellErrorBoundary.tsx`) — new class component; catches all render/commit errors at cell level; renders `'-'` fallback; logs `DOMException`/`NotFoundError` at `console.warn` (not an application error).
2. **`BodyCell`** (`ScrollableTable/BodyCell.tsx:170`) — wraps `<span>{children}</span>` in `<CellErrorBoundary>`.
3. **`Td`** (`Table.styles.tsx:199`) — adds `translate="no"` via `styled.td.attrs({ translate: 'no' })` to prevent translation extensions from targeting cell content in the first place.

## Evidence (after)

**Runtime stdout** (`[AFTER FIX]` test, same DOM mutation):
```
[AFTER FIX] PageLevelBoundary caught: 0 errors (expected 0)
[AFTER FIX] CellErrorBoundary logged at warn level: [CellErrorBoundary] DOMException in table cell (likely caused by a browser translation extension): The node to be removed is not a child of this node.
    at span (<anonymous>)
    at CellContent (CellErrorBoundary.domRepro.test.tsx:107:24)
    at span (<anonymous>)
    at CellErrorBoundary (CellErrorBoundary.tsx:20:3)
    at td (<anonymous>)
    at PostFixBodyCell (CellErrorBoundary.domRepro.test.tsx:136:28)
```

The component stack confirms `CellErrorBoundary` (not `PageLevelBoundary`) is the catch point.

Assertions:
- `caught.length === 0` ✅ — page-level boundary NOT triggered
- `screen.queryByText('page crashed')` → null ✅ — page does NOT crash
- `screen.getByText('-')` ✅ — cell shows graceful fallback
- `CellErrorBoundary` emitted `console.warn` ✅

| Repro | Before | After |
|---|---|---|
| Translation extension wraps text node in `<font>` → re-render removes text child | `NotFoundError` reaches `PageLevelBoundary` — page crashes | `CellErrorBoundary` catches at cell level — page intact, cell shows `'-'` |

Logs: [before-logs.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/cell-dom-exception-error-boundary/before-logs.txt) · [after-logs.txt](https://storage.googleapis.com/jarvis-hackathon-assets/repro-fix/cell-dom-exception-error-boundary/after-logs.txt)

- typecheck / lint / tests (6 unit + 2 DOM mutation repro): ✅