### PR TITLE
fix: graceful fallback when AI thread title generation fails

### DIFF
--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts
@@ -1,0 +1,80 @@
+import { ModelMessage } from 'ai';
+import { getFallbackTitle } from './titleGenerator';
+
+const TITLE_MAX_LENGTH_CHARS = 60;
+
+describe('getFallbackTitle', () => {
+    it('returns the first user message content when it fits within max length', () => {
+        const messages: ModelMessage[] = [
+            { role: 'user', content: 'Short question about revenue' },
+        ];
+        expect(getFallbackTitle(messages)).toBe('Short question about revenue');
+    });
+
+    it('truncates at word boundary and appends "..." when content exceeds max length', () => {
+        const longContent =
+            'What is the total revenue broken down by region for all of last year';
+        expect(longContent.length).toBeGreaterThan(TITLE_MAX_LENGTH_CHARS);
+        const result = getFallbackTitle([
+            { role: 'user', content: longContent },
+        ]);
+        expect(result.length).toBeLessThanOrEqual(TITLE_MAX_LENGTH_CHARS);
+        expect(result.endsWith('...')).toBe(true);
+        // Should not cut mid-word
+        const withoutEllipsis = result.slice(0, -3);
+        const lastChar = withoutEllipsis[withoutEllipsis.length - 1];
+        expect(lastChar).not.toBe(' ');
+    });
+
+    it('returns "New conversation" when messages array is empty', () => {
+        expect(getFallbackTitle([])).toBe('New conversation');
+    });
+
+    it('returns "New conversation" when there are no user messages', () => {
+        const messages: ModelMessage[] = [
+            {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'Hello, how can I help?' }],
+            },
+        ];
+        expect(getFallbackTitle(messages)).toBe('New conversation');
+    });
+
+    it('skips non-user messages and uses the first user message', () => {
+        const messages: ModelMessage[] = [
+            {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'I am the assistant' }],
+            },
+            { role: 'user', content: 'Show me top 5 customers by revenue' },
+        ];
+        expect(getFallbackTitle(messages)).toBe(
+            'Show me top 5 customers by revenue',
+        );
+    });
+
+    it('returns "New conversation" when first user message has empty content', () => {
+        const messages: ModelMessage[] = [{ role: 'user', content: '' }];
+        expect(getFallbackTitle(messages)).toBe('New conversation');
+    });
+
+    it('returns "New conversation" for non-string user message content', () => {
+        const messages: ModelMessage[] = [
+            {
+                role: 'user',
+                content: [{ type: 'text', text: 'multimodal content' }],
+            },
+        ];
+        expect(getFallbackTitle(messages)).toBe('New conversation');
+    });
+
+    it('handles a content string exactly at the max length limit', () => {
+        // Exactly 60 characters
+        const exactContent = 'a'.repeat(TITLE_MAX_LENGTH_CHARS);
+        const result = getFallbackTitle([
+            { role: 'user', content: exactContent },
+        ]);
+        expect(result).toBe(exactContent);
+        expect(result.endsWith('...')).toBe(false);
+    });
+});


### PR DESCRIPTION
## Bug
`AiAgentService.generateThreadTitle` wraps its entire body in a single try/catch. When the AI model call (`generateTitleFromMessages`) fails — due to an API error, rate limit, timeout, or Zod schema validation error — the catch block throws `new Error('Failed to generate thread title')` (a generic `Error` without `{ cause: e }`). The Express error handler (`errors.ts`) doesn't recognize it as a `LightdashError` and promotes it to `UnexpectedServerError` (HTTP 500), which is reported to Sentry. Linear: ZAP-166

## Expected
When the AI call fails, the service should fall back to extracting a title from the first user message text (truncated to 60 chars if needed), save it, and return it — never throwing. Auth/permission errors (`ForbiddenError`, `NotFoundError`) from `prepareAgentThreadResponse` should still propagate as proper `LightdashError` instances with correct HTTP status codes.

## Reproduction
Failing test: `packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts`

The test suite fails to compile because `getFallbackTitle` does not exist — the function that should implement the graceful fallback is missing entirely. The current code has no fallback path: any failure in the AI call throws a generic `Error`.

```
packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts:2:10 - error TS2305:
Module '"./titleGenerator"' has no exported member 'getFallbackTitle'.
```

**Root cause locations:**
- `packages/backend/src/ee/services/AiAgentService/AiAgentService.ts:1406-1408` — catch block throws generic `Error` without `{ cause: e }`:
  ```typescript
  } catch (e) {
      Logger.error('Failed to generate thread title:', e);
      throw new Error('Failed to generate thread title');
  }
  ```
- `packages/backend/src/ee/services/ai/agents/titleGenerator.ts` — no fallback function exists

## Evidence (before)
- Failing test: `packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts` — TypeScript compile error, `getFallbackTitle` not exported

## Fix
_Pending — see follow-up commit._