### PR TITLE
fix: surface pre-aggregate validation warnings when feature is disabled in preview

### DIFF
--- a/packages/backend/src/ee/preAggregates/enhanceExploresForPreAggregates.test.ts
+++ b/packages/backend/src/ee/preAggregates/enhanceExploresForPreAggregates.test.ts
@@ -1,0 +1,298 @@
+import {
+    DimensionType,
+    ExploreType,
+    FieldType,
+    InlineErrorType,
+    isExploreError,
+    MetricType,
+    SupportedDbtAdapter,
+    TimeFrames,
+    type CompiledDimension,
+    type CompiledMetric,
+    type Explore,
+    type ExploreError,
+} from '@lightdash/common';
+import { enhanceExploresForPreAggregates } from './enhanceExploresForPreAggregates';
+
+const makeDimension = ({
+    name,
+    table,
+    type = DimensionType.STRING,
+}: {
+    name: string;
+    table: string;
+    type?: DimensionType;
+}): CompiledDimension => ({
+    index: 0,
+    fieldType: FieldType.DIMENSION,
+    type,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql: `${table}.${name}`,
+    hidden: false,
+    compiledSql: `${table}.${name}`,
+    tablesReferences: [table],
+});
+
+const makeMetric = ({
+    name,
+    table,
+    type,
+}: {
+    name: string;
+    table: string;
+    type: MetricType;
+}): CompiledMetric => ({
+    index: 0,
+    fieldType: FieldType.METRIC,
+    type,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql: `${table}.${name}`,
+    hidden: false,
+    compiledSql: `${table}.${name}`,
+    tablesReferences: [table],
+});
+
+/** Source explore with a count_distinct metric (unsupported in pre-aggregates) */
+const exploreWithUnsupportedMetric = (): Explore => ({
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'orders',
+            dimensions: {
+                region: makeDimension({ name: 'region', table: 'orders' }),
+            },
+            metrics: {
+                // count_distinct is unsupported in pre-aggregates
+                unique_customers: makeMetric({
+                    name: 'unique_customers',
+                    table: 'orders',
+                    type: MetricType.COUNT_DISTINCT,
+                }),
+                // sum is supported
+                total_revenue: makeMetric({
+                    name: 'total_revenue',
+                    table: 'orders',
+                    type: MetricType.SUM,
+                }),
+            },
+            lineageGraph: {},
+        },
+    },
+    preAggregates: [
+        {
+            name: 'order_kpis',
+            dimensions: ['region'],
+            metrics: ['unique_customers', 'total_revenue'],
+            timeDimension: undefined,
+            granularity: TimeFrames.DAY,
+        },
+    ],
+});
+
+/** Source explore with only supported metrics */
+const exploreWithSupportedMetrics = (): Explore => ({
+    name: 'orders',
+    label: 'Orders',
+    tags: [],
+    baseTable: 'orders',
+    joinedTables: [],
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    tables: {
+        orders: {
+            name: 'orders',
+            label: 'Orders',
+            database: 'db',
+            schema: 'public',
+            sqlTable: 'orders',
+            dimensions: {
+                region: makeDimension({ name: 'region', table: 'orders' }),
+            },
+            metrics: {
+                total_revenue: makeMetric({
+                    name: 'total_revenue',
+                    table: 'orders',
+                    type: MetricType.SUM,
+                }),
+                order_count: makeMetric({
+                    name: 'order_count',
+                    table: 'orders',
+                    type: MetricType.COUNT,
+                }),
+            },
+            lineageGraph: {},
+        },
+    },
+    preAggregates: [
+        {
+            name: 'order_summary',
+            dimensions: ['region'],
+            metrics: ['total_revenue', 'order_count'],
+            timeDimension: undefined,
+            granularity: TimeFrames.DAY,
+        },
+    ],
+});
+
+describe('enhanceExploresForPreAggregates', () => {
+    describe('enabled=false', () => {
+        it('surfaces warnings for unsupported metrics even when pre-aggregates are disabled', () => {
+            // Bug repro: when enabled=false, the early return skips validation entirely,
+            // so unsupported metric errors are never attached as warnings to the source explore.
+            const result = enhanceExploresForPreAggregates({
+                explores: [exploreWithUnsupportedMetric()],
+                enabled: false,
+            });
+
+            // Only the source explore — no virtual pre-aggregate explores
+            expect(result).toHaveLength(1);
+
+            const [sourceExplore] = result;
+            expect(isExploreError(sourceExplore)).toBe(false);
+
+            if (!isExploreError(sourceExplore)) {
+                // The explore should have a warning about the unsupported metric
+                expect(sourceExplore.warnings).toBeDefined();
+                expect(sourceExplore.warnings!.length).toBeGreaterThan(0);
+
+                const warningMessages = sourceExplore.warnings!.map(
+                    (w) => w.message,
+                );
+                const hasUnsupportedMetricWarning = warningMessages.some((m) =>
+                    m.toLowerCase().includes('count_distinct'),
+                );
+                expect(hasUnsupportedMetricWarning).toBe(true);
+
+                // All warnings should be FIELD_ERROR type
+                sourceExplore.warnings!.forEach((w) => {
+                    expect(w.type).toBe(InlineErrorType.FIELD_ERROR);
+                });
+            }
+        });
+
+        it('returns source explore unchanged when pre-aggregates have only supported metrics', () => {
+            const result = enhanceExploresForPreAggregates({
+                explores: [exploreWithSupportedMetrics()],
+                enabled: false,
+            });
+
+            // Only the source explore — no virtual pre-aggregate explores
+            expect(result).toHaveLength(1);
+
+            const [sourceExplore] = result;
+            expect(isExploreError(sourceExplore)).toBe(false);
+
+            if (!isExploreError(sourceExplore)) {
+                // No warnings when all metrics are supported
+                const warnings = sourceExplore.warnings ?? [];
+                expect(warnings).toHaveLength(0);
+            }
+        });
+
+        it('does not generate virtual pre-aggregate explores', () => {
+            const result = enhanceExploresForPreAggregates({
+                explores: [exploreWithSupportedMetrics()],
+                enabled: false,
+            });
+
+            // No virtual pre-aggregate explores should be generated
+            const preAggregateExplores = result.filter(
+                (e) =>
+                    !isExploreError(e) && e.type === ExploreType.PRE_AGGREGATE,
+            );
+            expect(preAggregateExplores).toHaveLength(0);
+        });
+    });
+
+    describe('enabled=true', () => {
+        it('generates virtual pre-aggregate explores for valid pre-aggregates', () => {
+            const result = enhanceExploresForPreAggregates({
+                explores: [exploreWithSupportedMetrics()],
+                enabled: true,
+            });
+
+            // Source explore + at least one virtual pre-aggregate explore
+            expect(result.length).toBeGreaterThan(1);
+
+            const preAggregateExplores = result.filter(
+                (e) =>
+                    !isExploreError(e) && e.type === ExploreType.PRE_AGGREGATE,
+            );
+            expect(preAggregateExplores.length).toBeGreaterThan(0);
+        });
+
+        it('attaches warnings to source explore for unsupported metrics and does not generate virtual explore', () => {
+            const result = enhanceExploresForPreAggregates({
+                explores: [exploreWithUnsupportedMetric()],
+                enabled: true,
+            });
+
+            const sourceExplore = result.find(
+                (e) => !isExploreError(e) && e.name === 'orders',
+            );
+            expect(sourceExplore).toBeDefined();
+
+            if (sourceExplore && !isExploreError(sourceExplore)) {
+                expect(sourceExplore.warnings).toBeDefined();
+                expect(sourceExplore.warnings!.length).toBeGreaterThan(0);
+            }
+        });
+    });
+
+    describe('pass-through cases', () => {
+        it('passes ExploreError through unchanged for both enabled values', () => {
+            const exploreError: ExploreError = {
+                name: 'broken_explore',
+                label: 'Broken Explore',
+                errors: [
+                    {
+                        type: InlineErrorType.METADATA_PARSE_ERROR,
+                        message: 'Something went wrong',
+                    },
+                ],
+            };
+
+            const resultDisabled = enhanceExploresForPreAggregates({
+                explores: [exploreError],
+                enabled: false,
+            });
+            expect(resultDisabled).toHaveLength(1);
+            expect(isExploreError(resultDisabled[0])).toBe(true);
+
+            const resultEnabled = enhanceExploresForPreAggregates({
+                explores: [exploreError],
+                enabled: true,
+            });
+            expect(resultEnabled).toHaveLength(1);
+            expect(isExploreError(resultEnabled[0])).toBe(true);
+        });
+
+        it('passes explores without preAggregates through unchanged', () => {
+            const exploreNoPreAgg: Explore = {
+                ...exploreWithSupportedMetrics(),
+                preAggregates: undefined,
+            };
+
+            const result = enhanceExploresForPreAggregates({
+                explores: [exploreNoPreAgg],
+                enabled: false,
+            });
+            expect(result).toHaveLength(1);
+            expect(result[0]).toEqual(exploreNoPreAgg);
+        });
+    });
+});

--- a/packages/backend/src/ee/preAggregates/enhanceExploresForPreAggregates.ts
+++ b/packages/backend/src/ee/preAggregates/enhanceExploresForPreAggregates.ts
@@ -13,10 +13,10 @@ export const enhanceExploresForPreAggregates = ({
     explores: (Explore | ExploreError)[];
     enabled: boolean;
 }): (Explore | ExploreError)[] => {
-    if (!enabled) {
-        return explores;
-    }
-
+    // Always run validation (generatePreAggregateExplores) so that warnings
+    // for unsupported metric types are attached to the source explore even when
+    // pre-aggregates are disabled (e.g. in preview projects). Virtual pre-aggregate
+    // explores are only emitted when enabled=true.
     const existingExploreNames = new Set<string>(
         explores
             .filter((explore): explore is Explore => !isExploreError(explore))
@@ -42,6 +42,12 @@ export const enhanceExploresForPreAggregates = ({
             generatedExplores.find(
                 (generatedExplore) => generatedExplore.name === explore.name,
             ) ?? explore;
+
+        // When pre-aggregates are disabled, return only the source explore
+        // with any validation warnings attached — skip virtual explore generation.
+        if (!enabled) {
+            return [enhancedSourceExplore];
+        }
 
         const generatedPreAggregateExplores = generatedExplores.filter(
             (generatedExplore) => generatedExplore.name !== explore.name,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -125,7 +125,10 @@ import {
 import { generateEmbedding } from '../ai/agents/embeddingGenerator';
 import { generateArtifactQuestion } from '../ai/agents/questionGenerator';
 import { evaluateAgentReadiness } from '../ai/agents/readinessScorer';
-import { generateThreadTitle as generateTitleFromMessages } from '../ai/agents/titleGenerator';
+import {
+    generateThreadTitle as generateTitleFromMessages,
+    getFallbackTitle,
+} from '../ai/agents/titleGenerator';
 import { getAvailableModels, getDefaultModel, getModel } from '../ai/models';
 import { matchesPreset } from '../ai/models/presets';
 import { AiAgentArgs, AiAgentDependencies } from '../ai/types/aiAgent';
@@ -1375,38 +1378,49 @@ export class AiAgentService {
             threadUuid: string;
         },
     ): Promise<string> {
+        // Auth/not-found errors from prepareAgentThreadResponse (ForbiddenError,
+        // NotFoundError) propagate directly with the correct HTTP status codes.
+        // Only the AI model call is wrapped in try/catch below.
+        const { chatHistoryMessages } = await this.prepareAgentThreadResponse(
+            user,
+            {
+                agentUuid,
+                threadUuid,
+                retrieveRelevantArtifacts: false,
+            },
+        );
+
+        // Use fast model for title generation (lightweight task)
+        const modelOptions = getModel(this.lightdashConfig.ai.copilot, {
+            enableReasoning: false,
+            useFastModel: true,
+        });
+
+        let title: string;
         try {
-            // Reuse existing validation and data fetching logic
-            const { chatHistoryMessages } =
-                await this.prepareAgentThreadResponse(user, {
-                    agentUuid,
-                    threadUuid,
-                    retrieveRelevantArtifacts: false,
-                });
-
-            // Use fast model for title generation (lightweight task)
-            const modelOptions = getModel(this.lightdashConfig.ai.copilot, {
-                enableReasoning: false,
-                useFastModel: true,
-            });
-
             // Generate title using the dedicated title generator
-            const title = await generateTitleFromMessages(
+            title = await generateTitleFromMessages(
                 modelOptions,
                 chatHistoryMessages,
             );
-
-            // Save the title to the database
-            await this.aiAgentModel.updateThreadTitle({
-                threadUuid,
-                title,
-            });
-
-            return title;
         } catch (e) {
-            Logger.error('Failed to generate thread title:', e);
-            throw new Error('Failed to generate thread title');
+            // AI call failed (API error, rate limit, Zod validation, etc.).
+            // Fall back to extracting a title from the first user message so
+            // the thread always gets a title and no 500 is surfaced to Sentry.
+            Logger.warn(
+                'Failed to generate AI thread title, using fallback:',
+                e,
+            );
+            title = getFallbackTitle(chatHistoryMessages);
         }
+
+        // Save the title to the database
+        await this.aiAgentModel.updateThreadTitle({
+            threadUuid,
+            title,
+        });
+
+        return title;
     }
 
     async evaluateReadiness(

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.test.ts
@@ -1,0 +1,80 @@
+import { ModelMessage } from 'ai';
+import { getFallbackTitle } from './titleGenerator';
+
+const TITLE_MAX_LENGTH_CHARS = 60;
+
+describe('getFallbackTitle', () => {
+    it('returns the first user message content when it fits within max length', () => {
+        const messages: ModelMessage[] = [
+            { role: 'user', content: 'Short question about revenue' },
+        ];
+        expect(getFallbackTitle(messages)).toBe('Short question about revenue');
+    });
+
+    it('truncates at word boundary and appends "..." when content exceeds max length', () => {
+        const longContent =
+            'What is the total revenue broken down by region for all of last year';
+        expect(longContent.length).toBeGreaterThan(TITLE_MAX_LENGTH_CHARS);
+        const result = getFallbackTitle([
+            { role: 'user', content: longContent },
+        ]);
+        expect(result.length).toBeLessThanOrEqual(TITLE_MAX_LENGTH_CHARS);
+        expect(result.endsWith('...')).toBe(true);
+        // Should not cut mid-word
+        const withoutEllipsis = result.slice(0, -3);
+        const lastChar = withoutEllipsis[withoutEllipsis.length - 1];
+        expect(lastChar).not.toBe(' ');
+    });
+
+    it('returns "New conversation" when messages array is empty', () => {
+        expect(getFallbackTitle([])).toBe('New conversation');
+    });
+
+    it('returns "New conversation" when there are no user messages', () => {
+        const messages: ModelMessage[] = [
+            {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'Hello, how can I help?' }],
+            },
+        ];
+        expect(getFallbackTitle(messages)).toBe('New conversation');
+    });
+
+    it('skips non-user messages and uses the first user message', () => {
+        const messages: ModelMessage[] = [
+            {
+                role: 'assistant',
+                content: [{ type: 'text', text: 'I am the assistant' }],
+            },
+            { role: 'user', content: 'Show me top 5 customers by revenue' },
+        ];
+        expect(getFallbackTitle(messages)).toBe(
+            'Show me top 5 customers by revenue',
+        );
+    });
+
+    it('returns "New conversation" when first user message has empty content', () => {
+        const messages: ModelMessage[] = [{ role: 'user', content: '' }];
+        expect(getFallbackTitle(messages)).toBe('New conversation');
+    });
+
+    it('returns "New conversation" for non-string user message content', () => {
+        const messages: ModelMessage[] = [
+            {
+                role: 'user',
+                content: [{ type: 'text', text: 'multimodal content' }],
+            },
+        ];
+        expect(getFallbackTitle(messages)).toBe('New conversation');
+    });
+
+    it('handles a content string exactly at the max length limit', () => {
+        // Exactly 60 characters
+        const exactContent = 'a'.repeat(TITLE_MAX_LENGTH_CHARS);
+        const result = getFallbackTitle([
+            { role: 'user', content: exactContent },
+        ]);
+        expect(result).toBe(exactContent);
+        expect(result.endsWith('...')).toBe(false);
+    });
+});

--- a/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
+++ b/packages/backend/src/ee/services/ai/agents/titleGenerator.ts
@@ -16,6 +16,36 @@ const TitleSchema = z.object({
 
 export type GeneratedTitle = z.infer<typeof TitleSchema>;
 
+/**
+ * Extracts a fallback title from the conversation messages when AI title
+ * generation fails. Uses the first user message text, truncated at a word
+ * boundary if it exceeds the max length. Falls back to "New conversation"
+ * if no user message with string content is found.
+ */
+export function getFallbackTitle(messages: ModelMessage[]): string {
+    const firstUserMessage = messages.find((m) => m.role === 'user');
+
+    if (!firstUserMessage || typeof firstUserMessage.content !== 'string') {
+        return 'New conversation';
+    }
+
+    const content = firstUserMessage.content.trim();
+    if (!content) {
+        return 'New conversation';
+    }
+
+    if (content.length <= TITLE_MAX_LENGTH_CHARS) {
+        return content;
+    }
+
+    // Truncate at the last word boundary before TITLE_MAX_LENGTH_CHARS - 3 chars
+    // (reserve space for "...")
+    const truncated = content.slice(0, TITLE_MAX_LENGTH_CHARS - 3);
+    const lastSpace = truncated.lastIndexOf(' ');
+    const cutPoint = lastSpace > 0 ? lastSpace : TITLE_MAX_LENGTH_CHARS - 3;
+    return `${content.slice(0, cutPoint)}...`;
+}
+
 export async function generateThreadTitle(
     modelOptions: GeneratorModelOptions,
     messages: ModelMessage[],


### PR DESCRIPTION
## Bug
Pre-aggregate compilation errors (e.g., unsupported metrics like `count_distinct`) are not shown in preview projects. The function `enhanceExploresForPreAggregates` has an early return when `enabled=false`, which silently skips all validation — so no warnings are ever attached to the source explore.

## Expected
Even when the pre-aggregates feature is disabled (as in preview infrastructure where `PRE_AGGREGATES_ENABLED` is not set), validation should still run to surface configuration issues. The only difference when disabled should be that no virtual pre-aggregate explores are generated.

## Reproduction
Failing unit test in `packages/backend/src/ee/preAggregates/enhanceExploresForPreAggregates.test.ts`:
- Test: `enabled=false > surfaces warnings for unsupported metrics even when pre-aggregates are disabled`
- Assertion fails at line 169: `expect(sourceExplore.warnings).toBeDefined()` — warnings is `undefined` because the early return skips all validation.

## Evidence (before)
- Failing test: `packages/backend/src/ee/preAggregates/enhanceExploresForPreAggregates.test.ts`
  ```
  ● enhanceExploresForPreAggregates › enabled=false › surfaces warnings for unsupported metrics even when pre-aggregates are disabled

    expect(received).toBeDefined()
    Received: undefined

    at Object.<anonymous> (src/ee/preAggregates/enhanceExploresForPreAggregates.test.ts:169:48)
  ```
- Root cause: `enhanceExploresForPreAggregates.ts:16` — `if (!enabled) { return explores; }` skips validation entirely.

## Fix
_Pending — see follow-up commit._