### PR TITLE
Add metric-query CLI command for semantic layer queries

### DIFF
--- a/packages/cli/src/handlers/metricQuery.ts
+++ b/packages/cli/src/handlers/metricQuery.ts
@@ -1,0 +1,170 @@
+import {
+    ApiCompiledQueryResults,
+    ApiExecuteAsyncMetricQueryResults,
+    QueryHistoryStatus,
+} from '@lightdash/common';
+import { promises as fs } from 'fs';
+import { getConfig } from '../config';
+import GlobalState from '../globalState';
+import * as styles from '../styles';
+import { pollForResults, resultsToCsv } from './asyncQuery';
+import { lightdashApi } from './dbt/apiClient';
+
+type MetricQueryOptions = {
+    explore: string;
+    metrics: string[];
+    dimensions: string[];
+    sort?: string[];
+    limit?: number;
+    output?: string;
+    sql?: boolean;
+    pageSize?: number;
+    verbose?: boolean;
+};
+
+const DEFAULT_LIMIT = 500;
+const DEFAULT_PAGE_SIZE = 500;
+
+function parseSorts(
+    sorts: string[] | undefined,
+): { fieldId: string; descending: boolean }[] {
+    if (!sorts || sorts.length === 0) return [];
+
+    return sorts.map((sort) => {
+        // Format: "fieldId:desc" or "fieldId:asc" or just "fieldId" (defaults to asc)
+        const lastColon = sort.lastIndexOf(':');
+        if (lastColon === -1) {
+            return { fieldId: sort, descending: false };
+        }
+        const fieldId = sort.substring(0, lastColon);
+        const direction = sort.substring(lastColon + 1).toLowerCase();
+        if (direction === 'desc') {
+            return { fieldId, descending: true };
+        }
+        if (direction === 'asc') {
+            return { fieldId, descending: false };
+        }
+        // If the suffix isn't asc/desc, treat the whole string as a field name
+        return { fieldId: sort, descending: false };
+    });
+}
+
+export const metricQueryHandler = async (
+    options: MetricQueryOptions,
+): Promise<void> => {
+    GlobalState.setVerbose(options.verbose ?? false);
+
+    const config = await getConfig();
+    const projectUuid = config.context?.project;
+    if (!projectUuid) {
+        throw new Error(
+            `No project selected. Run 'lightdash config set-project' first.`,
+        );
+    }
+
+    const sorts = parseSorts(options.sort);
+    const limit = options.limit ?? DEFAULT_LIMIT;
+
+    GlobalState.debug(`> Explore: ${options.explore}`);
+    GlobalState.debug(`> Metrics: ${options.metrics.join(', ')}`);
+    GlobalState.debug(`> Dimensions: ${options.dimensions.join(', ')}`);
+    GlobalState.debug(`> Sorts: ${JSON.stringify(sorts)}`);
+    GlobalState.debug(`> Limit: ${limit}`);
+    GlobalState.debug(`> Project: ${projectUuid}`);
+
+    if (options.sql) {
+        // Compile query mode: just get the SQL without executing
+        const spinner = GlobalState.startSpinner('Compiling metric query...');
+
+        const result = await lightdashApi<ApiCompiledQueryResults>({
+            method: 'POST',
+            url: `/api/v1/projects/${projectUuid}/explores/${options.explore}/compileQuery`,
+            body: JSON.stringify({
+                exploreName: options.explore,
+                dimensions: options.dimensions,
+                metrics: options.metrics,
+                filters: {},
+                sorts,
+                limit,
+                tableCalculations: [],
+            }),
+        });
+
+        spinner.stop();
+
+        if (options.output) {
+            await fs.writeFile(options.output, result.query, 'utf8');
+            GlobalState.log(
+                `${styles.success('Success!')} Wrote compiled SQL to ${options.output}`,
+            );
+        } else {
+            GlobalState.log(result.query);
+        }
+        return;
+    }
+
+    // Execute query mode
+    const spinner = GlobalState.startSpinner('Executing metric query...');
+
+    const queryBody = {
+        exploreName: options.explore,
+        dimensions: options.dimensions,
+        metrics: options.metrics,
+        filters: {},
+        sorts,
+        limit,
+        tableCalculations: [],
+        additionalMetrics: [],
+        customDimensions: [],
+    };
+
+    const submitResult = await lightdashApi<ApiExecuteAsyncMetricQueryResults>({
+        method: 'POST',
+        url: `/api/v2/projects/${projectUuid}/query/metric-query`,
+        body: JSON.stringify({
+            query: queryBody,
+            context: 'cli',
+        }),
+    });
+
+    GlobalState.debug(`> Query UUID: ${submitResult.queryUuid}`);
+    spinner.text = 'Waiting for query results...';
+
+    const result = await pollForResults(projectUuid, submitResult.queryUuid, {
+        pageSize: options.output
+            ? (options.pageSize ?? DEFAULT_PAGE_SIZE)
+            : undefined,
+    });
+
+    if (result.status === QueryHistoryStatus.ERROR) {
+        spinner.fail('Query failed');
+        throw new Error(result.error ?? 'Query execution failed');
+    }
+
+    if (result.status === QueryHistoryStatus.CANCELLED) {
+        spinner.fail('Query cancelled');
+        throw new Error('Query was cancelled');
+    }
+
+    if (result.status !== QueryHistoryStatus.READY) {
+        spinner.fail('Unexpected query status');
+        throw new Error(`Unexpected query status: ${result.status}`);
+    }
+
+    const durationMs = result.metadata.performance.initialQueryExecutionMs;
+    const durationStr = durationMs ? ` (${durationMs}ms)` : '';
+
+    if (options.output) {
+        const columns = Object.keys(result.columns);
+        const csv = resultsToCsv(columns, result.rows);
+        await fs.writeFile(options.output, csv, 'utf8');
+        spinner.succeed(
+            `${styles.success('Success!')} Wrote ${result.rows.length} rows to ${options.output}${durationStr}`,
+        );
+    } else {
+        const columns = Object.keys(result.columns);
+        const csv = resultsToCsv(columns, result.rows);
+        spinner.stop();
+        GlobalState.log(csv);
+    }
+};

--- a/packages/cli/src/handlers/metricQuery.ts
+++ b/packages/cli/src/handlers/metricQuery.ts
@@ -2,6 +2,7 @@ import {
     ApiCompiledQueryResults,
     ApiExecuteAsyncMetricQueryResults,
     QueryHistoryStatus,
+    type Explore,
 } from '@lightdash/common';
 import { promises as fs } from 'fs';
 import { getConfig } from '../config';
@@ -25,23 +26,27 @@ type MetricQueryOptions = {
 const DEFAULT_LIMIT = 500;
 const DEFAULT_PAGE_SIZE = 500;
 
-// Field IDs in Lightdash are `{table}_{field}`. For single-table explores,
-// users can omit the prefix — we prepend the explore name automatically.
-function qualifyFieldId(fieldId: string, exploreName: string): string {
-    if (fieldId.startsWith(`${exploreName}_`)) {
-        return fieldId;
+function qualifyFieldId(
+    fieldId: string,
+    baseTable: string,
+    tableNames: Set<string>,
+): string {
+    for (const table of tableNames) {
+        if (fieldId.startsWith(`${table}_`)) {
+            return fieldId;
+        }
     }
-    return `${exploreName}_${fieldId}`;
+    return `${baseTable}_${fieldId}`;
 }
 
 function parseSorts(
     sorts: string[] | undefined,
-    exploreName: string,
+    baseTable: string,
+    tableNames: Set<string>,
 ): { fieldId: string; descending: boolean }[] {
     if (!sorts || sorts.length === 0) return [];
 
     return sorts.map((sort) => {
-        // Format: "fieldId:desc" or "fieldId:asc" or just "fieldId" (defaults to asc)
         const lastColon = sort.lastIndexOf(':');
         let rawFieldId: string;
         let descending = false;
@@ -54,16 +59,25 @@ function parseSorts(
                 descending = true;
             } else if (direction === 'asc') {
                 rawFieldId = sort.substring(0, lastColon);
-                descending = false;
             } else {
-                // Suffix isn't asc/desc — treat whole string as field name
                 rawFieldId = sort;
             }
         }
         return {
-            fieldId: qualifyFieldId(rawFieldId, exploreName),
+            fieldId: qualifyFieldId(rawFieldId, baseTable, tableNames),
             descending,
         };
+    });
+}
+
+async function fetchExplore(
+    projectUuid: string,
+    exploreName: string,
+): Promise<Explore> {
+    return lightdashApi<Explore>({
+        method: 'GET',
+        url: `/api/v1/projects/${projectUuid}/explores/${exploreName}`,
+        body: undefined,
     });
 }
 
@@ -80,25 +94,33 @@ export const metricQueryHandler = async (
         );
     }
 
+    const spinner = GlobalState.startSpinner(
+        `Fetching explore '${options.explore}'...`,
+    );
+
+    const explore = await fetchExplore(projectUuid, options.explore);
+    const { baseTable } = explore;
+    const tableNames = new Set(Object.keys(explore.tables));
+
+    GlobalState.debug(`> Base table: ${baseTable}`);
+    GlobalState.debug(`> Tables: ${[...tableNames].join(', ')}`);
+
     const metrics = options.metrics.map((m) =>
-        qualifyFieldId(m, options.explore),
+        qualifyFieldId(m, baseTable, tableNames),
     );
     const dimensions = options.dimensions.map((d) =>
-        qualifyFieldId(d, options.explore),
+        qualifyFieldId(d, baseTable, tableNames),
     );
-    const sorts = parseSorts(options.sort, options.explore);
+    const sorts = parseSorts(options.sort, baseTable, tableNames);
     const limit = options.limit ?? DEFAULT_LIMIT;
 
-    GlobalState.debug(`> Explore: ${options.explore}`);
     GlobalState.debug(`> Metrics: ${metrics.join(', ')}`);
     GlobalState.debug(`> Dimensions: ${dimensions.join(', ')}`);
     GlobalState.debug(`> Sorts: ${JSON.stringify(sorts)}`);
     GlobalState.debug(`> Limit: ${limit}`);
-    GlobalState.debug(`> Project: ${projectUuid}`);
 
     if (options.sql) {
-        // Compile query mode: just get the SQL without executing
-        const spinner = GlobalState.startSpinner('Compiling metric query...');
+        spinner.text = 'Compiling metric query...';
 
         const result = await lightdashApi<ApiCompiledQueryResults>({
             method: 'POST',
@@ -127,8 +149,7 @@ export const metricQueryHandler = async (
         return;
     }
 
-    // Execute query mode
-    const spinner = GlobalState.startSpinner('Executing metric query...');
+    spinner.text = 'Executing metric query...';
 
     const queryBody = {
         exploreName: options.explore,

--- a/packages/cli/src/handlers/metricQuery.ts
+++ b/packages/cli/src/handlers/metricQuery.ts
@@ -25,27 +25,45 @@ type MetricQueryOptions = {
 const DEFAULT_LIMIT = 500;
 const DEFAULT_PAGE_SIZE = 500;
 
+// Field IDs in Lightdash are `{table}_{field}`. For single-table explores,
+// users can omit the prefix — we prepend the explore name automatically.
+function qualifyFieldId(fieldId: string, exploreName: string): string {
+    if (fieldId.startsWith(`${exploreName}_`)) {
+        return fieldId;
+    }
+    return `${exploreName}_${fieldId}`;
+}
+
 function parseSorts(
     sorts: string[] | undefined,
+    exploreName: string,
 ): { fieldId: string; descending: boolean }[] {
     if (!sorts || sorts.length === 0) return [];
 
     return sorts.map((sort) => {
         // Format: "fieldId:desc" or "fieldId:asc" or just "fieldId" (defaults to asc)
         const lastColon = sort.lastIndexOf(':');
+        let rawFieldId: string;
+        let descending = false;
         if (lastColon === -1) {
-            return { fieldId: sort, descending: false };
+            rawFieldId = sort;
+        } else {
+            const direction = sort.substring(lastColon + 1).toLowerCase();
+            if (direction === 'desc') {
+                rawFieldId = sort.substring(0, lastColon);
+                descending = true;
+            } else if (direction === 'asc') {
+                rawFieldId = sort.substring(0, lastColon);
+                descending = false;
+            } else {
+                // Suffix isn't asc/desc — treat whole string as field name
+                rawFieldId = sort;
+            }
         }
-        const fieldId = sort.substring(0, lastColon);
-        const direction = sort.substring(lastColon + 1).toLowerCase();
-        if (direction === 'desc') {
-            return { fieldId, descending: true };
-        }
-        if (direction === 'asc') {
-            return { fieldId, descending: false };
-        }
-        // If the suffix isn't asc/desc, treat the whole string as a field name
-        return { fieldId: sort, descending: false };
+        return {
+            fieldId: qualifyFieldId(rawFieldId, exploreName),
+            descending,
+        };
     });
 }
 
@@ -62,12 +80,18 @@ export const metricQueryHandler = async (
         );
     }
 
-    const sorts = parseSorts(options.sort);
+    const metrics = options.metrics.map((m) =>
+        qualifyFieldId(m, options.explore),
+    );
+    const dimensions = options.dimensions.map((d) =>
+        qualifyFieldId(d, options.explore),
+    );
+    const sorts = parseSorts(options.sort, options.explore);
     const limit = options.limit ?? DEFAULT_LIMIT;
 
     GlobalState.debug(`> Explore: ${options.explore}`);
-    GlobalState.debug(`> Metrics: ${options.metrics.join(', ')}`);
-    GlobalState.debug(`> Dimensions: ${options.dimensions.join(', ')}`);
+    GlobalState.debug(`> Metrics: ${metrics.join(', ')}`);
+    GlobalState.debug(`> Dimensions: ${dimensions.join(', ')}`);
     GlobalState.debug(`> Sorts: ${JSON.stringify(sorts)}`);
     GlobalState.debug(`> Limit: ${limit}`);
     GlobalState.debug(`> Project: ${projectUuid}`);
@@ -81,8 +105,8 @@ export const metricQueryHandler = async (
             url: `/api/v1/projects/${projectUuid}/explores/${options.explore}/compileQuery`,
             body: JSON.stringify({
                 exploreName: options.explore,
-                dimensions: options.dimensions,
-                metrics: options.metrics,
+                dimensions,
+                metrics,
                 filters: {},
                 sorts,
                 limit,
@@ -108,8 +132,8 @@ export const metricQueryHandler = async (
 
     const queryBody = {
         exploreName: options.explore,
-        dimensions: options.dimensions,
-        metrics: options.metrics,
+        dimensions,
+        metrics,
         filters: {},
         sorts,
         limit,

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -1257,14 +1257,17 @@ program
     .command('metric-query')
     .description('Run a metric query against the semantic layer')
     .requiredOption('-e, --explore <explore>', 'Name of the explore to query')
-    .requiredOption('-m, --metrics <fields...>', 'Metric field IDs to include')
+    .requiredOption(
+        '-m, --metrics <fields...>',
+        'Metric field IDs. Names without the explore prefix are qualified automatically (e.g. `total_users` becomes `users_total_users` for the `users` explore)',
+    )
     .requiredOption(
         '-d, --dimensions <fields...>',
-        'Dimension field IDs to include',
+        'Dimension field IDs. Names without the explore prefix are qualified automatically',
     )
     .option(
         '-s, --sort <sorts...>',
-        'Sort fields (format: fieldId:asc or fieldId:desc)',
+        'Sort fields (format: fieldId:asc or fieldId:desc). Field names are qualified with the explore prefix if needed',
     )
     .option(
         '-l, --limit <number>',

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -33,6 +33,7 @@ import {
 import { lintHandler } from './handlers/lint';
 import { listProjectsHandler } from './handlers/listProjects';
 import { login } from './handlers/login';
+import { metricQueryHandler } from './handlers/metricQuery';
 import {
     previewHandler,
     startPreviewHandler,
@@ -1251,6 +1252,38 @@ program
     )
     .option('--verbose', 'Show detailed output', false)
     .action(runChartHandler);
+
+program
+    .command('metric-query')
+    .description('Run a metric query against the semantic layer')
+    .requiredOption('-e, --explore <explore>', 'Name of the explore to query')
+    .requiredOption('-m, --metrics <fields...>', 'Metric field IDs to include')
+    .requiredOption(
+        '-d, --dimensions <fields...>',
+        'Dimension field IDs to include',
+    )
+    .option(
+        '-s, --sort <sorts...>',
+        'Sort fields (format: fieldId:asc or fieldId:desc)',
+    )
+    .option(
+        '-l, --limit <number>',
+        'Row limit (default: 500)',
+        parseIntArgument,
+    )
+    .option('-o, --output <file>', 'Output file path for CSV results')
+    .option(
+        '--sql',
+        'Output compiled SQL instead of executing the query',
+        false,
+    )
+    .option(
+        '--page-size <number>',
+        'Number of rows per page (default: 500)',
+        parseIntArgument,
+    )
+    .option('--verbose', 'Show detailed output', false)
+    .action(metricQueryHandler);
 
 program
     .command('set-warehouse')


### PR DESCRIPTION
### Description:

This PR adds a new `metric-query` CLI command that allows users to run queries against the semantic layer using metrics and dimensions from Lightdash explores.

**Key features:**
- Query explores by specifying metrics and dimensions with automatic field ID qualification (users can omit the explore prefix)
- Support for sorting with `fieldId:asc` or `fieldId:desc` syntax
- Configurable row limits and pagination
- Two modes of operation:
  - **Execute mode** (default): Runs the query asynchronously and returns results as CSV
  - **SQL mode** (`--sql` flag): Compiles the query and outputs the generated SQL without executing
- Results can be written to a file or printed to stdout
- Verbose logging support for debugging

The implementation reuses existing async query polling and CSV conversion utilities, and follows the same patterns as the existing `run-chart` command.

https://claude.ai/code/session_01E9NqJ3ddpbjKc75NpVBcX2