### PR TITLE
fix: sort-only table calculations appearing as chart series (#21965)

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1153,6 +1153,14 @@ const models: TsoaRoute.Models = {
             nestedProperties: {
                 updatedAt: { dataType: 'datetime', required: true },
                 createdAt: { dataType: 'datetime', required: true },
+                slackChannelId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
                 enabledByUserUuid: {
                     dataType: 'union',
                     subSchemas: [
@@ -1174,6 +1182,13 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                slackChannelId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                },
                 scheduleCron: { dataType: 'string' },
                 enabled: { dataType: 'boolean' },
             },
@@ -1187,6 +1202,7 @@ const models: TsoaRoute.Models = {
             'flagged_stale',
             'soft_deleted',
             'flagged_broken',
+            'flagged_slow',
             'fixed_broken',
             'created_content',
             'insight',
@@ -5907,11 +5923,42 @@ const models: TsoaRoute.Models = {
         enums: ['virtual', 'default', 'pre_aggregate'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'Record_string.string-Array_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {},
+            additionalProperties: {
+                dataType: 'array',
+                array: { dataType: 'string' },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    UserAttributeValueMap: {
+        dataType: 'refAlias',
+        type: { ref: 'Record_string.string-Array_', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    PreAggregateMaterializationRole: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                attributes: { ref: 'UserAttributeValueMap', required: true },
+                email: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PreAggregateDef: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                materializationRole: { ref: 'PreAggregateMaterializationRole' },
                 refresh: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: { cron: { dataType: 'string' } },
@@ -5919,6 +5966,10 @@ const models: TsoaRoute.Models = {
                 maxRows: { dataType: 'double' },
                 granularity: { ref: 'TimeFrames' },
                 timeDimension: { dataType: 'string' },
+                filters: {
+                    dataType: 'array',
+                    array: { dataType: 'refObject', ref: 'MetricFilterRule' },
+                },
                 metrics: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -6150,6 +6201,11 @@ const models: TsoaRoute.Models = {
         enums: ['filter_dimension_not_in_pre_aggregate'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED': {
+        dataType: 'refEnum',
+        enums: ['pre_aggregate_filter_not_satisfied'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'PreAggregateMissReason.GRANULARITY_TOO_FINE': {
         dataType: 'refEnum',
         enums: ['granularity_too_fine'],
@@ -6240,6 +6296,16 @@ const models: TsoaRoute.Models = {
                         fieldId: { ref: 'FieldId', required: true },
                         reason: {
                             ref: 'PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        fieldId: { ref: 'FieldId', required: true },
+                        reason: {
+                            ref: 'PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED',
                             required: true,
                         },
                     },
@@ -8561,11 +8627,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8580,11 +8646,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8599,11 +8665,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8680,7 +8746,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                tableName:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -8691,7 +8757,7 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                tableName:
+                                                                                                fieldType:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'string',
@@ -8725,7 +8791,7 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
+                                                                                                joinedTables:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -8733,7 +8799,11 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'double',
+                                                                                                                        'array',
+                                                                                                                    array: {
+                                                                                                                        dataType:
+                                                                                                                            'string',
+                                                                                                                    },
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -8748,7 +8818,7 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                joinedTables:
+                                                                                                searchRank:
                                                                                                     {
                                                                                                         dataType:
                                                                                                             'union',
@@ -8756,11 +8826,7 @@ const models: TsoaRoute.Models = {
                                                                                                             [
                                                                                                                 {
                                                                                                                     dataType:
-                                                                                                                        'array',
-                                                                                                                    array: {
-                                                                                                                        dataType:
-                                                                                                                            'string',
-                                                                                                                    },
+                                                                                                                        'double',
                                                                                                                 },
                                                                                                                 {
                                                                                                                     dataType:
@@ -8812,11 +8878,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8938,7 +9004,7 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    tableName:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -8949,7 +9015,7 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    tableName:
+                                                                                                    fieldType:
                                                                                                         {
                                                                                                             dataType:
                                                                                                                 'string',
@@ -8986,11 +9052,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9005,11 +9071,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10787,6 +10853,11 @@ const models: TsoaRoute.Models = {
                     ],
                     required: true,
                 },
+                filters: {
+                    dataType: 'array',
+                    array: { dataType: 'refObject', ref: 'MetricFilterRule' },
+                    required: true,
+                },
                 metrics: {
                     dataType: 'array',
                     array: { dataType: 'string' },
@@ -10795,6 +10866,14 @@ const models: TsoaRoute.Models = {
                 dimensions: {
                     dataType: 'array',
                     array: { dataType: 'string' },
+                    required: true,
+                },
+                materializationRole: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'PreAggregateMaterializationRole' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
                     required: true,
                 },
                 sourceExploreName: { dataType: 'string', required: true },
@@ -14924,6 +15003,10 @@ const models: TsoaRoute.Models = {
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                sortOnlyColumns: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'ValuesColumn' },
+                },
                 metricsAsRows: { dataType: 'boolean' },
                 sortBy: {
                     dataType: 'union',

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -1199,6 +1199,10 @@
                         "type": "string",
                         "format": "date-time"
                     },
+                    "slackChannelId": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "enabledByUserUuid": {
                         "type": "string",
                         "nullable": true
@@ -1216,6 +1220,7 @@
                 "required": [
                     "updatedAt",
                     "createdAt",
+                    "slackChannelId",
                     "enabledByUserUuid",
                     "scheduleCron",
                     "enabled",
@@ -1225,6 +1230,10 @@
             },
             "UpdateManagedAgentSettings": {
                 "properties": {
+                    "slackChannelId": {
+                        "type": "string",
+                        "nullable": true
+                    },
                     "scheduleCron": {
                         "type": "string"
                     },
@@ -1239,6 +1248,7 @@
                     "flagged_stale",
                     "soft_deleted",
                     "flagged_broken",
+                    "flagged_slow",
                     "fixed_broken",
                     "created_content",
                     "insight"
@@ -7087,8 +7097,37 @@
                 "enum": ["virtual", "default", "pre_aggregate"],
                 "type": "string"
             },
+            "Record_string.string-Array_": {
+                "properties": {},
+                "additionalProperties": {
+                    "items": {
+                        "type": "string"
+                    },
+                    "type": "array"
+                },
+                "type": "object",
+                "description": "Construct a type with a set of properties K of type T"
+            },
+            "UserAttributeValueMap": {
+                "$ref": "#/components/schemas/Record_string.string-Array_"
+            },
+            "PreAggregateMaterializationRole": {
+                "properties": {
+                    "attributes": {
+                        "$ref": "#/components/schemas/UserAttributeValueMap"
+                    },
+                    "email": {
+                        "type": "string"
+                    }
+                },
+                "required": ["attributes", "email"],
+                "type": "object"
+            },
             "PreAggregateDef": {
                 "properties": {
+                    "materializationRole": {
+                        "$ref": "#/components/schemas/PreAggregateMaterializationRole"
+                    },
                     "refresh": {
                         "properties": {
                             "cron": {
@@ -7106,6 +7145,12 @@
                     },
                     "timeDimension": {
                         "type": "string"
+                    },
+                    "filters": {
+                        "items": {
+                            "$ref": "#/components/schemas/MetricFilterRule"
+                        },
+                        "type": "array"
                     },
                     "metrics": {
                         "items": {
@@ -7406,6 +7451,10 @@
                 "enum": ["filter_dimension_not_in_pre_aggregate"],
                 "type": "string"
             },
+            "PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED": {
+                "enum": ["pre_aggregate_filter_not_satisfied"],
+                "type": "string"
+            },
             "PreAggregateMissReason.GRANULARITY_TOO_FINE": {
                 "enum": ["granularity_too_fine"],
                 "type": "string"
@@ -7496,6 +7545,18 @@
                             },
                             "reason": {
                                 "$ref": "#/components/schemas/PreAggregateMissReason.FILTER_DIMENSION_NOT_IN_PRE_AGGREGATE"
+                            }
+                        },
+                        "required": ["fieldId", "reason"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "fieldId": {
+                                "$ref": "#/components/schemas/FieldId"
+                            },
+                            "reason": {
+                                "$ref": "#/components/schemas/PreAggregateMissReason.PRE_AGGREGATE_FILTER_NOT_SATISFIED"
                             }
                         },
                         "required": ["fieldId", "reason"],
@@ -10020,19 +10081,6 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "error",
-                                                            "success"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
@@ -10048,13 +10096,13 @@
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
+                                                                        "tableName": {
                                                                             "type": "string"
                                                                         },
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "tableName": {
+                                                                        "fieldType": {
                                                                             "type": "string"
                                                                         },
                                                                         "name": {
@@ -10062,9 +10110,9 @@
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
-                                                                        "label",
                                                                         "tableName",
+                                                                        "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10074,16 +10122,16 @@
                                                             "exploreSearchResults": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "searchRank": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "joinedTables": {
                                                                             "items": {
                                                                                 "type": "string"
                                                                             },
                                                                             "type": "array",
+                                                                            "nullable": true
+                                                                        },
+                                                                        "searchRank": {
+                                                                            "type": "number",
+                                                                            "format": "double",
                                                                             "nullable": true
                                                                         },
                                                                         "label": {
@@ -10113,8 +10161,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10168,13 +10216,13 @@
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
+                                                                                    "tableName": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "tableName": {
+                                                                                    "fieldType": {
                                                                                         "type": "string"
                                                                                     },
                                                                                     "name": {
@@ -10182,9 +10230,9 @@
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
-                                                                                    "label",
                                                                                     "tableName",
+                                                                                    "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10212,8 +10260,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -11761,6 +11809,12 @@
                         "type": "string",
                         "nullable": true
                     },
+                    "filters": {
+                        "items": {
+                            "$ref": "#/components/schemas/MetricFilterRule"
+                        },
+                        "type": "array"
+                    },
                     "metrics": {
                         "items": {
                             "type": "string"
@@ -11772,6 +11826,14 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "materializationRole": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/PreAggregateMaterializationRole"
+                            }
+                        ],
+                        "nullable": true
                     },
                     "sourceExploreName": {
                         "type": "string"
@@ -11794,8 +11856,10 @@
                     "refreshCron",
                     "granularity",
                     "timeDimension",
+                    "filters",
                     "metrics",
                     "dimensions",
+                    "materializationRole",
                     "sourceExploreName",
                     "preAggExploreName",
                     "preAggregateName",
@@ -15840,6 +15904,13 @@
             },
             "PivotConfiguration": {
                 "properties": {
+                    "sortOnlyColumns": {
+                        "items": {
+                            "$ref": "#/components/schemas/ValuesColumn"
+                        },
+                        "type": "array",
+                        "description": "Metrics/table calculations needed for sort anchor CTEs but not for display.\nThese are merged into valuesColumns for SQL generation in PivotQueryBuilder,\nbut excluded from pivotDetails so they don't appear as chart series."
+                    },
                     "metricsAsRows": {
                         "type": "boolean",
                         "description": "When true, metrics are displayed as rows instead of columns.\nThis affects column limit calculation - when metrics are rows,\nwe don't need to divide the column limit by the number of metrics.\nDefaults to false for backward compatibility (SQL runner behavior)."
@@ -30175,7 +30246,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2752.0",
+        "version": "0.2761.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -1435,8 +1435,19 @@ export class PivotQueryBuilder {
             this.pivotConfiguration.indexColumn,
         );
 
-        const { valuesColumns, groupByColumns, sortBy } =
-            this.pivotConfiguration;
+        const {
+            valuesColumns: displayColumns,
+            groupByColumns,
+            sortBy,
+            sortOnlyColumns,
+        } = this.pivotConfiguration;
+
+        // Merge sort-only columns into valuesColumns for SQL generation.
+        // These columns are needed for sort anchor CTEs but are excluded
+        // from pivotDetails downstream so they don't appear as chart series.
+        const valuesColumns = sortOnlyColumns?.length
+            ? [...displayColumns, ...sortOnlyColumns]
+            : displayColumns;
 
         // Validate that no groupBy column is also part of the index columns
         if (groupByColumns && groupByColumns.length > 0) {

--- a/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.test.ts
@@ -607,7 +607,7 @@ describe('derivePivotConfigurationFromChart', () => {
     });
 
     describe('Sort by metric not in viz (PROD-6906)', () => {
-        it('includes sort-only metrics in valuesColumns for Cartesian charts', () => {
+        it('puts sort-only metrics in sortOnlyColumns for Cartesian charts', () => {
             const itemsWithExtraMetric: ItemsMap = {
                 ...mockItems,
                 orders_count: {
@@ -648,12 +648,15 @@ describe('derivePivotConfigurationFromChart', () => {
             );
 
             expect(result).toBeDefined();
-            // orders_count should be added to valuesColumns even though it's not in yField
+            // orders_count should NOT be in valuesColumns
             expect(result?.valuesColumns).toEqual([
                 {
                     reference: 'payments_total_revenue',
                     aggregation: VizAggregationOptions.ANY,
                 },
+            ]);
+            // orders_count should be in sortOnlyColumns
+            expect(result?.sortOnlyColumns).toEqual([
                 {
                     reference: 'orders_count',
                     aggregation: VizAggregationOptions.ANY,
@@ -668,7 +671,7 @@ describe('derivePivotConfigurationFromChart', () => {
             ]);
         });
 
-        it('includes sort-only table calculation in valuesColumns', () => {
+        it('puts sort-only table calculation in sortOnlyColumns', () => {
             const mockTableCalc: TableCalculation = {
                 name: 'revenue_per_order',
                 displayName: 'Revenue per Order',
@@ -712,6 +715,8 @@ describe('derivePivotConfigurationFromChart', () => {
                     reference: 'payments_total_revenue',
                     aggregation: VizAggregationOptions.ANY,
                 },
+            ]);
+            expect(result?.sortOnlyColumns).toEqual([
                 {
                     reference: 'revenue_per_order',
                     aggregation: VizAggregationOptions.ANY,

--- a/packages/common/src/pivot/derivePivotConfigFromChart.ts
+++ b/packages/common/src/pivot/derivePivotConfigFromChart.ts
@@ -33,7 +33,8 @@ function getSortByForPivotConfiguration(
     partialPivot: Omit<PivotConfiguration, 'sortBy'>,
     metricQuery: MetricQuery,
 ): NonNullable<PivotConfiguration['sortBy']> | undefined {
-    const { groupByColumns, indexColumn, valuesColumns } = partialPivot;
+    const { groupByColumns, indexColumn, valuesColumns, sortOnlyColumns } =
+        partialPivot;
 
     const sortBy = metricQuery.sorts
         .map<NonNullable<PivotConfiguration['sortBy']>[number] | undefined>(
@@ -50,8 +51,17 @@ function getSortByForPivotConfiguration(
                     (col) => col.reference === sort.fieldId,
                 );
 
+                const isSortOnlyColumn = sortOnlyColumns?.some(
+                    (col) => col.reference === sort.fieldId,
+                );
+
                 // Include sort if the field is present in any part of the pivot configuration
-                if (isGroupByColumn || isIndexColumn || isValueColumn) {
+                if (
+                    isGroupByColumn ||
+                    isIndexColumn ||
+                    isValueColumn ||
+                    isSortOnlyColumn
+                ) {
                     return {
                         reference: sort.fieldId,
                         direction: sort.descending
@@ -284,12 +294,13 @@ function getCartesianPivotConfiguration(
                 reference: sort.fieldId,
                 aggregation: VizAggregationOptions.ANY,
             }));
-        valuesColumns.push(...sortOnlyMetrics);
-
         // Find columns that are not groupBy or value columns (these become index columns)
+        // Include sortOnlyMetrics in the valuesColumns passed to getIndexColumn
+        // so they aren't incorrectly classified as index columns.
+        const allValuesColumns = [...valuesColumns, ...sortOnlyMetrics];
         const indexColumn = getIndexColumn(
             groupByColumns,
-            valuesColumns,
+            allValuesColumns,
             fields,
             metricQuery,
             xField,
@@ -299,6 +310,9 @@ function getCartesianPivotConfiguration(
             indexColumn,
             valuesColumns,
             groupByColumns,
+            ...(sortOnlyMetrics.length > 0 && {
+                sortOnlyColumns: sortOnlyMetrics,
+            }),
         };
 
         const pivotConfiguration: PivotConfiguration = {

--- a/packages/common/src/pivot/pivotConfig.test.ts
+++ b/packages/common/src/pivot/pivotConfig.test.ts
@@ -2,8 +2,8 @@ import { ChartType } from '../types/savedCharts';
 import { getPivotConfig } from './pivotConfig';
 
 describe('getPivotConfig', () => {
-    describe('Cartesian chart visibleMetricFieldIds', () => {
-        it('sets visibleMetricFieldIds to yField for cartesian charts with pivot', () => {
+    describe('Cartesian chart pivot config', () => {
+        it('returns pivot config for cartesian charts with pivot', () => {
             const result = getPivotConfig({
                 chartConfig: {
                     type: ChartType.CARTESIAN,
@@ -20,75 +20,10 @@ describe('getPivotConfig', () => {
             });
 
             expect(result).toBeDefined();
-            expect(result?.visibleMetricFieldIds).toEqual([
-                'metric_a',
-                'metric_b',
-            ]);
-        });
-
-        it('includes table calculations in visibleMetricFieldIds when they are in yField', () => {
-            const result = getPivotConfig({
-                chartConfig: {
-                    type: ChartType.CARTESIAN,
-                    config: {
-                        layout: {
-                            xField: 'dim_a',
-                            yField: [
-                                'metric_a',
-                                'revenue_per_order', // table calculation
-                            ],
-                        },
-                        eChartsConfig: { series: [] },
-                    },
-                },
-                pivotConfig: { columns: ['dim_b'] },
-                tableConfig: { columnOrder: [] },
-            });
-
-            expect(result).toBeDefined();
-            expect(result?.visibleMetricFieldIds).toEqual([
-                'metric_a',
-                'revenue_per_order',
-            ]);
-        });
-
-        it('does not set visibleMetricFieldIds when yField is empty', () => {
-            const result = getPivotConfig({
-                chartConfig: {
-                    type: ChartType.CARTESIAN,
-                    config: {
-                        layout: {
-                            xField: 'dim_a',
-                            yField: [],
-                        },
-                        eChartsConfig: { series: [] },
-                    },
-                },
-                pivotConfig: { columns: ['dim_b'] },
-                tableConfig: { columnOrder: [] },
-            });
-
-            expect(result).toBeDefined();
-            expect(result?.visibleMetricFieldIds).toBeUndefined();
-        });
-
-        it('does not set visibleMetricFieldIds when yField is undefined', () => {
-            const result = getPivotConfig({
-                chartConfig: {
-                    type: ChartType.CARTESIAN,
-                    config: {
-                        layout: {
-                            xField: 'dim_a',
-                            yField: undefined,
-                        },
-                        eChartsConfig: { series: [] },
-                    },
-                },
-                pivotConfig: { columns: ['dim_b'] },
-                tableConfig: { columnOrder: [] },
-            });
-
-            expect(result).toBeDefined();
+            expect(result?.pivotDimensions).toEqual(['dim_b']);
+            expect(result?.metricsAsRows).toBe(false);
+            // visibleMetricFieldIds should NOT be set — sort-only columns
+            // are now excluded at the source via sortOnlyColumns
             expect(result?.visibleMetricFieldIds).toBeUndefined();
         });
 

--- a/packages/common/src/pivot/pivotConfig.ts
+++ b/packages/common/src/pivot/pivotConfig.ts
@@ -5,8 +5,6 @@ import type { PivotConfig } from '../types/pivot';
 import {
     ChartType,
     getHiddenTableFields,
-    isCartesianChartConfig,
-    type CartesianChartConfig,
     type CreateSavedChartVersion,
     type TableChartConfig,
 } from '../types/savedCharts';
@@ -29,29 +27,16 @@ const getTablePivotConfig = (
         : undefined;
 
 const getCartesianPivotConfig = (
-    chartConfig: CartesianChartConfig,
     pivotConfig: CreateSavedChartVersion['pivotConfig'],
 ): PivotConfig | undefined => {
     if (!pivotConfig || pivotConfig.columns.length === 0) {
         return undefined;
     }
 
-    const result: PivotConfig = {
+    return {
         pivotDimensions: pivotConfig.columns,
         metricsAsRows: false,
     };
-
-    // When sort-only metrics are injected into valuesColumns (PROD-6906),
-    // they would bleed into exports/UI. Set visibleMetricFieldIds to the
-    // chart's yField so only displayed metrics appear in pivot output.
-    if (isCartesianChartConfig(chartConfig.config)) {
-        const { yField } = chartConfig.config.layout;
-        if (yField && yField.length > 0) {
-            result.visibleMetricFieldIds = yField;
-        }
-    }
-
-    return result;
 };
 
 export const getPivotConfig = (
@@ -68,10 +53,7 @@ export const getPivotConfig = (
                 savedChart.tableConfig,
             );
         case ChartType.CARTESIAN:
-            return getCartesianPivotConfig(
-                savedChart.chartConfig,
-                savedChart.pivotConfig,
-            );
+            return getCartesianPivotConfig(savedChart.pivotConfig);
         default:
             return undefined;
     }

--- a/packages/common/src/types/pivot.ts
+++ b/packages/common/src/types/pivot.ts
@@ -26,6 +26,12 @@ export type PivotConfiguration = {
      * Defaults to false for backward compatibility (SQL runner behavior).
      */
     metricsAsRows?: boolean;
+    /**
+     * Metrics/table calculations needed for sort anchor CTEs but not for display.
+     * These are merged into valuesColumns for SQL generation in PivotQueryBuilder,
+     * but excluded from pivotDetails so they don't appear as chart series.
+     */
+    sortOnlyColumns?: ValuesColumn[];
 };
 
 type Field =


### PR DESCRIPTION
## Summary

- Adds a dedicated `sortOnlyColumns` field to `PivotConfiguration` to separate metrics needed for SQL sort anchor CTEs from metrics that should be displayed as chart series
- `PivotQueryBuilder.toSql()` merges both lists for SQL generation, but only `valuesColumns` flows through to `pivotDetails` in the API response
- Removes the `visibleMetricFieldIds` workaround in `getCartesianPivotConfig` that was added as a downstream patch for this issue

## Context

PR #21883 fixed pivot chart sorting when the sort field isn't on the Y-axis by adding sort-only metrics to `valuesColumns`. But `valuesColumns` serves double duty — it's both the list for SQL generation AND the list that flows to the frontend as chart series. This caused sort-only metrics to render as unwanted chart series.

## Test plan

- [x] `pnpm -F common typecheck` passes
- [x] `pnpm -F backend typecheck` passes (only pre-existing formula errors)
- [x] `pnpm -F common test -- --testPathPattern=pivot` — all 64 tests pass
- [ ] Manual: create a pivoted cartesian chart with a table calc sort field — the table calc should NOT appear as a series, sort should still work