### PR TITLE
feat: split CustomSql scope into CustomFields for custom dimensions/metrics

### DIFF
--- a/packages/backend/src/database/migrations/20260417111420_grant_custom_fields_to_custom_sql_roles.ts
+++ b/packages/backend/src/database/migrations/20260417111420_grant_custom_fields_to_custom_sql_roles.ts
@@ -1,0 +1,55 @@
+import { Knex } from 'knex';
+
+const ScopedRolesTableName = 'scoped_roles';
+const CUSTOM_SQL_SCOPE = 'manage:CustomSql';
+const CUSTOM_FIELDS_SCOPE = 'manage:CustomFields';
+
+/**
+ * `manage:CustomSql` used to gate both SQL Runner-adjacent features and custom
+ * dimensions. Those have been split: custom dimensions now require the new
+ * `manage:CustomFields` scope. Copy the new scope into every custom role that
+ * currently has `manage:CustomSql` so nobody loses access.
+ *
+ * Wrapped in try/catch because this is a backfill: failing it would block all
+ * later migrations, and the worst case (some roles miss CustomFields) is
+ * recoverable by re-running the SQL manually.
+ */
+export async function up(knex: Knex): Promise<void> {
+    try {
+        await knex.raw(
+            `
+            INSERT INTO ?? (role_uuid, scope_name, granted_by)
+            SELECT role_uuid, ?, granted_by
+            FROM ??
+            WHERE scope_name = ?
+            ON CONFLICT DO NOTHING
+            `,
+            [
+                ScopedRolesTableName,
+                CUSTOM_FIELDS_SCOPE,
+                ScopedRolesTableName,
+                CUSTOM_SQL_SCOPE,
+            ],
+        );
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260417111420] Failed to backfill ${CUSTOM_FIELDS_SCOPE} for roles with ${CUSTOM_SQL_SCOPE}. Affected custom roles will need to grant ${CUSTOM_FIELDS_SCOPE} manually.`,
+            error,
+        );
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    try {
+        await knex(ScopedRolesTableName)
+            .where('scope_name', CUSTOM_FIELDS_SCOPE)
+            .delete();
+    } catch (error) {
+        // eslint-disable-next-line no-console
+        console.error(
+            `[migration 20260417111420] Failed to remove ${CUSTOM_FIELDS_SCOPE} rows during rollback.`,
+            error,
+        );
+    }
+}

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -3360,7 +3360,7 @@ export class AsyncQueryService extends ProjectService {
             metricQuery.customDimensions?.some(isCustomSqlDimension) &&
             account.user.ability.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomFields', { organizationUuid, projectUuid }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();

--- a/packages/backend/src/services/GdriveService/GdriveService.ts
+++ b/packages/backend/src/services/GdriveService/GdriveService.ts
@@ -98,7 +98,7 @@ export class GdriveService extends BaseService {
             ) &&
             user.ability.cannot(
                 'manage',
-                subject('CustomSql', {
+                subject('CustomFields', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid: projectSummary.projectUuid,
                 }),

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -589,7 +589,7 @@ Affected charts:
         if (
             user.ability.cannot(
                 'manage',
-                subject('CustomSql', {
+                subject('CustomFields', {
                     organizationUuid: user.organizationUuid!,
                     projectUuid,
                 }),

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -3106,7 +3106,7 @@ export class ProjectService extends BaseService {
             metricQuery.customDimensions?.some(isCustomSqlDimension) &&
             account.user.ability.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomFields', { organizationUuid, projectUuid }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -3417,7 +3417,7 @@ export class ProjectService extends BaseService {
             metricQuery.customDimensions?.some(isCustomSqlDimension) &&
             account.user.ability.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomFields', { organizationUuid, projectUuid }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -3725,7 +3725,7 @@ export class ProjectService extends BaseService {
             metricQuery.customDimensions?.some(isCustomSqlDimension) &&
             account.user.ability.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomFields', { organizationUuid, projectUuid }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -7115,7 +7115,7 @@ export class ProjectService extends BaseService {
             data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
             account.user.ability.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomFields', { organizationUuid, projectUuid }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();
@@ -7265,7 +7265,7 @@ export class ProjectService extends BaseService {
             data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
             account.user.ability.cannot(
                 'manage',
-                subject('CustomSql', { organizationUuid, projectUuid }),
+                subject('CustomFields', { organizationUuid, projectUuid }),
             )
         ) {
             throw new CustomSqlQueryForbiddenError();

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -495,7 +495,7 @@ export class SavedChartService
             data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
             auditedAbility.cannot(
                 'manage',
-                subject('CustomSql', {
+                subject('CustomFields', {
                     organizationUuid,
                     projectUuid,
                     uuid: savedChartUuid,

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -232,6 +232,9 @@ const applyOrganizationMemberStaticAbilities: Record<
         can('manage', 'CustomSql', {
             organizationUuid: member.organizationUuid,
         });
+        can('manage', 'CustomFields', {
+            organizationUuid: member.organizationUuid,
+        });
         can('manage', 'SqlRunner', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -194,6 +194,9 @@ export const projectMemberAbilities: Record<
         can('manage', 'CustomSql', {
             projectUuid: member.projectUuid,
         });
+        can('manage', 'CustomFields', {
+            projectUuid: member.projectUuid,
+        });
         can('manage', 'SqlRunner', {
             projectUuid: member.projectUuid,
         });

--- a/packages/common/src/authorization/roleToScopeMapping.testUtils.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.testUtils.ts
@@ -201,6 +201,11 @@ export const createStandardTestCases = () => [
         subject: 'CustomSql' as const,
         resource: { projectUuid: 'test-project-uuid' },
     },
+    {
+        action: 'manage' as const,
+        subject: 'CustomFields' as const,
+        resource: { projectUuid: 'test-project-uuid' },
+    },
 
     // Admin-only permissions
     {

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -71,6 +71,7 @@ const BASE_ROLE_SCOPES = {
         'manage:PreAggregation',
         'manage:VirtualView',
         'manage:CustomSql',
+        'manage:CustomFields',
         'manage:SqlRunner',
         'manage:Validation',
         'manage:CompileProject',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -544,14 +544,21 @@ const scopes: Scope[] = [
     },
     {
         name: 'manage:SqlRunner',
-        description: 'Run SQL queries directly',
+        description: 'Run SQL queries and execute SQL charts',
         isEnterprise: false,
         group: ScopeGroup.DATA,
         getConditions: addDefaultUuidCondition,
     },
     {
         name: 'manage:CustomSql',
-        description: 'Create custom SQL queries',
+        description: 'Save SQL charts and browse warehouse schema',
+        isEnterprise: false,
+        group: ScopeGroup.DATA,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
+        name: 'manage:CustomFields',
+        description: 'Create and edit custom dimensions',
         isEnterprise: false,
         group: ScopeGroup.DATA,
         getConditions: addDefaultUuidCondition,

--- a/packages/common/src/authorization/serviceAccountAbility.ts
+++ b/packages/common/src/authorization/serviceAccountAbility.ts
@@ -223,6 +223,9 @@ const applyServiceAccountStaticAbilities: Record<
         can('manage', 'CustomSql', {
             organizationUuid,
         });
+        can('manage', 'CustomFields', {
+            organizationUuid,
+        });
         can('manage', 'SqlRunner', {
             organizationUuid,
         });

--- a/packages/common/src/authorization/types.ts
+++ b/packages/common/src/authorization/types.ts
@@ -28,6 +28,7 @@ export type CaslSubjectNames =
     | 'CompileProject'
     | 'ContentAsCode'
     | 'ContentVerification'
+    | 'CustomFields'
     | 'CustomSql'
     | 'DataApp'
     | 'Dashboard'

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -714,9 +714,9 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
                 projectUuid: chart.projectUuid,
             }),
         );
-        const userCanRunCustomSql = ability.can(
+        const userCanUseCustomFields = ability.can(
             'manage',
-            subject('CustomSql', {
+            subject('CustomFields', {
                 organizationUuid: chart.organizationUuid,
                 projectUuid: chart.projectUuid,
             }),
@@ -1001,7 +1001,7 @@ const DashboardChartTileMain: FC<DashboardChartTileMainProps> = memo(
             [chart, metricQuery],
         );
         const cannotUseCustomDimensions =
-            !userCanRunCustomSql &&
+            !userCanUseCustomFields &&
             chartWithDashboardFilters.metricQuery?.customDimensions;
 
         const { pathname: chartPathname, search: chartSearch } = useMemo(() => {

--- a/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
+++ b/packages/frontend/src/components/Explorer/ExploreTree/TableTree/Virtualization/VirtualSectionHeader.tsx
@@ -53,9 +53,9 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
             : allCustomDimensions.filter(isCustomSqlDimension);
     }, [allCustomDimensions, isWriteBackCustomBinDimensionsEnabled]);
 
-    const canManageCustomSql = user.data?.ability?.can(
+    const canManageCustomFields = user.data?.ability?.can(
         'manage',
-        subject('CustomSql', {
+        subject('CustomFields', {
             organizationUuid: user.data.organizationUuid,
             projectUuid,
         }),
@@ -119,7 +119,7 @@ const VirtualSectionHeaderComponent: FC<VirtualSectionHeaderProps> = ({
     }, [depth]);
 
     const showAddButton =
-        treeSection === TreeSection.Dimensions && canManageCustomSql;
+        treeSection === TreeSection.Dimensions && canManageCustomFields;
 
     const showWriteBackCustomMetrics =
         treeSection === TreeSection.CustomMetrics &&


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-5990/split-scope-for-custom-sql-for-custom-dimensions](https://linear.app/lightdash/issue/PROD-5990/split-scope-for-custom-sql-for-custom-dimensions)



### Description:

This PR introduces a new `manage:CustomFields` permission scope to separate custom dimensions/metrics access from SQL Runner functionality. Previously, the `manage:CustomSql` scope controlled both SQL Runner features and custom dimensions/metrics, which created overly broad permissions.

**Key Changes:**

- Added new `manage:CustomFields` scope for controlling access to custom dimensions and custom metrics
- Updated permission checks throughout the codebase to use `CustomFields` instead of `CustomSql` for custom dimension/metric operations
- Created database migration to automatically grant the new `manage:CustomFields` scope to all roles that currently have `manage:CustomSql` to ensure no users lose access
- Updated ability definitions for organization members, project members, and service accounts to include the new scope
- Modified frontend components to check for `CustomFields` permissions when displaying custom dimension controls

This change provides more granular permission control, allowing administrators to grant access to custom dimensions/metrics independently from SQL Runner capabilities.