### PR TITLE
refactor: extract navbar root element function and optimize Mantine8Provider theme handling

### DIFF
--- a/packages/frontend/src/components/NavBar/index.tsx
+++ b/packages/frontend/src/components/NavBar/index.tsx
@@ -57,6 +57,9 @@ const NavBarContent = ({
     );
 };
 
+const getNavBarRootElement = () =>
+    document.getElementById('navbar-header') ?? undefined;
+
 const NavBar = memo(({ isFixed = true }: NavBarProps) => {
     const { isFullscreen } = useFullscreen();
 
@@ -84,9 +87,7 @@ const NavBar = memo(({ isFixed = true }: NavBarProps) => {
             <Mantine8Provider
                 forceColorScheme="dark"
                 cssVariablesSelector="#navbar-header"
-                getRootElement={() =>
-                    document.getElementById('navbar-header') ?? undefined
-                }
+                getRootElement={getNavBarRootElement}
             >
                 {isImpersonating ? (
                     <ImpersonationBanner />

--- a/packages/frontend/src/providers/Mantine8Provider.tsx
+++ b/packages/frontend/src/providers/Mantine8Provider.tsx
@@ -16,23 +16,27 @@ type Props = {
 
 const Mantine8Provider: FC<React.PropsWithChildren<Props>> = ({
     children,
-    themeOverride = {},
+    themeOverride,
     forceColorScheme,
     cssVariablesSelector,
     getRootElement,
 }) => {
     const { colorScheme } = useMantineColorScheme();
-    // Use forceColorScheme for theme building when provided, otherwise use parent's colorScheme
     const effectiveColorScheme = forceColorScheme || colorScheme;
-    const theme = useMemo(
+    const baseTheme = useMemo(
         () => getMantine8ThemeOverride(effectiveColorScheme),
         [effectiveColorScheme],
     );
+    const mergedTheme = useMemo(
+        () => (themeOverride ? { ...baseTheme, ...themeOverride } : baseTheme),
+        [baseTheme, themeOverride],
+    );
+    const resolvedColorScheme = forceColorScheme || colorScheme;
 
     return (
         <MantineProviderBase
-            theme={{ ...theme, ...themeOverride }}
-            forceColorScheme={forceColorScheme || colorScheme}
+            theme={mergedTheme}
+            forceColorScheme={resolvedColorScheme}
             cssVariablesSelector={cssVariablesSelector}
             getRootElement={getRootElement}
             classNamesPrefix="mantine-8"


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

stabilize `Mantine8Provider`props so it stops invalidating memos and ref pipelines on every render. Also updated NavBar to hoist a constant for getting the root element instead of using inline arror that generates new reference on every render 

this is part of a work to trying to solve PROD-7019

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->