### PR TITLE
refactor: optimize dashboard tabs with constant extraction and useMemo

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -60,6 +60,12 @@ import { StagedMountProvider } from './useStagedMount';
 
 const ResponsiveGridLayout = WidthProvider(Responsive);
 
+const EMPTY_LAYOUTS: { lg: Layout[]; md: Layout[]; sm: Layout[] } = {
+    lg: [],
+    md: [],
+    sm: [],
+};
+
 type TabGridPanelProps = {
     tabUuid: string;
     /** Key that resets the stagger cascade (changes on each tab activation). */
@@ -1094,11 +1100,8 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                               layouts={
                                                                   layoutsByTab.get(
                                                                       tab.uuid,
-                                                                  ) ?? {
-                                                                      lg: [],
-                                                                      md: [],
-                                                                      sm: [],
-                                                                  }
+                                                                  ) ??
+                                                                  EMPTY_LAYOUTS
                                                               }
                                                               isActive={
                                                                   activeTab?.uuid ===

--- a/packages/frontend/src/features/dashboardTabs/useStagedMount.tsx
+++ b/packages/frontend/src/features/dashboardTabs/useStagedMount.tsx
@@ -1,5 +1,6 @@
 import {
     useEffect,
+    useMemo,
     useRef,
     useState,
     type FC,
@@ -67,8 +68,10 @@ export const StagedMountProvider: FC<StagedMountProviderProps> = ({
         };
     }, [waveKey, isActive, totalTiles]);
 
+    const contextValue = useMemo(() => ({ revealedCount }), [revealedCount]);
+
     return (
-        <StagedMountContext.Provider value={{ revealedCount }}>
+        <StagedMountContext.Provider value={contextValue}>
             {children}
         </StagedMountContext.Provider>
     );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

stabilize props feeding `TabGridPanel`'s memo comparator. This component was re-rendered every time during edit mode 

this is part of a work to trying to solve [PROD-7019](https://linear.app/lightdash/issue/CENG-7019)

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->