### PR TITLE
feat: add error boundaries to dashboard tiles and grid layout

### DIFF
--- a/packages/frontend/src/features/dashboardTabs/GridTile.tsx
+++ b/packages/frontend/src/features/dashboardTabs/GridTile.tsx
@@ -12,19 +12,20 @@ import LoomTile from '../../components/DashboardTiles/DashboardLoomTile';
 import MarkdownTile from '../../components/DashboardTiles/DashboardMarkdownTile';
 import SqlChartTile from '../../components/DashboardTiles/DashboardSqlChartTile';
 import TileBase from '../../components/DashboardTiles/TileBase';
+import ErrorBoundary from '../errorBoundary/ErrorBoundary';
 import { useStagedMount } from './stagedMountContext';
 
-const GridTile: FC<
-    Pick<
-        React.ComponentProps<typeof TileBase>,
-        'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
-    > & {
-        index: number;
-        tabs?: DashboardTab[];
-        onAddTiles: (tiles: IDashboard['tiles'][number][]) => Promise<void>;
-        locked: boolean;
-    }
-> = memo((props) => {
+type GridTileProps = Pick<
+    React.ComponentProps<typeof TileBase>,
+    'tile' | 'onEdit' | 'onDelete' | 'isEditMode'
+> & {
+    index: number;
+    tabs?: DashboardTab[];
+    onAddTiles: (tiles: IDashboard['tiles'][number][]) => Promise<void>;
+    locked: boolean;
+};
+
+const GridTileInner: FC<GridTileProps> = memo((props) => {
     const { tile } = props;
 
     if (props.locked) {
@@ -66,21 +67,27 @@ const GridTile: FC<
     }
 });
 
+const GridTile: FC<GridTileProps> = (props) => (
+    <ErrorBoundary wrapper={{ h: '100%', w: '100%' }}>
+        <GridTileInner {...props} />
+    </ErrorBoundary>
+);
+
 /**
  * Wrapper that defers rendering of the real GridTile until the staged
  * mount cascade reaches this tile's index. Shows a skeleton placeholder
  * until then, matching the tile's dimensions via the grid layout.
  */
-export const StagedGridTile: FC<
-    React.ComponentProps<typeof GridTile> & { stageIndex: number }
-> = memo(({ stageIndex, ...props }) => {
-    const { isReady } = useStagedMount(stageIndex);
+export const StagedGridTile: FC<GridTileProps & { stageIndex: number }> = memo(
+    ({ stageIndex, ...props }) => {
+        const { isReady } = useStagedMount(stageIndex);
 
-    if (!isReady) {
-        return <Skeleton h="100%" w="100%" radius="sm" />;
-    }
+        if (!isReady) {
+            return <Skeleton h="100%" w="100%" radius="sm" />;
+        }
 
-    return <GridTile {...props} />;
-});
+        return <GridTile {...props} />;
+    },
+);
 
 export default GridTile;

--- a/packages/frontend/src/features/dashboardTabs/index.tsx
+++ b/packages/frontend/src/features/dashboardTabs/index.tsx
@@ -37,11 +37,12 @@ import { useClientFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../providers/App/useApp';
 import useDashboardContext from '../../providers/Dashboard/useDashboardContext';
 import { TrackSection } from '../../providers/Tracking/TrackingProvider';
-import '../../styles/droppable.css';
 import { SectionName } from '../../types/Events';
+import '../../styles/droppable.css';
 import { DashboardFiltersBar } from '../dashboardFilters/DashboardFiltersBar';
 import { DashboardFiltersBarSummary } from '../dashboardFilters/DashboardFiltersBarSummary';
 import { doesFilterApplyToTile } from '../dashboardFilters/FilterConfiguration/utils';
+import ErrorBoundary from '../errorBoundary/ErrorBoundary';
 import { AddTabModal } from './AddTabModal';
 import { TabDeleteModal } from './DeleteTabModal';
 import DuplicateTabModal from './DuplicateTabModal';
@@ -136,36 +137,38 @@ const TabGridPanel = memo<TabGridPanelProps>(
                           }
                 }
             >
-                <ResponsiveGridLayout
-                    {...gridProps}
-                    className={locked ? 'locked' : ''}
-                    containerPadding={GRID_CONTAINER_PADDING}
-                    onDragStart={onDragStart}
-                    onDragStop={onDragStop}
-                    onResizeStart={onResizeStart}
-                    onResizeStop={onResizeStop}
-                    onBreakpointChange={onBreakpointChange}
-                    onWidthChange={onWidthChange}
-                    layouts={layouts}
-                >
-                    {tiles.map((tile, idx) => (
-                        <div key={tile.uuid} data-tile-uuid={tile.uuid}>
-                            <TrackSection name={SectionName.DASHBOARD_TILE}>
-                                <StagedGridTile
-                                    stageIndex={idx}
-                                    locked={locked}
-                                    index={idx}
-                                    isEditMode={isEditMode}
-                                    tile={tile}
-                                    onDelete={onDeleteTile}
-                                    onEdit={onEditTile}
-                                    tabs={dashboardTabs}
-                                    onAddTiles={onAddTiles}
-                                />
-                            </TrackSection>
-                        </div>
-                    ))}
-                </ResponsiveGridLayout>
+                <ErrorBoundary>
+                    <ResponsiveGridLayout
+                        {...gridProps}
+                        className={locked ? 'locked' : ''}
+                        containerPadding={GRID_CONTAINER_PADDING}
+                        onDragStart={onDragStart}
+                        onDragStop={onDragStop}
+                        onResizeStart={onResizeStart}
+                        onResizeStop={onResizeStop}
+                        onBreakpointChange={onBreakpointChange}
+                        onWidthChange={onWidthChange}
+                        layouts={layouts}
+                    >
+                        {tiles.map((tile, idx) => (
+                            <div key={tile.uuid} data-tile-uuid={tile.uuid}>
+                                <TrackSection name={SectionName.DASHBOARD_TILE}>
+                                    <StagedGridTile
+                                        stageIndex={idx}
+                                        locked={locked}
+                                        index={idx}
+                                        isEditMode={isEditMode}
+                                        tile={tile}
+                                        onDelete={onDeleteTile}
+                                        onEdit={onEditTile}
+                                        tabs={dashboardTabs}
+                                        onAddTiles={onAddTiles}
+                                    />
+                                </TrackSection>
+                            </div>
+                        ))}
+                    </ResponsiveGridLayout>
+                </ErrorBoundary>
             </div>
         </StagedMountProvider>
     ),
@@ -1151,82 +1154,86 @@ const DashboardTabs: FC<DashboardTabsProps> = ({
                                                   ))
                                             : /* Single grid for non-tabbed dashboards */
                                               dashboardTiles && (
-                                                  <ResponsiveGridLayout
-                                                      {...gridProps}
-                                                      className={`${
-                                                          hasRequiredFiltersForCurrentTab
-                                                              ? 'locked'
-                                                              : ''
-                                                      }`}
-                                                      containerPadding={
-                                                          GRID_CONTAINER_PADDING
-                                                      }
-                                                      onDragStart={
-                                                          handleDragStart
-                                                      }
-                                                      onDragStop={
-                                                          handleDragStop
-                                                      }
-                                                      onResizeStart={
-                                                          handleResizeStart
-                                                      }
-                                                      onResizeStop={
-                                                          handleResizeStop
-                                                      }
-                                                      onBreakpointChange={
-                                                          handleBreakpointChange
-                                                      }
-                                                      onWidthChange={
-                                                          handleWidthChange
-                                                      }
-                                                      layouts={allTilesLayouts}
-                                                  >
-                                                      {dashboardTiles.map(
-                                                          (tile, idx) => (
-                                                              <div
-                                                                  key={
-                                                                      tile.uuid
-                                                                  }
-                                                                  data-tile-uuid={
-                                                                      tile.uuid
-                                                                  }
-                                                              >
-                                                                  <TrackSection
-                                                                      name={
-                                                                          SectionName.DASHBOARD_TILE
+                                                  <ErrorBoundary>
+                                                      <ResponsiveGridLayout
+                                                          {...gridProps}
+                                                          className={`${
+                                                              hasRequiredFiltersForCurrentTab
+                                                                  ? 'locked'
+                                                                  : ''
+                                                          }`}
+                                                          containerPadding={
+                                                              GRID_CONTAINER_PADDING
+                                                          }
+                                                          onDragStart={
+                                                              handleDragStart
+                                                          }
+                                                          onDragStop={
+                                                              handleDragStop
+                                                          }
+                                                          onResizeStart={
+                                                              handleResizeStart
+                                                          }
+                                                          onResizeStop={
+                                                              handleResizeStop
+                                                          }
+                                                          onBreakpointChange={
+                                                              handleBreakpointChange
+                                                          }
+                                                          onWidthChange={
+                                                              handleWidthChange
+                                                          }
+                                                          layouts={
+                                                              allTilesLayouts
+                                                          }
+                                                      >
+                                                          {dashboardTiles.map(
+                                                              (tile, idx) => (
+                                                                  <div
+                                                                      key={
+                                                                          tile.uuid
+                                                                      }
+                                                                      data-tile-uuid={
+                                                                          tile.uuid
                                                                       }
                                                                   >
-                                                                      <GridTile
-                                                                          locked={
-                                                                              hasRequiredFiltersForCurrentTab
+                                                                      <TrackSection
+                                                                          name={
+                                                                              SectionName.DASHBOARD_TILE
                                                                           }
-                                                                          index={
-                                                                              idx
-                                                                          }
-                                                                          isEditMode={
-                                                                              isEditMode
-                                                                          }
-                                                                          tile={
-                                                                              tile
-                                                                          }
-                                                                          onDelete={
-                                                                              handleDeleteTile
-                                                                          }
-                                                                          onEdit={
-                                                                              handleEditTile
-                                                                          }
-                                                                          tabs={
-                                                                              dashboardTabs
-                                                                          }
-                                                                          onAddTiles={
-                                                                              handleAddTiles
-                                                                          }
-                                                                      />
-                                                                  </TrackSection>
-                                                              </div>
-                                                          ),
-                                                      )}
-                                                  </ResponsiveGridLayout>
+                                                                      >
+                                                                          <GridTile
+                                                                              locked={
+                                                                                  hasRequiredFiltersForCurrentTab
+                                                                              }
+                                                                              index={
+                                                                                  idx
+                                                                              }
+                                                                              isEditMode={
+                                                                                  isEditMode
+                                                                              }
+                                                                              tile={
+                                                                                  tile
+                                                                              }
+                                                                              onDelete={
+                                                                                  handleDeleteTile
+                                                                              }
+                                                                              onEdit={
+                                                                                  handleEditTile
+                                                                              }
+                                                                              tabs={
+                                                                                  dashboardTabs
+                                                                              }
+                                                                              onAddTiles={
+                                                                                  handleAddTiles
+                                                                              }
+                                                                          />
+                                                                      </TrackSection>
+                                                                  </div>
+                                                              ),
+                                                          )}
+                                                      </ResponsiveGridLayout>
+                                                  </ErrorBoundary>
                                               )}
                                     </div>
                                 </Group>


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

wrap each grid layout (per tab) and each grid tile in ErrorBoundary. A render crash now degrades to a scoped error card / tab instead of full page failure 

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->