### PR TITLE
chore: add `@lightdash/formula` alias to sdk-test-app vite config

### DIFF
--- a/packages/sdk-test-app/vite.config.ts
+++ b/packages/sdk-test-app/vite.config.ts
@@ -27,6 +27,10 @@ export default defineConfig({
                 replacement: resolve(__dirname, '../common/src/index.ts'),
             },
             {
+                find: '@lightdash/formula',
+                replacement: resolve(__dirname, '../formula/src/index.ts'),
+            },
+            {
                 find: '@lightdash/sdk/sdk.css',
                 replacement: resolve(__dirname, '../frontend/sdk/dist/sdk.css'),
             },


### PR DESCRIPTION
Closes:

### Description:
Adds a path alias for `@lightdash/formula` in the SDK test app's Vite configuration, pointing to the local `packages/formula/src/index.ts` source. This allows the SDK test app to resolve the `@lightdash/formula` package directly from source during development, consistent with how `@lightdash/common` is already aliased.