### PR TITLE
fix: table calculations and custom metrics now use default_show_underlying_values

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4274,9 +4274,21 @@ export class AsyncQueryService extends ProjectService {
                 ? underlyingDataItem.showUnderlyingValues
                 : undefined;
 
-        const itemShowUnderlyingTable = isField(underlyingDataItem)
-            ? underlyingDataItem.table
-            : undefined;
+        const baseTableDefault =
+            explore.tables[explore.baseTable]?.defaultShowUnderlyingValues;
+
+        const effectiveShowUnderlyingValues =
+            itemShowUnderlyingValues ?? baseTableDefault;
+
+        // When using the base table default, scope unqualified names to the base table
+        let effectiveShowUnderlyingTable: string | undefined;
+        if (itemShowUnderlyingValues !== undefined) {
+            effectiveShowUnderlyingTable = isField(underlyingDataItem)
+                ? underlyingDataItem.table
+                : undefined;
+        } else if (baseTableDefault !== undefined) {
+            effectiveShowUnderlyingTable = explore.baseTable;
+        }
 
         const hasMissingParameters = (
             field:
@@ -4333,12 +4345,12 @@ export class AsyncQueryService extends ProjectService {
                 (isValidNonCustomDimension(dimension) ||
                     isCustomDimension(dimension));
             const hasExplicitColumnList =
-                itemShowUnderlyingValues !== undefined;
+                effectiveShowUnderlyingValues !== undefined;
             const isInExplicitColumnList =
                 hasExplicitColumnList &&
-                ((itemShowUnderlyingValues.includes(dimension.name) &&
-                    itemShowUnderlyingTable === dimension.table) ||
-                    itemShowUnderlyingValues.includes(
+                ((effectiveShowUnderlyingValues.includes(dimension.name) &&
+                    effectiveShowUnderlyingTable === dimension.table) ||
+                    effectiveShowUnderlyingValues.includes(
                         `${dimension.table}.${dimension.name}`,
                     ));
 
@@ -4360,12 +4372,12 @@ export class AsyncQueryService extends ProjectService {
         ).filter((metric) => {
             const isValid = availableTables.has(metric.table) && !metric.hidden;
             const hasExplicitColumnList =
-                itemShowUnderlyingValues !== undefined;
+                effectiveShowUnderlyingValues !== undefined;
             const isInExplicitColumnList =
                 hasExplicitColumnList &&
-                ((itemShowUnderlyingValues?.includes(metric.name) &&
-                    itemShowUnderlyingTable === metric.table) ||
-                    itemShowUnderlyingValues?.includes(
+                ((effectiveShowUnderlyingValues?.includes(metric.name) &&
+                    effectiveShowUnderlyingTable === metric.table) ||
+                    effectiveShowUnderlyingValues?.includes(
                         `${metric.table}.${metric.name}`,
                     ));
             if (isValid) {

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -1007,6 +1007,12 @@ export const convertTable = (
                   },
               }
             : {}),
+        ...(meta.default_show_underlying_values
+            ? {
+                  defaultShowUnderlyingValues:
+                      meta.default_show_underlying_values,
+              }
+            : {}),
         ...(meta.ai_hint ? { aiHint: convertToAiHints(meta.ai_hint) } : {}),
         ...(meta.parameters ? { parameters: meta.parameters } : {}),
         ...(meta.sets ? { sets: meta.sets } : {}),

--- a/packages/common/src/types/table.ts
+++ b/packages/common/src/types/table.ts
@@ -38,6 +38,7 @@ export type TableBase = {
     anyAttributes?: Record<string, string | string[]>;
     groupDetails?: Record<string, GroupType>;
     defaultTimeDimension?: DefaultTimeDimension;
+    defaultShowUnderlyingValues?: string[];
     aiHint?: string | string[];
     warnings?: InlineError[];
 };

--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
@@ -106,12 +106,17 @@ const UnderlyingDataModalContent: FC = () => {
     );
 
     const showUnderlyingValues: string[] | undefined = useMemo(() => {
-        return underlyingDataConfig?.item !== undefined &&
+        if (
+            underlyingDataConfig?.item !== undefined &&
             isField(underlyingDataConfig.item) &&
-            isMetric(underlyingDataConfig.item)
-            ? underlyingDataConfig?.item.showUnderlyingValues
-            : undefined;
-    }, [underlyingDataConfig?.item]);
+            isMetric(underlyingDataConfig.item) &&
+            underlyingDataConfig.item.showUnderlyingValues !== undefined
+        ) {
+            return underlyingDataConfig.item.showUnderlyingValues;
+        }
+        // Fallback to base table's default for table calculations and custom metrics
+        return explore?.tables[explore.baseTable]?.defaultShowUnderlyingValues;
+    }, [underlyingDataConfig?.item, explore]);
 
     const sortByUnderlyingValues = useCallback(
         (columnA: TableColumn, columnB: TableColumn) => {


### PR DESCRIPTION
## Summary
- Table calculations and custom metrics now respect the model-level `default_show_underlying_values` when viewing underlying data
- Previously, only regular metrics used this config; table calcs and custom metrics showed up to 50 unfiltered dimensions
- Stores `defaultShowUnderlyingValues` on the compiled table and falls back to it when the item has no `showUnderlyingValues`

## Changes
- `packages/common/src/types/table.ts` — Added `defaultShowUnderlyingValues` to `TableBase`
- `packages/common/src/compiler/translator.ts` — Persists `default_show_underlying_values` during table compilation
- `packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts` — Falls back to base table default when item lacks `showUnderlyingValues`
- `packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx` — Same fallback for column sorting

## Test url 

http://localhost:3000/projects/3675b69e-8324-4110-bdca-059031aa8da3/tables/payments?create_saved_chart_version=%7B%22tableName%22%3A%22payments%22%2C%22metricQuery%22%3A%7B%22exploreName%22%3A%22payments%22%2C%22dimensions%22%3A%5B%22payments_payment_method%22%5D%2C%22metrics%22%3A%5B%22payments_total_revenue%22%2C%22payments_payment_id_count%22%2C%22payments_total_order_amount_deduped%22%5D%2C%22filters%22%3A%7B%7D%2C%22sorts%22%3A%5B%7B%22fieldId%22%3A%22payments_payment_method%22%2C%22descending%22%3Afalse%7D%5D%2C%22limit%22%3A500%2C%22tableCalculations%22%3A%5B%7B%22name%22%3A%22double_revenue%22%2C%22displayName%22%3A%22Double+revenue%22%2C%22format%22%3A%7B%22type%22%3A%22default%22%2C%22separator%22%3A%22default%22%7D%2C%22type%22%3A%22number%22%2C%22sql%22%3A%22%24%7Bpayments.total_revenue%7D+*+2%22%7D%5D%2C%22additionalMetrics%22%3A%5B%7B%22name%22%3A%22payment_id_count%22%2C%22label%22%3A%22Payment+count%22%2C%22table%22%3A%22payments%22%2C%22sql%22%3A%22%24%7BTABLE%7D.payment_id%22%2C%22type%22%3A%22count_distinct%22%7D%5D%2C%22metricOverrides%22%3A%7B%7D%7D%2C%22tableConfig%22%3A%7B%22columnOrder%22%3A%5B%22payments_payment_method%22%2C%22payments_total_revenue%22%2C%22payments_payment_id_count%22%2C%22double_revenue%22%2C%22payments_total_order_amount_deduped%22%5D%7D%2C%22chartConfig%22%3A%7B%22type%22%3A%22cartesian%22%2C%22config%22%3A%7B%22layout%22%3A%7B%22xField%22%3A%22payments_payment_method%22%2C%22yField%22%3A%5B%22payments_total_revenue%22%5D%7D%2C%22eChartsConfig%22%3A%7B%22showAxisTicks%22%3Afalse%2C%22series%22%3A%5B%7B%22type%22%3A%22bar%22%2C%22yAxisIndex%22%3A0%2C%22encode%22%3A%7B%22xRef%22%3A%7B%22field%22%3A%22payments_payment_method%22%7D%2C%22yRef%22%3A%7B%22field%22%3A%22payments_total_revenue%22%7D%7D%2C%22isFilteredOut%22%3Afalse%7D%5D%7D%2C%22conditionalFormattings%22%3A%5B%5D%7D%7D%7D&isExploreFromHere=true

## Test plan
- [x] Verified table calculation "View underlying data" shows only configured columns
- [x] Regular metrics with own `show_underlying_values` still use their own list
- [x] Explores without `default_show_underlying_values` still show up to 50 dimensions
- [ ] Verify custom metric "View underlying data" shows configured columns
- [ ] Verify no regressions on regular metric underlying data

Closes PROD-7029

🤖 Generated with [Claude Code](https://claude.com/claude-code)