### PR TITLE
fix: shorten pivot anchor CTE suffixes to fit Postgres 63-char identifier limit

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/CLAUDE.md
+++ b/packages/backend/src/utils/QueryBuilder/CLAUDE.md
@@ -73,10 +73,10 @@ const { sql, parameterReferences } = builder.getSqlAndReferences();
 ```mermaid
 graph TD
     A[original_query] --> B[group_by_query]
-    B --> C["column_anchor — FIRST_VALUE per groupBy value"]
+    B --> C["{ref}_ca (column anchor) — FIRST_VALUE per groupBy value"]
     C --> D["column_ranking — DENSE_RANK for col_idx"]
     D --> E["anchor_column — picks col_idx = 1"]
-    E --> F["row_anchor — metric value at anchor column via CROSS JOIN"]
+    E --> F["{ref}_ra (row anchor) — metric value at anchor column via CROSS JOIN"]
     F --> G["row_ranking — DENSE_RANK for row_index"]
     D --> H["pivot_query — JOINs row_ranking + column_ranking"]
     G --> H
@@ -87,7 +87,7 @@ graph TD
 
 **Precomputed rankings for Databricks/Spark**: Databricks inlines CTEs instead of materializing them. When `pivot_query` had inline DENSE_RANK with anchor column references, Spark couldn't resolve them across the inlined CTE boundary. Fix: `row_ranking` and `column_ranking` are self-contained CTEs with their own JOINs; `pivot_query` just JOINs the precomputed results. This activates automatically when metric sorting + index columns are present.
 
-**CTE name quoting**: Anchor CTE names are derived from field names (e.g., `revenue_column_anchor`). Since field names can contain spaces, all dynamic CTE names must be quoted with `${q}${cteName}${q}`. Hardcoded CTE names (`row_ranking`, `pivot_query`, etc.) don't need quoting.
+**CTE name quoting**: Anchor CTE names are derived from field names (e.g., `revenue_ca` for column anchor, `revenue_ra` for row anchor). The `_ca`/`_ra` suffixes are kept short to stay within Postgres' 63-char identifier limit when field references are long. Since field names can contain spaces, all dynamic CTE names must be quoted with `${q}${cteName}${q}`. Hardcoded CTE names (`row_ranking`, `pivot_query`, etc.) don't need quoting.
 
 **Two-phase pivot**: PivotQueryBuilder outputs rows tagged with `row_index` + `column_index`. The actual pivot (spreading values into `{field}_{aggregation}_{groupByValue}` columns) happens in `AsyncQueryService.runQueryAndTransformRows` which streams results and pivots on `row_index` changes.
 

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -397,7 +397,7 @@ describe('PivotQueryBuilder', () => {
             expect(result).not.toContain('anchor_column AS (');
 
             // Should NOT create row anchor CTEs for revenue
-            expect(result).not.toContain('"revenue_row_anchor" AS (');
+            expect(result).not.toContain('"revenue_ra" AS (');
         });
 
         test('Dimension sort: should NOT create metric anchor CTEs when sorting by groupBy column', () => {
@@ -433,8 +433,8 @@ describe('PivotQueryBuilder', () => {
             expect(result).not.toContain('anchor_column AS (');
 
             // Should NOT create metric anchor CTEs
-            expect(result).not.toContain('"revenue_row_anchor" AS (');
-            expect(result).not.toContain('"revenue_column_anchor" AS (');
+            expect(result).not.toContain('"revenue_ra" AS (');
+            expect(result).not.toContain('"revenue_ca" AS (');
         });
 
         test('Metric sort: should create column_ranking and anchor_column CTEs when sorting by value column', () => {
@@ -463,7 +463,7 @@ describe('PivotQueryBuilder', () => {
             // Metric sort: should create column_ranking CTE to compute column_index per groupBy value
             expect(result).toContain('column_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC',
             );
 
             // Metric sort: should create anchor_column CTE to identify first pivot column (column_index = 1)
@@ -475,7 +475,7 @@ describe('PivotQueryBuilder', () => {
 
             // Metric sort: row anchor should use CROSS JOIN with anchor_column
             // (gets metric value at first pivot column only, not MIN/MAX across all columns)
-            expect(result).toContain('"revenue_row_anchor" AS (');
+            expect(result).toContain('"revenue_ra" AS (');
             expect(replaceWhitespace(result)).toContain(
                 'MAX(CASE WHEN (q."category" = ac."anchor_category" OR (q."category" IS NULL AND ac."anchor_category" IS NULL)) THEN q."revenue_sum" END)',
             );
@@ -506,28 +506,28 @@ describe('PivotQueryBuilder', () => {
             const result = builder.toSql();
 
             // Should add additional CTEs for metric first values
-            expect(result).toContain('"revenue_row_anchor" AS (');
-            expect(result).toContain('"revenue_column_anchor" AS (');
+            expect(result).toContain('"revenue_ra" AS (');
+            expect(result).toContain('"revenue_ca" AS (');
 
             // row_ranking CTE should join with row_anchor and compute DENSE_RANK
             expect(result).toContain('row_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'JOIN "revenue_row_anchor" ON (g."date" = "revenue_row_anchor"."date" OR (g."date" IS NULL AND "revenue_row_anchor"."date" IS NULL))',
+                'JOIN "revenue_ra" ON (g."date" = "revenue_ra"."date" OR (g."date" IS NULL AND "revenue_ra"."date" IS NULL))',
             );
 
             // column_ranking CTE should join with column_anchor and compute DENSE_RANK
             expect(replaceWhitespace(result)).toContain(
-                'JOIN "revenue_column_anchor" ON (g."category" = "revenue_column_anchor"."category" OR (g."category" IS NULL AND "revenue_column_anchor"."category" IS NULL))',
+                'JOIN "revenue_ca" ON (g."category" = "revenue_ca"."category" OR (g."category" IS NULL AND "revenue_ca"."category" IS NULL))',
             );
 
             // Row index should be computed in row_ranking CTE (not in pivot_query)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" DESC, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC, g."date" ASC) AS "row_index"',
             );
 
             // Column index should be computed in column_ranking CTE (not in pivot_query)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC, g."category" ASC) AS "col_idx"',
             );
 
             // pivot_query should JOIN with precomputed rankings
@@ -569,7 +569,7 @@ describe('PivotQueryBuilder', () => {
 
             // Row index order must follow: revenue anchor ASC, store_id DESC, then date ASC (appended)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" ASC, g."store_id" DESC, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" ASC, g."store_id" DESC, g."date" ASC) AS "row_index"',
             );
         });
 
@@ -642,7 +642,7 @@ describe('PivotQueryBuilder', () => {
             // row_ranking CTE should compute row_index with DENSE_RANK in a self-contained CTE
             expect(result).toContain('row_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'row_ranking AS (SELECT DISTINCT g."date", DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" DESC, g."date" ASC) AS "row_index" FROM group_by_query g LEFT JOIN "revenue_row_anchor" ON (g."date" = "revenue_row_anchor"."date" OR (g."date" IS NULL AND "revenue_row_anchor"."date" IS NULL)))',
+                'row_ranking AS (SELECT DISTINCT g."date", DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC, g."date" ASC) AS "row_index" FROM group_by_query g LEFT JOIN "revenue_ra" ON (g."date" = "revenue_ra"."date" OR (g."date" IS NULL AND "revenue_ra"."date" IS NULL)))',
             );
 
             // pivot_query should JOIN with precomputed rankings instead of computing Window functions
@@ -2059,7 +2059,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Check that row_index ORDER BY has NULLS LAST
             expect(replaceWhitespace(result)).toContain(
-                '"revenue_row_anchor"."revenue_row_anchor_value" DESC NULLS LAST',
+                '"revenue_ra"."revenue_ra_value" DESC NULLS LAST',
             );
 
             // Check column anchor CTE has NULLS LAST
@@ -2097,7 +2097,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Row index should include NULLS FIRST when sorting by value column
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" ASC NULLS FIRST, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" ASC NULLS FIRST, g."date" ASC) AS "row_index"',
             );
         });
 
@@ -2130,7 +2130,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Column index should include NULLS LAST in column_ranking CTE
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC NULLS LAST, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC NULLS LAST, g."category" ASC) AS "col_idx"',
             );
         });
 
@@ -2231,13 +2231,11 @@ SELECT * FROM group_by_query LIMIT 50`);
             const result = builder.toSql();
 
             // Should use LEFT JOIN for both row and column anchor CTEs
-            expect(result).toContain('LEFT JOIN "revenue_row_anchor" ON');
-            expect(result).toContain('LEFT JOIN "revenue_column_anchor" ON');
+            expect(result).toContain('LEFT JOIN "revenue_ra" ON');
+            expect(result).toContain('LEFT JOIN "revenue_ca" ON');
             // Should not use regular JOIN (without LEFT)
-            expect(result).not.toMatch(/(?<!LEFT )JOIN "revenue_row_anchor"/);
-            expect(result).not.toMatch(
-                /(?<!LEFT )JOIN "revenue_column_anchor"/,
-            );
+            expect(result).not.toMatch(/(?<!LEFT )JOIN "revenue_ra"/);
+            expect(result).not.toMatch(/(?<!LEFT )JOIN "revenue_ca"/);
         });
     });
 
@@ -4372,7 +4370,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // https://github.com/lightdash/lightdash/issues/20683
             // Repro: a metric named "AVERAGE TAX RATE 2" combined with a
             // pivot + metric sort. The pivot pipeline derives CTE names like
-            // "events_AVERAGE TAX RATE 2_column_anchor" from field references,
+            // "events_AVERAGE TAX RATE 2_ca" from field references,
             // and an unquoted CTE name in WITH or in LEFT JOIN broke with
             // `syntax error at or near "TAX"`.
             // Expectation: anchor CTE names AND every JOIN target are wrapped
@@ -4404,31 +4402,25 @@ SELECT * FROM group_by_query LIMIT 50`);
             const result = builder.toSql();
 
             // CTE definitions in the WITH clause must be quoted.
-            expect(result).toContain(`"${fieldWithSpaces}_column_anchor" AS (`);
-            expect(result).toContain(`"${fieldWithSpaces}_row_anchor" AS (`);
+            expect(result).toContain(`"${fieldWithSpaces}_ca" AS (`);
+            expect(result).toContain(`"${fieldWithSpaces}_ra" AS (`);
 
             // Every reference of those CTEs (LEFT JOIN, qualified column
             // accesses) must also be quoted — the original bug was unquoted
             // names appearing in JOIN clauses, not just CTE definitions.
+            expect(result).toContain(`LEFT JOIN "${fieldWithSpaces}_ra"`);
+            expect(result).toContain(`LEFT JOIN "${fieldWithSpaces}_ca"`);
             expect(result).toContain(
-                `LEFT JOIN "${fieldWithSpaces}_row_anchor"`,
+                `"${fieldWithSpaces}_ca"."${fieldWithSpaces}_ca_value"`,
             );
             expect(result).toContain(
-                `LEFT JOIN "${fieldWithSpaces}_column_anchor"`,
-            );
-            expect(result).toContain(
-                `"${fieldWithSpaces}_column_anchor"."${fieldWithSpaces}_column_anchor_value"`,
-            );
-            expect(result).toContain(
-                `"${fieldWithSpaces}_row_anchor"."${fieldWithSpaces}_row_anchor_value"`,
+                `"${fieldWithSpaces}_ra"."${fieldWithSpaces}_ra_value"`,
             );
 
             // The bare unquoted form must not appear anywhere — that is what
             // would produce the original `syntax error at or near "TAX"`.
-            expect(result).not.toContain(`${fieldWithSpaces}_column_anchor AS`);
-            expect(result).not.toContain(
-                `LEFT JOIN ${fieldWithSpaces}_row_anchor`,
-            );
+            expect(result).not.toContain(`${fieldWithSpaces}_ca AS`);
+            expect(result).not.toContain(`LEFT JOIN ${fieldWithSpaces}_ra`);
         });
 
         test('Pivot SQL on Databricks emits self-contained row_ranking + column_ranking CTEs for metric sort (#20681)', () => {
@@ -4481,7 +4473,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // row_ranking is self-contained: it owns its JOIN to row_anchor
             // and produces row_index as a concrete output column.
             expect(replaceWhitespace(result)).toContain(
-                'row_ranking AS (SELECT DISTINCT g.`event_tier`, DENSE_RANK() OVER (ORDER BY `count_row_anchor`.`count_row_anchor_value` DESC, g.`event_tier` ASC) AS `row_index` FROM group_by_query g LEFT JOIN `count_row_anchor` ON (g.`event_tier` = `count_row_anchor`.`event_tier` OR (g.`event_tier` IS NULL AND `count_row_anchor`.`event_tier` IS NULL)))',
+                'row_ranking AS (SELECT DISTINCT g.`event_tier`, DENSE_RANK() OVER (ORDER BY `count_ra`.`count_ra_value` DESC, g.`event_tier` ASC) AS `row_index` FROM group_by_query g LEFT JOIN `count_ra` ON (g.`event_tier` = `count_ra`.`event_tier` OR (g.`event_tier` IS NULL AND `count_ra`.`event_tier` IS NULL)))',
             );
 
             // pivot_query just joins precomputed rankings — no inline
@@ -4542,7 +4534,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // row_ranking and row_anchor have no work without row dimensions.
             expect(result).not.toContain('row_ranking AS (');
-            expect(result).not.toContain('`count_row_anchor`');
+            expect(result).not.toContain('`count_ra`');
 
             // pivot_query must take the precomputed-rankings shape:
             //   - no inline DENSE_RANK (the bug shape that references
@@ -4606,7 +4598,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // column_ranking ORDER BY echoes the NULLS treatment for the
             // anchor value, then falls back to the groupBy field as tiebreaker.
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC NULLS FIRST, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC NULLS FIRST, g."category" ASC) AS "col_idx"',
             );
 
             // row_index ORDER BY combines BOTH sort entries with their own
@@ -4614,7 +4606,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // NULLS LAST. A regression that drops the per-entry nulls flag
             // would collapse one of these.
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" DESC NULLS FIRST, g."date" ASC NULLS LAST) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC NULLS FIRST, g."date" ASC NULLS LAST) AS "row_index"',
             );
         });
 
@@ -4714,8 +4706,8 @@ SELECT * FROM group_by_query LIMIT 50`);
             const result = builder.toSql();
 
             // Both sort metrics produce a column_anchor CTE.
-            expect(result).toContain('"revenue_column_anchor" AS (');
-            expect(result).toContain('"orders_column_anchor" AS (');
+            expect(result).toContain('"revenue_ca" AS (');
+            expect(result).toContain('"orders_ca" AS (');
 
             // Count is the assertion: every FIRST_VALUE must be paired with a
             // ROWS BETWEEN frame clause. A regression that leaves frames off
@@ -5109,11 +5101,9 @@ SELECT * FROM group_by_query LIMIT 50`);
             // scoped to just that CTE rather than the whole SQL. Nested
             // parens inside FIRST_VALUE / OVER (...) make a regex slice
             // brittle, so use named CTE markers as bounds.
-            const colAnchorStart = collapsed.indexOf(
-                '"revenue_column_anchor" AS (',
-            );
+            const colAnchorStart = collapsed.indexOf('"revenue_ca" AS (');
             const rowAnchorStart = collapsed.indexOf(
-                '"revenue_row_anchor" AS (',
+                '"revenue_ra" AS (',
                 colAnchorStart,
             );
             expect(colAnchorStart).toBeGreaterThanOrEqual(0);
@@ -5134,6 +5124,51 @@ SELECT * FROM group_by_query LIMIT 50`);
             // Mixing them up is the documented regression path.
             expect(colAnchorBody).not.toContain('MAX(CASE WHEN');
             expect(colAnchorBody).not.toContain('CROSS JOIN anchor_column');
+        });
+
+        test('Anchor CTE identifiers stay within the Postgres 63-byte limit for long field references (#21401)', () => {
+            // https://github.com/lightdash/lightdash/issues/21401 / Pylon #12225
+            // Repro: a metric with a 49-char reference combined with a pivot
+            // metric sort. Anchor CTE suffixes used to be `_column_anchor_value`
+            // (20 chars), so `{ref}_column_anchor_value` overflowed Postgres'
+            // 63-byte identifier limit and silently truncated, breaking the
+            // JOIN to the anchor CTE.
+            // Expectation: every quoted identifier in the emitted SQL fits in
+            // 63 bytes, and the anchor CTEs use the short `_ca` / `_ra`
+            // suffixes that buy ~17 chars of headroom for the field reference.
+            const longRef = 'fct_tickets_ticket_id_count_distinct_of_ticket_id';
+
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: longRef,
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: longRef, direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Every quoted identifier must fit in Postgres' 63-byte limit.
+            const overlong = (result.match(/"[^"]+"/g) ?? []).filter(
+                (q) => q.length - 2 > 63,
+            );
+            expect(overlong).toEqual([]);
+
+            // Sanity check: anchor CTEs use the short suffixes.
+            expect(result).toContain(`"${longRef}_ca" AS (`);
+            expect(result).toContain(`"${longRef}_ra" AS (`);
         });
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.test.ts
@@ -387,7 +387,7 @@ describe('PivotQueryBuilder', () => {
             expect(result).not.toContain('anchor_column AS (');
 
             // Should NOT create row anchor CTEs for revenue
-            expect(result).not.toContain('"revenue_row_anchor" AS (');
+            expect(result).not.toContain('"revenue_ra" AS (');
         });
 
         test('Dimension sort: should NOT create metric anchor CTEs when sorting by groupBy column', () => {
@@ -423,8 +423,8 @@ describe('PivotQueryBuilder', () => {
             expect(result).not.toContain('anchor_column AS (');
 
             // Should NOT create metric anchor CTEs
-            expect(result).not.toContain('"revenue_row_anchor" AS (');
-            expect(result).not.toContain('"revenue_column_anchor" AS (');
+            expect(result).not.toContain('"revenue_ra" AS (');
+            expect(result).not.toContain('"revenue_ca" AS (');
         });
 
         test('Metric sort: should create column_ranking and anchor_column CTEs when sorting by value column', () => {
@@ -453,7 +453,7 @@ describe('PivotQueryBuilder', () => {
             // Metric sort: should create column_ranking CTE to compute column_index per groupBy value
             expect(result).toContain('column_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC',
             );
 
             // Metric sort: should create anchor_column CTE to identify first pivot column (column_index = 1)
@@ -465,7 +465,7 @@ describe('PivotQueryBuilder', () => {
 
             // Metric sort: row anchor should use CROSS JOIN with anchor_column
             // (gets metric value at first pivot column only, not MIN/MAX across all columns)
-            expect(result).toContain('"revenue_row_anchor" AS (');
+            expect(result).toContain('"revenue_ra" AS (');
             expect(replaceWhitespace(result)).toContain(
                 'MAX(CASE WHEN (q."category" = ac."anchor_category" OR (q."category" IS NULL AND ac."anchor_category" IS NULL)) THEN q."revenue_sum" END)',
             );
@@ -496,28 +496,28 @@ describe('PivotQueryBuilder', () => {
             const result = builder.toSql();
 
             // Should add additional CTEs for metric first values
-            expect(result).toContain('"revenue_row_anchor" AS (');
-            expect(result).toContain('"revenue_column_anchor" AS (');
+            expect(result).toContain('"revenue_ra" AS (');
+            expect(result).toContain('"revenue_ca" AS (');
 
             // row_ranking CTE should join with row_anchor and compute DENSE_RANK
             expect(result).toContain('row_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'JOIN "revenue_row_anchor" ON (g."date" = "revenue_row_anchor"."date" OR (g."date" IS NULL AND "revenue_row_anchor"."date" IS NULL))',
+                'JOIN "revenue_ra" ON (g."date" = "revenue_ra"."date" OR (g."date" IS NULL AND "revenue_ra"."date" IS NULL))',
             );
 
             // column_ranking CTE should join with column_anchor and compute DENSE_RANK
             expect(replaceWhitespace(result)).toContain(
-                'JOIN "revenue_column_anchor" ON (g."category" = "revenue_column_anchor"."category" OR (g."category" IS NULL AND "revenue_column_anchor"."category" IS NULL))',
+                'JOIN "revenue_ca" ON (g."category" = "revenue_ca"."category" OR (g."category" IS NULL AND "revenue_ca"."category" IS NULL))',
             );
 
             // Row index should be computed in row_ranking CTE (not in pivot_query)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" DESC, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC, g."date" ASC) AS "row_index"',
             );
 
             // Column index should be computed in column_ranking CTE (not in pivot_query)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC, g."category" ASC) AS "col_idx"',
             );
 
             // pivot_query should JOIN with precomputed rankings
@@ -559,7 +559,7 @@ describe('PivotQueryBuilder', () => {
 
             // Row index order must follow: revenue anchor ASC, store_id DESC, then date ASC (appended)
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" ASC, g."store_id" DESC, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" ASC, g."store_id" DESC, g."date" ASC) AS "row_index"',
             );
         });
 
@@ -632,7 +632,7 @@ describe('PivotQueryBuilder', () => {
             // row_ranking CTE should compute row_index with DENSE_RANK in a self-contained CTE
             expect(result).toContain('row_ranking AS (');
             expect(replaceWhitespace(result)).toContain(
-                'row_ranking AS (SELECT DISTINCT g."date", DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" DESC, g."date" ASC) AS "row_index" FROM group_by_query g LEFT JOIN "revenue_row_anchor" ON (g."date" = "revenue_row_anchor"."date" OR (g."date" IS NULL AND "revenue_row_anchor"."date" IS NULL)))',
+                'row_ranking AS (SELECT DISTINCT g."date", DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC, g."date" ASC) AS "row_index" FROM group_by_query g LEFT JOIN "revenue_ra" ON (g."date" = "revenue_ra"."date" OR (g."date" IS NULL AND "revenue_ra"."date" IS NULL)))',
             );
 
             // pivot_query should JOIN with precomputed rankings instead of computing Window functions
@@ -1637,7 +1637,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Check that row_index ORDER BY has NULLS LAST
             expect(replaceWhitespace(result)).toContain(
-                '"revenue_row_anchor"."revenue_row_anchor_value" DESC NULLS LAST',
+                '"revenue_ra"."revenue_ra_value" DESC NULLS LAST',
             );
 
             // Check column anchor CTE has NULLS LAST
@@ -1675,7 +1675,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Row index should include NULLS FIRST when sorting by value column
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" ASC NULLS FIRST, g."date" ASC) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" ASC NULLS FIRST, g."date" ASC) AS "row_index"',
             );
         });
 
@@ -1708,7 +1708,7 @@ SELECT * FROM group_by_query LIMIT 50`);
 
             // Column index should include NULLS LAST in column_ranking CTE
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC NULLS LAST, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC NULLS LAST, g."category" ASC) AS "col_idx"',
             );
         });
 
@@ -1809,13 +1809,11 @@ SELECT * FROM group_by_query LIMIT 50`);
             const result = builder.toSql();
 
             // Should use LEFT JOIN for both row and column anchor CTEs
-            expect(result).toContain('LEFT JOIN "revenue_row_anchor" ON');
-            expect(result).toContain('LEFT JOIN "revenue_column_anchor" ON');
+            expect(result).toContain('LEFT JOIN "revenue_ra" ON');
+            expect(result).toContain('LEFT JOIN "revenue_ca" ON');
             // Should not use regular JOIN (without LEFT)
-            expect(result).not.toMatch(/(?<!LEFT )JOIN "revenue_row_anchor"/);
-            expect(result).not.toMatch(
-                /(?<!LEFT )JOIN "revenue_column_anchor"/,
-            );
+            expect(result).not.toMatch(/(?<!LEFT )JOIN "revenue_ra"/);
+            expect(result).not.toMatch(/(?<!LEFT )JOIN "revenue_ca"/);
         });
     });
 
@@ -3950,7 +3948,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // https://github.com/lightdash/lightdash/issues/20683
             // Repro: a metric named "AVERAGE TAX RATE 2" combined with a
             // pivot + metric sort. The pivot pipeline derives CTE names like
-            // "events_AVERAGE TAX RATE 2_column_anchor" from field references,
+            // "events_AVERAGE TAX RATE 2_ca" from field references,
             // and an unquoted CTE name in WITH or in LEFT JOIN broke with
             // `syntax error at or near "TAX"`.
             // Expectation: anchor CTE names AND every JOIN target are wrapped
@@ -3982,31 +3980,25 @@ SELECT * FROM group_by_query LIMIT 50`);
             const result = builder.toSql();
 
             // CTE definitions in the WITH clause must be quoted.
-            expect(result).toContain(`"${fieldWithSpaces}_column_anchor" AS (`);
-            expect(result).toContain(`"${fieldWithSpaces}_row_anchor" AS (`);
+            expect(result).toContain(`"${fieldWithSpaces}_ca" AS (`);
+            expect(result).toContain(`"${fieldWithSpaces}_ra" AS (`);
 
             // Every reference of those CTEs (LEFT JOIN, qualified column
             // accesses) must also be quoted — the original bug was unquoted
             // names appearing in JOIN clauses, not just CTE definitions.
+            expect(result).toContain(`LEFT JOIN "${fieldWithSpaces}_ra"`);
+            expect(result).toContain(`LEFT JOIN "${fieldWithSpaces}_ca"`);
             expect(result).toContain(
-                `LEFT JOIN "${fieldWithSpaces}_row_anchor"`,
+                `"${fieldWithSpaces}_ca"."${fieldWithSpaces}_ca_value"`,
             );
             expect(result).toContain(
-                `LEFT JOIN "${fieldWithSpaces}_column_anchor"`,
-            );
-            expect(result).toContain(
-                `"${fieldWithSpaces}_column_anchor"."${fieldWithSpaces}_column_anchor_value"`,
-            );
-            expect(result).toContain(
-                `"${fieldWithSpaces}_row_anchor"."${fieldWithSpaces}_row_anchor_value"`,
+                `"${fieldWithSpaces}_ra"."${fieldWithSpaces}_ra_value"`,
             );
 
             // The bare unquoted form must not appear anywhere — that is what
             // would produce the original `syntax error at or near "TAX"`.
-            expect(result).not.toContain(`${fieldWithSpaces}_column_anchor AS`);
-            expect(result).not.toContain(
-                `LEFT JOIN ${fieldWithSpaces}_row_anchor`,
-            );
+            expect(result).not.toContain(`${fieldWithSpaces}_ca AS`);
+            expect(result).not.toContain(`LEFT JOIN ${fieldWithSpaces}_ra`);
         });
 
         test('Pivot SQL on Databricks emits self-contained row_ranking + column_ranking CTEs for metric sort (#20681)', () => {
@@ -4059,7 +4051,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // row_ranking is self-contained: it owns its JOIN to row_anchor
             // and produces row_index as a concrete output column.
             expect(replaceWhitespace(result)).toContain(
-                'row_ranking AS (SELECT DISTINCT g.`event_tier`, DENSE_RANK() OVER (ORDER BY `count_row_anchor`.`count_row_anchor_value` DESC, g.`event_tier` ASC) AS `row_index` FROM group_by_query g LEFT JOIN `count_row_anchor` ON (g.`event_tier` = `count_row_anchor`.`event_tier` OR (g.`event_tier` IS NULL AND `count_row_anchor`.`event_tier` IS NULL)))',
+                'row_ranking AS (SELECT DISTINCT g.`event_tier`, DENSE_RANK() OVER (ORDER BY `count_ra`.`count_ra_value` DESC, g.`event_tier` ASC) AS `row_index` FROM group_by_query g LEFT JOIN `count_ra` ON (g.`event_tier` = `count_ra`.`event_tier` OR (g.`event_tier` IS NULL AND `count_ra`.`event_tier` IS NULL)))',
             );
 
             // pivot_query just joins precomputed rankings — no inline
@@ -4122,7 +4114,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // column_ranking ORDER BY echoes the NULLS treatment for the
             // anchor value, then falls back to the groupBy field as tiebreaker.
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_column_anchor"."revenue_column_anchor_value" DESC NULLS FIRST, g."category" ASC) AS "col_idx"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ca"."revenue_ca_value" DESC NULLS FIRST, g."category" ASC) AS "col_idx"',
             );
 
             // row_index ORDER BY combines BOTH sort entries with their own
@@ -4130,7 +4122,7 @@ SELECT * FROM group_by_query LIMIT 50`);
             // NULLS LAST. A regression that drops the per-entry nulls flag
             // would collapse one of these.
             expect(replaceWhitespace(result)).toContain(
-                'DENSE_RANK() OVER (ORDER BY "revenue_row_anchor"."revenue_row_anchor_value" DESC NULLS FIRST, g."date" ASC NULLS LAST) AS "row_index"',
+                'DENSE_RANK() OVER (ORDER BY "revenue_ra"."revenue_ra_value" DESC NULLS FIRST, g."date" ASC NULLS LAST) AS "row_index"',
             );
         });
 
@@ -4230,8 +4222,8 @@ SELECT * FROM group_by_query LIMIT 50`);
             const result = builder.toSql();
 
             // Both sort metrics produce a column_anchor CTE.
-            expect(result).toContain('"revenue_column_anchor" AS (');
-            expect(result).toContain('"orders_column_anchor" AS (');
+            expect(result).toContain('"revenue_ca" AS (');
+            expect(result).toContain('"orders_ca" AS (');
 
             // Count is the assertion: every FIRST_VALUE must be paired with a
             // ROWS BETWEEN frame clause. A regression that leaves frames off
@@ -4625,11 +4617,9 @@ SELECT * FROM group_by_query LIMIT 50`);
             // scoped to just that CTE rather than the whole SQL. Nested
             // parens inside FIRST_VALUE / OVER (...) make a regex slice
             // brittle, so use named CTE markers as bounds.
-            const colAnchorStart = collapsed.indexOf(
-                '"revenue_column_anchor" AS (',
-            );
+            const colAnchorStart = collapsed.indexOf('"revenue_ca" AS (');
             const rowAnchorStart = collapsed.indexOf(
-                '"revenue_row_anchor" AS (',
+                '"revenue_ra" AS (',
                 colAnchorStart,
             );
             expect(colAnchorStart).toBeGreaterThanOrEqual(0);
@@ -4650,6 +4640,51 @@ SELECT * FROM group_by_query LIMIT 50`);
             // Mixing them up is the documented regression path.
             expect(colAnchorBody).not.toContain('MAX(CASE WHEN');
             expect(colAnchorBody).not.toContain('CROSS JOIN anchor_column');
+        });
+
+        test('Anchor CTE identifiers stay within the Postgres 63-byte limit for long field references (#21401)', () => {
+            // https://github.com/lightdash/lightdash/issues/21401 / Pylon #12225
+            // Repro: a metric with a 49-char reference combined with a pivot
+            // metric sort. Anchor CTE suffixes used to be `_column_anchor_value`
+            // (20 chars), so `{ref}_column_anchor_value` overflowed Postgres'
+            // 63-byte identifier limit and silently truncated, breaking the
+            // JOIN to the anchor CTE.
+            // Expectation: every quoted identifier in the emitted SQL fits in
+            // 63 bytes, and the anchor CTEs use the short `_ca` / `_ra`
+            // suffixes that buy ~17 chars of headroom for the field reference.
+            const longRef = 'fct_tickets_ticket_id_count_distinct_of_ticket_id';
+
+            const pivotConfiguration = {
+                indexColumn: [{ reference: 'date', type: VizIndexType.TIME }],
+                valuesColumns: [
+                    {
+                        reference: longRef,
+                        aggregation: VizAggregationOptions.SUM,
+                    },
+                ],
+                groupByColumns: [{ reference: 'category' }],
+                sortBy: [
+                    { reference: longRef, direction: SortByDirection.DESC },
+                ],
+            };
+
+            const builder = new PivotQueryBuilder(
+                baseSql,
+                pivotConfiguration,
+                mockWarehouseSqlBuilder,
+            );
+
+            const result = builder.toSql();
+
+            // Every quoted identifier must fit in Postgres' 63-byte limit.
+            const overlong = (result.match(/"[^"]+"/g) ?? []).filter(
+                (q) => q.length - 2 > 63,
+            );
+            expect(overlong).toEqual([]);
+
+            // Sanity check: anchor CTEs use the short suffixes.
+            expect(result).toContain(`"${longRef}_ca" AS (`);
+            expect(result).toContain(`"${longRef}_ra" AS (`);
         });
     });
 });

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -511,7 +511,7 @@ export class PivotQueryBuilder {
                     const nullsClause = PivotQueryBuilder.getNullsFirstLast(
                         sort.nullsFirst,
                     );
-                    const colAnchorCteName = `${sort.reference}_column_anchor`;
+                    const colAnchorCteName = `${sort.reference}_ca`;
                     if (metricFirstValueQueries[colAnchorCteName]) {
                         acc.push(
                             `${q}${colAnchorCteName}${q}.${q}${colAnchorCteName}_value${q}${sortDirection}${nullsClause}`,
@@ -602,7 +602,7 @@ export class PivotQueryBuilder {
 
             if (isValueColumn) {
                 // Use the anchor value from the row anchor CTE
-                const rowAnchorCteName = `${sort.reference}_row_anchor`;
+                const rowAnchorCteName = `${sort.reference}_ra`;
                 if (metricFirstValueQueries[rowAnchorCteName]) {
                     const nullsClause = PivotQueryBuilder.getNullsFirstLast(
                         sort.nullsFirst,
@@ -686,7 +686,7 @@ export class PivotQueryBuilder {
                 sortConfig.nullsFirst,
             );
 
-            const colAnchorCteName = `${valCol.reference}_column_anchor`;
+            const colAnchorCteName = `${valCol.reference}_ca`;
             const groupColumnReferences = groupByColumns
                 .map((col) => `${q}${col.reference}${q}`)
                 .join(', ');
@@ -938,7 +938,7 @@ export class PivotQueryBuilder {
                 valCol.aggregation,
             );
 
-            const rowAnchorCteName = `${valCol.reference}_row_anchor`;
+            const rowAnchorCteName = `${valCol.reference}_ra`;
             const anchorCteName =
                 perMetricAnchorCte?.get(valCol.reference) ?? 'anchor_column';
             const anchorCteRef =
@@ -999,7 +999,7 @@ export class PivotQueryBuilder {
         // When sorting by a metric value, we need the column_ranking CTE so
         // that pivot_query can read col_idx from a precomputed scope instead
         // of emitting an inline Window ORDER BY that references the sibling
-        // *_column_anchor CTE — Databricks/Spark inlines those CTEs and can't
+        // *_ca CTE — Databricks/Spark inlines those CTEs and can't
         // resolve the cross-CTE column reference inside a Window function.
         // Row anchor CTEs (and the anchor_column CTE that feeds them) only
         // make sense when there are row dimensions to rank — without them
@@ -1231,7 +1231,7 @@ export class PivotQueryBuilder {
         // Add joins for metric first value CTEs
         // Use LEFT JOIN to preserve all rows even when anchor values are NULL
         Object.values(metricFirstValueQueries).forEach(({ cteName }) => {
-            if (cteName.endsWith('_row_anchor')) {
+            if (cteName.endsWith('_ra')) {
                 // Join on index columns for row anchor CTEs
                 // Skip if no index columns (row anchor CTEs shouldn't exist in this case)
                 if (indexColumns.length > 0) {
@@ -1247,7 +1247,7 @@ export class PivotQueryBuilder {
                         `LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`,
                     );
                 }
-            } else if (cteName.endsWith('_column_anchor')) {
+            } else if (cteName.endsWith('_ca')) {
                 // Join on group columns for column anchor CTEs
                 const joinConditions = groupByColumns
                     .map((col) =>
@@ -1450,7 +1450,7 @@ export class PivotQueryBuilder {
             // Extract only row anchor queries for the row_ranking CTE
             const rowAnchorQueries = Object.fromEntries(
                 Object.entries(metricFirstValueQueries).filter(([key]) =>
-                    key.endsWith('_row_anchor'),
+                    key.endsWith('_ra'),
                 ),
             );
             const rowRankingSQL = this.getRowRankingSQL(

--- a/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/PivotQueryBuilder.ts
@@ -504,7 +504,7 @@ export class PivotQueryBuilder {
                         sort.nullsFirst,
                     );
                     // Use column anchor value for value columns
-                    const colAnchorCteName = `${sort.reference}_column_anchor`;
+                    const colAnchorCteName = `${sort.reference}_ca`;
 
                     // todo: current SQL does not work with value sorting and multiple group columns
                     if (
@@ -600,7 +600,7 @@ export class PivotQueryBuilder {
 
             if (isValueColumn) {
                 // Use the anchor value from the row anchor CTE
-                const rowAnchorCteName = `${sort.reference}_row_anchor`;
+                const rowAnchorCteName = `${sort.reference}_ra`;
                 if (metricFirstValueQueries[rowAnchorCteName]) {
                     const nullsClause = PivotQueryBuilder.getNullsFirstLast(
                         sort.nullsFirst,
@@ -684,7 +684,7 @@ export class PivotQueryBuilder {
                 sortConfig.nullsFirst,
             );
 
-            const colAnchorCteName = `${valCol.reference}_column_anchor`;
+            const colAnchorCteName = `${valCol.reference}_ca`;
             const groupColumnReferences = groupByColumns
                 .map((col) => `${q}${col.reference}${q}`)
                 .join(', ');
@@ -848,7 +848,7 @@ export class PivotQueryBuilder {
                 valCol.aggregation,
             );
 
-            const rowAnchorCteName = `${valCol.reference}_row_anchor`;
+            const rowAnchorCteName = `${valCol.reference}_ra`;
 
             // Use CROSS JOIN with anchor_column and conditional aggregation
             // MAX is used because there should be at most one value per (indexCols, anchorCol)
@@ -1103,7 +1103,7 @@ export class PivotQueryBuilder {
         // Add joins for metric first value CTEs
         // Use LEFT JOIN to preserve all rows even when anchor values are NULL
         Object.values(metricFirstValueQueries).forEach(({ cteName }) => {
-            if (cteName.endsWith('_row_anchor')) {
+            if (cteName.endsWith('_ra')) {
                 // Join on index columns for row anchor CTEs
                 // Skip if no index columns (row anchor CTEs shouldn't exist in this case)
                 if (indexColumns.length > 0) {
@@ -1119,7 +1119,7 @@ export class PivotQueryBuilder {
                         `LEFT JOIN ${q}${cteName}${q} ON ${joinConditions}`,
                     );
                 }
-            } else if (cteName.endsWith('_column_anchor')) {
+            } else if (cteName.endsWith('_ca')) {
                 // Join on group columns for column anchor CTEs
                 const joinConditions = groupByColumns
                     .map((col) =>
@@ -1320,7 +1320,7 @@ export class PivotQueryBuilder {
             // Extract only row anchor queries for the row_ranking CTE
             const rowAnchorQueries = Object.fromEntries(
                 Object.entries(metricFirstValueQueries).filter(([key]) =>
-                    key.endsWith('_row_anchor'),
+                    key.endsWith('_ra'),
                 ),
             );
             const rowRankingSQL = this.getRowRankingSQL(


### PR DESCRIPTION
## Summary

- Renames pivot anchor CTE suffixes `_column_anchor` → `_ca` and `_row_anchor` → `_ra` so generated identifiers stay under Postgres' 63-byte limit
- Anchor aliases used to add 17–20 chars of suffix on top of `{table}_{field}`, so any reference longer than ~43 chars silently truncated and broke the query
- Customer's failing 69-char identifier `fct_tickets_ticket_id_count_distinct_of_ticket_id_column_anchor_value` now becomes 58 chars and runs cleanly

Closes https://github.com/lightdash/lightdash/issues/21401
Closes PROD-6580

## Test plan

- [x] `pnpm -F backend test -- PivotQueryBuilder` — 97/97 pass, including a new regression test that asserts no quoted identifier in the generated SQL exceeds 63 chars when sorting by a 49-char field reference
- [x] `pnpm -F backend typecheck` clean
- [x] Generated SQL executed end-to-end against Postgres 16 (`pgvector/pgvector:pg16`) — no truncation warnings, correct pivot output

test-frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)