### PR TITLE
ci: add socket.yml to scope Socket GitHub App on this monorepo

### DIFF
--- a/socket.yml
+++ b/socket.yml
@@ -1,0 +1,24 @@
+version: 2
+
+triggerPaths:
+  - "package.json"
+  - "packages/*/package.json"
+  - "packages/frontend/sdk/package.json"
+  - "pnpm-lock.yaml"
+  - ".npmrc"
+  - "pnpm-workspace.yaml"
+
+projectIgnorePaths:
+  - "examples/**"
+  - "**/node_modules"
+  - "packages/e2e/cypress/**"
+  - "packages/formula-tests/**"
+
+githubApp:
+  enabled: true
+  pullRequestAlertsEnabled: true
+  dependencyOverviewEnabled: true
+  projectReportsEnabled: true
+  ignoreUsers:
+    - "dependabot[bot]"
+    - "renovate[bot]"


### PR DESCRIPTION
Adds `socket.yml` at the repo root to configure the Socket GitHub App for this monorepo.

- `triggerPaths`: scopes Socket scanning to `package.json` (root + per-package + frontend SDK), `pnpm-lock.yaml`, `.npmrc`, and `pnpm-workspace.yaml`. Without an explicit list, `pnpm-lock.yaml` is not in the App's defaults so transitive dep changes are not scanned.
- `projectIgnorePaths`: excludes `examples/`, `node_modules`, cypress fixtures, and formula tests from project-level reports.
- `githubApp.ignoreUsers`: suppresses Socket comments on PRs authored by `dependabot[bot]` and `renovate[bot]` to avoid double-comments alongside the bots' own dep summaries.

No workflow or behavior changes.