### PR TITLE
ci: wrap dependency installs with Socket Firewall (sfw)

### DIFF
--- a/.claude/commands/docker-dev.md
+++ b/.claude/commands/docker-dev.md
@@ -102,7 +102,7 @@ if test -d node_modules \
   && test -f packages/warehouses/dist/warehouseClients/ca-bundle-aws-redshift.crt; then
   echo "OK: Dependencies installed"
 else
-  echo "NEED: Run pnpm install and build"
+  echo "NEED: Run sfw pnpm install and build"
 fi
 
 # Check 5: Python/dbt environment ready
@@ -391,12 +391,15 @@ fi
 
 ### Install Dependencies
 
+Ensure [Socket Firewall Free](https://github.com/SocketDev/sfw-free) is available on the machine, then run the install through `sfw` so known-malicious packages are blocked at download time:
+
 ```bash
-pnpm install
+command -v sfw >/dev/null 2>&1 || npm i -g sfw
+sfw pnpm install
 pnpm -F common build && pnpm -F warehouses build && pnpm -F @lightdash/formula build
 ```
 
-If `pnpm install` fails with canvas errors: https://github.com/Automattic/node-canvas?tab=readme-ov-file#installation
+If `sfw pnpm install` fails with canvas errors: https://github.com/Automattic/node-canvas?tab=readme-ov-file#installation
 
 ### Set Up Python/dbt
 

--- a/.claude/skills/fix-vulnerability/SKILL.md
+++ b/.claude/skills/fix-vulnerability/SKILL.md
@@ -59,8 +59,9 @@ Rules for the title:
 # Fetch and checkout the PR branch
 gh pr checkout <PR_NUMBER>
 
-# Install dependencies to regenerate the lockfile
-pnpm install
+# Install dependencies to regenerate the lockfile (sfw blocks known-malicious packages)
+# Requires `npm i -g sfw` to be installed globally once per machine.
+sfw pnpm install
 
 # Check if the lockfile was modified
 git status pnpm-lock.yaml

--- a/.github/workflows/_setup_node_pnpm_cypress/action.yml
+++ b/.github/workflows/_setup_node_pnpm_cypress/action.yml
@@ -8,6 +8,11 @@ runs:
         - name: Checkout
           uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+        - name: Setup Socket Firewall
+          uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+          with:
+              mode: firewall-free
+
         - name: Setup PNPM
           uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
         - name: Setup Node
@@ -18,10 +23,10 @@ runs:
               cache-dependency-path: 'pnpm-lock.yaml'
 
         - name: Install Dependencies
-          run: pnpm install --frozen-lockfile --prefer-offline
+          run: sfw pnpm install --frozen-lockfile --prefer-offline
           shell: bash
 
         - name: Install Cypress
-          run: pnpm exec cypress install
+          run: sfw pnpm exec cypress install
           working-directory: packages/e2e
           shell: bash

--- a/.github/workflows/ai-agent-integration-tests.yml
+++ b/.github/workflows/ai-agent-integration-tests.yml
@@ -37,6 +37,11 @@ jobs:
         steps:
             - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
+            - name: Setup Socket Firewall
+              uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+              with:
+                  mode: firewall-free
+
             - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
             - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
               with:
@@ -45,7 +50,7 @@ jobs:
                   cache-dependency-path: 'pnpm-lock.yaml'
 
             - name: Install packages
-              run: pnpm install --frozen-lockfile --prefer-offline
+              run: sfw pnpm install --frozen-lockfile --prefer-offline
 
             - name: Build common
               run: pnpm common-build

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -230,6 +230,11 @@ jobs:
         with:
           ref: ${{ github.event.release.tag_name }}
 
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -251,7 +256,7 @@ jobs:
         if: steps.cache-node-modules.outputs.cache-hit != 'true'
         # Force reinstall so pnpm includes optional DuckDB native bindings
         # needed to build both macOS pkg targets from a single runner.
-        run: pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force
+        run: sfw pnpm install --filter @lightdash/cli --filter @lightdash/common --filter @lightdash/warehouses --frozen-lockfile --prefer-offline --prod=false --force
 
       - name: Cache common build
         id: cache-common

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -83,6 +83,10 @@ jobs:
       NODE_OPTIONS: "--max-old-space-size=8192"
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -90,7 +94,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
       - name: Build
         run: pnpm build
       - name: Run quality checks in parallel
@@ -347,6 +351,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -354,7 +362,7 @@ jobs:
           cache: "pnpm"
           cache-dependency-path: "pnpm-lock.yaml"
       - name: Install packages
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
       - name: Build packages/common module
         run: pnpm common-build
       - name: Create BigQuery credentials file
@@ -512,7 +520,7 @@ jobs:
       - name: Build packages/warehouses module
         run: pnpm warehouses-build
       - name: Build and install packages/cli module
-        run: cd packages/cli && pnpm build && npm install -g
+        run: cd packages/cli && pnpm build && sfw npm install -g
       - name: Test lightdash version
         run: |
           lightdash_version=$(lightdash --version)
@@ -571,7 +579,7 @@ jobs:
       - name: Build packages/warehouses module
         run: pnpm warehouses-build
       - name: Build and install packages/cli module
-        run: cd packages/cli && pnpm build && npm install -g
+        run: cd packages/cli && pnpm build && sfw npm install -g
       - name: Test lightdash version
         run: |
           lightdash_version=$(lightdash --version)
@@ -643,7 +651,7 @@ jobs:
       - name: Build packages/warehouses module
         run: pnpm warehouses-build
       - name: Build and install packages/cli module
-        run: cd packages/cli && pnpm build && npm install -g
+        run: cd packages/cli && pnpm build && sfw npm install -g
       - name: Test lightdash version
         run: |
           lightdash_version=$(lightdash --version)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,10 @@ jobs:
       NODE_OPTIONS: '--max-old-space-size=8192'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
         with:
@@ -22,7 +26,7 @@ jobs:
           cache: 'pnpm'
           cache-dependency-path: 'pnpm-lock.yaml'
       - name: Install packages
-        run: pnpm install --frozen-lockfile --prefer-offline
+        run: sfw pnpm install --frozen-lockfile --prefer-offline
       - name: Build all packages
         run: pnpm build
 
@@ -39,6 +43,11 @@ jobs:
           token: ${{ secrets.CI_GITHUB_TOKEN }}
           persist-credentials: false
 
+      - name: Setup Socket Firewall
+        uses: socketdev/action@ba6de6cc0565af1f42295590380973573297e31f # v1.3.2
+        with:
+          mode: firewall-free
+
       - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
 
       - uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6
@@ -48,10 +57,10 @@ jobs:
           cache-dependency-path: 'pnpm-lock.yaml'
 
       - name: Upgrade npm for OIDC support
-        run: npm install -g npm@latest
+        run: sfw npm install -g npm@latest
 
       - name: Install dependencies
-        run: pnpm install --frozen-lockfile --prefer-offline --prod=false
+        run: sfw pnpm install --frozen-lockfile --prefer-offline --prod=false
 
       - name: Semantic Release
         # Config is on release.config.js

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -253,6 +253,18 @@ The canonical source of truth for field types is `packages/common/src/types/fiel
 
 ## Security Best Practices
 
+### Installing Dependencies — Always Use `sfw`
+
+Prefix every package-manager install with [Socket Firewall Free](https://github.com/SocketDev/sfw-free) (`sfw`) to block confirmed-malicious packages before they hit disk. Install once with `npm i -g sfw`, then use:
+
+```bash
+sfw pnpm install
+sfw pnpm add <package>
+sfw npm install -g @lightdash/cli
+```
+
+This applies to any install Claude runs in this repo — lockfile regeneration, Snyk fixes, debug snippets, global CLI installs. CI workflows already wrap installs via `socketdev/action@<SHA>`.
+
 ### Warehouse Credentials Protection
 
 **CRITICAL**: When adding new credential fields to warehouse configurations, always check if they contain sensitive data that should NOT be exposed via API responses.

--- a/packages/cli/CLAUDE.md
+++ b/packages/cli/CLAUDE.md
@@ -169,9 +169,9 @@ The CLI is installed globally by end users (`npm i -g @lightdash/cli`), so trans
    npm view axios time --json
    ```
 3. A caret range like `^1.13.4` will resolve to the latest matching version at install time — including a malicious one. If the compromised version falls within a transitive dep's semver range, **all published @lightdash/cli versions using that transitive dep are affected** for any user who does a fresh install during the compromise window.
-4. Verify what a fresh install resolves to right now:
+4. Verify what a fresh install resolves to right now (wrapped with `sfw` to block known-malicious packages — requires `npm i -g sfw` once):
    ```bash
-   tmp=$(mktemp -d) && cd "$tmp" && npm init -y --silent && npm install @lightdash/cli --package-lock-only && cat package-lock.json | python3 -c "import sys,json; [print(f'{k}: {v[\"version\"]}') for k,v in json.load(sys.stdin).get('packages',{}).items() if k.endswith('/<suspect-package>')]" && rm -rf "$tmp"
+   tmp=$(mktemp -d) && cd "$tmp" && npm init -y --silent && sfw npm install @lightdash/cli --package-lock-only && cat package-lock.json | python3 -c "import sys,json; [print(f'{k}: {v[\"version\"]}') for k,v in json.load(sys.stdin).get('packages',{}).items() if k.endswith('/<suspect-package>')]" && rm -rf "$tmp"
    ```
 5. Pin the dependency to a known-good exact version using a pnpm override in the root `package.json` (no caret, no tilde).
 


### PR DESCRIPTION
## Summary

- Adds the [Socket Firewall Free](https://docs.socket.dev/docs/socket-firewall-free) setup action to every CI job that installs deps, and prefixes every `pnpm install` / `npm install -g` with `sfw` so the proxy can block confirmed-malicious packages before they hit the runner.
- Updates Claude-facing docs that actually run installs (`/docker-dev start` setup, the `fix-vulnerability` skill's lockfile-regen step, the CLI supply-chain debug snippet) to do the same locally — with a one-time `npm i -g sfw` bootstrap.
- Adds a short policy note to the root `CLAUDE.md` so future sessions default to `sfw` for any new install command.

### Why now

We already run the Socket GitHub App (`socket.yml`) for PR-time dep analysis and `minimum-release-age=3d` in `.npmrc` to blunt fast-publish attacks. Socket Firewall layers on top of both: it's enforcement at install-time, so a malicious dep that slipped past PR review (or landed after review) still can't be fetched by a runner that holds `TURBO_TOKEN`, `CI_GITHUB_TOKEN`, or OIDC npm publish creds.

### Files touched

CI workflows (adds `socketdev/action@ba6de6cc... # v1.3.2` with `mode: firewall-free`, wraps installs):
- `.github/workflows/_setup_node_pnpm_cypress/action.yml` — composite, covers most jobs in `pr.yml`
- `.github/workflows/pr.yml` — build-and-test, api-tests, and 3 CLI jobs
- `.github/workflows/ai-agent-integration-tests.yml`
- `.github/workflows/release.yml` — includes the `npm install -g npm@latest` step
- `.github/workflows/post-release.yml` — macOS CLI pkg build

Claude-facing docs:
- `.claude/commands/docker-dev.md` — `sfw pnpm install` with self-healing `npm i -g sfw` bootstrap
- `.claude/skills/fix-vulnerability/SKILL.md` — lockfile regen
- `packages/cli/CLAUDE.md` — the `npm install @lightdash/cli --package-lock-only` debug snippet
- `CLAUDE.md` — new *Installing Dependencies — Always Use `sfw`* section

### Noted at runtime

Running `sfw pnpm install` locally where the pnpm content-addressed store was already warm produced `Warning: Socket Firewall did not detect any package fetch attempts`. That's expected — sfw only inspects network traffic, so cache-hit installs aren't re-validated. Enforcement applies on first download or after a cache miss, which is where new malicious deps would enter anyway.

## Test plan

- [ ] CI green on this PR (first run will exercise the `socketdev/action` setup step on every install job)
- [ ] `pnpm install` on a fresh runner still succeeds end-to-end (api-tests, CLI tests, release dry-run)
- [ ] `/docker-dev start` from a machine without `sfw` installed: bootstraps `sfw`, then installs successfully
- [ ] Verify `sfw npm install -g @lightdash/cli` path in `post-release.yml` still produces a working macOS pkg