### PR TITLE
fix: apply date zoom range filter to underlying data modal

### DIFF
--- a/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
+++ b/packages/frontend/src/components/MetricQueryData/UnderlyingDataModal.tsx
@@ -41,6 +41,7 @@ import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
 import { type TableColumn } from '../common/Table/types';
 import ExportResults from '../ExportResults';
+import { getZoomedDimFilter } from './dateZoomFilter';
 import UnderlyingDataResultsTable from './UnderlyingDataResultsTable';
 import { useMetricQueryDataContext } from './useMetricQueryDataContext';
 
@@ -140,7 +141,7 @@ const UnderlyingDataModalContent: FC = () => {
 
     const filters = useMemo<Filters>(() => {
         if (!underlyingDataConfig) return {};
-        const { item, fieldValues, pivotReference, value } =
+        const { item, fieldValues, pivotReference, value, dateZoom } =
             underlyingDataConfig;
 
         if (item === undefined) return {};
@@ -149,6 +150,14 @@ const UnderlyingDataModalContent: FC = () => {
         const dimensionFilters = !isDimension(item)
             ? Object.entries(fieldValues).reduce((acc, r) => {
                   const [key, { raw }] = r;
+
+                  const isValidDimension = allDimensions.find(
+                      (dimension) => getItemId(dimension) === key,
+                  );
+                  if (!isValidDimension) return acc;
+
+                  const zoomedFilters = getZoomedDimFilter(key, raw, dateZoom);
+                  if (zoomedFilters) return [...acc, ...zoomedFilters];
 
                   const dimensionFilter: FilterRule = {
                       id: uuidv4(),
@@ -161,16 +170,9 @@ const UnderlyingDataModalContent: FC = () => {
                               : FilterOperator.EQUALS,
                       values: raw === null ? undefined : [raw],
                   };
-                  const isValidDimension = allDimensions.find(
-                      (dimension) => getItemId(dimension) === key,
-                  );
-
-                  if (isValidDimension) {
-                      return [...acc, dimensionFilter];
-                  }
-                  return acc;
+                  return [...acc, dimensionFilter];
               }, [] as FilterRule[])
-            : [
+            : (getZoomedDimFilter(getItemId(item), value.raw, dateZoom) ?? [
                   {
                       id: uuidv4(),
                       target: {
@@ -182,7 +184,7 @@ const UnderlyingDataModalContent: FC = () => {
                               : FilterOperator.EQUALS,
                       values: value.raw === null ? undefined : [value.raw],
                   },
-              ];
+              ]);
 
         const pivotFilter: FilterRule[] = (
             pivotReference?.pivotValues || []

--- a/packages/frontend/src/components/MetricQueryData/dateZoomFilter.test.ts
+++ b/packages/frontend/src/components/MetricQueryData/dateZoomFilter.test.ts
@@ -1,0 +1,112 @@
+/// <reference types="vitest/globals" />
+import { DateGranularity, FilterOperator } from '@lightdash/common';
+import { getZoomedDimFilter } from './dateZoomFilter';
+
+vi.mock('uuid', () => {
+    let i = 0;
+    return {
+        v4: vi.fn(() => `uuid-${(i += 1)}`),
+    };
+});
+
+describe('getZoomedDimFilter', () => {
+    test('returns null when no date zoom is configured', () => {
+        expect(
+            getZoomedDimFilter('orders_order_date', '2025-01-06', undefined),
+        ).toBeNull();
+    });
+
+    test('returns null when the field is not the zoomed x-axis', () => {
+        expect(
+            getZoomedDimFilter('orders_status', 'pending', {
+                granularity: DateGranularity.WEEK,
+                xAxisFieldId: 'orders_order_date',
+            }),
+        ).toBeNull();
+    });
+
+    test('returns null for null values so NULL filter can be used', () => {
+        expect(
+            getZoomedDimFilter('orders_order_date', null, {
+                granularity: DateGranularity.WEEK,
+                xAxisFieldId: 'orders_order_date',
+            }),
+        ).toBeNull();
+    });
+
+    test('returns null for custom (non-standard) granularities', () => {
+        expect(
+            getZoomedDimFilter('orders_order_date', '2025-01-06', {
+                granularity: 'fiscal-quarter',
+                xAxisFieldId: 'orders_order_date',
+            }),
+        ).toBeNull();
+    });
+
+    test('builds a [start, nextStart) range for WEEK zoom', () => {
+        const filters = getZoomedDimFilter('orders_order_date', '2025-01-06', {
+            granularity: DateGranularity.WEEK,
+            xAxisFieldId: 'orders_order_date',
+        });
+        expect(filters).toHaveLength(2);
+        expect(filters?.[0]).toMatchObject({
+            target: { fieldId: 'orders_order_date' },
+            operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+            values: ['2025-01-06T00:00:00Z'],
+        });
+        expect(filters?.[1]).toMatchObject({
+            target: { fieldId: 'orders_order_date' },
+            operator: FilterOperator.LESS_THAN,
+            values: ['2025-01-13T00:00:00Z'],
+        });
+    });
+
+    test('builds range for MONTH zoom spanning the full month', () => {
+        const filters = getZoomedDimFilter('orders_order_date', '2025-02-01', {
+            granularity: DateGranularity.MONTH,
+            xAxisFieldId: 'orders_order_date',
+        });
+        expect(filters?.[0].values).toEqual(['2025-02-01T00:00:00Z']);
+        expect(filters?.[1].values).toEqual(['2025-03-01T00:00:00Z']);
+    });
+
+    test('builds range for QUARTER zoom spanning three months', () => {
+        const filters = getZoomedDimFilter('orders_order_date', '2025-01-01', {
+            granularity: DateGranularity.QUARTER,
+            xAxisFieldId: 'orders_order_date',
+        });
+        expect(filters?.[0].values).toEqual(['2025-01-01T00:00:00Z']);
+        expect(filters?.[1].values).toEqual(['2025-04-01T00:00:00Z']);
+    });
+
+    test('builds range for YEAR zoom spanning the full year', () => {
+        const filters = getZoomedDimFilter('orders_order_date', '2025-01-01', {
+            granularity: DateGranularity.YEAR,
+            xAxisFieldId: 'orders_order_date',
+        });
+        expect(filters?.[0].values).toEqual(['2025-01-01T00:00:00Z']);
+        expect(filters?.[1].values).toEqual(['2026-01-01T00:00:00Z']);
+    });
+
+    test('handles ISO timestamp raw values without local-timezone drift', () => {
+        const filters = getZoomedDimFilter(
+            'orders_order_date',
+            '2025-01-06T00:00:00.000Z',
+            {
+                granularity: DateGranularity.WEEK,
+                xAxisFieldId: 'orders_order_date',
+            },
+        );
+        expect(filters?.[0].values).toEqual(['2025-01-06T00:00:00Z']);
+        expect(filters?.[1].values).toEqual(['2025-01-13T00:00:00Z']);
+    });
+
+    test('returns null for invalid date input', () => {
+        expect(
+            getZoomedDimFilter('orders_order_date', 'not-a-date', {
+                granularity: DateGranularity.WEEK,
+                xAxisFieldId: 'orders_order_date',
+            }),
+        ).toBeNull();
+    });
+});

--- a/packages/frontend/src/components/MetricQueryData/dateZoomFilter.ts
+++ b/packages/frontend/src/components/MetricQueryData/dateZoomFilter.ts
@@ -1,0 +1,78 @@
+import {
+    assertUnreachable,
+    DateGranularity,
+    FilterOperator,
+    isStandardDateGranularity,
+    type DateZoom,
+    type FilterRule,
+} from '@lightdash/common';
+import dayjs, { type ManipulateType } from 'dayjs';
+import utc from 'dayjs/plugin/utc';
+import { v4 as uuidv4 } from 'uuid';
+
+dayjs.extend(utc);
+
+// Quarter is 3 months; dayjs's base ManipulateType doesn't include 'quarter'
+// without extending with the quarterOfYear plugin.
+const dateGranularityToDayjsShift = (
+    granularity: DateGranularity,
+): [number, ManipulateType] => {
+    switch (granularity) {
+        case DateGranularity.SECOND:
+            return [1, 'second'];
+        case DateGranularity.MINUTE:
+            return [1, 'minute'];
+        case DateGranularity.HOUR:
+            return [1, 'hour'];
+        case DateGranularity.DAY:
+            return [1, 'day'];
+        case DateGranularity.WEEK:
+            return [1, 'week'];
+        case DateGranularity.MONTH:
+            return [1, 'month'];
+        case DateGranularity.QUARTER:
+            return [3, 'month'];
+        case DateGranularity.YEAR:
+            return [1, 'year'];
+        default:
+            return assertUnreachable(granularity, 'Unknown DateGranularity');
+    }
+};
+
+// Date zoom truncates the chart's x-axis dim to a period (e.g. week). The
+// clicked value is already the period-start (from the warehouse's DATE_TRUNC),
+// so EQUALS filter on the raw dim only matches that exact moment. Replace with
+// a [start, nextStart) range so every row in the period is returned.
+export const getZoomedDimFilter = (
+    fieldId: string,
+    raw: unknown,
+    dateZoom: DateZoom | undefined,
+): FilterRule[] | null => {
+    if (
+        raw === null ||
+        !dateZoom?.granularity ||
+        dateZoom.xAxisFieldId !== fieldId ||
+        !isStandardDateGranularity(dateZoom.granularity)
+    ) {
+        return null;
+    }
+    const start = dayjs.utc(raw as dayjs.ConfigType);
+    if (!start.isValid()) return null;
+    const [amount, unit] = dateGranularityToDayjsShift(dateZoom.granularity);
+    const nextStart = start.add(amount, unit);
+    const isoFormat = 'YYYY-MM-DDTHH:mm:ss[Z]';
+    return [
+        {
+            id: uuidv4(),
+            target: { fieldId },
+            operator: FilterOperator.GREATER_THAN_OR_EQUAL,
+            values: [start.format(isoFormat)],
+        },
+        {
+            id: uuidv4(),
+            target: { fieldId },
+            operator: FilterOperator.LESS_THAN,
+            values: [nextStart.format(isoFormat)],
+        },
+    ];
+};


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/21951


Month zoom:

<img width="613" height="233" alt="CleanShot 2026-04-20 at 09 48 03" src="https://github.com/user-attachments/assets/a8eba4cb-f45d-4aa7-9f09-d3e5547d9d42" />

Day zoom: 

<img width="652" height="227" alt="CleanShot 2026-04-20 at 09 52 17" src="https://github.com/user-attachments/assets/e19c4ad7-efc0-40c7-91d3-328c1aba0c64" />



  Issue:           PROD-6941 — 'View underlying data' returns incorrect results when Date Zoom is not set to 'day'
  Symptom:         Dashboard with Date Zoom = Week: clicking a data point → "View underlying data" returned only rows for the first day of the period.
   Live repro on jaffle `orders`: week of 2025-01-06 had 15 orders; modal returned only the 2 orders dated 2025-01-06.
  Root cause:      UnderlyingDataModal built a single EQUALS filter on the clicked value. The clicked value is the period-start (e.g. Monday), so the
  backend SQL compares only that exact moment. Passing `dateZoom` to the backend does NOT rewrite the filter to use DATE_TRUNC semantics — only the
  SELECT uses the zoomed dim, so EQUALS filters through to the first-day rows.
  Fix:             New helper `getZoomedDimFilter` (`packages/frontend/src/components/MetricQueryData/dateZoomFilter.ts`) converts the EQUALS filter
  on the zoom x-axis field into [periodStart, nextPeriodStart) using GREATER_THAN_OR_EQUAL + LESS_THAN. `UnderlyingDataModal.tsx` calls it in both
  filter-build branches (metric/table-calc click and dimension click). Supports all standard granularities (Second → Year, Quarter = +3 months).
  Test:            10 unit tests in `dateZoomFilter.test.ts`. Live repro against backend:
                   - Before (EQUALS + dateZoom) → 2 rows ❌
                   - After (range + dateZoom)  → 15 rows ✓ (matches psql ground truth for the week)
                   Typecheck/lint clean on frontend.
  Regression risk: LOW. Range filter is scoped to the zoom x-axis field; falls back to original EQUALS behaviour when no dateZoom or the dim doesn't
  match.

### How to test

  End-to-end in the real browser:
  1. Logged in → created chart + dashboard via API → navigated to dashboard.
  2. Set Date Zoom = Week via the dashboard's Date Zoom menu.
  3. Right-clicked the tallest bar (week of 2025-01-06, Drill into 15 confirming hit).
  4. Picked "View underlying data".
  5. Modal shows 15 rows spanning 2025-01-06 → 2025-01-12 (2,3,1,1,2,3,3 per day — exactly matching psql).

  Before the fix: 2 rows (only Mon 2025-01-06). After the fix: 15 rows, full week. Fix works end-to-end through the UI.

### Description:

When a chart has date zoom enabled, clicking a data point to view underlying data was using an `EQUALS` filter on the truncated period-start value (e.g. the first day of a week). This only matched rows with that exact timestamp, missing all other rows within the period.

This fix replaces the `EQUALS` filter with a `[start, nextStart)` range filter for the zoomed x-axis dimension, ensuring all rows within the zoomed period are returned. For example, a week-granularity zoom on `2025-01-06` now filters `>= 2025-01-06T00:00:00Z` and `< 2025-01-13T00:00:00Z`.

The logic is extracted into a new `getZoomedDimFilter` utility that handles all standard `DateGranularity` values (second through year), guards against null values, non-matching fields, and invalid dates, and uses UTC-aware date arithmetic to avoid local-timezone drift. Full unit test coverage is included for all supported granularities and edge cases.