### PR TITLE
fix: guard pg-protocol Parser against unknown Redshift auth codes crashing the process

### DIFF
--- a/packages/warehouses/package.json
+++ b/packages/warehouses/package.json
@@ -38,6 +38,7 @@
     "node-fetch": "2.7.0",
     "pg": "8.13.1",
     "pg-cursor": "2.10.0",
+    "pg-protocol": "1.10.3",
     "snowflake-sdk": "2.3.4",
     "ssh2": "1.14.0",
     "trino-client": "0.2.9"

--- a/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
+++ b/packages/warehouses/src/warehouseClients/PostgresWarehouseClient.ts
@@ -21,6 +21,7 @@ import { Writable } from 'stream';
 import * as tls from 'tls';
 import { rootCertificates } from 'tls';
 import { normalizeUnicode } from '../utils/sql';
+import './pgProtocolGuard';
 import QueryStream from './PgQueryStream';
 import WarehouseBaseClient from './WarehouseBaseClient';
 import WarehouseBaseSqlBuilder from './WarehouseBaseSqlBuilder';

--- a/packages/warehouses/src/warehouseClients/pgProtocolGuard.integration.test.ts
+++ b/packages/warehouses/src/warehouseClients/pgProtocolGuard.integration.test.ts
@@ -1,0 +1,65 @@
+import './pgProtocolGuard';
+import * as net from 'net';
+import { Client } from 'pg';
+
+// Builds a full AuthenticationResponse wire message with the given sub-code.
+// Byte layout: 'R' (0x52) + Int32 length (includes length bytes, excludes
+// code) + Int32 sub-code. Mirrors what the Redshift server sends for IAM
+// Identity Center auth (sub-code 13) before pg-protocol's Parser throws.
+const buildAuthTypeMessage = (subCode: number): Buffer => {
+    const buffer = Buffer.alloc(9);
+    buffer.writeUInt8(0x52, 0); // 'R'
+    buffer.writeUInt32BE(8, 1); // length
+    buffer.writeInt32BE(subCode, 5);
+    return buffer;
+};
+
+const startFakePostgresServer = (subCode: number): Promise<net.Server> =>
+    new Promise((resolve) => {
+        const server = net.createServer((socket) => {
+            // Swallow the client's startup packet, then send the bad auth
+            // message. We only need one data event to kick it off.
+            socket.once('data', () => {
+                socket.write(buildAuthTypeMessage(subCode));
+            });
+            socket.on('error', () => {
+                /* ignore — client may RST after we send garbage */
+            });
+        });
+        server.listen(0, '127.0.0.1', () => resolve(server));
+    });
+
+describe('pgProtocolGuard (integration)', () => {
+    // End-to-end regression for https://github.com/lightdash/lightdash/issues/22098.
+    // Without the guard, pg-protocol throws synchronously inside the socket's
+    // 'data' listener, which becomes an uncaught exception and crashes the
+    // Node process. With the guard, the same scenario rejects pg.Client's
+    // connect() promise cleanly.
+    it('rejects pg.Client.connect() instead of crashing the process', async () => {
+        const server = await startFakePostgresServer(13);
+        const address = server.address();
+        if (!address || typeof address === 'string') {
+            throw new Error('fake server did not bind to a TCP address');
+        }
+
+        const client = new Client({
+            host: '127.0.0.1',
+            port: address.port,
+            user: 'anything',
+            password: 'anything',
+            database: 'anything',
+            ssl: false,
+        });
+
+        try {
+            await expect(client.connect()).rejects.toThrow(
+                /unsupported authentication method \(code 13\).*Identity Center/,
+            );
+        } finally {
+            await client.end().catch(() => {});
+            await new Promise<void>((resolve) => {
+                server.close(() => resolve());
+            });
+        }
+    });
+});

--- a/packages/warehouses/src/warehouseClients/pgProtocolGuard.test.ts
+++ b/packages/warehouses/src/warehouseClients/pgProtocolGuard.test.ts
@@ -1,0 +1,55 @@
+import './pgProtocolGuard';
+import { DatabaseError } from 'pg-protocol/dist/messages';
+import { Parser } from 'pg-protocol/dist/parser';
+
+// Build a single pg message: 1 byte code + UInt32BE length (incl. length
+// bytes, excl. code) + payload.
+const buildAuthenticationMessage = (authCode: number): Buffer => {
+    const codeByte = 82; // 'R' — AuthenticationResponse
+    const payload = Buffer.alloc(4);
+    payload.writeInt32BE(authCode, 0);
+    const length = 4 + payload.length; // length field itself + payload
+    const buffer = Buffer.alloc(1 + length);
+    buffer.writeUInt8(codeByte, 0);
+    buffer.writeUInt32BE(length, 1);
+    payload.copy(buffer, 5);
+    return buffer;
+};
+
+describe('pgProtocolGuard', () => {
+    // Regression for https://github.com/lightdash/lightdash/issues/22098
+    // Redshift IAM / Identity Center auth sends an unknown authentication
+    // message code (e.g. 13). Without the guard, pg-protocol's Parser
+    // throws synchronously from the TLSSocket 'data' listener, which
+    // becomes an uncaught exception and crashes the backend process.
+    it('converts synchronous parser errors into a DatabaseError callback', () => {
+        const parser = new Parser();
+        const buffer = buildAuthenticationMessage(13);
+        const received: unknown[] = [];
+
+        expect(() => {
+            parser.parse(buffer, (msg) => received.push(msg));
+        }).not.toThrow();
+
+        expect(received).toHaveLength(1);
+        const [msg] = received;
+        expect(msg).toBeInstanceOf(DatabaseError);
+        expect((msg as DatabaseError).name).toBe('error');
+        expect((msg as DatabaseError).message).toMatch(
+            /unsupported authentication method \(code 13\)/,
+        );
+        expect((msg as DatabaseError).message).toMatch(/Identity Center/);
+    });
+
+    it('passes known messages through unchanged', () => {
+        const parser = new Parser();
+        // Auth code 0 — AuthenticationOk
+        const buffer = buildAuthenticationMessage(0);
+        const received: unknown[] = [];
+
+        parser.parse(buffer, (msg) => received.push(msg));
+
+        expect(received).toHaveLength(1);
+        expect((received[0] as { name: string }).name).toBe('authenticationOk');
+    });
+});

--- a/packages/warehouses/src/warehouseClients/pgProtocolGuard.ts
+++ b/packages/warehouses/src/warehouseClients/pgProtocolGuard.ts
@@ -1,0 +1,159 @@
+// ============================================================================
+// pgProtocolGuard — crash protection for pg-protocol's Parser
+// ============================================================================
+//
+// Regression for https://github.com/lightdash/lightdash/issues/22098
+//
+// ─── Background: the PostgreSQL wire protocol ─────────────────────────────────
+//
+// The `pg` library that both our Postgres and Redshift clients sit on top of
+// speaks the PostgreSQL "Frontend/Backend" wire protocol v3. Every backend
+// message sent over the socket has a fixed layout:
+//
+//     ┌──────┬──────────────┬──────────────────────────┐
+//     │ byte │ UInt32BE len │ payload (len-4 bytes)    │
+//     │ code │              │                          │
+//     └──────┴──────────────┴──────────────────────────┘
+//
+// The first byte identifies the message type (e.g. 'R' = AuthenticationResponse,
+// 'D' = DataRow, 'E' = ErrorResponse). `pg-protocol`'s Parser reads this byte
+// in `handlePacket()` and dispatches to a specific sub-parser.
+//
+// During connection setup, the exchange goes:
+//
+//     Client ──► Server   StartupMessage (user, database, protocol version)
+//     Client ◄── Server   AuthenticationResponse  (tell me what to send)
+//                         └─ int32 sub-code:
+//                              0  AuthenticationOk — auth succeeded
+//                              3  CleartextPassword — send password plaintext
+//                              5  MD5Password — send MD5(password+salt)
+//                              10 SASL — start SCRAM negotiation
+//                              11 SASLContinue
+//                              12 SASLFinal
+//     Client ──► Server   (credentials in the requested format)
+//     Client ◄── Server   AuthenticationOk (sub-code 0)   ← auth really done
+//     Client ◄── Server   ReadyForQuery
+//
+// pg-protocol's `parseAuthenticationResponse` only understands sub-codes 0,
+// 3, 5, 10, 11, 12. It throws on anything else.
+//
+// ─── Why Redshift sends sub-code 13 ───────────────────────────────────────────
+//
+// AWS Redshift extends the PostgreSQL protocol with extra auth sub-codes for
+// its IDP plugin family. Sub-code 13 in particular is used when the cluster
+// or Serverless workgroup has IAM Identity Center integration enabled — the
+// server opens the auth handshake by asking the client for an IC OIDC token.
+// This happens *before* the client has a chance to present a password, so
+// selecting "user & password" in Lightdash doesn't avoid it — the trigger is
+// entirely server-side.
+//
+// ─── Why the throw crashes the backend ────────────────────────────────────────
+//
+// `pg` wires the parser into the TLS socket like this:
+//
+//     stream.on('data', buffer => parser.parse(buffer, callback));
+//
+// Node's EventEmitter invokes listeners synchronously. A synchronous throw
+// from a listener is NOT caught by the emitter — it bubbles up to the event
+// loop as an uncaught exception. There's no opportunity for pg.Client, pg.Pool,
+// or our own try/catch around `pool.connect()` to intercept it, because all of
+// those wrappers expect the driver to report errors *through* callbacks or
+// events, not by throwing out of a socket data handler.
+//
+// Result: the pod dies. Every other tenant on that pod has their in-flight
+// requests dropped. The autoscaler restarts it ~30–60s later.
+//
+// ─── What this guard does ─────────────────────────────────────────────────────
+//
+// We monkey-patch `Parser.prototype.parse` once, at module load. The wrapper
+// invokes the original implementation unchanged — so on the happy path it is
+// byte-for-byte identical. Only when the original throws do we intercept:
+// we construct a DatabaseError with `name: 'error'` and deliver it through
+// the same callback that pg-protocol would use for a real backend error.
+//
+// From there, pg's existing error plumbing takes over:
+//     Parser callback → Connection.attachListeners → emits 'errorMessage'
+//                     → Client._handleErrorMessage → _handleErrorWhileConnecting
+//                     → rejects the connect() promise
+//
+// So a would-be process crash becomes a regular rejected promise, which the
+// warehouse layer already knows how to turn into a user-visible error toast.
+//
+// ─── Scope / blast radius ─────────────────────────────────────────────────────
+//
+// The patch targets a singleton prototype, so it's process-wide. It affects:
+//   • Postgres warehouses  (PostgresWarehouseClient)
+//   • Redshift warehouses  (RedshiftWarehouseClient extends PostgresClient)
+//   • The backend's internal DB connection (Knex, `pg` driver)
+//
+// It does NOT affect warehouses that use other SDKs — BigQuery, Snowflake,
+// Databricks, Athena, Trino, Clickhouse, DuckDB — none of those load
+// pg-protocol.
+//
+// The happy path is unchanged (`originalParse.call(this, ...)` runs exactly
+// as before). The only behavior change is on throw: previously a crash, now
+// a rejected promise with a clear error message. That's strictly safer.
+//
+// ─── Caveat ───────────────────────────────────────────────────────────────────
+//
+// This stops the crash. It does NOT make IC-based Redshift connections
+// succeed — to do that we'd need to implement the IC token exchange (AWS's
+// `redshift-connector-node` does this) or advise the customer to use a
+// non-IC endpoint. The rewritten error message makes that action obvious.
+// ============================================================================
+import { BackendMessage, DatabaseError } from 'pg-protocol/dist/messages';
+import { MessageCallback, Parser } from 'pg-protocol/dist/parser';
+
+type Patchable = {
+    lightdashGuarded?: boolean;
+};
+
+const prototype = Parser.prototype as typeof Parser.prototype & Patchable;
+
+// pg-protocol's thrown wording for unknown auth sub-codes is misleading
+// because every AuthenticationResponse message is initialized with
+// `name: 'authenticationOk'` before the sub-code switch overwrites it — so
+// the thrown string reads "Unknown authenticationOk message type 13" even
+// though sub-code 13 is neither authenticationOk nor okay. Rewrite it to
+// something a customer and an on-call engineer can both act on.
+const rewriteParserError = (err: unknown): string => {
+    const rawMessage = err instanceof Error ? err.message : String(err);
+    const authCodeMatch = rawMessage.match(
+        /Unknown authenticationOk message type (\d+)/,
+    );
+    if (authCodeMatch) {
+        return `Warehouse server requested an unsupported authentication method (code ${authCodeMatch[1]}). This is commonly seen on AWS Redshift endpoints with IAM Identity Center enabled, which Lightdash does not support. Please use a Redshift endpoint configured for native username/password authentication.`;
+    }
+    return `Unsupported warehouse protocol message: ${rawMessage}`;
+};
+
+// Idempotent — Jest's module reset or accidental double-import should not
+// stack wrappers and ship every thrown error through multiple try/catches.
+if (!prototype.lightdashGuarded) {
+    const originalParse = prototype.parse;
+
+    prototype.parse = function guardedParse(
+        buffer: Buffer,
+        callback: MessageCallback,
+    ) {
+        try {
+            // Happy path: exactly the original implementation, no behavior
+            // change for valid messages.
+            originalParse.call(this, buffer, callback);
+        } catch (err) {
+            // Convert the sync throw into a DatabaseError routed through
+            // the same callback pg uses for real ErrorResponse messages.
+            // `name: 'error'` is what makes Connection re-emit it as an
+            // 'errorMessage' event, which Client then turns into a
+            // connect-promise rejection.
+            const databaseError = new DatabaseError(
+                rewriteParserError(err),
+                buffer?.length ?? 0,
+                'error',
+            );
+            callback(databaseError as unknown as BackendMessage);
+        }
+    };
+
+    prototype.lightdashGuarded = true;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1581,6 +1581,9 @@ importers:
       pg-cursor:
         specifier: 2.10.0
         version: 2.10.0(pg@8.13.1)
+      pg-protocol:
+        specifier: 1.10.3
+        version: 1.10.3
       snowflake-sdk:
         specifier: 2.3.4
         version: 2.3.4(asn1.js@5.4.1)(encoding@0.1.13)
@@ -15195,7 +15198,7 @@ snapshots:
   '@apm-js-collab/tracing-hooks@0.3.1':
     dependencies:
       '@apm-js-collab/code-transformer': 0.8.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -16103,11 +16106,11 @@ snapshots:
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.28.4(supports-color@5.5.0)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -16136,13 +16139,6 @@ snapshots:
 
   '@babel/helper-globals@7.28.0': {}
 
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.4
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/helper-module-imports@7.27.1(supports-color@5.5.0)':
     dependencies:
       '@babel/traverse': 7.28.4(supports-color@5.5.0)
@@ -16153,9 +16149,9 @@ snapshots:
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.28.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -16258,18 +16254,6 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
-
-  '@babel/traverse@7.28.4':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.3
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.27.2
-      '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
 
   '@babel/traverse@7.28.4(supports-color@5.5.0)':
     dependencies:
@@ -16486,7 +16470,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.10.6':
     dependencies:
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/runtime': 7.28.6
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
@@ -16728,7 +16712,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -17071,7 +17055,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -17451,7 +17435,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18674,7 +18658,7 @@ snapshots:
 
   '@pm2/pm2-version-check@1.0.4':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20922,7 +20906,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.0-beta)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 6.0.0-beta
@@ -20935,7 +20919,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(typescript@6.0.0-beta)
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       typescript: 6.0.0-beta
     transitivePeerDependencies:
@@ -20945,7 +20929,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.0-beta)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.0-beta
     transitivePeerDependencies:
       - supports-color
@@ -20954,7 +20938,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -20963,7 +20947,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.0-beta)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.0-beta
     transitivePeerDependencies:
       - supports-color
@@ -21004,7 +20988,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.0-beta)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@6.0.0-beta)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@6.0.0-beta)
     optionalDependencies:
@@ -21017,7 +21001,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(typescript@6.0.0-beta)
       '@typescript-eslint/utils': 8.43.0(eslint@8.57.1)(typescript@6.0.0-beta)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       ts-api-utils: 2.4.0(typescript@6.0.0-beta)
       typescript: 6.0.0-beta
@@ -21036,7 +21020,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.3
@@ -21050,7 +21034,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21067,7 +21051,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@6.0.0-beta)
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -21083,7 +21067,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.2
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -21098,7 +21082,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.0-beta)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.2
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -21527,7 +21511,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -22149,7 +22133,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -22883,7 +22867,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.54.11(@babel/core@7.28.4)
       globby: 11.1.0
@@ -23794,7 +23778,7 @@ snapshots:
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint: 8.57.1
       espree: 11.1.0
@@ -23912,7 +23896,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -24148,7 +24132,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -24353,7 +24337,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -24367,7 +24351,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       find-test-names: 1.29.19(@babel/core@7.28.4)
       minimatch: 10.2.5
       pluralize: 8.0.0
@@ -24391,7 +24375,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
       acorn-walk: 8.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       simple-bin-help: 1.8.0
       tinyglobby: 0.2.15
     transitivePeerDependencies:
@@ -24691,7 +24675,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.2.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 11.3.2
     transitivePeerDependencies:
       - supports-color
@@ -25176,14 +25160,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25196,14 +25180,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -25357,7 +25341,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -25654,7 +25638,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -27186,7 +27170,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -27194,7 +27178,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -27543,7 +27527,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -27987,7 +27971,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -28267,7 +28251,7 @@ snapshots:
 
   pm2-axon-rpc@0.7.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -28275,7 +28259,7 @@ snapshots:
     dependencies:
       amp: 0.3.1
       amp-message: 0.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -28292,7 +28276,7 @@ snapshots:
   pm2-sysmonit@1.2.8:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       pidusage: 2.0.21
       systeminformation: 5.30.7
       tx2: 1.0.5
@@ -28314,7 +28298,7 @@ snapshots:
       commander: 2.15.1
       croner: 4.1.97
       dayjs: 1.11.15
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       enquirer: 2.3.6
       eventemitter2: 5.0.1
       fclone: 1.0.11
@@ -28667,7 +28651,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -28789,7 +28773,7 @@ snapshots:
   react-docgen@8.0.3:
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.28.4(supports-color@5.5.0)
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
@@ -29304,7 +29288,7 @@ snapshots:
 
   require-in-the-middle@5.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -29312,7 +29296,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -29320,7 +29304,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -29466,7 +29450,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -29601,7 +29585,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -29766,7 +29750,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -29873,7 +29857,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -29881,7 +29865,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -29925,7 +29909,7 @@ snapshots:
   spec-change@1.11.21:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       deep-equal: 2.2.3
       dependency-tree: 11.4.0
       lazy-ass: 2.0.3
@@ -31325,7 +31309,7 @@ snapshots:
   vite-node@3.1.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.4.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2)
@@ -31346,7 +31330,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.10(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.7.0)
@@ -31367,7 +31351,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.10(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2)
@@ -31403,7 +31387,7 @@ snapshots:
       '@volar/typescript': 2.4.23
       '@vue/language-core': 2.2.0(typescript@6.0.0-beta)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -31513,7 +31497,7 @@ snapshots:
       '@vitest/spy': 3.1.1
       '@vitest/utils': 3.1.1
       chai: 5.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.3.0
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -31553,7 +31537,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.2.1
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -31595,7 +31579,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.2.1
       magic-string: 0.30.21
       pathe: 2.0.3


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: [https://linear.app/lightdash/issue/PROD-7035/redshift-auth-response-crashes-backend-with-uncaught-pg-protocol](https://linear.app/lightdash/issue/PROD-7035/redshift-auth-response-crashes-backend-with-uncaught-pg-protocol)<!-- reference the related issue e.g. #150 -->



Diff: 348 lines added across 6 files. New stuff is 3 files; the existing-file changes are tiny:

- package.json: 1 line (pg-protocol direct dep)
- PostgresWarehouseClient.ts: 1 line (import './pgProtocolGuard';)
- pnpm-lock.yaml: lockfile refresh

wrap pg-protocol's Parser.prototype.parse once, so any synchronous throw during wire-protocol parsing becomes a
DatabaseError delivered via pg's normal callback, instead of escaping as an uncaught exception.

### Before (bare pg, no guard):

Error: Unknown authenticationOk message type 13
at Parser.parseAuthenticationResponse (pg-protocol@1.10.3/dist/parser.js:272:23)
at Parser.handlePacket (pg-protocol@1.10.3/dist/parser.js:116:29)
at Parser.parse (pg-protocol@1.10.3/dist/parser.js:35:38)
at Socket.\<anonymous> (pg-protocol@1.10.3/dist/index.js:11:42)
at Socket.emit (node:events:524:28)
...
Node.js v20.19.6   ← process died, exit code 1

Identical to the stack trace in #22098.

### After (same scenario, with require('./dist/warehouseClients/pgProtocolGuard') loaded first):

rejected cleanly: Warehouse server requested an unsupported authentication method (code 13).
This is commonly seen on AWS Redshift endpoints with IAM Identity Center enabled, which
Lightdash does not support. Please use a Redshift endpoint configured for native
username/password authentication.
process still alive — would have been dead without guard

Same malformed server response, same pg client. The only difference is the guard — and the pod stays up, the user gets an actionable error. Exactly
the outcome we want in production.

### Description:

<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->