### PR TITLE
refactor: move uuid/name to metadata in CASL audit subjects

### DIFF
--- a/packages/backend/src/logging/auditLog.ts
+++ b/packages/backend/src/logging/auditLog.ts
@@ -59,8 +59,7 @@ export type CallStackEntry = {
 
 export const AuditResourceSchema = z.object({
     type: z.string(),
-    uuid: z.string().optional(),
-    name: z.string().optional(),
+    metadata: z.record(z.string(), z.unknown()).optional(),
     organizationUuid: z.string(),
     projectUuid: z.string().optional(),
 });

--- a/packages/backend/src/logging/caslAuditWrapper.test.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.test.ts
@@ -11,15 +11,15 @@ import {
 // Test subjects
 const createDashboard = (uuid: string, attributes: AnyObject = {}) =>
     subject('Dashboard', {
-        uuid,
         organizationUuid: 'test-org-uuid',
+        metadata: { uuid },
         ...attributes,
     });
 
 const createSavedChart = (uuid: string, attributes: AnyObject = {}) =>
     subject('SavedChart', {
-        uuid,
         organizationUuid: 'test-org-uuid',
+        metadata: { uuid },
         ...attributes,
     });
 
@@ -409,6 +409,39 @@ describe('CaslAuditWrapper', () => {
             expect(loggedEvent.resource.uuid).toBeUndefined();
             expect(loggedEvent.resource.type).toBe('Dashboard');
             expect(loggedEvent.resource.organizationUuid).toBe('test-org-uuid');
+        });
+    });
+
+    describe('createResourceFromSubject behavior', () => {
+        it('should use metadata.uuid and metadata.name', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+
+            const s = subject('Dashboard', {
+                organizationUuid: 'test-org-uuid',
+                metadata: { uuid: 'meta-uuid', name: 'meta-name' },
+            });
+
+            wrapper.can('read', s);
+
+            const { resource } = mockLogger.mock.calls[0][0];
+            expect(resource.uuid).toBe('meta-uuid');
+            expect(resource.name).toBe('meta-name');
+        });
+
+        it('should have undefined uuid and name when metadata is absent', () => {
+            const mockLogger = createMockLogger();
+            const wrapper = createWrapper(mockLogger);
+
+            const s = subject('Dashboard', {
+                organizationUuid: 'test-org-uuid',
+            });
+
+            wrapper.can('read', s);
+
+            const { resource } = mockLogger.mock.calls[0][0];
+            expect(resource.uuid).toBeUndefined();
+            expect(resource.name).toBeUndefined();
         });
     });
 

--- a/packages/backend/src/logging/caslAuditWrapper.test.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.test.ts
@@ -12,14 +12,14 @@ import {
 const createDashboard = (uuid: string, attributes: AnyObject = {}) =>
     subject('Dashboard', {
         organizationUuid: 'test-org-uuid',
-        metadata: { uuid },
+        metadata: { dashboardUuid: uuid },
         ...attributes,
     });
 
 const createSavedChart = (uuid: string, attributes: AnyObject = {}) =>
     subject('SavedChart', {
         organizationUuid: 'test-org-uuid',
-        metadata: { uuid },
+        metadata: { savedChartUuid: uuid },
         ...attributes,
     });
 
@@ -130,7 +130,7 @@ describe('CaslAuditWrapper', () => {
             expect(loggedEvent.actor.uuid).toBe(mockUser.userUuid);
             expect(loggedEvent.action).toBe('update');
             expect(loggedEvent.resource.type).toBe('Dashboard');
-            expect(loggedEvent.resource.uuid).toBe('2');
+            expect(loggedEvent.resource.metadata?.dashboardUuid).toBe('2');
             expect(loggedEvent.status).toBe('allowed');
             expect(loggedEvent.context.ip).toBe('127.0.0.1');
             expect(loggedEvent.context.userAgent).toBe('test-agent');
@@ -154,7 +154,7 @@ describe('CaslAuditWrapper', () => {
             expect(loggedEvent.actor.uuid).toBe(mockUser.userUuid);
             expect(loggedEvent.action).toBe('read');
             expect(loggedEvent.resource.type).toBe('Dashboard');
-            expect(loggedEvent.resource.uuid).toBe('3');
+            expect(loggedEvent.resource.metadata?.dashboardUuid).toBe('3');
             expect(loggedEvent.status).toBe('denied');
         });
 
@@ -266,7 +266,7 @@ describe('CaslAuditWrapper', () => {
             expect(loggedEvent.actor.uuid).toBe(mockUser.userUuid);
             expect(loggedEvent.action).toBe('read');
             expect(loggedEvent.resource.type).toBe('Dashboard');
-            expect(loggedEvent.resource.uuid).toBe('3');
+            expect(loggedEvent.resource.metadata?.dashboardUuid).toBe('3');
             expect(loggedEvent.status).toBe('denied');
         });
 
@@ -406,30 +406,32 @@ describe('CaslAuditWrapper', () => {
 
             expect(mockLogger).toHaveBeenCalledTimes(1);
             const loggedEvent = mockLogger.mock.calls[0][0];
-            expect(loggedEvent.resource.uuid).toBeUndefined();
+            expect(loggedEvent.resource.metadata).toBeUndefined();
             expect(loggedEvent.resource.type).toBe('Dashboard');
             expect(loggedEvent.resource.organizationUuid).toBe('test-org-uuid');
         });
     });
 
     describe('createResourceFromSubject behavior', () => {
-        it('should use metadata.uuid and metadata.name', () => {
+        it('should forward metadata object directly', () => {
             const mockLogger = createMockLogger();
             const wrapper = createWrapper(mockLogger);
 
             const s = subject('Dashboard', {
                 organizationUuid: 'test-org-uuid',
-                metadata: { uuid: 'meta-uuid', name: 'meta-name' },
+                metadata: { dashboardUuid: 'meta-uuid', name: 'meta-name' },
             });
 
             wrapper.can('read', s);
 
             const { resource } = mockLogger.mock.calls[0][0];
-            expect(resource.uuid).toBe('meta-uuid');
-            expect(resource.name).toBe('meta-name');
+            expect(resource.metadata).toEqual({
+                dashboardUuid: 'meta-uuid',
+                name: 'meta-name',
+            });
         });
 
-        it('should have undefined uuid and name when metadata is absent', () => {
+        it('should have undefined metadata when absent on the subject', () => {
             const mockLogger = createMockLogger();
             const wrapper = createWrapper(mockLogger);
 
@@ -440,8 +442,7 @@ describe('CaslAuditWrapper', () => {
             wrapper.can('read', s);
 
             const { resource } = mockLogger.mock.calls[0][0];
-            expect(resource.uuid).toBeUndefined();
-            expect(resource.name).toBeUndefined();
+            expect(resource.metadata).toBeUndefined();
         });
     });
 
@@ -476,8 +477,7 @@ describe('CaslAuditWrapper', () => {
             const loggedEvent = mockLogger.mock.calls[0][0];
             expect(loggedEvent.resource.type).toBe('Dashboard');
             expect(loggedEvent.resource.organizationUuid).toBe('unknown');
-            expect(loggedEvent.resource.uuid).toBeUndefined();
-            expect(loggedEvent.resource.name).toBeUndefined();
+            expect(loggedEvent.resource.metadata).toBeUndefined();
             expect(loggedEvent.resource.projectUuid).toBeUndefined();
         });
 

--- a/packages/backend/src/logging/caslAuditWrapper.test.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.test.ts
@@ -419,7 +419,10 @@ describe('CaslAuditWrapper', () => {
 
             const s = subject('Dashboard', {
                 organizationUuid: 'test-org-uuid',
-                metadata: { dashboardUuid: 'meta-uuid', name: 'meta-name' },
+                metadata: {
+                    dashboardUuid: 'meta-uuid',
+                    dashboardName: 'meta-name',
+                },
             });
 
             wrapper.can('read', s);
@@ -427,7 +430,7 @@ describe('CaslAuditWrapper', () => {
             const { resource } = mockLogger.mock.calls[0][0];
             expect(resource.metadata).toEqual({
                 dashboardUuid: 'meta-uuid',
-                name: 'meta-name',
+                dashboardName: 'meta-name',
             });
         });
 

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -36,9 +36,11 @@ export type AuditableUser = Pick<
 
 type AuditableCaslSubjectObject = ForcedSubject<CaslSubjectNames> & {
     organizationUuid: string;
-    uuid?: string;
-    name?: string;
     projectUuid?: string;
+    metadata?: {
+        uuid?: string;
+        name?: string;
+    };
 };
 
 type AuditableCaslSubject = AuditableCaslSubjectObject | CaslSubjectNames;
@@ -138,8 +140,8 @@ const createResourceFromSubject = (
     }
     return {
         type: subjectArg.__caslSubjectType__ || 'unknown',
-        uuid: subjectArg.uuid,
-        name: subjectArg.name,
+        uuid: subjectArg.metadata?.uuid,
+        name: subjectArg.metadata?.name,
         organizationUuid: subjectArg.organizationUuid || 'unknown',
         projectUuid: subjectArg.projectUuid,
     };

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -37,10 +37,7 @@ export type AuditableUser = Pick<
 type AuditableCaslSubjectObject = ForcedSubject<CaslSubjectNames> & {
     organizationUuid: string;
     projectUuid?: string;
-    metadata?: {
-        uuid?: string;
-        name?: string;
-    };
+    metadata?: Record<string, unknown>;
 };
 
 type AuditableCaslSubject = AuditableCaslSubjectObject | CaslSubjectNames;
@@ -140,8 +137,7 @@ const createResourceFromSubject = (
     }
     return {
         type: subjectArg.__caslSubjectType__ || 'unknown',
-        uuid: subjectArg.metadata?.uuid,
-        name: subjectArg.metadata?.name,
+        metadata: subjectArg.metadata,
         organizationUuid: subjectArg.organizationUuid || 'unknown',
         projectUuid: subjectArg.projectUuid,
     };

--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -107,8 +107,10 @@ describe('formatAuditResource', () => {
         expect(
             formatAuditResource({
                 type: 'Dashboard',
-                uuid: 'dash-uuid',
-                name: 'Sales Overview',
+                metadata: {
+                    dashboardUuid: 'dash-uuid',
+                    name: 'Sales Overview',
+                },
                 organizationUuid: 'org-uuid',
             }),
         ).toBe('Dashboard "Sales Overview"');
@@ -118,7 +120,7 @@ describe('formatAuditResource', () => {
         expect(
             formatAuditResource({
                 type: 'Dashboard',
-                uuid: 'dash-uuid',
+                metadata: { dashboardUuid: 'dash-uuid' },
                 organizationUuid: 'org-uuid',
             }),
         ).toBe('Dashboard dash-uuid');
@@ -128,7 +130,7 @@ describe('formatAuditResource', () => {
         expect(
             formatAuditResource({
                 type: 'Project',
-                uuid: 'proj-uuid',
+                metadata: { projectUuid: 'proj-uuid' },
                 organizationUuid: 'org-uuid',
                 projectUuid: 'proj-uuid',
             }),
@@ -139,7 +141,7 @@ describe('formatAuditResource', () => {
         expect(
             formatAuditResource({
                 type: 'Project',
-                uuid: 'proj-uuid',
+                metadata: { projectUuid: 'proj-uuid' },
                 organizationUuid: 'org-uuid',
             }),
         ).toBe('Project proj-uuid');
@@ -190,8 +192,7 @@ describe('formatAuditMessage', () => {
         action: 'update',
         resource: {
             type: 'Dashboard',
-            uuid: 'dash-uuid',
-            name: 'Sales Overview',
+            metadata: { dashboardUuid: 'dash-uuid', name: 'Sales Overview' },
             organizationUuid: 'org-uuid',
             projectUuid: 'proj-uuid',
         },
@@ -247,8 +248,7 @@ describe('formatAuditMessage', () => {
                 action: 'manage',
                 resource: {
                     type: 'Group',
-                    uuid: 'group-uuid',
-                    name: 'Engineering',
+                    metadata: { groupUuid: 'group-uuid', name: 'Engineering' },
                     organizationUuid: 'org-uuid',
                 },
             }),

--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -109,7 +109,7 @@ describe('formatAuditResource', () => {
                 type: 'Dashboard',
                 metadata: {
                     dashboardUuid: 'dash-uuid',
-                    name: 'Sales Overview',
+                    dashboardName: 'Sales Overview',
                 },
                 organizationUuid: 'org-uuid',
             }),
@@ -192,7 +192,10 @@ describe('formatAuditMessage', () => {
         action: 'update',
         resource: {
             type: 'Dashboard',
-            metadata: { dashboardUuid: 'dash-uuid', name: 'Sales Overview' },
+            metadata: {
+                dashboardUuid: 'dash-uuid',
+                dashboardName: 'Sales Overview',
+            },
             organizationUuid: 'org-uuid',
             projectUuid: 'proj-uuid',
         },
@@ -248,7 +251,10 @@ describe('formatAuditMessage', () => {
                 action: 'manage',
                 resource: {
                     type: 'Group',
-                    metadata: { groupUuid: 'group-uuid', name: 'Engineering' },
+                    metadata: {
+                        groupUuid: 'group-uuid',
+                        groupName: 'Engineering',
+                    },
                     organizationUuid: 'org-uuid',
                 },
             }),

--- a/packages/backend/src/logging/winston.test.ts
+++ b/packages/backend/src/logging/winston.test.ts
@@ -103,7 +103,7 @@ describe('formatAuditActor', () => {
 });
 
 describe('formatAuditResource', () => {
-    it('shows type with name when name is available', () => {
+    it('renders all metadata entries as key: value pairs', () => {
         expect(
             formatAuditResource({
                 type: 'Dashboard',
@@ -113,20 +113,22 @@ describe('formatAuditResource', () => {
                 },
                 organizationUuid: 'org-uuid',
             }),
-        ).toBe('Dashboard "Sales Overview"');
+        ).toBe(
+            'Dashboard -> dashboardUuid: dash-uuid, dashboardName: Sales Overview',
+        );
     });
 
-    it('shows type with uuid when name is missing', () => {
+    it('renders a single metadata entry', () => {
         expect(
             formatAuditResource({
                 type: 'Dashboard',
                 metadata: { dashboardUuid: 'dash-uuid' },
                 organizationUuid: 'org-uuid',
             }),
-        ).toBe('Dashboard dash-uuid');
+        ).toBe('Dashboard -> dashboardUuid: dash-uuid');
     });
 
-    it('shows Project uuid even when uuid equals projectUuid', () => {
+    it('renders Project metadata even when it duplicates projectUuid', () => {
         expect(
             formatAuditResource({
                 type: 'Project',
@@ -134,20 +136,10 @@ describe('formatAuditResource', () => {
                 organizationUuid: 'org-uuid',
                 projectUuid: 'proj-uuid',
             }),
-        ).toBe('Project proj-uuid');
+        ).toBe('Project -> projectUuid: proj-uuid');
     });
 
-    it('shows Project with uuid when projectUuid is not set', () => {
-        expect(
-            formatAuditResource({
-                type: 'Project',
-                metadata: { projectUuid: 'proj-uuid' },
-                organizationUuid: 'org-uuid',
-            }),
-        ).toBe('Project proj-uuid');
-    });
-
-    it('shows type with project context for permission-type subjects', () => {
+    it('falls back to project context when metadata is absent', () => {
         expect(
             formatAuditResource({
                 type: 'Explore',
@@ -157,7 +149,7 @@ describe('formatAuditResource', () => {
         ).toBe('Explore in project proj-uuid');
     });
 
-    it('shows type with org context when only org uuid is available', () => {
+    it('falls back to org context when only org uuid is available', () => {
         expect(
             formatAuditResource({
                 type: 'CustomSql',
@@ -166,7 +158,7 @@ describe('formatAuditResource', () => {
         ).toBe('CustomSql in organization org-uuid');
     });
 
-    it('shows just type when no uuid, name, project, or org', () => {
+    it('shows just type when no metadata, project, or org is available', () => {
         expect(
             formatAuditResource({
                 type: 'CustomSql',
@@ -205,7 +197,7 @@ describe('formatAuditMessage', () => {
 
     it('formats a full allowed event', () => {
         expect(formatAuditMessage(baseEvent)).toBe(
-            'john@company.com updated Dashboard "Sales Overview" (allowed)',
+            'john@company.com updated Dashboard -> dashboardUuid: dash-uuid, dashboardName: Sales Overview (allowed)',
         );
     });
 
@@ -217,7 +209,7 @@ describe('formatAuditMessage', () => {
                 reason: 'Insufficient permissions',
             }),
         ).toBe(
-            'john@company.com updated Dashboard "Sales Overview" (denied) - Insufficient permissions',
+            'john@company.com updated Dashboard -> dashboardUuid: dash-uuid, dashboardName: Sales Overview (denied) - Insufficient permissions',
         );
     });
 
@@ -259,7 +251,7 @@ describe('formatAuditMessage', () => {
                 },
             }),
         ).toBe(
-            'service-account "ci@company.com" managed Group "Engineering" (allowed)',
+            'service-account "ci@company.com" managed Group -> groupUuid: group-uuid, groupName: Engineering (allowed)',
         );
     });
 
@@ -274,6 +266,8 @@ describe('formatAuditMessage', () => {
                 },
                 action: 'view',
             }),
-        ).toBe('anonymous user viewed Dashboard "Sales Overview" (allowed)');
+        ).toBe(
+            'anonymous user viewed Dashboard -> dashboardUuid: dash-uuid, dashboardName: Sales Overview (allowed)',
+        );
     });
 });

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -187,12 +187,13 @@ export const formatAuditActor = (actor: AuditActor): string => {
     return actor.uuid;
 };
 
-const findUuidInMetadata = (
+const findStringBySuffix = (
     metadata: Record<string, unknown> | undefined,
+    suffix: string,
 ): string | undefined => {
     if (!metadata) return undefined;
     for (const [key, val] of Object.entries(metadata)) {
-        if (key.endsWith('Uuid') && typeof val === 'string' && val) {
+        if (key.endsWith(suffix) && typeof val === 'string' && val) {
             return val;
         }
     }
@@ -201,10 +202,10 @@ const findUuidInMetadata = (
 
 export const formatAuditResource = (resource: AuditResource): string => {
     const typePart = resource.type;
-    const name = resource.metadata?.name;
-    const uuid = findUuidInMetadata(resource.metadata);
+    const name = findStringBySuffix(resource.metadata, 'Name');
+    const uuid = findStringBySuffix(resource.metadata, 'Uuid');
 
-    if (typeof name === 'string' && name) {
+    if (name) {
         return `${typePart} "${name}"`;
     }
     if (

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -187,17 +187,31 @@ export const formatAuditActor = (actor: AuditActor): string => {
     return actor.uuid;
 };
 
+const findUuidInMetadata = (
+    metadata: Record<string, unknown> | undefined,
+): string | undefined => {
+    if (!metadata) return undefined;
+    for (const [key, val] of Object.entries(metadata)) {
+        if (key.endsWith('Uuid') && typeof val === 'string' && val) {
+            return val;
+        }
+    }
+    return undefined;
+};
+
 export const formatAuditResource = (resource: AuditResource): string => {
     const typePart = resource.type;
+    const name = resource.metadata?.name;
+    const uuid = findUuidInMetadata(resource.metadata);
 
-    if (resource.name) {
-        return `${typePart} "${resource.name}"`;
+    if (typeof name === 'string' && name) {
+        return `${typePart} "${name}"`;
     }
     if (
-        resource.uuid &&
-        (resource.uuid !== resource.projectUuid || resource.type === 'Project')
+        uuid &&
+        (uuid !== resource.projectUuid || resource.type === 'Project')
     ) {
-        return `${typePart} ${resource.uuid}`;
+        return `${typePart} ${uuid}`;
     }
     // Permission-type subjects (CustomSql, UnderlyingData, Explore, Project, etc.)
     // with no meaningful unique identifier — fall back to project/org context

--- a/packages/backend/src/logging/winston.ts
+++ b/packages/backend/src/logging/winston.ts
@@ -187,32 +187,14 @@ export const formatAuditActor = (actor: AuditActor): string => {
     return actor.uuid;
 };
 
-const findStringBySuffix = (
-    metadata: Record<string, unknown> | undefined,
-    suffix: string,
-): string | undefined => {
-    if (!metadata) return undefined;
-    for (const [key, val] of Object.entries(metadata)) {
-        if (key.endsWith(suffix) && typeof val === 'string' && val) {
-            return val;
-        }
-    }
-    return undefined;
-};
-
 export const formatAuditResource = (resource: AuditResource): string => {
     const typePart = resource.type;
-    const name = findStringBySuffix(resource.metadata, 'Name');
-    const uuid = findStringBySuffix(resource.metadata, 'Uuid');
 
-    if (name) {
-        return `${typePart} "${name}"`;
-    }
-    if (
-        uuid &&
-        (uuid !== resource.projectUuid || resource.type === 'Project')
-    ) {
-        return `${typePart} ${uuid}`;
+    if (resource.metadata) {
+        const parts = Object.entries(resource.metadata)
+            .map(([key, value]) => `${key}: ${value}`)
+            .join(', ');
+        return `${typePart} -> ${parts}`;
     }
     // Permission-type subjects (CustomSql, UnderlyingData, Explore, Project, etc.)
     // with no meaningful unique identifier — fall back to project/org context

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -384,7 +384,7 @@ export class AsyncQueryService extends ProjectService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             ) &&
             ability.cannot(
@@ -392,8 +392,8 @@ export class AsyncQueryService extends ProjectService {
                 subject('Explore', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
                     exploreNames: [exploreName],
+                    metadata: { projectUuid, exploreName },
                 }),
             );
 
@@ -417,7 +417,7 @@ export class AsyncQueryService extends ProjectService {
                 subject('PreAggregation', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             )
         ) {

--- a/packages/backend/src/services/CatalogService/CatalogService.ts
+++ b/packages/backend/src/services/CatalogService/CatalogService.ts
@@ -702,8 +702,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -764,8 +763,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -851,8 +849,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -897,8 +894,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -951,8 +947,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -1065,8 +1060,7 @@ export class CatalogService<
                 subject('Tags', {
                     projectUuid: tag.projectUuid,
                     organizationUuid: tagOrganizationUuid,
-                    uuid: tag.tagUuid,
-                    name: tag.name,
+                    metadata: { tagUuid: tag.tagUuid, tagName: tag.name },
                 }),
             )
         ) {
@@ -1113,8 +1107,7 @@ export class CatalogService<
                 subject('Tags', {
                     projectUuid: tag.projectUuid,
                     organizationUuid: tagOrganizationUuid,
-                    uuid: tag.tagUuid,
-                    name: tag.name,
+                    metadata: { tagUuid: tag.tagUuid, tagName: tag.name },
                 }),
             )
         ) {
@@ -1181,8 +1174,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -1452,8 +1444,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -1517,8 +1508,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -1591,8 +1581,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -1647,8 +1636,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -1733,8 +1721,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -1759,8 +1746,7 @@ export class CatalogService<
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -1811,7 +1797,7 @@ export class CatalogService<
                 subject('MetricsTree', {
                     projectUuid,
                     organizationUuid,
-                    uuid: metricsTreeUuidOrSlug,
+                    metadata: { metricsTreeUuidOrSlug },
                 }),
             )
         ) {
@@ -1881,7 +1867,7 @@ export class CatalogService<
                 subject('MetricsTree', {
                     projectUuid,
                     organizationUuid,
-                    uuid: metricsTreeUuid,
+                    metadata: { metricsTreeUuid },
                 }),
             )
         ) {
@@ -1911,7 +1897,7 @@ export class CatalogService<
                 subject('MetricsTree', {
                     projectUuid,
                     organizationUuid,
-                    uuid: metricsTreeUuid,
+                    metadata: { metricsTreeUuid },
                 }),
             )
         ) {
@@ -1939,7 +1925,7 @@ export class CatalogService<
                 subject('MetricsTree', {
                     projectUuid,
                     organizationUuid,
-                    uuid: metricsTreeUuid,
+                    metadata: { metricsTreeUuid },
                 }),
             )
         ) {
@@ -1965,7 +1951,7 @@ export class CatalogService<
                 subject('MetricsTree', {
                     projectUuid,
                     organizationUuid,
-                    uuid: metricsTreeUuid,
+                    metadata: { metricsTreeUuid },
                 }),
             )
         ) {
@@ -2014,7 +2000,7 @@ export class CatalogService<
                 subject('MetricsTree', {
                     projectUuid,
                     organizationUuid,
-                    uuid: metricsTreeUuid,
+                    metadata: { metricsTreeUuid },
                 }),
             )
         ) {

--- a/packages/backend/src/services/CommentService/CommentService.test.ts
+++ b/packages/backend/src/services/CommentService/CommentService.test.ts
@@ -189,7 +189,7 @@ describe('CommentService', () => {
                     type: 'DashboardComments',
                     organizationUuid: 'org-uuid',
                     projectUuid: 'project-uuid',
-                    name: 'Test Dashboard',
+                    metadata: { dashboardName: 'Test Dashboard' },
                 },
             );
         });

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -347,7 +347,7 @@ export class CommentService extends BaseService {
                 type: 'DashboardComments',
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
-                metadata: { name: dashboard.name },
+                metadata: { dashboardName: dashboard.name },
             });
         }
 

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -347,7 +347,7 @@ export class CommentService extends BaseService {
                 type: 'DashboardComments',
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
-                name: dashboard.name,
+                metadata: { name: dashboard.name },
             });
         }
 

--- a/packages/backend/src/services/CommentService/CommentService.ts
+++ b/packages/backend/src/services/CommentService/CommentService.ts
@@ -165,7 +165,7 @@ export class CommentService extends BaseService {
                 subject('DashboardComments', {
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
-                    name: dashboard.name,
+                    metadata: { dashboardName: dashboard.name },
                 }),
             )
         ) {
@@ -234,7 +234,7 @@ export class CommentService extends BaseService {
                 subject('DashboardComments', {
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
-                    name: dashboard.name,
+                    metadata: { dashboardName: dashboard.name },
                 }),
             )
         ) {
@@ -252,7 +252,7 @@ export class CommentService extends BaseService {
             subject('DashboardComments', {
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
-                name: dashboard.name,
+                metadata: { dashboardName: dashboard.name },
             }),
         );
 
@@ -279,7 +279,7 @@ export class CommentService extends BaseService {
                 subject('DashboardComments', {
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
-                    name: dashboard.name,
+                    metadata: { dashboardName: dashboard.name },
                 }),
             )
         ) {
@@ -331,7 +331,7 @@ export class CommentService extends BaseService {
             subject('DashboardComments', {
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
-                name: dashboard.name,
+                metadata: { dashboardName: dashboard.name },
             }),
         );
 

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -108,8 +108,8 @@ export class ContentService extends BaseService {
                         organizationUuid,
                         projectUuid: project.projectUuid,
                         metadata: {
-                            uuid: project.projectUuid,
-                            name: project.name,
+                            projectUuid: project.projectUuid,
+                            projectName: project.name,
                         },
                     }),
                 ),
@@ -215,7 +215,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid, name: projectName },
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -310,7 +310,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid, name: projectName },
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -396,7 +396,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid, name: projectName },
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -452,7 +452,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid, name: projectName },
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {
@@ -502,7 +502,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid, name: projectName },
+                    metadata: { projectUuid, projectName },
                 }),
             )
         ) {

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -107,8 +107,10 @@ export class ContentService extends BaseService {
                     subject('Project', {
                         organizationUuid,
                         projectUuid: project.projectUuid,
-                        uuid: project.projectUuid,
-                        name: project.name,
+                        metadata: {
+                            uuid: project.projectUuid,
+                            name: project.name,
+                        },
                     }),
                 ),
             )
@@ -213,8 +215,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { uuid: projectUuid, name: projectName },
                 }),
             )
         ) {
@@ -309,8 +310,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { uuid: projectUuid, name: projectName },
                 }),
             )
         ) {
@@ -396,8 +396,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { uuid: projectUuid, name: projectName },
                 }),
             )
         ) {
@@ -453,8 +452,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { uuid: projectUuid, name: projectName },
                 }),
             )
         ) {
@@ -504,8 +502,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
-                    name: projectName,
+                    metadata: { uuid: projectUuid, name: projectName },
                 }),
             )
         ) {

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -215,7 +215,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid, name: projectName },
+                    metadata: { projectUuid, name: projectName },
                 }),
             )
         ) {
@@ -310,7 +310,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid, name: projectName },
+                    metadata: { projectUuid, name: projectName },
                 }),
             )
         ) {
@@ -396,7 +396,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid, name: projectName },
+                    metadata: { projectUuid, name: projectName },
                 }),
             )
         ) {
@@ -452,7 +452,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid, name: projectName },
+                    metadata: { projectUuid, name: projectName },
                 }),
             )
         ) {
@@ -502,7 +502,7 @@ export class ContentService extends BaseService {
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid, name: projectName },
+                    metadata: { projectUuid, name: projectName },
                 }),
             )
         ) {

--- a/packages/backend/src/services/ContentVerificationService.ts
+++ b/packages/backend/src/services/ContentVerificationService.ts
@@ -45,7 +45,7 @@ export class ContentVerificationService extends BaseService {
                 subject('ContentVerification', {
                     organizationUuid: project.organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             )
         ) {

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -476,7 +476,7 @@ export class DashboardService
                     ...dashboard,
                     metadata: {
                         dashboardUuid: dashboard.uuid,
-                        name: dashboard.name,
+                        dashboardName: dashboard.name,
                     },
                 }),
             )
@@ -629,7 +629,7 @@ export class DashboardService
                     ...dashboard,
                     metadata: {
                         dashboardUuid: dashboard.uuid,
-                        name: dashboard.name,
+                        dashboardName: dashboard.name,
                     },
                 }),
             )
@@ -1036,8 +1036,8 @@ export class DashboardService
                 subject('Dashboard', {
                     ...existingDashboard,
                     metadata: {
-                        uuid: existingDashboard.uuid,
-                        name: existingDashboard.name,
+                        dashboardUuid: existingDashboard.uuid,
+                        dashboardName: existingDashboard.name,
                     },
                 }),
             )
@@ -1559,7 +1559,7 @@ export class DashboardService
                     ...dashboard,
                     metadata: {
                         dashboardUuid: dashboard.uuid,
-                        name: dashboard.name,
+                        dashboardName: dashboard.name,
                     },
                 }),
             )
@@ -1658,8 +1658,8 @@ export class DashboardService
                     inheritsFromOrgOrProject,
                     access,
                     metadata: {
-                        uuid: dashboardDao.uuid,
-                        name: dashboardDao.name,
+                        dashboardUuid: dashboardDao.uuid,
+                        dashboardName: dashboardDao.name,
                     },
                 }),
             )
@@ -1706,8 +1706,8 @@ export class DashboardService
                     inheritsFromOrgOrProject,
                     access,
                     metadata: {
-                        uuid: dashboardDao.uuid,
-                        name: dashboardDao.name,
+                        dashboardUuid: dashboardDao.uuid,
+                        dashboardName: dashboardDao.name,
                     },
                 }),
             )
@@ -1852,8 +1852,8 @@ export class DashboardService
                     inheritsFromOrgOrProject,
                     access,
                     metadata: {
-                        uuid: dashboardDao.uuid,
-                        name: dashboardDao.name,
+                        dashboardUuid: dashboardDao.uuid,
+                        dashboardName: dashboardDao.name,
                     },
                 }),
             )

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -190,7 +190,7 @@ export class DashboardService
                 subject('ContentVerification', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid },
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -243,7 +243,7 @@ export class DashboardService
                 subject('ContentVerification', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid },
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -435,7 +435,7 @@ export class DashboardService
                 'view',
                 subject('Dashboard', {
                     ...spaceContext,
-                    metadata: { uuid: dashboard.uuid },
+                    metadata: { dashboardUuid: dashboard.uuid },
                 }),
             );
             return includePrivate
@@ -474,7 +474,10 @@ export class DashboardService
                 'view',
                 subject('Dashboard', {
                     ...dashboard,
-                    metadata: { uuid: dashboard.uuid, name: dashboard.name },
+                    metadata: {
+                        dashboardUuid: dashboard.uuid,
+                        name: dashboard.name,
+                    },
                 }),
             )
         ) {
@@ -624,7 +627,10 @@ export class DashboardService
                 'create',
                 subject('Dashboard', {
                     ...dashboard,
-                    metadata: { uuid: dashboard.uuid, name: dashboard.name },
+                    metadata: {
+                        dashboardUuid: dashboard.uuid,
+                        name: dashboard.name,
+                    },
                 }),
             )
         ) {
@@ -791,7 +797,7 @@ export class DashboardService
             'update',
             subject('Dashboard', {
                 ...currentSpace,
-                metadata: { uuid: existingDashboardDao.uuid },
+                metadata: { dashboardUuid: existingDashboardDao.uuid },
             }),
         );
 
@@ -812,7 +818,7 @@ export class DashboardService
                     'update',
                     subject('Dashboard', {
                         ...newSpace,
-                        metadata: { uuid: existingDashboardDao.uuid },
+                        metadata: { dashboardUuid: existingDashboardDao.uuid },
                     }),
                 );
                 if (!canUpdateDashboardInNewSpace) {
@@ -1017,7 +1023,7 @@ export class DashboardService
                 subject('PinnedItems', {
                     projectUuid,
                     organizationUuid,
-                    metadata: { uuid: existingDashboard.uuid },
+                    metadata: { dashboardUuid: existingDashboard.uuid },
                 }),
             )
         ) {
@@ -1099,7 +1105,7 @@ export class DashboardService
                     'update',
                     subject('Dashboard', {
                         ...currentSpaceContext,
-                        metadata: { uuid: dashboard.uuid },
+                        metadata: { dashboardUuid: dashboard.uuid },
                     }),
                 );
                 const newSpaceContext =
@@ -1111,7 +1117,7 @@ export class DashboardService
                     'update',
                     subject('Dashboard', {
                         ...newSpaceContext,
-                        metadata: { uuid: dashboardToUpdate.uuid },
+                        metadata: { dashboardUuid: dashboardToUpdate.uuid },
                     }),
                 );
                 return (
@@ -1189,7 +1195,7 @@ export class DashboardService
                         projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        metadata: { uuid: dashboardUuid },
+                        metadata: { dashboardUuid },
                     }),
                 )
             ) {
@@ -1278,7 +1284,7 @@ export class DashboardService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'delete', {
                 type: 'Dashboard',
-                uuid: dashboardUuid,
+                metadata: { dashboardUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
@@ -1298,7 +1304,7 @@ export class DashboardService
                         projectUuid: dashboard.projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        metadata: { uuid: dashboardUuid },
+                        metadata: { dashboardUuid },
                     }),
                 )
             ) {
@@ -1337,7 +1343,7 @@ export class DashboardService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                uuid: dashboardUuid,
+                metadata: { dashboardUuid },
                 organizationUuid: dashboard.organizationUuid,
                 projectUuid: dashboard.projectUuid,
             });
@@ -1349,7 +1355,7 @@ export class DashboardService
                     subject('DeletedContent', {
                         organizationUuid: dashboard.organizationUuid,
                         projectUuid: dashboard.projectUuid,
-                        metadata: { uuid: dashboardUuid },
+                        metadata: { dashboardUuid },
                     }),
                 )
             ) {
@@ -1387,7 +1393,7 @@ export class DashboardService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                uuid: dashboardUuid,
+                metadata: { dashboardUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
@@ -1402,7 +1408,7 @@ export class DashboardService
                     subject('DeletedContent', {
                         organizationUuid: dashboard.organizationUuid,
                         projectUuid: dashboard.projectUuid,
-                        metadata: { uuid: dashboardUuid },
+                        metadata: { dashboardUuid },
                     }),
                 )
             ) {
@@ -1551,7 +1557,10 @@ export class DashboardService
                 'view',
                 subject('Dashboard', {
                     ...dashboard,
-                    metadata: { uuid: dashboard.uuid, name: dashboard.name },
+                    metadata: {
+                        dashboardUuid: dashboard.uuid,
+                        name: dashboard.name,
+                    },
                 }),
             )
         ) {
@@ -1593,7 +1602,7 @@ export class DashboardService
                 projectUuid: actor.projectUuid,
                 inheritsFromOrgOrProject,
                 access,
-                metadata: { uuid: dashboard.uuid },
+                metadata: { dashboardUuid: dashboard.uuid },
             }),
         );
 
@@ -1617,7 +1626,7 @@ export class DashboardService
                     projectUuid: actor.projectUuid,
                     inheritsFromOrgOrProject: newSpace.inheritsFromOrgOrProject,
                     access: newSpace.access,
-                    metadata: { uuid: dashboard.uuid },
+                    metadata: { dashboardUuid: dashboard.uuid },
                 }),
             );
 

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -190,7 +190,7 @@ export class DashboardService
                 subject('ContentVerification', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { uuid: projectUuid },
                 }),
             )
         ) {
@@ -243,7 +243,7 @@ export class DashboardService
                 subject('ContentVerification', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { uuid: projectUuid },
                 }),
             )
         ) {
@@ -433,7 +433,10 @@ export class DashboardService
             if (!spaceContext) return false;
             const hasAbility = auditedAbility.can(
                 'view',
-                subject('Dashboard', { ...spaceContext, uuid: dashboard.uuid }),
+                subject('Dashboard', {
+                    ...spaceContext,
+                    metadata: { uuid: dashboard.uuid },
+                }),
             );
             return includePrivate
                 ? hasAbility
@@ -466,7 +469,15 @@ export class DashboardService
 
         const auditedAbility = this.createAuditedAbility(user);
 
-        if (auditedAbility.cannot('view', subject('Dashboard', dashboard))) {
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Dashboard', {
+                    ...dashboard,
+                    metadata: { uuid: dashboard.uuid, name: dashboard.name },
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 "You don't have access to the space this dashboard belongs to",
             );
@@ -608,7 +619,15 @@ export class DashboardService
         };
 
         const auditedAbility = this.createAuditedAbility(user);
-        if (auditedAbility.cannot('create', subject('Dashboard', dashboard))) {
+        if (
+            auditedAbility.cannot(
+                'create',
+                subject('Dashboard', {
+                    ...dashboard,
+                    metadata: { uuid: dashboard.uuid, name: dashboard.name },
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 "You don't have access to the space this dashboard belongs to",
             );
@@ -772,7 +791,7 @@ export class DashboardService
             'update',
             subject('Dashboard', {
                 ...currentSpace,
-                uuid: existingDashboardDao.uuid,
+                metadata: { uuid: existingDashboardDao.uuid },
             }),
         );
 
@@ -793,7 +812,7 @@ export class DashboardService
                     'update',
                     subject('Dashboard', {
                         ...newSpace,
-                        uuid: existingDashboardDao.uuid,
+                        metadata: { uuid: existingDashboardDao.uuid },
                     }),
                 );
                 if (!canUpdateDashboardInNewSpace) {
@@ -998,7 +1017,7 @@ export class DashboardService
                 subject('PinnedItems', {
                     projectUuid,
                     organizationUuid,
-                    uuid: existingDashboard.uuid,
+                    metadata: { uuid: existingDashboard.uuid },
                 }),
             )
         ) {
@@ -1008,7 +1027,13 @@ export class DashboardService
         if (
             auditedAbility.cannot(
                 'view',
-                subject('Dashboard', existingDashboard),
+                subject('Dashboard', {
+                    ...existingDashboard,
+                    metadata: {
+                        uuid: existingDashboard.uuid,
+                        name: existingDashboard.name,
+                    },
+                }),
             )
         ) {
             throw new ForbiddenError(
@@ -1074,7 +1099,7 @@ export class DashboardService
                     'update',
                     subject('Dashboard', {
                         ...currentSpaceContext,
-                        uuid: dashboard.uuid,
+                        metadata: { uuid: dashboard.uuid },
                     }),
                 );
                 const newSpaceContext =
@@ -1086,7 +1111,7 @@ export class DashboardService
                     'update',
                     subject('Dashboard', {
                         ...newSpaceContext,
-                        uuid: dashboardToUpdate.uuid,
+                        metadata: { uuid: dashboardToUpdate.uuid },
                     }),
                 );
                 return (
@@ -1164,7 +1189,7 @@ export class DashboardService
                         projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        uuid: dashboardUuid,
+                        metadata: { uuid: dashboardUuid },
                     }),
                 )
             ) {
@@ -1273,7 +1298,7 @@ export class DashboardService
                         projectUuid: dashboard.projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        uuid: dashboardUuid,
+                        metadata: { uuid: dashboardUuid },
                     }),
                 )
             ) {
@@ -1324,7 +1349,7 @@ export class DashboardService
                     subject('DeletedContent', {
                         organizationUuid: dashboard.organizationUuid,
                         projectUuid: dashboard.projectUuid,
-                        uuid: dashboardUuid,
+                        metadata: { uuid: dashboardUuid },
                     }),
                 )
             ) {
@@ -1377,7 +1402,7 @@ export class DashboardService
                     subject('DeletedContent', {
                         organizationUuid: dashboard.organizationUuid,
                         projectUuid: dashboard.projectUuid,
-                        uuid: dashboardUuid,
+                        metadata: { uuid: dashboardUuid },
                     }),
                 )
             ) {
@@ -1521,7 +1546,15 @@ export class DashboardService
         ) {
             throw new ForbiddenError();
         }
-        if (auditedAbility.cannot('view', subject('Dashboard', dashboard))) {
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('Dashboard', {
+                    ...dashboard,
+                    metadata: { uuid: dashboard.uuid, name: dashboard.name },
+                }),
+            )
+        ) {
             throw new ForbiddenError(
                 "You don't have access to the space this dashboard belongs to",
             );
@@ -1560,7 +1593,7 @@ export class DashboardService
                 projectUuid: actor.projectUuid,
                 inheritsFromOrgOrProject,
                 access,
-                uuid: dashboard.uuid,
+                metadata: { uuid: dashboard.uuid },
             }),
         );
 
@@ -1584,7 +1617,7 @@ export class DashboardService
                     projectUuid: actor.projectUuid,
                     inheritsFromOrgOrProject: newSpace.inheritsFromOrgOrProject,
                     access: newSpace.access,
-                    uuid: dashboard.uuid,
+                    metadata: { uuid: dashboard.uuid },
                 }),
             );
 
@@ -1615,6 +1648,10 @@ export class DashboardService
                     ...dashboardDao,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: {
+                        uuid: dashboardDao.uuid,
+                        name: dashboardDao.name,
+                    },
                 }),
             )
         ) {
@@ -1659,6 +1696,10 @@ export class DashboardService
                     ...dashboardDao,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: {
+                        uuid: dashboardDao.uuid,
+                        name: dashboardDao.name,
+                    },
                 }),
             )
         ) {
@@ -1801,6 +1842,10 @@ export class DashboardService
                     ...dashboardDao,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: {
+                        uuid: dashboardDao.uuid,
+                        name: dashboardDao.name,
+                    },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -191,7 +191,10 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: savedChart.uuid, name: savedChart.name },
+                    metadata: {
+                        savedChartUuid: savedChart.uuid,
+                        name: savedChart.name,
+                    },
                 }),
             )
         ) {
@@ -215,7 +218,10 @@ export class SavedChartService
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: savedChart.uuid, name: savedChart.name },
+                    metadata: {
+                        savedChartUuid: savedChart.uuid,
+                        name: savedChart.name,
+                    },
                 }),
             )
         ) {
@@ -495,7 +501,7 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: savedChartUuid },
+                    metadata: { savedChartUuid },
                 }),
             )
         ) {
@@ -509,7 +515,7 @@ export class SavedChartService
                 subject('CustomFields', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: savedChartUuid },
+                    metadata: { savedChartUuid },
                 }),
             )
         ) {
@@ -618,7 +624,7 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: savedChartUuid, name },
+                    metadata: { savedChartUuid, name },
                 }),
             )
         ) {
@@ -689,7 +695,7 @@ export class SavedChartService
                 subject('PinnedItems', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: savedChartUuid },
+                    metadata: { savedChartUuid },
                 }),
             )
         ) {
@@ -755,7 +761,7 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: chart.uuid },
+                    metadata: { savedChartUuid: chart.uuid },
                 }),
             );
         });
@@ -810,7 +816,7 @@ export class SavedChartService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'delete', {
                 type: 'SavedChart',
-                uuid: resolvedUuid,
+                metadata: { savedChartUuid: resolvedUuid },
                 organizationUuid,
                 projectUuid,
             });
@@ -829,7 +835,7 @@ export class SavedChartService
                         projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        metadata: { uuid: resolvedUuid },
+                        metadata: { savedChartUuid: resolvedUuid },
                     }),
                 )
             ) {
@@ -889,7 +895,7 @@ export class SavedChartService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'delete', {
                 type: 'SavedChart',
-                uuid: savedChartUuid,
+                metadata: { savedChartUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
@@ -908,7 +914,7 @@ export class SavedChartService
                         projectUuid: chart.projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        metadata: { uuid: savedChartUuid, name: chart.name },
+                        metadata: { savedChartUuid, name: chart.name },
                     }),
                 )
             ) {
@@ -951,7 +957,10 @@ export class SavedChartService
                     ...savedChart,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: savedChart.uuid, name: savedChart.name },
+                    metadata: {
+                        savedChartUuid: savedChart.uuid,
+                        name: savedChart.name,
+                    },
                 }),
             )
         ) {
@@ -1003,7 +1012,10 @@ export class SavedChartService
                     ...savedChart,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: savedChart.uuid, name: savedChart.name },
+                    metadata: {
+                        savedChartUuid: savedChart.uuid,
+                        name: savedChart.name,
+                    },
                 }),
             )
         ) {
@@ -1073,7 +1085,7 @@ export class SavedChartService
                 subject('ContentVerification', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid },
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1122,7 +1134,7 @@ export class SavedChartService
                 subject('ContentVerification', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid },
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1318,7 +1330,7 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: chart.uuid, name: chart.name },
+                    metadata: { savedChartUuid: chart.uuid, name: chart.name },
                 }),
             )
         ) {
@@ -1580,7 +1592,7 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: chart.uuid, name: chart.name },
+                    metadata: { savedChartUuid: chart.uuid, name: chart.name },
                 }),
             )
         ) {
@@ -1623,7 +1635,7 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { uuid: chart.uuid, name: chart.name },
+                    metadata: { savedChartUuid: chart.uuid, name: chart.name },
                 }),
             )
         ) {
@@ -1889,7 +1901,7 @@ export class SavedChartService
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid },
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1902,7 +1914,7 @@ export class SavedChartService
             subject('DeletedContent', {
                 organizationUuid,
                 projectUuid,
-                metadata: { uuid: projectUuid },
+                metadata: { projectUuid },
             }),
         );
 
@@ -1936,7 +1948,7 @@ export class SavedChartService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                uuid: chartUuid,
+                metadata: { savedChartUuid: chartUuid },
                 organizationUuid,
                 projectUuid,
             });
@@ -1948,7 +1960,7 @@ export class SavedChartService
                     subject('Project', {
                         organizationUuid,
                         projectUuid,
-                        metadata: { uuid: projectUuid },
+                        metadata: { projectUuid },
                     }),
                 )
             ) {
@@ -1960,7 +1972,7 @@ export class SavedChartService
                 subject('DeletedContent', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: chartUuid },
+                    metadata: { savedChartUuid: chartUuid },
                 }),
             );
 
@@ -2008,7 +2020,7 @@ export class SavedChartService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                uuid: chartUuid,
+                metadata: { savedChartUuid: chartUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
@@ -2026,7 +2038,7 @@ export class SavedChartService
                     subject('Project', {
                         organizationUuid,
                         projectUuid,
-                        metadata: { uuid: projectUuid },
+                        metadata: { projectUuid },
                     }),
                 )
             ) {
@@ -2038,7 +2050,7 @@ export class SavedChartService
                 subject('DeletedContent', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: chartUuid },
+                    metadata: { savedChartUuid: chartUuid },
                 }),
             );
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -191,8 +191,7 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    uuid: savedChart.uuid,
-                    name: savedChart.name,
+                    metadata: { uuid: savedChart.uuid, name: savedChart.name },
                 }),
             )
         ) {
@@ -216,8 +215,7 @@ export class SavedChartService
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
-                    uuid: savedChart.uuid,
-                    name: savedChart.name,
+                    metadata: { uuid: savedChart.uuid, name: savedChart.name },
                 }),
             )
         ) {
@@ -497,7 +495,7 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    uuid: savedChartUuid,
+                    metadata: { uuid: savedChartUuid },
                 }),
             )
         ) {
@@ -511,7 +509,7 @@ export class SavedChartService
                 subject('CustomFields', {
                     organizationUuid,
                     projectUuid,
-                    uuid: savedChartUuid,
+                    metadata: { uuid: savedChartUuid },
                 }),
             )
         ) {
@@ -620,8 +618,7 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    uuid: savedChartUuid,
-                    name,
+                    metadata: { uuid: savedChartUuid, name },
                 }),
             )
         ) {
@@ -692,7 +689,7 @@ export class SavedChartService
                 subject('PinnedItems', {
                     organizationUuid,
                     projectUuid,
-                    uuid: savedChartUuid,
+                    metadata: { uuid: savedChartUuid },
                 }),
             )
         ) {
@@ -758,7 +755,7 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    uuid: chart.uuid,
+                    metadata: { uuid: chart.uuid },
                 }),
             );
         });
@@ -832,7 +829,7 @@ export class SavedChartService
                         projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        uuid: resolvedUuid,
+                        metadata: { uuid: resolvedUuid },
                     }),
                 )
             ) {
@@ -911,8 +908,7 @@ export class SavedChartService
                         projectUuid: chart.projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        uuid: savedChartUuid,
-                        name: chart.name,
+                        metadata: { uuid: savedChartUuid, name: chart.name },
                     }),
                 )
             ) {
@@ -955,6 +951,7 @@ export class SavedChartService
                     ...savedChart,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: { uuid: savedChart.uuid, name: savedChart.name },
                 }),
             )
         ) {
@@ -1006,6 +1003,7 @@ export class SavedChartService
                     ...savedChart,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: { uuid: savedChart.uuid, name: savedChart.name },
                 }),
             )
         ) {
@@ -1075,7 +1073,7 @@ export class SavedChartService
                 subject('ContentVerification', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { uuid: projectUuid },
                 }),
             )
         ) {
@@ -1124,7 +1122,7 @@ export class SavedChartService
                 subject('ContentVerification', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { uuid: projectUuid },
                 }),
             )
         ) {
@@ -1320,6 +1318,7 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: { uuid: chart.uuid, name: chart.name },
                 }),
             )
         ) {
@@ -1581,6 +1580,7 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: { uuid: chart.uuid, name: chart.name },
                 }),
             )
         ) {
@@ -1623,6 +1623,7 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: { uuid: chart.uuid, name: chart.name },
                 }),
             )
         ) {
@@ -1888,7 +1889,7 @@ export class SavedChartService
                 subject('Project', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { uuid: projectUuid },
                 }),
             )
         ) {
@@ -1901,7 +1902,7 @@ export class SavedChartService
             subject('DeletedContent', {
                 organizationUuid,
                 projectUuid,
-                uuid: projectUuid,
+                metadata: { uuid: projectUuid },
             }),
         );
 
@@ -1947,7 +1948,7 @@ export class SavedChartService
                     subject('Project', {
                         organizationUuid,
                         projectUuid,
-                        uuid: projectUuid,
+                        metadata: { uuid: projectUuid },
                     }),
                 )
             ) {
@@ -1959,7 +1960,7 @@ export class SavedChartService
                 subject('DeletedContent', {
                     organizationUuid,
                     projectUuid,
-                    uuid: chartUuid,
+                    metadata: { uuid: chartUuid },
                 }),
             );
 
@@ -2025,7 +2026,7 @@ export class SavedChartService
                     subject('Project', {
                         organizationUuid,
                         projectUuid,
-                        uuid: projectUuid,
+                        metadata: { uuid: projectUuid },
                     }),
                 )
             ) {
@@ -2037,7 +2038,7 @@ export class SavedChartService
                 subject('DeletedContent', {
                     organizationUuid,
                     projectUuid,
-                    uuid: chartUuid,
+                    metadata: { uuid: chartUuid },
                 }),
             );
 

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -193,7 +193,7 @@ export class SavedChartService
                     access,
                     metadata: {
                         savedChartUuid: savedChart.uuid,
-                        name: savedChart.name,
+                        savedChartName: savedChart.name,
                     },
                 }),
             )
@@ -220,7 +220,7 @@ export class SavedChartService
                     projectUuid,
                     metadata: {
                         savedChartUuid: savedChart.uuid,
-                        name: savedChart.name,
+                        savedChartName: savedChart.name,
                     },
                 }),
             )
@@ -624,7 +624,7 @@ export class SavedChartService
                     projectUuid,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { savedChartUuid, name },
+                    metadata: { savedChartUuid, savedChartName: name },
                 }),
             )
         ) {
@@ -914,7 +914,10 @@ export class SavedChartService
                         projectUuid: chart.projectUuid,
                         inheritsFromOrgOrProject,
                         access,
-                        metadata: { savedChartUuid, name: chart.name },
+                        metadata: {
+                            savedChartUuid,
+                            savedChartName: chart.name,
+                        },
                     }),
                 )
             ) {
@@ -959,7 +962,7 @@ export class SavedChartService
                     access,
                     metadata: {
                         savedChartUuid: savedChart.uuid,
-                        name: savedChart.name,
+                        savedChartName: savedChart.name,
                     },
                 }),
             )
@@ -1014,7 +1017,7 @@ export class SavedChartService
                     access,
                     metadata: {
                         savedChartUuid: savedChart.uuid,
-                        name: savedChart.name,
+                        savedChartName: savedChart.name,
                     },
                 }),
             )
@@ -1330,7 +1333,10 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { savedChartUuid: chart.uuid, name: chart.name },
+                    metadata: {
+                        savedChartUuid: chart.uuid,
+                        savedChartName: chart.name,
+                    },
                 }),
             )
         ) {
@@ -1592,7 +1598,10 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { savedChartUuid: chart.uuid, name: chart.name },
+                    metadata: {
+                        savedChartUuid: chart.uuid,
+                        savedChartName: chart.name,
+                    },
                 }),
             )
         ) {
@@ -1635,7 +1644,10 @@ export class SavedChartService
                     ...chart,
                     inheritsFromOrgOrProject,
                     access,
-                    metadata: { savedChartUuid: chart.uuid, name: chart.name },
+                    metadata: {
+                        savedChartUuid: chart.uuid,
+                        savedChartName: chart.name,
+                    },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -182,7 +182,7 @@ export class SavedSqlService
                 action,
                 subject('SavedChart', {
                     ...ctx[spaceUuid],
-                    uuid: resource.savedSqlUuid ?? '',
+                    metadata: { uuid: resource.savedSqlUuid ?? '' },
                 }),
             )
         ) {
@@ -197,7 +197,7 @@ export class SavedSqlService
                     action,
                     subject('SavedChart', {
                         ...ctx[resource.spaceUuid!],
-                        uuid: resource.savedSqlUuid ?? '',
+                        metadata: { uuid: resource.savedSqlUuid ?? '' },
                     }),
                 )
             ) {
@@ -270,7 +270,7 @@ export class SavedSqlService
                 subject('CustomSql', {
                     organizationUuid,
                     projectUuid,
-                    uuid: '',
+                    metadata: { uuid: '' },
                 }),
             )
         ) {
@@ -334,7 +334,7 @@ export class SavedSqlService
                 subject('CustomSql', {
                     organizationUuid,
                     projectUuid,
-                    uuid: savedSqlUuid,
+                    metadata: { uuid: savedSqlUuid },
                 }),
             )
         ) {
@@ -490,7 +490,7 @@ export class SavedSqlService
                     subject('Project', {
                         organizationUuid,
                         projectUuid,
-                        uuid: projectUuid,
+                        metadata: { uuid: projectUuid },
                     }),
                 )
             ) {
@@ -502,7 +502,7 @@ export class SavedSqlService
                 subject('DeletedContent', {
                     organizationUuid,
                     projectUuid,
-                    uuid: savedSqlUuid,
+                    metadata: { uuid: savedSqlUuid },
                 }),
             );
 
@@ -552,7 +552,7 @@ export class SavedSqlService
                     subject('Project', {
                         organizationUuid,
                         projectUuid,
-                        uuid: projectUuid,
+                        metadata: { uuid: projectUuid },
                     }),
                 )
             ) {
@@ -564,7 +564,7 @@ export class SavedSqlService
                 subject('DeletedContent', {
                     organizationUuid,
                     projectUuid,
-                    uuid: savedSqlUuid,
+                    metadata: { uuid: savedSqlUuid },
                 }),
             );
 
@@ -593,7 +593,7 @@ export class SavedSqlService
                 subject('Job', {
                     organizationUuid,
                     projectUuid,
-                    uuid: '',
+                    metadata: { uuid: '' },
                 }),
             ) ||
             auditedAbility.cannot(
@@ -601,7 +601,7 @@ export class SavedSqlService
                 subject('SqlRunner', {
                     organizationUuid,
                     projectUuid,
-                    uuid: '',
+                    metadata: { uuid: '' },
                 }),
             )
         ) {
@@ -654,7 +654,7 @@ export class SavedSqlService
                     subject('Job', {
                         organizationUuid,
                         projectUuid,
-                        uuid: '',
+                        metadata: { uuid: '' },
                     }),
                 ) ||
                 auditedAbility.cannot(
@@ -662,7 +662,7 @@ export class SavedSqlService
                     subject('SqlRunner', {
                         organizationUuid,
                         projectUuid,
-                        uuid: '',
+                        metadata: { uuid: '' },
                     }),
                 )
             ) {
@@ -811,7 +811,7 @@ export class SavedSqlService
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
-                    uuid: savedSqlUuid,
+                    metadata: { uuid: savedSqlUuid },
                 }),
             )
         ) {
@@ -839,7 +839,7 @@ export class SavedSqlService
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
-                    uuid: savedSqlUuid,
+                    metadata: { uuid: savedSqlUuid },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -182,7 +182,7 @@ export class SavedSqlService
                 action,
                 subject('SavedChart', {
                     ...ctx[spaceUuid],
-                    metadata: { uuid: resource.savedSqlUuid ?? '' },
+                    metadata: { savedSqlUuid: resource.savedSqlUuid ?? '' },
                 }),
             )
         ) {
@@ -197,7 +197,7 @@ export class SavedSqlService
                     action,
                     subject('SavedChart', {
                         ...ctx[resource.spaceUuid!],
-                        metadata: { uuid: resource.savedSqlUuid ?? '' },
+                        metadata: { savedSqlUuid: resource.savedSqlUuid ?? '' },
                     }),
                 )
             ) {
@@ -270,7 +270,6 @@ export class SavedSqlService
                 subject('CustomSql', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: '' },
                 }),
             )
         ) {
@@ -334,7 +333,7 @@ export class SavedSqlService
                 subject('CustomSql', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: savedSqlUuid },
+                    metadata: { savedSqlUuid },
                 }),
             )
         ) {
@@ -404,7 +403,7 @@ export class SavedSqlService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'delete', {
                 type: 'SavedChart',
-                uuid: savedSqlUuid,
+                metadata: { savedSqlUuid },
                 organizationUuid: savedChart.organization.organizationUuid,
                 projectUuid,
             });
@@ -446,7 +445,7 @@ export class SavedSqlService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'delete', {
                 type: 'SavedChart',
-                uuid: savedSqlUuid,
+                metadata: { savedSqlUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
@@ -478,7 +477,7 @@ export class SavedSqlService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                uuid: savedSqlUuid,
+                metadata: { savedSqlUuid },
                 organizationUuid,
                 projectUuid,
             });
@@ -490,7 +489,7 @@ export class SavedSqlService
                     subject('Project', {
                         organizationUuid,
                         projectUuid,
-                        metadata: { uuid: projectUuid },
+                        metadata: { projectUuid },
                     }),
                 )
             ) {
@@ -502,7 +501,7 @@ export class SavedSqlService
                 subject('DeletedContent', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: savedSqlUuid },
+                    metadata: { savedSqlUuid },
                 }),
             );
 
@@ -534,7 +533,7 @@ export class SavedSqlService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                uuid: savedSqlUuid,
+                metadata: { savedSqlUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
@@ -552,7 +551,7 @@ export class SavedSqlService
                     subject('Project', {
                         organizationUuid,
                         projectUuid,
-                        metadata: { uuid: projectUuid },
+                        metadata: { projectUuid },
                     }),
                 )
             ) {
@@ -564,7 +563,7 @@ export class SavedSqlService
                 subject('DeletedContent', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: savedSqlUuid },
+                    metadata: { savedSqlUuid },
                 }),
             );
 
@@ -593,7 +592,6 @@ export class SavedSqlService
                 subject('Job', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: '' },
                 }),
             ) ||
             auditedAbility.cannot(
@@ -601,7 +599,6 @@ export class SavedSqlService
                 subject('SqlRunner', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: '' },
                 }),
             )
         ) {
@@ -654,7 +651,6 @@ export class SavedSqlService
                     subject('Job', {
                         organizationUuid,
                         projectUuid,
-                        metadata: { uuid: '' },
                     }),
                 ) ||
                 auditedAbility.cannot(
@@ -662,7 +658,6 @@ export class SavedSqlService
                     subject('SqlRunner', {
                         organizationUuid,
                         projectUuid,
-                        metadata: { uuid: '' },
                     }),
                 )
             ) {
@@ -767,7 +762,7 @@ export class SavedSqlService
         } else {
             this.logBypassEvent(user, 'update', {
                 type: 'SavedChart',
-                uuid: savedSqlUuid,
+                metadata: { savedSqlUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         }
@@ -811,7 +806,7 @@ export class SavedSqlService
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: savedSqlUuid },
+                    metadata: { savedSqlUuid },
                 }),
             )
         ) {
@@ -839,7 +834,7 @@ export class SavedSqlService
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { uuid: savedSqlUuid },
+                    metadata: { savedSqlUuid },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -859,7 +859,7 @@ export class SchedulerService extends BaseService {
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'ScheduledDeliveries',
-                uuid: chartUuid,
+                metadata: { savedChartUuid: chartUuid },
                 organizationUuid: context.organizationUuid,
                 projectUuid: context.projectUuid,
             });
@@ -915,7 +915,7 @@ export class SchedulerService extends BaseService {
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'ScheduledDeliveries',
-                uuid: dashboardUuid,
+                metadata: { dashboardUuid },
                 organizationUuid: context.organizationUuid,
                 projectUuid: context.projectUuid,
             });
@@ -970,7 +970,7 @@ export class SchedulerService extends BaseService {
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'ScheduledDeliveries',
-                uuid: chartUuid,
+                metadata: { savedChartUuid: chartUuid },
                 organizationUuid: context.organizationUuid,
                 projectUuid: context.projectUuid,
             });
@@ -1021,7 +1021,7 @@ export class SchedulerService extends BaseService {
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'ScheduledDeliveries',
-                uuid: dashboardUuid,
+                metadata: { dashboardUuid },
                 organizationUuid: context.organizationUuid,
                 projectUuid: context.projectUuid,
             });
@@ -1341,7 +1341,7 @@ export class SchedulerService extends BaseService {
                 subject('Project', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid },
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1433,7 +1433,7 @@ export class SchedulerService extends BaseService {
                 subject('Project', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
-                    metadata: { uuid: projectUuid },
+                    metadata: { projectUuid },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SchedulerService/SchedulerService.ts
+++ b/packages/backend/src/services/SchedulerService/SchedulerService.ts
@@ -1341,7 +1341,7 @@ export class SchedulerService extends BaseService {
                 subject('Project', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { uuid: projectUuid },
                 }),
             )
         ) {
@@ -1433,7 +1433,7 @@ export class SchedulerService extends BaseService {
                 subject('Project', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { uuid: projectUuid },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -200,10 +200,12 @@ export class SpaceService
             auditedAbility.cannot(
                 'create',
                 subject('Space', {
-                    uuid: '' /* resource doesn't exist yet */,
-                    name: space.name,
                     organizationUuid,
                     projectUuid,
+                    metadata: {
+                        uuid: '' /* resource doesn't exist yet */,
+                        name: space.name,
+                    },
                 }),
             )
         ) {
@@ -640,10 +642,9 @@ export class SpaceService
             const isAdmin = auditedAbility.can(
                 'manage',
                 subject('DeletedContent', {
-                    uuid: spaceUuid,
-                    name: space.name,
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
+                    metadata: { uuid: spaceUuid, name: space.name },
                 }),
             );
 
@@ -736,10 +737,9 @@ export class SpaceService
                 auditedAbility.cannot(
                     'manage',
                     subject('DeletedContent', {
-                        uuid: spaceUuid,
-                        name: space.name,
                         organizationUuid: space.organizationUuid,
                         projectUuid: space.projectUuid,
+                        metadata: { uuid: spaceUuid, name: space.name },
                     }),
                 )
             ) {
@@ -828,10 +828,9 @@ export class SpaceService
             auditedAbility.cannot(
                 'manage',
                 subject('PinnedItems', {
-                    uuid: spaceUuid,
-                    name: existingSpace.name,
                     projectUuid,
                     organizationUuid,
+                    metadata: { uuid: spaceUuid, name: existingSpace.name },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -202,10 +202,7 @@ export class SpaceService
                 subject('Space', {
                     organizationUuid,
                     projectUuid,
-                    metadata: {
-                        uuid: '' /* resource doesn't exist yet */,
-                        name: space.name,
-                    },
+                    metadata: { spaceName: space.name },
                 }),
             )
         ) {
@@ -632,7 +629,7 @@ export class SpaceService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                metadata: { spaceUuid, name: space.name },
+                metadata: { spaceUuid, spaceName: space.name },
                 organizationUuid: space.organizationUuid,
                 projectUuid: space.projectUuid,
             });
@@ -643,7 +640,7 @@ export class SpaceService
                 subject('DeletedContent', {
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
-                    metadata: { spaceUuid, name: space.name },
+                    metadata: { spaceUuid, spaceName: space.name },
                 }),
             );
 
@@ -651,7 +648,7 @@ export class SpaceService
                 if (space.deletedBy?.userUuid === user.userUuid) {
                     this.logBypassEvent(user, 'manage', {
                         type: 'DeletedContent',
-                        metadata: { spaceUuid, name: space.name },
+                        metadata: { spaceUuid, spaceName: space.name },
                         organizationUuid: space.organizationUuid,
                         projectUuid: space.projectUuid,
                     });
@@ -737,7 +734,7 @@ export class SpaceService
                     subject('DeletedContent', {
                         organizationUuid: space.organizationUuid,
                         projectUuid: space.projectUuid,
-                        metadata: { spaceUuid, name: space.name },
+                        metadata: { spaceUuid, spaceName: space.name },
                     }),
                 )
             ) {
@@ -828,7 +825,7 @@ export class SpaceService
                 subject('PinnedItems', {
                     projectUuid,
                     organizationUuid,
-                    metadata: { spaceUuid, name: existingSpace.name },
+                    metadata: { spaceUuid, spaceName: existingSpace.name },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -490,7 +490,7 @@ export class SpaceService
         } else {
             this.logBypassEvent(user, 'delete', {
                 type: 'Space',
-                uuid: spaceUuid,
+                metadata: { spaceUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         }
@@ -538,7 +538,7 @@ export class SpaceService
         } else {
             this.logBypassEvent(user, 'delete', {
                 type: 'Space',
-                uuid: spaceUuid,
+                metadata: { spaceUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         }
@@ -632,8 +632,7 @@ export class SpaceService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                uuid: spaceUuid,
-                name: space.name,
+                metadata: { spaceUuid, name: space.name },
                 organizationUuid: space.organizationUuid,
                 projectUuid: space.projectUuid,
             });
@@ -644,7 +643,7 @@ export class SpaceService
                 subject('DeletedContent', {
                     organizationUuid: space.organizationUuid,
                     projectUuid: space.projectUuid,
-                    metadata: { uuid: spaceUuid, name: space.name },
+                    metadata: { spaceUuid, name: space.name },
                 }),
             );
 
@@ -652,8 +651,7 @@ export class SpaceService
                 if (space.deletedBy?.userUuid === user.userUuid) {
                     this.logBypassEvent(user, 'manage', {
                         type: 'DeletedContent',
-                        uuid: spaceUuid,
-                        name: space.name,
+                        metadata: { spaceUuid, name: space.name },
                         organizationUuid: space.organizationUuid,
                         projectUuid: space.projectUuid,
                     });
@@ -725,7 +723,7 @@ export class SpaceService
         if (options?.bypassPermissions) {
             this.logBypassEvent(user, 'manage', {
                 type: 'DeletedContent',
-                uuid: spaceUuid,
+                metadata: { spaceUuid },
                 organizationUuid: user.organizationUuid ?? 'unknown',
             });
         } else {
@@ -739,7 +737,7 @@ export class SpaceService
                     subject('DeletedContent', {
                         organizationUuid: space.organizationUuid,
                         projectUuid: space.projectUuid,
-                        metadata: { uuid: spaceUuid, name: space.name },
+                        metadata: { spaceUuid, name: space.name },
                     }),
                 )
             ) {
@@ -830,7 +828,7 @@ export class SpaceService
                 subject('PinnedItems', {
                     projectUuid,
                     organizationUuid,
-                    metadata: { uuid: spaceUuid, name: existingSpace.name },
+                    metadata: { spaceUuid, name: existingSpace.name },
                 }),
             )
         ) {

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -942,7 +942,7 @@ export class ValidationService extends BaseService {
                 subject('Validation', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1059,7 +1059,7 @@ export class ValidationService extends BaseService {
                 subject('Validation', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1132,7 +1132,7 @@ export class ValidationService extends BaseService {
                 subject('Validation', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1194,7 +1194,7 @@ export class ValidationService extends BaseService {
                 subject('Validation', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1307,7 +1307,7 @@ export class ValidationService extends BaseService {
                 subject('Validation', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1387,7 +1387,7 @@ export class ValidationService extends BaseService {
                 subject('Validation', {
                     organizationUuid,
                     projectUuid,
-                    uuid: projectUuid,
+                    metadata: { projectUuid },
                 }),
             )
         ) {


### PR DESCRIPTION
## Summary

Makes CASL subject metadata an opaque passthrough for audit logging, and tightens the call sites so every id **and** name is typed.

### Before
The CASL subject carried `uuid` / `name` fields at the top level, mixed in with authorization condition fields (`organizationUuid`, `projectUuid`, `access`, etc.). Readers couldn't tell which fields drove permission checks and which were just there for log enrichment.

### After
- **`metadata` is a typed-opaque bag** on the subject: `Record<string, unknown>`. The wrapper forwards it straight through to the audit event without projecting specific columns.
- **Condition fields stay at the top level** of the subject where CASL reads them.
- **Audit-only fields live inside `metadata`**, and keys name the entity precisely:
  - ids — `dashboardUuid`, `savedChartUuid`, `savedSqlUuid`, `spaceUuid`, `projectUuid`, `groupUuid`, `tagUuid`, `metricsTreeUuid`, etc. No more generic `uuid`.
  - names — `dashboardName`, `savedChartName`, `spaceName`, `projectName`, `groupName`, `tagName`. No more generic `name`.
- **`AuditResource` schema** now exposes `metadata` instead of typed `uuid` / `name` columns.
- **`formatAuditResource`** dumps the full metadata bag as `Type -> key: value, key: value`, so every typed id/name the call site provided is visible in the audit log (not just a single picked one). Falls back to `Type in project <uuid>` / `Type in organization <uuid>` when metadata is absent.
- **Empty-string placeholders dropped** from permission-type subjects (`CustomSql`, `Job`, `SqlRunner`) that never had a meaningful id.

### Sample audit log output
```
john@company.com updated Dashboard -> dashboardUuid: dash-uuid, dashboardName: Sales Overview (allowed)
service-account "ci@company.com" managed Group -> groupUuid: group-uuid, groupName: Engineering (allowed)
john@company.com viewed Explore in project proj-uuid (allowed)
```

### Changed files
| File | Purpose |
|------|---------|
| `caslAuditWrapper.ts` | `metadata: Record<string, unknown>`; forward it as-is onto the audit resource |
| `auditLog.ts` | `AuditResourceSchema` carries `metadata` instead of `uuid` / `name` |
| `winston.ts` | `formatAuditResource` dumps all metadata entries as `key: value` pairs |
| `AsyncQueryService.ts` | `projectUuid` / `exploreName` in metadata (Project, Explore, PreAggregation subjects) |
| `CatalogService.ts` | `projectUuid` / `projectName` / `tagUuid` / `tagName` / `metricsTreeUuid` in metadata (18 subjects) |
| `CommentService.ts` | `dashboardName` in metadata |
| `ContentService.ts` | `projectUuid` / `projectName` in metadata |
| `ContentVerificationService.ts` | `projectUuid` in metadata |
| `DashboardService.ts` | `dashboardUuid` / `dashboardName` in metadata |
| `SavedChartService.ts` | `savedChartUuid` / `savedChartName` in metadata |
| `SavedSqlService.ts` | `savedSqlUuid` in metadata; drop empty placeholders |
| `SchedulerService.ts` | `savedChartUuid` / `dashboardUuid` in metadata |
| `SpaceService.ts` | `spaceUuid` / `spaceName` in metadata |
| `ValidationService.ts` | `projectUuid` in metadata (6 subjects) |
| `caslAuditWrapper.test.ts` / `winston.test.ts` / `CommentService.test.ts` | Update fixtures and assertions |

## Test plan
- [x] `pnpm -F backend typecheck` — clean
- [x] `pnpm -F backend test` — 1539/1540 pass (1 skipped, no failures)
- [x] `pnpm -F backend lint` — no new errors
- [x] Spot-check audit log output in dev

🤖 Generated with [Claude Code](https://claude.com/claude-code)