### PR TITLE
fix(formula): aggregate functions in table calc formulas now emit valid SQL

### DIFF
--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -1163,6 +1163,28 @@ test('Should compile a formula aggregate as a window aggregate', () => {
     expect(formulaCalc?.compiledSql).toBe('SUM("table_3_metric_1") OVER ()');
 });
 
+test('Should throw error when formula aggregate references unknown column', () => {
+    const metricQuery = {
+        ...METRIC_QUERY_NO_CALCS,
+        tableCalculations: [
+            {
+                name: 'bad_sum',
+                displayName: 'Bad Sum',
+                formula: '=SUM(nonexistent_field)',
+            } satisfies FormulaTableCalculation,
+        ],
+    };
+
+    expect(() =>
+        compileMetricQuery({
+            explore: EXPLORE,
+            metricQuery,
+            warehouseSqlBuilder: warehouseClientMock,
+            availableParameters: [],
+        }),
+    ).toThrow();
+});
+
 test('Should compile a formula SUMIF as a window aggregate', () => {
     const metricQuery = {
         ...METRIC_QUERY_NO_CALCS,

--- a/packages/backend/src/queryCompiler.test.ts
+++ b/packages/backend/src/queryCompiler.test.ts
@@ -1136,3 +1136,57 @@ test('Should compile a formula that references another table calculation', () =>
     expect(formulaCalc?.compiledSql).toBe('("base_calc" * 2)');
     expect(formulaCalc?.dependsOn).toEqual(['base_calc']);
 });
+
+test('Should compile a formula aggregate as a window aggregate', () => {
+    const metricQuery = {
+        ...METRIC_QUERY_NO_CALCS,
+        tableCalculations: [
+            {
+                name: 'formula_sum',
+                displayName: 'Formula Sum',
+                formula: '=SUM(table_3_metric_1)',
+            } satisfies FormulaTableCalculation,
+        ],
+    };
+
+    const result = compileMetricQuery({
+        explore: EXPLORE,
+        metricQuery,
+        warehouseSqlBuilder: warehouseClientMock,
+        availableParameters: [],
+    });
+
+    const formulaCalc = result.compiledTableCalculations.find(
+        (c) => c.name === 'formula_sum',
+    );
+
+    expect(formulaCalc?.compiledSql).toBe('SUM("table_3_metric_1") OVER ()');
+});
+
+test('Should compile a formula SUMIF as a window aggregate', () => {
+    const metricQuery = {
+        ...METRIC_QUERY_NO_CALCS,
+        tableCalculations: [
+            {
+                name: 'formula_sumif',
+                displayName: 'Formula SumIf',
+                formula: '=SUMIF(table_3_metric_1, table_3_metric_1 > 100)',
+            } satisfies FormulaTableCalculation,
+        ],
+    };
+
+    const result = compileMetricQuery({
+        explore: EXPLORE,
+        metricQuery,
+        warehouseSqlBuilder: warehouseClientMock,
+        availableParameters: [],
+    });
+
+    const formulaCalc = result.compiledTableCalculations.find(
+        (c) => c.name === 'formula_sumif',
+    );
+
+    expect(formulaCalc?.compiledSql).toBe(
+        'SUM(CASE WHEN ("table_3_metric_1" > 100) THEN "table_3_metric_1" END) OVER ()',
+    );
+});

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -184,10 +184,15 @@ const compileTableCalculation = (
                     columns[dep.name] = dep.name;
                 }
             }
+            // Table calcs land in a post-aggregation SELECT alongside non-
+            // aggregate dimension columns, so bare SQL aggregates would be
+            // rejected by the warehouse. Wrapping as `AGG(x) OVER ()` turns
+            // them into window aggregates — legal in that context and
+            // preserving Sheets-like whole-result-set semantics.
             const compiledSql = compileFormula(tableCalculation.formula, {
                 dialect,
                 columns,
-                aggregateContext: 'window',
+                renderAggregate: (inner) => `${inner} OVER ()`,
             });
             return {
                 ...tableCalculation,

--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -187,6 +187,7 @@ const compileTableCalculation = (
             const compiledSql = compileFormula(tableCalculation.formula, {
                 dialect,
                 columns,
+                aggregateContext: 'window',
             });
             return {
                 ...tableCalculation,

--- a/packages/formula/src/ast.ts
+++ b/packages/formula/src/ast.ts
@@ -1,5 +1,51 @@
+import { FUNCTION_DEFINITIONS } from './functions';
 import type { ASTNode } from './types';
 import { assertUnreachable } from './utils';
+
+const AGGREGATE_FUNCTION_NAMES: ReadonlySet<string> = new Set(
+    FUNCTION_DEFINITIONS.filter((f) => f.category === 'aggregate').map(
+        (f) => f.name,
+    ),
+);
+
+// Recognises AST nodes that represent an aggregate function call.
+// Used by the codegen dispatcher to decide whether to window-wrap output when
+// `aggregateContext === 'window'`. Centralising this in one place means new
+// aggregates added to `functions.ts` with category `'aggregate'` are picked up
+// automatically — the codegen can't silently forget to wrap them.
+// MIN/MAX are polymorphic (1-arg aggregate, 2-arg scalar LEAST/GREATEST) and
+// live under category `'math'`, so they're handled explicitly.
+export const isAggregateCall = (node: ASTNode): boolean => {
+    switch (node.type) {
+        case 'ConditionalAggregate':
+        case 'CountIf':
+            return true;
+        case 'SingleArgFn':
+        case 'ZeroOrOneArgFn':
+            return AGGREGATE_FUNCTION_NAMES.has(node.name);
+        case 'OneOrTwoArgFn':
+            return (
+                (node.name === 'MIN' || node.name === 'MAX') &&
+                node.args.length === 1
+            );
+        case 'BinaryOp':
+        case 'UnaryOp':
+        case 'If':
+        case 'ZeroArgFn':
+        case 'VariadicFn':
+        case 'WindowFn':
+        case 'ColumnRef':
+        case 'NumberLiteral':
+        case 'StringLiteral':
+        case 'BooleanLiteral':
+        case 'Comparison':
+        case 'Logical':
+        case 'WindowClause':
+            return false;
+        default:
+            return assertUnreachable(node, `Unknown AST node type`);
+    }
+};
 
 export const extractColumnRefs = (node: ASTNode): string[] => {
     switch (node.type) {

--- a/packages/formula/src/codegen/base.ts
+++ b/packages/formula/src/codegen/base.ts
@@ -73,6 +73,12 @@ export abstract class BaseSqlGenerator {
         }
     }
 
+    protected wrapAggregate(sql: string): string {
+        return this.options.aggregateContext === 'window'
+            ? `${sql} OVER ()`
+            : sql;
+    }
+
     protected generateBinaryOp(node: BinaryOpNode): string {
         const left = this.generate(node.left);
         const right = this.generate(node.right);
@@ -187,7 +193,7 @@ export abstract class BaseSqlGenerator {
             case 'ISNULL':
                 return `(${arg} IS NULL)`;
             case 'SUM':
-                return `SUM(${arg})`;
+                return this.wrapAggregate(`SUM(${arg})`);
             case 'AVERAGE':
             case 'AVG':
                 return `AVG(${arg})`;

--- a/packages/formula/src/codegen/base.ts
+++ b/packages/formula/src/codegen/base.ts
@@ -27,18 +27,16 @@ export abstract class BaseSqlGenerator {
     constructor(protected options: CompileOptions) {}
 
     // Public entry point. Dispatches to the node-specific generator, then
-    // centrally applies the aggregate-context wrap. Every recursive call from
-    // child arms goes back through `generate()`, so the wrap decision is made
-    // once per node, in exactly one place. New aggregate functions introduced
-    // via `functions.ts` (or via new AST shapes via `isAggregateCall`) inherit
-    // window-wrapping automatically — no individual arm has to remember.
+    // hands aggregate output to the caller-supplied `renderAggregate` callback
+    // (if any) so the caller decides how to embed the aggregate in their SQL
+    // context — e.g. window-wrap for post-aggregation SELECTs, pass through
+    // for GROUP BY contexts. Every recursive call from child arms goes back
+    // through `generate()`, so the hook is applied once per aggregate node
+    // anywhere in the tree.
     generate(node: ASTNode): string {
         const sql = this.generateNode(node);
-        if (
-            this.options.aggregateContext === 'window' &&
-            isAggregateCall(node)
-        ) {
-            return `${sql} OVER ()`;
+        if (isAggregateCall(node) && this.options.renderAggregate) {
+            return this.options.renderAggregate(sql);
         }
         return sql;
     }

--- a/packages/formula/src/codegen/base.ts
+++ b/packages/formula/src/codegen/base.ts
@@ -1,3 +1,4 @@
+import { isAggregateCall } from '../ast';
 import type {
     ASTNode,
     BinaryOpNode,
@@ -25,7 +26,24 @@ import { assertUnreachable } from '../utils';
 export abstract class BaseSqlGenerator {
     constructor(protected options: CompileOptions) {}
 
+    // Public entry point. Dispatches to the node-specific generator, then
+    // centrally applies the aggregate-context wrap. Every recursive call from
+    // child arms goes back through `generate()`, so the wrap decision is made
+    // once per node, in exactly one place. New aggregate functions introduced
+    // via `functions.ts` (or via new AST shapes via `isAggregateCall`) inherit
+    // window-wrapping automatically — no individual arm has to remember.
     generate(node: ASTNode): string {
+        const sql = this.generateNode(node);
+        if (
+            this.options.aggregateContext === 'window' &&
+            isAggregateCall(node)
+        ) {
+            return `${sql} OVER ()`;
+        }
+        return sql;
+    }
+
+    protected generateNode(node: ASTNode): string {
         switch (node.type) {
             case 'BinaryOp':
                 return this.generateBinaryOp(node);
@@ -71,12 +89,6 @@ export abstract class BaseSqlGenerator {
                     `Unknown node type: ${(node as Record<string, unknown>).type}`,
                 );
         }
-    }
-
-    protected wrapAggregate(sql: string): string {
-        return this.options.aggregateContext === 'window'
-            ? `${sql} OVER ()`
-            : sql;
     }
 
     protected generateBinaryOp(node: BinaryOpNode): string {
@@ -135,13 +147,9 @@ export abstract class BaseSqlGenerator {
         const condition = this.generate(node.condition);
         switch (node.name) {
             case 'SUMIF':
-                return this.wrapAggregate(
-                    `SUM(CASE WHEN ${condition} THEN ${value} END)`,
-                );
+                return `SUM(CASE WHEN ${condition} THEN ${value} END)`;
             case 'AVERAGEIF':
-                return this.wrapAggregate(
-                    `AVG(CASE WHEN ${condition} THEN ${value} END)`,
-                );
+                return `AVG(CASE WHEN ${condition} THEN ${value} END)`;
             default:
                 return assertUnreachable(
                     node.name,
@@ -152,7 +160,7 @@ export abstract class BaseSqlGenerator {
 
     protected generateCountIf(node: CountIfNode): string {
         const condition = this.generate(node.condition);
-        return this.wrapAggregate(`COUNT(CASE WHEN ${condition} THEN 1 END)`);
+        return `COUNT(CASE WHEN ${condition} THEN 1 END)`;
     }
 
     protected generateZeroArgFn(node: ZeroArgFnNode): string {
@@ -197,10 +205,10 @@ export abstract class BaseSqlGenerator {
             case 'ISNULL':
                 return `(${arg} IS NULL)`;
             case 'SUM':
-                return this.wrapAggregate(`SUM(${arg})`);
+                return `SUM(${arg})`;
             case 'AVERAGE':
             case 'AVG':
-                return this.wrapAggregate(`AVG(${arg})`);
+                return `AVG(${arg})`;
             default:
                 return assertUnreachable(
                     node.name,
@@ -216,11 +224,11 @@ export abstract class BaseSqlGenerator {
                 return `ROUND(${args[0]}${args[1] !== undefined ? `, ${args[1]}` : ''})`;
             case 'MIN':
                 return args.length === 1
-                    ? this.wrapAggregate(`MIN(${args[0]})`)
+                    ? `MIN(${args[0]})`
                     : `LEAST(${args.join(', ')})`;
             case 'MAX':
                 return args.length === 1
-                    ? this.wrapAggregate(`MAX(${args[0]})`)
+                    ? `MAX(${args[0]})`
                     : `GREATEST(${args.join(', ')})`;
             default:
                 return assertUnreachable(
@@ -233,9 +241,9 @@ export abstract class BaseSqlGenerator {
     protected generateZeroOrOneArgFn(node: ZeroOrOneArgFnNode): string {
         switch (node.name) {
             case 'COUNT':
-                return this.wrapAggregate(
-                    node.arg ? `COUNT(${this.generate(node.arg)})` : 'COUNT(*)',
-                );
+                return node.arg
+                    ? `COUNT(${this.generate(node.arg)})`
+                    : 'COUNT(*)';
             default:
                 return assertUnreachable(
                     node.name,

--- a/packages/formula/src/codegen/base.ts
+++ b/packages/formula/src/codegen/base.ts
@@ -135,9 +135,13 @@ export abstract class BaseSqlGenerator {
         const condition = this.generate(node.condition);
         switch (node.name) {
             case 'SUMIF':
-                return `SUM(CASE WHEN ${condition} THEN ${value} END)`;
+                return this.wrapAggregate(
+                    `SUM(CASE WHEN ${condition} THEN ${value} END)`,
+                );
             case 'AVERAGEIF':
-                return `AVG(CASE WHEN ${condition} THEN ${value} END)`;
+                return this.wrapAggregate(
+                    `AVG(CASE WHEN ${condition} THEN ${value} END)`,
+                );
             default:
                 return assertUnreachable(
                     node.name,
@@ -148,7 +152,7 @@ export abstract class BaseSqlGenerator {
 
     protected generateCountIf(node: CountIfNode): string {
         const condition = this.generate(node.condition);
-        return `COUNT(CASE WHEN ${condition} THEN 1 END)`;
+        return this.wrapAggregate(`COUNT(CASE WHEN ${condition} THEN 1 END)`);
     }
 
     protected generateZeroArgFn(node: ZeroArgFnNode): string {
@@ -196,7 +200,7 @@ export abstract class BaseSqlGenerator {
                 return this.wrapAggregate(`SUM(${arg})`);
             case 'AVERAGE':
             case 'AVG':
-                return `AVG(${arg})`;
+                return this.wrapAggregate(`AVG(${arg})`);
             default:
                 return assertUnreachable(
                     node.name,
@@ -212,11 +216,11 @@ export abstract class BaseSqlGenerator {
                 return `ROUND(${args[0]}${args[1] !== undefined ? `, ${args[1]}` : ''})`;
             case 'MIN':
                 return args.length === 1
-                    ? `MIN(${args[0]})`
+                    ? this.wrapAggregate(`MIN(${args[0]})`)
                     : `LEAST(${args.join(', ')})`;
             case 'MAX':
                 return args.length === 1
-                    ? `MAX(${args[0]})`
+                    ? this.wrapAggregate(`MAX(${args[0]})`)
                     : `GREATEST(${args.join(', ')})`;
             default:
                 return assertUnreachable(
@@ -229,9 +233,9 @@ export abstract class BaseSqlGenerator {
     protected generateZeroOrOneArgFn(node: ZeroOrOneArgFnNode): string {
         switch (node.name) {
             case 'COUNT':
-                return node.arg
-                    ? `COUNT(${this.generate(node.arg)})`
-                    : 'COUNT(*)';
+                return this.wrapAggregate(
+                    node.arg ? `COUNT(${this.generate(node.arg)})` : 'COUNT(*)',
+                );
             default:
                 return assertUnreachable(
                     node.name,

--- a/packages/formula/src/index.ts
+++ b/packages/formula/src/index.ts
@@ -3,6 +3,7 @@ import { parse } from './compiler';
 import { FUNCTION_DEFINITIONS } from './functions';
 import type { FunctionDefinitionEntry } from './functions';
 import type {
+    AggregateContext,
     ASTNode,
     CompileOptions,
     Dialect,
@@ -11,6 +12,7 @@ import type {
 } from './types';
 
 export type {
+    AggregateContext,
     ASTNode,
     CompileOptions,
     Dialect,

--- a/packages/formula/src/index.ts
+++ b/packages/formula/src/index.ts
@@ -3,7 +3,6 @@ import { parse } from './compiler';
 import { FUNCTION_DEFINITIONS } from './functions';
 import type { FunctionDefinitionEntry } from './functions';
 import type {
-    AggregateContext,
     ASTNode,
     CompileOptions,
     Dialect,
@@ -12,7 +11,6 @@ import type {
 } from './types';
 
 export type {
-    AggregateContext,
     ASTNode,
     CompileOptions,
     Dialect,

--- a/packages/formula/src/types.ts
+++ b/packages/formula/src/types.ts
@@ -11,12 +11,16 @@ import type {
 
 export type Dialect = 'postgres' | 'bigquery' | 'snowflake' | 'duckdb';
 
-export type AggregateContext = 'bare' | 'window';
-
 export interface CompileOptions {
     dialect: Dialect;
     columns: Record<string, string>;
-    aggregateContext?: AggregateContext;
+    // Invoked with the bare SQL emitted for each aggregate call (SUM, SUMIF,
+    // COUNT, 1-arg MIN/MAX, AVG, AVERAGEIF, COUNTIF). Callers whose SQL lands
+    // in a context where bare aggregates are illegal (e.g. a post-aggregation
+    // SELECT alongside non-aggregate columns) can return `${inner} OVER ()`.
+    // Callers that compose their own GROUP BY around the output leave this
+    // unset. The formula package has no opinion on embedding context.
+    renderAggregate?: (innerSql: string) => string;
 }
 
 // AST Node Types

--- a/packages/formula/src/types.ts
+++ b/packages/formula/src/types.ts
@@ -11,9 +11,12 @@ import type {
 
 export type Dialect = 'postgres' | 'bigquery' | 'snowflake' | 'duckdb';
 
+export type AggregateContext = 'bare' | 'window';
+
 export interface CompileOptions {
     dialect: Dialect;
     columns: Record<string, string>;
+    aggregateContext?: AggregateContext;
 }
 
 // AST Node Types

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -224,4 +224,49 @@ describe('codegen', () => {
             ).toBe('/*agg*/SUM("revenue")');
         });
     });
+
+    describe('renderAggregate invocation protocol', () => {
+        // Identity renderer used to observe invocation count and order
+        // without changing the generated SQL.
+        const track = (calls: string[]) => (inner: string) => {
+            calls.push(inner);
+            return inner;
+        };
+
+        it('invokes the callback once per aggregate node, in recursion order, with bare SQL', () => {
+            const calls: string[] = [];
+            compile('=SUM(revenue) + AVG(revenue) - SUM(revenue)', {
+                dialect: 'postgres',
+                columns,
+                renderAggregate: track(calls),
+            });
+            expect(calls).toEqual([
+                'SUM("revenue")',
+                'AVG("revenue")',
+                'SUM("revenue")',
+            ]);
+        });
+
+        it('invokes the callback exactly once for a ConditionalAggregate, with the full CASE WHEN as input', () => {
+            const calls: string[] = [];
+            compile('=SUMIF(revenue, region = "EU")', {
+                dialect: 'postgres',
+                columns,
+                renderAggregate: track(calls),
+            });
+            expect(calls).toEqual([
+                `SUM(CASE WHEN ("region" = 'EU') THEN "revenue" END)`,
+            ]);
+        });
+
+        it('does not invoke the callback for formulas with no aggregates', () => {
+            const calls: string[] = [];
+            compile('=revenue * 2 + IF(region = "EU", 1, 0)', {
+                dialect: 'postgres',
+                columns,
+                renderAggregate: track(calls),
+            });
+            expect(calls).toEqual([]);
+        });
+    });
 });

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest';
+import { compile } from '../src/index';
+
+const columns = { revenue: 'revenue', region: 'region' };
+
+describe('codegen aggregateContext', () => {
+    describe('SUM', () => {
+        it('emits bare SUM by default', () => {
+            const sql = compile('=SUM(revenue)', {
+                dialect: 'postgres',
+                columns,
+            });
+            expect(sql).toBe('SUM("revenue")');
+        });
+
+        it('emits bare SUM when aggregateContext is explicitly bare', () => {
+            const sql = compile('=SUM(revenue)', {
+                dialect: 'postgres',
+                columns,
+                aggregateContext: 'bare',
+            });
+            expect(sql).toBe('SUM("revenue")');
+        });
+
+        it('emits window SUM when aggregateContext is window', () => {
+            const sql = compile('=SUM(revenue)', {
+                dialect: 'postgres',
+                columns,
+                aggregateContext: 'window',
+            });
+            expect(sql).toBe('SUM("revenue") OVER ()');
+        });
+    });
+});

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -31,4 +31,253 @@ describe('codegen aggregateContext', () => {
             expect(sql).toBe('SUM("revenue") OVER ()');
         });
     });
+
+    describe('AVG / AVERAGE', () => {
+        it('emits bare AVG by default', () => {
+            expect(
+                compile('=AVG(revenue)', { dialect: 'postgres', columns }),
+            ).toBe('AVG("revenue")');
+        });
+
+        it('emits window AVG in window context', () => {
+            expect(
+                compile('=AVG(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('AVG("revenue") OVER ()');
+        });
+
+        it('treats AVERAGE as an alias for AVG', () => {
+            expect(
+                compile('=AVERAGE(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('AVG("revenue") OVER ()');
+        });
+    });
+
+    describe('COUNT', () => {
+        it('emits bare COUNT(x) by default', () => {
+            expect(
+                compile('=COUNT(revenue)', { dialect: 'postgres', columns }),
+            ).toBe('COUNT("revenue")');
+        });
+
+        it('emits window COUNT(x) in window context', () => {
+            expect(
+                compile('=COUNT(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('COUNT("revenue") OVER ()');
+        });
+
+        it('emits bare COUNT(*) by default', () => {
+            expect(
+                compile('=COUNT()', { dialect: 'postgres', columns }),
+            ).toBe('COUNT(*)');
+        });
+
+        it('emits window COUNT(*) in window context', () => {
+            expect(
+                compile('=COUNT()', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('COUNT(*) OVER ()');
+        });
+    });
+
+    describe('MIN / MAX (1-arg aggregate form)', () => {
+        it('emits bare MIN(x) by default', () => {
+            expect(
+                compile('=MIN(revenue)', { dialect: 'postgres', columns }),
+            ).toBe('MIN("revenue")');
+        });
+
+        it('emits window MIN(x) in window context', () => {
+            expect(
+                compile('=MIN(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('MIN("revenue") OVER ()');
+        });
+
+        it('emits bare MAX(x) by default', () => {
+            expect(
+                compile('=MAX(revenue)', { dialect: 'postgres', columns }),
+            ).toBe('MAX("revenue")');
+        });
+
+        it('emits window MAX(x) in window context', () => {
+            expect(
+                compile('=MAX(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('MAX("revenue") OVER ()');
+        });
+    });
+
+    describe('MIN / MAX (2-arg scalar form)', () => {
+        it('emits LEAST regardless of context', () => {
+            const bare = compile('=MIN(revenue, 100)', {
+                dialect: 'postgres',
+                columns,
+            });
+            const window = compile('=MIN(revenue, 100)', {
+                dialect: 'postgres',
+                columns,
+                aggregateContext: 'window',
+            });
+            expect(bare).toBe('LEAST("revenue", 100)');
+            expect(window).toBe('LEAST("revenue", 100)');
+        });
+
+        it('emits GREATEST regardless of context', () => {
+            const bare = compile('=MAX(revenue, 100)', {
+                dialect: 'postgres',
+                columns,
+            });
+            const window = compile('=MAX(revenue, 100)', {
+                dialect: 'postgres',
+                columns,
+                aggregateContext: 'window',
+            });
+            expect(bare).toBe('GREATEST("revenue", 100)');
+            expect(window).toBe('GREATEST("revenue", 100)');
+        });
+    });
+
+    describe('SUMIF / AVERAGEIF / COUNTIF', () => {
+        it('emits bare SUMIF by default', () => {
+            expect(
+                compile('=SUMIF(revenue, region = "EU")', {
+                    dialect: 'postgres',
+                    columns,
+                }),
+            ).toBe(
+                `SUM(CASE WHEN ("region" = 'EU') THEN "revenue" END)`,
+            );
+        });
+
+        it('emits window SUMIF in window context', () => {
+            expect(
+                compile('=SUMIF(revenue, region = "EU")', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe(
+                `SUM(CASE WHEN ("region" = 'EU') THEN "revenue" END) OVER ()`,
+            );
+        });
+
+        it('emits bare AVERAGEIF by default', () => {
+            expect(
+                compile('=AVERAGEIF(revenue, region = "EU")', {
+                    dialect: 'postgres',
+                    columns,
+                }),
+            ).toBe(
+                `AVG(CASE WHEN ("region" = 'EU') THEN "revenue" END)`,
+            );
+        });
+
+        it('emits window AVERAGEIF in window context', () => {
+            expect(
+                compile('=AVERAGEIF(revenue, region = "EU")', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe(
+                `AVG(CASE WHEN ("region" = 'EU') THEN "revenue" END) OVER ()`,
+            );
+        });
+
+        it('emits bare COUNTIF by default', () => {
+            expect(
+                compile('=COUNTIF(region = "EU")', {
+                    dialect: 'postgres',
+                    columns,
+                }),
+            ).toBe(`COUNT(CASE WHEN ("region" = 'EU') THEN 1 END)`);
+        });
+
+        it('emits window COUNTIF in window context', () => {
+            expect(
+                compile('=COUNTIF(region = "EU")', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe(
+                `COUNT(CASE WHEN ("region" = 'EU') THEN 1 END) OVER ()`,
+            );
+        });
+    });
+
+    describe('row-level functions are unaffected by context', () => {
+        it('ABS stays scalar in window context', () => {
+            expect(
+                compile('=ABS(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('ABS("revenue")');
+        });
+
+        it('IF stays scalar in window context', () => {
+            expect(
+                compile('=IF(revenue > 0, 1, 0)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('CASE WHEN ("revenue" > 0) THEN 1 ELSE 0 END');
+        });
+
+        it('arithmetic stays scalar in window context', () => {
+            expect(
+                compile('=revenue * 2', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('("revenue" * 2)');
+        });
+    });
+
+    describe('mixed expressions', () => {
+        it('wraps aggregates while leaving row-level pieces scalar', () => {
+            expect(
+                compile('=revenue - AVG(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('("revenue" - AVG("revenue") OVER ())');
+        });
+
+        it('wraps SUM in share-of-total with safe division', () => {
+            expect(
+                compile('=revenue / SUM(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('("revenue" / NULLIF(SUM("revenue") OVER (), 0))');
+        });
+    });
 });

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -3,209 +3,69 @@ import { compile } from '../src/index';
 
 const columns = { revenue: 'revenue', region: 'region' };
 
-describe('codegen aggregateContext', () => {
-    describe('SUM', () => {
-        it('emits bare SUM by default', () => {
-            const sql = compile('=SUM(revenue)', {
-                dialect: 'postgres',
-                columns,
-            });
-            expect(sql).toBe('SUM("revenue")');
+describe('codegen', () => {
+    describe('aggregates emit bare SQL by default', () => {
+        it('SUM', () => {
+            expect(
+                compile('=SUM(revenue)', { dialect: 'postgres', columns }),
+            ).toBe('SUM("revenue")');
         });
 
-        it('emits bare SUM when aggregateContext is explicitly bare', () => {
-            const sql = compile('=SUM(revenue)', {
-                dialect: 'postgres',
-                columns,
-                aggregateContext: 'bare',
-            });
-            expect(sql).toBe('SUM("revenue")');
-        });
-
-        it('emits window SUM when aggregateContext is window', () => {
-            const sql = compile('=SUM(revenue)', {
-                dialect: 'postgres',
-                columns,
-                aggregateContext: 'window',
-            });
-            expect(sql).toBe('SUM("revenue") OVER ()');
-        });
-    });
-
-    describe('AVG / AVERAGE', () => {
-        it('emits bare AVG by default', () => {
+        it('AVG', () => {
             expect(
                 compile('=AVG(revenue)', { dialect: 'postgres', columns }),
             ).toBe('AVG("revenue")');
         });
 
-        it('emits window AVG in window context', () => {
+        it('AVERAGE (alias of AVG)', () => {
             expect(
-                compile('=AVG(revenue)', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('AVG("revenue") OVER ()');
+                compile('=AVERAGE(revenue)', { dialect: 'postgres', columns }),
+            ).toBe('AVG("revenue")');
         });
 
-        it('treats AVERAGE as an alias for AVG', () => {
-            expect(
-                compile('=AVERAGE(revenue)', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('AVG("revenue") OVER ()');
-        });
-    });
-
-    describe('COUNT', () => {
-        it('emits bare COUNT(x) by default', () => {
+        it('COUNT with arg', () => {
             expect(
                 compile('=COUNT(revenue)', { dialect: 'postgres', columns }),
             ).toBe('COUNT("revenue")');
         });
 
-        it('emits window COUNT(x) in window context', () => {
-            expect(
-                compile('=COUNT(revenue)', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('COUNT("revenue") OVER ()');
+        it('COUNT(*)', () => {
+            expect(compile('=COUNT()', { dialect: 'postgres', columns })).toBe(
+                'COUNT(*)',
+            );
         });
 
-        it('emits bare COUNT(*) by default', () => {
-            expect(
-                compile('=COUNT()', { dialect: 'postgres', columns }),
-            ).toBe('COUNT(*)');
-        });
-
-        it('emits window COUNT(*) in window context', () => {
-            expect(
-                compile('=COUNT()', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('COUNT(*) OVER ()');
-        });
-    });
-
-    describe('MIN / MAX (1-arg aggregate form)', () => {
-        it('emits bare MIN(x) by default', () => {
+        it('1-arg MIN', () => {
             expect(
                 compile('=MIN(revenue)', { dialect: 'postgres', columns }),
             ).toBe('MIN("revenue")');
         });
 
-        it('emits window MIN(x) in window context', () => {
-            expect(
-                compile('=MIN(revenue)', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('MIN("revenue") OVER ()');
-        });
-
-        it('emits bare MAX(x) by default', () => {
+        it('1-arg MAX', () => {
             expect(
                 compile('=MAX(revenue)', { dialect: 'postgres', columns }),
             ).toBe('MAX("revenue")');
         });
 
-        it('emits window MAX(x) in window context', () => {
-            expect(
-                compile('=MAX(revenue)', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('MAX("revenue") OVER ()');
-        });
-    });
-
-    describe('MIN / MAX (2-arg scalar form)', () => {
-        it('emits LEAST regardless of context', () => {
-            const bare = compile('=MIN(revenue, 100)', {
-                dialect: 'postgres',
-                columns,
-            });
-            const window = compile('=MIN(revenue, 100)', {
-                dialect: 'postgres',
-                columns,
-                aggregateContext: 'window',
-            });
-            expect(bare).toBe('LEAST("revenue", 100)');
-            expect(window).toBe('LEAST("revenue", 100)');
-        });
-
-        it('emits GREATEST regardless of context', () => {
-            const bare = compile('=MAX(revenue, 100)', {
-                dialect: 'postgres',
-                columns,
-            });
-            const window = compile('=MAX(revenue, 100)', {
-                dialect: 'postgres',
-                columns,
-                aggregateContext: 'window',
-            });
-            expect(bare).toBe('GREATEST("revenue", 100)');
-            expect(window).toBe('GREATEST("revenue", 100)');
-        });
-    });
-
-    describe('SUMIF / AVERAGEIF / COUNTIF', () => {
-        it('emits bare SUMIF by default', () => {
+        it('SUMIF', () => {
             expect(
                 compile('=SUMIF(revenue, region = "EU")', {
                     dialect: 'postgres',
                     columns,
                 }),
-            ).toBe(
-                `SUM(CASE WHEN ("region" = 'EU') THEN "revenue" END)`,
-            );
+            ).toBe(`SUM(CASE WHEN ("region" = 'EU') THEN "revenue" END)`);
         });
 
-        it('emits window SUMIF in window context', () => {
-            expect(
-                compile('=SUMIF(revenue, region = "EU")', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe(
-                `SUM(CASE WHEN ("region" = 'EU') THEN "revenue" END) OVER ()`,
-            );
-        });
-
-        it('emits bare AVERAGEIF by default', () => {
+        it('AVERAGEIF', () => {
             expect(
                 compile('=AVERAGEIF(revenue, region = "EU")', {
                     dialect: 'postgres',
                     columns,
                 }),
-            ).toBe(
-                `AVG(CASE WHEN ("region" = 'EU') THEN "revenue" END)`,
-            );
+            ).toBe(`AVG(CASE WHEN ("region" = 'EU') THEN "revenue" END)`);
         });
 
-        it('emits window AVERAGEIF in window context', () => {
-            expect(
-                compile('=AVERAGEIF(revenue, region = "EU")', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe(
-                `AVG(CASE WHEN ("region" = 'EU') THEN "revenue" END) OVER ()`,
-            );
-        });
-
-        it('emits bare COUNTIF by default', () => {
+        it('COUNTIF', () => {
             expect(
                 compile('=COUNTIF(region = "EU")', {
                     dialect: 'postgres',
@@ -213,117 +73,155 @@ describe('codegen aggregateContext', () => {
                 }),
             ).toBe(`COUNT(CASE WHEN ("region" = 'EU') THEN 1 END)`);
         });
-
-        it('emits window COUNTIF in window context', () => {
-            expect(
-                compile('=COUNTIF(region = "EU")', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe(
-                `COUNT(CASE WHEN ("region" = 'EU') THEN 1 END) OVER ()`,
-            );
-        });
     });
 
-    describe('row-level functions are unaffected by context', () => {
-        it('ABS stays scalar in window context', () => {
+    describe('scalar functions stay bare', () => {
+        it('2-arg MIN emits LEAST', () => {
             expect(
-                compile('=ABS(revenue)', {
+                compile('=MIN(revenue, 100)', {
                     dialect: 'postgres',
                     columns,
-                    aggregateContext: 'window',
                 }),
+            ).toBe('LEAST("revenue", 100)');
+        });
+
+        it('2-arg MAX emits GREATEST', () => {
+            expect(
+                compile('=MAX(revenue, 100)', {
+                    dialect: 'postgres',
+                    columns,
+                }),
+            ).toBe('GREATEST("revenue", 100)');
+        });
+
+        it('ABS stays scalar', () => {
+            expect(
+                compile('=ABS(revenue)', { dialect: 'postgres', columns }),
             ).toBe('ABS("revenue")');
         });
 
-        it('IF stays scalar in window context', () => {
+        it('IF stays scalar', () => {
             expect(
                 compile('=IF(revenue > 0, 1, 0)', {
                     dialect: 'postgres',
                     columns,
-                    aggregateContext: 'window',
                 }),
             ).toBe('CASE WHEN ("revenue" > 0) THEN 1 ELSE 0 END');
         });
 
-        it('arithmetic stays scalar in window context', () => {
+        it('arithmetic stays scalar', () => {
             expect(
-                compile('=revenue * 2', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
+                compile('=revenue * 2', { dialect: 'postgres', columns }),
             ).toBe('("revenue" * 2)');
         });
     });
 
-    describe('mixed expressions', () => {
-        it('wraps aggregates while leaving row-level pieces scalar', () => {
+    describe('renderAggregate callback', () => {
+        // A test-local renderer that demonstrates the protocol — callers own
+        // the embedding choice. Kept inline to avoid coupling the package to
+        // any particular embedding style.
+        const asWindowAggregate = (inner: string) => `${inner} OVER ()`;
+
+        it('is invoked on SUM', () => {
             expect(
-                compile('=revenue - AVG(revenue)', {
+                compile('=SUM(revenue)', {
                     dialect: 'postgres',
                     columns,
-                    aggregateContext: 'window',
+                    renderAggregate: asWindowAggregate,
                 }),
-            ).toBe('("revenue" - AVG("revenue") OVER ())');
+            ).toBe('SUM("revenue") OVER ()');
         });
 
-        it('wraps SUM in share-of-total with safe division', () => {
+        it('is invoked on SUMIF', () => {
             expect(
-                compile('=revenue / SUM(revenue)', {
+                compile('=SUMIF(revenue, region = "EU")', {
                     dialect: 'postgres',
                     columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('("revenue" / NULLIF(SUM("revenue") OVER (), 0))');
-        });
-
-        it('wraps multiple aggregates in a single expression', () => {
-            expect(
-                compile('=SUM(revenue) - AVG(revenue)', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('(SUM("revenue") OVER () - AVG("revenue") OVER ())');
-        });
-    });
-
-    describe('nested aggregates', () => {
-        it('wraps the aggregate, not the scalar function around it', () => {
-            expect(
-                compile('=ABS(SUM(revenue))', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
-                }),
-            ).toBe('ABS(SUM("revenue") OVER ())');
-        });
-
-        it('wraps the aggregate inside an IF branch', () => {
-            expect(
-                compile('=IF(revenue > 0, SUM(revenue), 0)', {
-                    dialect: 'postgres',
-                    columns,
-                    aggregateContext: 'window',
+                    renderAggregate: asWindowAggregate,
                 }),
             ).toBe(
-                'CASE WHEN ("revenue" > 0) THEN SUM("revenue") OVER () ELSE 0 END',
+                `SUM(CASE WHEN ("region" = 'EU') THEN "revenue" END) OVER ()`,
             );
         });
 
-        it('does not double-wrap a native window function', () => {
+        it('is invoked on COUNTIF', () => {
+            expect(
+                compile('=COUNTIF(region = "EU")', {
+                    dialect: 'postgres',
+                    columns,
+                    renderAggregate: asWindowAggregate,
+                }),
+            ).toBe(`COUNT(CASE WHEN ("region" = 'EU') THEN 1 END) OVER ()`);
+        });
+
+        it('is invoked on 1-arg MIN but not 2-arg (scalar LEAST)', () => {
+            expect(
+                compile('=MIN(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    renderAggregate: asWindowAggregate,
+                }),
+            ).toBe('MIN("revenue") OVER ()');
+            expect(
+                compile('=MIN(revenue, 100)', {
+                    dialect: 'postgres',
+                    columns,
+                    renderAggregate: asWindowAggregate,
+                }),
+            ).toBe('LEAST("revenue", 100)');
+        });
+
+        it('is not invoked on row-level functions', () => {
+            expect(
+                compile('=ABS(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    renderAggregate: asWindowAggregate,
+                }),
+            ).toBe('ABS("revenue")');
+        });
+
+        it('is not invoked on native window functions (they emit their own OVER)', () => {
             expect(
                 compile('=RUNNING_TOTAL(revenue)', {
                     dialect: 'postgres',
                     columns,
-                    aggregateContext: 'window',
+                    renderAggregate: asWindowAggregate,
                 }),
-            ).toBe(
-                'SUM("revenue") OVER ( ROWS UNBOUNDED PRECEDING)',
-            );
+            ).toBe('SUM("revenue") OVER ( ROWS UNBOUNDED PRECEDING)');
+        });
+
+        it('is applied recursively to nested aggregates', () => {
+            expect(
+                compile('=ABS(SUM(revenue))', {
+                    dialect: 'postgres',
+                    columns,
+                    renderAggregate: asWindowAggregate,
+                }),
+            ).toBe('ABS(SUM("revenue") OVER ())');
+        });
+
+        it('wraps each aggregate independently in mixed expressions', () => {
+            expect(
+                compile('=revenue - AVG(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    renderAggregate: asWindowAggregate,
+                }),
+            ).toBe('("revenue" - AVG("revenue") OVER ())');
+        });
+
+        it('lets callers express any embedding (demonstration)', () => {
+            // Callers aren't limited to OVER () — the protocol is generic.
+            // Here a hypothetical consumer tags aggregates for later processing.
+            const tag = (inner: string) => `/*agg*/${inner}`;
+            expect(
+                compile('=SUM(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    renderAggregate: tag,
+                }),
+            ).toBe('/*agg*/SUM("revenue")');
         });
     });
 });

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -279,5 +279,51 @@ describe('codegen aggregateContext', () => {
                 }),
             ).toBe('("revenue" / NULLIF(SUM("revenue") OVER (), 0))');
         });
+
+        it('wraps multiple aggregates in a single expression', () => {
+            expect(
+                compile('=SUM(revenue) - AVG(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('(SUM("revenue") OVER () - AVG("revenue") OVER ())');
+        });
+    });
+
+    describe('nested aggregates', () => {
+        it('wraps the aggregate, not the scalar function around it', () => {
+            expect(
+                compile('=ABS(SUM(revenue))', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe('ABS(SUM("revenue") OVER ())');
+        });
+
+        it('wraps the aggregate inside an IF branch', () => {
+            expect(
+                compile('=IF(revenue > 0, SUM(revenue), 0)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe(
+                'CASE WHEN ("revenue" > 0) THEN SUM("revenue") OVER () ELSE 0 END',
+            );
+        });
+
+        it('does not double-wrap a native window function', () => {
+            expect(
+                compile('=RUNNING_TOTAL(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    aggregateContext: 'window',
+                }),
+            ).toBe(
+                'SUM("revenue") OVER ( ROWS UNBOUNDED PRECEDING)',
+            );
+        });
     });
 });

--- a/packages/formula/tests/isAggregateCall.test.ts
+++ b/packages/formula/tests/isAggregateCall.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { isAggregateCall } from '../src/ast';
+import { parse } from '../src/compiler';
+
+describe('isAggregateCall', () => {
+    it.each([
+        ['=SUM(A)', true, 'SUM'],
+        ['=AVG(A)', true, 'AVG'],
+        ['=AVERAGE(A)', true, 'AVERAGE (alias of AVG)'],
+        ['=COUNT(A)', true, 'COUNT with arg'],
+        ['=COUNT()', true, 'COUNT(*)'],
+        ['=MIN(A)', true, '1-arg MIN'],
+        ['=MAX(A)', true, '1-arg MAX'],
+        ['=SUMIF(A, B > 0)', true, 'SUMIF'],
+        ['=AVERAGEIF(A, B > 0)', true, 'AVERAGEIF'],
+        ['=COUNTIF(B > 0)', true, 'COUNTIF'],
+    ])('recognises %s as aggregate (%s)', (formula, expected, _desc) => {
+        expect(isAggregateCall(parse(formula))).toBe(expected);
+    });
+
+    it.each([
+        ['=A + B', 'binary arithmetic'],
+        ['=-A', 'unary minus'],
+        ['=A > 0', 'comparison'],
+        ['=A > 0 AND B > 0', 'logical AND'],
+        ['=IF(A > 0, A, 0)', 'IF expression'],
+        ['=ABS(A)', 'scalar single-arg ABS'],
+        ['=ROUND(A, 2)', '2-arg ROUND'],
+        ['=MIN(A, B)', '2-arg MIN (scalar LEAST)'],
+        ['=MAX(A, B)', '2-arg MAX (scalar GREATEST)'],
+        ['=CONCAT(A, B)', 'variadic CONCAT'],
+        ['=COALESCE(A, B)', 'variadic COALESCE'],
+        ['=TODAY()', 'zero-arg TODAY'],
+        ['=ROW_NUMBER()', 'window ROW_NUMBER (native windowing, not an aggregate call)'],
+        ['=RUNNING_TOTAL(A)', 'window RUNNING_TOTAL (emits its own OVER)'],
+        ['=LAG(A, 1)', 'window LAG'],
+        ['=A', 'column reference'],
+        ['=42', 'number literal'],
+        ['="hello"', 'string literal'],
+        ['=TRUE', 'boolean literal'],
+    ])('does NOT recognise %s as aggregate (%s)', (formula, _desc) => {
+        expect(isAggregateCall(parse(formula))).toBe(false);
+    });
+});


### PR DESCRIPTION
## Summary

- Formula table calcs using any aggregate function (`SUM`, `AVG`, `COUNT`, 1-arg `MIN`/`MAX`, `SUMIF`, `AVERAGEIF`, `COUNTIF`) currently produce invalid SQL at runtime on every supported warehouse. Example error on Postgres: `column "customers_customer_id" must appear in the GROUP BY clause or be used in an aggregate function`.
- Root cause: the formula package emitted bare SQL aggregates (e.g. `SUM(x)`) which `MetricQueryBuilder` splices into a post-aggregation SELECT alongside non-aggregate dimension columns — mixing bare aggregates with non-aggregates in that position is rejected by the warehouse.
- Fix: the formula package now exposes a `renderAggregate?: (innerSql: string) => string` callback on `CompileOptions`. The generator identifies aggregate nodes (via a new `isAggregateCall` AST helper that derives from `FUNCTION_DEFINITIONS`) and hands the bare SQL to the callback. The backend passes `(inner) => \`${inner} OVER ()\`` at its single call site, which turns aggregates into window aggregates valid in the post-aggregation SELECT — preserving Sheets-like whole-result-set semantics.

## Architecture notes

- **`OVER ()` is the caller's choice, not the package's.** The formula package stays a generic expression-to-SQL compiler with zero knowledge of SQL embedding contexts. The wrapping function lives inline in `queryCompiler.ts` next to its rationale comment, not exported from the package — exporting it would re-introduce the embedding-context coupling the callback exists to avoid.
- **Single point of wrapping.** The dispatcher (`generate()`) applies the callback once per aggregate node anywhere in the AST, so new aggregates added to `FUNCTION_DEFINITIONS` with category `'aggregate'` are picked up automatically. No individual codegen arm has to remember to wrap — the class of bug we're fixing can't recur in the same shape.
- **Nested aggregates compose.** Expressions like `revenue - AVG(revenue)`, `revenue / SUM(revenue)`, and `ABS(SUM(revenue))` now compile correctly because the dispatcher wraps each aggregate independently on recursive descent.
- **Native window functions are untouched.** `isAggregateCall` returns false for `WindowFn` nodes, so `RUNNING_TOTAL(x)` still emits its own `OVER (...)` without double-wrapping.
- **Backwards-compatible default.** `renderAggregate` is optional and defaults to identity, so the `formula-tests` runner and any future consumer that doesn't want window wrapping continues to get bare SQL.

## Known limitations (out of scope, unchanged)

- Nested aggregates in conditions (e.g. `SUMIF(x, y > AVG(y))`) remain broken — the inner `AVG(y)` inside the `CASE WHEN` is not wrapped. Rare; documented; follow-up.
- Unsupported warehouses (Redshift, Trino, Athena, ClickHouse, Databricks) still throw at `mapAdapterToFormulaDialect`. Tracked as ZAP-324; this PR does not touch warehouse coverage.

## Docs

Design spec and implementation plan committed under `docs/superpowers/` for review context — happy to drop if they're out of place for the repo.

## Test Plan

- [x] Formula unit tests: 112/112 pass (`pnpm -F formula test`)
- [x] Backend queryCompiler tests: 65/65 pass (`pnpm -F backend test:dev:nowatch --testPathPattern queryCompiler`), including new error-path test for aggregate formulas referencing unknown columns
- [x] Formula integration tests (DuckDB): 297/298 pass — the one failure (`logical/not-operator`) is pre-existing on `main` and unrelated
- [x] Backend typecheck: clean
- [x] Manual smoke on Postgres local dev: `SUM(Total Shipping Revenue)`, `SUMIF(..., condition)`, and `revenue - AVG(revenue)` all render charts correctly with per-row repeated aggregate values
- [ ] Tier1/tier2 integration tests (Postgres / BigQuery / Snowflake) — require CI credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)