### PR TITLE
fix: invalidate cache for scheduled Google Sheets dashboard exports

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2768,6 +2768,7 @@ export default class SchedulerTask {
                         account,
                         projectUuid: chart.projectUuid,
                         chartUuid: savedChartUuid,
+                        invalidateCache: true,
                         context:
                             QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
                         pivotResults: shouldPivot,
@@ -2934,6 +2935,7 @@ export default class SchedulerTask {
                                 dashboardUuid,
                                 dashboardFilters,
                                 dashboardSorts: [],
+                                invalidateCache: true,
                                 context:
                                     QueryExecutionContext.SCHEDULED_GSHEETS_DASHBOARD,
                                 pivotResults: shouldPivotChart,


### PR DESCRIPTION
Closes: #22074 

### Description:
When exporting dashboard charts to Google Sheets via the scheduler, the query cache is now invalidated to ensure fresh data is always fetched. Previously, scheduled Google Sheets exports could return stale cached results instead of up-to-date data.