### PR TITLE
refactor: add timezone parameter to formatting functions

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -747,6 +747,7 @@ export function formatRow(
     itemsMap: ItemsMap,
     pivotValuesColumns?: Record<string, PivotValuesColumn> | null,
     parameters?: Record<string, unknown>,
+    timezone?: string,
 ): ResultRow {
     const resultRow: ResultRow = {};
     const columnNames = Object.keys(row || {});
@@ -759,7 +760,13 @@ export function formatRow(
         resultRow[columnName] = {
             value: {
                 raw: formatRawValue(item, value),
-                formatted: formatItemValue(item, value, false, parameters),
+                formatted: formatItemValue(
+                    item,
+                    value,
+                    false,
+                    parameters,
+                    timezone,
+                ),
             },
         };
     }
@@ -772,9 +779,10 @@ export function formatRows(
     itemsMap: ItemsMap,
     pivotValuesColumns?: Record<string, PivotValuesColumn> | null,
     parameters?: Record<string, unknown>,
+    timezone?: string,
 ): ResultRow[] {
     return rows.map((row) =>
-        formatRow(row, itemsMap, pivotValuesColumns, parameters),
+        formatRow(row, itemsMap, pivotValuesColumns, parameters, timezone),
     );
 }
 

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -16,8 +16,10 @@ import {
     applyDefaultFormat,
     convertCustomFormatToFormatExpression,
     currencies,
+    formatDate,
     formatItemValue,
     formatNumberValue,
+    formatTimestamp,
     formatValueWithExpression,
     getCustomFormatFromLegacy,
     isMomentInput,
@@ -1731,6 +1733,85 @@ describe('Formatting', () => {
                         symbol: '£',
                     }),
                 ).toBe('£1,000.50');
+            });
+        });
+    });
+
+    describe('timezone-aware formatting', () => {
+        const utcTimestamp = '2020-04-04T02:00:00.000Z';
+
+        describe('formatDate', () => {
+            test('formats date in project timezone', () => {
+                // 2020-04-04 02:00 UTC = 2020-04-03 22:00 New York
+                expect(
+                    formatDate(
+                        utcTimestamp,
+                        TimeFrames.DAY,
+                        false,
+                        'America/New_York',
+                    ),
+                ).toBe('2020-04-03');
+            });
+
+            test('formats date in UTC timezone', () => {
+                expect(
+                    formatDate(utcTimestamp, TimeFrames.DAY, false, 'UTC'),
+                ).toBe('2020-04-04');
+            });
+
+            test('existing behavior unchanged when no timezone', () => {
+                const withTrue = formatDate(utcTimestamp, TimeFrames.DAY, true);
+                const withFalse = formatDate(
+                    utcTimestamp,
+                    TimeFrames.DAY,
+                    false,
+                );
+                const withDefault = formatDate(utcTimestamp, TimeFrames.DAY);
+                expect(withTrue).toBe('2020-04-04');
+                expect(withFalse).toBe(withDefault);
+            });
+
+            test('timezone takes precedence over convertToUTC', () => {
+                expect(
+                    formatDate(
+                        utcTimestamp,
+                        TimeFrames.DAY,
+                        true,
+                        'America/New_York',
+                    ),
+                ).toBe('2020-04-03');
+            });
+        });
+
+        describe('formatTimestamp', () => {
+            test('formats timestamp in project timezone', () => {
+                const result = formatTimestamp(
+                    utcTimestamp,
+                    TimeFrames.SECOND,
+                    false,
+                    'America/New_York',
+                );
+                expect(result).toBe('2020-04-03, 22:00:00 (-04:00)');
+            });
+
+            test('formats timestamp with correct offset in MILLISECOND interval', () => {
+                const result = formatTimestamp(
+                    utcTimestamp,
+                    TimeFrames.MILLISECOND,
+                    false,
+                    'America/New_York',
+                );
+                expect(result).toContain('2020-04-03, 22:00:00:000');
+                expect(result).toContain('-04:00');
+            });
+
+            test('existing behavior unchanged when no timezone', () => {
+                const withTrue = formatTimestamp(
+                    utcTimestamp,
+                    TimeFrames.MILLISECOND,
+                    true,
+                );
+                expect(withTrue).toBe('2020-04-04, 02:00:00:000 (+00:00)');
             });
         });
     });

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -1,6 +1,6 @@
 import dayjs from 'dayjs';
-import timezone from 'dayjs/plugin/timezone';
-import moment, { type MomentInput } from 'moment';
+import dayjsTimezone from 'dayjs/plugin/timezone';
+import moment, { type MomentInput } from 'moment-timezone';
 import {
     format as formatWithExpression,
     isDateFormat,
@@ -42,7 +42,7 @@ import assertUnreachable from './assertUnreachable';
 import { evaluateConditionalFormatExpression } from './conditionalFormatExpressions';
 import { getItemType, isNumericItem } from './item';
 
-dayjs.extend(timezone);
+dayjs.extend(dayjsTimezone);
 
 export const currencies = [
     'USD',
@@ -135,8 +135,16 @@ export function formatDate(
     date: MomentInput,
     timeInterval: TimeFrames = TimeFrames.DAY,
     convertToUTC: boolean = false,
+    timezone?: string,
 ): string {
-    const momentDate = convertToUTC ? moment(date).utc() : moment(date);
+    let momentDate;
+    if (timezone) {
+        momentDate = moment.utc(date).tz(timezone);
+    } else if (convertToUTC) {
+        momentDate = moment(date).utc();
+    } else {
+        momentDate = moment(date);
+    }
 
     if (!momentDate.isValid()) {
         return 'NaT';
@@ -149,8 +157,16 @@ export function formatTimestamp(
     value: MomentInput,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,
     convertToUTC: boolean = false,
+    timezone?: string,
 ): string {
-    const momentDate = convertToUTC ? moment(value).utc() : moment(value);
+    let momentDate;
+    if (timezone) {
+        momentDate = moment.utc(value).tz(timezone);
+    } else if (convertToUTC) {
+        momentDate = moment(value).utc();
+    } else {
+        momentDate = moment(value);
+    }
 
     if (!momentDate.isValid()) {
         return 'NaT';
@@ -772,6 +788,7 @@ export function formatItemValue(
     value: unknown,
     convertToUTC?: boolean,
     parameters?: Record<string, unknown>,
+    timezone?: string,
 ): string {
     if (value === null) return '∅';
     if (value === undefined) return '-';
@@ -838,6 +855,7 @@ export function formatItemValue(
                               value,
                               isDimension(item) ? item.timeInterval : undefined,
                               convertToUTC,
+                              timezone,
                           )
                         : 'NaT';
                 case DimensionType.TIMESTAMP:
@@ -848,6 +866,7 @@ export function formatItemValue(
                               value,
                               isDimension(item) ? item.timeInterval : undefined,
                               convertToUTC,
+                              timezone,
                           )
                         : 'NaT';
                 case MetricType.MAX:
@@ -857,6 +876,7 @@ export function formatItemValue(
                             value,
                             isDimension(item) ? item.timeInterval : undefined,
                             convertToUTC,
+                            timezone,
                         );
                     }
                     break;

--- a/packages/common/src/visualizations/helpers/valueFormatter.ts
+++ b/packages/common/src/visualizations/helpers/valueFormatter.ts
@@ -11,10 +11,11 @@ export const getFormattedValue = (
     convertToUTC: boolean = true,
     pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
     parameters?: ParametersValuesMap,
+    timezone?: string,
 ): string => {
     const pivotValuesColumn = pivotValuesColumnsMap?.[key];
     const item = itemsMap[pivotValuesColumn?.referenceField ?? key];
-    return formatItemValue(item, value, convertToUTC, parameters);
+    return formatItemValue(item, value, convertToUTC, parameters, timezone);
 };
 
 export const valueFormatter =
@@ -23,6 +24,7 @@ export const valueFormatter =
         itemsMap: ItemsMap,
         pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
         parameters?: ParametersValuesMap,
+        timezone?: string,
     ) =>
     (rawValue: AnyType) =>
         getFormattedValue(
@@ -32,4 +34,5 @@ export const valueFormatter =
             undefined,
             pivotValuesColumnsMap,
             parameters,
+            timezone,
         );


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-291

## Summary

- Add optional `timezone?: string` parameter to core formatting functions (`formatDate`, `formatTimestamp`, `formatItemValue`, `formatRow`, `formatRows`, `getFormattedValue`, `valueFormatter`)
- When `timezone` is provided, it takes precedence over the existing `convertToUTC` boolean — uses `moment.utc(value).tz(timezone)` for correct timezone-aware formatting
- Existing callers are completely unaffected — all new parameters are optional, no signature changes to existing call sites
- This is the foundation for GLITCH-291 (timezone-aware result formatting). Backend and frontend threading come in follow-up PRs.

## Test plan

- [x] New tests for `formatDate` and `formatTimestamp` with timezone parameter
- [x] Tests verify timezone takes precedence over `convertToUTC`
- [x] Tests verify existing behavior unchanged when no timezone provided
- [x] All existing formatting tests pass (80/80)
- [x] Typecheck passes for common, backend, and frontend