### PR TITLE
fix(duplicate): parse date strings as UTC in formatDate/formatTimestamp to preve…

### DIFF
--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -137,11 +137,14 @@ export function formatDate(
     convertToUTC: boolean = false,
     timezone?: string,
 ): string {
+    // moment.utc(date) parses date-only strings as UTC. moment(date).utc()
+    // parses in the local timezone first, shifting the date back a day
+    // in UTC+ browsers (e.g. JST).
     let momentDate;
     if (timezone) {
         momentDate = moment.utc(date).tz(timezone);
     } else if (convertToUTC) {
-        momentDate = moment(date).utc();
+        momentDate = moment.utc(date);
     } else {
         momentDate = moment(date);
     }
@@ -163,7 +166,7 @@ export function formatTimestamp(
     if (timezone) {
         momentDate = moment.utc(value).tz(timezone);
     } else if (convertToUTC) {
-        momentDate = moment(value).utc();
+        momentDate = moment.utc(value);
     } else {
         momentDate = moment(value);
     }


### PR DESCRIPTION
…nt 1-day offset in stacked bar tooltip

When `convertToUTC=true`, `moment(date).utc()` first parses a date-only string (e.g. "2026-03-14") as local midnight, then switches to UTC view. In UTC+ timezones (e.g. JST/UTC+9) this shifts the date back by one day.

Switch to `moment.utc(date)` which parses the string *as* UTC from the start, matching ECharts' `useUTC: true` behaviour and fixing the 1-day offset seen in stacked bar chart item-mode hover tooltips.

<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Closes: <!-- reference the related issue e.g. #150 -->

### Description:
<!-- Add a description of the changes proposed in the pull request. -->

<!-- Even better add a screenshot / gif / loom -->
