### PR TITLE
fix(formula): accept NOT(expr) function-call syntax

### DIFF
--- a/packages/formula/src/grammar/formula.pegjs
+++ b/packages/formula/src/grammar/formula.pegjs
@@ -34,10 +34,15 @@ BooleanAnd
     }
 
 BooleanAtom
-  = Comparison
-  / "NOT"i _ operand:BooleanAtom {
+  // NOT must be tried before Comparison: PEG is first-match-wins, and
+  // `NOT(expr)` otherwise falls through `Comparison → Arithmetic → Primary
+  // → InvalidFn`, which throws "Unknown function: NOT" before the unary
+  // NOT rule ever gets a chance. Trying NOT first lets both
+  // `=NOT A > 100` and `=NOT(A > 100)` parse.
+  = "NOT"i _ operand:BooleanAtom {
       return { type: "UnaryOp", op: "NOT", operand };
     }
+  / Comparison
   / BooleanFn
   / "(" _ expr:BooleanOr _ ")" { return expr; }
   / BooleanLiteral

--- a/packages/formula/tests/grammar.test.ts
+++ b/packages/formula/tests/grammar.test.ts
@@ -229,6 +229,44 @@ describe('Formula Grammar', () => {
             });
         });
 
+        it('parses function-call-style NOT(expr) — Excel/Sheets idiom', () => {
+            const ast = parse('=NOT(A > 100)');
+            expect(ast).toEqual({
+                type: 'UnaryOp',
+                op: 'NOT',
+                operand: {
+                    type: 'Comparison',
+                    op: '>',
+                    left: { type: 'ColumnRef', name: 'A' },
+                    right: { type: 'NumberLiteral', value: 100 },
+                },
+            });
+        });
+
+        it('parses NOT wrapping a parenthesised boolean OR', () => {
+            const ast = parse('=NOT(A > 0 OR B < 0)');
+            expect(ast).toEqual({
+                type: 'UnaryOp',
+                op: 'NOT',
+                operand: {
+                    type: 'Logical',
+                    op: 'OR',
+                    left: {
+                        type: 'Comparison',
+                        op: '>',
+                        left: { type: 'ColumnRef', name: 'A' },
+                        right: { type: 'NumberLiteral', value: 0 },
+                    },
+                    right: {
+                        type: 'Comparison',
+                        op: '<',
+                        left: { type: 'ColumnRef', name: 'B' },
+                        right: { type: 'NumberLiteral', value: 0 },
+                    },
+                },
+            });
+        });
+
         it('rejects bare column refs in AND', () => {
             expect(() => parse('=A AND B')).toThrow();
         });


### PR DESCRIPTION
## Summary

Users familiar with Excel/Sheets naturally type `=NOT(A > 100)` — parens, function-call style. The formula grammar rejected it with `Unknown function: NOT`, because `NOT` was only accepted as a unary prefix operator (`=NOT A > 100`, no parens).

One-line grammar reorder: try the `NOT`-unary rule in `BooleanAtom` *before* `Comparison`. Both syntaxes now parse to the same AST.

## Why the old behaviour existed

PEG is first-match-wins. With `Comparison` listed first, the parser descended `BooleanAtom → Comparison → Arithmetic → Primary → InvalidFn`, whose catch-all rule `name:Identifier _ "(" ... ")"` throws `Unknown function: ${name}` and matched `NOT(...)` before the parser ever got to the `"NOT"i _ operand` alternative further down.

Moving the `NOT`-unary alternative to the top of `BooleanAtom` short-circuits the descent before it can hit the `InvalidFn` throw.

## Scope

- `packages/formula/src/grammar/formula.pegjs` — single alternative reorder (the alternative body is unchanged)
- `packages/formula/tests/grammar.test.ts` — two new unit tests locking in `NOT(A > 100)` and `NOT(A > 0 OR B < 0)`

Zero codegen changes. Zero AST changes (both forms parse to the same `UnaryOp { op: 'NOT', operand: ... }`). Zero dialect-specific work.

## Impact

`logical/not-operator` was the **single remaining failing integration test on every dialect** (DuckDB, Postgres, BigQuery, Snowflake, Redshift, Databricks, ClickHouse) — the universal "known issue" footnote on every warehouse-support PR in the stack. This PR flips each of those from 297/298 → **298/298**.

Verified locally: `pnpm formula:test:fast` now reports `SUMMARY: 298/298 passed (100.0%)`.

## Test Plan

- [x] Formula unit tests: **117/117** (47 grammar including 2 new ones, 14 ast, 27 codegen, 29 isAggregateCall)
- [x] DuckDB integration: **298/298** (was 297/298 on main; the NOT test is now `✓`)
- [x] Existing `=NOT A > 100` (no parens) still parses correctly — the original unary-NOT rule body is unchanged, only the alternative ordering moves

## Relation to other in-flight PRs

Independent of [#22112](https://github.com/lightdash/lightdash/pull/22112) / [#22113](https://github.com/lightdash/lightdash/pull/22113) / [#22114](https://github.com/lightdash/lightdash/pull/22114) / [#22119](https://github.com/lightdash/lightdash/pull/22119) — the dialect stack. Merging this in any order against those is fine; the grammar file doesn't overlap with any of their changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)