### PR TITLE
fix: show non-empty error message on failed dashboard tile queries

### DIFF
--- a/packages/common/src/types/errors.ts
+++ b/packages/common/src/types/errors.ts
@@ -510,8 +510,10 @@ export class NotImplementedError extends LightdashError {
         });
     }
 }
-export const getErrorMessage = (e: unknown) =>
-    e instanceof Error ? e.message : `Unknown ${typeof e} error`;
+export const getErrorMessage = (e: unknown) => {
+    if (e instanceof Error && e.message) return e.message;
+    return `Unknown ${typeof e} error`;
+};
 
 export class ScreenshotError extends LightdashError {
     constructor(

--- a/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardChartTile.tsx
@@ -2012,7 +2012,7 @@ export const GenericDashboardChartTile: FC<
                     title={tileTitle}
                     description={
                         getDashboardTileErrorMessage(error) ||
-                        'No data available'
+                        'Error running query'
                     }
                 />
             </TileBase>

--- a/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
+++ b/packages/frontend/src/components/DashboardTiles/DashboardSqlChartTile.tsx
@@ -244,7 +244,7 @@ const SqlChartTile: FC<Props> = ({ tile, isEditMode, ...rest }) => {
                         title={tile.properties.chartName}
                         description={
                             chartResultsError?.error?.message ||
-                            'No data available'
+                            'Error running query'
                         }
                     />
                 )}

--- a/packages/frontend/src/hooks/useInfiniteQueryResults.test.tsx
+++ b/packages/frontend/src/hooks/useInfiniteQueryResults.test.tsx
@@ -136,7 +136,7 @@ describe('useInfiniteQueryResults', () => {
         });
     });
 
-    it('falls back to a non-empty message when the backend error is empty (PROD-7014)', async () => {
+    it('falls back to a non-empty message when the backend error is empty (PROD-7011)', async () => {
         const errorResponse: ApiGetAsyncQueryResults = {
             queryUuid: 'q1',
             status: QueryHistoryStatus.ERROR,
@@ -155,8 +155,8 @@ describe('useInfiniteQueryResults', () => {
         });
 
         // Empty backend error must not surface as an empty message — the tile
-        // UI renders 'No data available' when the message is empty, masking
-        // the real failure. See PROD-7014.
+        // UI renders 'Error running query' when the message is empty, masking
+        // the real failure. See PROD-7011.
         expect(result.current.error?.error?.message).toBeTruthy();
     });
 

--- a/packages/frontend/src/hooks/useInfiniteQueryResults.test.tsx
+++ b/packages/frontend/src/hooks/useInfiniteQueryResults.test.tsx
@@ -136,6 +136,30 @@ describe('useInfiniteQueryResults', () => {
         });
     });
 
+    it('falls back to a non-empty message when the backend error is empty (PROD-7014)', async () => {
+        const errorResponse: ApiGetAsyncQueryResults = {
+            queryUuid: 'q1',
+            status: QueryHistoryStatus.ERROR,
+            error: '',
+            erroredAt: new Date(),
+        };
+        mockGetResultsPage.mockResolvedValue(errorResponse);
+
+        const { result } = renderHook(
+            () => useInfiniteQueryResults('p1', 'q1'),
+            { wrapper: createWrapper() },
+        );
+
+        await waitFor(() => {
+            expect(result.current.error).not.toBeNull();
+        });
+
+        // Empty backend error must not surface as an empty message — the tile
+        // UI renders 'No data available' when the message is empty, masking
+        // the real failure. See PROD-7014.
+        expect(result.current.error?.error?.message).toBeTruthy();
+    });
+
     it('resets pages when queryUuid changes', async () => {
         const page1Q1 = makeReadyPage(1, { queryUuid: 'q1', rows: 5 });
         const page1Q2 = makeReadyPage(1, { queryUuid: 'q2', rows: 3 });

--- a/packages/frontend/src/hooks/useQueryResults.ts
+++ b/packages/frontend/src/hooks/useQueryResults.ts
@@ -417,7 +417,7 @@ export const useInfiniteQueryResults = (
                         error: {
                             name: 'Error',
                             statusCode: 500,
-                            message: results.error ?? 'Query failed',
+                            message: results.error || 'Query failed',
                             data: {},
                         },
                     };


### PR DESCRIPTION
Closes: PROD-7014 / #22069

### Description:

When a query fails with an empty error message from the backend, the dashboard tile was silently showing "No data available" instead of indicating an actual error occurred. This masked real query failures and made it difficult to distinguish between a query returning no results and a query that errored.

- `getErrorMessage` now guards against empty error messages, falling back to a descriptive unknown error string when the message is falsy
- `useInfiniteQueryResults` uses a logical OR (`||`) instead of nullish coalescing (`??`) when constructing the error message, so empty strings correctly fall back to `'Query failed'`
- Dashboard chart tiles (both standard and SQL) now display `'Error running query'` instead of `'No data available'` when an error is present
- A regression test has been added to verify that an empty backend error string surfaces as a non-empty message on the error object