### PR TITLE
feat(analytics): track formula table calculation saves

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -436,6 +436,22 @@ type RestoredSavedChartEvent = BaseTrack & {
     };
 };
 
+type FormulaTableCalculationSavedEvent = BaseTrack & {
+    event: 'formula_table_calculation.saved';
+    properties: {
+        organizationId: string;
+        projectId: string;
+        savedChartUuid: string;
+        // `created` covers first-time chart creation AND duplication; `updated`
+        // covers saveVersion (the path that persists table-calc edits on an
+        // existing chart). The two together let us separate adopters from
+        // iterators in Lightdash analytics.
+        action: 'created' | 'updated';
+        formulaCount: number;
+        totalTableCalculationCount: number;
+    };
+};
+
 type ChartHistoryEvent = BaseTrack & {
     event: 'saved_chart_history.view';
     properties: {
@@ -1620,6 +1636,7 @@ type TypedEvent =
     | UpdateSavedChartEvent
     | DeleteSavedChartEvent
     | RestoredSavedChartEvent
+    | FormulaTableCalculationSavedEvent
     | CreateSavedChartEvent
     | ChartHistoryEvent
     | ViewChartVersionEvent

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -26,6 +26,7 @@ import {
     isConditionalFormattingConfigWithColorRange,
     isConditionalFormattingConfigWithSingleColor,
     isCustomSqlDimension,
+    isFormulaTableCalculation,
     isJwtUser,
     isSchedulerGsheetsOptions,
     isUserWithOrg,
@@ -416,6 +417,36 @@ export class SavedChartService
         return eventProperties;
     }
 
+    static getFormulaTableCalculationEventProperties(
+        savedChart: SavedChartDAO,
+        action: 'created' | 'updated',
+    ):
+        | {
+              organizationId: string;
+              projectId: string;
+              savedChartUuid: string;
+              action: 'created' | 'updated';
+              formulaCount: number;
+              totalTableCalculationCount: number;
+          }
+        | undefined {
+        const { tableCalculations } = savedChart.metricQuery;
+        const formulaCount = tableCalculations.filter(
+            isFormulaTableCalculation,
+        ).length;
+        if (formulaCount === 0) {
+            return undefined;
+        }
+        return {
+            organizationId: savedChart.organizationUuid,
+            projectId: savedChart.projectUuid,
+            savedChartUuid: savedChart.uuid,
+            action,
+            formulaCount,
+            totalTableCalculationCount: tableCalculations.length,
+        };
+    }
+
     private async updateChartFieldUsage(
         projectUuid: string,
         chartExplore: Explore | ExploreError,
@@ -506,6 +537,19 @@ export class SavedChartService
             userId: user.userUuid,
             properties: SavedChartService.getCreateEventProperties(savedChart),
         });
+
+        const formulaProperties =
+            SavedChartService.getFormulaTableCalculationEventProperties(
+                savedChart,
+                'updated',
+            );
+        if (formulaProperties) {
+            this.analytics.track({
+                event: 'formula_table_calculation.saved',
+                userId: user.userUuid,
+                properties: formulaProperties,
+            });
+        }
 
         SavedChartService.getConditionalFormattingEventProperties(
             savedChart,
@@ -1208,6 +1252,19 @@ export class SavedChartService
             },
         });
 
+        const createFormulaProperties =
+            SavedChartService.getFormulaTableCalculationEventProperties(
+                newSavedChart,
+                'created',
+            );
+        if (createFormulaProperties) {
+            this.analytics.track({
+                event: 'formula_table_calculation.saved',
+                userId: user.userUuid,
+                properties: createFormulaProperties,
+            });
+        }
+
         SavedChartService.getConditionalFormattingEventProperties(
             newSavedChart,
         )?.forEach((properties) => {
@@ -1331,6 +1388,19 @@ export class SavedChartService
                 duplicateOfSavedQueryId: chartUuid,
             },
         });
+
+        const duplicateFormulaProperties =
+            SavedChartService.getFormulaTableCalculationEventProperties(
+                newSavedChart,
+                'created',
+            );
+        if (duplicateFormulaProperties) {
+            this.analytics.track({
+                event: 'formula_table_calculation.saved',
+                userId: user.userUuid,
+                properties: duplicateFormulaProperties,
+            });
+        }
 
         try {
             await this.updateChartFieldUsage(projectUuid, cachedExplore, {


### PR DESCRIPTION
## Summary

Fires a new `formula_table_calculation.saved` event alongside the existing `saved_chart.created` / `saved_chart_version.created` / duplicate paths whenever a chart contains ≥1 formula table calculation. Lets us answer *"are people using this feature?"* with a simple `count distinct savedChartUuid` in Lightdash analytics.

## Why save, not compile

Compile fires on every chart view, dashboard refresh, and scheduler run — a dashboard with 5 formula calcs × 10 auto-refreshes/day × 100 viewers would produce 5000 events/day from one dashboard. You'd drown in volume and end up deduping to answer the same question.

Save is the clearest commitment signal: someone typed a formula and kept it. Low volume, already-instrumented in `SavedChartService`, and the `action: 'created' | 'updated'` split separates adopters from iterators in a single event.

## Event shape

```ts
{
  event: 'formula_table_calculation.saved',
  userId,
  properties: {
    organizationId: string,
    projectId: string,
    savedChartUuid: string,
    action: 'created' | 'updated',
    formulaCount: number,
    totalTableCalculationCount: number,
  }
}
```

Properties kept lean on purpose:

- **No `warehouseType`.** `projectId` joins to it in the analytics warehouse — the alternative is an extra DB lookup on every chart save for a value we already have elsewhere.
- **No formula text / column names.** PII and config-drift risk; counts are enough for adoption measurement.

## Queries this unlocks

- **New adopters per week:** `count distinct userId where event = 'formula_table_calculation.saved' and action = 'created'` grouped by week
- **Engagement:** all events per user — iterators show up with multiple `updated` events
- **Adoption rate vs. install base:** adopters / total active users
- **Share of table calcs that are formulas:** `sum(formulaCount) / sum(totalTableCalculationCount)` — trends upward as adoption deepens
- **Per-org intensity:** `sum(formulaCount)` per `organizationId` — identifies power-user orgs

## Where it fires

Three entry points in `SavedChartService`, each gated on `isFormulaTableCalculation`:

1. **`saveVersion`** (new metric-query version on an existing chart, where table-calc edits land) → `action: 'updated'`
2. **`create`** (first-time chart save) → `action: 'created'`
3. **`duplicate`** (chart copy that retains formulas) → `action: 'created'`

Charts with no formulas emit nothing — no wasted events.

## Stacked on

[#22119](https://github.com/lightdash/lightdash/pull/22119) (ClickHouse) → [#22114](https://github.com/lightdash/lightdash/pull/22114) (Databricks) → [#22113](https://github.com/lightdash/lightdash/pull/22113) (refactor) → [#22112](https://github.com/lightdash/lightdash/pull/22112) (Redshift).

Target base is ClickHouse because the analytics event naturally follows the dialect stack — once all seven warehouses support formulas, this is the event that tells us whether users actually use them.

## Test Plan

- [x] 4 unit tests on `SavedChartService.getFormulaTableCalculationEventProperties`:
  - Returns `undefined` for charts with no table calculations
  - Returns `undefined` for charts with only non-formula calcs (SQL, template)
  - Counts only formula calcs against the total (SQL + 2 formulas → `formulaCount: 2, total: 3`)
  - Carries `action: 'created' | 'updated'` through verbatim
- [x] Backend typecheck clean
- [x] Event type registered in the `LightdashAnalytics` event union — unknown events would be a TS error at the `track` call site

🤖 Generated with [Claude Code](https://claude.com/claude-code)

test-all