### PR TITLE
feat: GA content verification by removing feature flag

### DIFF
--- a/packages/backend/src/services/ContentVerificationService.test.ts
+++ b/packages/backend/src/services/ContentVerificationService.test.ts
@@ -1,7 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
     ContentType,
-    FeatureFlags,
     ForbiddenError,
     OrganizationMemberRole,
     type PossibleAbilities,
@@ -11,7 +10,6 @@ import {
 import { ContentVerificationModel } from '../models/ContentVerificationModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
 import { ContentVerificationService } from './ContentVerificationService';
-import { FeatureFlagService } from './FeatureFlag/FeatureFlagService';
 
 const projectSummary = {
     organizationUuid: 'org-uuid',
@@ -66,10 +64,6 @@ const mockVerifiedItems: VerifiedContentListItem[] = [
     },
 ];
 
-const featureFlagService = {
-    get: jest.fn(),
-};
-
 const projectModel = {
     getSummary: jest.fn(async () => projectSummary),
 };
@@ -83,7 +77,6 @@ describe('ContentVerificationService', () => {
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
         projectModel: projectModel as unknown as ProjectModel,
-        featureFlagService: featureFlagService as unknown as FeatureFlagService,
     });
 
     afterEach(() => {
@@ -91,31 +84,7 @@ describe('ContentVerificationService', () => {
     });
 
     describe('listVerifiedContent', () => {
-        it('should throw ForbiddenError when flag is disabled', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: false,
-            });
-
-            await expect(
-                service.listVerifiedContent(adminUser, 'project-uuid'),
-            ).rejects.toThrow(ForbiddenError);
-
-            await expect(
-                service.listVerifiedContent(adminUser, 'project-uuid'),
-            ).rejects.toThrow('Content verification is not enabled');
-
-            expect(
-                contentVerificationModel.getAllForProject,
-            ).not.toHaveBeenCalled();
-        });
-
         it('should throw ForbiddenError when user lacks manage:ContentVerification', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: true,
-            });
-
             await expect(
                 service.listVerifiedContent(editorUser, 'project-uuid'),
             ).rejects.toThrow(ForbiddenError);
@@ -125,12 +94,7 @@ describe('ContentVerificationService', () => {
             ).not.toHaveBeenCalled();
         });
 
-        it('should return verified content when flag is on and user is admin', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: true,
-            });
-
+        it('should return verified content when user is admin', async () => {
             const result = await service.listVerifiedContent(
                 adminUser,
                 'project-uuid',

--- a/packages/backend/src/services/ContentVerificationService.ts
+++ b/packages/backend/src/services/ContentVerificationService.ts
@@ -1,6 +1,5 @@
 import { subject } from '@casl/ability';
 import {
-    FeatureFlags,
     ForbiddenError,
     type SessionUser,
     type VerifiedContentListItem,
@@ -10,12 +9,10 @@ import { logAuditEvent } from '../logging/winston';
 import { ContentVerificationModel } from '../models/ContentVerificationModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
 import { BaseService } from './BaseService';
-import { FeatureFlagService } from './FeatureFlag/FeatureFlagService';
 
 type ContentVerificationServiceArguments = {
     contentVerificationModel: ContentVerificationModel;
     projectModel: ProjectModel;
-    featureFlagService: FeatureFlagService;
 };
 
 export class ContentVerificationService extends BaseService {
@@ -23,36 +20,19 @@ export class ContentVerificationService extends BaseService {
 
     private readonly projectModel: ProjectModel;
 
-    private readonly featureFlagService: FeatureFlagService;
-
     constructor({
         contentVerificationModel,
         projectModel,
-        featureFlagService,
     }: ContentVerificationServiceArguments) {
         super({ serviceName: 'ContentVerificationService' });
         this.contentVerificationModel = contentVerificationModel;
         this.projectModel = projectModel;
-        this.featureFlagService = featureFlagService;
-    }
-
-    private async assertContentVerificationEnabled(
-        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
-    ): Promise<void> {
-        const flag = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.ContentVerification,
-        });
-        if (!flag.enabled) {
-            throw new ForbiddenError('Content verification is not enabled');
-        }
     }
 
     async listVerifiedContent(
         user: SessionUser,
         projectUuid: string,
     ): Promise<VerifiedContentListItem[]> {
-        await this.assertContentVerificationEnabled(user);
         const project = await this.projectModel.getSummary(projectUuid);
 
         const auditedAbility = new CaslAuditWrapper(user.ability, user, {

--- a/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.contentVerification.test.ts
@@ -1,7 +1,6 @@
 import { Ability } from '@casl/ability';
 import {
     ContentType,
-    FeatureFlags,
     ForbiddenError,
     OrganizationMemberRole,
     PossibleAbilities,
@@ -19,7 +18,6 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
-import { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import { SchedulerService } from '../SchedulerService/SchedulerService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -73,10 +71,6 @@ const editorUser = {
     ]),
 };
 
-const featureFlagService = {
-    get: jest.fn(),
-};
-
 const dashboardModel = {
     getByIdOrSlug: jest.fn(async () => dashboardData),
 };
@@ -108,50 +102,14 @@ describe('DashboardService - Content Verification', () => {
         spacePermissionService: {} as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
-        featureFlagService: featureFlagService as unknown as FeatureFlagService,
     });
 
     afterEach(() => {
         jest.clearAllMocks();
     });
 
-    describe('Feature flag gating', () => {
-        it('should throw ForbiddenError on verifyDashboard when flag is disabled', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: false,
-            });
-
-            await expect(
-                service.verifyDashboard(adminUser, 'dashboard-uuid'),
-            ).rejects.toThrow(ForbiddenError);
-
-            await expect(
-                service.verifyDashboard(adminUser, 'dashboard-uuid'),
-            ).rejects.toThrow('Content verification is not enabled');
-
-            expect(contentVerificationModel.verify).not.toHaveBeenCalled();
-        });
-
-        it('should throw ForbiddenError on unverifyDashboard when flag is disabled', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: false,
-            });
-
-            await expect(
-                service.unverifyDashboard(adminUser, 'dashboard-uuid'),
-            ).rejects.toThrow(ForbiddenError);
-
-            expect(contentVerificationModel.unverify).not.toHaveBeenCalled();
-        });
-
-        it('should allow verifyDashboard when flag is enabled and user is admin', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: true,
-            });
-
+    describe('CASL authorization', () => {
+        it('should allow verifyDashboard when user is admin', async () => {
             const result = await service.verifyDashboard(
                 adminUser,
                 'dashboard-uuid',
@@ -165,15 +123,8 @@ describe('DashboardService - Content Verification', () => {
                 'user-uuid',
             );
         });
-    });
 
-    describe('CASL authorization', () => {
         it('should throw ForbiddenError when user lacks manage:ContentVerification', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: true,
-            });
-
             await expect(
                 service.verifyDashboard(editorUser, 'dashboard-uuid'),
             ).rejects.toThrow(ForbiddenError);

--- a/packages/backend/src/services/DashboardService/DashboardService.test.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.test.ts
@@ -26,7 +26,6 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
-import { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -145,7 +144,6 @@ describe('DashboardService', () => {
             spacePermissionService as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
-        featureFlagService: {} as FeatureFlagService,
     });
     afterEach(() => {
         jest.clearAllMocks();

--- a/packages/backend/src/services/DashboardService/DashboardService.ts
+++ b/packages/backend/src/services/DashboardService/DashboardService.ts
@@ -13,7 +13,6 @@ import {
     DashboardTileTypes,
     DashboardVersionedFields,
     ExploreType,
-    FeatureFlags,
     ForbiddenError,
     generateSlug,
     getSchedulerResourceTypeAndId,
@@ -74,7 +73,6 @@ import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { createTwoColumnTiles } from '../../utils/dashboardTileUtils';
 import { BaseService } from '../BaseService';
-import { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 import { SavedChartService } from '../SavedChartsService/SavedChartService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
 import type {
@@ -101,7 +99,6 @@ type DashboardServiceArguments = {
     catalogModel: CatalogModel;
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
-    featureFlagService: FeatureFlagService;
 };
 
 export class DashboardService
@@ -140,8 +137,6 @@ export class DashboardService
 
     contentVerificationModel: ContentVerificationModel;
 
-    featureFlagService: FeatureFlagService;
-
     constructor({
         lightdashConfig,
         analytics,
@@ -159,7 +154,6 @@ export class DashboardService
         catalogModel,
         spacePermissionService,
         contentVerificationModel,
-        featureFlagService,
     }: DashboardServiceArguments) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -178,26 +172,12 @@ export class DashboardService
         this.slackClient = slackClient;
         this.spacePermissionService = spacePermissionService;
         this.contentVerificationModel = contentVerificationModel;
-        this.featureFlagService = featureFlagService;
-    }
-
-    private async assertContentVerificationEnabled(
-        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
-    ): Promise<void> {
-        const flag = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.ContentVerification,
-        });
-        if (!flag.enabled) {
-            throw new ForbiddenError('Content verification is not enabled');
-        }
     }
 
     async verifyDashboard(
         user: SessionUser,
         dashboardUuid: string,
     ): Promise<ContentVerificationInfo> {
-        await this.assertContentVerificationEnabled(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const { organizationUuid, projectUuid } = dashboard;
@@ -251,7 +231,6 @@ export class DashboardService
         user: SessionUser,
         dashboardUuid: string,
     ): Promise<void> {
-        await this.assertContentVerificationEnabled(user);
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
         const { organizationUuid, projectUuid } = dashboard;

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -6507,15 +6507,6 @@ export class ProjectService extends BaseService {
             return [];
         }
 
-        const { enabled: contentVerificationEnabled } =
-            await this.featureFlagModel.get({
-                user,
-                featureFlagId: FeatureFlags.ContentVerification,
-            });
-        if (!contentVerificationEnabled) {
-            return [];
-        }
-
         const projectSummary = await this.projectModel.getSummary(projectUuid);
         if (
             user.ability.cannot(

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.contentVerification.test.ts
@@ -2,7 +2,6 @@ import { Ability } from '@casl/ability';
 import {
     ChartType,
     ContentType,
-    FeatureFlags,
     ForbiddenError,
     OrganizationMemberRole,
     PossibleAbilities,
@@ -21,7 +20,6 @@ import { SavedChartModel } from '../../models/SavedChartModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
-import { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import { SchedulerService } from '../SchedulerService/SchedulerService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
@@ -96,10 +94,6 @@ const editorUser = {
     ]),
 };
 
-const featureFlagService = {
-    get: jest.fn(),
-};
-
 const savedChartModel = {
     getSummary: jest.fn(async () => chartSummary),
     get: jest.fn(async () => savedChartData),
@@ -150,50 +144,14 @@ describe('SavedChartService - Content Verification', () => {
             spacePermissionService as unknown as SpacePermissionService,
         contentVerificationModel:
             contentVerificationModel as unknown as ContentVerificationModel,
-        featureFlagService: featureFlagService as unknown as FeatureFlagService,
     });
 
     afterEach(() => {
         jest.clearAllMocks();
     });
 
-    describe('Feature flag gating', () => {
-        it('should throw ForbiddenError on verifyChart when flag is disabled', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: false,
-            });
-
-            await expect(
-                service.verifyChart(adminUser, 'chart-uuid'),
-            ).rejects.toThrow(ForbiddenError);
-
-            await expect(
-                service.verifyChart(adminUser, 'chart-uuid'),
-            ).rejects.toThrow('Content verification is not enabled');
-
-            expect(contentVerificationModel.verify).not.toHaveBeenCalled();
-        });
-
-        it('should throw ForbiddenError on unverifyChart when flag is disabled', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: false,
-            });
-
-            await expect(
-                service.unverifyChart(adminUser, 'chart-uuid'),
-            ).rejects.toThrow(ForbiddenError);
-
-            expect(contentVerificationModel.unverify).not.toHaveBeenCalled();
-        });
-
-        it('should allow verifyChart when flag is enabled and user is admin', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: true,
-            });
-
+    describe('CASL authorization', () => {
+        it('should allow verifyChart when user is admin', async () => {
             const result = await service.verifyChart(adminUser, 'chart-uuid');
 
             expect(result).toEqual(verificationInfo);
@@ -204,15 +162,8 @@ describe('SavedChartService - Content Verification', () => {
                 'user-uuid',
             );
         });
-    });
 
-    describe('CASL authorization', () => {
         it('should throw ForbiddenError when user lacks manage:ContentVerification', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: true,
-            });
-
             await expect(
                 service.verifyChart(editorUser, 'chart-uuid'),
             ).rejects.toThrow(ForbiddenError);
@@ -225,11 +176,6 @@ describe('SavedChartService - Content Verification', () => {
         });
 
         it('should throw ForbiddenError on unverifyChart for non-admin', async () => {
-            featureFlagService.get.mockResolvedValue({
-                id: FeatureFlags.ContentVerification,
-                enabled: true,
-            });
-
             await expect(
                 service.unverifyChart(editorUser, 'chart-uuid'),
             ).rejects.toThrow(ForbiddenError);

--- a/packages/backend/src/services/SavedChartsService/SavedChartService.ts
+++ b/packages/backend/src/services/SavedChartsService/SavedChartService.ts
@@ -18,7 +18,6 @@ import {
     DeletedContentFilters,
     DeletedDbtChartContentSummary,
     ExploreType,
-    FeatureFlags,
     ForbiddenError,
     generateSlug,
     getSchedulerResourceTypeAndId,
@@ -79,7 +78,6 @@ import { SchedulerModel } from '../../models/SchedulerModel';
 import { SpaceModel } from '../../models/SpaceModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { BaseService } from '../BaseService';
-import { FeatureFlagService } from '../FeatureFlag/FeatureFlagService';
 import { PermissionsService } from '../PermissionsService/PermissionsService';
 import type { SchedulerService } from '../SchedulerService/SchedulerService';
 import type {
@@ -108,7 +106,6 @@ type SavedChartServiceArguments = {
     userService: UserService;
     spacePermissionService: SpacePermissionService;
     contentVerificationModel: ContentVerificationModel;
-    featureFlagService: FeatureFlagService;
 };
 
 export class SavedChartService
@@ -151,8 +148,6 @@ export class SavedChartService
 
     private readonly contentVerificationModel: ContentVerificationModel;
 
-    private readonly featureFlagService: FeatureFlagService;
-
     constructor(args: SavedChartServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -173,19 +168,6 @@ export class SavedChartService
         this.userService = args.userService;
         this.spacePermissionService = args.spacePermissionService;
         this.contentVerificationModel = args.contentVerificationModel;
-        this.featureFlagService = args.featureFlagService;
-    }
-
-    private async assertContentVerificationEnabled(
-        user: Pick<SessionUser, 'userUuid' | 'organizationUuid'>,
-    ): Promise<void> {
-        const flag = await this.featureFlagService.get({
-            user,
-            featureFlagId: FeatureFlags.ContentVerification,
-        });
-        if (!flag.enabled) {
-            throw new ForbiddenError('Content verification is not enabled');
-        }
     }
 
     private async checkUpdateAccess(
@@ -1038,7 +1020,6 @@ export class SavedChartService
         user: SessionUser,
         chartUuid: string,
     ): Promise<ContentVerificationInfo> {
-        await this.assertContentVerificationEnabled(user);
         const savedChart = await this.savedChartModel.getSummary(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
 
@@ -1088,7 +1069,6 @@ export class SavedChartService
     }
 
     async unverifyChart(user: SessionUser, chartUuid: string): Promise<void> {
-        await this.assertContentVerificationEnabled(user);
         const savedChart = await this.savedChartModel.getSummary(chartUuid);
         const { organizationUuid, projectUuid } = savedChart;
 

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -367,7 +367,6 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
-                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }
@@ -739,7 +738,6 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
-                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }
@@ -1071,7 +1069,6 @@ export class ServiceRepository
                     contentVerificationModel:
                         this.models.getContentVerificationModel(),
                     projectModel: this.models.getProjectModel(),
-                    featureFlagService: this.getFeatureFlagService(),
                 }),
         );
     }

--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -101,11 +101,6 @@ export enum FeatureFlags {
     LargeChartPerformance = 'large-chart-performance',
 
     /**
-     * Enable content verification (verified seal for charts and dashboards)
-     */
-    ContentVerification = 'content-verification',
-
-    /**
      * Enable show/hide N rows from start/end of chart data
      */
     ShowHideRows = 'show-hide-rows',

--- a/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileBase/index.tsx
@@ -27,7 +27,6 @@ import {
     IconTrash,
 } from '@tabler/icons-react';
 import { useState } from 'react';
-import { useContentVerificationEnabled } from '../../../hooks/useContentVerificationEnabled';
 import { useDelayedHover } from '../../../hooks/useDelayedHover';
 import MantineIcon from '../../common/MantineIcon';
 import DeleteChartTileThatBelongsToDashboardModal from '../../common/modal/DeleteChartTileThatBelongsToDashboardModal';
@@ -95,12 +94,8 @@ const TileBase = <T extends Dashboard['tiles'][number]>({
     const isMarkdownTileTitleEmpty =
         tile.type === DashboardTileTypes.MARKDOWN && !title;
 
-    const isContentVerificationEnabled = useContentVerificationEnabled();
     const hasMenuContent = isEditMode || !!extraMenuItems;
-    const isVerified =
-        isContentVerificationEnabled &&
-        verification !== null &&
-        verification !== undefined;
+    const isVerified = verification !== null && verification !== undefined;
     const hasHeaderContent = hasMenuContent || isVerified;
 
     return (

--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -84,7 +84,6 @@ import {
     useUnverifyChartMutation,
     useVerifyChartMutation,
 } from '../../../hooks/useContentVerification';
-import { useContentVerificationEnabled } from '../../../hooks/useContentVerificationEnabled';
 import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { useProject } from '../../../hooks/useProject';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
@@ -361,8 +360,6 @@ const SavedChartsHeader: FC = () => {
         }),
     );
 
-    const isContentVerificationEnabled = useContentVerificationEnabled();
-
     const canManageContentVerification =
         user.data?.ability?.can(
             'manage',
@@ -483,27 +480,25 @@ const SavedChartsHeader: FC = () => {
                                     {savedChart.name}
                                 </Title>
 
-                                {isContentVerificationEnabled &&
-                                    isChartVerified && (
-                                        <Tooltip
-                                            label={
-                                                savedChart?.verification
-                                                    ?.verifiedBy
-                                                    ? `Verified by ${savedChart.verification.verifiedBy.firstName} ${savedChart.verification.verifiedBy.lastName}`
-                                                    : 'Verified'
-                                            }
-                                            withArrow
-                                            withinPortal
-                                            zIndex={10000}
-                                        >
-                                            <IconCircleCheckFilled
-                                                size={16}
-                                                style={{
-                                                    color: 'var(--mantine-color-green-6)',
-                                                }}
-                                            />
-                                        </Tooltip>
-                                    )}
+                                {isChartVerified && (
+                                    <Tooltip
+                                        label={
+                                            savedChart?.verification?.verifiedBy
+                                                ? `Verified by ${savedChart.verification.verifiedBy.firstName} ${savedChart.verification.verifiedBy.lastName}`
+                                                : 'Verified'
+                                        }
+                                        withArrow
+                                        withinPortal
+                                        zIndex={10000}
+                                    >
+                                        <IconCircleCheckFilled
+                                            size={16}
+                                            style={{
+                                                color: 'var(--mantine-color-green-6)',
+                                            }}
+                                        />
+                                    </Tooltip>
+                                )}
 
                                 <ActionIcon
                                     size="xs"
@@ -814,8 +809,7 @@ const SavedChartsHeader: FC = () => {
                                     </Tooltip>
                                 }
 
-                                {isContentVerificationEnabled &&
-                                    canManageContentVerification &&
+                                {canManageContentVerification &&
                                     savedChart?.uuid && (
                                         <Menu.Item
                                             leftSection={

--- a/packages/frontend/src/components/Home/HomepageContentPanel/index.tsx
+++ b/packages/frontend/src/components/Home/HomepageContentPanel/index.tsx
@@ -10,7 +10,6 @@ import { Button } from '@mantine-8/core';
 import { IconChartBar, IconPlus } from '@tabler/icons-react';
 import { useMemo, type FC } from 'react';
 import { useNavigate } from 'react-router';
-import { useContentVerificationEnabled } from '../../../hooks/useContentVerificationEnabled';
 import useCreateInAnySpaceAccess from '../../../hooks/user/useCreateInAnySpaceAccess';
 import { useVerifiedContentForHomepage } from '../../../hooks/useVerifiedContentList';
 import useApp from '../../../providers/App/useApp';
@@ -27,7 +26,6 @@ export const HomepageContentPanel: FC<Props> = ({ data, projectUuid }) => {
     const MAX_NUMBER_OF_ITEMS_IN_PANEL = 10;
     const navigate = useNavigate();
     const { health } = useApp();
-    const isContentVerificationEnabled = useContentVerificationEnabled();
 
     const { data: verifiedContentData } =
         useVerifiedContentForHomepage(projectUuid);
@@ -53,24 +51,18 @@ export const HomepageContentPanel: FC<Props> = ({ data, projectUuid }) => {
                 ),
                 category: ResourceItemCategory.RECENTLY_UPDATED,
             })) ?? [];
-        const verifiedItems = isContentVerificationEnabled
-            ? (verifiedContentData?.map((item) => ({
-                  ...wrapResource(
-                      item,
-                      'chartType' in item
-                          ? ResourceViewItemType.CHART
-                          : ResourceViewItemType.DASHBOARD,
-                  ),
-                  category: ResourceItemCategory.VERIFIED,
-              })) ?? [])
-            : [];
+        const verifiedItems =
+            verifiedContentData?.map((item) => ({
+                ...wrapResource(
+                    item,
+                    'chartType' in item
+                        ? ResourceViewItemType.CHART
+                        : ResourceViewItemType.DASHBOARD,
+                ),
+                category: ResourceItemCategory.VERIFIED,
+            })) ?? [];
         return [...mostPopularItems, ...recentlyUpdatedItems, ...verifiedItems];
-    }, [
-        data?.mostPopular,
-        data?.recentlyUpdated,
-        verifiedContentData,
-        isContentVerificationEnabled,
-    ]);
+    }, [data?.mostPopular, data?.recentlyUpdated, verifiedContentData]);
 
     const handleCreateChart = () => {
         void navigate(`/projects/${projectUuid}/tables`);
@@ -102,23 +94,18 @@ export const HomepageContentPanel: FC<Props> = ({ data, projectUuid }) => {
                         'category' in item &&
                         item.category === ResourceItemCategory.RECENTLY_UPDATED,
                 },
-                ...(isContentVerificationEnabled
-                    ? [
-                          {
-                              id: 'verified',
-                              name: 'Verified',
-                              filter: (item: ResourceViewItem) =>
-                                  'category' in item &&
-                                  item.category ===
-                                      ResourceItemCategory.VERIFIED,
-                              emptyStateProps: {
-                                  title: 'No verified content yet',
-                                  description: undefined,
-                                  action: undefined,
-                              },
-                          },
-                      ]
-                    : []),
+                {
+                    id: 'verified',
+                    name: 'Verified',
+                    filter: (item: ResourceViewItem) =>
+                        'category' in item &&
+                        item.category === ResourceItemCategory.VERIFIED,
+                    emptyStateProps: {
+                        title: 'No verified content yet',
+                        description: undefined,
+                        action: undefined,
+                    },
+                },
             ]}
             listProps={{
                 enableSorting: false,

--- a/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
+++ b/packages/frontend/src/components/VerifiedContent/VerifiedContentPanel.tsx
@@ -30,7 +30,6 @@ import {
     useUnverifyChartMutation,
     useUnverifyDashboardMutation,
 } from '../../hooks/useContentVerification';
-import { useContentVerificationEnabled } from '../../hooks/useContentVerificationEnabled';
 import { useVerifiedContentList } from '../../hooks/useVerifiedContentList';
 import MantineIcon from '../common/MantineIcon';
 import MantineModal from '../common/MantineModal';
@@ -41,7 +40,6 @@ type Props = {
 };
 
 const VerifiedContentPanel: FC<Props> = ({ projectUuid }) => {
-    const isContentVerificationEnabled = useContentVerificationEnabled();
     const theme = useMantineTheme();
     const { data: verifiedContent, isLoading } =
         useVerifiedContentList(projectUuid);
@@ -280,18 +278,6 @@ const VerifiedContentPanel: FC<Props> = ({ projectUuid }) => {
             },
         }),
     });
-
-    if (!isContentVerificationEnabled) {
-        return (
-            <Paper p="xl">
-                <SuboptimalState
-                    icon={IconCircleX}
-                    title="Content verification is not enabled"
-                    description="This feature is not currently available."
-                />
-            </Paper>
-        );
-    }
 
     if (!isLoading && items.length === 0) {
         return (

--- a/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
+++ b/packages/frontend/src/components/common/Dashboard/DashboardHeader.tsx
@@ -64,7 +64,6 @@ import {
     useUnverifyDashboardMutation,
     useVerifyDashboardMutation,
 } from '../../../hooks/useContentVerification';
-import { useContentVerificationEnabled } from '../../../hooks/useContentVerificationEnabled';
 import { useProject } from '../../../hooks/useProject';
 import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import useApp from '../../../providers/App/useApp';
@@ -300,8 +299,6 @@ const DashboardHeader = memo(
             }),
         );
 
-        const isContentVerificationEnabled = useContentVerificationEnabled();
-
         const canManageContentVerification =
             user.data?.ability?.can(
                 'manage',
@@ -378,7 +375,7 @@ const DashboardHeader = memo(
                         </Popover.Dropdown>
                     </Popover>
 
-                    {isContentVerificationEnabled && isDashboardVerified && (
+                    {isDashboardVerified && (
                         <Tooltip
                             label={
                                 dashboard?.verification?.verifiedBy
@@ -893,8 +890,7 @@ const DashboardHeader = memo(
                                             </Menu.Item>
                                         )}
 
-                                    {isContentVerificationEnabled &&
-                                        canManageContentVerification &&
+                                    {canManageContentVerification &&
                                         dashboardUuid && (
                                             <Menu.Item
                                                 leftSection={

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -14,7 +14,6 @@ import {
     IconLayoutDashboard,
 } from '@tabler/icons-react';
 import { Link } from 'react-router';
-import { useContentVerificationEnabled } from '../../../hooks/useContentVerificationEnabled';
 import { ResourceIcon, ResourceIndicator } from '../ResourceIcon';
 import { ResourceInfoPopup } from '../ResourceInfoPopup/ResourceInfoPopup';
 import AttributeCount from './ResourceAttributeCount';
@@ -104,8 +103,7 @@ const ResourceVerifiedIndicator = ({
     verification,
     children,
 }: ResourceVerifiedIndicatorProps) => {
-    const isContentVerificationEnabled = useContentVerificationEnabled();
-    if (!isContentVerificationEnabled || !verification) {
+    if (!verification) {
         return children;
     }
 

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -41,7 +41,6 @@ import {
     useVerifyChartMutation,
     useVerifyDashboardMutation,
 } from '../../../hooks/useContentVerification';
-import { useContentVerificationEnabled } from '../../../hooks/useContentVerificationEnabled';
 import { useProject } from '../../../hooks/useProject';
 import { useSpaceSummaries } from '../../../hooks/useSpaces';
 import useApp from '../../../providers/App/useApp';
@@ -85,7 +84,6 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const isPinned = !!item.data.pinnedListUuid;
     const isDashboardPage = location.pathname.includes('/dashboards');
 
-    const isContentVerificationEnabled = useContentVerificationEnabled();
     const isChartOrDashboard =
         isResourceViewItemChart(item) || isResourceViewItemDashboard(item);
     const isVerified = isChartOrDashboard && item.data.verification !== null;
@@ -405,8 +403,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 </Menu.Item>
                             ) : null}
 
-                            {isContentVerificationEnabled &&
-                                userCanManageVerification &&
+                            {userCanManageVerification &&
                                 isChartOrDashboard &&
                                 !hideVerification && (
                                     <Menu.Item

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridChartItem.tsx
@@ -3,7 +3,6 @@ import { Box, Flex, Group, Paper, Text, Tooltip } from '@mantine-8/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import { IconCircleCheckFilled, IconEye } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
-import { useContentVerificationEnabled } from '../../../../hooks/useContentVerificationEnabled';
 import { ResourceIcon, ResourceIndicator } from '../../ResourceIcon';
 import ResourceViewActionMenu, {
     type ResourceViewActionMenuCommonProps,
@@ -26,7 +25,6 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
     onAction,
     dragIcon,
 }) => {
-    const isContentVerificationEnabled = useContentVerificationEnabled();
     const { hovered, ref } = useHover();
     const [opened, handlers] = useDisclosure(false);
 
@@ -47,7 +45,7 @@ const ResourceViewGridChartItem: FC<ResourceViewGridChartItemProps> = ({
                 className={classes.gridCardTopSection}
             >
                 {dragIcon}
-                {isContentVerificationEnabled && item.data.verification ? (
+                {item.data.verification ? (
                     <ResourceIndicator
                         iconProps={{
                             icon: IconCircleCheckFilled,

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/ResourceViewGridDashboardItem.tsx
@@ -3,7 +3,6 @@ import { Box, Flex, Group, Paper, Text, Tooltip } from '@mantine-8/core';
 import { useDisclosure, useHover } from '@mantine/hooks';
 import { IconCircleCheckFilled, IconEye } from '@tabler/icons-react';
 import { type FC, type ReactNode } from 'react';
-import { useContentVerificationEnabled } from '../../../../hooks/useContentVerificationEnabled';
 import { ResourceIcon, ResourceIndicator } from '../../ResourceIcon';
 import ResourceViewActionMenu, {
     type ResourceViewActionMenuCommonProps,
@@ -26,7 +25,6 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
     onAction,
     dragIcon,
 }) => {
-    const isContentVerificationEnabled = useContentVerificationEnabled();
     const { hovered, ref } = useHover();
     const [opened, handlers] = useDisclosure(false);
 
@@ -47,7 +45,7 @@ const ResourceViewGridDashboardItem: FC<ResourceViewGridDashboardItemProps> = ({
                 className={classes.gridCardTopSection}
             >
                 {dragIcon}
-                {isContentVerificationEnabled && item.data.verification ? (
+                {item.data.verification ? (
                     <ResourceIndicator
                         iconProps={{
                             icon: IconCircleCheckFilled,

--- a/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
+++ b/packages/frontend/src/features/omnibar/components/OmnibarItem.tsx
@@ -1,7 +1,6 @@
 import { Badge, Box, Group, Stack, Text } from '@mantine-8/core';
 import { IconCircleCheckFilled } from '@tabler/icons-react';
 import { type FC, type MutableRefObject } from 'react';
-import { useContentVerificationEnabled } from '../../../hooks/useContentVerificationEnabled';
 import { type SearchItem } from '../types/searchItem';
 import classes from './OmnibarItem.module.css';
 import {
@@ -38,7 +37,6 @@ const OmnibarItem: FC<Props> = ({
     onClick,
     scrollRef,
 }) => {
-    const isContentVerificationEnabled = useContentVerificationEnabled();
     return (
         <Group
             role="menuitem"
@@ -66,20 +64,17 @@ const OmnibarItem: FC<Props> = ({
                     <Text fw={500} size="sm" truncate ref={scrollRef}>
                         {item.prefix} {item.title}
                     </Text>
-                    {isContentVerificationEnabled &&
-                        itemHasVerification(item) && (
-                            <Badge
-                                size="xs"
-                                variant="light"
-                                color="green"
-                                leftSection={
-                                    <IconCircleCheckFilled size={10} />
-                                }
-                                style={{ flexShrink: 0 }}
-                            >
-                                Verified
-                            </Badge>
-                        )}
+                    {itemHasVerification(item) && (
+                        <Badge
+                            size="xs"
+                            variant="light"
+                            color="green"
+                            leftSection={<IconCircleCheckFilled size={10} />}
+                            style={{ flexShrink: 0 }}
+                        >
+                            Verified
+                        </Badge>
+                    )}
                 </Group>
 
                 {item.description || item.typeLabel ? (

--- a/packages/frontend/src/hooks/useContentVerificationEnabled.ts
+++ b/packages/frontend/src/hooks/useContentVerificationEnabled.ts
@@ -1,5 +1,0 @@
-import { FeatureFlags } from '@lightdash/common';
-import { useClientFeatureFlag } from './useServerOrClientFeatureFlag';
-
-export const useContentVerificationEnabled = () =>
-    useClientFeatureFlag(FeatureFlags.ContentVerification);

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -76,7 +76,6 @@ import { CustomRoleEdit } from '../ee/pages/customRoles/CustomRoleEdit';
 import { CustomRoles } from '../ee/pages/customRoles/CustomRoles';
 import { useOrganization } from '../hooks/organization/useOrganization';
 import { useActiveProjectUuid } from '../hooks/useActiveProject';
-import { useContentVerificationEnabled } from '../hooks/useContentVerificationEnabled';
 import { useProject } from '../hooks/useProject';
 import {
     useClientFeatureFlag,
@@ -108,8 +107,6 @@ const Settings: FC = () => {
     const isServiceAccountFeatureFlagEnabled = useClientFeatureFlag(
         CommercialFeatureFlags.ServiceAccounts,
     );
-
-    const isContentVerificationEnabled = useContentVerificationEnabled();
 
     const {
         health: {
@@ -1095,8 +1092,7 @@ const Settings: FC = () => {
                                         />
                                     ) : null}
 
-                                    {isContentVerificationEnabled &&
-                                    user.ability?.can(
+                                    {user.ability?.can(
                                         'manage',
                                         subject('ContentVerification', {
                                             organizationUuid:


### PR DESCRIPTION
## Summary
- Removes the `content-verification` feature flag and makes verified charts/dashboards available to all users.
- Drops the flag enforcement from backend services (`ContentVerificationService`, `DashboardService`, `SavedChartService`, `ProjectService`) and removes the now-unused `featureFlagService` dependency from the first three.
- Deletes the `useContentVerificationEnabled` frontend hook and removes all the `isContentVerificationEnabled &&` conditionals across the affected components (settings page, dashboard header, chart header, omnibar, resource view, tile base, homepage panel, verified-content panel).

## Test plan
- [x] `pnpm -F common build` and `pnpm -F backend typecheck` and `pnpm -F frontend typecheck` pass
- [x] `pnpm -F common lint`, `pnpm -F backend lint`, `pnpm -F frontend lint` (no new errors)
- [x] `pnpm -F common test` (1779 passing)
- [x] Backend `ContentVerificationService`, `DashboardService`, `SavedChartService` tests (28 passing)
- [ ] Manual smoke: verify a chart and a dashboard, see the badges on the homepage / search / resource grid; settings page shows "Verified content" tab for admins regardless of any flag override

🤖 Generated with [Claude Code](https://claude.com/claude-code)