### PR TITLE
refactor(formula): consolidate DialectConfig + align with production SqlBuilders

### DIFF
--- a/packages/formula-tests/runner/warehouse-connections.ts
+++ b/packages/formula-tests/runner/warehouse-connections.ts
@@ -33,12 +33,7 @@ export async function createDuckDBConnection(): Promise<WarehouseConnection> {
         dialect: 'duckdb',
         execute,
         async seed(sql: string) {
-            // Split on semicolons and execute each statement
-            const statements = sql
-                .split(';')
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0 && !s.startsWith('--'));
-            for (const stmt of statements) {
+            for (const stmt of splitSqlStatements(sql)) {
                 await run(stmt);
             }
         },
@@ -46,6 +41,26 @@ export async function createDuckDBConnection(): Promise<WarehouseConnection> {
             db.close();
         },
     };
+}
+
+// Split a multi-statement SQL blob on `;` and remove leading `--` comment
+// lines from each chunk. Naive "filter out statements that start with --"
+// would silently drop valid statements like
+//   -- comment explaining the next DDL
+//   DROP TABLE IF EXISTS foo;
+// because the `--` line ends up prefixed to the DROP after the split. We
+// keep the statement but peel off its leading comment lines.
+function splitSqlStatements(sql: string): string[] {
+    return sql
+        .split(';')
+        .map((s) =>
+            s
+                .split('\n')
+                .filter((line) => !line.trim().startsWith('--'))
+                .join('\n')
+                .trim(),
+        )
+        .filter((s) => s.length > 0);
 }
 
 export async function createPostgresConnection(
@@ -95,16 +110,32 @@ export async function createRedshiftConnection(
         user: config.user,
         password: config.password,
         ssl: { rejectUnauthorized: false },
+        // Force a single connection so one failed query can't leave a
+        // sibling pool member in an aborted-transaction state that silently
+        // cascades into "relation does not exist" errors on later tests.
+        max: 1,
     });
 
     return {
         dialect: 'redshift',
         async execute(sql: string) {
             const result = await pool.query(sql);
-            return result.rows;
+            // Guard against unusual pg result shapes on Redshift: for some
+            // queries `result.rows` comes back undefined rather than `[]`,
+            // which crashes the comparator downstream with a useless
+            // "Cannot read properties of undefined" error. Normalise to
+            // an empty array so the caller sees a consistent shape.
+            return (result as { rows?: Record<string, any>[] }).rows ?? [];
         },
         async seed(sql: string) {
-            await pool.query(sql);
+            // Redshift's simple query protocol does not accept multiple
+            // statements in a single `pool.query()` call the way Postgres
+            // does — it fails without a useful error. Split on `;` and run
+            // each statement individually, matching the Databricks /
+            // ClickHouse approach.
+            for (const stmt of splitSqlStatements(sql)) {
+                await pool.query(stmt);
+            }
         },
         async close() {
             await pool.end();
@@ -166,11 +197,7 @@ export async function createDatabricksConnection(
             return execute(sql);
         },
         async seed(sql: string) {
-            const statements = sql
-                .split(';')
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0 && !s.startsWith('--'));
-            for (const stmt of statements) {
+            for (const stmt of splitSqlStatements(sql)) {
                 await execute(stmt);
             }
         },
@@ -222,11 +249,7 @@ export async function createClickhouseConnection(
             return execute(sql);
         },
         async seed(sql: string) {
-            const statements = sql
-                .split(';')
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0 && !s.startsWith('--'));
-            for (const stmt of statements) {
+            for (const stmt of splitSqlStatements(sql)) {
                 // Seed uses DDL/DML that doesn't return rows — use `command`
                 // so the client doesn't try to stream a result set.
                 await client.command({ query: stmt });
@@ -268,11 +291,7 @@ export async function createBigQueryConnection(
             return rows;
         },
         async seed(sql: string) {
-            const statements = sql
-                .split(';')
-                .map((s) => s.trim())
-                .filter((s) => s.length > 0 && !s.startsWith('--'));
-            for (const stmt of statements) {
+            for (const stmt of splitSqlStatements(sql)) {
                 await client.query({ query: stmt, defaultDataset });
             }
             // BigQuery CREATE TABLE needs a moment before tables are queryable

--- a/packages/formula/src/codegen/dialects.ts
+++ b/packages/formula/src/codegen/dialects.ts
@@ -1,37 +1,54 @@
 import type { Dialect, StringLiteralNode } from '../types';
 
-// Per-dialect SQL emission overrides. Any field that's unset uses the
-// ANSI-standard default implemented directly in SqlGenerator (see
-// generator.ts). Adding a new warehouse = a single record in DIALECTS below.
-// No new files, no subclasses, no factory updates.
+// Per-dialect SQL emission overrides. Every field is a full replacement for
+// the ANSI default implemented in SqlGenerator (see generator.ts). Adding a
+// new warehouse = one record in DIALECTS below — no subclasses, no factory
+// updates.
 //
-// Keep the surface minimal: only add a field here the first time a real
-// dialect actually diverges. The escape-hatch philosophy is "pay for what
-// you use" — we don't preempt divergences that haven't happened yet.
+// Design principle: each field is one cohesive emitter, not a flag / partial
+// transform / string knob. If two concerns always move together (e.g. LAG's
+// function name + its frame clause + its default-arg handling) they belong
+// in one hook, not three. "Pay for what you use" applies at the emitter
+// granularity — dialects only override the emitters they actually diverge
+// on.
 export interface DialectConfig {
     quoteIdentifier: (name: string) => string;
     generateStringLiteral?: (node: StringLiteralNode) => string;
     generateModulo?: (left: string, right: string) => string;
-    // Dialect-specific transform for the value argument of LAG/LEAD. Needed
-    // for ClickHouse, which returns the type-default (0 for numbers, empty
-    // string, etc.) instead of NULL at partition boundaries unless the
-    // argument is Nullable. Other dialects leave this unset and follow
-    // ANSI LAG/LEAD semantics without help.
-    wrapLagLeadArg?: (arg: string) => string;
-    // Override the SQL function name emitted for LAG / LEAD. ClickHouse
-    // needs `lagInFrame` / `leadInFrame`, which work against the user's
-    // ORDER BY correctly; the plain `LAG`/`LEAD` silently use the default
-    // RANGE frame that excludes future rows, making `LEAD` return NULL
-    // everywhere. Other dialects leave these unset and use the ANSI names.
-    lagFunctionName?: string;
-    leadFunctionName?: string;
-    // Explicit frame clause attached to LAG/LEAD. ClickHouse's default
-    // frame is `ROWS UNBOUNDED PRECEDING` which excludes future rows, so
-    // `leadInFrame` returns NULL for every row. Setting an explicit
-    // `UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING` frame lets LEAD see
-    // future rows. Other dialects leave this unset and rely on the ANSI
-    // default frame.
-    lagLeadFrameClause?: string;
+    generateConcat?: (args: string[]) => string;
+    generateLagLead?: (ctx: LagLeadContext) => string;
+    // AVG emission. Covers both the aggregate `=AVG(A)` and the windowed
+    // `=MOVING_AVG(A, N, …)` (which fans out to `AVG(...) OVER (…)`).
+    // Set for Postgres / Redshift to widen the argument to DOUBLE
+    // PRECISION, matching `PostgresWarehouseClient.getMetricSql` (case
+    // AVERAGE). Unset for BigQuery, Snowflake, DuckDB, Databricks, and
+    // ClickHouse, whose production clients also defer to the base
+    // `getDefaultMetricSql` that returns plain `AVG(arg)`.
+    generateAvg?: (arg: string) => string;
+}
+
+// Everything a dialect needs to emit `LAG(...) OVER (...)` or
+// `LEAD(...) OVER (...)` without owning the windowing boilerplate.
+//
+// `sqlFunc` is the ANSI name ('LAG' | 'LEAD') — dialects that need a
+// different SQL-level function (ClickHouse's `lagInFrame`) swap it when
+// they call `emitWindow`.
+//
+// `args` is the already-generated SQL strings for the user's arguments:
+// `[value]`, `[value, offset]`, or `[value, offset, default]`.
+//
+// `emitWindow(sqlFunc, funcArgs, frameClause?)` produces the full
+// `sqlFunc(funcArgs) OVER (…)` string with the current node's PARTITION BY
+// / ORDER BY already attached. This keeps the window-clause machinery out
+// of the dialect and lets the dialect focus on argument shape + frame.
+interface LagLeadContext {
+    sqlFunc: 'LAG' | 'LEAD';
+    args: string[];
+    emitWindow: (
+        sqlFunc: string,
+        funcArgs: string[],
+        frameClause?: string,
+    ) => string;
 }
 
 // --- Shared emitters ---
@@ -47,12 +64,12 @@ const backslashEscapedStringLiteral = (node: StringLiteralNode): string => {
 };
 
 // ANSI-doubled single quotes for quote-escape PLUS backslash-escape for
-// backslashes. Used by engines (ClickHouse) whose string parser interprets
-// both conventions — doubling alone silently loses backslashes because
-// ClickHouse unescapes `\\` to `\`. Matches the defensive approach in
-// `ClickhouseSqlBuilder.escapeString` (packages/warehouses) so a single
-// query produced by MetricQueryBuilder + the formula package has one
-// consistent string-literal style.
+// backslashes. Required for engines whose string parser interprets both
+// conventions — ClickHouse unescapes `\\` → `\`, and Redshift interprets
+// `\'` as an escaped quote even with `standard_conforming_strings` on
+// (letting a user value like `\';DROP TABLE …` break out of the literal).
+// Doubling alone is unsafe on those engines. Matches the defensive
+// approach in `ClickhouseSqlBuilder.escapeString` (packages/warehouses).
 const ansiQuoteWithEscapedBackslashesStringLiteral = (
     node: StringLiteralNode,
 ): string => {
@@ -65,14 +82,71 @@ const infixPercentModulo = (left: string, right: string): string =>
 
 // --- Dialect configs ---
 
-// Postgres and Redshift share identically: double-quoted identifiers, `%`
-// modulo, doubled-quote string escaping, EXTRACT-style date parts, ANSI
-// window-aggregate syntax. Redshift is effectively PostgreSQL 8.x with
-// columnar storage — every SQL construct the formula package emits is
-// valid on both. Defined once and referenced twice from DIALECTS.
-const POSTGRES_LIKE_CONFIG: DialectConfig = {
+// Shared Postgres-family emitters. These match, byte-for-byte, the
+// behaviour of `PostgresWarehouseClient` in `packages/warehouses` so that
+// a formula-mode table calculation and a metric-level expression over the
+// same column produce SQL with identical runtime semantics on any
+// Postgres-compatible warehouse (Postgres, Redshift). If you change one,
+// change the other — the two live in separate packages on purpose (formula
+// is intentionally zero-runtime-dep and does not import `@lightdash/common`)
+// but they MUST stay in sync. See also `packages/warehouses/src/
+// warehouseClients/PostgresWarehouseClient.ts`.
+//
+// AVG: widened to DOUBLE PRECISION so the division inside AVG never
+// truncates to the input DECIMAL scale. On Redshift that truncation
+// silently drops the fractional part (650/3 → 216.66 instead of
+// 216.666…); on Postgres it's a no-op. Matches
+// `PostgresWarehouseClient.getMetricSql` case AVERAGE.
+const postgresStyleAvg = (arg: string): string =>
+    `AVG(${arg}::DOUBLE PRECISION)`;
+// CONCAT: infix `||` rather than variadic `CONCAT(...)`. Sidesteps
+// Redshift's two-argument CONCAT limit and its strict overload resolution
+// against untyped `'literal'` values in one stroke, and matches Postgres's
+// native concatenation operator exactly. Matches
+// `PostgresWarehouseClient.concatString`.
+// NOTE: `||` is NULL-propagating (`a || NULL || b` is NULL), whereas
+// `CONCAT(a, NULL, b)` returns `ab`. This matches production behaviour on
+// Postgres-family warehouses; callers wanting NULL-ignoring concatenation
+// should COALESCE the inputs at the call site.
+const postgresStyleConcat = (args: string[]): string =>
+    `(${args.join(' || ')})`;
+
+const POSTGRES_CONFIG: DialectConfig = {
     quoteIdentifier: doubleQuoteIdentifier,
     generateModulo: infixPercentModulo,
+    generateAvg: postgresStyleAvg,
+    generateConcat: postgresStyleConcat,
+};
+
+// Redshift is Postgres-wire-compatible and inherits every Postgres-family
+// emitter above (AVG double-precision cast, `||` concatenation, `%`
+// modulo, double-quoted identifiers). It adds two SECURITY- and
+// SEMANTICS-critical divergences not shared with Postgres:
+//   1. String literals — `\'` escapes the quote in Redshift even with
+//      `standard_conforming_strings` on, so the naive doubled-quote
+//      escape Postgres gets away with would let a user value containing
+//      `\';DROP TABLE …` break out of its literal. Uses the same
+//      backslash-also-escaped approach as
+//      `PostgresWarehouseClient.escapeString` (which `RedshiftSqlBuilder`
+//      inherits — the production client has been applying this defence
+//      on Redshift for years).
+//   2. LAG / LEAD — Redshift rejects the 3-arg `(col, offset, default)`
+//      form with "Default parameter not be supported for window function
+//      lag". Wrapping `LAG(col, offset)` in COALESCE preserves the
+//      surface behaviour without the 3-arg call.
+const REDSHIFT_CONFIG: DialectConfig = {
+    ...POSTGRES_CONFIG,
+    generateStringLiteral: ansiQuoteWithEscapedBackslashesStringLiteral,
+    generateLagLead: ({ sqlFunc, args, emitWindow }) => {
+        if (args.length >= 3) {
+            const [value, offset, defaultValue] = args;
+            return `COALESCE(${emitWindow(sqlFunc, [
+                value,
+                offset,
+            ])}, ${defaultValue})`;
+        }
+        return emitWindow(sqlFunc, args);
+    },
 };
 
 const SNOWFLAKE_CONFIG: DialectConfig = {
@@ -82,6 +156,11 @@ const SNOWFLAKE_CONFIG: DialectConfig = {
 const DUCKDB_CONFIG: DialectConfig = {
     quoteIdentifier: doubleQuoteIdentifier,
     generateModulo: infixPercentModulo,
+    // DuckDB's production client (`DuckdbWarehouseClient.concatString`)
+    // uses the same `(a || b || c)` infix form as the Postgres family,
+    // so share the emitter. Keeps formula-package and warehouse-package
+    // SQL byte-identical on DuckDB.
+    generateConcat: postgresStyleConcat,
 };
 
 const BIGQUERY_CONFIG: DialectConfig = {
@@ -106,42 +185,46 @@ const DATABRICKS_CONFIG: DialectConfig = {
     // `MOD(a, b)` (the ANSI default) is valid Spark SQL with no type casts.
 };
 
+// ClickHouse has four dialect quirks the formula package cares about:
+//   1. Identifier quoting — ClickHouse accepts both backticks and double
+//      quotes. Use double quotes to match `ClickhouseSqlBuilder` so every
+//      identifier in a query produced by MetricQueryBuilder + the formula
+//      package looks alike.
+//   2. String literals — doubling quotes alone silently halves backslashes
+//      because ClickHouse unescapes `\\` → `\`. Matches the quote-double
+//      + backslash-escape used by `ClickhouseSqlBuilder.escapeString`.
+//   3. `Decimal(10,2) % Int32` silently truncates to `0` — ClickHouse
+//      picks the Int side's scale. Casting both operands to `Float64`
+//      preserves precision and matches every other dialect (integer
+//      modulo returns Float, absorbed by the runner's tolerance).
+//   4. LAG / LEAD — the bare names inherit the default RANGE frame
+//      (UNBOUNDED PRECEDING..CURRENT ROW) which excludes future rows, so
+//      `LEAD` returns NULL for every row. The `lagInFrame` / `leadInFrame`
+//      variants work against the user's ORDER BY once given an explicit
+//      `ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING` frame.
+//      Additionally, ClickHouse returns type-default (e.g. 0 for numbers)
+//      at partition boundaries instead of NULL unless the value arg is
+//      wrapped with `toNullable()`.
 const CLICKHOUSE_CONFIG: DialectConfig = {
-    // ClickHouse accepts both backticks and double quotes for identifiers.
-    // Use double quotes to match the convention in ClickhouseSqlBuilder
-    // (packages/warehouses) — that way identifiers in a single query
-    // produced by MetricQueryBuilder + the formula package all look alike.
     quoteIdentifier: doubleQuoteIdentifier,
-    // ClickHouse `Decimal(10,2) % Int32` silently truncates to `0` (it
-    // picks the Int side's scale, not the Decimal's). `Decimal % Decimal`
-    // or `Float % *` preserves precision. Casting both operands to
-    // `Float64` gives cross-type behaviour that matches every other
-    // dialect, at the cost of an integer-only `a % b` returning a Float
-    // (`0` → `0.0`) — the runner's tolerance comparison absorbs that.
+    generateStringLiteral: ansiQuoteWithEscapedBackslashesStringLiteral,
     generateModulo: (left, right) =>
         `(toFloat64(${left}) % toFloat64(${right}))`,
-    // Doubled single quotes for quote-escape AND backslash-on-backslash
-    // — ClickHouse interprets both. Doubling alone silently halves any
-    // backslashes in the value (ClickHouse unescapes `\\` to `\`). Same
-    // approach as ClickhouseSqlBuilder.escapeString for consistency.
-    generateStringLiteral: ansiQuoteWithEscapedBackslashesStringLiteral,
-    // ClickHouse LAG/LEAD return the type default (e.g. 0 for numbers) at
-    // partition boundaries unless the input is Nullable. Wrapping with
-    // `toNullable()` makes the boundary rows return NULL like every other
-    // dialect.
-    wrapLagLeadArg: (arg) => `toNullable(${arg})`,
-    // Use ClickHouse's purpose-built frame-aware variants. The plain
-    // `LAG`/`LEAD` inherit the default RANGE frame (UNBOUNDED PRECEDING to
-    // CURRENT ROW) which excludes future rows, silently breaking LEAD.
-    lagFunctionName: 'lagInFrame',
-    leadFunctionName: 'leadInFrame',
-    lagLeadFrameClause:
-        'ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
+    generateLagLead: ({ sqlFunc, args, emitWindow }) => {
+        const chFunc = sqlFunc === 'LAG' ? 'lagInFrame' : 'leadInFrame';
+        const [value, ...rest] = args;
+        const wrapped = [`toNullable(${value})`, ...rest];
+        return emitWindow(
+            chFunc,
+            wrapped,
+            'ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
+        );
+    },
 };
 
 export const DIALECTS: Record<Dialect, DialectConfig> = {
-    postgres: POSTGRES_LIKE_CONFIG,
-    redshift: POSTGRES_LIKE_CONFIG,
+    postgres: POSTGRES_CONFIG,
+    redshift: REDSHIFT_CONFIG,
     bigquery: BIGQUERY_CONFIG,
     snowflake: SNOWFLAKE_CONFIG,
     duckdb: DUCKDB_CONFIG,

--- a/packages/formula/src/codegen/generator.ts
+++ b/packages/formula/src/codegen/generator.ts
@@ -209,7 +209,7 @@ export class SqlGenerator {
                 return `SUM(${arg})`;
             case 'AVERAGE':
             case 'AVG':
-                return `AVG(${arg})`;
+                return this.generateAvg(arg);
             default:
                 return assertUnreachable(
                     node.name,
@@ -286,33 +286,28 @@ export class SqlGenerator {
                 );
             case 'NTILE':
                 return this.generateWindowFunction('NTILE', [args[0]], node);
+            // FIRST_VALUE and LAST_VALUE both get an explicit
+            // `UNBOUNDED PRECEDING..UNBOUNDED FOLLOWING` frame. For
+            // LAST_VALUE it's required — the ANSI default frame ends at
+            // CURRENT ROW, so without this LAST_VALUE returns the current
+            // row (not the last). For FIRST_VALUE it's a semantic no-op
+            // (the first row of the partition is the first row regardless
+            // of the frame's upper bound) but required on Redshift, which
+            // rejects aggregate-style windows with ORDER BY and no frame.
             case 'FIRST':
+            case 'LAST': {
+                const sqlFn =
+                    node.name === 'FIRST' ? 'FIRST_VALUE' : 'LAST_VALUE';
                 return this.generateWindowFunction(
-                    'FIRST_VALUE',
-                    [args[0]],
-                    node,
-                );
-            case 'LAST':
-                return this.generateWindowFunction(
-                    'LAST_VALUE',
+                    sqlFn,
                     [args[0]],
                     node,
                     'ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING',
                 );
+            }
             case 'LAG':
-                return this.generateWindowFunction(
-                    this.dialect.lagFunctionName ?? 'LAG',
-                    this.wrapLagLeadArgs(args),
-                    node,
-                    this.dialect.lagLeadFrameClause,
-                );
             case 'LEAD':
-                return this.generateWindowFunction(
-                    this.dialect.leadFunctionName ?? 'LEAD',
-                    this.wrapLagLeadArgs(args),
-                    node,
-                    this.dialect.lagLeadFrameClause,
-                );
+                return this.dispatchLagLead(node.name, args, node);
             // TODO: unsafe cast — MOVING_SUM/MOVING_AVG assume second arg is a NumberLiteral
             // but the grammar accepts any Expression. Fix by adding a grammar rule that
             // enforces NumberLiteral in the second position (same pattern as BooleanExpression).
@@ -327,9 +322,11 @@ export class SqlGenerator {
             }
             case 'MOVING_AVG': {
                 const preceding = (node.args[1] as NumberLiteralNode).value;
-                return this.generateWindowFunction(
-                    'AVG',
-                    [args[0]],
+                // Route through generateAvg so dialects that need to
+                // preserve precision across the AVG division (Redshift)
+                // can inject a cast on the value argument.
+                return this.appendOverClause(
+                    this.generateAvg(args[0]),
                     node,
                     `ROWS BETWEEN ${preceding} PRECEDING AND CURRENT ROW`,
                 );
@@ -395,18 +392,47 @@ export class SqlGenerator {
         );
     }
 
-    // Only the first (value) argument is wrapped; subsequent offset/default
-    // args stay as-is.
-    protected wrapLagLeadArgs(args: string[]): string[] {
-        if (!this.dialect.wrapLagLeadArg || args.length === 0) return args;
-        return [this.dialect.wrapLagLeadArg(args[0]), ...args.slice(1)];
+    // LAG / LEAD dispatch: hand off to the dialect's `generateLagLead` if
+    // present, otherwise use the ANSI-compatible default (bare LAG/LEAD
+    // with default frame, variadic args). The dialect callback receives
+    // an `emitWindow` bound to this node's window clause so dialects don't
+    // have to own PARTITION BY / ORDER BY plumbing.
+    protected dispatchLagLead(
+        sqlFunc: 'LAG' | 'LEAD',
+        args: string[],
+        node: { windowClause?: WindowClauseNode | null },
+    ): string {
+        const emitWindow = (
+            fn: string,
+            funcArgs: string[],
+            frameClause?: string,
+        ) => this.generateWindowFunction(fn, funcArgs, node, frameClause);
+
+        if (this.dialect.generateLagLead) {
+            return this.dialect.generateLagLead({
+                sqlFunc,
+                args,
+                emitWindow,
+            });
+        }
+        return emitWindow(sqlFunc, args);
     }
 
     // --- ANSI defaults shared across all dialects today ---
     // Promote to DialectConfig fields when a real dialect first diverges.
 
     protected generateConcat(args: string[]): string {
+        if (this.dialect.generateConcat) {
+            return this.dialect.generateConcat(args);
+        }
         return `CONCAT(${args.join(', ')})`;
+    }
+
+    protected generateAvg(arg: string): string {
+        if (this.dialect.generateAvg) {
+            return this.dialect.generateAvg(arg);
+        }
+        return `AVG(${arg})`;
     }
 
     protected generateLength(expr: string): string {
@@ -425,16 +451,15 @@ export class SqlGenerator {
         return `EXTRACT(${part} FROM ${expr})`;
     }
 
-    protected generateWindowFunction(
-        sqlFunc: string,
-        funcArgs: string[],
+    // Attach an OVER (…) clause to a pre-built function-call string. Lets
+    // callers that need per-function argument transforms (e.g. AVG's
+    // precision-preserving cast on Redshift) build the call via their own
+    // emitter and still share the PARTITION BY / ORDER BY / frame plumbing.
+    protected appendOverClause(
+        funcCall: string,
         node: { windowClause?: WindowClauseNode | null },
         frameClause?: string,
     ): string {
-        const funcCall =
-            funcArgs.length > 0
-                ? `${sqlFunc}(${funcArgs.join(', ')})`
-                : `${sqlFunc}()`;
         const overParts: string[] = [];
 
         const wc = node.windowClause;
@@ -449,7 +474,19 @@ export class SqlGenerator {
         }
 
         const framePart = frameClause ? ` ${frameClause}` : '';
-
         return `${funcCall} OVER (${overParts.join(' ')}${framePart})`;
+    }
+
+    protected generateWindowFunction(
+        sqlFunc: string,
+        funcArgs: string[],
+        node: { windowClause?: WindowClauseNode | null },
+        frameClause?: string,
+    ): string {
+        const funcCall =
+            funcArgs.length > 0
+                ? `${sqlFunc}(${funcArgs.join(', ')})`
+                : `${sqlFunc}()`;
+        return this.appendOverClause(funcCall, node, frameClause);
     }
 }

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -12,15 +12,20 @@ describe('codegen', () => {
         });
 
         it('AVG', () => {
+            // Postgres-family dialects wrap AVG in a ::DOUBLE PRECISION
+            // cast to match production's `PostgresWarehouseClient
+            // .getMetricSql` (case AVERAGE) and to prevent Redshift's
+            // DECIMAL-truncation quirk from silently dropping fractional
+            // values inside the AVG division.
             expect(
                 compile('=AVG(revenue)', { dialect: 'postgres', columns }),
-            ).toBe('AVG("revenue")');
+            ).toBe('AVG("revenue"::DOUBLE PRECISION)');
         });
 
         it('AVERAGE (alias of AVG)', () => {
             expect(
                 compile('=AVERAGE(revenue)', { dialect: 'postgres', columns }),
-            ).toBe('AVG("revenue")');
+            ).toBe('AVG("revenue"::DOUBLE PRECISION)');
         });
 
         it('COUNT with arg', () => {
@@ -208,7 +213,7 @@ describe('codegen', () => {
                     columns,
                     renderAggregate: asWindowAggregate,
                 }),
-            ).toBe('("revenue" - AVG("revenue") OVER ())');
+            ).toBe('("revenue" - AVG("revenue"::DOUBLE PRECISION) OVER ())');
         });
 
         it('lets callers express any embedding (demonstration)', () => {
@@ -247,14 +252,22 @@ describe('codegen', () => {
             );
         });
 
-        it('handles mixed aggregate and row-level expressions', () => {
+        it('widens AVG argument to DOUBLE PRECISION to avoid truncation', () => {
+            // Redshift's AVG over DECIMAL truncates to the input scale —
+            // `AVG(DECIMAL(10,2))` of 200/150/300 returns 216.66 rather
+            // than 216.666…, silently dropping the fractional cents.
+            // The `::DOUBLE PRECISION` cast preserves precision through
+            // the division and matches, byte-for-byte, what
+            // `PostgresWarehouseClient.getMetricSql` emits for AVERAGE
+            // metrics — so a formula AVG and a metric AVG over the same
+            // column produce the same value on Redshift.
             expect(
                 compile('=revenue - AVG(revenue)', {
                     dialect: 'redshift',
                     columns,
                     renderAggregate: (inner) => `${inner} OVER ()`,
                 }),
-            ).toBe('("revenue" - AVG("revenue") OVER ())');
+            ).toBe('("revenue" - AVG("revenue"::DOUBLE PRECISION) OVER ())');
         });
     });
 
@@ -341,7 +354,7 @@ describe('codegen', () => {
             });
             expect(calls).toEqual([
                 'SUM("revenue")',
-                'AVG("revenue")',
+                'AVG("revenue"::DOUBLE PRECISION)',
                 'SUM("revenue")',
             ]);
         });


### PR DESCRIPTION
## Summary

Two motivations converged into one PR because they reshape the same API surface:

**1. The dialect pattern had grown 10 ad-hoc knobs of inconsistent shapes** (full-override emitters, partial transforms, string knobs, boolean flags). LAG/LEAD alone had five separate fields. Collapsed to **6 cohesive \`generateX\` full-override hooks** — one kind of knob, one shape.

**2. Redshift integration tests surfaced real dialect gaps:** SQL injection via \`\\'\` escaping out of string literals, AVG truncating DECIMAL division, 3-arg LAG/LEAD rejected by Redshift, CONCAT failing on variadic calls. Production's \`PostgresWarehouseClient\` already solves most of these via \`getMetricSql\` / \`concatString\` / \`escapeString\`. Aligned the formula package emitters **byte-for-byte** with production so a formula-mode table calculation and a metric-level expression over the same column behave identically.

### Surface changes
- \`DialectConfig\` — 6 hooks total, all \`generateX\`: \`quoteIdentifier\`, \`generateStringLiteral\`, \`generateModulo\`, \`generateConcat\`, \`generateLagLead\`, \`generateAvg\`.
- \`LagLeadContext\` — one hook receiving \`{ sqlFunc, args, emitWindow }\` replaces the previous five LAG/LEAD fields. ClickHouse rewrites its \`lagInFrame\` / \`leadInFrame\` override in the new shape.
- **\`generateAvg\`** — new hook, set by Postgres/Redshift to emit \`AVG(arg::DOUBLE PRECISION)\`, matching \`PostgresWarehouseClient.getMetricSql\` case AVERAGE.
- **\`POSTGRES_CONFIG\`** — \`generateConcat\` set to \`(a || b || c)\`, matching \`PostgresWarehouseClient.concatString\`. \`REDSHIFT_CONFIG\` spreads \`POSTGRES_CONFIG\` and adds the two Redshift-specific divergences not shared with Postgres: backslash-escaped string literals (security fix — \`\\'\` would otherwise break out of the literal even with \`standard_conforming_strings\` on) and a \`COALESCE\` wrap for the 3-arg LAG/LEAD form Redshift rejects.
- **\`DUCKDB_CONFIG\`** — \`generateConcat\` aligned with \`DuckdbWarehouseClient.concatString\` (also \`||\`). Caught by the audit.
- \`FIRST_VALUE\` now always emits an explicit \`ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING\` frame (ANSI-equivalent for FIRST_VALUE, required on Redshift). Was previously a fake dialect knob.
- \`appendOverClause\` extracted from \`generateWindowFunction\` so callers that need per-function argument transforms (MOVING_AVG injecting the AVG precision cast) can build the call string themselves and share the window-clause plumbing.

### Cleanups
- Removed dead \`export type { WindowClauseNode }\` re-export.
- Dropped \`export\` on \`LagLeadContext\` (internal-only).
- Fixed stale \`generateAvg\` jsdoc.
- Fixed ClickHouse "three quirks" → "four quirks" miscount.

### Cross-package drift
Cross-reference comments in \`dialects.ts\` name the production counterpart file so the two locations stay in sync without a cross-package test dep. If you change the SQL here, update the matching emitter in \`PostgresWarehouseClient.ts\` (or the counterpart for other dialects).

## Test plan
Verified against real warehouses:
- [x] DuckDB: 298/298
- [x] Postgres: 298/298
- [x] Redshift: 298/298 (was 273/298 before the Redshift-specific fixes)
- [x] BigQuery: 298/298
- [x] Databricks: 298/298
- [x] ClickHouse: 298/298
- [x] Formula unit tests: 134/134

🤖 Generated with [Claude Code](https://claude.com/claude-code)