### PR TITLE
fix(formatting): remove timezone param from formatDate

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1741,24 +1741,6 @@ describe('Formatting', () => {
         const utcTimestamp = '2020-04-04T02:00:00.000Z';
 
         describe('formatDate', () => {
-            test('formats date in project timezone', () => {
-                // 2020-04-04 02:00 UTC = 2020-04-03 22:00 New York
-                expect(
-                    formatDate(
-                        utcTimestamp,
-                        TimeFrames.DAY,
-                        false,
-                        'America/New_York',
-                    ),
-                ).toBe('2020-04-03');
-            });
-
-            test('formats date in UTC timezone', () => {
-                expect(
-                    formatDate(utcTimestamp, TimeFrames.DAY, false, 'UTC'),
-                ).toBe('2020-04-04');
-            });
-
             test('existing behavior unchanged when no timezone', () => {
                 const withTrue = formatDate(utcTimestamp, TimeFrames.DAY, true);
                 const withFalse = formatDate(
@@ -1769,17 +1751,6 @@ describe('Formatting', () => {
                 const withDefault = formatDate(utcTimestamp, TimeFrames.DAY);
                 expect(withTrue).toBe('2020-04-04');
                 expect(withFalse).toBe(withDefault);
-            });
-
-            test('timezone takes precedence over convertToUTC', () => {
-                expect(
-                    formatDate(
-                        utcTimestamp,
-                        TimeFrames.DAY,
-                        true,
-                        'America/New_York',
-                    ),
-                ).toBe('2020-04-03');
             });
         });
 

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -135,19 +135,11 @@ export function formatDate(
     date: MomentInput,
     timeInterval: TimeFrames = TimeFrames.DAY,
     convertToUTC: boolean = false,
-    timezone?: string,
 ): string {
     // moment.utc(date) parses date-only strings as UTC. moment(date).utc()
     // parses in the local timezone first, shifting the date back a day
     // in UTC+ browsers (e.g. JST).
-    let momentDate;
-    if (timezone) {
-        momentDate = moment.utc(date).tz(timezone);
-    } else if (convertToUTC) {
-        momentDate = moment.utc(date);
-    } else {
-        momentDate = moment(date);
-    }
+    const momentDate = convertToUTC ? moment.utc(date) : moment(date);
 
     if (!momentDate.isValid()) {
         return 'NaT';
@@ -853,12 +845,12 @@ export function formatItemValue(
                 case DimensionType.DATE:
                 case MetricType.DATE:
                 case TableCalculationType.DATE:
+                    // DATE has no time component; timezone doesn't apply.
                     return isMomentInput(value)
                         ? formatDate(
                               value,
                               isDimension(item) ? item.timeInterval : undefined,
                               convertToUTC,
-                              timezone,
                           )
                         : 'NaT';
                 case DimensionType.TIMESTAMP:


### PR DESCRIPTION
Reverts the double-shift on DATE values introduced by #22108.

## Problem

#22108 added an optional `timezone` parameter to `formatDate`. When supplied, the function did `moment.utc(date).tz(timezone)` — which double-shifts DATE values that were already truncated in the project timezone at the SQL layer (timezone-aware `DATE_TRUNC`). E.g. with project timezone `America/New_York`, a Jan 15 bucket would display as Jan 14.

A `DATE` has no time component — a calendar day has no instant to shift — so the parameter was semantically meaningless.

## Flag-off parity

When no timezone is supplied, behavior is the same as pre-#22108.

No production callers passed a timezone to `formatDate` directly — only tests and the `formatItemValue` dispatcher (which is updated here).