### PR TITLE
fix(formatting): don't apply timezone shift to truncated TIMESTAMP dimensions

### DIFF
--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -1785,5 +1785,83 @@ describe('Formatting', () => {
                 expect(withTrue).toBe('2020-04-04, 02:00:00:000 (+00:00)');
             });
         });
+
+        describe('formatItemValue TIMESTAMP double-shift prevention', () => {
+            // Truncated TIMESTAMP values arrive from SQL's DATE_TRUNC(..., AT
+            // TIME ZONE tz) already wall-clock-shifted into the project TZ
+            // (stamped UTC by the pg driver). Re-applying .tz() at format time
+            // double-shifts. formatItemValue should suppress that second shift
+            // for truncated intervals only, leaving raw/undefined intervals
+            // alone so genuine timestamptz columns still display in the
+            // project TZ.
+            const truncatedBase = {
+                ...dimension,
+                type: DimensionType.TIMESTAMP,
+            };
+
+            test('truncated HOUR does not double-shift when timezone supplied', () => {
+                const value = new Date('2024-01-14T15:00:00.000Z');
+                expect(
+                    formatItemValue(
+                        { ...truncatedBase, timeInterval: TimeFrames.HOUR },
+                        value,
+                        false,
+                        undefined,
+                        'Pacific/Pago_Pago',
+                    ),
+                ).toBe('2024-01-14, 15 (+00:00)');
+            });
+
+            test.each([
+                TimeFrames.MILLISECOND,
+                TimeFrames.SECOND,
+                TimeFrames.MINUTE,
+                TimeFrames.HOUR,
+            ])(
+                '%s-truncated TIMESTAMP formats as UTC when timezone supplied',
+                (ti) => {
+                    const value = new Date('2024-01-14T15:00:00.000Z');
+                    const result = formatItemValue(
+                        { ...truncatedBase, timeInterval: ti },
+                        value,
+                        false,
+                        undefined,
+                        'Pacific/Pago_Pago',
+                    );
+                    expect(result).toContain('2024-01-14');
+                    expect(result).toContain('(+00:00)');
+                },
+            );
+
+            test('RAW TIMESTAMP still applies project timezone shift', () => {
+                const value = new Date('2024-01-14T15:00:00.000Z');
+                expect(
+                    formatItemValue(
+                        { ...truncatedBase, timeInterval: TimeFrames.RAW },
+                        value,
+                        false,
+                        undefined,
+                        'Pacific/Pago_Pago',
+                    ),
+                ).toContain('(-11:00)');
+            });
+
+            test('flag-off (no timezone) is byte-identical for truncated TIMESTAMP', () => {
+                const value = new Date('2024-01-14T15:00:00.000Z');
+                const hourItem = {
+                    ...truncatedBase,
+                    timeInterval: TimeFrames.HOUR,
+                };
+                expect(formatItemValue(hourItem, value)).toBe(
+                    formatItemValue(
+                        hourItem,
+                        value,
+                        undefined,
+                        undefined,
+                        undefined,
+                    ),
+                );
+            });
+        });
     });
 });

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -41,6 +41,7 @@ import { TimeFrames } from '../types/timeFrames';
 import assertUnreachable from './assertUnreachable';
 import { evaluateConditionalFormatExpression } from './conditionalFormatExpressions';
 import { getItemType, isNumericItem } from './item';
+import { truncatableTimeFrames } from './timeFrames';
 
 dayjs.extend(dayjsTimezone);
 
@@ -856,12 +857,23 @@ export function formatItemValue(
                 case DimensionType.TIMESTAMP:
                 case MetricType.TIMESTAMP:
                 case TableCalculationType.TIMESTAMP:
+                    const timeInterval = isDimension(item)
+                        ? item.timeInterval
+                        : undefined;
+
+                    // SQL's DATE_TRUNC(... AT TIME ZONE tz) already shifted the
+                    // wall-clock; don't shift again.
+                    const isTruncated =
+                        timezone &&
+                        timeInterval &&
+                        truncatableTimeFrames.has(timeInterval);
+
                     return isMomentInput(value)
                         ? formatTimestamp(
                               value,
-                              isDimension(item) ? item.timeInterval : undefined,
-                              convertToUTC,
-                              timezone,
+                              timeInterval,
+                              isTruncated ? true : convertToUTC,
+                              isTruncated ? undefined : timezone,
                           )
                         : 'NaT';
                 case MetricType.MAX:


### PR DESCRIPTION
Follow-up to #22142 covering the same class of bug for truncated TIMESTAMP dimensions (`_hour`, `_minute`, `_second`, `_millisecond`).

## Problem

SQL's `DATE_TRUNC(<interval>, ts AT TIME ZONE 'tz')` returns a `timestamp without time zone` that already represents the wall-clock in the project TZ. The value arrives at the formatter looking like a UTC instant, and `formatTimestamp` then re-applies `.tz(tz)` — shifting the already-shifted value a second time. Under Pago_Pago, every hour in a query response came out 11h earlier than ground truth.

#22142 fixed this for `DimensionType.DATE`. Same fix pattern for `DimensionType.TIMESTAMP` when `timeInterval` is truncatable (anything in `truncatableTimeFrames`).

## Changes

- `formatItemValue` TIMESTAMP dispatch: when `timezone` is supplied and `timeInterval` is truncatable, format as UTC (skip the `.tz()` shift). `RAW`/undefined intervals keep the existing shift — those are genuine timestamptz values where the project TZ display is the point.

## Flag-off parity

Gate is `timezone !== undefined`. When no timezone is threaded (flag off), the branch doesn't fire and the call collapses to the pre-fix arguments — byte-identical to pre-#22108.