### PR TITLE
feat(analytics): add event tracking to data apps pipeline

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1127,6 +1127,131 @@ export type SchedulerNotificationJobEvent = BaseTrack & {
     };
 };
 
+export type DataAppCreatedEvent = BaseTrack & {
+    event: 'data_app.created';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        promptLength: number;
+        hasImage: boolean;
+        imageMimeType?: string;
+    };
+};
+
+export type DataAppIteratedEvent = BaseTrack & {
+    event: 'data_app.iterated';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        iterationNumber: number;
+        promptLength: number;
+        hasImage: boolean;
+        imageMimeType?: string;
+        previousVersionStatus: string | null;
+        msSinceLastVersion: number | null;
+    };
+};
+
+export type DataAppVersionCancelledEvent = BaseTrack & {
+    event: 'data_app.version.cancelled';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        stageAtCancellation: string;
+        msElapsedBeforeCancel: number;
+    };
+};
+
+export type DataAppVersionCompletedEvent = BaseTrack & {
+    event: 'data_app.version.completed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        isIteration: boolean;
+        wasResumed: boolean;
+        totalDurationMs: number;
+        sandboxMs?: number;
+        resumeMs?: number;
+        restoreMs?: number;
+        catalogMs?: number;
+        generateMs?: number;
+        buildMs?: number;
+        packageMs?: number;
+        uploadMs?: number;
+        buildFixAttempts: number;
+        buildFixGenerationMs: number;
+        toolCallCount: number;
+        catalogTableCount: number;
+        catalogDimensionCount: number;
+        catalogMetricCount: number;
+        catalogYamlBytes: number;
+        distBytes: number;
+        sourceBytes: number;
+    };
+};
+
+export type DataAppVersionFailedEvent = BaseTrack & {
+    event: 'data_app.version.failed';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+        version: number;
+        isIteration: boolean;
+        failureStage:
+            | 'sandbox'
+            | 'catalog'
+            | 'generating'
+            | 'building'
+            | 'packaging'
+            | 'db'
+            | 'config'
+            | 'timeout';
+        errorMessage: string;
+        buildFixAttempts: number;
+        totalDurationMs: number;
+        sandboxMs?: number;
+        resumeMs?: number;
+        restoreMs?: number;
+        catalogMs?: number;
+        generateMs?: number;
+        buildMs?: number;
+    };
+};
+
+export type DataAppImageUploadedEvent = BaseTrack & {
+    event: 'data_app.image_uploaded';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid?: string;
+        mimeType: string;
+        sizeBytes?: number;
+    };
+};
+
+export type DataAppEvent =
+    | DataAppCreatedEvent
+    | DataAppIteratedEvent
+    | DataAppVersionCancelledEvent
+    | DataAppVersionCompletedEvent
+    | DataAppVersionFailedEvent
+    | DataAppImageUploadedEvent;
+
 export type CommentsEvent = BaseTrack & {
     event: 'comment.created' | 'comment.deleted' | 'comment.resolved';
     userId: string;
@@ -1685,6 +1810,7 @@ type TypedEvent =
     | SchedulerRestoredEvent
     | SchedulerJobEvent
     | SchedulerNotificationJobEvent
+    | DataAppEvent
     | PinnedListUpdated
     | FavoriteToggled
     | DownloadCsv

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -79,6 +79,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
             appGenerateService: ({ context, models, clients }) =>
                 new AppGenerateService({
                     lightdashConfig: context.lightdashConfig,
+                    analytics: context.lightdashAnalytics,
                     catalogModel: models.getCatalogModel(),
                     appModel: models.getAppModel(),
                     featureFlagModel: models.getFeatureFlagModel(),

--- a/packages/backend/src/ee/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/ee/scheduler/SchedulerWorker.ts
@@ -207,6 +207,7 @@ export class CommercialSchedulerWorker extends SchedulerWorker {
                             e,
                             'Build timed out. Please try again.',
                         );
+                        this.appGenerateService.trackTimeoutFailure(payload, e);
                     },
                 );
             },

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -20,6 +20,7 @@ import { performance } from 'node:perf_hooks';
 import { PassThrough, Readable } from 'node:stream';
 import { extract, type Headers } from 'tar-stream';
 import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
+import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../../config/parseConfig';
 import {
     APP_VERSION_STAGE_ORDER,
@@ -37,6 +38,7 @@ import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient'
 
 type AppGenerateServiceDeps = {
     lightdashConfig: LightdashConfig;
+    analytics: LightdashAnalytics;
     catalogModel: CatalogModel;
     appModel: AppModel;
     featureFlagModel: FeatureFlagModel;
@@ -51,6 +53,8 @@ type GenerateAppResult = {
 export class AppGenerateService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
+    private readonly analytics: LightdashAnalytics;
+
     private readonly catalogModel: CatalogModel;
 
     private readonly appModel: AppModel;
@@ -61,6 +65,7 @@ export class AppGenerateService extends BaseService {
 
     constructor({
         lightdashConfig,
+        analytics,
         catalogModel,
         appModel,
         featureFlagModel,
@@ -68,6 +73,7 @@ export class AppGenerateService extends BaseService {
     }: AppGenerateServiceDeps) {
         super();
         this.lightdashConfig = lightdashConfig;
+        this.analytics = analytics;
         this.catalogModel = catalogModel;
         this.appModel = appModel;
         this.featureFlagModel = featureFlagModel;
@@ -198,6 +204,18 @@ export class AppGenerateService extends BaseService {
             }),
         );
 
+        this.analytics.track({
+            event: 'data_app.image_uploaded',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                appUuid,
+                mimeType,
+                sizeBytes: contentLength,
+            },
+        });
+
         return { s3Key };
     }
 
@@ -208,6 +226,58 @@ export class AppGenerateService extends BaseService {
 
     private static elapsed(start: number): number {
         return Math.round(performance.now() - start);
+    }
+
+    trackTimeoutFailure(
+        payload: AppGeneratePipelineJobPayload,
+        error: unknown,
+    ): void {
+        this.trackVersionFailed(payload, 'timeout', error, {}, null, 0);
+    }
+
+    private trackVersionFailed(
+        payload: AppGeneratePipelineJobPayload,
+        failureStage:
+            | 'sandbox'
+            | 'catalog'
+            | 'generating'
+            | 'building'
+            | 'packaging'
+            | 'db'
+            | 'config'
+            | 'timeout',
+        error: unknown,
+        durations: Record<string, number>,
+        overallStart: number | null,
+        buildFixAttempts: number,
+    ): void {
+        this.analytics.track({
+            event: 'data_app.version.failed',
+            userId: payload.userUuid,
+            properties: {
+                organizationId: payload.organizationUuid,
+                projectId: payload.projectUuid,
+                appUuid: payload.appUuid,
+                version: payload.version,
+                isIteration: payload.isIteration,
+                failureStage,
+                errorMessage: AppGenerateService.truncateEnd(
+                    getErrorMessage(error),
+                    500,
+                ),
+                buildFixAttempts,
+                totalDurationMs:
+                    overallStart !== null
+                        ? AppGenerateService.elapsed(overallStart)
+                        : 0,
+                sandboxMs: durations.sandboxMs,
+                resumeMs: durations.resumeMs,
+                restoreMs: durations.restoreMs,
+                catalogMs: durations.catalogMs,
+                generateMs: durations.generateMs,
+                buildMs: durations.buildMs,
+            },
+        });
     }
 
     async markError(
@@ -432,7 +502,13 @@ export class AppGenerateService extends BaseService {
         image: AppImageAttachment | undefined,
         s3Client: S3Client,
         bucket: string,
-    ): Promise<number> {
+    ): Promise<{
+        durationMs: number;
+        tableCount: number;
+        dimensionCount: number;
+        metricCount: number;
+        yamlBytes: number;
+    }> {
         const start = performance.now();
 
         const catalogItems =
@@ -488,7 +564,13 @@ export class AppGenerateService extends BaseService {
         this.logger.info(
             `App ${appUuid}: model context written (tables=${tableCount}, dimensions=${totalDimensions}, metrics=${totalMetrics}, yamlBytes=${modelYaml.length}, ${durationMs}ms)`,
         );
-        return durationMs;
+        return {
+            durationMs,
+            tableCount,
+            dimensionCount: totalDimensions,
+            metricCount: totalMetrics,
+            yamlBytes: modelYaml.length,
+        };
     }
 
     /**
@@ -639,7 +721,11 @@ export class AppGenerateService extends BaseService {
         version: number,
         continueSession: boolean,
         anthropicApiKey: string,
-    ): Promise<{ durationMs: number; responseText: string | null }> {
+    ): Promise<{
+        durationMs: number;
+        responseText: string | null;
+        toolCallCount: number;
+    }> {
         const start = performance.now();
         let stdoutBuffer = '';
         let toolCallCount = 0;
@@ -719,7 +805,7 @@ export class AppGenerateService extends BaseService {
                 `Claude generation failed (exit ${result.exitCode}): ${result.stderr}`,
             );
         }
-        return { durationMs, responseText };
+        return { durationMs, responseText, toolCallCount };
     }
 
     private async runBuild(
@@ -967,8 +1053,7 @@ export class AppGenerateService extends BaseService {
      * completed stages. `claude --continue` resumes the conversation.
      */
     async runPipeline(payload: AppGeneratePipelineJobPayload): Promise<void> {
-        const { appUuid, version, projectUuid, prompt, image, isIteration } =
-            payload;
+        const { appUuid, version, projectUuid, image, isIteration } = payload;
 
         // Check if version was cancelled while we were dead
         const currentStatus = await this.appModel.getVersionStatus(
@@ -997,6 +1082,7 @@ export class AppGenerateService extends BaseService {
                 error,
                 'Something went wrong. Please try again.',
             );
+            this.trackVersionFailed(payload, 'config', error, {}, null, 0);
             return;
         }
 
@@ -1050,17 +1136,36 @@ export class AppGenerateService extends BaseService {
                     error,
                     'Failed to set up build environment. Please try again.',
                 );
+                this.trackVersionFailed(
+                    payload,
+                    'sandbox',
+                    error,
+                    durations,
+                    overallStart,
+                    0,
+                );
                 return;
             }
         } else {
             // Resuming past sandbox stage — reconnect
             const app = await this.appModel.getApp(appUuid, projectUuid);
             if (!app.sandbox_id) {
+                const missingSandboxError = new Error(
+                    'No sandbox_id found for resume',
+                );
                 await this.markError(
                     appUuid,
                     version,
-                    new Error('No sandbox_id found for resume'),
+                    missingSandboxError,
                     'Failed to resume build environment. Please try again.',
+                );
+                this.trackVersionFailed(
+                    payload,
+                    'sandbox',
+                    missingSandboxError,
+                    durations,
+                    overallStart,
+                    0,
                 );
                 return;
             }
@@ -1080,6 +1185,14 @@ export class AppGenerateService extends BaseService {
                     error,
                     'Failed to resume build environment. Please try again.',
                 );
+                this.trackVersionFailed(
+                    payload,
+                    'sandbox',
+                    error,
+                    durations,
+                    overallStart,
+                    0,
+                );
                 return;
             }
         }
@@ -1087,10 +1200,7 @@ export class AppGenerateService extends BaseService {
         try {
             await this.runPipelineStages(
                 sandbox,
-                appUuid,
-                version,
-                projectUuid,
-                prompt,
+                payload,
                 s3Client,
                 bucket,
                 durations,
@@ -1107,10 +1217,7 @@ export class AppGenerateService extends BaseService {
 
     private async runPipelineStages(
         sandbox: Sandbox,
-        appUuid: string,
-        version: number,
-        projectUuid: string,
-        prompt: string,
+        payload: AppGeneratePipelineJobPayload,
         s3Client: S3Client,
         bucket: string,
         extraDurations: Record<string, number>,
@@ -1120,9 +1227,22 @@ export class AppGenerateService extends BaseService {
         anthropicApiKey: string,
         image: AppImageAttachment | undefined,
     ): Promise<void> {
+        const { appUuid, version, projectUuid, prompt } = payload;
         const durations: Record<string, number> = { ...extraDurations };
         const shouldRun = (stage: AppVersionStatus) =>
             AppGenerateService.shouldRunStage(currentStatus, stage);
+
+        let catalogStats = {
+            tableCount: 0,
+            dimensionCount: 0,
+            metricCount: 0,
+            yamlBytes: 0,
+        };
+        let toolCallCount = 0;
+        let buildFixAttempts = 0;
+        let buildFixGenerationMs = 0;
+        let distBytes = 0;
+        let sourceBytes = 0;
 
         // --- Stage: catalog ---
         if (shouldRun('catalog')) {
@@ -1133,7 +1253,7 @@ export class AppGenerateService extends BaseService {
                     'catalog',
                     'Loading your data models',
                 );
-                durations.catalogMs = await this.writeCatalogAndPrompt(
+                const catalogResult = await this.writeCatalogAndPrompt(
                     sandbox,
                     appUuid,
                     projectUuid,
@@ -1142,6 +1262,13 @@ export class AppGenerateService extends BaseService {
                     s3Client,
                     bucket,
                 );
+                durations.catalogMs = catalogResult.durationMs;
+                catalogStats = {
+                    tableCount: catalogResult.tableCount,
+                    dimensionCount: catalogResult.dimensionCount,
+                    metricCount: catalogResult.metricCount,
+                    yamlBytes: catalogResult.yamlBytes,
+                };
             } catch (error) {
                 const totalMs = AppGenerateService.elapsed(overallStart);
                 this.logger.error(
@@ -1152,6 +1279,14 @@ export class AppGenerateService extends BaseService {
                     version,
                     error,
                     'Failed to load your data models. Please try again.',
+                );
+                this.trackVersionFailed(
+                    payload,
+                    'catalog',
+                    error,
+                    durations,
+                    overallStart,
+                    buildFixAttempts,
                 );
                 return;
             }
@@ -1181,6 +1316,7 @@ export class AppGenerateService extends BaseService {
                 );
                 durations.generateMs = generation.durationMs;
                 responseText = generation.responseText;
+                toolCallCount = generation.toolCallCount;
             } catch (error) {
                 const totalMs = AppGenerateService.elapsed(overallStart);
                 this.logger.error(
@@ -1191,6 +1327,14 @@ export class AppGenerateService extends BaseService {
                     version,
                     error,
                     'Failed to generate app code. Try rephrasing your request.',
+                );
+                this.trackVersionFailed(
+                    payload,
+                    'generating',
+                    error,
+                    durations,
+                    overallStart,
+                    buildFixAttempts,
                 );
                 return;
             }
@@ -1212,6 +1356,8 @@ export class AppGenerateService extends BaseService {
                     anthropicApiKey,
                 );
                 durations.buildMs = buildResult.buildMs;
+                buildFixAttempts = buildResult.fixAttempts;
+                buildFixGenerationMs = buildResult.fixGenerationMs;
                 if (buildResult.fixAttempts > 0) {
                     durations.buildFixMs = buildResult.fixGenerationMs;
                     durations.buildFixAttempts = buildResult.fixAttempts;
@@ -1226,6 +1372,14 @@ export class AppGenerateService extends BaseService {
                     version,
                     error,
                     "The generated code couldn't be compiled. Try again or simplify your request.",
+                );
+                this.trackVersionFailed(
+                    payload,
+                    'building',
+                    error,
+                    durations,
+                    overallStart,
+                    buildFixAttempts,
                 );
                 return;
             }
@@ -1242,6 +1396,8 @@ export class AppGenerateService extends BaseService {
                 );
                 const artifacts = await this.packageArtifacts(sandbox, appUuid);
                 durations.packageMs = artifacts.durationMs;
+                distBytes = artifacts.distTar.length;
+                sourceBytes = artifacts.sourceTar.length;
 
                 durations.uploadMs = await this.uploadToS3(
                     s3Client,
@@ -1261,6 +1417,14 @@ export class AppGenerateService extends BaseService {
                     version,
                     error,
                     'Failed to deploy your app. Please try again.',
+                );
+                this.trackVersionFailed(
+                    payload,
+                    'packaging',
+                    error,
+                    durations,
+                    overallStart,
+                    buildFixAttempts,
                 );
                 return;
             }
@@ -1292,6 +1456,14 @@ export class AppGenerateService extends BaseService {
                 error,
                 'Something went wrong. Please try again.',
             );
+            this.trackVersionFailed(
+                payload,
+                'db',
+                error,
+                durations,
+                overallStart,
+                buildFixAttempts,
+            );
             return;
         }
 
@@ -1303,6 +1475,37 @@ export class AppGenerateService extends BaseService {
                 .map(([k, v]) => `${k}=${v}ms`)
                 .join(', ')})`,
         );
+
+        this.analytics.track({
+            event: 'data_app.version.completed',
+            userId: payload.userUuid,
+            properties: {
+                organizationId: payload.organizationUuid,
+                projectId: projectUuid,
+                appUuid,
+                version,
+                isIteration: payload.isIteration,
+                wasResumed,
+                totalDurationMs: totalMs,
+                sandboxMs: durations.sandboxMs,
+                resumeMs: durations.resumeMs,
+                restoreMs: durations.restoreMs,
+                catalogMs: durations.catalogMs,
+                generateMs: durations.generateMs,
+                buildMs: durations.buildMs,
+                packageMs: durations.packageMs,
+                uploadMs: durations.uploadMs,
+                buildFixAttempts,
+                buildFixGenerationMs,
+                toolCallCount,
+                catalogTableCount: catalogStats.tableCount,
+                catalogDimensionCount: catalogStats.dimensionCount,
+                catalogMetricCount: catalogStats.metricCount,
+                catalogYamlBytes: catalogStats.yamlBytes,
+                distBytes,
+                sourceBytes,
+            },
+        });
     }
 
     async generateApp(
@@ -1351,6 +1554,20 @@ export class AppGenerateService extends BaseService {
             );
             throw error;
         }
+
+        this.analytics.track({
+            event: 'data_app.created',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                appUuid,
+                version,
+                promptLength: prompt.length,
+                hasImage: image !== undefined,
+                imageMimeType: image?.mimeType,
+            },
+        });
 
         await this.schedulerClient.appGeneratePipeline({
             appUuid,
@@ -1413,6 +1630,25 @@ export class AppGenerateService extends BaseService {
             user.userUuid,
         );
 
+        this.analytics.track({
+            event: 'data_app.iterated',
+            userId: user.userUuid,
+            properties: {
+                organizationId: user.organizationUuid!,
+                projectId: projectUuid,
+                appUuid,
+                version: newVersion,
+                iterationNumber: newVersion - 1,
+                promptLength: prompt.length,
+                hasImage: image !== undefined,
+                imageMimeType: image?.mimeType,
+                previousVersionStatus: latestVersion?.status ?? null,
+                msSinceLastVersion: latestVersion?.created_at
+                    ? Date.now() - latestVersion.created_at.getTime()
+                    : null,
+            },
+        });
+
         await this.schedulerClient.appGeneratePipeline({
             appUuid,
             version: newVersion,
@@ -1450,6 +1686,10 @@ export class AppGenerateService extends BaseService {
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
 
+        // Read the version before updating it so we can capture the stage
+        // it was at when the cancel hit.
+        const versionRow = await this.appModel.getVersion(appUuid, version);
+
         // Atomically mark the version as cancelled (only if still building)
         const updated = await this.appModel.updateVersionStatusIfInProgress(
             appUuid,
@@ -1465,6 +1705,22 @@ export class AppGenerateService extends BaseService {
         this.logger.info(
             `App ${appUuid}: version ${version} cancelled by user ${user.userUuid}`,
         );
+
+        if (versionRow) {
+            this.analytics.track({
+                event: 'data_app.version.cancelled',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: user.organizationUuid!,
+                    projectId: projectUuid,
+                    appUuid,
+                    version,
+                    stageAtCancellation: versionRow.status,
+                    msElapsedBeforeCancel:
+                        Date.now() - versionRow.created_at.getTime(),
+                },
+            });
+        }
 
         // Pause the sandbox to interrupt any running commands while keeping
         // it resumable for the next iteration.

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -130,6 +130,16 @@ export class AppModel {
         return row;
     }
 
+    async getVersion(
+        appId: string,
+        version: number,
+    ): Promise<DbAppVersion | null> {
+        const row = await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version })
+            .first();
+        return row ?? null;
+    }
+
     async getLatestVersion(appId: string): Promise<DbAppVersion | null> {
         const row = await this.database(AppVersionsTableName)
             .where({ app_id: appId })


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-333/add-event-tracking

### Description:
Emits six typed RudderStack events from AppGenerateService covering the full data app lifecycle:

- data_app.created — top-of-funnel, prompt length, image attach rate
- data_app.iterated — engagement depth, ms since last version
- data_app.version.cancelled — stage-at-cancel (UX friction signal)
- data_app.version.completed — per-stage durations, tool calls, catalog size, build auto-fix stats, artifact sizes
- data_app.version.failed — failure stage, truncated error message
- data_app.image_uploaded — multimodal adoption

All events include userId/organizationId/projectId/appUuid/version. Pipeline-stage failures emit from each catch block in runPipelineStages; timeout failures emit from the scheduler worker wrapper.

Threads catalog stats and tool call count out of the pipeline helpers so they can be attached to the completed event. Adds AppModel.getVersion so cancelVersion can capture the stage the version was in at cancel time.
