### PR TITLE
fix: route sum_distinct refs through dd CTE when fanout protection is active (SPK-333)

### DIFF
--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.mock.ts
@@ -3272,3 +3272,213 @@ export const METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT_NO_DIMS: CompiledMetricQuery 
         compiledAdditionalMetrics: [],
         compiledCustomDimensions: [],
     };
+
+// Repro for SPK-333: a type:number metric referencing a sum_distinct metric
+// is selected alongside a simple sum metric on a joined (one-to-many) table
+// that triggers fanout protection. The non-aggregate metric's ${sum_distinct}
+// reference must resolve to the dd CTE alias; inlining the fallback SUM breaks
+// because the raw table is not in scope of the dd_base outer SELECT.
+export const EXPLORE_WITH_FANOUT_AND_DD_REFERENCE: Explore = {
+    targetDatabase: SupportedDbtAdapter.POSTGRES,
+    name: 'customers',
+    label: 'customers',
+    baseTable: 'customers',
+    tags: [],
+    tables: {
+        customers: {
+            name: 'customers',
+            label: 'customers',
+            database: 'mydb',
+            schema: 'public',
+            sqlTable: 'customers',
+            primaryKey: ['customer_id'],
+            lineageGraph: {},
+            dimensions: {
+                customer_id: {
+                    type: DimensionType.STRING,
+                    name: 'customer_id',
+                    label: 'Customer ID',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.customer_id',
+                    compiledSql: '"customers".customer_id',
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                unique_customer_count: {
+                    type: MetricType.COUNT_DISTINCT,
+                    name: 'unique_customer_count',
+                    label: 'Unique Customer Count',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${TABLE}.customer_id',
+                    compiledSql: 'COUNT(DISTINCT "customers".customer_id)',
+                    tablesReferences: ['customers'],
+                    hidden: false,
+                },
+                total_order_amount_deduped: {
+                    type: MetricType.SUM_DISTINCT,
+                    name: 'total_order_amount_deduped',
+                    label: 'Total Order Amount (Deduped)',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${orders.amount}',
+                    distinctKeys: ['orders.order_id'],
+                    compiledSql: 'SUM("orders".amount)',
+                    compiledValueSql: '("orders".amount)',
+                    compiledDistinctKeys: ['("orders".order_id)'],
+                    tablesReferences: ['customers', 'orders'],
+                    hidden: false,
+                },
+                average_customer_lifetime_value: {
+                    type: MetricType.NUMBER,
+                    name: 'average_customer_lifetime_value',
+                    label: 'Average Customer Lifetime Value',
+                    table: 'customers',
+                    tableLabel: 'customers',
+                    fieldType: FieldType.METRIC,
+                    sql: '${total_order_amount_deduped} / NULLIF(${unique_customer_count}, 0)',
+                    // compileMetricSql inlines the fallback SUM for the
+                    // sum_distinct ref; the query builder must rewrite this
+                    // to point at the dd CTE instead of emitting it raw.
+                    compiledSql:
+                        '(SUM("orders".amount)) / NULLIF(COUNT(DISTINCT "customers".customer_id), 0)',
+                    tablesReferences: ['customers', 'orders'],
+                    hidden: false,
+                },
+            },
+        },
+        orders: {
+            name: 'orders',
+            label: 'orders',
+            database: 'mydb',
+            schema: 'public',
+            sqlTable: 'orders',
+            primaryKey: ['order_id'],
+            lineageGraph: {},
+            dimensions: {
+                order_id: {
+                    type: DimensionType.STRING,
+                    name: 'order_id',
+                    label: 'Order ID',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.order_id',
+                    compiledSql: '"orders".order_id',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+                amount: {
+                    type: DimensionType.NUMBER,
+                    name: 'amount',
+                    label: 'Amount',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.amount',
+                    compiledSql: '"orders".amount',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                total_order_amount: {
+                    type: MetricType.SUM,
+                    name: 'total_order_amount',
+                    label: 'Total Order Amount',
+                    table: 'orders',
+                    tableLabel: 'orders',
+                    fieldType: FieldType.METRIC,
+                    sql: '${TABLE}.amount',
+                    compiledSql: 'SUM("orders".amount)',
+                    tablesReferences: ['orders'],
+                    hidden: false,
+                },
+            },
+        },
+        payments: {
+            name: 'payments',
+            label: 'payments',
+            database: 'mydb',
+            schema: 'public',
+            sqlTable: 'payments',
+            primaryKey: ['payment_id'],
+            lineageGraph: {},
+            dimensions: {
+                payment_id: {
+                    type: DimensionType.STRING,
+                    name: 'payment_id',
+                    label: 'Payment ID',
+                    table: 'payments',
+                    tableLabel: 'payments',
+                    fieldType: FieldType.DIMENSION,
+                    sql: '${TABLE}.payment_id',
+                    compiledSql: '"payments".payment_id',
+                    tablesReferences: ['payments'],
+                    hidden: false,
+                },
+            },
+            metrics: {
+                payment_count: {
+                    type: MetricType.COUNT,
+                    name: 'payment_count',
+                    label: 'Payment Count',
+                    table: 'payments',
+                    tableLabel: 'payments',
+                    fieldType: FieldType.METRIC,
+                    sql: '${TABLE}.payment_id',
+                    compiledSql: 'COUNT("payments".payment_id)',
+                    tablesReferences: ['payments'],
+                    hidden: false,
+                },
+            },
+        },
+    },
+    joinedTables: [
+        {
+            table: 'orders',
+            sqlOn: '${customers.customer_id} = ${orders.customer_id}',
+            compiledSqlOn: '("customers".customer_id) = ("orders".customer_id)',
+            type: 'left',
+            relationship: JoinRelationship.ONE_TO_MANY,
+            tablesReferences: ['customers', 'orders'],
+        },
+        {
+            table: 'payments',
+            sqlOn: '${orders.order_id} = ${payments.order_id}',
+            compiledSqlOn: '("orders".order_id) = ("payments".order_id)',
+            type: 'left',
+            relationship: JoinRelationship.ONE_TO_MANY,
+            tablesReferences: ['orders', 'payments'],
+        },
+    ],
+};
+
+export const METRIC_QUERY_FANOUT_AND_DD_REFERENCE: CompiledMetricQuery = {
+    exploreName: 'customers',
+    dimensions: [],
+    metrics: [
+        'customers_average_customer_lifetime_value',
+        'customers_total_order_amount_deduped',
+        'orders_total_order_amount',
+        'payments_payment_count',
+    ],
+    filters: {},
+    sorts: [
+        {
+            fieldId: 'customers_average_customer_lifetime_value',
+            descending: true,
+        },
+    ],
+    limit: 500,
+    tableCalculations: [],
+    compiledTableCalculations: [],
+    compiledAdditionalMetrics: [],
+    compiledCustomDimensions: [],
+};

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.test.ts
@@ -31,6 +31,7 @@ import {
     EXPLORE_WITH_CROSS_TABLE_METRICS,
     EXPLORE_WITH_DATE_DIMENSION,
     EXPLORE_WITH_DATE_DIMENSION_ZOOMED,
+    EXPLORE_WITH_FANOUT_AND_DD_REFERENCE,
     EXPLORE_WITH_NESTED_AGG,
     EXPLORE_WITH_SAME_MODEL_NUMBER_AND_SUM_DISTINCT,
     EXPLORE_WITH_SQL_FILTER,
@@ -44,6 +45,7 @@ import {
     METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT,
     METRIC_QUERY_CROSS_MODEL_SUM_DISTINCT_NO_DIMS,
     METRIC_QUERY_CROSS_TABLE,
+    METRIC_QUERY_FANOUT_AND_DD_REFERENCE,
     METRIC_QUERY_NESTED_AGG_COMPLEX,
     METRIC_QUERY_NESTED_AGG_CONDITIONAL,
     METRIC_QUERY_NESTED_AGG_COUNT_DISTINCT,
@@ -2347,6 +2349,56 @@ LIMIT 10`;
             expect(result.query).toContain(
                 'dd_orders_total_revenue."orders_total_revenue"',
             );
+        });
+
+        // SPK-333: when a non-aggregate metric references a sum_distinct metric
+        // AND another metric on the query forces fanout protection (cte_keys_/
+        // cte_metrics_/cte_unaffected), the non-aggregate metric must still
+        // route the sum_distinct reference through the dd CTE. Previously the
+        // fanout flow inlined the fallback SUM() into dd_base, referencing a
+        // table not in scope and producing invalid SQL.
+        test('non-aggregate referencing sum_distinct should route through dd CTE even with fanout protection', () => {
+            const result = buildQuery({
+                explore: EXPLORE_WITH_FANOUT_AND_DD_REFERENCE,
+                compiledMetricQuery: METRIC_QUERY_FANOUT_AND_DD_REFERENCE,
+                warehouseSqlBuilder: warehouseClientMock,
+                intrinsicUserAttributes: INTRINSIC_USER_ATTRIBUTES,
+                timezone: QUERY_BUILDER_UTC_TIMEZONE,
+            });
+
+            // Fanout protection is active.
+            expect(result.query).toContain('cte_unaffected');
+            expect(result.query).toContain('cte_metrics_orders');
+            // Sum_distinct has its own dd CTE.
+            expect(result.query).toContain(
+                'dd_customers_total_order_amount_deduped',
+            );
+            // dd_base wraps the fanout result.
+            expect(result.query).toContain('dd_base');
+
+            // The inlined fallback SUM referencing "orders" outside its CTE
+            // scope must NOT appear anywhere (it would be invalid SQL inside
+            // dd_base, which projects FROM cte_unaffected CROSS JOIN ...).
+            expect(result.query).not.toContain(
+                'SUM(("orders".amount))) / NULLIF',
+            );
+
+            // The non-aggregate metric must reference the dd CTE alias for
+            // its sum_distinct dependency, not raw SQL.
+            expect(result.query).toContain(
+                'dd_customers_total_order_amount_deduped."customers_total_order_amount_deduped" / NULLIF',
+            );
+
+            // customers_average_customer_lifetime_value must be projected
+            // exactly once in the final SELECT — emitting it both via
+            // dd_base.* and explicitly in the outer SELECT produces
+            // "column specified more than once" errors on most warehouses.
+            const occurrences = (
+                result.query.match(
+                    /AS "customers_average_customer_lifetime_value"/g,
+                ) ?? []
+            ).length;
+            expect(occurrences).toBe(1);
         });
     });
 

--- a/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
+++ b/packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts
@@ -1897,6 +1897,14 @@ export class MetricQueryBuilder {
                 ({ outerMetricId }) => outerMetricId,
             ),
         );
+        // Non-aggregate metrics that reference a sum_distinct/average_distinct
+        // metric must be projected from the outer dd_base SELECT (where the
+        // dd_* CTE aliases exist), not inlined into this fanout flow's
+        // finalMetricSelects. Inlining would expand the ${sum_distinct} ref
+        // to its raw fallback SUM(...) referencing tables not in scope of
+        // the dd_base CTE. See SPK-333.
+        const nonAggReferencingDd =
+            this.getNonAggregateMetricsReferencingDistinct();
         const metricsWithCteReferences: Array<CompiledMetric> = [];
         const referencedMetricObjects = metricsObjects.reduce<CompiledMetric[]>(
             (acc, metricObject) => {
@@ -1910,7 +1918,14 @@ export class MetricQueryBuilder {
                     isNonAggregateMetric(metricObject) &&
                     referencesAnotherTable
                 ) {
-                    metricsWithCteReferences.push(metricObject);
+                    // Defer dd-referencing metrics to the outer dd_base
+                    // SELECT (see nonAggReferencingDd above), but still
+                    // collect their transitively-referenced metrics so
+                    // non-dd dependencies (e.g. the count_distinct in the
+                    // denominator) still land in cte_unaffected/dd_base.
+                    if (!nonAggReferencingDd.has(getItemId(metricObject))) {
+                        metricsWithCteReferences.push(metricObject);
+                    }
                     const metricReferences = parseAllReferences(
                         metricObject.sql,
                         metricObject.table,
@@ -2306,10 +2321,19 @@ export class MetricQueryBuilder {
                 const notSumDistinct =
                     metric.type !== MetricType.SUM_DISTINCT &&
                     metric.type !== MetricType.AVERAGE_DISTINCT;
+                // Non-aggregate metrics referencing distinct metrics are
+                // projected by the outer dd_base SELECT (SPK-333). Keep
+                // them out of cte_unaffected so their broken compiledSql
+                // (which still inlines the sum_distinct as raw SUM) isn't
+                // emitted here either.
+                const notNonAggReferencingDd = !nonAggReferencingDd.has(
+                    getItemId(metric),
+                );
                 return (
                     notInMetricCtes &&
                     notMetricWithCteReferences &&
                     notSumDistinct &&
+                    notNonAggReferencingDd &&
                     !nestedAggOuterIds.has(getItemId(metric))
                 );
             });


### PR DESCRIPTION
Closes: [SPK-333](https://linear.app/lightdash/issue/SPK-333/investigate-sum-distinct-metrics-referenced-by-other-metrics)


### Before

<img width="1662" height="374" alt="CleanShot 2026-04-21 at 13 24 06" src="https://github.com/user-attachments/assets/48627e26-1ab3-410b-bda2-fbe2f3ccc6b2" />


### After


<img width="1672" height="265" alt="CleanShot 2026-04-21 at 13 22 52" src="https://github.com/user-attachments/assets/a8065425-0c07-4d73-bf24-d8c640833676" />



### Issue:   

SPK-333 — Investigate sum_distinct metrics referenced by other metrics

### Symptom: 

When a type:number metric references a sum_distinct metric AND another metric in the
query triggers fanout protection (cte_keys_/cte_metrics_/cte_unaffected), the
generated SQL projects the type:number metric inside dd_base with the sum_distinct
reference expanded to its inlined fallback `SUM("orders".amount)`. That expression
references a base table that is not in scope of the dd_base CROSS JOIN cte_unaffected
context, producing either invalid SQL or a duplicate-column error (the same metric
also showed up in the outer SELECT via nonAggDdSelects, correctly routed).
###  Root cause: 

getExperimentalMetricsCteSQL (the fanout-protection code path) pushed every
non-aggregate metric with cross-table references into metricsWithCteReferences and
then inlined their compiledSql via replaceMetricReferencesWithCteReferences. When the
referenced metric was a sum_distinct, no CTE contained it yet (the dd_* CTE is built
later), so the reference fell through to compileMetricSql and was inlined as the raw
fallback SUM. The existing fix (PR #21923) only applied to the non-fanout path via
getMetricsSQL; the fanout path was never taught about nonAggReferencingDd.
###  Fix:

packages/backend/src/utils/QueryBuilder/MetricQueryBuilder.ts:1900, 1921, 2324 —
inside getExperimentalMetricsCteSQL, compute nonAggReferencingDd and skip adding
those metrics to metricsWithCteReferences; also exclude them from unaffectedMetrics.
The referenced dependencies (e.g. unique_customer_count) are still collected into
referencedMetricObjects so they land in cte_unaffected/dd_base where the later
nonAggDdSelects logic can resolve the reference via dd_base.
###  Test:

Added unit test `non-aggregate referencing sum_distinct should route through dd CTE
even with fanout protection` + mock `EXPLORE_WITH_FANOUT_AND_DD_REFERENCE`. Test
fails without the fix (inlined SUM in dd_base body) and passes with it. Also
manually verified via the live Jaffle shop — both SPK-333 scenarios return
mathematically consistent data ($4,149.12 deduped = orders total; $41.08 CLV =
4149.12 / 101 customers). All 167 existing MetricQueryBuilder tests + 59 SQL
snapshots pass unchanged.
### Regression risk: LOW 

the change is scoped to the fanout-protection branch and gated on
`nonAggReferencingDd.has(id)`, a set already consumed correctly by the later dd CTE
flow; existing fanout-only and distinct-only paths are byte-identical via snapshots.
### Status:

          DONE


---

### Description:

Fixes a bug where a `type: number` metric referencing a `sum_distinct` metric would produce invalid SQL when another metric on the same query triggered fanout protection (i.e. the `cte_keys_`/`cte_metrics_`/`cte_unaffected` CTE flow).

Previously, when fanout protection was active, the query builder would inline the non-aggregate metric's `${sum_distinct}` reference as a raw fallback `SUM(...)` directly into `dd_base`. This was invalid because the underlying table (e.g. `"orders"`) is not in scope inside `dd_base`, which projects from `cte_unaffected CROSS JOIN ...` rather than the raw joined tables.

The fix identifies non-aggregate metrics that reference a `sum_distinct` or `average_distinct` metric and defers their projection to the outer `dd_base` SELECT, where the `dd_*` CTE aliases are in scope. Their transitive dependencies (e.g. a `count_distinct` in the denominator) are still collected so they continue to land correctly in `cte_unaffected`/`dd_base`. Additionally, these metrics are excluded from `cte_unaffected` to prevent their broken `compiledSql` from being emitted there.

A new test case (`EXPLORE_WITH_FANOUT_AND_DD_REFERENCE` / `METRIC_QUERY_FANOUT_AND_DD_REFERENCE`) covers the repro scenario: `average_customer_lifetime_value` (a `type: number` metric dividing `total_order_amount_deduped` by `unique_customer_count`) selected alongside `orders.total_order_amount` and `payments.payment_count`, both of which trigger fanout protection. The test asserts that:
- The `dd_customers_total_order_amount_deduped` CTE alias is used in the final expression rather than the raw `SUM("orders".amount)`
- `customers_average_customer_lifetime_value` is aliased exactly once in the output, avoiding "column specified more than once" errors

deploy-preview frontend-test backend-test