### PR TITLE
chore: remove beta/experimental labels from GA features

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCardOptions/index.tsx
@@ -4,7 +4,7 @@ import {
     ChartType,
     isSeriesWithMixedChartTypes,
 } from '@lightdash/common';
-import { Button, Group, Menu } from '@mantine-8/core';
+import { Button, Menu } from '@mantine-8/core';
 import {
     IconChartArea,
     IconChartAreaLine,
@@ -23,7 +23,6 @@ import {
     IconTable,
 } from '@tabler/icons-react';
 import { memo, useMemo, type FC, type ReactNode } from 'react';
-import { BetaBadge } from '../../common/BetaBadge';
 import MantineIcon from '../../common/MantineIcon';
 import {
     isBigNumberVisualizationConfig,
@@ -184,7 +183,7 @@ const VisualizationCardOptions: FC = memo(() => {
                 };
             case ChartType.MAP:
                 return {
-                    text: 'Map (Beta)',
+                    text: 'Map',
                     icon: <MantineIcon icon={IconMap} color="ldGray" />,
                 };
             case ChartType.CUSTOM:
@@ -194,7 +193,7 @@ const VisualizationCardOptions: FC = memo(() => {
                 };
             case ChartType.SANKEY:
                 return {
-                    text: 'Sankey (Beta)',
+                    text: 'Sankey',
                     icon: <MantineIcon icon={IconGitMerge} color="ldGray" />,
                 };
             default: {
@@ -436,10 +435,7 @@ const VisualizationCardOptions: FC = memo(() => {
                         setChartType(ChartType.SANKEY);
                     }}
                 >
-                    <Group gap="xs">
-                        Sankey
-                        <BetaBadge />
-                    </Group>
+                    Sankey
                 </Menu.Item>
 
                 <Menu.Item
@@ -456,10 +452,7 @@ const VisualizationCardOptions: FC = memo(() => {
                         setChartType(ChartType.MAP);
                     }}
                 >
-                    <Group gap="xs">
-                        Map
-                        <BetaBadge />
-                    </Group>
+                    Map
                 </Menu.Item>
 
                 <Menu.Item

--- a/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/SlackSettingsPanel/index.tsx
@@ -40,7 +40,6 @@ import {
 import { useActiveProjectUuid } from '../../../hooks/useActiveProject';
 import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import slackSvg from '../../../svgs/slack.svg';
-import { BetaBadge } from '../../common/BetaBadge';
 import { ComingSoonBadge } from '../../common/ComingSoonBadge';
 import { default as MantineIcon } from '../../common/MantineIcon';
 import { SettingsGridCard } from '../../common/Settings/SettingsCard';
@@ -337,9 +336,7 @@ const SlackSettingsPanel: FC = () => {
                                                     />
                                                 </Tooltip>
                                             )}
-                                            {isSlackMultiAgentChannelEnabled ? (
-                                                <BetaBadge />
-                                            ) : (
+                                            {!isSlackMultiAgentChannelEnabled && (
                                                 <ComingSoonBadge />
                                             )}
                                         </Group>

--- a/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
+++ b/packages/frontend/src/ee/features/aiCopilot/components/AiAgentFormSetup.tsx
@@ -428,19 +428,6 @@ export const AiAgentFormSetup = ({
                                                     icon={IconInfoCircle}
                                                 />
                                             </Tooltip>
-                                            <Badge
-                                                color="yellow"
-                                                radius="sm"
-                                                variant="light"
-                                                leftSection={
-                                                    <MantineIcon
-                                                        icon={IconAlertTriangle}
-                                                        size={12}
-                                                    />
-                                                }
-                                            >
-                                                Experimental
-                                            </Badge>
                                         </Group>
                                     }
                                     description={

--- a/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
+++ b/packages/frontend/src/features/metricsCatalog/components/MetricsCatalogPanel.tsx
@@ -2,14 +2,12 @@ import { subject } from '@casl/ability';
 import { CatalogCategoryFilterMode, isCompileJob } from '@lightdash/common';
 import {
     ActionIcon,
-    Badge,
     Box,
     Button,
     Group,
     Popover,
     Stack,
     Text,
-    Tooltip,
     useMantineTheme,
     type ButtonProps,
 } from '@mantine/core';
@@ -17,7 +15,6 @@ import { useClickOutside, useDisclosure } from '@mantine/hooks';
 import { IconRefresh, IconSparkles, IconX } from '@tabler/icons-react';
 import { useCallback, useEffect, useRef, useState, type FC } from 'react';
 import { useNavigate, useParams } from 'react-router';
-import { useIntercom } from 'react-use-intercom';
 import MantineIcon from '../../../components/common/MantineIcon';
 import RefreshDbtButton from '../../../components/RefreshDbtButton';
 import { useProject } from '../../../hooks/useProject';
@@ -176,7 +173,6 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
 }) => {
     const dispatch = useAppDispatch();
     const theme = useMantineTheme();
-    const { show: showIntercom } = useIntercom();
     const projectUuid = useAppSelector(
         (state) => state.metricsCatalog.projectUuid,
     );
@@ -455,44 +451,9 @@ export const MetricsCatalogPanel: FC<MetricsCatalogPanelProps> = ({
         <Stack w="100%" spacing="xxl">
             <Group position="apart">
                 <Box>
-                    <Group spacing="xs">
-                        <Text color="ldGray.8" weight={600} size="xl">
-                            Metrics Catalog
-                        </Text>
-                        <Tooltip
-                            variant="xs"
-                            label="This feature is in beta. We're actively testing and improving it—your feedback is welcome!"
-                            position="right"
-                        >
-                            <Badge
-                                variant="filled"
-                                color="indigo.5"
-                                radius={6}
-                                size="md"
-                                py="xxs"
-                                px="xs"
-                                sx={{
-                                    cursor: 'default',
-                                    boxShadow:
-                                        '0px -2px 0px 0px rgba(4, 4, 4, 0.04) inset',
-                                    '&:hover': {
-                                        cursor: 'pointer',
-                                    },
-                                }}
-                                onClick={() => {
-                                    // @ts-ignore
-                                    if (window.Pylon) {
-                                        // @ts-ignore
-                                        window.Pylon('show');
-                                    } else {
-                                        showIntercom();
-                                    }
-                                }}
-                            >
-                                Beta
-                            </Badge>
-                        </Tooltip>
-                    </Group>
+                    <Text color="ldGray.8" weight={600} size="xl">
+                        Metrics Catalog
+                    </Text>
                     <Text color="ldGray.6" size="sm" weight={400}>
                         Browse all Metrics & KPIs across this project
                     </Text>


### PR DESCRIPTION
## Summary

Remove beta/experimental labels from features that are now GA.

| Feature | Has feature flag | Status (before → after) |
|---------|-----------------|------------------------|
| Map chart | No | Beta → GA |
| Sankey chart | No | Beta → GA |
| Custom charts | No | Beta → GA |
| Metrics Catalog / Spotlight | No | Beta → GA |
| Table calculation functions | No | Experimental → GA |
| Slack multi-agent channel | Yes (`multi-agent-channel`) | Beta → GA |
| AI agent reasoning | Yes (`agent-reasoning`) | Experimental → GA |

This PR covers the **app/UI** changes only. Docs updates are handled separately.

## Test plan
- [ ] Open chart type picker — Map and Sankey no longer show "(Beta)"
- [ ] Navigate to Metrics Catalog — no beta badge next to title
- [ ] AI Agent settings — Enable Reasoning toggle has no "Experimental" badge
- [ ] Slack settings — Multi-agent channel shows no beta badge (still shows "Coming Soon" when feature flag is off)