### PR TITLE
fix: move total and subtotal calculations to AsyncQueryService

### DIFF
--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -398,7 +398,7 @@ export class ProjectController extends BaseController {
     ): Promise<ApiCalculateTotalResponse> {
         this.setStatus(200);
         const totalResult = await this.services
-            .getProjectService()
+            .getAsyncQueryService()
             .calculateTotalFromQuery(req.account!, projectUuid, body);
         return {
             status: 'ok',
@@ -421,7 +421,7 @@ export class ProjectController extends BaseController {
     ): Promise<ApiCalculateSubtotalsResponse> {
         this.setStatus(200);
         const subtotalsResult = await this.services
-            .getProjectService()
+            .getAsyncQueryService()
             .calculateSubtotalsFromQuery(req.account!, projectUuid, body);
         return {
             status: 'ok',

--- a/packages/backend/src/controllers/savedChartController.ts
+++ b/packages/backend/src/controllers/savedChartController.ts
@@ -301,7 +301,7 @@ export class SavedChartController extends BaseController {
     ): Promise<ApiCalculateTotalResponse> {
         this.setStatus(200);
         const totalResult = await this.services
-            .getProjectService()
+            .getAsyncQueryService()
             .calculateTotalFromSavedChart(
                 req.account!,
                 chartUuid,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1369,13 +1369,9 @@ export class EmbedService extends BaseService {
                 dashboardFilters,
             );
 
-        const { warehouseClient } = await this._getWarehouseClient(
-            projectUuid,
-            explore,
-        );
-
         const { userAttributes, intrinsicUserAttributes } =
             this.getAccessControls(account);
+        const filteredExplore = getFilteredExplore(explore, userAttributes);
 
         // For chart embeds, dashboardUuid is undefined - use empty parameters
         const dashboardParameters = dashboardUuid
@@ -1396,39 +1392,14 @@ export class EmbedService extends BaseService {
             dashboardParameters,
         );
 
-        const availableParameterDefinitions = await this.getAvailableParameters(
-            projectUuid,
-            explore,
-        );
-
-        const projectTimezone =
-            await this.projectService.getQueryTimezoneForProject(projectUuid);
-        const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
-        const useTimezoneAwareDateTrunc =
-            await this.projectService.isTimezoneSupportEnabled({
-                userUuid: account.user.id,
-                organizationUuid: account.organization.organizationUuid,
-            });
-
         try {
-            const { totalQuery: totalMetricQuery } =
-                await ProjectService._getCalculateTotalQuery(
-                    timezone,
-                    userAttributes,
-                    intrinsicUserAttributes,
-                    explore,
-                    metricQuery,
-                    warehouseClient,
-                    availableParameterDefinitions,
-                    combinedParameters,
-                    useTimezoneAwareDateTrunc,
-                    warehouseClient.credentials.dataTimezone,
-                );
-
-            const { rows } = await this._runEmbedQuery({
+            const row = await this.asyncQueryService.calculateMetricQueryTotal({
+                account,
                 projectUuid,
-                metricQuery: totalMetricQuery,
-                explore,
+                organizationUuid: chart.organizationUuid,
+                metricQuery,
+                explore: filteredExplore,
+                context: QueryExecutionContext.CALCULATE_TOTAL,
                 queryTags: {
                     embed: 'true',
                     external_id: account.user.id,
@@ -1439,18 +1410,19 @@ export class EmbedService extends BaseService {
                     explore_name: chart.tableName,
                     query_context: QueryExecutionContext.CALCULATE_TOTAL,
                 },
-                account,
-                timezone,
-                combinedParameters,
+                parameters: combinedParameters,
+                invalidateCache,
+                userAccessControls: {
+                    userAttributes,
+                    intrinsicUserAttributes,
+                },
             });
 
-            if (rows.length === 0) {
+            if (!row) {
                 throw new NotFoundError('No results found');
             }
 
-            const row = rows[0];
-
-            return row;
+            return row as Record<string, number>;
         } catch (e) {
             if (e instanceof NotSupportedError) {
                 this.logger.warn(e.message);
@@ -1554,66 +1526,39 @@ export class EmbedService extends BaseService {
             },
         });
 
-        const projectTimezone =
-            await this.projectService.getQueryTimezoneForProject(projectUuid);
-        const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
+        if (dimensionGroupsToSubtotal.length === 0) {
+            return {};
+        }
 
-        // Run the query for each dimension group using embed query runner
-        const subtotalsPromises = dimensionGroupsToSubtotal.map<
-            Promise<[string, Record<string, unknown>[]]>
-        >(async (subtotalDimensions) => {
-            let subtotals: Record<string, unknown>[] = [];
+        const { userAttributes, intrinsicUserAttributes } =
+            this.getAccessControls(account);
 
-            try {
-                // Use utility to create properly configured subtotal query
-                const { metricQuery: subtotalMetricQuery } =
-                    SubtotalsCalculator.createSubtotalQueryConfig(
-                        metricQuery,
-                        subtotalDimensions,
-                        pivotDimensions,
-                    );
-
-                const { rows, fields } = await this._runEmbedQuery({
-                    projectUuid,
-                    metricQuery: subtotalMetricQuery,
-                    explore,
-                    queryTags: {
-                        embed: 'true',
-                        external_id: account.user.id,
-                        project_uuid: projectUuid,
-                        organization_uuid: organizationUuid || '',
-                        chart_uuid: chartUuid || '',
-                        dashboard_uuid: dashboardUuid || '',
-                        explore_name: explore.name,
-                        query_context: QueryExecutionContext.CALCULATE_SUBTOTAL,
-                    },
-                    account,
-                    timezone,
-                    combinedParameters,
-                    dateZoomGranularity: dateZoom?.granularity,
-                });
-
-                // Format raw rows (this matches the logic in ProjectService)
-                subtotals = formatRawRows(rows, fields) as Record<
-                    string,
-                    number
-                >[];
-            } catch (e) {
-                this.logger.error(
-                    `Error running subtotal query for dimensions ${subtotalDimensions.join(
-                        ',',
-                    )}`,
-                );
-            }
-
-            return [
-                SubtotalsCalculator.getSubtotalKey(subtotalDimensions),
-                subtotals,
-            ] satisfies [string, Record<string, unknown>[]];
+        return this.asyncQueryService.calculateMetricQuerySubtotals({
+            account,
+            projectUuid,
+            organizationUuid: organizationUuid || '',
+            metricQuery,
+            explore: getFilteredExplore(explore, userAttributes),
+            context: QueryExecutionContext.CALCULATE_SUBTOTAL,
+            queryTags: {
+                embed: 'true',
+                external_id: account.user.id,
+                project_uuid: projectUuid,
+                organization_uuid: organizationUuid || '',
+                chart_uuid: chartUuid || '',
+                dashboard_uuid: dashboardUuid || '',
+                explore_name: explore.name,
+                query_context: QueryExecutionContext.CALCULATE_SUBTOTAL,
+            },
+            columnOrder,
+            pivotDimensions,
+            parameters: combinedParameters,
+            dateZoom,
+            userAccessControls: {
+                userAttributes,
+                intrinsicUserAttributes,
+            },
         });
-
-        const subtotalsEntries = await Promise.all(subtotalsPromises);
-        return SubtotalsCalculator.formatSubtotalEntries(subtotalsEntries);
     }
 
     /**
@@ -1639,13 +1584,9 @@ export class EmbedService extends BaseService {
             );
         }
 
-        const { warehouseClient } = await this._getWarehouseClient(
-            projectUuid,
-            explore,
-        );
-
         const { userAttributes, intrinsicUserAttributes } =
             this.getAccessControls(account);
+        const filteredExplore = getFilteredExplore(explore, userAttributes);
 
         // Handle parameter interactivity - only accept user parameters if enabled
         const acceptedUserParameters =
@@ -1660,42 +1601,14 @@ export class EmbedService extends BaseService {
             acceptedUserParameters,
         );
 
-        const availableParameterDefinitions = await this.getAvailableParameters(
-            projectUuid,
-            explore,
-        );
-
-        const projectTimezone =
-            await this.projectService.getQueryTimezoneForProject(projectUuid);
-        const timezone = resolveQueryTimezone(
-            data.metricQuery,
-            projectTimezone,
-        );
-        const useTimezoneAwareDateTrunc =
-            await this.projectService.isTimezoneSupportEnabled({
-                userUuid: account.user.id,
-                organizationUuid: account.organization.organizationUuid,
-            });
-
         try {
-            const { totalQuery: totalMetricQuery } =
-                await ProjectService._getCalculateTotalQuery(
-                    timezone,
-                    userAttributes,
-                    intrinsicUserAttributes,
-                    explore,
-                    data.metricQuery,
-                    warehouseClient,
-                    availableParameterDefinitions,
-                    combinedParameters,
-                    useTimezoneAwareDateTrunc,
-                    warehouseClient.credentials.dataTimezone,
-                );
-
-            const { rows } = await this._runEmbedQuery({
+            const row = await this.asyncQueryService.calculateMetricQueryTotal({
+                account,
                 projectUuid,
-                metricQuery: totalMetricQuery,
-                explore,
+                organizationUuid,
+                metricQuery: data.metricQuery,
+                explore: filteredExplore,
+                context: QueryExecutionContext.CALCULATE_TOTAL,
                 queryTags: {
                     embed: 'true',
                     external_id: account.user.id,
@@ -1705,16 +1618,18 @@ export class EmbedService extends BaseService {
                     explore_name: data.explore,
                     query_context: QueryExecutionContext.CALCULATE_TOTAL,
                 },
-                account,
-                timezone,
-                combinedParameters,
+                parameters: combinedParameters,
+                userAccessControls: {
+                    userAttributes,
+                    intrinsicUserAttributes,
+                },
             });
 
-            if (rows.length === 0) {
+            if (!row) {
                 throw new NotFoundError('No results found');
             }
 
-            return rows[0] as Record<string, number>;
+            return row as Record<string, number>;
         } catch (e) {
             if (e instanceof NotSupportedError) {
                 this.logger.warn(e.message);

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1,7 +1,9 @@
+import { Ability } from '@casl/ability';
 import {
     AnyType,
     DimensionType,
     ExploreType,
+    FilterOperator,
     ForbiddenError,
     NotFoundError,
     QueryExecutionContext,
@@ -11,6 +13,7 @@ import {
     WarehouseTypes,
     type CreateWarehouseCredentials,
     type ExecuteAsyncQueryRequestParams,
+    type PossibleAbilities,
     type QueryHistory,
     type ResultColumns,
     type WarehouseClient,
@@ -63,6 +66,7 @@ import { PersistentDownloadFileService } from '../PersistentDownloadFileService/
 import { PivotTableService } from '../PivotTableService/PivotTableService';
 import {
     allExplores,
+    buildAccount,
     expectedColumns,
     expectedFormattedRow,
     job,
@@ -268,6 +272,9 @@ const getMockedAsyncQueryService = (
         spacePermissionService: {} as SpacePermissionService,
         ...overrides,
     });
+
+const getJsonlStream = (rows: Record<string, unknown>[]) =>
+    Readable.from(rows.map((row) => `${JSON.stringify(row)}\n`).join(''));
 
 describe('AsyncQueryService', () => {
     describe('executeAsyncQuery', () => {
@@ -2169,6 +2176,268 @@ describe('AsyncQueryService', () => {
                         invalidateCache: false,
                     }),
                 ).rejects.toThrow();
+            });
+        });
+
+        describe('legacy total and subtotal flows', () => {
+            beforeEach(() => {
+                jest.clearAllMocks();
+            });
+
+            it('routes raw calculate total through async query history instead of runQuery', async () => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+                const warehouseClient = {
+                    ...warehouseClientMock,
+                    runQuery: jest.fn(),
+                    executeAsyncQuery: jest.fn(
+                        warehouseClientMock.executeAsyncQuery,
+                    ),
+                };
+
+                (
+                    projectModel.getWarehouseClientFromCredentials as jest.Mock
+                ).mockReturnValue(warehouseClient);
+                service.pollForQueryCompletion = jest
+                    .fn()
+                    .mockResolvedValue(undefined);
+                (service.queryHistoryModel.get as jest.Mock).mockResolvedValue({
+                    context: QueryExecutionContext.CALCULATE_TOTAL,
+                    resultsFileName: 'results.jsonl',
+                    pivotConfiguration: null,
+                    pivotValuesColumns: null,
+                    pivotTotalColumnCount: null,
+                    originalColumns: null,
+                } satisfies Partial<QueryHistory>);
+                (
+                    service.resultsStorageClient.getDownloadStream as jest.Mock
+                ).mockReturnValue(getJsonlStream([{ a_met1: '123' }]));
+
+                const result = await service.calculateTotalFromQuery(
+                    sessionAccount,
+                    projectUuid,
+                    {
+                        explore: validExplore.name,
+                        metricQuery: metricQueryMock,
+                    },
+                );
+
+                expect(result).toEqual({ a_met1: '123' });
+                expect(service.queryHistoryModel.create).toHaveBeenCalled();
+                expect(warehouseClient.executeAsyncQuery).toHaveBeenCalled();
+                expect(warehouseClient.runQuery).not.toHaveBeenCalled();
+            });
+
+            it('falls back to warehouse async results when totals have no results file', async () => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+                const warehouseClient = {
+                    ...warehouseClientMock,
+                    runQuery: jest.fn(),
+                    getAsyncQueryResults: jest.fn(async () => ({
+                        queryId: null,
+                        fields: { a_met1: { type: DimensionType.STRING } },
+                        pageCount: 1,
+                        totalRows: 1,
+                        rows: [{ a_met1: '789' }],
+                    })),
+                    executeAsyncQuery: jest.fn(
+                        warehouseClientMock.executeAsyncQuery,
+                    ),
+                };
+
+                (
+                    projectModel.getWarehouseClientFromCredentials as jest.Mock
+                ).mockReturnValue(warehouseClient);
+                service.pollForQueryCompletion = jest
+                    .fn()
+                    .mockResolvedValue(undefined);
+                (service.queryHistoryModel.get as jest.Mock).mockResolvedValue({
+                    queryUuid: 'queryUuid',
+                    projectUuid,
+                    context: QueryExecutionContext.CALCULATE_TOTAL,
+                    resultsFileName: null,
+                    totalRowCount: 1,
+                    compiledSql: 'SELECT 1',
+                    warehouseQueryId: null,
+                    warehouseQueryMetadata: null,
+                    pivotConfiguration: null,
+                    pivotValuesColumns: null,
+                    pivotTotalColumnCount: null,
+                    originalColumns: null,
+                } satisfies Partial<QueryHistory>);
+
+                const result = await service.calculateTotalFromQuery(
+                    sessionAccount,
+                    projectUuid,
+                    {
+                        explore: validExplore.name,
+                        metricQuery: metricQueryMock,
+                    },
+                );
+
+                expect(result).toEqual({ a_met1: '789' });
+                expect(service.queryHistoryModel.create).toHaveBeenCalled();
+                expect(warehouseClient.executeAsyncQuery).toHaveBeenCalled();
+                expect(warehouseClient.getAsyncQueryResults).toHaveBeenCalled();
+                expect(warehouseClient.runQuery).not.toHaveBeenCalled();
+            });
+
+            it('preserves dashboard filters and parameter precedence for saved chart totals', async () => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+                const account = buildAccount();
+                account.user.ability = new Ability<PossibleAbilities>([
+                    { subject: 'Project', action: ['view'] },
+                    { subject: 'Explore', action: ['manage'] },
+                    { subject: 'SavedChart', action: ['view'] },
+                ]);
+
+                const warehouseClient = {
+                    ...warehouseClientMock,
+                    runQuery: jest.fn(),
+                    executeAsyncQuery: jest.fn(
+                        warehouseClientMock.executeAsyncQuery,
+                    ),
+                };
+
+                (
+                    projectModel.getWarehouseClientFromCredentials as jest.Mock
+                ).mockReturnValue(warehouseClient);
+                (service as AnyType).savedChartModel = {
+                    get: jest.fn().mockResolvedValue({
+                        uuid: 'chart-1',
+                        organizationUuid: projectSummary.organizationUuid,
+                        projectUuid,
+                        spaceUuid: 'space-1',
+                        tableName: validExplore.name,
+                        metricQuery: metricQueryMock,
+                        parameters: {
+                            saved_only: 'saved',
+                            clash: 'saved',
+                        },
+                    }),
+                };
+                (service as AnyType).spacePermissionService = {
+                    getSpaceAccessContext: jest.fn().mockResolvedValue({
+                        organizationUuid: projectSummary.organizationUuid,
+                        projectUuid,
+                        inheritsFromOrgOrProject: true,
+                        access: [],
+                    }),
+                };
+                service.pollForQueryCompletion = jest
+                    .fn()
+                    .mockResolvedValue(undefined);
+                (service.queryHistoryModel.get as jest.Mock).mockResolvedValue({
+                    context: QueryExecutionContext.CALCULATE_TOTAL,
+                    resultsFileName: 'results.jsonl',
+                    pivotConfiguration: null,
+                    pivotValuesColumns: null,
+                    pivotTotalColumnCount: null,
+                    originalColumns: null,
+                } satisfies Partial<QueryHistory>);
+                (
+                    service.resultsStorageClient.getDownloadStream as jest.Mock
+                ).mockReturnValue(getJsonlStream([{ a_met1: '456' }]));
+
+                await service.calculateTotalFromSavedChart(
+                    account,
+                    'chart-1',
+                    {
+                        dimensions: [
+                            {
+                                id: 'filter-1',
+                                target: {
+                                    fieldId: 'a_dim1',
+                                    tableName: 'a',
+                                },
+                                operator: FilterOperator.EQUALS,
+                                values: ['foo'],
+                                settings: {},
+                            },
+                        ],
+                        metrics: [],
+                        tableCalculations: [],
+                    } as AnyType,
+                    false,
+                    {
+                        clash: 'request',
+                    },
+                );
+
+                const createCall = (
+                    service.queryHistoryModel.create as jest.Mock
+                ).mock.calls[0][1];
+
+                expect(createCall.metricQuery.filters.dimensions).toEqual(
+                    expect.objectContaining({
+                        and: [
+                            expect.objectContaining({
+                                target: expect.objectContaining({
+                                    fieldId: 'a_dim1',
+                                }),
+                            }),
+                        ],
+                    }),
+                );
+                expect(createCall.requestParameters.parameters).toEqual(
+                    expect.objectContaining({
+                        saved_only: 'saved',
+                        clash: 'request',
+                    }),
+                );
+            });
+
+            it('returns subtotals in the legacy formatted shape through async execution', async () => {
+                const service = getMockedAsyncQueryService(lightdashConfigMock);
+                const warehouseClient = {
+                    ...warehouseClientMock,
+                    runQuery: jest.fn(),
+                    executeAsyncQuery: jest.fn(
+                        warehouseClientMock.executeAsyncQuery,
+                    ),
+                };
+
+                (
+                    projectModel.getWarehouseClientFromCredentials as jest.Mock
+                ).mockReturnValue(warehouseClient);
+                service.pollForQueryCompletion = jest
+                    .fn()
+                    .mockResolvedValue(undefined);
+                (service.queryHistoryModel.get as jest.Mock).mockResolvedValue({
+                    context: QueryExecutionContext.CALCULATE_SUBTOTAL,
+                    resultsFileName: 'results.jsonl',
+                    pivotConfiguration: null,
+                    pivotValuesColumns: null,
+                    pivotTotalColumnCount: null,
+                    originalColumns: null,
+                } satisfies Partial<QueryHistory>);
+                (
+                    service.resultsStorageClient.getDownloadStream as jest.Mock
+                ).mockReturnValue(
+                    getJsonlStream([{ a_dim1: 'group-1', a_met1: '123' }]),
+                );
+
+                const result = await service.calculateSubtotalsFromQuery(
+                    sessionAccount,
+                    projectUuid,
+                    {
+                        explore: validExplore.name,
+                        metricQuery: {
+                            ...metricQueryMock,
+                            dimensions: ['a_dim1', 'b_dim1'],
+                            tableCalculations: [],
+                        },
+                        columnOrder: ['a_dim1', 'b_dim1', 'a_met1'],
+                    },
+                );
+
+                expect(result).toEqual({
+                    a_dim1: [{ a_dim1: 'group-1', a_met1: '123' }],
+                });
+                expect(service.queryHistoryModel.create).toHaveBeenCalledTimes(
+                    1,
+                );
+                expect(warehouseClient.executeAsyncQuery).toHaveBeenCalled();
+                expect(warehouseClient.runQuery).not.toHaveBeenCalled();
             });
         });
     });

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -8,6 +8,8 @@ import {
     ApiPreAggregateStatsResults,
     assertIsAccountWithOrg,
     assertUnreachable,
+    CalculateSubtotalsFromQuery,
+    CalculateTotalFromQuery,
     CompiledDimension,
     convertCustomFormatToFormatExpression,
     convertFieldRefToFieldId,
@@ -25,10 +27,13 @@ import {
     ExploreCompiler,
     ExploreType,
     FieldType,
+    flattenFilterGroup,
     ForbiddenError,
     formatItemValue,
+    formatRawRows,
     formatRawValue,
     formatRow,
+    getDashboardFilterRulesForTables,
     getDashboardFilterRulesForTileAndReferences,
     getDashboardFiltersForTileAndTables,
     getDimensions,
@@ -57,6 +62,7 @@ import {
     MetricQuery,
     normalizeIndexColumns,
     NotFoundError,
+    NotSupportedError,
     ParameterError,
     ParseError,
     PivotConfig,
@@ -137,6 +143,7 @@ import {
     applyLimitToSqlQuery,
     replaceUserAttributesAsStrings,
 } from '../../utils/QueryBuilder/utils';
+import { SubtotalsCalculator } from '../../utils/SubtotalsCalculator';
 import type { ICacheService } from '../CacheService/ICacheService';
 import { CreateCacheResult } from '../CacheService/types';
 import { CsvService } from '../CsvService/CsvService';
@@ -2775,7 +2782,7 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
-    async executeAsyncQuery(
+    private async executePreparedAsyncQuery(
         // TODO: remove metric query, fields, etc from args once they are no longer needed in the database
         args: ExecuteAsyncMetricQueryArgs & {
             queryTags: RunQueryTags;
@@ -2791,6 +2798,7 @@ export class AsyncQueryService extends ProjectService {
             availableParameterDefinitions?: ParameterDefinitions;
         },
         requestParameters: ExecuteAsyncQueryRequestParams,
+        organizationUuid: string,
     ): Promise<ExecuteAsyncQueryReturn> {
         return wrapSentryTransaction(
             'ProjectService.executeAsyncQuery',
@@ -2819,29 +2827,6 @@ export class AsyncQueryService extends ProjectService {
 
                 try {
                     assertIsAccountWithOrg(account);
-
-                    const { organizationUuid } =
-                        await this.projectModel.getSummary(projectUuid);
-                    const isForbidden =
-                        account.user.ability.cannot(
-                            'view',
-                            subject('Project', {
-                                organizationUuid,
-                                projectUuid,
-                            }),
-                        ) &&
-                        account.user.ability.cannot(
-                            'view',
-                            subject('Explore', {
-                                organizationUuid,
-                                projectUuid,
-                                exploreNames: [explore.name],
-                            }),
-                        );
-
-                    if (isForbidden) {
-                        throw new ForbiddenError();
-                    }
 
                     // Once we remove the feature flag we won't need to fetch the credentials here, they will only be fetched in the scheduler task
                     const warehouseCredentials =
@@ -3337,6 +3322,56 @@ export class AsyncQueryService extends ProjectService {
                     span.end();
                 }
             },
+        );
+    }
+
+    async executeAsyncQuery(
+        // TODO: remove metric query, fields, etc from args once they are no longer needed in the database
+        args: ExecuteAsyncMetricQueryArgs & {
+            queryTags: RunQueryTags;
+            explore: Explore;
+            fields: ItemsMap;
+            sql: string; // SQL generated from metric query or provided by user
+            originalColumns?: ResultColumns;
+            missingParameterReferences: string[];
+            timezone?: string;
+            routingTarget?: PreAggregationRoutingDecision['target'];
+            preAggregationRoute?: PreAggregationRoute;
+            userAccessControls?: UserAccessControls;
+            availableParameterDefinitions?: ParameterDefinitions;
+        },
+        requestParameters: ExecuteAsyncQueryRequestParams,
+    ): Promise<ExecuteAsyncQueryReturn> {
+        assertIsAccountWithOrg(args.account);
+
+        const { organizationUuid } = await this.projectModel.getSummary(
+            args.projectUuid,
+        );
+        const isForbidden =
+            args.account.user.ability.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid: args.projectUuid,
+                }),
+            ) &&
+            args.account.user.ability.cannot(
+                'view',
+                subject('Explore', {
+                    organizationUuid,
+                    projectUuid: args.projectUuid,
+                    exploreNames: [args.explore.name],
+                }),
+            );
+
+        if (isForbidden) {
+            throw new ForbiddenError();
+        }
+
+        return this.executePreparedAsyncQuery(
+            args,
+            requestParameters,
+            organizationUuid,
         );
     }
 
@@ -5089,6 +5124,33 @@ export class AsyncQueryService extends ProjectService {
             ...pollingOptions,
         });
 
+        return this.getReadyQueryResults({
+            account,
+            projectUuid,
+            queryUuid,
+            cacheMetadata,
+            fields,
+        });
+    }
+
+    private async getReadyQueryResults({
+        account,
+        projectUuid,
+        queryUuid,
+        cacheMetadata,
+        fields,
+    }: {
+        account: Account;
+        projectUuid: string;
+        queryUuid: string;
+        cacheMetadata: CacheMetadata;
+        fields: ItemsMap;
+    }): Promise<{
+        rows: Record<string, unknown>[];
+        cacheMetadata: CacheMetadata;
+        fields: ItemsMap;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+    }> {
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
             projectUuid,
@@ -5116,6 +5178,191 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    private static getCalculateTotalMetricQuery(
+        metricQuery: MetricQuery,
+    ): MetricQuery {
+        const totalQuery: MetricQuery = {
+            ...metricQuery,
+            limit: 1,
+            tableCalculations: [],
+            sorts: [],
+            dimensions: [],
+            customDimensions: metricQuery.customDimensions,
+            metrics: metricQuery.metrics,
+            additionalMetrics: metricQuery.additionalMetrics,
+        };
+
+        const hasMetricFilters =
+            !!totalQuery.filters.metrics &&
+            flattenFilterGroup(totalQuery.filters.metrics).length > 0;
+        const hasTableCalculationFilters =
+            !!totalQuery.filters.tableCalculations &&
+            flattenFilterGroup(totalQuery.filters.tableCalculations).length > 0;
+
+        if (hasMetricFilters || hasTableCalculationFilters) {
+            throw new NotSupportedError(
+                'Totals cannot be correctly calculated with metric filters or table calculation filters',
+            );
+        }
+
+        return totalQuery;
+    }
+
+    async executeMetricQueryAndGetResultsFromExplore({
+        account,
+        projectUuid,
+        organizationUuid,
+        metricQuery,
+        explore,
+        context,
+        queryTags,
+        parameters,
+        dateZoom,
+        invalidateCache,
+        userAccessControls,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        metricQuery: MetricQuery;
+        explore: Explore;
+        context: QueryExecutionContext;
+        queryTags: RunQueryTags & {
+            embed?: string;
+            external_id?: string;
+            chart_uuid?: string;
+            dashboard_uuid?: string;
+        };
+        parameters?: ParametersValuesMap;
+        dateZoom?: ExecuteAsyncMetricQueryArgs['dateZoom'];
+        invalidateCache?: boolean;
+        userAccessControls?: UserAccessControls;
+    }): Promise<{
+        rows: Record<string, unknown>[];
+        cacheMetadata: CacheMetadata;
+        fields: ItemsMap;
+        pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+    }> {
+        const warehouseCredentials = await this.getWarehouseCredentials({
+            projectUuid,
+            userId: account.user.id,
+            isRegisteredUser: account.isRegisteredUser(),
+            isServiceAccount: account.isServiceAccount(),
+        });
+
+        const warehouseSqlBuilder = warehouseSqlBuilderFromType(
+            warehouseCredentials.type,
+            warehouseCredentials.startOfWeek,
+        );
+
+        const {
+            sql,
+            fields,
+            missingParameterReferences,
+            userAccessControls: resolvedUserAccessControls,
+            availableParameterDefinitions,
+            resolvedTimezone,
+        } = await this.prepareMetricQueryAsyncQueryArgs({
+            account,
+            metricQuery,
+            dateZoom,
+            explore,
+            warehouseSqlBuilder,
+            parameters,
+            projectUuid,
+            materializationRole: userAccessControls,
+            dataTimezone: warehouseCredentials.dataTimezone,
+        });
+
+        const routingDecision = this.getPreAggregationRoutingDecision({
+            metricQuery,
+            explore,
+            context,
+            forceWarehouse: false,
+        });
+
+        if (routingDecision.preAggregateMetadata) {
+            this.prometheusMetrics?.incrementPreAggregateMatch(
+                routingDecision.preAggregateMetadata.hit,
+                routingDecision.preAggregateMetadata.reason?.reason,
+            );
+        }
+
+        const { queryUuid, cacheMetadata } =
+            await this.executePreparedAsyncQuery(
+                {
+                    account,
+                    projectUuid,
+                    explore,
+                    metricQuery,
+                    context,
+                    queryTags,
+                    invalidateCache,
+                    dateZoom,
+                    parameters,
+                    fields,
+                    sql,
+                    originalColumns: undefined,
+                    missingParameterReferences,
+                    timezone: resolvedTimezone,
+                    routingTarget: routingDecision.target,
+                    ...(routingDecision.target === 'pre_aggregate' && {
+                        preAggregationRoute: routingDecision.route,
+                        userAccessControls: resolvedUserAccessControls,
+                        availableParameterDefinitions,
+                    }),
+                },
+                {
+                    context,
+                    query: metricQuery,
+                    parameters,
+                },
+                organizationUuid,
+            );
+
+        await this.pollForQueryCompletion({
+            account,
+            projectUuid,
+            queryUuid,
+        });
+
+        const queryHistory = await this.queryHistoryModel.get(
+            queryUuid,
+            projectUuid,
+            account,
+        );
+
+        if (!queryHistory.resultsFileName) {
+            // Some self-hosted installs disable results-file storage, so the
+            // async query still completes but there is no file to download.
+            const { rows } = await this.getResultsPageFromWarehouse(
+                account,
+                queryHistory,
+                1,
+                Math.max(queryHistory.totalRowCount ?? 0, 1),
+                (row) => row as ResultRow,
+            );
+
+            return {
+                rows,
+                cacheMetadata,
+                fields,
+                pivotDetails:
+                    AsyncQueryService.getPivotDetailsFromQueryHistory(
+                        queryHistory,
+                    ),
+            };
+        }
+
+        return this.getReadyQueryResults({
+            account,
+            projectUuid,
+            queryUuid,
+            cacheMetadata,
+            fields,
+        });
+    }
+
     /**
      * Execute saved chart query and wait for all results.
      * Returns raw rows from warehouse with pivot details.
@@ -5141,31 +5388,13 @@ export class AsyncQueryService extends ProjectService {
             ...pollingOptions,
         });
 
-        const queryHistory = await this.queryHistoryModel.get(
-            queryUuid,
-            projectUuid,
+        return this.getReadyQueryResults({
             account,
-        );
-
-        const resultsStream = await this.getResultsStorageClientForContext(
-            queryHistory.context,
-        ).getDownloadStream(queryHistory.resultsFileName!);
-
-        const rows: Record<string, unknown>[] = [];
-        await streamJsonlData<void>({
-            readStream: resultsStream,
-            onRow: (rawRow) => {
-                rows.push(rawRow);
-            },
-        });
-
-        return {
-            rows,
+            projectUuid,
+            queryUuid,
             cacheMetadata,
             fields,
-            pivotDetails:
-                AsyncQueryService.getPivotDetailsFromQueryHistory(queryHistory),
-        };
+        });
     }
 
     /**
@@ -5244,31 +5473,405 @@ export class AsyncQueryService extends ProjectService {
             ...pollingOptions,
         });
 
-        const queryHistory = await this.queryHistoryModel.get(
-            queryUuid,
-            projectUuid,
+        return this.getReadyQueryResults({
             account,
+            projectUuid,
+            queryUuid,
+            cacheMetadata,
+            fields,
+        });
+    }
+
+    async calculateMetricQueryTotal({
+        account,
+        projectUuid,
+        organizationUuid,
+        metricQuery,
+        explore,
+        context,
+        queryTags,
+        parameters,
+        invalidateCache,
+        userAccessControls,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        metricQuery: MetricQuery;
+        explore: Explore;
+        context: QueryExecutionContext;
+        queryTags: RunQueryTags & {
+            embed?: string;
+            external_id?: string;
+            chart_uuid?: string;
+            dashboard_uuid?: string;
+        };
+        parameters?: ParametersValuesMap;
+        invalidateCache?: boolean;
+        userAccessControls?: UserAccessControls;
+    }): Promise<Record<string, unknown> | undefined> {
+        const totalMetricQuery =
+            AsyncQueryService.getCalculateTotalMetricQuery(metricQuery);
+
+        const { rows } = await this.executeMetricQueryAndGetResultsFromExplore({
+            account,
+            projectUuid,
+            organizationUuid,
+            metricQuery: totalMetricQuery,
+            explore,
+            context,
+            queryTags,
+            parameters,
+            invalidateCache,
+            userAccessControls,
+        });
+
+        return rows[0];
+    }
+
+    async calculateMetricQuerySubtotals({
+        account,
+        projectUuid,
+        organizationUuid,
+        metricQuery,
+        explore,
+        context,
+        queryTags,
+        columnOrder,
+        pivotDimensions,
+        parameters,
+        dateZoom,
+        userAccessControls,
+    }: {
+        account: Account;
+        projectUuid: string;
+        organizationUuid: string;
+        metricQuery: MetricQuery;
+        explore: Explore;
+        context: QueryExecutionContext;
+        queryTags: RunQueryTags & {
+            embed?: string;
+            external_id?: string;
+            chart_uuid?: string;
+            dashboard_uuid?: string;
+        };
+        columnOrder: string[];
+        pivotDimensions?: string[];
+        parameters?: ParametersValuesMap;
+        dateZoom?: ExecuteAsyncMetricQueryArgs['dateZoom'];
+        userAccessControls?: UserAccessControls;
+    }) {
+        const { dimensionGroupsToSubtotal } =
+            SubtotalsCalculator.prepareDimensionGroups(
+                metricQuery,
+                columnOrder,
+                pivotDimensions,
+            );
+
+        const subtotalsPromises = dimensionGroupsToSubtotal.map<
+            Promise<[string, Record<string, unknown>[]]>
+        >(async (subtotalDimensions) => {
+            let subtotals: Record<string, unknown>[] = [];
+
+            try {
+                const { metricQuery: subtotalMetricQuery } =
+                    SubtotalsCalculator.createSubtotalQueryConfig(
+                        metricQuery,
+                        subtotalDimensions,
+                        pivotDimensions,
+                    );
+
+                const { rows, fields } =
+                    await this.executeMetricQueryAndGetResultsFromExplore({
+                        account,
+                        projectUuid,
+                        organizationUuid,
+                        metricQuery: subtotalMetricQuery,
+                        explore,
+                        context,
+                        queryTags,
+                        parameters,
+                        dateZoom,
+                        userAccessControls,
+                    });
+
+                subtotals = formatRawRows(rows, fields);
+            } catch (e) {
+                this.logger.error(
+                    `Error running subtotal query for dimensions ${subtotalDimensions.join(
+                        ',',
+                    )}`,
+                );
+            }
+
+            return [
+                SubtotalsCalculator.getSubtotalKey(subtotalDimensions),
+                subtotals,
+            ] satisfies [string, Record<string, unknown>[]];
+        });
+
+        const subtotalsEntries = await Promise.all(subtotalsPromises);
+        return SubtotalsCalculator.formatSubtotalEntries(subtotalsEntries);
+    }
+
+    async calculateTotalFromSavedChart(
+        account: Account,
+        chartUuid: string,
+        dashboardFilters?: DashboardFilters,
+        invalidateCache: boolean = false,
+        parameters?: ParametersValuesMap,
+    ) {
+        assertIsAccountWithOrg(account);
+
+        const savedChart = await this.savedChartModel.get(chartUuid, undefined);
+        const { organizationUuid, projectUuid } = savedChart;
+
+        const explore = await this.getExplore(
+            account,
+            projectUuid,
+            savedChart.tableName,
+            organizationUuid,
+        );
+        const availableFieldIds = [
+            ...getDimensions(explore)
+                .filter((f) => isFilterableDimension(f) && !f.hidden)
+                .map(getItemId),
+            ...getMetrics(explore)
+                .filter((f) => !f.hidden)
+                .map(getItemId),
+        ];
+
+        const appliedDashboardFilters = dashboardFilters
+            ? {
+                  dimensions: getDashboardFilterRulesForTables(
+                      availableFieldIds,
+                      dashboardFilters.dimensions,
+                  ),
+                  metrics: getDashboardFilterRulesForTables(
+                      availableFieldIds,
+                      dashboardFilters.metrics,
+                  ),
+                  tableCalculations: getDashboardFilterRulesForTables(
+                      availableFieldIds,
+                      dashboardFilters.tableCalculations,
+                  ),
+              }
+            : undefined;
+
+        const metricQuery: MetricQuery = appliedDashboardFilters
+            ? addDashboardFiltersToMetricQuery(
+                  savedChart.metricQuery,
+                  appliedDashboardFilters,
+              )
+            : savedChart.metricQuery;
+
+        const spaceCtx =
+            await this.spacePermissionService.getSpaceAccessContext(
+                account.user.id,
+                savedChart.spaceUuid,
+            );
+
+        if (
+            account.user.ability.cannot(
+                'view',
+                subject('SavedChart', spaceCtx),
+            ) ||
+            account.user.ability.cannot(
+                'view',
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        const combinedParameters = await this.combineParameters(
+            projectUuid,
+            explore,
+            parameters,
+            savedChart.parameters,
         );
 
-        const resultsStream = await this.getResultsStorageClientForContext(
-            queryHistory.context,
-        ).getDownloadStream(queryHistory.resultsFileName!);
+        try {
+            return (await this.calculateMetricQueryTotal({
+                account,
+                projectUuid,
+                organizationUuid: savedChart.organizationUuid,
+                metricQuery,
+                explore,
+                context: QueryExecutionContext.CALCULATE_TOTAL,
+                queryTags: {
+                    ...this.getUserQueryTags(account),
+                    organization_uuid: savedChart.organizationUuid,
+                    project_uuid: projectUuid,
+                    explore_name: explore.name,
+                    query_context: QueryExecutionContext.CALCULATE_TOTAL,
+                },
+                parameters: combinedParameters,
+                invalidateCache,
+            })) as Record<string, number>;
+        } catch (e) {
+            if (e instanceof NotSupportedError) {
+                this.logger.warn(e.message);
+                return {};
+            }
+            throw e;
+        }
+    }
 
-        const rows: Record<string, unknown>[] = [];
-        await streamJsonlData<void>({
-            readStream: resultsStream,
-            onRow: (rawRow) => {
-                rows.push(rawRow);
+    async calculateTotalFromQuery(
+        account: Account,
+        projectUuid: string,
+        data: CalculateTotalFromQuery,
+    ) {
+        assertIsAccountWithOrg(account);
+
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+
+        if (
+            account.user.ability.cannot(
+                'manage',
+                subject('Explore', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (
+            data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
+            account.user.ability.cannot(
+                'manage',
+                subject('CustomFields', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new CustomSqlQueryForbiddenError();
+        }
+
+        const explore = await this.getExplore(
+            account,
+            projectUuid,
+            data.explore,
+            organizationUuid,
+        );
+
+        const combinedParameters = await this.combineParameters(
+            projectUuid,
+            explore,
+            data.parameters,
+        );
+
+        try {
+            return (await this.calculateMetricQueryTotal({
+                account,
+                projectUuid,
+                organizationUuid,
+                metricQuery: data.metricQuery,
+                explore,
+                context: QueryExecutionContext.CALCULATE_TOTAL,
+                queryTags: {
+                    ...this.getUserQueryTags(account),
+                    organization_uuid: account.organization.organizationUuid,
+                    project_uuid: projectUuid,
+                    explore_name: data.explore,
+                    query_context: QueryExecutionContext.CALCULATE_TOTAL,
+                },
+                parameters: combinedParameters,
+            })) as Record<string, number>;
+        } catch (e) {
+            if (e instanceof NotSupportedError) {
+                this.logger.warn(e.message);
+                return {};
+            }
+            throw e;
+        }
+    }
+
+    async calculateSubtotalsFromQuery(
+        account: Account,
+        projectUuid: string,
+        data: CalculateSubtotalsFromQuery,
+    ) {
+        assertIsAccountWithOrg(account);
+
+        const { organizationUuid } =
+            await this.projectModel.getSummary(projectUuid);
+
+        if (
+            account.user.ability.cannot(
+                'manage',
+                subject('Explore', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (
+            data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
+            account.user.ability.cannot(
+                'manage',
+                subject('CustomFields', { organizationUuid, projectUuid }),
+            )
+        ) {
+            throw new CustomSqlQueryForbiddenError();
+        }
+
+        const explore = await this.getExplore(
+            account,
+            projectUuid,
+            data.explore,
+            organizationUuid,
+        );
+
+        const combinedParameters = await this.combineParameters(
+            projectUuid,
+            explore,
+            data.parameters,
+        );
+
+        const { dimensionGroupsToSubtotal, analyticsData } =
+            SubtotalsCalculator.prepareDimensionGroups(
+                data.metricQuery,
+                data.columnOrder,
+                data.pivotDimensions,
+            );
+
+        this.analytics.trackAccount(account, {
+            event: 'query.subtotal',
+            properties: {
+                context: QueryExecutionContext.CALCULATE_SUBTOTAL,
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                exploreName: data.explore,
+                ...analyticsData,
             },
         });
 
-        return {
-            rows,
-            cacheMetadata,
-            fields,
-            pivotDetails:
-                AsyncQueryService.getPivotDetailsFromQueryHistory(queryHistory),
-        };
+        if (dimensionGroupsToSubtotal.length === 0) {
+            return {};
+        }
+
+        return this.calculateMetricQuerySubtotals({
+            account,
+            projectUuid,
+            organizationUuid,
+            metricQuery: data.metricQuery,
+            explore,
+            context: QueryExecutionContext.CALCULATE_SUBTOTAL,
+            queryTags: {
+                ...this.getUserQueryTags(account),
+                organization_uuid: account.organization.organizationUuid,
+                project_uuid: projectUuid,
+                explore_name: data.explore,
+                query_context: QueryExecutionContext.CALCULATE_SUBTOTAL,
+            },
+            columnOrder: data.columnOrder,
+            pivotDimensions: data.pivotDimensions,
+            parameters: combinedParameters,
+            dateZoom: data.dateZoom,
+        });
     }
 
     async getPreAggregateStats(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -17,7 +17,6 @@ import {
     BigqueryAuthenticationType,
     CacheMetadata,
     calculateCompilationReport,
-    CalculateTotalFromQuery,
     ChartSourceType,
     ChartSummary,
     CompiledDimension,
@@ -58,13 +57,8 @@ import {
     ExploreType,
     FeatureFlags,
     FilterableDimension,
-    FilterGroupItem,
-    FilterOperator,
-    findFieldByIdInExplore,
     findReplaceableCustomMetrics,
-    flattenFilterGroup,
     ForbiddenError,
-    formatRawRows,
     formatRows,
     getAllDimensionsMap,
     getAvailableParametersFromTables,
@@ -86,10 +80,8 @@ import {
     isCartesianChartConfig,
     isCustomSqlDimension,
     isDateItem,
-    isDimension,
     isExploreError,
     isFilterableDimension,
-    isFilterRule,
     isJwtUser,
     isNotNull,
     isStandardDateGranularity,
@@ -113,7 +105,6 @@ import {
     MostPopularAndRecentlyUpdated,
     normalizeIndexColumns,
     NotFoundError,
-    NotSupportedError,
     OpenIdIdentityIssuerType,
     ParameterError,
     PivotChartData,
@@ -136,7 +127,6 @@ import {
     ReplaceCustomFieldsPayload,
     replaceDimensionInExplore,
     RequestMethod,
-    resolveBaseDimension,
     resolveQueryTimezone,
     resolveToBaseTimeDimension,
     ResultRow,
@@ -163,9 +153,7 @@ import {
     UserAccessControls,
     UserAttributeValueMap,
     UserWarehouseCredentials,
-    ValuesColumn,
     VizColumn,
-    VizIndexType,
     WarehouseClient,
     WarehouseConnectionError,
     WarehouseCredentials,
@@ -173,7 +161,6 @@ import {
     WarehouseTableSchema,
     WarehouseTypes,
     type ApiCreateProjectResults,
-    type CalculateSubtotalsFromQuery,
     type CreateDatabricksCredentials,
     type Metric,
     type ParameterDefinitions,
@@ -6782,517 +6769,6 @@ export class ProjectService extends BaseService {
                     spaces,
                 );
             },
-        );
-    }
-
-    static async _getCalculateTotalQuery(
-        timezone: string,
-        userAttributes: UserAttributeValueMap,
-        intrinsicUserAttributes: IntrinsicUserAttributes,
-        explore: Explore,
-        metricQuery: MetricQuery,
-        warehouseClient: WarehouseClient,
-        availableParameterDefinitions: ParameterDefinitions,
-        parameters?: ParametersValuesMap,
-        useTimezoneAwareDateTrunc?: boolean,
-        dataTimezone?: string,
-    ) {
-        const totalQuery: MetricQuery = {
-            ...metricQuery,
-            limit: 1,
-            tableCalculations: [],
-            sorts: [],
-            dimensions: [],
-            customDimensions: metricQuery.customDimensions,
-            metrics: metricQuery.metrics,
-            additionalMetrics: metricQuery.additionalMetrics,
-        };
-
-        const hasMetricFilters =
-            !!totalQuery.filters.metrics &&
-            flattenFilterGroup(totalQuery.filters.metrics).length > 0;
-        const hasTableCalculationFilters =
-            !!totalQuery.filters.tableCalculations &&
-            flattenFilterGroup(totalQuery.filters.tableCalculations).length > 0;
-
-        if (hasMetricFilters || hasTableCalculationFilters) {
-            throw new NotSupportedError(
-                'Totals cannot be correctly calculated with metric filters or table calculation filters',
-            );
-        }
-
-        const { query } = await ProjectService._compileQuery({
-            metricQuery: totalQuery,
-            explore,
-            warehouseSqlBuilder: warehouseClient,
-            intrinsicUserAttributes,
-            userAttributes,
-            timezone,
-            parameters,
-            availableParameterDefinitions,
-            useTimezoneAwareDateTrunc,
-            dataTimezone,
-        });
-
-        return { query, totalQuery };
-    }
-
-    async _calculateTotal(
-        account: Account,
-        projectUuid: string,
-        explore: Explore,
-        metricQuery: MetricQuery,
-        organizationUuid: string,
-        parameters?: ParametersValuesMap,
-    ) {
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            await this.getWarehouseCredentials({
-                projectUuid,
-                userId: account.user.id,
-                isRegisteredUser: account.isRegisteredUser(),
-                isServiceAccount: account.isServiceAccount(),
-            }),
-            {
-                snowflakeVirtualWarehouse: explore.warehouse,
-                databricksCompute: explore.databricksCompute,
-            },
-        );
-
-        const { userAttributes, intrinsicUserAttributes } =
-            await this.getUserAttributes({ account });
-
-        const availableParameterDefinitions = await this.getAvailableParameters(
-            projectUuid,
-            explore,
-        );
-
-        const projectTimezone =
-            await this.getQueryTimezoneForProject(projectUuid);
-        const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
-        const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
-            userUuid: account.user.id,
-            organizationUuid: account.organization.organizationUuid,
-        });
-
-        try {
-            const { query } = await ProjectService._getCalculateTotalQuery(
-                timezone,
-                userAttributes,
-                intrinsicUserAttributes,
-                explore,
-                metricQuery,
-                warehouseClient,
-                availableParameterDefinitions,
-                parameters,
-                useTimezoneAwareDateTrunc,
-                warehouseClient.credentials.dataTimezone,
-            );
-
-            const queryTags: RunQueryTags = {
-                ...this.getUserQueryTags(account),
-                organization_uuid: account.organization.organizationUuid,
-                project_uuid: projectUuid,
-                explore_name: explore.name,
-                query_context: QueryExecutionContext.CALCULATE_TOTAL,
-            };
-
-            const { rows } = await warehouseClient.runQuery(query, queryTags);
-            await sshTunnel.disconnect();
-            return { row: rows[0] };
-        } catch (e) {
-            if (e instanceof NotSupportedError) {
-                this.logger.warn(e.message);
-                return { row: {} }; // no totals
-            }
-            throw e;
-        }
-    }
-
-    async _calculateTotalFromCacheOrWarehouse(
-        account: Account,
-        projectUuid: string,
-        explore: Explore,
-        metricQuery: MetricQuery,
-        invalidateCache: boolean,
-        organizationUuid: string,
-        parameters?: ParametersValuesMap,
-    ) {
-        const warehouseCredentials = await this.getWarehouseCredentials({
-            projectUuid,
-            userId: account.user.id,
-            isRegisteredUser: account.isRegisteredUser(),
-            isServiceAccount: account.isServiceAccount(),
-        });
-        const { warehouseClient, sshTunnel } = await this._getWarehouseClient(
-            projectUuid,
-            warehouseCredentials,
-            {
-                snowflakeVirtualWarehouse: explore.warehouse,
-                databricksCompute: explore.databricksCompute,
-            },
-        );
-
-        const { userAttributes, intrinsicUserAttributes } =
-            await this.getUserAttributes({ account });
-
-        const availableParameterDefinitions = await this.getAvailableParameters(
-            projectUuid,
-            explore,
-        );
-
-        const projectTimezone =
-            await this.getQueryTimezoneForProject(projectUuid);
-        const timezone = resolveQueryTimezone(metricQuery, projectTimezone);
-        const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
-            userUuid: account.user.id,
-            organizationUuid: account.organization.organizationUuid,
-        });
-
-        try {
-            const { query, totalQuery } =
-                await ProjectService._getCalculateTotalQuery(
-                    timezone,
-                    userAttributes,
-                    intrinsicUserAttributes,
-                    explore,
-                    metricQuery,
-                    warehouseClient,
-                    availableParameterDefinitions,
-                    parameters,
-                    useTimezoneAwareDateTrunc,
-                    warehouseClient.credentials.dataTimezone,
-                );
-
-            const queryTags: RunQueryTags = {
-                ...this.getUserQueryTags(account),
-                organization_uuid: organizationUuid,
-                project_uuid: projectUuid,
-                explore_name: explore.name,
-                query_context: QueryExecutionContext.CALCULATE_TOTAL,
-            };
-
-            const userUuid = getCacheUserUuid(
-                warehouseCredentials,
-                account.user.id,
-            );
-            const { rows, cacheMetadata } =
-                await this.getResultsFromCacheOrWarehouse({
-                    projectUuid,
-                    userUuid,
-                    context: QueryExecutionContext.CALCULATE_TOTAL,
-                    warehouseClient,
-                    metricQuery: totalQuery,
-                    query,
-                    queryTags,
-                    invalidateCache,
-                });
-            await sshTunnel.disconnect();
-            return { row: rows[0], cacheMetadata };
-        } catch (e) {
-            if (e instanceof NotSupportedError) {
-                this.logger.warn(e.message);
-                return { row: {} }; // no totals
-            }
-            throw e;
-        }
-    }
-
-    async calculateTotalFromSavedChart(
-        account: Account,
-        chartUuid: string,
-        dashboardFilters?: DashboardFilters,
-        invalidateCache: boolean = false,
-        parameters?: ParametersValuesMap,
-    ) {
-        assertIsAccountWithOrg(account);
-
-        const savedChart = await this.savedChartModel.get(
-            chartUuid,
-            undefined, // VersionUuid
-        );
-        const { organizationUuid, projectUuid } = savedChart;
-
-        const explore = await this.getExplore(
-            account,
-            projectUuid,
-            savedChart.tableName,
-            organizationUuid,
-        );
-        const availableFieldIds = [
-            ...getDimensions(explore)
-                .filter((f) => isFilterableDimension(f) && !f.hidden)
-                .map(getItemId),
-            ...getMetrics(explore)
-                .filter((f) => !f.hidden)
-                .map(getItemId),
-        ];
-
-        const appliedDashboardFilters = dashboardFilters
-            ? {
-                  dimensions: getDashboardFilterRulesForTables(
-                      availableFieldIds,
-                      dashboardFilters.dimensions,
-                  ),
-                  metrics: getDashboardFilterRulesForTables(
-                      availableFieldIds,
-                      dashboardFilters.metrics,
-                  ),
-                  tableCalculations: getDashboardFilterRulesForTables(
-                      availableFieldIds,
-                      dashboardFilters.tableCalculations,
-                  ),
-              }
-            : undefined;
-
-        const metricQuery: MetricQuery = appliedDashboardFilters
-            ? addDashboardFiltersToMetricQuery(
-                  savedChart.metricQuery,
-                  appliedDashboardFilters,
-              )
-            : savedChart.metricQuery;
-
-        const spaceCtx =
-            await this.spacePermissionService.getSpaceAccessContext(
-                account.user.id,
-                savedChart.spaceUuid,
-            );
-
-        if (
-            account.user.ability.cannot(
-                'view',
-                subject('SavedChart', spaceCtx),
-            ) ||
-            account.user.ability.cannot(
-                'view',
-                subject('Project', {
-                    organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
-        const combinedParameters = await this.combineParameters(
-            projectUuid,
-            explore,
-            parameters,
-            savedChart.parameters,
-        );
-
-        const results = await this._calculateTotalFromCacheOrWarehouse(
-            account,
-            projectUuid,
-            explore,
-            metricQuery,
-            invalidateCache,
-            savedChart.organizationUuid,
-            combinedParameters,
-        );
-        return results.row;
-    }
-
-    async calculateTotalFromQuery(
-        account: Account,
-        projectUuid: string,
-        data: CalculateTotalFromQuery,
-    ) {
-        assertIsAccountWithOrg(account);
-
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
-
-        if (
-            account.user.ability.cannot(
-                'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
-        if (
-            data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            account.user.ability.cannot(
-                'manage',
-                subject('CustomFields', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new CustomSqlQueryForbiddenError();
-        }
-
-        const explore = await this.getExplore(
-            account,
-            projectUuid,
-            data.explore,
-            organizationUuid,
-        );
-
-        const combinedParameters = await this.combineParameters(
-            projectUuid,
-            explore,
-            data.parameters,
-        );
-
-        const results = await this._calculateTotal(
-            account,
-            projectUuid,
-            explore,
-            data.metricQuery,
-            organizationUuid,
-            combinedParameters,
-        );
-        return results.row;
-    }
-
-    async _calculateSubtotals(
-        account: Account,
-        projectUuid: string,
-        data: CalculateSubtotalsFromQuery,
-        explore: Explore,
-        organizationUuid: string,
-        parameters?: ParametersValuesMap,
-    ) {
-        const {
-            explore: exploreName,
-            metricQuery,
-            columnOrder,
-            pivotDimensions,
-            dateZoom,
-        } = data;
-
-        // Use the shared utility to prepare dimension groups
-        const { dimensionGroupsToSubtotal, analyticsData } =
-            SubtotalsCalculator.prepareDimensionGroups(
-                metricQuery,
-                columnOrder,
-                pivotDimensions,
-            );
-
-        this.analytics.trackAccount(account, {
-            event: 'query.subtotal',
-            properties: {
-                context: QueryExecutionContext.CALCULATE_SUBTOTAL,
-                organizationId: organizationUuid,
-                projectId: projectUuid,
-                exploreName,
-                ...analyticsData,
-            },
-        });
-
-        const queryTags: RunQueryTags = {
-            ...this.getUserQueryTags(account),
-            organization_uuid: account.organization.organizationUuid,
-            project_uuid: projectUuid,
-            explore_name: exploreName,
-            query_context: QueryExecutionContext.CALCULATE_SUBTOTAL,
-        };
-
-        // Run the query for each dimension group and format the raw rows, this is needed because we apply raw formatting to date dimensions, and we need to compare values in the same format in the frontend
-        const runQueryAndFormatRaw = async (
-            subtotalMetricQuery: MetricQuery,
-        ) => {
-            const { rows, fields } = await this.runMetricQuery({
-                account,
-                metricQuery: subtotalMetricQuery,
-                explore,
-                queryTags,
-                projectUuid,
-                exploreName,
-                context: QueryExecutionContext.CALCULATE_SUBTOTAL,
-                csvLimit: null,
-                chartUuid: undefined,
-                parameters,
-                dateZoom,
-            });
-
-            return formatRawRows(rows, fields);
-        };
-
-        const subtotalsPromises = dimensionGroupsToSubtotal.map<
-            Promise<[string, Record<string, unknown>[]]>
-        >(async (subtotalDimensions) => {
-            let subtotals: Record<string, unknown>[] = [];
-
-            try {
-                // Use utility to create properly configured subtotal query
-                const { metricQuery: subtotalMetricQuery } =
-                    SubtotalsCalculator.createSubtotalQueryConfig(
-                        metricQuery,
-                        subtotalDimensions,
-                        pivotDimensions,
-                    );
-
-                subtotals = await runQueryAndFormatRaw(subtotalMetricQuery);
-            } catch (e) {
-                this.logger.error(
-                    `Error running subtotal query for dimensions ${subtotalDimensions.join(
-                        ',',
-                    )}`,
-                );
-            }
-
-            return [
-                SubtotalsCalculator.getSubtotalKey(subtotalDimensions),
-                subtotals,
-            ] satisfies [string, Record<string, unknown>[]];
-        });
-
-        const subtotalsEntries = await Promise.all(subtotalsPromises);
-        return SubtotalsCalculator.formatSubtotalEntries(subtotalsEntries);
-    }
-
-    async calculateSubtotalsFromQuery(
-        account: Account,
-        projectUuid: string,
-        data: CalculateSubtotalsFromQuery,
-    ) {
-        assertIsAccountWithOrg(account);
-
-        const { organizationUuid } =
-            await this.projectModel.getSummary(projectUuid);
-
-        if (
-            account.user.ability.cannot(
-                'manage',
-                subject('Explore', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new ForbiddenError();
-        }
-
-        if (
-            data.metricQuery.customDimensions?.some(isCustomSqlDimension) &&
-            account.user.ability.cannot(
-                'manage',
-                subject('CustomFields', { organizationUuid, projectUuid }),
-            )
-        ) {
-            throw new CustomSqlQueryForbiddenError();
-        }
-
-        const explore = await this.getExplore(
-            account,
-            projectUuid,
-            data.explore,
-            organizationUuid,
-        );
-
-        const combinedParameters = await this.combineParameters(
-            projectUuid,
-            explore,
-            data.parameters,
-        );
-
-        // Reuse the _calculateTotal method by passing the explore, metricQuery, and organizationUuid
-        return this._calculateSubtotals(
-            account,
-            projectUuid,
-            data,
-            explore,
-            organizationUuid,
-            combinedParameters,
         );
     }
 


### PR DESCRIPTION
Closes: [PROD-6932: Pre-aggregate compilation errors not shown in preview projects](https://linear.app/lightdash/issue/PROD-6932/pre-aggregate-compilation-errors-not-shown-in-preview-projects)

Closes: [SPK-373: Migrate Calculate Total to async query service](https://linear.app/lightdash/issue/SPK-373/migrate-calculate-total-to-async-query-service)

### Description:

Moves `calculateTotalFromQuery`, `calculateTotalFromSavedChart`, and `calculateSubtotalsFromQuery` from `ProjectService` into `AsyncQueryService`, and updates the `projectController` and `savedChartController` to call these methods via `getAsyncQueryService()` instead of `getProjectService()`.

The total and subtotal calculations now execute through the async query pipeline (`executePreparedAsyncQuery` + `pollForQueryCompletion`) rather than calling `warehouseClient.runQuery` directly. This means totals and subtotals benefit from the same async execution path, result file storage, and cache handling as regular metric queries.

A new shared helper `executeMetricQueryAndGetResultsFromExplore` encapsulates the full flow of preparing, executing, polling, and reading back results for a metric query from an explore, and is used by both `calculateMetricQueryTotal` and `calculateMetricQuerySubtotals`.

The `EmbedService` total and subtotal methods are also updated to delegate to `asyncQueryService.calculateMetricQueryTotal` and `asyncQueryService.calculateMetricQuerySubtotals` instead of duplicating the warehouse client setup and query compilation inline.

The `executeAsyncQuery` public method now handles the permission check itself, while the internal `executePreparedAsyncQuery` skips it, allowing internal callers to bypass the redundant project summary fetch.

Tests covering the new async-backed total and subtotal flows are added, including routing verification, fallback behaviour when no results file is present, dashboard filter and parameter precedence for saved chart totals, and the formatted subtotal response shape.