### PR TITLE
fix(data-apps): hide "Load earlier messages" button when all versions are loaded

### DIFF
--- a/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppBuildPoller.ts
@@ -1,6 +1,11 @@
-import { APP_VERSION_TERMINAL_STATUSES } from '@lightdash/common';
+import {
+    APP_VERSION_TERMINAL_STATUSES,
+    type ApiGetAppResponse,
+} from '@lightdash/common';
 import { useQueryClient } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
+
+type GetAppResult = ApiGetAppResponse['results'];
 
 // Inline Web Worker that polls the API in the background.
 // Dedicated Workers continue running even when the parent tab is throttled/frozen.
@@ -62,22 +67,33 @@ export function useAppBuildPoller(
 
         worker.onmessage = (e: MessageEvent) => {
             if (e.data.type === 'data' && e.data.results) {
+                const poll: GetAppResult = e.data.results;
                 queryClient.setQueryData(
                     ['app', projectUuid, appUuid],
                     (
                         old:
-                            | { pages: unknown[]; pageParams: unknown[] }
+                            | {
+                                  pages: GetAppResult[];
+                                  pageParams: unknown[];
+                              }
                             | undefined,
                     ) => ({
+                        // The poll uses limit=1, so its `hasMore` reflects that
+                        // limit rather than the original page size. Keep the
+                        // first page's `hasMore` so pagination stays accurate.
                         pages: [
-                            e.data.results,
+                            {
+                                ...poll,
+                                hasMore:
+                                    old?.pages?.[0]?.hasMore ?? poll.hasMore,
+                            },
                             ...(old?.pages?.slice(1) ?? []),
                         ],
                         pageParams: old?.pageParams ?? [undefined],
                     }),
                 );
 
-                const latest = e.data.results.versions?.[0];
+                const latest = poll.versions?.[0];
                 if (
                     latest &&
                     (

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -329,6 +329,14 @@ const AppGenerate: FC = () => {
         [historyMessages, localMessages],
     );
 
+    // `hasNextPage` reflects the server's "more pages exist" signal, but we
+    // accumulate versions across fetches in `versionCacheRef` — so even if the
+    // server thinks more exist, we may already have them all. Versions are
+    // 1-indexed and contiguous, so seeing version 1 means we've loaded
+    // everything and the "Load earlier messages" button is misleading.
+    const hasUnloadedEarlierVersions =
+        hasNextPage && !allVersions.some((v) => v.version === 1);
+
     // Stable reference for the preview — only updates when a new version
     // becomes ready, preventing iframe reloads during status polling.
     const latestReadyPreview = useMemo(() => {
@@ -594,7 +602,7 @@ const AppGenerate: FC = () => {
                 <Panel defaultSize={30} minSize={20} maxSize={50}>
                     <Box className={classes.chatPanel}>
                         <Box className={classes.chatMessages}>
-                            {hasNextPage && (
+                            {hasUnloadedEarlierVersions && (
                                 <Group
                                     gap="xs"
                                     justify="center"


### PR DESCRIPTION
### Description:
The build poller fetches with limit=1 and was overwriting the first page's `hasMore` with a value derived from that smaller limit, spuriously showing the pagination button after the second prompt. Preserve the original `hasMore` on poll updates, and also gate the button on whether version 1 is already in the accumulated cache so it doesn't appear once everything is loaded.
