### PR TITLE
feat(logging): add structured metadata to async query execution errors

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2267,6 +2267,17 @@ export class AsyncQueryService extends ProjectService {
         } catch (e) {
             this.logger.error(
                 `Query ${queryUuid} execution error: ${getErrorMessage(e)}`,
+                {
+                    queryUuid,
+                    projectUuid,
+                    organizationUuid,
+                    userUuid: isRegisteredUser ? userUuid : undefined,
+                    isEmbed: !isRegisteredUser,
+                    warehouseType: warehouseCredentialsType,
+                    errorName: e instanceof Error ? e.name : undefined,
+                    errorCode: (e as { code?: string })?.code,
+                    queryContext: queryTags.query_context,
+                },
             );
 
             // Override clients are used for fallback attempts such as DuckDB


### PR DESCRIPTION
## Summary

- Attach `organizationUuid`, `projectUuid`, `warehouseType` and other customer context to the `AsyncQueryService` error log so failures can be grouped per tenant.
- Enables single-step log triage for multi-tenant clusters (e.g. `eu1`) without Sentry-trace joins.
- No behaviour change — metadata only added to the existing `logger.error` call.

## Context

During the 2026-04-21 EU Cloud NAT incident (see internal postmortem) we had to identify which `eu1` multi-tenant orgs were hitting warehouse connection failures. The existing error log payload only contained:

```json
{
  "level": "error",
  "message": "Query <uuid> execution error: Connection terminated due to connection timeout",
  "sentryTraceId": "...",
  "serviceName": "AsyncQueryService",
  "timestamp": "..."
}
```

No `organizationUuid`, no `projectUuid`, no `userUuid`. Correlating a failed async query back to a customer required joining Sentry traces against HTTP request logs and parsing request URLs — which broke down on `eu1` where the trace ID often wasn't stamped on both sides of the async worker handoff.

The incident's customer-identification action item (postmortem AI-2) would be trivially resolved by this change: affected orgs can be listed with a single `gcloud logging read` filter.

## Change

All fields are already in scope at the error site — they're parameters to `runAsyncWarehouseQuery` (line 1932) or used in the adjacent `analytics.track` call a few lines below. The second-argument metadata pattern is already used elsewhere in the codebase (e.g. `ProjectService.ts:1896`, `ProjectService.ts:3368`).

Fields included:
- `queryUuid` — primary query identifier
- `projectUuid` — Lightdash project owning the query
- `organizationUuid` — **tenant identifier; the key field for multi-tenant triage**
- `userUuid` — only included for registered users (not for embed sessions)
- `isEmbed` — distinguishes embed traffic from authenticated UI / CLI / scheduled runs
- `warehouseType` — e.g. `redshift`, `snowflake`, `bigquery`; lets you slice by warehouse vendor
- `errorName` — e.g. `WarehouseQueryError`, `WarehouseConnectionError`
- `errorCode` — pg has `.code` (e.g. `57P01`), Snowflake has `sqlState`
- `queryContext` — e.g. `chart`, `dashboard`, `sqlRunner`, `scheduled_delivery`

## Test plan

- [ ] Trigger a query error in a dev/staging environment (e.g. by breaking warehouse connection mid-query) and confirm the log payload contains the expected fields.
- [ ] Verify with `gcloud logging read` on staging that `jsonPayload.organizationUuid` is searchable.
- [ ] Confirm no new errors in CI — type-safe, uses only in-scope variables, pattern already established in the codebase.

## Follow-ups (out of scope for this PR)

Tracked separately in the postmortem remediation items:
- Enable Cloud NAT flow logging for infra-level egress visibility
- Standardize customer context propagation via AsyncLocalStorage so this pattern doesn't have to be applied log-site-by-log-site
- Add a Prometheus metric `warehouse_connection_failures_total` tagged by `organizationUuid` for alerting

🤖 Generated with [Claude Code](https://claude.com/claude-code)