### PR TITLE
fix: improve error logging for dashboard CSV export fetch failures

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -3825,21 +3825,47 @@ export default class SchedulerTask {
                     // Fetch all CSVs from presigned URLs in parallel
                     const csvStreams = await Promise.all(
                         successfulResults.map(async (r) => {
-                            const csvResponse = await fetch(r.value.fileUrl);
-                            if (!csvResponse.ok || !csvResponse.body) {
-                                Logger.warn(
-                                    `Failed to fetch CSV for ${r.value.chartName} from presigned URL`,
+                            try {
+                                const csvResponse = await fetch(
+                                    r.value.fileUrl,
+                                );
+                                if (!csvResponse.ok || !csvResponse.body) {
+                                    Logger.warn(
+                                        `Failed to fetch CSV for ${r.value.chartName} from presigned URL: HTTP ${csvResponse.status} ${csvResponse.statusText}`,
+                                    );
+                                    return null;
+                                }
+                                return {
+                                    filename: r.value.filename,
+                                    stream: Readable.fromWeb(
+                                        csvResponse.body as Parameters<
+                                            typeof Readable.fromWeb
+                                        >[0],
+                                    ),
+                                };
+                            } catch (e) {
+                                const cause =
+                                    e instanceof Error && e.cause
+                                        ? e.cause
+                                        : undefined;
+                                Logger.error(
+                                    `Failed to fetch CSV for chart "${r.value.chartName}" from presigned URL: ${e instanceof Error ? e.message : String(e)}`,
+                                    {
+                                        chartName: r.value.chartName,
+                                        fileUrl: r.value.fileUrl,
+                                        cause:
+                                            cause instanceof Error
+                                                ? {
+                                                      message: cause.message,
+                                                      code: (
+                                                          cause as NodeJS.ErrnoException
+                                                      ).code,
+                                                  }
+                                                : cause,
+                                    },
                                 );
                                 return null;
                             }
-                            return {
-                                filename: r.value.filename,
-                                stream: Readable.fromWeb(
-                                    csvResponse.body as Parameters<
-                                        typeof Readable.fromWeb
-                                    >[0],
-                                ),
-                            };
                         }),
                     );
 


### PR DESCRIPTION
## Summary
- The `fetch()` call to S3 presigned URLs in `exportCsvDashboard` had no try-catch — when the fetch failed (DNS, connection refused, timeout, etc.), the entire job crashed with just `"fetch failed"` and no actionable detail.
- Wrapped the fetch in a try-catch that logs the underlying `cause` (including error code like `ENOTFOUND`, `ECONNREFUSED`, `ETIMEDOUT`), the chart name, and the presigned URL.
- Failed individual chart fetches now return `null` (graceful skip) instead of aborting the entire dashboard CSV export.

## Test plan
- [ ] Trigger a dashboard CSV export with a valid S3/MinIO setup — verify all charts are included in the zip
- [ ] Trigger a dashboard CSV export with an unreachable S3 endpoint — verify the error log contains the cause code and the job doesn't crash silently
- [ ] Verify that if one chart's presigned URL fails, the remaining charts still appear in the exported zip

🤖 Generated with [Claude Code](https://claude.com/claude-code)