### PR TITLE
fix: defer SDK filter conversion until tile metadata and available filters are ready

### DIFF
--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/utils.test.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/utils.test.ts
@@ -5,7 +5,10 @@ import {
     type FilterableDimension,
 } from '@lightdash/common';
 import { describe, expect, it } from 'vitest';
-import { convertSdkFilterToDashboardFilter } from './utils';
+import {
+    convertSdkFilterToDashboardFilter,
+    shouldDeferSdkFilters,
+} from './utils';
 
 const makeDimension = (
     table: string,
@@ -122,5 +125,53 @@ describe('convertSdkFilterToDashboardFilter', () => {
                 tableName: 'payments',
             },
         });
+    });
+});
+
+describe('shouldDeferSdkFilters', () => {
+    it('defers when chart tile metadata has not loaded yet', () => {
+        // Tiles haven't arrived from POST /dashboard yet, so we cannot know
+        // whether to wait on the available-filters query or not.
+        expect(shouldDeferSdkFilters(undefined, undefined)).toBe(true);
+    });
+
+    it('proceeds when there are no filterable chart tiles', () => {
+        // Dashboard has only markdown / non-chart tiles. There is nothing
+        // for the available-filters query to fetch (it stays disabled), so
+        // there is nothing to wait for. Apply with empty tileTargets.
+        expect(shouldDeferSdkFilters([], undefined)).toBe(false);
+    });
+
+    it('defers when chart tiles exist but available filters have not resolved', () => {
+        // useDashboardsAvailableFilters reports isInitialLoading=false for
+        // disabled queries, so we must gate on the data itself, not the
+        // loading flag. Without filterableFieldsByTileUuid we cannot build
+        // cross-explore tileTargets and would silently drop the filter
+        // from tiles on other explores.
+        expect(
+            shouldDeferSdkFilters(
+                [{ tileUuid: 't1', savedChartUuid: 'c1' }],
+                undefined,
+            ),
+        ).toBe(true);
+    });
+
+    it('proceeds once chart tiles and available filters are both ready', () => {
+        expect(
+            shouldDeferSdkFilters([{ tileUuid: 't1', savedChartUuid: 'c1' }], {
+                t1: [makeDimension('payments', 'payment_method')],
+            }),
+        ).toBe(false);
+    });
+
+    it('proceeds when available filters resolved to an empty mapping', () => {
+        // Edge case: query succeeded but returned no filterable fields for
+        // any tile. We treat that as "ready" so we don't deadlock the load.
+        expect(
+            shouldDeferSdkFilters(
+                [{ tileUuid: 't1', savedChartUuid: 'c1' }],
+                {},
+            ),
+        ).toBe(false);
     });
 });

--- a/packages/frontend/src/ee/features/embed/EmbedDashboard/utils.ts
+++ b/packages/frontend/src/ee/features/embed/EmbedDashboard/utils.ts
@@ -5,9 +5,35 @@ import {
     type DashboardFilterableField,
     type DashboardFilterRule,
     type FilterOperator,
+    type SavedChartsInfoForDashboardAvailableFilters,
 } from '@lightdash/common';
 import { v4 as uuidv4 } from 'uuid';
 import { type SdkFilter } from './types';
+
+/**
+ * Whether SDK filter conversion should be deferred until the data needed to
+ * build cross-explore tileTargets is available.
+ *
+ * The available-filters query is `enabled: savedChartUuidsAndTileUuids.length > 0`,
+ * which means React Query reports `isInitialLoading: false` for the whole
+ * window between provider mount and dashboard tile metadata arriving — even
+ * though no fetch has happened yet. Gating SDK filter conversion on that
+ * loading flag therefore lets the converter fire too early on a cold load,
+ * with `filterableFieldsByTileUuid` undefined, producing `tileTargets: {}`
+ * and silently dropping the filter from any tile on a different explore.
+ */
+export const shouldDeferSdkFilters = (
+    savedChartUuidsAndTileUuids:
+        | SavedChartsInfoForDashboardAvailableFilters
+        | undefined,
+    filterableFieldsByTileUuid:
+        | Record<string, DashboardFilterableField[] | undefined>
+        | undefined,
+): boolean => {
+    if (savedChartUuidsAndTileUuids === undefined) return true;
+    if (savedChartUuidsAndTileUuids.length === 0) return false;
+    return filterableFieldsByTileUuid === undefined;
+};
 
 /**
  * Build tileTargets for an SDK filter by matching fields across all tiles.

--- a/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
+++ b/packages/frontend/src/providers/Dashboard/DashboardProvider.tsx
@@ -38,7 +38,10 @@ import { useLocation, useNavigate, useParams } from 'react-router';
 import { useDeepCompareEffect, useMount } from 'react-use';
 import { getConditionalRuleLabelFromItem } from '../../components/common/Filters/FilterInputs/utils';
 import { type SdkFilter } from '../../ee/features/embed/EmbedDashboard/types';
-import { convertSdkFilterToDashboardFilter } from '../../ee/features/embed/EmbedDashboard/utils';
+import {
+    convertSdkFilterToDashboardFilter,
+    shouldDeferSdkFilters,
+} from '../../ee/features/embed/EmbedDashboard/utils';
 import { LightdashEventType } from '../../ee/features/embed/events/types';
 import { useEmbedEventEmitter } from '../../ee/features/embed/hooks/useEmbedEventEmitter';
 import useEmbed from '../../ee/providers/Embed/useEmbed';
@@ -673,11 +676,19 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
             const sdkFilters =
                 embed.mode === 'sdk' && embed.filters ? embed.filters : [];
             if (sdkFilters.length > 0) {
-                // Wait for available filters query to finish (success or error)
-                // so we can build cross-explore tileTargets.
-                // If the query failed, filterableFieldsByTileUuid will be
-                // undefined and we gracefully fall back to tileTargets: {}
-                if (isLoadingDashboardFilters) return;
+                // Wait until we have the data needed to build cross-explore
+                // tileTargets. `isLoadingDashboardFilters` alone is not
+                // enough because the available-filters query is disabled
+                // until tile metadata loads, and React Query reports a
+                // disabled query as not loading.
+                if (
+                    shouldDeferSdkFilters(
+                        savedChartUuidsAndTileUuids,
+                        filterableFieldsByTileUuid,
+                    )
+                ) {
+                    return;
+                }
 
                 updatedDashboardFilters.dimensions = sdkFilters.map(
                     (sdkFilter) =>
@@ -734,7 +745,7 @@ const DashboardProviderInner: React.FC<DashboardProviderProps> = ({
         overridesForSavedDashboardFilters,
         embed,
         applyInteractivityFiltering,
-        isLoadingDashboardFilters,
+        savedChartUuidsAndTileUuids,
         filterableFieldsByTileUuid,
     ]);
 


### PR DESCRIPTION
Closes: #22148<!-- reference the related issue e.g. #150 -->

### Description:

Fixes a bug where SDK filters applied to embedded dashboards would silently drop filter targets for tiles on different explores during a cold load.

The root cause was that the available-filters query is disabled until dashboard tile metadata has loaded. React Query reports a disabled query as `isInitialLoading: false`, so gating SDK filter conversion on `isLoadingDashboardFilters` allowed the converter to fire too early — before `filterableFieldsByTileUuid` was populated — resulting in `tileTargets: {}` and the filter only applying to the primary explore's tiles.

The fix introduces a `shouldDeferSdkFilters` utility that correctly gates conversion on the underlying data rather than the loading flag:

- Defers if tile metadata (`savedChartUuidsAndTileUuids`) hasn't arrived yet
- Proceeds immediately if there are no filterable chart tiles (nothing to wait for)
- Defers if chart tiles exist but `filterableFieldsByTileUuid` hasn't resolved yet
- Proceeds once both tile metadata and available filters are ready (including the edge case where the query succeeds but returns no filterable fields)

Unit tests covering all five cases are included.