### PR TITLE
chore: add renovate.json for dependency updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -12,34 +12,7 @@
     "prConcurrentLimit": 5,
     "prHourlyLimit": 2,
     "labels": ["dependencies"],
-    "packageRules": [
-        {
-            "description": "Auto-merge low-risk updates: patch bumps, repins, and SHA digest bumps",
-            "matchUpdateTypes": ["patch", "pin", "digest"],
-            "automerge": true
-        },
-        {
-            "description": "Auto-merge devDependencies on minor + patch (lower blast radius than runtime deps)",
-            "matchDepTypes": ["devDependencies"],
-            "matchUpdateTypes": ["minor", "patch"],
-            "automerge": true
-        },
-        {
-            "description": "Hold framework majors for human review",
-            "matchPackageNames": [
-                "typescript",
-                "react",
-                "react-dom",
-                "node",
-                "pnpm",
-                "vite",
-                "express"
-            ],
-            "automerge": false
-        }
-    ],
     "vulnerabilityAlerts": {
-        "labels": ["security"],
-        "automerge": false
+        "labels": ["security"]
     }
 }

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,45 @@
+{
+    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+    "extends": [
+        "config:best-practices",
+        "group:monorepos",
+        "schedule:weekly",
+        ":dependencyDashboard",
+        ":semanticCommits",
+        "helpers:pinGitHubActionDigests"
+    ],
+    "minimumReleaseAge": "3 days",
+    "prConcurrentLimit": 5,
+    "prHourlyLimit": 2,
+    "labels": ["dependencies"],
+    "packageRules": [
+        {
+            "description": "Auto-merge low-risk updates: patch bumps, repins, and SHA digest bumps",
+            "matchUpdateTypes": ["patch", "pin", "digest"],
+            "automerge": true
+        },
+        {
+            "description": "Auto-merge devDependencies on minor + patch (lower blast radius than runtime deps)",
+            "matchDepTypes": ["devDependencies"],
+            "matchUpdateTypes": ["minor", "patch"],
+            "automerge": true
+        },
+        {
+            "description": "Hold framework majors for human review",
+            "matchPackageNames": [
+                "typescript",
+                "react",
+                "react-dom",
+                "node",
+                "pnpm",
+                "vite",
+                "express"
+            ],
+            "automerge": false
+        }
+    ],
+    "vulnerabilityAlerts": {
+        "labels": ["security"],
+        "automerge": false
+    }
+}


### PR DESCRIPTION
Configures the Mend Renovate GitHub App for this monorepo. Free for OSS — uses the hosted App at https://github.com/apps/renovate.

## Settings

- `config:best-practices` — Renovate's recommended preset
- `group:monorepos` — groups related ecosystem bumps into single PRs
- `schedule:weekly` — batched weekly cadence
- `:dependencyDashboard` — single GitHub issue with checkboxes instead of a PR storm
- `helpers:pinGitHubActionDigests` — auto-bumps SHA pins on GitHub Actions
- `minimumReleaseAge: "3 days"` — aligns with the supply-chain cooldown landing in #21701

## Auto-merge policy

**Disabled.** Every Renovate PR waits for a human to click merge.

Rationale: post-axios-incident conservatism. Auto-merge is a documented supply-chain risk (GitGuardian found 30 Renovate PRs auto-merged the malicious axios in the Mar 31 attack window). The 3-day cooldown handles most of this risk, but pairing it with mandatory review is a free additional layer. Can relax this later once we trust the tooling.

## Required after merge

1. **Install the Renovate GitHub App** at https://github.com/apps/renovate (org-level, select `lightdash/lightdash`). Renovate won't run until the App is installed.
2. **Optional: disable Dependabot security update PRs** (Settings → Code security → toggle off "Dependabot security updates") to avoid duplicate noise once Socket Fix is wired up. Keep "Dependabot alerts" ON — those are passive notifications.

## What this does NOT do

- No auto-merge (every bump needs human review)
- No bypass of the 3-day cooldown
- No interaction with `socket.yml` — Socket and Renovate operate independently