### PR TITLE
chore: add .github/dependabot.yml for dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,7 +12,7 @@ updates:
     # Mirrors pnpm-workspace.yaml `minimumReleaseAge` and .npmrc `min-release-age`.
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     labels:
       - 'dependencies'
     commit-message:
@@ -63,7 +63,7 @@ updates:
       day: 'monday'
     cooldown:
       default-days: 3
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 2
     labels:
       - 'dependencies'
       - 'ci'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,8 +6,7 @@ updates:
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
+      interval: 'daily'
     # Supply-chain cooldown — refuses versions published less than 3 days ago.
     # Mirrors pnpm-workspace.yaml `minimumReleaseAge` and .npmrc `min-release-age`.
     cooldown:
@@ -59,8 +58,7 @@ updates:
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
-      interval: 'weekly'
-      day: 'monday'
+      interval: 'daily'
     cooldown:
       default-days: 3
     open-pull-requests-limit: 2

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,72 @@
+version: 2
+updates:
+  # ============================================================================
+  # npm / pnpm dependencies across the monorepo
+  # ============================================================================
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    # Supply-chain cooldown — refuses versions published less than 3 days ago.
+    # Mirrors pnpm-workspace.yaml `minimumReleaseAge` and .npmrc `min-release-age`.
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'
+    # Group related ecosystem bumps into single PRs rather than one-per-package.
+    # Renovate's `group:monorepos` preset has no Dependabot equivalent — groups
+    # must be enumerated manually. Add new ecosystems here as they're adopted.
+    groups:
+      types:
+        patterns: ['@types/*']
+      mantine:
+        patterns: ['@mantine/*']
+      tiptap:
+        patterns: ['@tiptap/*']
+      sentry:
+        patterns: ['@sentry/*', '@sentry-internal/*']
+      octokit:
+        patterns: ['@octokit/*']
+      aws-sdk:
+        patterns: ['@aws-sdk/*']
+      testing-library:
+        patterns: ['@testing-library/*']
+      tanstack:
+        patterns: ['@tanstack/*']
+      ai-sdk:
+        patterns: ['@ai-sdk/*']
+      storybook:
+        patterns: ['@storybook/*', 'storybook']
+      slack:
+        patterns: ['@slack/*']
+      dnd-kit:
+        patterns: ['@dnd-kit/*']
+      typescript-eslint:
+        patterns: ['@typescript-eslint/*', 'eslint', 'eslint-*']
+      langchain:
+        patterns: ['@langchain/*', 'langchain']
+      react:
+        patterns: ['react', 'react-dom']
+
+  # ============================================================================
+  # GitHub Actions — keep SHA pins on third-party actions current
+  # ============================================================================
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'weekly'
+      day: 'monday'
+    cooldown:
+      default-days: 3
+    open-pull-requests-limit: 5
+    labels:
+      - 'dependencies'
+      - 'ci'
+    commit-message:
+      prefix: 'chore'
+      include: 'scope'


### PR DESCRIPTION
Enables Dependabot version updates on the monorepo. Supersedes the closed Renovate attempt (#22167) — once auto-merge was dropped, the two tools are close to functional parity, and Dependabot's GitHub-native surface area is easier to justify.

## Settings

- `cooldown: 3 days` — refuses package versions published less than 3 days ago. Mirrors `pnpm-workspace.yaml` `minimumReleaseAge: 4320` and `.npmrc` `min-release-age=3` landing in #21701.
- Weekly schedule (Monday) — batched review, single pass per week.
- `open-pull-requests-limit: 5` per ecosystem — caps weekly review burden.
- 15 monorepo-style groups (`@mantine/*`, `@types/*`, `@tanstack/*`, etc.) — related bumps land as single PRs instead of one-per-package. Enumerated from the current dep graph; add new ecosystems here as they're adopted.
- GitHub Actions ecosystem enabled — keeps third-party action SHA pins fresh.

## Auto-merge policy

**None.** Every PR waits for a human to click merge. Rationale: GitGuardian reported 111 Dependabot PRs auto-merged the malicious axios during the 3-hour Mar 31 window. The cooldown closes most of that risk, but human review is a free additional layer.

## Related security layers

| Layer | Handled by |
|---|---|
| Known-malicious packages at install time | Socket Firewall (follow-up) |
| Transitive CVE upgrade chains | Socket Fix (follow-up, when #21701 merges) |
| Supply-chain cooldown on install | `.npmrc` + `pnpm-workspace.yaml` (#21701) |
| Supply-chain cooldown on PR open | This file's `cooldown: 3 days` |
| Passive CVE alerts | GitHub's Dependabot alerts (Settings UI) |
| PR-time dep scanning | Socket GitHub App (#22096) |

## What's not in this file

- **Auto-merge** — can add later via separate `.github/workflows/dependabot-auto-merge.yml` if desired. Starting conservative.
- **Docker ecosystem** — skipped for now; the repo has 4 Dockerfiles with non-standard naming and may need testing before enabling.
- **"Dependabot security updates"** — controlled in Settings → Code security UI, not in this file. Recommend enabling until Socket Fix is wired up as the canonical CVE-remediation tool, then toggling off to avoid duplicate noise.

## Why not Renovate?

Renovate's Dependency Dashboard and richer preset system are real advantages, but the delta shrinks significantly without auto-merge in play. Dependabot's merits for this repo: no third-party app install, GitHub-native review UI, one less maintainer-dashboard to check. See #22167 discussion for the full comparison.