### PR TITLE
fix(tooltip): don't re-format already-formatted header in tuple mode

### DIFF
--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -1317,25 +1317,28 @@ export const buildCartesianTooltipFormatter =
                 ? field.format !== undefined
                 : false;
             if (hasFormat || isTimeBasedDimension(field)) {
-                // Use raw value from data object for the specific dimensionId
-                // Don't use axisValue directly as it may be from a different axis
-                // (e.g., in flipped charts, axisValue might be "Phillip" but dimensionId is the date field)
+                // Only re-format when we have a raw value; otherwise trust
+                // `header` — re-parsing the already-formatted string breaks
+                // tuple-mode time axes (returns "NaT").
                 const firstParam = params[0];
-                const rawHeaderValue =
-                    (firstParam?.data as Record<string, unknown> | undefined)?.[
-                        dimensionId
-                    ] ??
-                    firstParam?.axisValue ??
-                    header;
+                const data = firstParam?.data;
+                const valueByDim =
+                    data && typeof data === 'object' && !Array.isArray(data)
+                        ? (data as Record<string, unknown>)[dimensionId]
+                        : undefined;
+                const rawHeaderValue = valueByDim ?? firstParam?.axisValue;
 
-                const headerText = getFormattedValue(
-                    rawHeaderValue,
-                    dimensionId,
-                    itemsMap,
-                    undefined,
-                    pivotValuesColumnsMap,
-                    parameters,
-                );
+                const headerText =
+                    rawHeaderValue !== undefined
+                        ? getFormattedValue(
+                              rawHeaderValue,
+                              dimensionId,
+                              itemsMap,
+                              undefined,
+                              pivotValuesColumnsMap,
+                              parameters,
+                          )
+                        : header;
                 return `${formatTooltipHeader(
                     headerText,
                 )}${divider}${tooltipHtml}${rowsHtml}`;


### PR DESCRIPTION
## Summary

Cartesian chart tooltips showed `NaT` as the title when hovering a specific bar on a time-axis x-field (e.g. hourly `TIMESTAMP` dimension) with a group-by. Axis-mode (hovering next to the stack) was unaffected — only item-mode hover on the bar itself.

## Root cause

In item-mode on a `type: 'time'` axis, ECharts does not populate `param.axisValue`, and `param.data` is the tuple array (not a keyed object). The header fallback in `buildCartesianTooltipFormatter` fell all the way through to the already-formatted `header` string:

```ts
const rawHeaderValue =
    (firstParam?.data)?.[dimensionId] ??   // undefined (array, string key)
    firstParam?.axisValue ??                // undefined (time axis, item mode)
    header;                                 // already-formatted, e.g. "2024-01-15, 18 (+00:00)"
```

`getFormattedValue` then re-parsed that formatted string as a date, moment.js couldn't parse the comma/parens, and returned `NaT`.


**Before**
<img width="364" height="422" alt="CleanShot 2026-04-21 at 16 13 06" src="https://github.com/user-attachments/assets/aef7d942-ddbb-432c-b9f1-1e61648ea2dc" />

**After**
<img width="337" height="398" alt="CleanShot 2026-04-21 at 16 10 53" src="https://github.com/user-attachments/assets/2e1109ab-e3fe-451a-85c6-21e74802eadc" />


Regression from #19335.