### PR TITLE
refactor: migrate 7 single-call services to audited ability

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -102,10 +102,17 @@ module.exports = {
             files: [
                 'src/services/CatalogService/**/*.ts',
                 'src/services/ContentService/**/*.ts',
+                'src/services/CsvService/**/*.ts',
                 'src/services/DashboardService/**/*.ts',
+                'src/services/DeployService.ts',
+                'src/services/FunnelService/**/*.ts',
+                'src/services/GitlabAppService/**/*.ts',
+                'src/services/ProjectParametersService.ts',
                 'src/services/SavedChartsService/**/*.ts',
                 'src/services/SavedSqlService/**/*.ts',
                 'src/services/SchedulerService/**/*.ts',
+                'src/services/ShareService/**/*.ts',
+                'src/services/SlackIntegrationService/**/*.ts',
                 'src/services/SpaceService/**/*.ts',
             ],
             rules: {

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -1771,8 +1771,10 @@ export class McpService extends BaseService {
 
         // Validate header attributes if present (admin + narrowing check)
         if (headerUserAttributes) {
+            const auditedAbility = this.createAuditedAbility(user);
             validateUserAttributeOverrides(
                 user,
+                auditedAbility,
                 headerUserAttributes,
                 dbAttributes,
             );
@@ -1801,8 +1803,10 @@ export class McpService extends BaseService {
                 organizationUuid,
                 userUuid: user.userUuid,
             });
+        const auditedAbility = this.createAuditedAbility(user);
         validateUserAttributeOverrides(
             user,
+            auditedAbility,
             headerUserAttributes,
             dbAttributes,
         );

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -608,12 +608,17 @@ export class CsvService extends BaseService {
     ) {
         const dashboard =
             await this.dashboardModel.getByIdOrSlug(dashboardUuid);
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('ExportCsv', {
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
+                    metadata: {
+                        dashboardUuid: dashboard.uuid,
+                        dashboardName: dashboard.name,
+                    },
                 }),
             )
         ) {

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -66,14 +66,19 @@ export class DeployService extends BaseService {
 
         // manage:DeployProject for non-preview projects (restrictable via custom roles)
         // manage:DeployProject@self for preview projects created by the user
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('DeployProject', {
                     projectUuid,
                     organizationUuid: project.organizationUuid,
                     type: project.type,
                     createdByUserUuid: project.createdByUserUuid,
+                    metadata: {
+                        projectUuid,
+                        projectName: project.name,
+                    },
                 }),
             )
         ) {

--- a/packages/backend/src/services/FunnelService/FunnelService.ts
+++ b/packages/backend/src/services/FunnelService/FunnelService.ts
@@ -73,13 +73,18 @@ export class FunnelService extends BaseService {
             throw new ForbiddenError('Funnel Builder feature is not enabled');
         }
 
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
-                subject('SqlRunner', { organizationUuid, projectUuid }),
+                subject('SqlRunner', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { projectUuid, projectName },
+                }),
             )
         ) {
             throw new ForbiddenError(

--- a/packages/backend/src/services/GitlabAppService/GitlabAppService.ts
+++ b/packages/backend/src/services/GitlabAppService/GitlabAppService.ts
@@ -177,13 +177,13 @@ export class GitlabAppService extends BaseService {
         }
     }
 
-    // eslint-disable-next-line class-methods-use-this
     private canManageOrg(user: SessionUser) {
         if (!isUserWithOrg(user)) {
             throw new Error('User is not part of an organization');
         }
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            !user.ability.can(
+            !auditedAbility.can(
                 'manage',
                 subject('Organization', {
                     organizationUuid: user.organizationUuid,

--- a/packages/backend/src/services/ProjectParametersService.ts
+++ b/packages/backend/src/services/ProjectParametersService.ts
@@ -48,13 +48,18 @@ export class ProjectParametersService extends BaseService {
             sortOrder?: 'asc' | 'desc';
         },
     ) {
-        const { organizationUuid } =
+        const { organizationUuid, name: projectName } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
-                subject('Project', { organizationUuid, projectUuid }),
+                subject('Project', {
+                    organizationUuid,
+                    projectUuid,
+                    metadata: { projectUuid, projectName },
+                }),
             )
         ) {
             throw new ForbiddenError();

--- a/packages/backend/src/services/ShareService/ShareService.ts
+++ b/packages/backend/src/services/ShareService/ShareService.ts
@@ -2,6 +2,7 @@ import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     isUserWithOrg,
+    NotFoundError,
     SessionUser,
     ShareUrl,
 } from '@lightdash/common';
@@ -46,12 +47,17 @@ export class ShareService extends BaseService {
             throw new ForbiddenError('User is not part of an organization');
         }
         const shareUrl = await this.shareModel.getSharedUrl(nanoid);
+        if (!shareUrl.organizationUuid) {
+            throw new NotFoundError('Shared link does not exist');
+        }
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('OrganizationMemberProfile', {
                     organizationUuid: shareUrl.organizationUuid,
+                    metadata: { shareNanoid: shareUrl.nanoid },
                 }),
             )
         ) {

--- a/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
+++ b/packages/backend/src/services/SlackIntegrationService/SlackIntegrationService.ts
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import {
     ForbiddenError,
     NotFoundError,
@@ -107,7 +108,13 @@ export class SlackIntegrationService<
         const organizationUuid = user?.organizationUuid;
         if (!organizationUuid) throw new ForbiddenError();
 
-        if (user.ability.cannot('manage', 'Organization')) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('Organization', { organizationUuid }),
+            )
+        ) {
             throw new ForbiddenError();
         }
 

--- a/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
+++ b/packages/backend/src/services/UserAttributesService/UserAttributeUtils.ts
@@ -1,4 +1,4 @@
-import { subject } from '@casl/ability';
+import { subject, type Ability } from '@casl/ability';
 import {
     AuthorizationError,
     CorruptedExploreError,
@@ -8,6 +8,7 @@ import {
     UserAttributeValueMap,
 } from '@lightdash/common';
 import { z } from 'zod';
+import type { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
 
 /**
  * Zod schema for parsing user attribute overrides from headers.
@@ -30,14 +31,18 @@ export const userAttributeOverridesSchema = z
  */
 export const validateUserAttributeOverrides = (
     user: SessionUser,
+    auditedAbility: CaslAuditWrapper<Ability>,
     headerAttributes: UserAttributeValueMap,
     dbAttributes: UserAttributeValueMap,
 ): void => {
     const { organizationUuid } = user;
+    if (!organizationUuid) {
+        throw new ForbiddenError('User is not part of an organization');
+    }
 
     // Check admin permission - only admins can override via header
     if (
-        user.ability.cannot(
+        auditedAbility.cannot(
             'manage',
             subject('Organization', { organizationUuid }),
         )


### PR DESCRIPTION
## Summary

Migrates all 7 services that had a single direct `.ability.` call site to `this.createAuditedAbility()` with type-prefixed metadata for ITGC-compliant audit logging:

| File | Subject | Metadata |
|------|---------|----------|
| `CsvService.ts` | `ExportCsv` | `dashboardUuid`, `dashboardName` |
| `DeployService.ts` | `DeployProject` | `projectUuid`, `projectName` |
| `SlackIntegrationService.ts` | `Organization` | — (converted from string subject to object form) |
| `UserAttributeUtils.ts` | `Organization` | — |
| `GitlabAppService.ts` | `Organization` | — |
| `ProjectParametersService.ts` | `Project` | `projectUuid`, `projectName` |
| `FunnelService.ts` | `SqlRunner` | `projectUuid`, `projectName` |

Promotes `no-direct-ability-check` from `warn` → `error` for all 6 fully-migrated folders (CsvService, DeployService, FunnelService, GitlabAppService, ProjectParametersService, SlackIntegrationService). `UserAttributesService/` is not promoted because `UserAttributesService.ts` still has 4 unmigrated calls.

## Notable change: `validateUserAttributeOverrides` signature

`UserAttributeUtils.ts` is a standalone utility file (not a class), so it can't call `this.createAuditedAbility()`. Refactored `validateUserAttributeOverrides` to accept a `CaslAuditWrapper<Ability>` parameter; both `McpService` call sites now create the wrapper via `this.createAuditedAbility(user)` and pass it in. Also added an explicit `organizationUuid` guard since the audited subject type requires it to be a `string`.

Two other minor behavior changes:

- `ShareService.getShareUrl` now throws `NotFoundError` when `shareUrl.organizationUuid` is missing (the left-join in `ShareModel.getSharedUrl` can produce `null` if the org row is gone). Before, this path silently ran an ability check with `undefined` — which would always deny.
- `GitlabAppService.canManageOrg` lost its `// eslint-disable-next-line class-methods-use-this` comment since the method now uses `this`.

## Test plan

- [x] `pnpm -F backend typecheck` clean
- [x] `pnpm -F backend lint` — 0 errors, only warnings on the other unmigrated services
- [x] `pnpm -F backend exec jest src/services/CsvService src/services/ShareService` — 15/15 pass, audit events visible
- [ ] Manual smoke: schedule CSV dashboard export, trigger a deploy, delete Slack installation, use header attribute overrides via MCP, connect/disconnect GitLab, list project parameters, open Funnel Builder — confirm audit events in PM2 logs for each

🤖 Generated with [Claude Code](https://claude.com/claude-code)

deploy-preview test-frontend test-backend