### PR TITLE
feat: return explore warning report from deploy endpoints

### DIFF
--- a/packages/backend/src/controllers/exploreController.ts
+++ b/packages/backend/src/controllers/exploreController.ts
@@ -4,7 +4,7 @@ import {
     ApiErrorPayload,
     ApiExploreResults,
     ApiExploresResults,
-    ApiSuccessEmpty,
+    ApiSetExploresResponse,
     MetricQuery,
     type ApiFormulaValidationResults,
     type ApiPreAggregateCheckResponse,
@@ -53,15 +53,15 @@ export class ExploreController extends BaseController {
         @Path() projectUuid: string,
         @Request() req: express.Request,
         @Body() body: AnyType[], // tsoa doesn't seem to work with explores from CLI
-    ): Promise<ApiSuccessEmpty> {
+    ): Promise<ApiSetExploresResponse> {
         this.setStatus(200);
-        await this.services
+        const results = await this.services
             .getProjectService()
             .setExplores(req.user!, projectUuid, body);
 
         return {
             status: 'ok',
-            results: undefined,
+            results,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6860,24 +6860,33 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    AppImageAttachment: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                filename: { dataType: 'string', required: true },
+                mimeType: { dataType: 'string', required: true },
+                s3Key: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GenerateAppRequestBody: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
-                chartUuids: {
-                    dataType: 'array',
-                    array: { dataType: 'string' },
-                },
                 appUuid: { dataType: 'string' },
-                imageId: { dataType: 'string' },
+                image: { ref: 'AppImageAttachment' },
                 prompt: { dataType: 'string', required: true },
             },
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__imageId-string__': {
+    'ApiSuccess__s3Key-string__': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -6885,7 +6894,7 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        imageId: { dataType: 'string', required: true },
+                        s3Key: { dataType: 'string', required: true },
                     },
                     required: true,
                 },
@@ -6897,7 +6906,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAppImageUploadResponse: {
         dataType: 'refAlias',
-        type: { ref: 'ApiSuccess__imageId-string__', validators: {} },
+        type: { ref: 'ApiSuccess__s3Key-string__', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AppVersionStatus: {
@@ -8641,11 +8650,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8660,11 +8669,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8679,11 +8688,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8714,29 +8723,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 searchRank:
                                                                                                     {
                                                                                                         dataType:
@@ -8760,11 +8746,28 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
                                                                                                     },
                                                                                                 tableName:
                                                                                                     {
@@ -8777,6 +8780,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -8892,11 +8901,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8972,29 +8981,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    chartUsage:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     searchRank:
                                                                                                         {
                                                                                                             dataType:
@@ -9018,11 +9004,28 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
                                                                                                         },
                                                                                                     tableName:
                                                                                                         {
@@ -9035,6 +9038,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9066,11 +9075,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9085,11 +9094,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -24362,6 +24371,85 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'NonNullable_Explore-at-warnings_': {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'InlineError' },
+                },
+                { dataType: 'nestedObjectLiteral', nestedProperties: {} },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExploreWarningSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'intersection',
+            subSchemas: [
+                { ref: 'Pick_Explore.name_' },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        warnings: {
+                            ref: 'NonNullable_Explore-at-warnings_',
+                            required: true,
+                        },
+                    },
+                },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ExploreWarningReport: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                exploresWithWarnings: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'ExploreWarningSummary',
+                    },
+                    required: true,
+                },
+                warningExploreCount: { dataType: 'double', required: true },
+                warningCount: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDeployExploresResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                warnings: { ref: 'ExploreWarningReport', required: true },
+                exploreCount: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSetExploresResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'ApiDeployExploresResults', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'Pick_Explore.SummaryExploreFields_': {
         dataType: 'refAlias',
         type: {
@@ -26822,6 +26910,10 @@ const models: TsoaRoute.Models = {
                             ref: 'QueryHistoryStatus.READY',
                             required: true,
                         },
+                        resolvedTimezone: {
+                            dataType: 'string',
+                            required: true,
+                        },
                         metadata: {
                             ref: 'QueryResultsMetadata',
                             required: true,
@@ -28000,11 +28092,19 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 results: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        status: { ref: 'DeploySessionStatus', required: true },
-                        exploreCount: { dataType: 'double', required: true },
-                    },
+                    dataType: 'intersection',
+                    subSchemas: [
+                        { ref: 'ApiDeployExploresResults' },
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                status: {
+                                    ref: 'DeploySessionStatus',
+                                    required: true,
+                                },
+                            },
+                        },
+                    ],
                     required: true,
                 },
                 status: { dataType: 'enum', enums: ['ok'], required: true },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8227,19 +8227,29 @@
             "ApiGenerateAppResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__appUuid-string--version-number__"
             },
+            "AppImageAttachment": {
+                "properties": {
+                    "filename": {
+                        "type": "string"
+                    },
+                    "mimeType": {
+                        "type": "string"
+                    },
+                    "s3Key": {
+                        "type": "string"
+                    }
+                },
+                "required": ["filename", "mimeType", "s3Key"],
+                "type": "object",
+                "description": "Image attached to a data app generation request.\nThe image is uploaded to S3 via the backend proxy; the s3Key\nreferences the uploaded object."
+            },
             "GenerateAppRequestBody": {
                 "properties": {
-                    "chartUuids": {
-                        "items": {
-                            "type": "string"
-                        },
-                        "type": "array"
-                    },
                     "appUuid": {
                         "type": "string"
                     },
-                    "imageId": {
-                        "type": "string"
+                    "image": {
+                        "$ref": "#/components/schemas/AppImageAttachment"
                     },
                     "prompt": {
                         "type": "string"
@@ -8248,15 +8258,15 @@
                 "required": ["prompt"],
                 "type": "object"
             },
-            "ApiSuccess__imageId-string__": {
+            "ApiSuccess__s3Key-string__": {
                 "properties": {
                     "results": {
                         "properties": {
-                            "imageId": {
+                            "s3Key": {
                                 "type": "string"
                             }
                         },
-                        "required": ["imageId"],
+                        "required": ["s3Key"],
                         "type": "object"
                     },
                     "status": {
@@ -8269,7 +8279,7 @@
                 "type": "object"
             },
             "ApiAppImageUploadResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__imageId-string__"
+                "$ref": "#/components/schemas/ApiSuccess__s3Key-string__"
             },
             "AppVersionStatus": {
                 "type": "string",
@@ -10091,23 +10101,33 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10115,14 +10135,17 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10171,8 +10194,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10216,18 +10239,15 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10235,14 +10255,17 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10270,8 +10293,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -25628,6 +25651,88 @@
                 "required": ["contentUuid", "contentType"],
                 "type": "object"
             },
+            "NonNullable_Explore-at-warnings_": {
+                "allOf": [
+                    {
+                        "items": {
+                            "$ref": "#/components/schemas/InlineError"
+                        },
+                        "type": "array"
+                    },
+                    {
+                        "properties": {},
+                        "type": "object"
+                    }
+                ],
+                "description": "Exclude null and undefined from T"
+            },
+            "ExploreWarningSummary": {
+                "allOf": [
+                    {
+                        "$ref": "#/components/schemas/Pick_Explore.name_"
+                    },
+                    {
+                        "properties": {
+                            "warnings": {
+                                "$ref": "#/components/schemas/NonNullable_Explore-at-warnings_"
+                            }
+                        },
+                        "required": ["warnings"],
+                        "type": "object"
+                    }
+                ]
+            },
+            "ExploreWarningReport": {
+                "properties": {
+                    "exploresWithWarnings": {
+                        "items": {
+                            "$ref": "#/components/schemas/ExploreWarningSummary"
+                        },
+                        "type": "array"
+                    },
+                    "warningExploreCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "warningCount": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": [
+                    "exploresWithWarnings",
+                    "warningExploreCount",
+                    "warningCount"
+                ],
+                "type": "object"
+            },
+            "ApiDeployExploresResults": {
+                "properties": {
+                    "warnings": {
+                        "$ref": "#/components/schemas/ExploreWarningReport"
+                    },
+                    "exploreCount": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["warnings", "exploreCount"],
+                "type": "object"
+            },
+            "ApiSetExploresResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ApiDeployExploresResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
             "Pick_Explore.SummaryExploreFields_": {
                 "properties": {
                     "name": {
@@ -27976,6 +28081,9 @@
                             "status": {
                                 "$ref": "#/components/schemas/QueryHistoryStatus.READY"
                             },
+                            "resolvedTimezone": {
+                                "type": "string"
+                            },
                             "metadata": {
                                 "$ref": "#/components/schemas/QueryResultsMetadata"
                             },
@@ -27995,6 +28103,7 @@
                         "required": [
                             "pivotDetails",
                             "status",
+                            "resolvedTimezone",
                             "metadata",
                             "rows",
                             "columns",
@@ -29074,17 +29183,20 @@
             "ApiFinalizeDeployResponse": {
                 "properties": {
                     "results": {
-                        "properties": {
-                            "status": {
-                                "$ref": "#/components/schemas/DeploySessionStatus"
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ApiDeployExploresResults"
                             },
-                            "exploreCount": {
-                                "type": "number",
-                                "format": "double"
+                            {
+                                "properties": {
+                                    "status": {
+                                        "$ref": "#/components/schemas/DeploySessionStatus"
+                                    }
+                                },
+                                "required": ["status"],
+                                "type": "object"
                             }
-                        },
-                        "required": ["status", "exploreCount"],
-                        "type": "object"
+                        ]
                     },
                     "status": {
                         "type": "string",
@@ -30258,7 +30370,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2775.0",
+        "version": "0.2775.1",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -44279,7 +44391,7 @@
                         "content": {
                             "application/json": {
                                 "schema": {
-                                    "$ref": "#/components/schemas/ApiSuccessEmpty"
+                                    "$ref": "#/components/schemas/ApiSetExploresResponse"
                                 }
                             }
                         }

--- a/packages/backend/src/services/DeployService.ts
+++ b/packages/backend/src/services/DeployService.ts
@@ -1,5 +1,6 @@
 import { subject } from '@casl/ability';
 import {
+    calculateExploreWarningReport,
     DeploySessionStatus,
     Explore,
     ExploreError,
@@ -7,6 +8,7 @@ import {
     NotFoundError,
     ProjectType,
     SessionUser,
+    type ApiDeployExploresResults,
 } from '@lightdash/common';
 import { DeploySessionModel } from '../models/DeploySessionModel';
 import { ProjectModel } from '../models/ProjectModel/ProjectModel';
@@ -173,7 +175,7 @@ export class DeployService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         sessionUuid: string,
-    ): Promise<{ exploreCount: number; status: DeploySessionStatus }> {
+    ): Promise<ApiDeployExploresResults & { status: DeploySessionStatus }> {
         const session = await this.deploySessionModel.getSession(sessionUuid);
 
         // Validate ownership
@@ -244,6 +246,7 @@ export class DeployService extends BaseService {
 
             return {
                 exploreCount: explores.length,
+                warnings: calculateExploreWarningReport({ explores }),
                 status: DeploySessionStatus.COMPLETED,
             };
         } catch (error) {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -7,6 +7,7 @@ import {
     AnyType,
     ApiChartAndResults,
     ApiCreatePreviewResults,
+    ApiDeployExploresResults,
     ApiFormulaValidationResults,
     ApiQueryResults,
     ApiSqlQueryResults,
@@ -17,6 +18,7 @@ import {
     BigqueryAuthenticationType,
     CacheMetadata,
     calculateCompilationReport,
+    calculateExploreWarningReport,
     ChartSourceType,
     ChartSummary,
     CompiledDimension,
@@ -2151,7 +2153,7 @@ export class ProjectService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         explores: (Explore | ExploreError)[],
-    ): Promise<void> {
+    ): Promise<ApiDeployExploresResults> {
         const project =
             await this.projectModel.getWithSensitiveFields(projectUuid);
 
@@ -2195,6 +2197,13 @@ export class ProjectService extends BaseService {
             context: 'cli',
             organizationUuid: project.organizationUuid,
         });
+
+        return {
+            exploreCount: exploresWithPreAggregates.length,
+            warnings: calculateExploreWarningReport({
+                explores: exploresWithPreAggregates,
+            }),
+        };
     }
 
     /* When editing a project, most fields are optional

--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -1,4 +1,5 @@
 import {
+    ApiDeployExploresResults,
     AuthorizationError,
     DeploySessionStatus,
     Explore,
@@ -57,6 +58,35 @@ type DeployHandlerOptions = DbtCompileOptions & {
 
 type DeployArgs = DeployHandlerOptions & {
     projectUuid: string;
+};
+
+export const logDeployWarnings = (
+    warningResults: ApiDeployExploresResults['warnings'] | undefined,
+) => {
+    if (
+        !warningResults ||
+        warningResults.warningCount === 0 ||
+        !warningResults.exploresWithWarnings?.length
+    ) {
+        return;
+    }
+
+    console.error(
+        styles.warning(
+            `\nCompilation warnings (${warningResults.warningCount})`,
+        ),
+    );
+
+    warningResults.exploresWithWarnings.forEach((explore) => {
+        explore.warnings.forEach((warning) => {
+            console.error(
+                `- ${styles.warning(explore.name)}: ${styles.warning(
+                    warning.message,
+                )}`,
+            );
+        });
+    });
+    console.error('');
 };
 
 const replaceProjectYamlTags = async (
@@ -209,18 +239,20 @@ const deployBatched = async (
 
     // Finalize deploy
     GlobalState.log(`Finalizing deploy...`);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const finalizeResponse = (await lightdashApi<any>({
+    const finalizeResponse = await lightdashApi<
+        ApiDeployExploresResults & { status: DeploySessionStatus }
+    >({
         method: 'POST',
         url: `/api/v2/projects/${options.projectUuid}/deploy/${sessionUuid}/finalize`,
         body: JSON.stringify({}),
-    })) as { exploreCount: number; status: DeploySessionStatus };
+    });
 
     GlobalState.log(
         styles.success(
             `Deploy completed! ${finalizeResponse.exploreCount} explores deployed.`,
         ),
     );
+    logDeployWarnings(finalizeResponse.warnings);
 
     await LightdashAnalytics.track({
         event: 'deploy.triggered',
@@ -310,11 +342,16 @@ export const deploy = async (
         const deployStartTime = Date.now();
         const deployPayload = JSON.stringify(explores);
         try {
-            await lightdashApi<null>({
-                method: 'PUT',
-                url: `/api/v1/projects/${options.projectUuid}/explores`,
-                body: deployPayload,
-            });
+            const deployResponse = await lightdashApi<ApiDeployExploresResults>(
+                {
+                    method: 'PUT',
+                    url: `/api/v1/projects/${options.projectUuid}/explores`,
+                    body: deployPayload,
+                },
+            );
+            if (deployResponse) {
+                logDeployWarnings(deployResponse.warnings);
+            }
             await LightdashAnalytics.track({
                 event: 'deploy.triggered',
                 properties: {

--- a/packages/common/src/compiler/compilationReport.ts
+++ b/packages/common/src/compiler/compilationReport.ts
@@ -12,6 +12,16 @@ export type CompilationHistoryReport = {
     baseTableNames: string[];
 };
 
+export type ExploreWarningSummary = Pick<Explore, 'name'> & {
+    warnings: NonNullable<Explore['warnings']>;
+};
+
+export type ExploreWarningReport = {
+    warningCount: number;
+    warningExploreCount: number;
+    exploresWithWarnings: ExploreWarningSummary[];
+};
+
 export const calculateCompilationReport = (args: {
     explores: (Explore | ExploreError)[];
 }): CompilationHistoryReport => {
@@ -44,5 +54,33 @@ export const calculateCompilationReport = (args: {
         dimensionsCount,
         exploresWithErrors,
         baseTableNames,
+    };
+};
+
+export const calculateExploreWarningReport = (args: {
+    explores: (Explore | ExploreError)[];
+}): ExploreWarningReport => {
+    const exploresWithWarnings = args.explores.flatMap<ExploreWarningSummary>(
+        (explore) => {
+            if (isExploreError(explore) || !explore.warnings?.length) {
+                return [];
+            }
+
+            return [
+                {
+                    name: explore.name,
+                    warnings: explore.warnings,
+                },
+            ];
+        },
+    );
+
+    return {
+        warningCount: exploresWithWarnings.reduce(
+            (count, explore) => count + explore.warnings.length,
+            0,
+        ),
+        warningExploreCount: exploresWithWarnings.length,
+        exploresWithWarnings,
     };
 };

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -1,3 +1,4 @@
+import { type ExploreWarningReport } from '../compiler/compilationReport';
 // Note: EE types removed from direct import to avoid circular module resolution
 // They are still available via the re-export below: export * from './ee';
 import type {
@@ -546,10 +547,19 @@ export type ApiAddDeployBatchResponse = {
     };
 };
 
+export type ApiDeployExploresResults = {
+    exploreCount: number;
+    warnings: ExploreWarningReport;
+};
+
+export type ApiSetExploresResponse = {
+    status: 'ok';
+    results: ApiDeployExploresResults;
+};
+
 export type ApiFinalizeDeployResponse = {
     status: 'ok';
-    results: {
-        exploreCount: number;
+    results: ApiDeployExploresResults & {
         status: DeploySessionStatus;
     };
 };
@@ -924,6 +934,7 @@ type ApiResults =
     | ApiDeleteComment
     | ApiSuccessEmpty
     | ApiCreateProjectResults
+    | ApiDeployExploresResults
     | ApiAiDashboardSummaryResponse['results']
     | ApiAiGetDashboardSummaryResponse['results']
     | ApiAiGenerateChartMetadataResponse['results']


### PR DESCRIPTION
Closes: [PROD-6932: Pre-aggregate compilation errors not shown in preview projects](https://linear.app/lightdash/issue/PROD-6932/pre-aggregate-compilation-errors-not-shown-in-preview-projects)

### Description:

The `PUT /api/v1/projects/:projectUuid/explores` endpoint now returns meaningful results instead of an empty response. The return type has been changed from `ApiSuccessEmpty` to a new `ApiSetExploresResponse` type that includes the number of explores deployed and a warning report.

A new `ExploreWarningReport` type has been introduced to surface compilation warnings after a deploy. It includes the total warning count, the number of explores with warnings, and a per-explore breakdown of warning messages. This report is now returned by both the direct deploy endpoint (`PUT /explores`) and the batched deploy finalize endpoint.

The CLI `deploy` handler has been updated to consume and display these warnings after a successful deploy, printing them to `stderr` in both the batched and non-batched deploy flows. A `logDeployWarnings` helper function has been extracted and covered with unit tests.