### PR TITLE
feat(data-apps): surface data apps in space content listings

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -83,9 +83,12 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     catalogModel: models.getCatalogModel(),
                     appModel: models.getAppModel(),
                     featureFlagModel: models.getFeatureFlagModel(),
+                    projectModel: models.getProjectModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,
                     savedChartService: repository.getSavedChartService(),
+                    spacePermissionService:
+                        repository.getSpacePermissionService(),
                 }),
             embedService: ({ repository, context, models }) =>
                 new EmbedService({

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -33,9 +33,11 @@ import {
 import { AppModel } from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
 import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
+import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
 import type { SavedChartService } from '../../../services/SavedChartsService/SavedChartService';
+import type { SpacePermissionService } from '../../../services/SpaceService/SpacePermissionService';
 import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient';
 
 type AppGenerateServiceDeps = {
@@ -44,8 +46,10 @@ type AppGenerateServiceDeps = {
     catalogModel: CatalogModel;
     appModel: AppModel;
     featureFlagModel: FeatureFlagModel;
+    projectModel: ProjectModel;
     schedulerClient: CommercialSchedulerClient;
     savedChartService: SavedChartService;
+    spacePermissionService: SpacePermissionService;
 };
 
 type GenerateAppResult = {
@@ -64,9 +68,13 @@ export class AppGenerateService extends BaseService {
 
     private readonly featureFlagModel: FeatureFlagModel;
 
+    private readonly projectModel: ProjectModel;
+
     private readonly schedulerClient: CommercialSchedulerClient;
 
     private readonly savedChartService: SavedChartService;
+
+    private readonly spacePermissionService: SpacePermissionService;
 
     constructor({
         lightdashConfig,
@@ -74,8 +82,10 @@ export class AppGenerateService extends BaseService {
         catalogModel,
         appModel,
         featureFlagModel,
+        projectModel,
         schedulerClient,
         savedChartService,
+        spacePermissionService,
     }: AppGenerateServiceDeps) {
         super();
         this.lightdashConfig = lightdashConfig;
@@ -83,8 +93,82 @@ export class AppGenerateService extends BaseService {
         this.catalogModel = catalogModel;
         this.appModel = appModel;
         this.featureFlagModel = featureFlagModel;
+        this.projectModel = projectModel;
         this.schedulerClient = schedulerClient;
         this.savedChartService = savedChartService;
+        this.spacePermissionService = spacePermissionService;
+    }
+
+    /**
+     * Resolve the organization UUID for a project. Used to derive the CASL
+     * subject's `organizationUuid` from the resource (the project itself)
+     * rather than the user — so cross-org access attempts are denied by
+     * CASL instead of relying only on upstream project scoping.
+     */
+    private async getProjectOrgUuid(projectUuid: string): Promise<string> {
+        const summary = await this.projectModel.getSummary(projectUuid);
+        return summary.organizationUuid;
+    }
+
+    /**
+     * Run a CASL check on `DataApp`, throwing `ForbiddenError` if denied.
+     * Callers must pass the resource-derived organizationUuid so that the
+     * check is a genuine cross-org guard, not a tautology on the user's own
+     * org.
+     */
+    private assertDataAppAbility(
+        user: SessionUser,
+        action: 'view' | 'manage',
+        organizationUuid: string,
+        projectUuid: string,
+        errorMessage: string,
+        extraContext: Record<string, unknown> = {},
+    ): void {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                action,
+                subject('DataApp', {
+                    organizationUuid,
+                    projectUuid,
+                    ...extraContext,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(errorMessage);
+        }
+    }
+
+    /**
+     * Permission check for reading a data app.
+     *
+     * Apps can live in two modes:
+     * - Assigned to a space → the subject carries space access context and
+     *   viewers with space access match `view:DataApp`.
+     * - Personal / unassigned → the subject has no space context, so only
+     *   the admin-level `manage:DataApp` rule (which matches any action,
+     *   including view) grants access.
+     */
+    private async assertCanViewApp(
+        user: SessionUser,
+        app: Pick<DbApp, 'project_uuid' | 'space_uuid'> & {
+            organization_uuid: string;
+        },
+    ): Promise<void> {
+        const spaceContext = app.space_uuid
+            ? await this.spacePermissionService.getSpaceAccessContext(
+                  user.userUuid,
+                  app.space_uuid,
+              )
+            : {};
+        this.assertDataAppAbility(
+            user,
+            'view',
+            app.organization_uuid,
+            app.project_uuid,
+            'Insufficient permissions to access this data app',
+            spaceContext,
+        );
     }
 
     private getAnthropicApiKey(): string {
@@ -249,19 +333,14 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
     ): Promise<{ imageId: string }> {
         await this.assertDataAppsEnabled(user);
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'Insufficient permissions to upload app images',
-            );
-        }
+        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
+        this.assertDataAppAbility(
+            user,
+            'manage',
+            organizationUuid,
+            projectUuid,
+            'Insufficient permissions to upload app images',
+        );
 
         const validTypes = [
             'image/png',
@@ -1865,19 +1944,14 @@ export class AppGenerateService extends BaseService {
         chartUuids?: string[],
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'Insufficient permissions to create data apps',
-            );
-        }
+        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
+        this.assertDataAppAbility(
+            user,
+            'manage',
+            organizationUuid,
+            projectUuid,
+            'Insufficient permissions to create data apps',
+        );
 
         if (imageId !== undefined && !isValidUuid(imageId)) {
             throw new ParameterError('Invalid imageId: must be a valid UUID');
@@ -2040,21 +2114,14 @@ export class AppGenerateService extends BaseService {
         version: number,
     ): Promise<void> {
         await this.assertDataAppsEnabled(user);
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'Insufficient permissions to cancel app generation',
-            );
-        }
-
         const app = await this.appModel.getApp(appUuid, projectUuid);
+        this.assertDataAppAbility(
+            user,
+            'manage',
+            app.organization_uuid,
+            projectUuid,
+            'Insufficient permissions to cancel app generation',
+        );
 
         // Read the version before updating it so we can capture the stage
         // it was at when the cancel hit.
@@ -2124,6 +2191,7 @@ export class AppGenerateService extends BaseService {
         name: string;
         description: string;
         createdByUserUuid: string;
+        spaceUuid: string | null;
         versions: {
             version: number;
             prompt: string;
@@ -2134,28 +2202,29 @@ export class AppGenerateService extends BaseService {
         hasMore: boolean;
     }> {
         await this.assertDataAppsEnabled(user);
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'Insufficient permissions to access data apps',
-            );
-        }
 
-        const { name, description, createdByUserUuid, versions, hasMore } =
-            await this.appModel.getAppWithVersions(appUuid, projectUuid, opts);
+        const {
+            name,
+            description,
+            createdByUserUuid,
+            organizationUuid,
+            spaceUuid,
+            versions,
+            hasMore,
+        } = await this.appModel.getAppWithVersions(appUuid, projectUuid, opts);
+
+        await this.assertCanViewApp(user, {
+            project_uuid: projectUuid,
+            space_uuid: spaceUuid,
+            organization_uuid: organizationUuid,
+        });
 
         return {
             appUuid,
             name,
             description,
             createdByUserUuid,
+            spaceUuid,
             versions: versions.map((v) => ({
                 version: v.version,
                 prompt: v.prompt,
@@ -2189,7 +2258,8 @@ export class AppGenerateService extends BaseService {
         };
     }> {
         await this.assertDataAppsEnabled(user);
-        if (user.ability.cannot('manage', 'DataApp')) {
+        const auditedAbility = this.createAuditedAbility(user);
+        if (auditedAbility.cannot('manage', 'DataApp')) {
             throw new ForbiddenError('Insufficient permissions');
         }
 
@@ -2220,19 +2290,14 @@ export class AppGenerateService extends BaseService {
         update: { name?: string; description?: string },
     ): Promise<{ appUuid: string; name: string; description: string }> {
         await this.assertDataAppsEnabled(user);
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'Insufficient permissions to manage data apps',
-            );
-        }
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        this.assertDataAppAbility(
+            user,
+            'manage',
+            app.organization_uuid,
+            projectUuid,
+            'Insufficient permissions to manage data apps',
+        );
 
         const fieldsToUpdate: Partial<{ name: string; description: string }> =
             {};
@@ -2264,15 +2329,15 @@ export class AppGenerateService extends BaseService {
             );
         }
 
-        const app = await this.appModel.updateApp(
+        const updatedApp = await this.appModel.updateApp(
             appUuid,
             projectUuid,
             fieldsToUpdate,
         );
         return {
-            appUuid: app.app_id,
-            name: app.name,
-            description: app.description,
+            appUuid: updatedApp.app_id,
+            name: updatedApp.name,
+            description: updatedApp.description,
         };
     }
 
@@ -2360,19 +2425,6 @@ export class AppGenerateService extends BaseService {
         version: number,
     ): Promise<string> {
         await this.assertDataAppsEnabled(user);
-        if (
-            user.ability.cannot(
-                'manage',
-                subject('DataApp', {
-                    organizationUuid: user.organizationUuid,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'Insufficient permissions to access data apps',
-            );
-        }
 
         if (!isValidUuid(appUuid)) {
             throw new ParameterError('Invalid UUID format');
@@ -2381,6 +2433,9 @@ export class AppGenerateService extends BaseService {
         if (!Number.isInteger(version) || version < 1) {
             throw new ParameterError('Version must be a positive integer');
         }
+
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        await this.assertCanViewApp(user, app);
 
         return mintPreviewToken(
             this.lightdashConfig.lightdashSecret,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6874,33 +6874,24 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AppImageAttachment: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                filename: { dataType: 'string', required: true },
-                mimeType: { dataType: 'string', required: true },
-                s3Key: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GenerateAppRequestBody: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                chartUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
                 appUuid: { dataType: 'string' },
-                image: { ref: 'AppImageAttachment' },
+                imageId: { dataType: 'string' },
                 prompt: { dataType: 'string', required: true },
             },
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__s3Key-string__': {
+    'ApiSuccess__imageId-string__': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -6908,7 +6899,7 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        s3Key: { dataType: 'string', required: true },
+                        imageId: { dataType: 'string', required: true },
                     },
                     required: true,
                 },
@@ -6920,7 +6911,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAppImageUploadResponse: {
         dataType: 'refAlias',
-        type: { ref: 'ApiSuccess__s3Key-string__', validators: {} },
+        type: { ref: 'ApiSuccess__imageId-string__', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AppVersionStatus: {
@@ -6968,7 +6959,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
+    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
         {
             dataType: 'refAlias',
             type: {
@@ -6984,6 +6975,14 @@ const models: TsoaRoute.Models = {
                                     dataType: 'refAlias',
                                     ref: 'ApiAppVersionSummary',
                                 },
+                                required: true,
+                            },
+                            spaceUuid: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { dataType: 'string' },
+                                    { dataType: 'enum', enums: [null] },
+                                ],
                                 required: true,
                             },
                             createdByUserUuid: {
@@ -7005,7 +7004,7 @@ const models: TsoaRoute.Models = {
     ApiGetAppResponse: {
         dataType: 'refAlias',
         type: {
-            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
+            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
             validators: {},
         },
     },
@@ -8645,11 +8644,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9127,11 +9126,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9146,11 +9145,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9165,11 +9164,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9184,11 +9183,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9203,11 +9202,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -21585,7 +21584,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ContentType: {
         dataType: 'refEnum',
-        enums: ['chart', 'dashboard', 'space'],
+        enums: ['chart', 'dashboard', 'space', 'data_app'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     VerifiedContentListItem: {
@@ -22413,27 +22412,28 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ResourceViewItemType: {
         dataType: 'refEnum',
-        enums: ['chart', 'dashboard', 'space'],
+        enums: ['chart', 'dashboard', 'space', 'data_app'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_': {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                uuid: { dataType: 'string', required: true },
-                pinnedListOrder: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'double' },
-                        { dataType: 'enum', enums: [null] },
-                    ],
-                    required: true,
+    'Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data.uuid-or-pinnedListOrder_':
+        {
+            dataType: 'refAlias',
+            type: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    uuid: { dataType: 'string', required: true },
+                    pinnedListOrder: {
+                        dataType: 'union',
+                        subSchemas: [
+                            { dataType: 'double' },
+                            { dataType: 'enum', enums: [null] },
+                        ],
+                        required: true,
+                    },
                 },
+                validators: {},
             },
-            validators: {},
         },
-    },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     UpdatePinnedItemOrder: {
         dataType: 'refAlias',
@@ -22441,7 +22441,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 data: {
-                    ref: 'Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_',
+                    ref: 'Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data.uuid-or-pinnedListOrder_',
                     required: true,
                 },
                 type: { ref: 'ResourceViewItemType', required: true },
@@ -28524,6 +28524,139 @@ const models: TsoaRoute.Models = {
         additionalProperties: true,
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ContentType.DATA_APP': {
+        dataType: 'refEnum',
+        enums: ['data_app'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DataAppContent: {
+        dataType: 'refObject',
+        properties: {
+            contentType: { ref: 'ContentType.DATA_APP', required: true },
+            uuid: { dataType: 'string', required: true },
+            slug: { dataType: 'string', required: true },
+            name: { dataType: 'string', required: true },
+            description: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'string' },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+            createdAt: { dataType: 'datetime', required: true },
+            createdBy: {
+                dataType: 'union',
+                subSchemas: [
+                    {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            lastName: { dataType: 'string', required: true },
+                            firstName: { dataType: 'string', required: true },
+                            uuid: { dataType: 'string', required: true },
+                        },
+                    },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+            lastUpdatedAt: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'datetime' },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+            lastUpdatedBy: {
+                dataType: 'union',
+                subSchemas: [
+                    {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            lastName: { dataType: 'string', required: true },
+                            firstName: { dataType: 'string', required: true },
+                            uuid: { dataType: 'string', required: true },
+                        },
+                    },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+            project: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                },
+                required: true,
+            },
+            organization: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                },
+                required: true,
+            },
+            space: {
+                dataType: 'nestedObjectLiteral',
+                nestedProperties: {
+                    name: { dataType: 'string', required: true },
+                    uuid: { dataType: 'string', required: true },
+                },
+                required: true,
+            },
+            pinnedList: {
+                dataType: 'union',
+                subSchemas: [
+                    {
+                        dataType: 'nestedObjectLiteral',
+                        nestedProperties: {
+                            uuid: { dataType: 'string', required: true },
+                        },
+                    },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+            views: { dataType: 'double', required: true },
+            firstViewedAt: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'datetime' },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+            verification: {
+                dataType: 'union',
+                subSchemas: [
+                    { ref: 'ContentVerificationInfo' },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+            latestVersionNumber: {
+                dataType: 'union',
+                subSchemas: [
+                    { dataType: 'double' },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+            latestVersionStatus: {
+                dataType: 'union',
+                subSchemas: [
+                    { ref: 'AppVersionStatus' },
+                    { dataType: 'enum', enums: [null] },
+                ],
+                required: true,
+            },
+        },
+        additionalProperties: true,
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     SummaryContent: {
         dataType: 'refAlias',
         type: {
@@ -28532,6 +28665,7 @@ const models: TsoaRoute.Models = {
                 { ref: 'ChartContent' },
                 { ref: 'DashboardContent' },
                 { ref: 'SpaceContent' },
+                { ref: 'DataAppContent' },
             ],
             validators: {},
         },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8240,29 +8240,19 @@
             "ApiGenerateAppResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__appUuid-string--version-number__"
             },
-            "AppImageAttachment": {
-                "properties": {
-                    "filename": {
-                        "type": "string"
-                    },
-                    "mimeType": {
-                        "type": "string"
-                    },
-                    "s3Key": {
-                        "type": "string"
-                    }
-                },
-                "required": ["filename", "mimeType", "s3Key"],
-                "type": "object",
-                "description": "Image attached to a data app generation request.\nThe image is uploaded to S3 via the backend proxy; the s3Key\nreferences the uploaded object."
-            },
             "GenerateAppRequestBody": {
                 "properties": {
+                    "chartUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "appUuid": {
                         "type": "string"
                     },
-                    "image": {
-                        "$ref": "#/components/schemas/AppImageAttachment"
+                    "imageId": {
+                        "type": "string"
                     },
                     "prompt": {
                         "type": "string"
@@ -8271,15 +8261,15 @@
                 "required": ["prompt"],
                 "type": "object"
             },
-            "ApiSuccess__s3Key-string__": {
+            "ApiSuccess__imageId-string__": {
                 "properties": {
                     "results": {
                         "properties": {
-                            "s3Key": {
+                            "imageId": {
                                 "type": "string"
                             }
                         },
-                        "required": ["s3Key"],
+                        "required": ["imageId"],
                         "type": "object"
                     },
                     "status": {
@@ -8292,7 +8282,7 @@
                 "type": "object"
             },
             "ApiAppImageUploadResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__s3Key-string__"
+                "$ref": "#/components/schemas/ApiSuccess__imageId-string__"
             },
             "AppVersionStatus": {
                 "type": "string",
@@ -8337,7 +8327,7 @@
                 ],
                 "type": "object"
             },
-            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
+            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
                 "properties": {
                     "results": {
                         "properties": {
@@ -8349,6 +8339,10 @@
                                     "$ref": "#/components/schemas/ApiAppVersionSummary"
                                 },
                                 "type": "array"
+                            },
+                            "spaceUuid": {
+                                "type": "string",
+                                "nullable": true
                             },
                             "createdByUserUuid": {
                                 "type": "string"
@@ -8366,6 +8360,7 @@
                         "required": [
                             "hasMore",
                             "versions",
+                            "spaceUuid",
                             "createdByUserUuid",
                             "description",
                             "name",
@@ -8383,7 +8378,7 @@
                 "type": "object"
             },
             "ApiGetAppResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
             },
             "ApiCancelAppVersionResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"
@@ -10094,19 +10089,6 @@
                                                         "type": "string",
                                                         "enum": ["error"],
                                                         "nullable": false
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "error",
-                                                            "success"
-                                                        ]
                                                     }
                                                 },
                                                 "required": ["status"],
@@ -22843,7 +22825,7 @@
                 "type": "object"
             },
             "ContentType": {
-                "enum": ["chart", "dashboard", "space"],
+                "enum": ["chart", "dashboard", "space", "data_app"],
                 "type": "string"
             },
             "VerifiedContentListItem": {
@@ -23613,10 +23595,10 @@
                 "type": "object"
             },
             "ResourceViewItemType": {
-                "enum": ["chart", "dashboard", "space"],
+                "enum": ["chart", "dashboard", "space", "data_app"],
                 "type": "string"
             },
-            "Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_": {
+            "Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data.uuid-or-pinnedListOrder_": {
                 "properties": {
                     "uuid": {
                         "type": "string"
@@ -23634,7 +23616,7 @@
             "UpdatePinnedItemOrder": {
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/Pick_ResourceViewItem-at-data.uuid-or-pinnedListOrder_"
+                        "$ref": "#/components/schemas/Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data.uuid-or-pinnedListOrder_"
                     },
                     "type": {
                         "$ref": "#/components/schemas/ResourceViewItemType"
@@ -29735,6 +29717,169 @@
                 "type": "object",
                 "additionalProperties": true
             },
+            "ContentType.DATA_APP": {
+                "enum": ["data_app"],
+                "type": "string"
+            },
+            "DataAppContent": {
+                "properties": {
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentType.DATA_APP"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    },
+                    "slug": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "createdAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "createdBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "uuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "lastUpdatedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "lastUpdatedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "uuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "project": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name", "uuid"],
+                        "type": "object"
+                    },
+                    "organization": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name", "uuid"],
+                        "type": "object"
+                    },
+                    "space": {
+                        "properties": {
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["name", "uuid"],
+                        "type": "object"
+                    },
+                    "pinnedList": {
+                        "properties": {
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["uuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "views": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "firstViewedAt": {
+                        "type": "string",
+                        "format": "date-time",
+                        "nullable": true
+                    },
+                    "verification": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/ContentVerificationInfo"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "latestVersionNumber": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "latestVersionStatus": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/AppVersionStatus"
+                            }
+                        ],
+                        "nullable": true
+                    }
+                },
+                "required": [
+                    "contentType",
+                    "uuid",
+                    "slug",
+                    "name",
+                    "description",
+                    "createdAt",
+                    "createdBy",
+                    "lastUpdatedAt",
+                    "lastUpdatedBy",
+                    "project",
+                    "organization",
+                    "space",
+                    "pinnedList",
+                    "views",
+                    "firstViewedAt",
+                    "verification",
+                    "latestVersionNumber",
+                    "latestVersionStatus"
+                ],
+                "type": "object",
+                "additionalProperties": true
+            },
             "SummaryContent": {
                 "anyOf": [
                     {
@@ -29745,6 +29890,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/SpaceContent"
+                    },
+                    {
+                        "$ref": "#/components/schemas/DataAppContent"
                     }
                 ]
             },
@@ -30379,7 +30527,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2775.3",
+        "version": "0.2780.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -13,6 +13,7 @@ import {
     type DbApp,
     type DbAppVersion,
 } from '../database/entities/apps';
+import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectTableName } from '../database/entities/projects';
 import KnexPaginate from '../database/pagination';
 
@@ -119,10 +120,28 @@ export class AppModel {
         return row.status;
     }
 
-    async getApp(appId: string, projectUuid: string): Promise<DbApp> {
+    async getApp(
+        appId: string,
+        projectUuid: string,
+    ): Promise<DbApp & { organization_uuid: string }> {
         const row = await this.database(AppsTableName)
-            .where({ app_id: appId, project_uuid: projectUuid })
-            .whereNull('deleted_at')
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${AppsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${AppsTableName}.app_id`, appId)
+            .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
+            .whereNull(`${AppsTableName}.deleted_at`)
+            .select<(DbApp & { organization_uuid: string })[]>(
+                `${AppsTableName}.*`,
+                `${OrganizationTableName}.organization_uuid`,
+            )
             .first();
         if (!row) {
             throw new NotFoundError(`App not found: ${appId}`);
@@ -181,11 +200,23 @@ export class AppModel {
         name: string;
         description: string;
         createdByUserUuid: string;
+        organizationUuid: string;
+        spaceUuid: string | null;
         versions: DbAppVersion[];
         hasMore: boolean;
     }> {
         const limit = opts.limit ?? 20;
         const query = this.database(AppsTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${AppsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
             .leftJoin(
                 AppVersionsTableName,
                 `${AppsTableName}.app_id`,
@@ -199,6 +230,8 @@ export class AppModel {
                 `${AppsTableName}.name`,
                 `${AppsTableName}.description`,
                 `${AppsTableName}.created_by_user_uuid`,
+                `${AppsTableName}.space_uuid`,
+                `${OrganizationTableName}.organization_uuid`,
             )
             .orderBy(`${AppVersionsTableName}.version`, 'desc')
             .limit(limit + 1);
@@ -215,6 +248,8 @@ export class AppModel {
             name: string;
             description: string;
             created_by_user_uuid: string;
+            space_uuid: string | null;
+            organization_uuid: string;
         })[] = await query;
 
         // Left join: if app doesn't exist, zero rows → 404
@@ -227,18 +262,29 @@ export class AppModel {
             name,
             description,
             created_by_user_uuid: createdByUserUuid,
+            space_uuid: spaceUuid,
+            organization_uuid: organizationUuid,
         } = rows[0];
 
         // If app exists but no versions match, we get one row with all nulls
         const versions = rows.filter(
-            (r): r is DbAppVersion & { name: string; description: string } =>
-                r.version !== null,
+            (
+                r,
+            ): r is DbAppVersion & {
+                name: string;
+                description: string;
+                created_by_user_uuid: string;
+                space_uuid: string | null;
+                organization_uuid: string;
+            } => r.version !== null,
         );
         const hasMore = versions.length > limit;
         return {
             name,
             description,
             createdByUserUuid,
+            organizationUuid,
+            spaceUuid,
             versions: versions.slice(0, limit),
             hasMore,
         };

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -1,0 +1,228 @@
+import { ContentType, DataAppContent } from '@lightdash/common';
+import { Knex } from 'knex';
+import {
+    AppsTableName,
+    AppVersionsTableName,
+} from '../../../database/entities/apps';
+import { OrganizationTableName } from '../../../database/entities/organizations';
+import { ProjectTableName } from '../../../database/entities/projects';
+import { SpaceTableName } from '../../../database/entities/spaces';
+import { UserTableName } from '../../../database/entities/users';
+import {
+    ContentConfiguration,
+    ContentFilters,
+    ContentTypePriority,
+    SummaryContentRow,
+} from '../ContentModelTypes';
+
+export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow> =
+    {
+        shouldQueryBeIncluded: (filters: ContentFilters) => {
+            // Apps don't participate in the soft-delete / restore flow yet,
+            // so exclude them from the deleted-content listing.
+            if (filters.deleted) return false;
+            return (
+                !filters.contentTypes ||
+                filters.contentTypes?.includes(ContentType.DATA_APP)
+            );
+        },
+        getSummaryQuery: (
+            knex: Knex,
+            filters: ContentFilters,
+        ): Knex.QueryBuilder =>
+            knex
+                .from(AppsTableName)
+                .where((deletedFilter) => {
+                    if (filters.deleted) {
+                        void deletedFilter.whereNotNull(
+                            `${AppsTableName}.deleted_at`,
+                        );
+                        if (filters.deletedByUserUuids) {
+                            void deletedFilter.whereIn(
+                                `${AppsTableName}.deleted_by_user_uuid`,
+                                filters.deletedByUserUuids,
+                            );
+                        }
+                    } else {
+                        void deletedFilter.whereNull(
+                            `${AppsTableName}.deleted_at`,
+                        );
+                    }
+                })
+                // Apps without a space are personal drafts — excluded from
+                // space-based content listings. They surface only in /user/apps.
+                .whereNotNull(`${AppsTableName}.space_uuid`)
+                .innerJoin(
+                    SpaceTableName,
+                    `${SpaceTableName}.space_uuid`,
+                    `${AppsTableName}.space_uuid`,
+                )
+                .innerJoin(
+                    ProjectTableName,
+                    `${ProjectTableName}.project_uuid`,
+                    `${AppsTableName}.project_uuid`,
+                )
+                .innerJoin(
+                    OrganizationTableName,
+                    `${OrganizationTableName}.organization_id`,
+                    `${ProjectTableName}.organization_id`,
+                )
+                .leftJoin(
+                    `${UserTableName} as created_by_user`,
+                    `created_by_user.user_uuid`,
+                    `${AppsTableName}.created_by_user_uuid`,
+                )
+                .leftJoin(
+                    `${AppVersionsTableName} as latest_version`,
+                    `latest_version.app_id`,
+                    `${AppsTableName}.app_id`,
+                )
+                .leftJoin(
+                    `${UserTableName} as last_updated_by_user`,
+                    `last_updated_by_user.user_uuid`,
+                    `latest_version.created_by_user_uuid`,
+                )
+                .select<SummaryContentRow[]>([
+                    knex.raw(`'${ContentType.DATA_APP}' as content_type`),
+                    knex.raw(
+                        `${ContentTypePriority.DATA_APP} as content_type_rank`,
+                    ),
+                    knex.raw(`${AppsTableName}.app_id::text as uuid`),
+                    `${AppsTableName}.name`,
+                    `${AppsTableName}.description`,
+                    // Apps don't have a real slug column yet — synthesize one
+                    // for the content listing URL shape. Uniqueness isn't
+                    // relied upon since we link by UUID.
+                    knex.raw(
+                        `'data-app-' || ${AppsTableName}.app_id::text as slug`,
+                    ),
+                    `${SpaceTableName}.space_uuid`,
+                    `${SpaceTableName}.name as space_name`,
+                    `${ProjectTableName}.project_uuid`,
+                    `${ProjectTableName}.name as project_name`,
+                    `${OrganizationTableName}.organization_uuid`,
+                    `${OrganizationTableName}.organization_name`,
+                    knex.raw(`NULL::uuid as pinned_list_uuid`),
+                    knex.raw(
+                        `${AppsTableName}.created_at::timestamp as created_at`,
+                    ),
+                    `created_by_user.user_uuid             as created_by_user_uuid`,
+                    `created_by_user.first_name            as created_by_user_first_name`,
+                    `created_by_user.last_name             as created_by_user_last_name`,
+                    `latest_version.created_at             as last_updated_at`,
+                    `last_updated_by_user.user_uuid        as last_updated_by_user_uuid`,
+                    `last_updated_by_user.first_name       as last_updated_by_user_first_name`,
+                    `last_updated_by_user.last_name        as last_updated_by_user_last_name`,
+
+                    knex.raw(`0 as views`),
+                    knex.raw(`NULL::timestamp as first_viewed_at`),
+                    knex.raw(
+                        `${AppsTableName}.deleted_at::timestamp as deleted_at`,
+                    ),
+                    `${AppsTableName}.deleted_by_user_uuid as deleted_by_user_uuid`,
+                    knex.raw(
+                        `(SELECT first_name FROM users WHERE user_uuid = ${AppsTableName}.deleted_by_user_uuid) as deleted_by_user_first_name`,
+                    ),
+                    knex.raw(
+                        `(SELECT last_name FROM users WHERE user_uuid = ${AppsTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
+                    ),
+                    knex.raw(
+                        `json_build_object(
+                            'latestVersionNumber', latest_version.version,
+                            'latestVersionStatus', latest_version.status
+                        ) as metadata`,
+                    ),
+                ])
+                .where((builder) => {
+                    if (filters.projectUuids) {
+                        void builder.whereIn(
+                            `${ProjectTableName}.project_uuid`,
+                            filters.projectUuids,
+                        );
+                    }
+
+                    if (filters.spaceUuids) {
+                        void builder.whereIn(
+                            `${SpaceTableName}.space_uuid`,
+                            filters.spaceUuids,
+                        );
+                    }
+
+                    // Pick the latest version per app — every app has at
+                    // least one version (created atomically with the app).
+                    void builder.where(
+                        `latest_version.app_version_id`,
+                        knex.raw(
+                            `(select app_version_id
+                                from ${AppVersionsTableName}
+                                where app_id = ${AppsTableName}.app_id
+                                order by version desc
+                                limit 1)`,
+                        ),
+                    );
+
+                    if (filters.search) {
+                        void builder.whereRaw(
+                            `LOWER(${AppsTableName}.name) LIKE ?`,
+                            [`%${filters.search.toLowerCase()}%`],
+                        );
+                    }
+
+                    // Exclude apps in deleted spaces
+                    void builder.whereNull(`${SpaceTableName}.deleted_at`);
+                }),
+        shouldRowBeConverted: (value): value is SummaryContentRow =>
+            value.content_type === ContentType.DATA_APP,
+        convertSummaryRow: (value): DataAppContent => {
+            if (!dataAppContentConfiguration.shouldRowBeConverted(value)) {
+                throw new Error('Invalid content row');
+            }
+            return {
+                contentType: ContentType.DATA_APP,
+                uuid: value.uuid,
+                slug: value.slug,
+                name: value.name,
+                description: value.description,
+                createdAt: value.created_at,
+                createdBy: value.created_by_user_uuid
+                    ? {
+                          uuid: value.created_by_user_uuid,
+                          firstName: value.created_by_user_first_name ?? '',
+                          lastName: value.created_by_user_last_name ?? '',
+                      }
+                    : null,
+                lastUpdatedAt: value.last_updated_at,
+                lastUpdatedBy: value.last_updated_by_user_uuid
+                    ? {
+                          uuid: value.last_updated_by_user_uuid,
+                          firstName:
+                              value.last_updated_by_user_first_name ?? '',
+                          lastName: value.last_updated_by_user_last_name ?? '',
+                      }
+                    : null,
+                project: {
+                    uuid: value.project_uuid,
+                    name: value.project_name,
+                },
+                organization: {
+                    uuid: value.organization_uuid,
+                    name: value.organization_name,
+                },
+                space: {
+                    uuid: value.space_uuid,
+                    name: value.space_name,
+                },
+                pinnedList: null,
+                views: value.views,
+                firstViewedAt: value.first_viewed_at,
+                verification: null,
+                latestVersionNumber:
+                    (value.metadata.latestVersionNumber as number | null) ??
+                    null,
+                latestVersionStatus:
+                    (value.metadata.latestVersionStatus as
+                        | DataAppContent['latestVersionStatus']
+                        | null) ?? null,
+            };
+        },
+    };

--- a/packages/backend/src/models/ContentModel/ContentModel.ts
+++ b/packages/backend/src/models/ContentModel/ContentModel.ts
@@ -11,6 +11,7 @@ import {
 import { Knex } from 'knex';
 import KnexPaginate from '../../database/pagination';
 import { dashboardContentConfiguration } from './ContentConfigurations/DashboardContentConfiguration';
+import { dataAppContentConfiguration } from './ContentConfigurations/DataAppContentConfiguration';
 import { dbtExploreChartContentConfiguration } from './ContentConfigurations/DbtExploreChartContentConfiguration';
 import { spaceContentConfiguration } from './ContentConfigurations/SpaceContentConfiguration';
 import { sqlChartContentConfiguration } from './ContentConfigurations/SqlChartContentConfiguration';
@@ -35,6 +36,7 @@ export class ContentModel {
         dbtExploreChartContentConfiguration,
         dashboardContentConfiguration,
         spaceContentConfiguration,
+        dataAppContentConfiguration,
     ];
 
     constructor(args: { database: Knex }) {

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -13,6 +13,7 @@ export enum ContentTypePriority {
     SPACE = 1,
     DASHBOARD = 2,
     CHART = 3,
+    DATA_APP = 4,
 }
 
 export type ContentFilters = {

--- a/packages/backend/src/services/FavoritesService/FavoritesService.ts
+++ b/packages/backend/src/services/FavoritesService/FavoritesService.ts
@@ -3,6 +3,7 @@ import {
     assertUnreachable,
     ContentType,
     ForbiddenError,
+    ParameterError,
     ResourceViewItemType,
     type FavoriteItems,
     type ResourceViewSpaceItem,
@@ -102,6 +103,11 @@ export class FavoritesService extends BaseService {
                 spaceUuid = dashboard.spaceUuid;
                 break;
             }
+            case ContentType.DATA_APP:
+                // Favoriting data apps is not supported yet
+                throw new ParameterError(
+                    'Favoriting data apps is not supported',
+                );
             default:
                 return assertUnreachable(
                     contentType,

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -70,6 +70,16 @@ const applyOrganizationMemberStaticAbilities: Record<
                 $elemMatch: { userUuid: member.userUuid },
             },
         });
+        can('view', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            inheritsFromOrgOrProject: true,
+        });
+        can('view', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            access: {
+                $elemMatch: { userUuid: member.userUuid },
+            },
+        });
         can('view', 'Project', {
             organizationUuid: member.organizationUuid,
         });

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -72,6 +72,16 @@ export const projectMemberAbilities: Record<
             projectUuid: member.projectUuid,
             userUuid: member.userUuid,
         });
+        can('view', 'DataApp', {
+            projectUuid: member.projectUuid,
+            inheritsFromOrgOrProject: true,
+        });
+        can('view', 'DataApp', {
+            projectUuid: member.projectUuid,
+            access: {
+                $elemMatch: { userUuid: member.userUuid },
+            },
+        });
     },
     interactive_viewer(member, { can }) {
         projectMemberAbilities.viewer(member, { can });

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -29,6 +29,7 @@ const BASE_ROLE_SCOPES = {
         'view:MetricsTree',
         'view:SpotlightTableConfig',
         'view:AiAgentThread@self',
+        'view:DataApp',
     ],
 
     [ProjectMemberRole.INTERACTIVE_VIEWER]: [
@@ -170,6 +171,7 @@ export const getNonEnterpriseScopesForRole = (
         'manage:AiAgent',
         'manage:AiAgentThread',
         'manage:ContentAsCode',
+        'view:DataApp',
         'manage:DataApp',
         'manage:PersonalAccessToken',
         'manage:PreAggregation',

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -700,6 +700,16 @@ const scopes: Scope[] = [
 
     // Data Apps
     {
+        name: 'view:DataApp',
+        description: 'View data apps',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        getConditions: (context) => [
+            addUuidCondition(context, { inheritsFromOrgOrProject: true }),
+            addAccessCondition(context),
+        ],
+    },
+    {
         name: 'manage:DataApp',
         description: 'Create and manage data apps',
         isEnterprise: false,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -60,6 +60,7 @@ export type ApiGetAppResponse = ApiSuccess<{
     name: string;
     description: string;
     createdByUserUuid: string;
+    spaceUuid: string | null;
     versions: ApiAppVersionSummary[];
     hasMore: boolean;
 }>;

--- a/packages/common/src/types/content.ts
+++ b/packages/common/src/types/content.ts
@@ -1,3 +1,4 @@
+import { type AppVersionStatus } from '../ee/apps/types';
 import { type ContentVerificationInfo } from './contentVerification';
 import type { KnexPaginatedData } from './knex-paginate';
 import { type ChartKind } from './savedCharts';
@@ -7,6 +8,7 @@ export enum ContentType {
     CHART = 'chart',
     DASHBOARD = 'dashboard',
     SPACE = 'space',
+    DATA_APP = 'data_app',
 }
 
 export interface Content {
@@ -76,6 +78,14 @@ export interface DashboardContent extends Content {
     contentType: ContentType.DASHBOARD;
 }
 
+// Data App types
+
+export interface DataAppContent extends Content {
+    contentType: ContentType.DATA_APP;
+    latestVersionNumber: number | null;
+    latestVersionStatus: AppVersionStatus | null;
+}
+
 export interface SpaceContentBase extends Content {
     contentType: ContentType.SPACE;
     inheritParentPermissions: boolean;
@@ -100,10 +110,15 @@ export interface SpaceContent extends SpaceContentBase {
 export type SummaryContentBase =
     | ChartContent
     | DashboardContent
-    | SpaceContentBase;
+    | SpaceContentBase
+    | DataAppContent;
 
 // What the API returns (spaces enriched with access data)
-export type SummaryContent = ChartContent | DashboardContent | SpaceContent; // Note: more types will be added.
+export type SummaryContent =
+    | ChartContent
+    | DashboardContent
+    | SpaceContent
+    | DataAppContent;
 
 // API types
 

--- a/packages/common/src/types/pinning.ts
+++ b/packages/common/src/types/pinning.ts
@@ -1,7 +1,6 @@
 import {
     type ResourceViewChartItem,
     type ResourceViewDashboardItem,
-    type ResourceViewItem,
     type ResourceViewItemType,
     type ResourceViewSpaceItem,
 } from './resourceViewItem';
@@ -66,7 +65,12 @@ export type CreatePinnedItem =
 
 export type UpdatePinnedItemOrder = {
     type: ResourceViewItemType;
-    data: Pick<ResourceViewItem['data'], 'uuid' | 'pinnedListOrder'>;
+    data: Pick<
+        | ResourceViewChartItem['data']
+        | ResourceViewDashboardItem['data']
+        | ResourceViewSpaceItem['data'],
+        'uuid' | 'pinnedListOrder'
+    >;
 };
 
 export const isCreateChartPinnedItem = (

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -1,3 +1,4 @@
+import { type AppVersionStatus } from '../ee/apps/types';
 import assertUnreachable from '../utils/assertUnreachable';
 import {
     ContentType as ResourceViewItemType,
@@ -83,15 +84,36 @@ export type ResourceViewSpaceItem = {
     };
 };
 
+export type ResourceViewDataAppItem = {
+    type: ResourceViewItemType.DATA_APP;
+    data: {
+        uuid: string;
+        name: string;
+        description: string | undefined;
+        spaceUuid: string;
+        updatedAt: Date;
+        updatedByUser: {
+            userUuid: string;
+            firstName: string;
+            lastName: string;
+        } | null;
+        latestVersionNumber: number | null;
+        latestVersionStatus: AppVersionStatus | null;
+    };
+    category?: ResourceItemCategory;
+};
+
 type ResourceViewAcceptedItems =
     | ResourceViewSpaceItem['data']
     | ResourceViewChartItem['data']
-    | ResourceViewDashboardItem['data'];
+    | ResourceViewDashboardItem['data']
+    | ResourceViewDataAppItem['data'];
 
 export type ResourceViewItem =
     | ResourceViewChartItem
     | ResourceViewDashboardItem
-    | ResourceViewSpaceItem;
+    | ResourceViewSpaceItem
+    | ResourceViewDataAppItem;
 
 export const isResourceViewItemChart = (
     item: ResourceViewItem,
@@ -106,6 +128,11 @@ export const isResourceViewSpaceItem = (
     item: ResourceViewItem,
 ): item is ResourceViewSpaceItem => item.type === ResourceViewItemType.SPACE;
 
+export const isResourceViewDataAppItem = (
+    item: ResourceViewItem,
+): item is ResourceViewDataAppItem =>
+    item.type === ResourceViewItemType.DATA_APP;
+
 export const wrapResource = <T extends ResourceViewAcceptedItems>(
     resource: T,
     type: ResourceViewItemType,
@@ -117,6 +144,11 @@ export const wrapResource = <T extends ResourceViewAcceptedItems>(
             return { type, data: resource as DashboardBasicDetails };
         case ResourceViewItemType.SPACE:
             return { type, data: resource as ResourceViewSpaceItem['data'] };
+        case ResourceViewItemType.DATA_APP:
+            return {
+                type,
+                data: resource as ResourceViewDataAppItem['data'],
+            };
         default:
             return assertUnreachable(type, `Unknown resource type: ${type}`);
     }
@@ -215,6 +247,24 @@ export const contentToResourceViewItem = (content: SummaryContent) => {
                 }),
                 ResourceViewItemType.SPACE,
             );
+        case ResourceViewItemType.DATA_APP:
+            const dataAppViewItem: ResourceViewDataAppItem['data'] = {
+                uuid: content.uuid,
+                name: content.name,
+                description: content.description || undefined,
+                spaceUuid: content.space.uuid,
+                updatedAt: content.lastUpdatedAt || content.createdAt,
+                updatedByUser: updatedByUser
+                    ? {
+                          userUuid: updatedByUser.uuid,
+                          firstName: updatedByUser.firstName,
+                          lastName: updatedByUser.lastName,
+                      }
+                    : null,
+                latestVersionNumber: content.latestVersionNumber,
+                latestVersionStatus: content.latestVersionStatus,
+            };
+            return wrapResource(dataAppViewItem, ResourceViewItemType.DATA_APP);
         default:
             return assertUnreachable(content, `Unsupported content type`);
     }
@@ -227,6 +277,8 @@ export const resourceToContent = (resource: ResourceViewItem) => {
         case ResourceViewItemType.DASHBOARD:
             return resource.data;
         case ResourceViewItemType.SPACE:
+            return resource.data;
+        case ResourceViewItemType.DATA_APP:
             return resource.data;
         default:
             return assertUnreachable(resource, `Unsupported resource type`);

--- a/packages/frontend/src/components/NavBar/BrowseMenu.tsx
+++ b/packages/frontend/src/components/NavBar/BrowseMenu.tsx
@@ -19,6 +19,7 @@ import {
     IconChartAreaLine,
     IconChevronDown,
     IconChevronRight,
+    IconAppWindow,
     IconFolder,
     IconFolders,
     IconLayoutDashboard,
@@ -45,6 +46,8 @@ const getFavoriteItemUrl = (projectUuid: string, item: ResourceViewItem) => {
             return `/projects/${projectUuid}/saved/${item.data.uuid}`;
         case ResourceViewItemType.SPACE:
             return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
+        case ResourceViewItemType.DATA_APP:
+            return `/projects/${projectUuid}/apps/${item.data.uuid}/preview`;
         default:
             return assertUnreachable(item, `Unknown favorite item type`);
     }
@@ -58,6 +61,8 @@ const getFavoriteItemIcon = (item: ResourceViewItem) => {
             return IconChartAreaLine;
         case ResourceViewItemType.SPACE:
             return IconFolder;
+        case ResourceViewItemType.DATA_APP:
+            return IconAppWindow;
         default:
             return assertUnreachable(item, `Unknown favorite item type`);
     }

--- a/packages/frontend/src/components/common/ResourceIcon/index.tsx
+++ b/packages/frontend/src/components/common/ResourceIcon/index.tsx
@@ -12,6 +12,7 @@ import {
     type TooltipProps,
 } from '@mantine-8/core';
 import {
+    IconAppWindow,
     IconFolder,
     IconLayoutDashboard,
     type Icon as TablerIconType,
@@ -75,6 +76,8 @@ export const ResourceIcon: FC<ResourceIconProps> = ({ item }) => {
             return <IconBox icon={IconFolder} color="violet.6" />;
         case ResourceViewItemType.CHART:
             return <ChartIcon chartKind={item.data.chartKind} />;
+        case ResourceViewItemType.DATA_APP:
+            return <IconBox icon={IconAppWindow} color="orange.6" />;
         default:
             return assertUnreachable(item, 'Resource type not supported');
     }

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -7,6 +7,7 @@ import {
     contentToResourceViewItem,
     ContentType,
     isResourceViewSpaceItem,
+    type ApiContentBulkActionBody,
     type ResourceViewItem,
     type SpaceSummary,
 } from '@lightdash/common';
@@ -806,33 +807,46 @@ const InfiniteResourceTable = ({
                     type: 'move',
                     targetSpaceUuid: spaceUuid,
                 },
-                content: selectedItems.map((item) => {
-                    switch (item.type) {
-                        case ContentType.CHART:
-                            return {
-                                uuid: item.data.uuid,
-                                contentType: ContentType.CHART,
-                                source:
-                                    item.data.source ??
-                                    ChartSourceType.DBT_EXPLORE,
-                            };
-                        case ContentType.DASHBOARD:
-                            return {
-                                uuid: item.data.uuid,
-                                contentType: ContentType.DASHBOARD,
-                            };
-                        case ContentType.SPACE:
-                            return {
-                                uuid: item.data.uuid,
-                                contentType: ContentType.SPACE,
-                            };
-                        default:
-                            return assertUnreachable(
-                                item,
-                                'Invalid item type in bulk move handler',
-                            );
-                    }
-                }),
+                content: selectedItems.flatMap(
+                    (item): ApiContentBulkActionBody['content'] => {
+                        switch (item.type) {
+                            case ContentType.CHART:
+                                return [
+                                    {
+                                        uuid: item.data.uuid,
+                                        contentType: ContentType.CHART,
+                                        source:
+                                            item.data.source ??
+                                            ChartSourceType.DBT_EXPLORE,
+                                    },
+                                ];
+                            case ContentType.DASHBOARD:
+                                return [
+                                    {
+                                        uuid: item.data.uuid,
+                                        contentType: ContentType.DASHBOARD,
+                                    },
+                                ];
+                            case ContentType.SPACE:
+                                return [
+                                    {
+                                        uuid: item.data.uuid,
+                                        contentType: ContentType.SPACE,
+                                    },
+                                ];
+                            case ContentType.DATA_APP:
+                                // Moving data apps between spaces is not
+                                // supported yet; skip them in bulk-move
+                                // payloads.
+                                return [];
+                            default:
+                                return assertUnreachable(
+                                    item,
+                                    'Invalid item type in bulk move handler',
+                                );
+                        }
+                    },
+                ),
             });
 
             table.resetRowSelection();

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -126,6 +126,9 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                             contentType: ContentType.SPACE,
                         },
                     });
+                case ResourceViewItemType.DATA_APP:
+                    // Moving data apps between spaces is not supported yet
+                    return Promise.resolve();
                 default:
                     return assertUnreachable(
                         item,
@@ -156,6 +159,9 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                 return pinDashboard({ uuid: action.item.data.uuid });
             case ResourceViewItemType.SPACE:
                 return pinSpace(action.item.data.uuid);
+            case ResourceViewItemType.DATA_APP:
+                // Pinning data apps is not supported yet
+                return undefined;
             default:
                 return assertUnreachable(
                     action.item,
@@ -210,6 +216,9 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                             parentSpaceUuid={action.item.data.parentSpaceUuid}
                         />
                     );
+                case ResourceViewItemType.DATA_APP:
+                    // Update via this modal isn't supported for data apps yet
+                    return null;
                 default:
                     return assertUnreachable(
                         action.item,
@@ -263,7 +272,9 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                             parentSpaceUuid={null}
                         />
                     );
-
+                case ResourceViewItemType.DATA_APP:
+                    // Delete from this menu isn't supported for data apps yet
+                    return null;
                 default:
                     return assertUnreachable(
                         action.item,

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -81,7 +81,9 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const { data: project } = useProject(projectUuid);
     const organizationUuid = user.data?.organizationUuid;
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
-    const isPinned = !!item.data.pinnedListUuid;
+    const isPinned =
+        item.type !== ResourceViewItemType.DATA_APP &&
+        !!item.data.pinnedListUuid;
     const isDashboardPage = location.pathname.includes('/dashboards');
 
     const isChartOrDashboard =
@@ -201,6 +203,13 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                         access: userAccess ? [userAccess] : [],
                     }),
                 ) === true;
+            break;
+        }
+        case ResourceViewItemType.DATA_APP: {
+            // Write-path space permissions for data apps land in a later PR.
+            // For now this menu only shows manage-gated actions (move, delete,
+            // verify) which aren't supported for data apps yet, so hide them.
+            userCanManage = false;
             break;
         }
         default:
@@ -459,19 +468,23 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 display={isSqlChart ? 'none' : 'block'}
                             />
 
-                            <Menu.Item
-                                component="button"
-                                role="menuitem"
-                                leftSection={<IconFolderSymlink size={18} />}
-                                onClick={() => {
-                                    onAction({
-                                        type: ResourceViewItemAction.TRANSFER_TO_SPACE,
-                                        item,
-                                    });
-                                }}
-                            >
-                                Move
-                            </Menu.Item>
+                            {item.type !== ResourceViewItemType.DATA_APP && (
+                                <Menu.Item
+                                    component="button"
+                                    role="menuitem"
+                                    leftSection={
+                                        <IconFolderSymlink size={18} />
+                                    }
+                                    onClick={() => {
+                                        onAction({
+                                            type: ResourceViewItemAction.TRANSFER_TO_SPACE,
+                                            item,
+                                        });
+                                    }}
+                                >
+                                    Move
+                                </Menu.Item>
+                            )}
 
                             {item.type === ResourceViewItemType.SPACE && (
                                 <Menu.Item

--- a/packages/frontend/src/components/common/ResourceView/ResourceLastEdited.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceLastEdited.tsx
@@ -1,6 +1,7 @@
 import {
     type ResourceViewChartItem,
     type ResourceViewDashboardItem,
+    type ResourceViewDataAppItem,
 } from '@lightdash/common';
 import { Text, Tooltip } from '@mantine-8/core';
 import dayjs from 'dayjs';
@@ -8,7 +9,10 @@ import type { FC } from 'react';
 import { useTimeAgo } from '../../../hooks/useTimeAgo';
 
 interface ResourceLastEditedProps {
-    item: ResourceViewChartItem | ResourceViewDashboardItem;
+    item:
+        | ResourceViewChartItem
+        | ResourceViewDashboardItem
+        | ResourceViewDataAppItem;
 }
 
 const ResourceLastEdited: FC<ResourceLastEditedProps> = ({

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -20,6 +20,7 @@ import { CSS } from '@dnd-kit/utilities';
 import {
     assertUnreachable,
     ResourceViewItemType,
+    type PinnedItems,
     type ResourceViewItem,
 } from '@lightdash/common';
 import { Box, SimpleGrid, Stack, Text } from '@mantine-8/core';
@@ -88,30 +89,41 @@ const ResourceCard: FC<ResourceCardProps> = ({
     onAction,
     dragIcon,
 }) => {
-    return item.type === ResourceViewItemType.SPACE ? (
-        <ResourceViewGridSpaceItem
-            item={item}
-            allowDelete={allowDelete}
-            onAction={onAction}
-            dragIcon={dragIcon}
-        />
-    ) : item.type === ResourceViewItemType.DASHBOARD ? (
-        <ResourceViewGridDashboardItem
-            item={item}
-            allowDelete={allowDelete}
-            onAction={onAction}
-            dragIcon={dragIcon}
-        />
-    ) : item.type === ResourceViewItemType.CHART ? (
-        <ResourceViewGridChartItem
-            item={item}
-            allowDelete={allowDelete}
-            onAction={onAction}
-            dragIcon={dragIcon}
-        />
-    ) : (
-        assertUnreachable(item, `Resource type not supported`)
-    );
+    switch (item.type) {
+        case ResourceViewItemType.SPACE:
+            return (
+                <ResourceViewGridSpaceItem
+                    item={item}
+                    allowDelete={allowDelete}
+                    onAction={onAction}
+                    dragIcon={dragIcon}
+                />
+            );
+        case ResourceViewItemType.DASHBOARD:
+            return (
+                <ResourceViewGridDashboardItem
+                    item={item}
+                    allowDelete={allowDelete}
+                    onAction={onAction}
+                    dragIcon={dragIcon}
+                />
+            );
+        case ResourceViewItemType.CHART:
+            return (
+                <ResourceViewGridChartItem
+                    item={item}
+                    allowDelete={allowDelete}
+                    onAction={onAction}
+                    dragIcon={dragIcon}
+                />
+            );
+        case ResourceViewItemType.DATA_APP:
+            // Data apps don't appear in grid views yet — they only surface
+            // via the list table in the Space page.
+            return null;
+        default:
+            return assertUnreachable(item, `Resource type not supported`);
+    }
 };
 
 const DraggableItem: FC<DraggableItemProps> = ({
@@ -295,13 +307,17 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
 
     // this method converts groupedItems to the format required by the API
     const pinnedItemsOrder = useCallback(
-        (data: ResourceViewGridGroup[]) =>
+        (data: ResourceViewGridGroup[]): PinnedItems =>
             data.flatMap((group) =>
-                group.items.map((item, index) => {
-                    return {
-                        type: item.type,
-                        data: { ...item.data, pinnedListOrder: index },
-                    } as ResourceViewItem;
+                group.items.flatMap((item, index) => {
+                    // Data apps don't participate in pinning
+                    if (item.type === ResourceViewItemType.DATA_APP) return [];
+                    return [
+                        {
+                            type: item.type,
+                            data: { ...item.data, pinnedListOrder: index },
+                        } as PinnedItems[number],
+                    ];
                 }),
             ),
         [],

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -14,6 +14,8 @@ export const getResourceTypeName = (item: ResourceViewItem) => {
             return 'Dashboard';
         case ResourceViewItemType.SPACE:
             return 'Space';
+        case ResourceViewItemType.DATA_APP:
+            return 'Data app';
         case ResourceViewItemType.CHART:
             switch (item.data.chartKind) {
                 case undefined:
@@ -85,6 +87,8 @@ export const getResourceUrl = (projectUuid: string, item: ResourceViewItem) => {
             return getChartResourceUrl(projectUuid, item);
         case ResourceViewItemType.SPACE:
             return `/projects/${projectUuid}/spaces/${item.data.uuid}`;
+        case ResourceViewItemType.DATA_APP:
+            return `/projects/${projectUuid}/apps/${item.data.uuid}/preview`;
         default:
             return assertUnreachable(item, `Can't get URL for ${itemType}`);
     }
@@ -98,6 +102,8 @@ export const getResourceName = (type: ResourceViewItemType) => {
             return 'Chart';
         case ResourceViewItemType.SPACE:
             return 'Space';
+        case ResourceViewItemType.DATA_APP:
+            return 'Data app';
         default:
             return assertUnreachable(type, 'Resource type not supported');
     }

--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -71,6 +71,7 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
                 return item.data.parentSpaceUuid ?? undefined;
             case ResourceViewItemType.CHART:
             case ResourceViewItemType.DASHBOARD:
+            case ResourceViewItemType.DATA_APP:
                 return item.data.spaceUuid;
             default:
                 return assertUnreachable(item, 'Invalid item type');

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,14 +1,13 @@
-import { subject } from '@casl/ability';
 import { FeatureFlags } from '@lightdash/common';
 import { ActionIcon, Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
 import { IconDots, IconPencil } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
+import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
-import { useAbilityContext } from '../providers/Ability/useAbilityContext';
 import useApp from '../providers/App/useApp';
 import classes from './AppPreviewTest.module.css';
 
@@ -28,9 +27,10 @@ export default function AppPreviewTest() {
 
     const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
     const { user } = useApp();
-    const ability = useAbilityContext();
 
-    // Always fetch app to get creator info + latest ready version when needed
+    // Always fetch app to get creator info + latest ready version when needed.
+    // The backend enforces space-aware view permissions and will 403 if the
+    // user doesn't have access — we surface that as the error state below.
     const appQuery = useGetApp(projectUuid, appUuid);
 
     const latestReadyVersion = appQuery.data?.pages[0]?.versions.find(
@@ -70,18 +70,6 @@ export default function AppPreviewTest() {
         return <Navigate to={`/projects/${projectUuid}/home`} replace />;
     }
 
-    if (
-        !ability.can(
-            'manage',
-            subject('DataApp', {
-                organizationUuid: user.data?.organizationUuid,
-                projectUuid,
-            }),
-        )
-    ) {
-        return <Navigate to={`/projects/${projectUuid}/home`} replace />;
-    }
-
     if (!projectUuid || !appUuid) {
         return <div>Missing route params</div>;
     }
@@ -90,7 +78,22 @@ export default function AppPreviewTest() {
         appQuery.isLoading || (version !== undefined && isTokenLoading);
     const error = appQuery.error ?? tokenError;
 
-    if (!explicitVersion && !appQuery.isLoading && !latestReadyVersion) {
+    // Forbidden / not-found → render the standard no-access panel, not a
+    // "no ready version" message which would be misleading.
+    const isForbidden =
+        appQuery.error?.error?.statusCode === 403 ||
+        tokenError?.error?.statusCode === 403 ||
+        appQuery.error?.error?.statusCode === 404;
+    if (isForbidden) {
+        return <ForbiddenPanel />;
+    }
+
+    if (
+        !explicitVersion &&
+        !appQuery.isLoading &&
+        !appQuery.error &&
+        !latestReadyVersion
+    ) {
         return (
             <Stack align="center" justify="center" h="calc(100vh - 50px)">
                 <Text c="red" size="sm">

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -395,6 +395,7 @@ const Space: FC = () => {
                                 ContentType.DASHBOARD,
                                 ContentType.CHART,
                                 ContentType.SPACE,
+                                ContentType.DATA_APP,
                             ],
                         }}
                         contentTypeFilter={{


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-316/add-apps-to-spaces

### Description:
Data apps with a space_uuid now appear alongside dashboards and charts in /api/v2/content and the Space page table. Permissions follow the space: view:DataApp is space-aware (inherit or direct access), manage:DataApp stays admin-only for now. Personal apps (null space_uuid) are excluded from listings and remain accessible to the creator/admin via /user/apps.


The first PR here is big and will give us a nice vertical chunk of the feature, while not exposing anything quite yet to the users as they aren't able yet to add apps to spaces.

Follow-up PRs will refine and add more functionality.

<img width="1601" height="718" alt="image" src="https://github.com/user-attachments/assets/64b0e1b6-2d4e-4542-9b0a-3f8e11feb28b" />
