### PR TITLE
chore: get query ids from input instead of text

### DIFF
--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -54,6 +54,7 @@ export class AppGenerateController extends BaseController {
             body.prompt,
             body.image,
             body.appUuid,
+            body.chartUuids,
         );
         return {
             status: 'ok',
@@ -153,6 +154,7 @@ export class AppGenerateController extends BaseController {
             appUuid,
             body.prompt,
             body.image,
+            body.chartUuids,
         );
         return {
             status: 'ok',

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1685,13 +1685,10 @@ export class AppGenerateService extends BaseService {
      * any that resolve.
      */
     private async resolveChartReferences(
-        prompt: string,
+        chartUuids: string[],
         user: SessionUser,
     ): Promise<ChartReference[]> {
-        const UUID_REGEX =
-            /[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}/gi;
-        const uuids = [...new Set(prompt.match(UUID_REGEX) ?? [])];
-
+        const uuids = [...new Set(chartUuids)];
         if (uuids.length === 0) return [];
 
         const account = fromSession(user);
@@ -1716,7 +1713,7 @@ export class AppGenerateService extends BaseService {
 
         if (references.length > 0) {
             this.logger.info(
-                `Resolved ${references.length} chart reference(s) from ${uuids.length} UUID(s) in prompt`,
+                `Resolved ${references.length} chart reference(s) from ${uuids.length} UUID(s)`,
             );
         }
 
@@ -1729,6 +1726,7 @@ export class AppGenerateService extends BaseService {
         prompt: string,
         image?: AppImageAttachment,
         preGeneratedAppUuid?: string,
+        chartUuids?: string[],
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
         if (
@@ -1784,7 +1782,10 @@ export class AppGenerateService extends BaseService {
             },
         });
 
-        const chartReferences = await this.resolveChartReferences(prompt, user);
+        const chartReferences = await this.resolveChartReferences(
+            chartUuids ?? [],
+            user,
+        );
 
         await this.schedulerClient.appGeneratePipeline({
             appUuid,
@@ -1808,6 +1809,7 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
         prompt: string,
         image?: AppImageAttachment,
+        chartUuids?: string[],
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
         if (
@@ -1868,7 +1870,10 @@ export class AppGenerateService extends BaseService {
             },
         });
 
-        const chartReferences = await this.resolveChartReferences(prompt, user);
+        const chartReferences = await this.resolveChartReferences(
+            chartUuids ?? [],
+            user,
+        );
 
         await this.schedulerClient.appGeneratePipeline({
             appUuid,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -51,6 +51,7 @@ export type GenerateAppRequestBody = {
     prompt: string;
     image?: AppImageAttachment;
     appUuid?: string; // pre-generated UUID so images can be scoped to the app in S3
+    chartUuids?: string[]; // saved chart UUIDs to resolve and pass as structured metric queries
 };
 
 export type ApiPreviewTokenResponse = ApiSuccess<{

--- a/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
@@ -11,6 +11,7 @@ type GenerateAppParams = {
     prompt: string;
     image?: AppImageAttachment;
     appUuid?: string; // pre-generated UUID so images are scoped to the app in S3
+    chartUuids?: string[];
 };
 
 type GenerateAppResult = ApiGenerateAppResponse['results'];
@@ -20,11 +21,12 @@ const generateApp = async ({
     prompt,
     image,
     appUuid,
+    chartUuids,
 }: GenerateAppParams): Promise<GenerateAppResult> => {
     const data = await lightdashApi<GenerateAppResult>({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/apps/`,
-        body: JSON.stringify({ prompt, image, appUuid }),
+        body: JSON.stringify({ prompt, image, appUuid, chartUuids }),
     });
     return data;
 };

--- a/packages/frontend/src/features/apps/hooks/useIterateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useIterateApp.ts
@@ -11,6 +11,7 @@ type IterateAppParams = {
     appUuid: string;
     prompt: string;
     image?: AppImageAttachment;
+    chartUuids?: string[];
 };
 
 type IterateAppResult = ApiGenerateAppResponse['results'];
@@ -20,11 +21,12 @@ const iterateApp = async ({
     appUuid,
     prompt,
     image,
+    chartUuids,
 }: IterateAppParams): Promise<IterateAppResult> => {
     const data = await lightdashApi<IterateAppResult>({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/apps/${appUuid}/versions`,
-        body: JSON.stringify({ prompt, image }),
+        body: JSON.stringify({ prompt, image, chartUuids }),
     });
     return data;
 };

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -467,14 +467,11 @@ const AppGenerate: FC = () => {
         const trimmed = prompt.trim();
         if (!trimmed || isLoading) return;
 
-        // Append chart references block if any charts are selected
-        let finalPrompt = trimmed;
-        if (selectedCharts.length > 0) {
-            const chartLines = selectedCharts
-                .map((c) => `- ${c.name} (id: ${c.uuid})`)
-                .join('\n');
-            finalPrompt = `${trimmed}\n\n---\nCharts to include:\n${chartLines}`;
-        }
+        // Collect chart UUIDs to send as structured data (resolved server-side)
+        const chartUuids =
+            selectedCharts.length > 0
+                ? selectedCharts.map((c) => c.uuid)
+                : undefined;
 
         // For new apps, pre-generate the UUID so the image upload and
         // the generate request both use the same app-scoped S3 path.
@@ -506,12 +503,6 @@ const AppGenerate: FC = () => {
         const sentImageUrl = imageAttachment?.previewUrl ?? null;
         if (sentImageUrl) {
             sentImagesByPrompt.current.set(trimmed, sentImageUrl);
-            // Also key by finalPrompt (with chart block) since the server
-            // stores the enriched prompt and that's what we match against
-            // when rebuilding messages from version history.
-            if (finalPrompt !== trimmed) {
-                sentImagesByPrompt.current.set(finalPrompt, sentImageUrl);
-            }
         }
 
         setLocalMessages((prev) => [
@@ -566,8 +557,9 @@ const AppGenerate: FC = () => {
                 {
                     projectUuid,
                     appUuid: activeAppUuid,
-                    prompt: finalPrompt,
+                    prompt: trimmed,
                     image,
+                    chartUuids,
                 },
                 callbacks,
             );
@@ -575,9 +567,10 @@ const AppGenerate: FC = () => {
             generateMutate(
                 {
                     projectUuid,
-                    prompt: finalPrompt,
+                    prompt: trimmed,
                     image,
                     appUuid: newAppUuid,
+                    chartUuids,
                 },
                 callbacks,
             );


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: [GLITCH-338](https://linear.app/lightdash/issue/GLITCH-338)

### Description:

Get chart ids from input component instead of parsing them out of the prompt
