### PR TITLE
feat(compiler): warn when a metric name is defined in multiple sources

### DIFF
--- a/packages/common/src/compiler/translator.mock.ts
+++ b/packages/common/src/compiler/translator.mock.ts
@@ -781,6 +781,30 @@ export const MODEL_WITH_WRONG_METRICS: DbtModelNode = {
     },
 };
 
+export const MODEL_WITH_DUPLICATE_METRIC_ACROSS_COLUMNS: DbtModelNode = {
+    ...model,
+    columns: {
+        amount: {
+            name: 'amount',
+            data_type: DimensionType.NUMBER,
+            meta: {
+                metrics: {
+                    revenue: { type: MetricType.SUM },
+                },
+            },
+        },
+        total: {
+            name: 'total',
+            data_type: DimensionType.NUMBER,
+            meta: {
+                metrics: {
+                    revenue: { type: MetricType.SUM },
+                },
+            },
+        },
+    },
+};
+
 export const LIGHTDASH_TABLE_WITH_METRICS: Omit<Table, 'lineageGraph'> = {
     ...BASE_LIGHTDASH_TABLE,
     description: MODEL_WITH_METRIC.description,

--- a/packages/common/src/compiler/translator.test.ts
+++ b/packages/common/src/compiler/translator.test.ts
@@ -56,6 +56,7 @@ import {
     MODEL_WITH_DEFAULT_TIME_INTERVAL_DIMENSIONS,
     MODEL_WITH_DIMENSION_AI_HINT,
     MODEL_WITH_DIMENSION_AI_HINT_ARRAY,
+    MODEL_WITH_DUPLICATE_METRIC_ACROSS_COLUMNS,
     MODEL_WITH_DUPLICATE_METRIC_DIMENSION_NAME,
     MODEL_WITH_GROUP_LABEL,
     MODEL_WITH_GROUPS_BLOCK,
@@ -469,6 +470,29 @@ describe('convert tables from dbt models', () => {
         expect(result.dimensions).toHaveProperty('user_id2');
         expect(result.metrics).not.toHaveProperty('user_id');
         expect(result.metrics).not.toHaveProperty('user_id2');
+    });
+    it('should warn when the same metric name is defined on multiple columns', () => {
+        const result = convertTable(
+            SupportedDbtAdapter.BIGQUERY,
+            MODEL_WITH_DUPLICATE_METRIC_ACROSS_COLUMNS,
+            [],
+            DEFAULT_SPOTLIGHT_CONFIG,
+        );
+        expect(result.metrics).toHaveProperty('revenue');
+        expect(
+            Object.keys(result.metrics).filter((n) => n === 'revenue'),
+        ).toHaveLength(1);
+        const duplicateWarnings = (result.warnings ?? []).filter(
+            (w) => w.type === InlineErrorType.DUPLICATE_FIELD_NAME,
+        );
+        expect(duplicateWarnings).toHaveLength(1);
+        expect(duplicateWarnings[0].message).toContain('revenue');
+        expect(duplicateWarnings[0].message).toContain(
+            'column "amount" meta.metrics',
+        );
+        expect(duplicateWarnings[0].message).toContain(
+            'column "total" meta.metrics',
+        );
     });
 
     it('should convert dbt model with group label', async () => {

--- a/packages/common/src/compiler/translator.ts
+++ b/packages/common/src/compiler/translator.ts
@@ -923,6 +923,34 @@ export const convertTable = (
         ]),
     );
 
+    // Detect metric names defined in multiple sources on the same model.
+    // The aggregation below silently overwrites collisions; warn the user instead.
+    const metricNameSources: Record<string, string[]> = {};
+    const recordMetricSource = (name: string, source: string) => {
+        if (!metricNameSources[name]) metricNameSources[name] = [];
+        metricNameSources[name].push(source);
+    };
+    dbtMetrics.forEach((m) => recordMetricSource(m.name, 'dbt metric'));
+    Object.keys(meta.metrics || {}).forEach((name) =>
+        recordMetricSource(name, 'model meta.metrics'),
+    );
+    Object.values(model.columns).forEach((column) => {
+        const colMeta = merge({}, column.meta, column.config?.meta);
+        Object.keys(colMeta.metrics || {}).forEach((name) =>
+            recordMetricSource(name, `column "${column.name}" meta.metrics`),
+        );
+    });
+    Object.entries(metricNameSources).forEach(([name, sources]) => {
+        if (sources.length > 1) {
+            tableWarnings.push({
+                type: InlineErrorType.DUPLICATE_FIELD_NAME,
+                message: `Metric "${name}" is defined multiple times on model "${model.name}" (in ${sources.join(
+                    ', ',
+                )}). Only one definition will be used.`,
+            });
+        }
+    });
+
     const allMetrics: Record<string, Metric> = Object.values({
         ...convertedDbtMetrics,
         ...modelMetrics,


### PR DESCRIPTION
## Summary

When the same metric name is defined in more than one place on a single dbt model, `convertTable` was silently merging via spread/reduce — keeping only one definition with no feedback. This surfaces a `DUPLICATE_FIELD_NAME` warning naming the metric, the model, and all conflicting sources, so users get an actionable message instead of losing definitions silently.

The new check covers metric names colliding across:
- multiple columns' `meta.metrics`
- model-level `meta.metrics` and any column's `meta.metrics`
- a dbt metric and a Lightdash `meta.metrics` definition

Aggregation behavior is unchanged. The warning matches the existing metric-vs-dimension duplicate pattern (warn rather than fail). Surfaces in the UI alongside other table warnings.

Out of scope: literal duplicate YAML keys within a single `meta.metrics` dict (dbt rejects those at parse time, before the translator runs).

## Test plan

- [x] New unit test in `translator.test.ts` covering cross-column metric collision (asserts a single `revenue` metric remains and the warning names both source columns)
- [x] All 64 existing common test suites pass (1784 tests, 2 skipped)
- [x] `pnpm -F common typecheck` clean
- [x] `pnpm -F common lint` clean (only pre-existing warnings)