### PR TITLE
fix: guard against undefined tableCalculations in createSavedChartVersion

### DIFF
--- a/packages/backend/src/models/SavedChartModel.ts
+++ b/packages/backend/src/models/SavedChartModel.ts
@@ -274,7 +274,7 @@ const createSavedChartVersion = async (
         );
         await createSavedChartVersionTableCalculations(
             trx,
-            tableCalculations.map((tableCalculation) => ({
+            (tableCalculations || []).map((tableCalculation) => ({
                 name: tableCalculation.name,
                 display_name: tableCalculation.displayName,
                 calculation_raw_sql: isSqlTableCalculation(tableCalculation)


### PR DESCRIPTION
Closes:

Fixes: https://lightdash.sentry.io/issues/7034244240/?notification_uuid=3d34ed86-48a4-4b1a-85e2-c1fe50f1b100&project=5959292&referrer=regression_activity-email

### Description:
Adds a null safety check for `tableCalculations` when creating a saved chart version. Previously, if `tableCalculations` was `null` or `undefined`, calling `.map()` on it would throw an error. This change defaults to an empty array when `tableCalculations` is falsy, preventing potential runtime errors during chart version creation.