### PR TITLE
fix: stage uploaded images for data apps

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -205,24 +205,40 @@ to Claude as context during code generation.
 ```mermaid
 flowchart LR
     A["1. User attaches\nimage in chat UI"] --> B["2. POST raw bytes\nto backend"]
-    B --> C["3. Backend streams\nto S3 (no buffering)"]
-    C --> D["4. Return s3Key"]
-    D --> E["5. Include s3Key in\ngenerate/iterate request"]
+    B --> C["3. Backend streams\nto S3 staging path"]
+    C --> D["4. Return imageId\n(opaque UUID)"]
+    D --> E["5. Include imageId in\ngenerate/iterate request"]
+    E --> F["6. Pipeline copies to\nversion assets folder"]
+    F --> G["7. Write to sandbox\nfor Claude"]
 ```
 
 1. **User attaches image** — The chat UI lets users add an image file. A local preview is shown immediately.
 
 2. **Upload to backend** — The frontend sends the raw file bytes directly to the backend via
-   `POST /api/v1/ee/projects/{projectUuid}/apps/upload-image?appUuid={appUuid}` with the image's MIME type as the
+   `POST /api/v1/ee/projects/{projectUuid}/apps/{appUuid}/upload-image` with the image's MIME type as the
    `Content-Type` header. This is a plain `fetch` call (not `lightdashApi`) because the body is raw binary, not JSON.
 
-3. **Stream to S3** — The backend streams the request body directly to S3 via `PutObjectCommand` without buffering the
-   entire file in memory. The image is stored at `apps/{appDir}/images/{uuid}.{ext}`.
+3. **Stream to S3 staging** — The backend streams the request body directly to S3 via `PutObjectCommand` without
+   buffering the entire file in memory. The image is stored at a deterministic staging path:
+   `apps/{appUuid}/uploads/{imageId}` (no file extension — MIME type is stored as the S3 object's `ContentType`).
 
-4. **Return s3Key** — The backend returns `{ s3Key }` — the S3 object key where the image was stored.
+4. **Return imageId** — The backend returns `{ imageId }` — an opaque UUID. The frontend never sees the S3 key.
 
-5. **Attach to prompt** — When the user submits their prompt, the s3Key is included as an `AppImageAttachment` in the
-   generate or iterate request body. The pipeline reads the image from S3 and provides it to Claude.
+5. **Attach to prompt** — When the user submits their prompt, the `imageId` is included in the generate or iterate
+   request body. The backend reconstructs the S3 staging key from the deterministic convention.
+
+6. **Copy to version assets** — During the pipeline, the image is copied from the staging path to the version assets
+   folder: `apps/{appUuid}/versions/{version}/assets/images/{imageId}.{ext}`.
+
+7. **Write to sandbox** — The image bytes are written to the E2B sandbox at `/tmp/images/reference.{ext}` for Claude
+   to read as a design reference.
+
+### Security
+
+The frontend only ever sees an opaque `imageId` (UUID). It has no knowledge of S3 keys, bucket names, or storage
+paths. The backend reconstructs all storage paths from a deterministic convention using values it controls
+(`appUuid` + `imageId`). This eliminates Insecure Direct Object Reference (IDOR) risks where a modified client
+could read arbitrary S3 objects.
 
 ### Constraints
 

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -52,7 +52,7 @@ export class AppGenerateController extends BaseController {
             req.user!,
             projectUuid,
             body.prompt,
-            body.image,
+            body.imageId,
             body.appUuid,
             body.chartUuids,
         );
@@ -70,12 +70,12 @@ export class AppGenerateController extends BaseController {
      */
     @Middlewares([allowApiKeyAuthentication, isAuthenticated])
     @SuccessResponse('200', 'Success')
-    @Post('/upload-image')
+    @Post('/{appUuid}/upload-image')
     @OperationId('uploadAppImage')
     async uploadImage(
         @Request() req: express.Request,
         @Path() projectUuid: string,
-        @Query() appUuid?: string,
+        @Path() appUuid: string,
     ): Promise<ApiAppImageUploadResponse> {
         this.setStatus(200);
         const mimeType = req.headers['content-type'];
@@ -153,7 +153,7 @@ export class AppGenerateController extends BaseController {
             projectUuid,
             appUuid,
             body.prompt,
-            body.image,
+            body.imageId,
             body.chartUuids,
         );
         return {

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -12,7 +12,6 @@ import {
     MissingConfigError,
     ParameterError,
     type AppGeneratePipelineJobPayload,
-    type AppImageAttachment,
     type ChartReference,
     type SessionUser,
 } from '@lightdash/common';
@@ -145,6 +144,14 @@ export class AppGenerateService extends BaseService {
         }
     }
 
+    /**
+     * Deterministic staging path for uploaded images.
+     * No file extension — the MIME type is stored as the S3 object's ContentType.
+     */
+    private static imageStagingKey(appUuid: string, imageId: string): string {
+        return `apps/${appUuid}/uploads/${imageId}`;
+    }
+
     private static mimeToExt(mimeType: string): string {
         const extMap: Record<string, string> = {
             'image/png': 'png',
@@ -239,8 +246,8 @@ export class AppGenerateService extends BaseService {
         mimeType: string,
         body: Readable,
         contentLength: number,
-        appUuid?: string,
-    ): Promise<{ s3Key: string }> {
+        appUuid: string,
+    ): Promise<{ imageId: string }> {
         await this.assertDataAppsEnabled(user);
         if (
             user.ability.cannot(
@@ -254,10 +261,6 @@ export class AppGenerateService extends BaseService {
             throw new ForbiddenError(
                 'Insufficient permissions to upload app images',
             );
-        }
-
-        if (appUuid !== undefined && !isValidUuid(appUuid)) {
-            throw new ParameterError(`Invalid appUuid: must be a valid UUID`);
         }
 
         const validTypes = [
@@ -286,9 +289,8 @@ export class AppGenerateService extends BaseService {
             );
 
         const { client: s3Client, bucket } = this.getS3Client();
-        const ext = AppGenerateService.mimeToExt(mimeType);
-        const appDir = appUuid ?? uuidv4();
-        const s3Key = `apps/${appDir}/images/${uuidv4()}.${ext}`;
+        const imageId = uuidv4();
+        const s3Key = AppGenerateService.imageStagingKey(appUuid, imageId);
 
         await s3Client.send(
             new PutObjectCommand({
@@ -307,12 +309,13 @@ export class AppGenerateService extends BaseService {
                 organizationId: user.organizationUuid!,
                 projectId: projectUuid,
                 appUuid,
+                imageId,
                 mimeType,
                 sizeBytes: contentLength,
             },
         });
 
-        return { s3Key };
+        return { imageId };
     }
 
     private static truncateEnd(text: string, maxLength: number): string {
@@ -647,9 +650,10 @@ export class AppGenerateService extends BaseService {
     private async writeCatalogAndPrompt(
         sandbox: Sandbox,
         appUuid: string,
+        version: number,
         projectUuid: string,
         prompt: string,
-        image: AppImageAttachment | undefined,
+        imageId: string | undefined,
         s3Client: S3Client,
         bucket: string,
         chartReferences: ChartReference[] | undefined,
@@ -687,12 +691,13 @@ export class AppGenerateService extends BaseService {
             finalPrompt = referenceBlock + finalPrompt;
         }
 
-        // Write image to sandbox and prepend path reference to prompt
-        if (image) {
+        // Resolve image from staging, copy to version path, and write to sandbox
+        if (imageId) {
             const imagePath = await this.writeImageToSandbox(
                 sandbox,
                 appUuid,
-                image,
+                version,
+                imageId,
                 s3Client,
                 bucket,
             );
@@ -735,30 +740,37 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
-     * Stream an image from S3 and write it into the sandbox.
-     * Returns the sandbox file path where the image was written.
+     * Reconstruct the image's staging S3 key from convention, read the object
+     * (which gives us the MIME type from ContentType), copy it to the version
+     * assets folder, and write it into the sandbox for Claude to read.
+     * Returns the sandbox file path.
      */
     private async writeImageToSandbox(
         sandbox: Sandbox,
         appUuid: string,
-        image: AppImageAttachment,
+        version: number,
+        imageId: string,
         s3Client: S3Client,
         bucket: string,
     ): Promise<string> {
-        const ext = AppGenerateService.mimeToExt(image.mimeType);
-        const filePath = `/tmp/images/reference.${ext}`;
+        const stagingKey = AppGenerateService.imageStagingKey(appUuid, imageId);
 
         this.logger.info(
-            `App ${appUuid}: streaming image from S3 (key=${image.s3Key}, type=${image.mimeType})`,
+            `App ${appUuid}: reading staged image (key=${stagingKey})`,
         );
 
         const response = await s3Client.send(
             new GetObjectCommand({
                 Bucket: bucket,
-                Key: image.s3Key,
+                Key: stagingKey,
             }),
         );
 
+        const mimeType = response.ContentType ?? 'image/png';
+        const ext = AppGenerateService.mimeToExt(mimeType);
+        const sandboxPath = `/tmp/images/reference.${ext}`;
+
+        // Read the image bytes
         const chunks: Uint8Array[] = [];
         const body = response.Body;
         if (body && typeof (body as NodeJS.ReadableStream).on === 'function') {
@@ -770,22 +782,36 @@ export class AppGenerateService extends BaseService {
         }
         const buffer = Buffer.concat(chunks);
 
+        // Copy to version assets folder
+        const versionKey = `apps/${appUuid}/versions/${version}/assets/images/${imageId}.${ext}`;
         this.logger.info(
-            `App ${appUuid}: writing image to sandbox (${image.mimeType}, ${buffer.length} bytes)`,
+            `App ${appUuid}: copying image to version path (${stagingKey} → ${versionKey})`,
+        );
+        await s3Client.send(
+            new PutObjectCommand({
+                Bucket: bucket,
+                Key: versionKey,
+                Body: buffer,
+                ContentType: mimeType,
+            }),
         );
 
+        // Write to sandbox
+        this.logger.info(
+            `App ${appUuid}: writing image to sandbox (${mimeType}, ${buffer.length} bytes)`,
+        );
         await sandbox.commands.run('mkdir -p /tmp/images', {
             timeoutMs: 5_000,
         });
         await sandbox.files.write(
-            filePath,
+            sandboxPath,
             buffer.buffer.slice(
                 buffer.byteOffset,
                 buffer.byteOffset + buffer.byteLength,
             ) as ArrayBuffer,
         );
 
-        return filePath;
+        return sandboxPath;
     }
 
     /**
@@ -1218,7 +1244,7 @@ export class AppGenerateService extends BaseService {
             appUuid,
             version,
             projectUuid,
-            image,
+            imageId,
             isIteration,
             chartReferences,
         } = payload;
@@ -1376,7 +1402,7 @@ export class AppGenerateService extends BaseService {
                 currentStatus,
                 wasResumed,
                 anthropicApiKey,
-                image,
+                imageId,
                 chartReferences,
             );
         } finally {
@@ -1394,7 +1420,7 @@ export class AppGenerateService extends BaseService {
         currentStatus: AppVersionStatus,
         wasResumed: boolean,
         anthropicApiKey: string,
-        image: AppImageAttachment | undefined,
+        imageId: string | undefined,
         chartReferences: ChartReference[] | undefined,
     ): Promise<void> {
         const { appUuid, version, projectUuid, prompt } = payload;
@@ -1426,9 +1452,10 @@ export class AppGenerateService extends BaseService {
                 const catalogResult = await this.writeCatalogAndPrompt(
                     sandbox,
                     appUuid,
+                    version,
                     projectUuid,
                     prompt,
-                    image,
+                    imageId,
                     s3Client,
                     bucket,
                     chartReferences,
@@ -1724,7 +1751,7 @@ export class AppGenerateService extends BaseService {
         user: SessionUser,
         projectUuid: string,
         prompt: string,
-        image?: AppImageAttachment,
+        imageId?: string,
         preGeneratedAppUuid?: string,
         chartUuids?: string[],
     ): Promise<GenerateAppResult> {
@@ -1741,6 +1768,10 @@ export class AppGenerateService extends BaseService {
             throw new ForbiddenError(
                 'Insufficient permissions to create data apps',
             );
+        }
+
+        if (imageId !== undefined && !isValidUuid(imageId)) {
+            throw new ParameterError('Invalid imageId: must be a valid UUID');
         }
 
         const appUuid = preGeneratedAppUuid ?? uuidv4();
@@ -1777,8 +1808,7 @@ export class AppGenerateService extends BaseService {
                 appUuid,
                 version,
                 promptLength: prompt.length,
-                hasImage: image !== undefined,
-                imageMimeType: image?.mimeType,
+                hasImage: imageId !== undefined,
             },
         });
 
@@ -1794,7 +1824,7 @@ export class AppGenerateService extends BaseService {
             organizationUuid: user.organizationUuid!,
             userUuid: user.userUuid,
             prompt,
-            image,
+            imageId,
             isIteration: false,
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,
@@ -1808,7 +1838,7 @@ export class AppGenerateService extends BaseService {
         projectUuid: string,
         appUuid: string,
         prompt: string,
-        image?: AppImageAttachment,
+        imageId?: string,
         chartUuids?: string[],
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
@@ -1824,6 +1854,10 @@ export class AppGenerateService extends BaseService {
             throw new ForbiddenError(
                 'Insufficient permissions to modify data apps',
             );
+        }
+
+        if (imageId !== undefined && !isValidUuid(imageId)) {
+            throw new ParameterError('Invalid imageId: must be a valid UUID');
         }
 
         await this.appModel.getApp(appUuid, projectUuid); // validates app exists
@@ -1861,8 +1895,7 @@ export class AppGenerateService extends BaseService {
                 version: newVersion,
                 iterationNumber: newVersion - 1,
                 promptLength: prompt.length,
-                hasImage: image !== undefined,
-                imageMimeType: image?.mimeType,
+                hasImage: imageId !== undefined,
                 previousVersionStatus: latestVersion?.status ?? null,
                 msSinceLastVersion: latestVersion?.created_at
                     ? Date.now() - latestVersion.created_at.getTime()
@@ -1882,7 +1915,7 @@ export class AppGenerateService extends BaseService {
             organizationUuid: user.organizationUuid!,
             userUuid: user.userUuid,
             prompt,
-            image,
+            imageId,
             isIteration: true,
             chartReferences:
                 chartReferences.length > 0 ? chartReferences : undefined,

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6860,33 +6860,24 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    AppImageAttachment: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                filename: { dataType: 'string', required: true },
-                mimeType: { dataType: 'string', required: true },
-                s3Key: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     GenerateAppRequestBody: {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
+                chartUuids: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                },
                 appUuid: { dataType: 'string' },
-                image: { ref: 'AppImageAttachment' },
+                imageId: { dataType: 'string' },
                 prompt: { dataType: 'string', required: true },
             },
             validators: {},
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__s3Key-string__': {
+    'ApiSuccess__imageId-string__': {
         dataType: 'refAlias',
         type: {
             dataType: 'nestedObjectLiteral',
@@ -6894,7 +6885,7 @@ const models: TsoaRoute.Models = {
                 results: {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
-                        s3Key: { dataType: 'string', required: true },
+                        imageId: { dataType: 'string', required: true },
                     },
                     required: true,
                 },
@@ -6906,7 +6897,7 @@ const models: TsoaRoute.Models = {
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     ApiAppImageUploadResponse: {
         dataType: 'refAlias',
-        type: { ref: 'ApiSuccess__s3Key-string__', validators: {} },
+        type: { ref: 'ApiSuccess__imageId-string__', validators: {} },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     AppVersionStatus: {
@@ -8650,11 +8641,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8669,11 +8660,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8688,11 +8679,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8723,29 +8714,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 chartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -8769,6 +8737,35 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -8780,12 +8777,6 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -8901,11 +8892,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8981,29 +8972,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     chartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -9027,6 +8995,35 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
+                                                                                                    searchRank:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                        },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -9038,12 +9035,6 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    fieldType:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9075,11 +9066,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9094,11 +9085,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -32206,10 +32197,15 @@ export function RegisterRoutes(app: Router) {
             required: true,
             dataType: 'string',
         },
-        appUuid: { in: 'query', name: 'appUuid', dataType: 'string' },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
     };
     app.post(
-        '/api/v1/ee/projects/:projectUuid/apps/upload-image',
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/upload-image',
         ...fetchMiddlewares<RequestHandler>(AppGenerateController),
         ...fetchMiddlewares<RequestHandler>(
             AppGenerateController.prototype.uploadImage,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8227,29 +8227,19 @@
             "ApiGenerateAppResponse": {
                 "$ref": "#/components/schemas/ApiSuccess__appUuid-string--version-number__"
             },
-            "AppImageAttachment": {
-                "properties": {
-                    "filename": {
-                        "type": "string"
-                    },
-                    "mimeType": {
-                        "type": "string"
-                    },
-                    "s3Key": {
-                        "type": "string"
-                    }
-                },
-                "required": ["filename", "mimeType", "s3Key"],
-                "type": "object",
-                "description": "Image attached to a data app generation request.\nThe image is uploaded to S3 via the backend proxy; the s3Key\nreferences the uploaded object."
-            },
             "GenerateAppRequestBody": {
                 "properties": {
+                    "chartUuids": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
                     "appUuid": {
                         "type": "string"
                     },
-                    "image": {
-                        "$ref": "#/components/schemas/AppImageAttachment"
+                    "imageId": {
+                        "type": "string"
                     },
                     "prompt": {
                         "type": "string"
@@ -8258,15 +8248,15 @@
                 "required": ["prompt"],
                 "type": "object"
             },
-            "ApiSuccess__s3Key-string__": {
+            "ApiSuccess__imageId-string__": {
                 "properties": {
                     "results": {
                         "properties": {
-                            "s3Key": {
+                            "imageId": {
                                 "type": "string"
                             }
                         },
-                        "required": ["s3Key"],
+                        "required": ["imageId"],
                         "type": "object"
                     },
                     "status": {
@@ -8279,7 +8269,7 @@
                 "type": "object"
             },
             "ApiAppImageUploadResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__s3Key-string__"
+                "$ref": "#/components/schemas/ApiSuccess__imageId-string__"
             },
             "AppVersionStatus": {
                 "type": "string",
@@ -10101,33 +10091,23 @@
                                             },
                                             {
                                                 "properties": {
-                                                    "status": {
-                                                        "type": "string",
-                                                        "enum": [
-                                                            "success",
-                                                            "error"
-                                                        ]
-                                                    }
-                                                },
-                                                "required": ["status"],
-                                                "type": "object"
-                                            },
-                                            {
-                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
+                                                                        "fieldType": {
+                                                                            "type": "string"
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10135,17 +10115,14 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
-                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10194,8 +10171,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -10239,15 +10216,18 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10255,17 +10235,14 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
-                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10293,8 +10270,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -30281,7 +30258,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2770.1",
+        "version": "0.2775.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -33,23 +33,12 @@ export type ApiGenerateAppResponse = ApiSuccess<{
 }>;
 
 export type ApiAppImageUploadResponse = ApiSuccess<{
-    s3Key: string;
+    imageId: string;
 }>;
-
-/**
- * Image attached to a data app generation request.
- * The image is uploaded to S3 via the backend proxy; the s3Key
- * references the uploaded object.
- */
-export type AppImageAttachment = {
-    s3Key: string; // S3 object key (e.g. 'apps/images/{uuid}.png')
-    mimeType: string; // e.g. 'image/png', 'image/jpeg'
-    filename: string; // original filename
-};
 
 export type GenerateAppRequestBody = {
     prompt: string;
-    image?: AppImageAttachment;
+    imageId?: string;
     appUuid?: string; // pre-generated UUID so images can be scoped to the app in S3
     chartUuids?: string[]; // saved chart UUIDs to resolve and pass as structured metric queries
 };

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -1,7 +1,6 @@
 import includes from 'lodash/includes';
 import {
     type AiAgentEvalRunJobPayload,
-    type AppImageAttachment,
     type ChartReference,
     type EmbedArtifactVersionJobPayload,
     type GenerateArtifactQuestionJobPayload,
@@ -40,7 +39,7 @@ export type AppGeneratePipelineJobPayload = TraceTaskBase & {
     appUuid: string;
     version: number;
     prompt: string;
-    image?: AppImageAttachment;
+    imageId?: string;
     isIteration: boolean;
     chartReferences?: ChartReference[];
 };

--- a/packages/frontend/src/features/apps/hooks/useAppImageUpload.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppImageUpload.ts
@@ -7,7 +7,7 @@ import { useMutation } from '@tanstack/react-query';
 type UploadImageParams = {
     projectUuid: string;
     file: File;
-    appUuid?: string;
+    appUuid: string;
 };
 
 type UploadImageResult = ApiAppImageUploadResponse['results'];
@@ -17,9 +17,8 @@ const uploadImage = async ({
     file,
     appUuid,
 }: UploadImageParams): Promise<UploadImageResult> => {
-    const queryParams = appUuid ? `?appUuid=${appUuid}` : '';
     const response = await fetch(
-        `/api/v1/ee/projects/${projectUuid}/apps/upload-image${queryParams}`,
+        `/api/v1/ee/projects/${projectUuid}/apps/${appUuid}/upload-image`,
         {
             method: 'POST',
             body: file,

--- a/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useGenerateApp.ts
@@ -1,15 +1,11 @@
-import {
-    type ApiError,
-    type ApiGenerateAppResponse,
-    type AppImageAttachment,
-} from '@lightdash/common';
+import { type ApiError, type ApiGenerateAppResponse } from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
 type GenerateAppParams = {
     projectUuid: string;
     prompt: string;
-    image?: AppImageAttachment;
+    imageId?: string;
     appUuid?: string; // pre-generated UUID so images are scoped to the app in S3
     chartUuids?: string[];
 };
@@ -19,14 +15,14 @@ type GenerateAppResult = ApiGenerateAppResponse['results'];
 const generateApp = async ({
     projectUuid,
     prompt,
-    image,
+    imageId,
     appUuid,
     chartUuids,
 }: GenerateAppParams): Promise<GenerateAppResult> => {
     const data = await lightdashApi<GenerateAppResult>({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/apps/`,
-        body: JSON.stringify({ prompt, image, appUuid, chartUuids }),
+        body: JSON.stringify({ prompt, imageId, appUuid, chartUuids }),
     });
     return data;
 };

--- a/packages/frontend/src/features/apps/hooks/useIterateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useIterateApp.ts
@@ -1,8 +1,4 @@
-import {
-    type ApiError,
-    type ApiGenerateAppResponse,
-    type AppImageAttachment,
-} from '@lightdash/common';
+import { type ApiError, type ApiGenerateAppResponse } from '@lightdash/common';
 import { useMutation } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 
@@ -10,7 +6,7 @@ type IterateAppParams = {
     projectUuid: string;
     appUuid: string;
     prompt: string;
-    image?: AppImageAttachment;
+    imageId?: string;
     chartUuids?: string[];
 };
 
@@ -20,13 +16,13 @@ const iterateApp = async ({
     projectUuid,
     appUuid,
     prompt,
-    image,
+    imageId,
     chartUuids,
 }: IterateAppParams): Promise<IterateAppResult> => {
     const data = await lightdashApi<IterateAppResult>({
         method: 'POST',
         url: `/ee/projects/${projectUuid}/apps/${appUuid}/versions`,
-        body: JSON.stringify({ prompt, image, chartUuids }),
+        body: JSON.stringify({ prompt, imageId, chartUuids }),
     });
     return data;
 };

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -3,7 +3,6 @@ import {
     FeatureFlags,
     isAppVersionInProgress,
     type ApiAppVersionSummary,
-    type AppImageAttachment,
 } from '@lightdash/common';
 import {
     ActionIcon,
@@ -489,20 +488,16 @@ const AppGenerate: FC = () => {
         const newAppUuid = activeAppUuid ? undefined : uuid4();
         const targetAppUuid = activeAppUuid ?? newAppUuid;
 
-        // Upload image via backend proxy, then reference by S3 key
-        let image: AppImageAttachment | undefined;
+        // Upload image via backend proxy, then reference by opaque imageId
+        let imageId: string | undefined;
         if (imageAttachment) {
             try {
-                const { s3Key } = await uploadImage({
+                const result = await uploadImage({
                     projectUuid: projectUuid!,
                     file: imageAttachment.file,
-                    appUuid: targetAppUuid,
+                    appUuid: targetAppUuid!,
                 });
-                image = {
-                    s3Key,
-                    mimeType: imageAttachment.file.type,
-                    filename: imageAttachment.file.name,
-                };
+                imageId = result.imageId;
             } catch {
                 // If upload fails, proceed without the image
                 // rather than blocking the entire submission
@@ -578,7 +573,7 @@ const AppGenerate: FC = () => {
                     projectUuid,
                     appUuid: activeAppUuid,
                     prompt: trimmed,
-                    image,
+                    imageId,
                     chartUuids,
                 },
                 callbacks,
@@ -588,7 +583,7 @@ const AppGenerate: FC = () => {
                 {
                     projectUuid,
                     prompt: trimmed,
-                    image,
+                    imageId,
                     appUuid: newAppUuid,
                     chartUuids,
                 },


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

## Description

- Frontend now only receives an opaque `imageId` (UUID) instead of an S3 key
- Images are staged at a deterministic path (`apps/{appUuid}/uploads/{imageId}`) with no extension — MIME type stored as S3 `ContentType`
- At pipeline time, backend reconstructs the staging key from `appUuid` + `imageId`, copies to version assets folder, and writes to sandbox
- Removes `AppImageAttachment` type entirely — no S3 paths, MIME types, or filenames cross the API boundary
- No database changes — storage path is fully deterministic from values the backend already has
