### PR TITLE
feat: skip materialization for preview projects and add no active materialization miss reason

### DIFF
--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6240,6 +6240,11 @@ const models: TsoaRoute.Models = {
         enums: ['explore_resolution_error'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION': {
+        dataType: 'refEnum',
+        enums: ['no_active_materialization'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PreAggregateMatchMiss: {
         dataType: 'refAlias',
         type: {
@@ -6378,6 +6383,15 @@ const models: TsoaRoute.Models = {
                     nestedProperties: {
                         reason: {
                             ref: 'PreAggregateMissReason.EXPLORE_RESOLUTION_ERROR',
+                            required: true,
+                        },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        reason: {
+                            ref: 'PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION',
                             required: true,
                         },
                     },
@@ -26908,10 +26922,6 @@ const models: TsoaRoute.Models = {
                         },
                         status: {
                             ref: 'QueryHistoryStatus.READY',
-                            required: true,
-                        },
-                        resolvedTimezone: {
-                            dataType: 'string',
                             required: true,
                         },
                         metadata: {

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -7485,6 +7485,10 @@
                 "enum": ["explore_resolution_error"],
                 "type": "string"
             },
+            "PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION": {
+                "enum": ["no_active_materialization"],
+                "type": "string"
+            },
             "PreAggregateMatchMiss": {
                 "anyOf": [
                     {
@@ -7638,6 +7642,15 @@
                         "properties": {
                             "reason": {
                                 "$ref": "#/components/schemas/PreAggregateMissReason.EXPLORE_RESOLUTION_ERROR"
+                            }
+                        },
+                        "required": ["reason"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "reason": {
+                                "$ref": "#/components/schemas/PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION"
                             }
                         },
                         "required": ["reason"],
@@ -28081,9 +28094,6 @@
                             "status": {
                                 "$ref": "#/components/schemas/QueryHistoryStatus.READY"
                             },
-                            "resolvedTimezone": {
-                                "type": "string"
-                            },
                             "metadata": {
                                 "$ref": "#/components/schemas/QueryResultsMetadata"
                             },
@@ -28103,7 +28113,6 @@
                         "required": [
                             "pivotDetails",
                             "status",
-                            "resolvedTimezone",
                             "metadata",
                             "rows",
                             "columns",
@@ -30370,7 +30379,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2775.1",
+        "version": "0.2775.3",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/services/ProjectService/ProjectService.test.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.test.ts
@@ -3,9 +3,12 @@ import {
     defineUserAbility,
     FilterOperator,
     ForbiddenError,
+    MetricType,
     NotFoundError,
     OrganizationMemberRole,
     ParameterError,
+    PreAggregateMissReason,
+    ProjectType,
     SessionUser,
     WarehouseTypes,
     type Explore,
@@ -145,12 +148,15 @@ const projectModel = {
         runQuery: jest.fn(async () => resultsWith1Row),
     })),
     findExploreByTableName: jest.fn(async () => validExplore),
+    getAllExploresFromCache: jest.fn(async () => ({})),
+    saveExploresToCache: jest.fn(async () => ({ cachedExploreUuids: [] })),
     updateDefaultUserSpaces: jest.fn(async () => undefined),
 };
 const preAggregateModel = {
     upsertPreAggregateDefinitions: jest.fn(),
     getPreAggregateDefinitionsForProject: jest.fn(async () => []),
     getPreAggregateDefinitionByDefinitionName: jest.fn(async () => undefined),
+    getActiveMaterialization: jest.fn(async () => undefined),
 };
 const onboardingModel = {
     getByOrganizationUuid: jest.fn(async () => ({
@@ -176,8 +182,20 @@ const schedulerClient = {
     deleteScheduledPreAggregateCronJobsForProject: jest.fn(
         async () => undefined,
     ),
+    indexCatalog: jest.fn(async () => ({ jobId: 'catalog-job-1' })),
     materializePreAggregate: jest.fn(async () => ({ jobId: 'job-1' })),
     schedulePreAggregateCronJobs: jest.fn(async () => []),
+};
+
+const catalogModel = {
+    getCatalogItemsWithTags: jest.fn(async () => []),
+    getCatalogItemsWithIcons: jest.fn(async () => []),
+    getAllMetricsTreeEdges: jest.fn(async () => []),
+    getAllMetricsTreeNodes: jest.fn(async () => []),
+};
+
+const projectCompileLogModel = {
+    insert: jest.fn(async () => undefined),
 };
 
 const getMockedProjectService = (lightdashConfig: LightdashConfig) =>
@@ -213,7 +231,7 @@ const getMockedProjectService = (lightdashConfig: LightdashConfig) =>
         fileStorageClient: {} as FileStorageClient,
         groupsModel: {} as GroupsModel,
         tagsModel: {} as TagsModel,
-        catalogModel: {} as CatalogModel,
+        catalogModel: catalogModel as unknown as CatalogModel,
         contentModel: {} as ContentModel,
         encryptionUtil: {} as EncryptionUtil,
         userModel: {} as UserModel,
@@ -228,7 +246,8 @@ const getMockedProjectService = (lightdashConfig: LightdashConfig) =>
         } as unknown as ProjectParametersModel,
         organizationWarehouseCredentialsModel:
             {} as unknown as OrganizationWarehouseCredentialsModel,
-        projectCompileLogModel: {} as ProjectCompileLogModel,
+        projectCompileLogModel:
+            projectCompileLogModel as unknown as ProjectCompileLogModel,
         adminNotificationService: {
             notifyConnectionSettingsChange: jest.fn(async () => undefined),
         } as unknown as AdminNotificationService,
@@ -1363,6 +1382,121 @@ describe('ProjectService', () => {
                 [],
             ),
         };
+
+        test('saveExploresToCacheAndIndexCatalog skips preview project materialization jobs', async () => {
+            const serviceWithPreAggregatesEnabled = getMockedProjectService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+
+            (projectModel.get as jest.Mock).mockResolvedValueOnce({
+                ...projectWithSensitiveFields,
+                type: ProjectType.PREVIEW,
+            });
+
+            await serviceWithPreAggregatesEnabled.saveExploresToCacheAndIndexCatalog(
+                user.userUuid,
+                projectUuid,
+                [validExplore],
+                'cli_deploy',
+            );
+
+            expect(
+                preAggregateModel.upsertPreAggregateDefinitions,
+            ).toHaveBeenCalledTimes(1);
+            expect(
+                preAggregateModel.getPreAggregateDefinitionsForProject,
+            ).not.toHaveBeenCalled();
+            expect(
+                schedulerClient.materializePreAggregate,
+            ).not.toHaveBeenCalled();
+            expect(
+                schedulerClient.schedulePreAggregateCronJobs,
+            ).not.toHaveBeenCalled();
+        });
+
+        test('checkPreAggregateMatch returns a miss when the pre-aggregate is not materialized', async () => {
+            const serviceWithPreAggregatesEnabled = getMockedProjectService({
+                ...lightdashConfigMock,
+                preAggregates: {
+                    ...lightdashConfigMock.preAggregates,
+                    enabled: true,
+                },
+            });
+            const sourceExplore = {
+                ...validExplore,
+                tables: {
+                    ...validExplore.tables,
+                    a: {
+                        ...validExplore.tables.a,
+                        metrics: {
+                            ...validExplore.tables.a.metrics,
+                            met1: {
+                                ...validExplore.tables.a.metrics.met1,
+                                type: MetricType.COUNT,
+                            },
+                        },
+                    },
+                },
+                preAggregates: [
+                    {
+                        name: 'rollup',
+                        dimensions: ['dim1'],
+                        metrics: ['met1'],
+                    },
+                ],
+            } as Explore;
+
+            (
+                projectModel.findExploresFromCache as jest.Mock
+            ).mockImplementation(
+                async (
+                    _projectUuid: string,
+                    _field: string,
+                    exploreNames: string[],
+                ) =>
+                    Object.fromEntries(
+                        exploreNames
+                            .map((exploreName) => [
+                                exploreName,
+                                {
+                                    [sourceExplore.name]: sourceExplore,
+                                    [preAggregateExplore.name]:
+                                        preAggregateExplore,
+                                }[exploreName],
+                            ])
+                            .filter(([, explore]) => explore !== undefined),
+                    ),
+            );
+            (
+                preAggregateModel.getActiveMaterialization as jest.Mock
+            ).mockResolvedValueOnce(undefined);
+
+            const result =
+                await serviceWithPreAggregatesEnabled.checkPreAggregateMatch({
+                    account: developerAccount,
+                    projectUuid,
+                    exploreName: sourceExplore.name,
+                    metricQuery: {
+                        ...metricQueryMock,
+                        tableCalculations: [],
+                    },
+                    usePreAggregateCache: true,
+                });
+
+            expect(result).toEqual({
+                hit: false,
+                reason: {
+                    reason: PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION,
+                },
+            });
+            expect(
+                preAggregateModel.getActiveMaterialization,
+            ).toHaveBeenCalledWith(projectUuid, preAggregateExplore.name);
+        });
 
         test('refreshPreAggregates schedules only materializable definitions', async () => {
             (

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1543,9 +1543,17 @@ export class ProjectService extends BaseService {
         projectUuid: string;
         organizationUuid: string;
         userUuid: string;
+        skipMaterialization: boolean;
     }): Promise<void> {
         try {
             await this.syncPreAggregateDefinitionsRegistry(args.projectUuid);
+
+            if (args.skipMaterialization) {
+                this.logger.info(
+                    `Skipping pre-aggregate materialization enqueue for preview project ${args.projectUuid}`,
+                );
+                return;
+            }
 
             const preAggregateDefinitions =
                 await this.preAggregateModel.getPreAggregateDefinitionsForProject(
@@ -1666,6 +1674,7 @@ export class ProjectService extends BaseService {
                 projectUuid,
                 organizationUuid,
                 userUuid,
+                skipMaterialization: project.type === ProjectType.PREVIEW,
             });
         }
 
@@ -3355,6 +3364,22 @@ export class ProjectService extends BaseService {
         );
         try {
             await this.getExplore(account, projectUuid, preAggExploreName);
+
+            const activeMaterialization =
+                await this.preAggregateModel.getActiveMaterialization(
+                    projectUuid,
+                    preAggExploreName,
+                );
+
+            if (!activeMaterialization) {
+                return {
+                    hit: false,
+                    reason: {
+                        reason: PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION,
+                    },
+                };
+            }
+
             return {
                 hit: true,
                 preAggregateName: matchResult.preAggregateName,

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -69,6 +69,7 @@ export enum PreAggregateMissReason {
     TABLE_CALCULATION_PRESENT = 'table_calculation_present',
     USER_BYPASS = 'user_bypass',
     EXPLORE_RESOLUTION_ERROR = 'explore_resolution_error',
+    NO_ACTIVE_MATERIALIZATION = 'no_active_materialization',
 }
 
 export type PreAggregateMatchMiss =
@@ -121,6 +122,9 @@ export type PreAggregateMatchMiss =
       }
     | {
           reason: PreAggregateMissReason.EXPLORE_RESOLUTION_ERROR;
+      }
+    | {
+          reason: PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION;
       };
 
 export type PreAggregateCheckResult =
@@ -192,6 +196,8 @@ export const preAggregateMissReasonLabels: Record<
     [PreAggregateMissReason.USER_BYPASS]: 'Bypassed by user',
     [PreAggregateMissReason.EXPLORE_RESOLUTION_ERROR]:
         'Materialized explore not found',
+    [PreAggregateMissReason.NO_ACTIVE_MATERIALIZATION]:
+        'No active materialization',
 };
 
 export const PRE_AGGREGATE_ROW_COUNT_WARNING_THRESHOLD = 1_000_000;


### PR DESCRIPTION
Closes: [PROD-6932: Pre-aggregate compilation errors not shown in preview projects](https://linear.app/lightdash/issue/PROD-6932/pre-aggregate-compilation-errors-not-shown-in-preview-projects)

### Description:

Adds a new `NO_ACTIVE_MATERIALIZATION` miss reason for pre-aggregate cache checks. When a query matches a pre-aggregate definition but no active materialization exists for it, the check now returns a cache miss with this reason rather than proceeding as a hit.

Preview projects are also excluded from pre-aggregate materialization job scheduling — definitions are still synced, but no materialization or cron jobs are enqueued for preview project types.

Tests have been added to cover both behaviors: verifying that preview projects skip materialization scheduling, and that `checkPreAggregateMatch` correctly returns a miss when no active materialization is found.