### PR TITLE
fix: enable attching images in the browser

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -426,7 +426,7 @@ export default class App {
                         "'self'",
                         ...contentSecurityPolicyAllowedDomains,
                     ],
-                    'img-src': ["'self'", 'data:', 'https://*'],
+                    'img-src': ["'self'", 'data:', 'blob:', 'https://*'],
                     'frame-src': ["'self'", 'https://*'],
                     'frame-ancestors': [
                         "'self'",


### PR DESCRIPTION
### Description:
- CSP for uploads was failing for images
- **CSP `blob:` for image previews**: Added `blob:` to the `img-src` CSP directive so `URL.createObjectURL()` previews render. Blob URLs are origin-scoped and can't be forged — no meaningful expansion of attack
  surface beyond existing XSS scenarios.
