### PR TITLE
feat(cli): retry batched deploy on transient failures

### DIFF
--- a/packages/cli/src/handlers/deploy.ts
+++ b/packages/cli/src/handlers/deploy.ts
@@ -6,6 +6,7 @@ import {
     friendlyName,
     getErrorMessage,
     isExploreError,
+    LightdashError,
     ParseError,
     Project,
     ProjectType,
@@ -104,6 +105,53 @@ const replaceProjectDefaults = async (
     }
 };
 
+const BATCH_UPLOAD_MAX_ATTEMPTS = 4;
+const BATCH_UPLOAD_INITIAL_BACKOFF_MS = 500;
+const BATCH_UPLOAD_MAX_BACKOFF_MS = 4000;
+
+const sleep = (ms: number): Promise<void> =>
+    new Promise((resolve) => {
+        setTimeout(resolve, ms);
+    });
+
+const isRetriableBatchError = (err: unknown): boolean => {
+    if (err instanceof LightdashError) {
+        return err.statusCode >= 500 || err.statusCode === 429;
+    }
+    // Non-LightdashError thrown by lightdashApi (network failures or non-JSON
+    // server responses) — treat as transient.
+    return true;
+};
+
+const retryBatchUpload = async <T>(
+    task: () => Promise<T>,
+    batchNumber: number,
+): Promise<T> => {
+    let backoffMs = BATCH_UPLOAD_INITIAL_BACKOFF_MS;
+    for (let attempt = 1; attempt <= BATCH_UPLOAD_MAX_ATTEMPTS; attempt += 1) {
+        try {
+            // eslint-disable-next-line no-await-in-loop
+            return await task();
+        } catch (err) {
+            const isLastAttempt = attempt === BATCH_UPLOAD_MAX_ATTEMPTS;
+            if (isLastAttempt || !isRetriableBatchError(err)) {
+                throw err;
+            }
+            GlobalState.log(
+                styles.warning(
+                    `  ⚠ Batch ${batchNumber} failed (attempt ${attempt}/${BATCH_UPLOAD_MAX_ATTEMPTS}), retrying in ${backoffMs}ms: ${getErrorMessage(
+                        err,
+                    )}`,
+                ),
+            );
+            // eslint-disable-next-line no-await-in-loop
+            await sleep(backoffMs);
+            backoffMs = Math.min(backoffMs * 2, BATCH_UPLOAD_MAX_BACKOFF_MS);
+        }
+    }
+    throw new Error(`Batch ${batchNumber} upload failed unexpectedly`);
+};
+
 const deployBatched = async (
     explores: (Explore | ExploreError)[],
     options: DeployArgs,
@@ -162,15 +210,19 @@ const deployBatched = async (
             `  Uploading batch ${batchIndex + 1}/${batches.length} (${batch.length} explores)...`,
         );
 
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const response = (await lightdashApi<any>({
-            method: 'POST',
-            url: `/api/v2/projects/${options.projectUuid}/deploy/${sessionUuid}/batch`,
-            body: JSON.stringify({
-                explores: batch,
-                batchNumber: batchIndex,
-            }),
-        })) as { batchNumber: number; exploreCount: number };
+        const response = await retryBatchUpload(
+            () =>
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+                lightdashApi<any>({
+                    method: 'POST',
+                    url: `/api/v2/projects/${options.projectUuid}/deploy/${sessionUuid}/batch`,
+                    body: JSON.stringify({
+                        explores: batch,
+                        batchNumber: batchIndex,
+                    }),
+                }) as Promise<{ batchNumber: number; exploreCount: number }>,
+            batchIndex + 1,
+        );
 
         GlobalState.log(
             styles.success(


### PR DESCRIPTION
## Summary

- When running `lightdash deploy --use-batched-deploy`, a single failed batch currently aborts the entire deploy. This adds a simple retry around each batch upload so transient errors don't force a full restart.
- Each batch upload retries up to 3 times (4 total attempts) with exponential backoff: 500ms → 1000ms → 2000ms (capped at 4000ms).
- Only transient failures retry: `LightdashError` with `statusCode >= 500` or `429`, plus any non-`LightdashError` thrown by `lightdashApi` (network failures / non-JSON responses). 4xx client errors (400/401/403/404/413) fail fast — retrying won't help them.
- Session start and finalize calls are intentionally left unchanged (scope kept narrow to the most common failure point).
- On retry, logs a warning line: `⚠ Batch N failed (attempt M/4), retrying in Xms: <error>`. After retries are exhausted the error propagates as before.
- No new CLI flags — retry count/backoff are hardcoded defaults.

## Test plan

- [ ] `pnpm -F cli lint` and `pnpm -F cli typecheck` pass
- [ ] Happy path: `lightdash deploy --use-batched-deploy --batch-size 5` still completes with no retry log lines
- [ ] Transient failure: inject a 503 on the first `/deploy/{session}/batch` call — expect one retry log line, then success
- [ ] Non-retriable: inject a 400 — expect no retry, immediate failure
- [ ] Retries exhausted: inject persistent 503 — expect 3 retry log lines then the usual error path

🤖 Generated with [Claude Code](https://claude.com/claude-code)