### PR TITLE
feat: add Databricks OAuth M2M (service principal) authentication support

### DIFF
--- a/packages/backend/src/ee/controllers/databricksSSOController.ts
+++ b/packages/backend/src/ee/controllers/databricksSSOController.ts
@@ -1,6 +1,7 @@
 import {
     ApiErrorPayload,
     ApiSuccessEmpty,
+    DatabricksAuthenticationType,
     NotFoundError,
     WarehouseTypes,
 } from '@lightdash/common';
@@ -44,6 +45,20 @@ export class DatabricksSSOController extends BaseController {
                 ? req.query.serverHostName
                 : undefined;
         if (projectUuid) {
+            const authInfo = await this.services
+                .getProjectService()
+                .getProjectWarehouseAuthInfo(req.user!, projectUuid);
+            // M2M auth uses project-level credentials, so no per-user SSO is expected.
+            if (
+                authInfo.type === WarehouseTypes.DATABRICKS &&
+                authInfo.authenticationType ===
+                    DatabricksAuthenticationType.OAUTH_M2M
+            ) {
+                return {
+                    status: 'ok',
+                    results: undefined,
+                };
+            }
             const credentials = await this.services
                 .getProjectService()
                 .getProjectCredentialsPreference(req.user!, projectUuid);

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -1167,6 +1167,34 @@ export class ProjectService extends BaseService {
         return args;
     }
 
+    // The project-update form sends masked oauthClientId / oauthClientSecret
+    // (placeholder values), so merge them in from the saved project before
+    // _resolveWarehouseClientCredentials runs the M2M token exchange. No-op for
+    // anything that isn't Databricks M2M.
+    // eslint-disable-next-line class-methods-use-this
+    private mergeMissingDatabricksM2MSecrets<
+        T extends { warehouseConnection: CreateWarehouseCredentials },
+    >(
+        data: T,
+        savedProject: { warehouseConnection?: CreateWarehouseCredentials },
+    ): T {
+        if (
+            data.warehouseConnection.type === WarehouseTypes.DATABRICKS &&
+            data.warehouseConnection.authenticationType ===
+                DatabricksAuthenticationType.OAUTH_M2M &&
+            savedProject.warehouseConnection
+        ) {
+            return {
+                ...data,
+                warehouseConnection: ProjectModel.mergeMissingWarehouseSecrets(
+                    data.warehouseConnection,
+                    savedProject.warehouseConnection,
+                ),
+            };
+        }
+        return data;
+    }
+
     // Extra security measure, we remove the "secrets" from the project/org credentials
     // and let the user override that token/password later on
     // eslint-disable-next-line class-methods-use-this
@@ -2311,7 +2339,7 @@ export class ProjectService extends BaseService {
             ],
         };
         const createProject = await this._resolveWarehouseClientCredentials(
-            data,
+            this.mergeMissingDatabricksM2MSecrets(data, savedProject),
             account.user.id,
             savedProject.organizationUuid,
         );
@@ -2413,7 +2441,10 @@ export class ProjectService extends BaseService {
         };
 
         const resolvedData = await this._resolveWarehouseClientCredentials(
-            updatedProjectData,
+            this.mergeMissingDatabricksM2MSecrets(
+                updatedProjectData,
+                savedProject,
+            ),
             account.user.id,
             savedProject.organizationUuid,
         );
@@ -7430,6 +7461,30 @@ export class ProjectService extends BaseService {
             user.userUuid,
             credentials.type,
         );
+    }
+
+    async getProjectWarehouseAuthInfo(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<{
+        type: WarehouseTypes;
+        authenticationType?: string;
+    }> {
+        const project = await this.projectModel.getSummary(projectUuid);
+        if (user.ability.cannot('view', subject('Project', project))) {
+            throw new ForbiddenError();
+        }
+        const credentials =
+            await this.projectModel.getWarehouseCredentialsForProject(
+                projectUuid,
+            );
+        return {
+            type: credentials.type,
+            authenticationType:
+                'authenticationType' in credentials
+                    ? credentials.authenticationType
+                    : undefined,
+        };
     }
 
     async getProjectUserWarehouseCredentials(

--- a/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/WarehouseForms/DatabricksForm.tsx
@@ -178,23 +178,24 @@ const DatabricksForm: FC<{
         form.values.warehouse.authenticationType ?? defaultAuthType;
 
     // Build authentication options based on SSO availability
-    const authOptions = isSsoEnabled
-        ? [
-              {
-                  value: DatabricksAuthenticationType.OAUTH_U2M,
-                  label: getSsoLabel(WarehouseTypes.DATABRICKS),
-              },
-              {
-                  value: DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN,
-                  label: PERSONAL_ACCESS_TOKEN_LABEL,
-              },
-          ]
-        : [
-              {
-                  value: DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN,
-                  label: PERSONAL_ACCESS_TOKEN_LABEL,
-              },
-          ];
+    const authOptions = [
+        ...(isSsoEnabled
+            ? [
+                  {
+                      value: DatabricksAuthenticationType.OAUTH_U2M,
+                      label: getSsoLabel(WarehouseTypes.DATABRICKS),
+                  },
+              ]
+            : []),
+        {
+            value: DatabricksAuthenticationType.PERSONAL_ACCESS_TOKEN,
+            label: PERSONAL_ACCESS_TOKEN_LABEL,
+        },
+        {
+            value: DatabricksAuthenticationType.OAUTH_M2M,
+            label: 'OAuth Machine-to-Machine (Service Principal)',
+        },
+    ];
 
     const computes = form.values.warehouse?.compute ?? [];
     const addCompute = () => {
@@ -320,6 +321,38 @@ const DatabricksForm: FC<{
                         }
                         disabled={disabled}
                     />
+                ) : authenticationType ===
+                  DatabricksAuthenticationType.OAUTH_M2M ? (
+                    <Stack spacing="sm">
+                        <PasswordInput
+                            name="warehouse.oauthClientId"
+                            {...form.getInputProps('warehouse.oauthClientId')}
+                            label="OAuth Client ID"
+                            description="Service principal client ID (UUID)."
+                            required={requireSecrets}
+                            placeholder={
+                                disabled || !requireSecrets
+                                    ? '**************'
+                                    : undefined
+                            }
+                            disabled={disabled}
+                        />
+                        <PasswordInput
+                            name="warehouse.oauthClientSecret"
+                            {...form.getInputProps(
+                                'warehouse.oauthClientSecret',
+                            )}
+                            label="OAuth Client Secret"
+                            description="Service principal client secret."
+                            required={requireSecrets}
+                            placeholder={
+                                disabled || !requireSecrets
+                                    ? '**************'
+                                    : undefined
+                            }
+                            disabled={disabled}
+                        />
+                    </Stack>
                 ) : (
                     <DatabricksSSOInput
                         isAuthenticated={isAuthenticated}


### PR DESCRIPTION
Closes: https://github.com/lightdash/lightdash/issues/22205

<img width="956" height="743" alt="CleanShot 2026-04-22 at 13 05 44" src="https://github.com/user-attachments/assets/24a35bd8-098a-40e7-a962-467e0c3f6b2a" />

Sample Projects variable using M2M

```
export LD_SETUP_PROJECTS='[
    {
      "name": "Databricks M2M Test",
      "warehouseConnection": {
        "type": "databricks",
        "serverHostName": "dbc-xxxxcloud.databricks.com",
        "httpPath": "/sql/1.0/warehouses/xxxx",
        "catalog": "lightdash_staging",
        "database": "jaffle",
        "authenticationType": "oauth_m2m",
        "oauthClientId": "xxxxx",
        "oauthClientSecret": "xxxxx"
      },
      "dbtConnection": {
        "type": "github",
        "authorization_method": "personal_access_token",
        "personal_access_token": "ghp_REPLACE_ME",
        "repository": "myorg/my-dbt-repo",
        "branch": "main",
        "project_sub_path": "/"
      }
    }
  ]'

```


### Description:

Adds support for Databricks OAuth Machine-to-Machine (M2M / Service Principal) authentication as a new authentication type option in the Databricks warehouse connection form.

- Adds OAuth Client ID and OAuth Client Secret fields to the Databricks connection form when M2M authentication is selected.
- When a project is configured with M2M authentication, the Databricks SSO controller now short-circuits and returns an empty success response, since M2M uses project-level credentials and per-user SSO is not applicable.
- Fixes a bug where masked/missing secrets (such as the OAuth client ID and secret) were merged from the stored project **after** credential resolution, which prevented M2M token refresh from finding the existing credentials. The merge now happens **before** resolution so that secrets are available during the credential refresh step.
- Adds a `getProjectWarehouseAuthInfo` method to `ProjectService` that returns the warehouse type and authentication type for a given project, used by the SSO controller to detect M2M configurations.