### PR TITLE
Support defaultOrderBy for LAG/LEAD window functions

### DIFF
--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -189,10 +189,21 @@ const compileTableCalculation = (
             // rejected by the warehouse. Wrapping as `AGG(x) OVER ()` turns
             // them into window aggregates — legal in that context and
             // preserving Sheets-like whole-result-set semantics.
+            //
+            // `defaultOrderBy` provides the query's sort fields as the default
+            // ordering for window functions like LAG/LEAD that require ORDER BY.
+            const defaultOrderBy = sortFields?.map((s) => ({
+                column: s.fieldId,
+                direction: s.descending ? 'DESC' : 'ASC',
+            })) as
+                | Array<{ column: string; direction?: 'ASC' | 'DESC' }>
+                | undefined;
+
             const compiledSql = compileFormula(tableCalculation.formula, {
                 dialect,
                 columns,
                 renderAggregate: (inner) => `${inner} OVER ()`,
+                defaultOrderBy,
             });
             return {
                 ...tableCalculation,

--- a/packages/formula/src/codegen/generator.ts
+++ b/packages/formula/src/codegen/generator.ts
@@ -400,6 +400,10 @@ export class SqlGenerator {
     // with default frame, variadic args). The dialect callback receives
     // an `emitWindow` bound to this node's window clause so dialects don't
     // have to own PARTITION BY / ORDER BY plumbing.
+    //
+    // LAG/LEAD require ORDER BY to be semantically defined (what is "previous"
+    // without ordering?). When no explicit ORDER BY is in the formula, we fall
+    // back to `options.defaultOrderBy` — typically the query's sort fields.
     protected dispatchLagLead(
         sqlFunc: 'LAG' | 'LEAD',
         args: string[],
@@ -409,7 +413,7 @@ export class SqlGenerator {
             fn: string,
             funcArgs: string[],
             frameClause?: string,
-        ) => this.generateWindowFunction(fn, funcArgs, node, frameClause);
+        ) => this.generateWindowFunction(fn, funcArgs, node, frameClause, true);
 
         if (this.dialect.generateLagLead) {
             return this.dialect.generateLagLead({
@@ -458,10 +462,15 @@ export class SqlGenerator {
     // callers that need per-function argument transforms (e.g. AVG's
     // precision-preserving cast on Redshift) build the call via their own
     // emitter and still share the PARTITION BY / ORDER BY / frame plumbing.
+    //
+    // `useDefaultOrderBy` — when true and no explicit ORDER BY is in the
+    // window clause, falls back to `options.defaultOrderBy`. Used by LAG/LEAD
+    // which require ordering to be semantically defined.
     protected appendOverClause(
         funcCall: string,
         node: { windowClause?: WindowClauseNode | null },
         frameClause?: string,
+        useDefaultOrderBy?: boolean,
     ): string {
         const overParts: string[] = [];
 
@@ -474,6 +483,13 @@ export class SqlGenerator {
             overParts.push(
                 `ORDER BY ${this.generate(wc.orderBy.column)}${dir}`,
             );
+        } else if (useDefaultOrderBy && this.options.defaultOrderBy?.length) {
+            const orderExprs = this.options.defaultOrderBy.map((o) => {
+                const col = this.quoteIdentifier(o.column);
+                const dir = o.direction ? ` ${o.direction}` : '';
+                return `${col}${dir}`;
+            });
+            overParts.push(`ORDER BY ${orderExprs.join(', ')}`);
         }
 
         const framePart = frameClause ? ` ${frameClause}` : '';
@@ -485,11 +501,17 @@ export class SqlGenerator {
         funcArgs: string[],
         node: { windowClause?: WindowClauseNode | null },
         frameClause?: string,
+        useDefaultOrderBy?: boolean,
     ): string {
         const funcCall =
             funcArgs.length > 0
                 ? `${sqlFunc}(${funcArgs.join(', ')})`
                 : `${sqlFunc}()`;
-        return this.appendOverClause(funcCall, node, frameClause);
+        return this.appendOverClause(
+            funcCall,
+            node,
+            frameClause,
+            useDefaultOrderBy,
+        );
     }
 }

--- a/packages/formula/src/types.ts
+++ b/packages/formula/src/types.ts
@@ -28,6 +28,11 @@ export interface CompileOptions {
     // Callers that compose their own GROUP BY around the output leave this
     // unset. The formula package has no opinion on embedding context.
     renderAggregate?: (innerSql: string) => string;
+    // Default ORDER BY for window functions that require ordering (LAG, LEAD).
+    // When no explicit ORDER BY is specified in the formula's window clause,
+    // these columns are used. Each entry maps to a column name (key in
+    // `columns`) and optional sort direction.
+    defaultOrderBy?: Array<{ column: string; direction?: 'ASC' | 'DESC' }>;
 }
 
 // AST Node Types

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -451,4 +451,58 @@ describe('codegen', () => {
             expect(calls).toEqual([]);
         });
     });
+
+    describe('defaultOrderBy for LAG/LEAD', () => {
+        it('uses defaultOrderBy when LAG has no explicit ORDER BY', () => {
+            expect(
+                compile('=LAG(revenue)', {
+                    dialect: 'bigquery',
+                    columns,
+                    defaultOrderBy: [{ column: 'region', direction: 'ASC' }],
+                }),
+            ).toBe('LAG(`revenue`) OVER (ORDER BY `region` ASC)');
+        });
+
+        it('uses defaultOrderBy with multiple columns', () => {
+            expect(
+                compile('=LAG(revenue, 1)', {
+                    dialect: 'postgres',
+                    columns,
+                    defaultOrderBy: [
+                        { column: 'region', direction: 'DESC' },
+                        { column: 'revenue' },
+                    ],
+                }),
+            ).toBe('LAG("revenue", 1) OVER (ORDER BY "region" DESC, "revenue")');
+        });
+
+        it('applies to LEAD as well', () => {
+            expect(
+                compile('=LEAD(revenue)', {
+                    dialect: 'bigquery',
+                    columns,
+                    defaultOrderBy: [{ column: 'region' }],
+                }),
+            ).toBe('LEAD(`revenue`) OVER (ORDER BY `region`)');
+        });
+
+        it('emits empty OVER () when no defaultOrderBy and no explicit ORDER BY', () => {
+            expect(
+                compile('=LAG(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                }),
+            ).toBe('LAG("revenue") OVER ()');
+        });
+
+        it('does not affect other window functions', () => {
+            expect(
+                compile('=RUNNING_TOTAL(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    defaultOrderBy: [{ column: 'region' }],
+                }),
+            ).toBe('SUM("revenue") OVER ( ROWS UNBOUNDED PRECEDING)');
+        });
+    });
 });


### PR DESCRIPTION
### Description:

Adds support for a `defaultOrderBy` option in formula compilation to provide default ordering for window functions that semantically require it (LAG/LEAD). When these functions are used without an explicit ORDER BY clause, the compiler now falls back to the query's sort fields.

#### Changes:

**Formula Package:**
- Added `defaultOrderBy` option to `CompileOptions` interface to specify default column ordering
- Updated `dispatchLagLead()` to pass a flag indicating LAG/LEAD functions should use default ordering
- Modified `appendOverClause()` and `generateWindowFunction()` to accept and apply `defaultOrderBy` when no explicit ORDER BY is present
- Added comprehensive test coverage for LAG/LEAD with default ordering, multiple columns, and edge cases

**Backend:**
- Updated `compileTableCalculation()` to extract sort fields from the query and pass them as `defaultOrderBy` to the formula compiler

#### Rationale:

LAG/LEAD require ORDER BY to be semantically meaningful (what is "previous" without ordering?). This change allows queries to implicitly use their sort order for these functions, improving usability while maintaining explicit ORDER BY when specified in the formula.

#### Test Coverage:

Added 5 new test cases covering:
- LAG with single default column
- LAG with multiple default columns and directions
- LEAD function support
- Empty OVER clause when no defaults provided
- Other window functions unaffected by the change

https://claude.ai/code/session_01NKG2mmsZnb2JFMP9FgqvTH