### PR TITLE
feat: add analytics tracking for pre-aggregate materialization and refresh events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -244,6 +244,14 @@ type SqlExecutionProperties = {
     usingStreaming: boolean;
 };
 
+type PreAggregateAnalyticsProperties = {
+    preAggregateEligible?: boolean;
+    preAggregateHit?: boolean;
+    preAggregateName?: string;
+    preAggregateMissReason?: string;
+    preAggregateMode?: 'required' | 'opportunistic';
+};
+
 type QueryExecutionEvent = BaseTrack & {
     event: 'query.executed';
     properties: {
@@ -251,11 +259,12 @@ type QueryExecutionEvent = BaseTrack & {
         organizationId: string;
         projectId: string;
         cacheMetadata?: CacheMetadata;
-    } & (
-        | PaginatedMetricQueryExecutionProperties
-        | MetricQueryExecutionProperties
-        | SqlExecutionProperties
-    );
+    } & PreAggregateAnalyticsProperties &
+        (
+            | PaginatedMetricQueryExecutionProperties
+            | MetricQueryExecutionProperties
+            | SqlExecutionProperties
+        );
 };
 
 type QueryReadyEvent = BaseTrack & {
@@ -276,6 +285,38 @@ type QueryErrorEvent = BaseTrack & {
         queryId: string;
         projectId: string;
         warehouseType: WarehouseTypes | undefined;
+    };
+};
+
+type PreAggregateMaterializationEvent = BaseTrack & {
+    event:
+        | 'pre_aggregate.materialization_completed'
+        | 'pre_aggregate.materialization_failed';
+    properties: {
+        organizationId: string;
+        projectId: string;
+        preAggregateName: string;
+        trigger: string;
+        status: 'active' | 'superseded' | 'failed';
+        format: 'jsonl' | 'parquet';
+        rowCount: number | null;
+        columnCount: number | null;
+        totalBytes: number | null;
+        warehouseExecutionTimeMs: number | null;
+        totalDurationMs: number;
+        warningRowCountExceeded: boolean;
+        warningMaxRowsApplied: boolean;
+        errorMessage?: string;
+    };
+};
+
+type PreAggregateRefreshRequestedEvent = BaseTrack & {
+    event: 'pre_aggregate.refresh_requested';
+    properties: {
+        organizationId: string;
+        projectId: string;
+        preAggregateName: string;
+        trigger: 'manual';
     };
 };
 
@@ -1857,7 +1898,9 @@ type TypedEvent =
     | AiAgentArtifactsRetrievedEvent
     | ContentVerificationEvent
     | SchedulerOwnershipReassignedEvent
-    | ImpersonationEvent;
+    | ImpersonationEvent
+    | PreAggregateMaterializationEvent
+    | PreAggregateRefreshRequestedEvent;
 
 type UntypedEvent<T extends BaseTrack> = Omit<BaseTrack, 'event'> &
     T & {

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
@@ -1,12 +1,10 @@
-import {
-    QueryExecutionContext,
-    QueryHistoryStatus,
-    type Account,
-} from '@lightdash/common';
+import { QueryExecutionContext, QueryHistoryStatus } from '@lightdash/common';
+import { analyticsMock } from '../../../analytics/LightdashAnalytics.mock';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
 import { type QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
 import { type AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import { sessionAccount } from '../../../services/ProjectService/ProjectService.mock';
 import { type PreAggregateModel } from '../../models/PreAggregateModel';
 import { PreAggregateMaterializationService } from './PreAggregateMaterializationService';
 
@@ -47,6 +45,7 @@ describe('PreAggregateMaterializationService', () => {
         asyncQueryService: asyncQueryService as unknown as AsyncQueryService,
         preAggregateResultsStorageClient:
             preAggregateResultsStorageClient as unknown as S3ResultsFileStorageClient,
+        analytics: analyticsMock,
     });
 
     beforeEach(() => {
@@ -65,7 +64,7 @@ describe('PreAggregateMaterializationService', () => {
         });
 
         const result = await service.materializePreAggregate({
-            account: {} as Account,
+            account: sessionAccount,
             projectUuid: 'project-1',
             preAggregateDefinitionUuid: 'def-1',
             trigger: 'manual',
@@ -126,7 +125,7 @@ describe('PreAggregateMaterializationService', () => {
         });
 
         const result = await service.materializePreAggregate({
-            account: {} as Account,
+            account: sessionAccount,
             projectUuid: 'project-1',
             preAggregateDefinitionUuid: 'def-1',
             trigger: 'manual',
@@ -204,7 +203,7 @@ describe('PreAggregateMaterializationService', () => {
         });
 
         await service.materializePreAggregate({
-            account: {} as Account,
+            account: sessionAccount,
             projectUuid: 'project-1',
             preAggregateDefinitionUuid: 'def-1',
             trigger: 'manual',
@@ -254,7 +253,7 @@ describe('PreAggregateMaterializationService', () => {
         });
 
         const result = await service.materializePreAggregate({
-            account: {} as Account,
+            account: sessionAccount,
             projectUuid: 'project-1',
             preAggregateDefinitionUuid: 'def-1',
             trigger: 'manual',
@@ -319,7 +318,7 @@ describe('PreAggregateMaterializationService', () => {
         });
 
         await service.materializePreAggregate({
-            account: {} as Account,
+            account: sessionAccount,
             projectUuid: 'project-1',
             preAggregateDefinitionUuid: 'def-1',
             trigger: 'manual',

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -1,4 +1,5 @@
 import {
+    assertIsAccountWithOrg,
     getErrorMessage,
     getIntrinsicUserAttributes,
     NotFoundError,
@@ -13,6 +14,7 @@ import {
     type PreAggregateMaterializationTrigger,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
+import { type LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type LightdashConfig } from '../../../config/parseConfig';
 import { type QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
@@ -37,12 +39,15 @@ export class PreAggregateMaterializationService extends BaseService {
 
     private readonly preAggregateResultsStorageClient: S3ResultsFileStorageClient;
 
+    private readonly analytics: LightdashAnalytics;
+
     constructor(args: {
         lightdashConfig: LightdashConfig;
         preAggregateModel: PreAggregateModel;
         queryHistoryModel: QueryHistoryModel;
         asyncQueryService: AsyncQueryService;
         preAggregateResultsStorageClient: S3ResultsFileStorageClient;
+        analytics: LightdashAnalytics;
         prometheusMetrics?: PrometheusMetrics;
     }) {
         super({ serviceName: 'PreAggregateMaterializationService' });
@@ -52,6 +57,7 @@ export class PreAggregateMaterializationService extends BaseService {
         this.asyncQueryService = args.asyncQueryService;
         this.preAggregateResultsStorageClient =
             args.preAggregateResultsStorageClient;
+        this.analytics = args.analytics;
         this.prometheusMetrics = args.prometheusMetrics;
     }
 
@@ -76,6 +82,51 @@ export class PreAggregateMaterializationService extends BaseService {
         return this.parquetEnabled ? 'parquet' : 'jsonl';
     }
 
+    private trackMaterializationEvent(args: {
+        account: Account;
+        event:
+            | 'pre_aggregate.materialization_completed'
+            | 'pre_aggregate.materialization_failed';
+        projectUuid: string;
+        preAggregateName: string;
+        trigger: PreAggregateMaterializationTrigger;
+        status: 'active' | 'superseded' | 'failed';
+        rowCount: number | null;
+        columnCount: number | null;
+        totalBytes: number | null;
+        warehouseExecutionTimeMs: number | null;
+        totalDurationMs: number;
+        materializationMaxRows?: number | null;
+        errorMessage?: string;
+    }) {
+        assertIsAccountWithOrg(args.account);
+
+        this.analytics.trackAccount(args.account, {
+            event: args.event,
+            properties: {
+                organizationId: args.account.organization.organizationUuid,
+                projectId: args.projectUuid,
+                preAggregateName: args.preAggregateName,
+                trigger: args.trigger,
+                status: args.status,
+                format: this.getMaterializationFormat(),
+                rowCount: args.rowCount,
+                columnCount: args.columnCount,
+                totalBytes: args.totalBytes,
+                warehouseExecutionTimeMs: args.warehouseExecutionTimeMs,
+                totalDurationMs: args.totalDurationMs,
+                warningRowCountExceeded:
+                    args.rowCount != null &&
+                    args.rowCount > PRE_AGGREGATE_ROW_COUNT_WARNING_THRESHOLD,
+                warningMaxRowsApplied:
+                    args.materializationMaxRows != null &&
+                    args.rowCount != null &&
+                    args.rowCount >= args.materializationMaxRows,
+                errorMessage: args.errorMessage,
+            },
+        });
+    }
+
     async materializePreAggregate(args: {
         account: Account;
         projectUuid: string;
@@ -86,11 +137,18 @@ export class PreAggregateMaterializationService extends BaseService {
         status: 'active' | 'superseded' | 'failed';
         queryUuid?: string;
     }> {
+        let definition:
+            | Awaited<
+                  ReturnType<
+                      PreAggregateModel['getPreAggregateDefinitionByUuid']
+                  >
+              >
+            | undefined;
         let materializationUuid: string | undefined;
         const startTime = Date.now();
 
         try {
-            const definition =
+            definition =
                 await this.preAggregateModel.getPreAggregateDefinitionByUuid({
                     projectUuid: args.projectUuid,
                     preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
@@ -101,6 +159,8 @@ export class PreAggregateMaterializationService extends BaseService {
                     `Pre-aggregate definition "${args.preAggregateDefinitionUuid}" was not found`,
                 );
             }
+
+            const storedDefinition = definition;
 
             this.logger.info(
                 `Starting pre-aggregate materialization for definition ${args.preAggregateDefinitionUuid}`,
@@ -115,17 +175,38 @@ export class PreAggregateMaterializationService extends BaseService {
                 await this.preAggregateModel.insertInProgress({
                     projectUuid: args.projectUuid,
                     preAggregateDefinitionUuid:
-                        definition.preAggregateDefinitionUuid,
+                        storedDefinition.preAggregateDefinitionUuid,
                     trigger: args.trigger,
                 });
             materializationUuid = materializationRow.materializationUuid;
 
-            const { materializationMetricQuery } = definition;
+            const { materializationMetricQuery } = storedDefinition;
             if (!materializationMetricQuery) {
                 await this.preAggregateModel.markFailed({
                     materializationUuid,
                     errorMessage:
-                        definition.materializationQueryError ||
+                        storedDefinition.materializationQueryError ||
+                        'Pre-aggregate definition is missing materialization query',
+                });
+
+                this.trackMaterializationEvent({
+                    account: args.account,
+                    event: 'pre_aggregate.materialization_failed',
+                    projectUuid: args.projectUuid,
+                    preAggregateName:
+                        storedDefinition.preAggregateDefinition.name,
+                    trigger: args.trigger,
+                    status: 'failed',
+                    rowCount: null,
+                    columnCount: null,
+                    totalBytes: null,
+                    warehouseExecutionTimeMs: null,
+                    totalDurationMs: Date.now() - startTime,
+                    materializationMaxRows:
+                        storedDefinition.materializationMetricQuery
+                            ?.resolvedMaxRows,
+                    errorMessage:
+                        storedDefinition.materializationQueryError ||
                         'Pre-aggregate definition is missing materialization query',
                 });
 
@@ -172,18 +253,19 @@ export class PreAggregateMaterializationService extends BaseService {
                                         materializationMetricQuery.timeDimensionFieldId,
                                 })),
                         },
-                        ...(definition.preAggregateDefinition
+                        ...(storedDefinition.preAggregateDefinition
                             .materializationRole
                             ? {
                                   materializationRole: {
                                       intrinsicUserAttributes:
                                           getIntrinsicUserAttributes({
-                                              email: definition
+                                              email: storedDefinition
                                                   .preAggregateDefinition
                                                   .materializationRole.email,
                                           }),
                                       userAttributes:
-                                          definition.preAggregateDefinition
+                                          storedDefinition
+                                              .preAggregateDefinition
                                               .materializationRole.attributes,
                                   },
                               }
@@ -247,6 +329,10 @@ export class PreAggregateMaterializationService extends BaseService {
                 },
             );
 
+            const columnCount = queryHistory.columns
+                ? Object.keys(queryHistory.columns).length
+                : null;
+
             if (queryHistory.status !== QueryHistoryStatus.READY) {
                 const errorMessage =
                     queryHistory.error ||
@@ -276,6 +362,26 @@ export class PreAggregateMaterializationService extends BaseService {
                     durationMs / 1000,
                 );
 
+                this.trackMaterializationEvent({
+                    account: args.account,
+                    event: 'pre_aggregate.materialization_failed',
+                    projectUuid: args.projectUuid,
+                    preAggregateName:
+                        storedDefinition.preAggregateDefinition.name,
+                    trigger: args.trigger,
+                    status: 'failed',
+                    rowCount: queryHistory.totalRowCount,
+                    columnCount: null,
+                    totalBytes: null,
+                    warehouseExecutionTimeMs:
+                        queryHistory.warehouseExecutionTimeMs,
+                    totalDurationMs: durationMs,
+                    materializationMaxRows:
+                        storedDefinition.materializationMetricQuery
+                            ?.resolvedMaxRows,
+                    errorMessage,
+                });
+
                 return {
                     materializationUuid,
                     status: 'failed',
@@ -301,16 +407,33 @@ export class PreAggregateMaterializationService extends BaseService {
                         'Materialization query completed without a persisted results file',
                 });
 
+                this.trackMaterializationEvent({
+                    account: args.account,
+                    event: 'pre_aggregate.materialization_failed',
+                    projectUuid: args.projectUuid,
+                    preAggregateName:
+                        storedDefinition.preAggregateDefinition.name,
+                    trigger: args.trigger,
+                    status: 'failed',
+                    rowCount: queryHistory.totalRowCount,
+                    columnCount,
+                    totalBytes: null,
+                    warehouseExecutionTimeMs:
+                        queryHistory.warehouseExecutionTimeMs,
+                    totalDurationMs: Date.now() - startTime,
+                    materializationMaxRows:
+                        storedDefinition.materializationMetricQuery
+                            ?.resolvedMaxRows,
+                    errorMessage:
+                        'Materialization query completed without a persisted results file',
+                });
+
                 return {
                     materializationUuid,
                     status: 'failed',
                     queryUuid,
                 };
             }
-
-            const columnCount = queryHistory.columns
-                ? Object.keys(queryHistory.columns).length
-                : null;
 
             // Get file size from S3 and promote to active — timed together
             const promoteStart = Date.now();
@@ -441,6 +564,23 @@ export class PreAggregateMaterializationService extends BaseService {
                 );
             }
 
+            this.trackMaterializationEvent({
+                account: args.account,
+                event: 'pre_aggregate.materialization_completed',
+                projectUuid: args.projectUuid,
+                preAggregateName: storedDefinition.preAggregateDefinition.name,
+                trigger: args.trigger,
+                status,
+                rowCount: queryHistory.totalRowCount,
+                columnCount,
+                totalBytes,
+                warehouseExecutionTimeMs: queryHistory.warehouseExecutionTimeMs,
+                totalDurationMs: durationMs,
+                materializationMaxRows:
+                    storedDefinition.materializationMetricQuery
+                        ?.resolvedMaxRows,
+            });
+
             return {
                 materializationUuid,
                 status,
@@ -478,6 +618,30 @@ export class PreAggregateMaterializationService extends BaseService {
                             ? error.message
                             : 'Unknown materialization error',
                 });
+
+                if (definition) {
+                    this.trackMaterializationEvent({
+                        account: args.account,
+                        event: 'pre_aggregate.materialization_failed',
+                        projectUuid: args.projectUuid,
+                        preAggregateName:
+                            definition.preAggregateDefinition.name,
+                        trigger: args.trigger,
+                        status: 'failed',
+                        rowCount: null,
+                        columnCount: null,
+                        totalBytes: null,
+                        warehouseExecutionTimeMs: null,
+                        totalDurationMs: durationMs,
+                        materializationMaxRows:
+                            definition.materializationMetricQuery
+                                ?.resolvedMaxRows,
+                        errorMessage:
+                            error instanceof Error
+                                ? error.message
+                                : 'Unknown materialization error',
+                    });
+                }
 
                 return {
                     materializationUuid,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -200,6 +200,11 @@ const SQL_QUERY_MOCK_EXPLORER_NAME = 'sql_query_explorer';
 export const QUEUED_QUERY_EXPIRED_MESSAGE =
     'Your query expired while waiting in the queue. Please try again.';
 
+type ExecuteAsyncQueryAnalyticsMetadata = {
+    preAggregateMetadata?: CacheMetadata['preAggregate'];
+    preAggregateMode?: PreAggregationRoute['mode'];
+};
+
 type AsyncQueryExecutionPlan =
     | {
           target: 'warehouse';
@@ -1761,6 +1766,31 @@ export class AsyncQueryService extends ProjectService {
         };
     }
 
+    private static getPreAggregateAnalyticsProperties({
+        preAggregateMetadata,
+        preAggregateMode,
+    }: {
+        preAggregateMetadata?: CacheMetadata['preAggregate'];
+        preAggregateMode?: PreAggregationRoute['mode'];
+    }) {
+        const isEligible =
+            preAggregateMetadata !== undefined ||
+            preAggregateMode !== undefined;
+
+        return {
+            ...(isEligible ? { preAggregateEligible: true } : undefined),
+            ...(preAggregateMetadata
+                ? {
+                      preAggregateHit: preAggregateMetadata.hit,
+                      preAggregateName: preAggregateMetadata.name,
+                      preAggregateMissReason:
+                          preAggregateMetadata.reason?.reason,
+                  }
+                : undefined),
+            ...(preAggregateMode ? { preAggregateMode } : undefined),
+        };
+    }
+
     public async runAsyncPreAggregateQuery({
         userUuid,
         organizationUuid,
@@ -2826,6 +2856,9 @@ export class AsyncQueryService extends ProjectService {
                     userAccessControls,
                     availableParameterDefinitions,
                 } = args;
+                const { preAggregateMetadata, preAggregateMode } =
+                    requestParameters as ExecuteAsyncQueryRequestParams &
+                        ExecuteAsyncQueryAnalyticsMetadata;
 
                 try {
                     assertIsAccountWithOrg(account);
@@ -2976,6 +3009,12 @@ export class AsyncQueryService extends ProjectService {
                                             : undefined,
                                     explore,
                                     parameters: requestParameters.parameters,
+                                },
+                            ),
+                            ...AsyncQueryService.getPreAggregateAnalyticsProperties(
+                                {
+                                    preAggregateMetadata,
+                                    preAggregateMode,
                                 },
                             ),
                             cacheMetadata: {
@@ -3501,18 +3540,24 @@ export class AsyncQueryService extends ProjectService {
         });
         const prepareMs = Date.now() - prepareStart;
 
-        const requestParameters: ExecuteAsyncMetricQueryRequestParams = {
-            context,
-            query: metricQuery,
-            parameters: combinedParameters,
-        };
-
         const routingDecision = this.getPreAggregationRoutingDecision({
             metricQuery,
             explore,
             context,
             forceWarehouse: usePreAggregateCache === false,
         });
+
+        const requestParameters: ExecuteAsyncMetricQueryRequestParams &
+            ExecuteAsyncQueryAnalyticsMetadata = {
+            context,
+            query: metricQuery,
+            parameters: combinedParameters,
+            preAggregateMetadata: routingDecision.preAggregateMetadata,
+            preAggregateMode:
+                routingDecision.target === 'pre_aggregate'
+                    ? routingDecision.route.mode
+                    : undefined,
+        };
 
         this.logger.info(
             `Metric query prep for ${metricQuery.exploreName}: get_explore=${getExploreMs}ms get_wh_credentials=${getWarehouseCredentialsMs}ms prepare_query=${prepareMs}ms routing=${routingDecision.target} total=${Date.now() - metricQueryStart}ms`,
@@ -3524,6 +3569,15 @@ export class AsyncQueryService extends ProjectService {
                 routingDecision.preAggregateMetadata.reason?.reason,
             );
         }
+
+        this.recordPreAggregateStats({
+            projectUuid,
+            exploreName: explore.name,
+            routingDecision,
+            chartUuid: null,
+            dashboardUuid: null,
+            queryContext: context,
+        });
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
@@ -3787,7 +3841,8 @@ export class AsyncQueryService extends ProjectService {
             account.isRegisteredUser() ? account.user.id : null,
         );
 
-        const requestParameters: ExecuteAsyncSavedChartRequestParams = {
+        const requestParameters: ExecuteAsyncSavedChartRequestParams &
+            ExecuteAsyncQueryAnalyticsMetadata = {
             context,
             chartUuid,
             versionUuid,
@@ -3897,6 +3952,13 @@ export class AsyncQueryService extends ProjectService {
             dashboardUuid: null,
             queryContext: context,
         });
+
+        requestParameters.preAggregateMetadata =
+            routingDecision.preAggregateMetadata;
+        requestParameters.preAggregateMode =
+            routingDecision.target === 'pre_aggregate'
+                ? routingDecision.route.mode
+                : undefined;
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {
@@ -4110,7 +4172,8 @@ export class AsyncQueryService extends ProjectService {
             };
         }
 
-        const requestParameters: ExecuteAsyncDashboardChartRequestParams = {
+        const requestParameters: ExecuteAsyncDashboardChartRequestParams &
+            ExecuteAsyncQueryAnalyticsMetadata = {
             tileUuid,
             chartUuid,
             context,
@@ -4216,6 +4279,13 @@ export class AsyncQueryService extends ProjectService {
             dashboardUuid,
             queryContext: context,
         });
+
+        requestParameters.preAggregateMetadata =
+            routingDecision.preAggregateMetadata;
+        requestParameters.preAggregateMode =
+            routingDecision.target === 'pre_aggregate'
+                ? routingDecision.route.mode
+                : undefined;
 
         const { queryUuid, cacheMetadata } = await this.executeAsyncQuery(
             {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -5128,16 +5128,28 @@ export class ProjectService extends BaseService {
         }
 
         const jobs = await Promise.all(
-            materializableDefinitions.map((definition) =>
-                this.schedulerClient.materializePreAggregate({
+            materializableDefinitions.map(async (definition) => {
+                this.analytics.track({
+                    userId: user.userUuid,
+                    event: 'pre_aggregate.refresh_requested',
+                    properties: {
+                        organizationId: organizationUuid,
+                        projectId: projectUuid,
+                        preAggregateName:
+                            definition.preAggregateDefinition.name,
+                        trigger: 'manual',
+                    },
+                });
+
+                return this.schedulerClient.materializePreAggregate({
                     organizationUuid,
                     projectUuid,
                     userUuid: user.userUuid,
                     preAggregateDefinitionUuid:
                         definition.preAggregateDefinitionUuid,
                     trigger: 'manual',
-                }),
-            ),
+                });
+            }),
         );
 
         return {
@@ -5177,6 +5189,18 @@ export class ProjectService extends BaseService {
                 }`,
             );
         }
+
+        this.analytics.track({
+            userId: user.userUuid,
+            event: 'pre_aggregate.refresh_requested',
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                preAggregateName:
+                    preAggregateDefinition.preAggregateDefinition.name,
+                trigger: 'manual',
+            },
+        });
 
         const { jobId } = await this.schedulerClient.materializePreAggregate({
             organizationUuid,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -557,6 +557,7 @@ export class ServiceRepository
                     asyncQueryService: this.getAsyncQueryService(),
                     preAggregateResultsStorageClient:
                         this.clients.getPreAggregateResultsFileStorageClient(),
+                    analytics: this.context.lightdashAnalytics,
                     prometheusMetrics: this.prometheusMetrics,
                 }),
         );


### PR DESCRIPTION
Closes:

### Description:

Adds analytics tracking for pre-aggregate materialization and refresh events.

Two new analytics event types are introduced:

- `pre_aggregate.materialization_completed` / `pre_aggregate.materialization_failed` — emitted at each outcome path within `PreAggregateMaterializationService.materializePreAggregate`, capturing details such as row count, column count, total bytes, warehouse execution time, total duration, format, trigger, and whether row count warnings were exceeded.
- `pre_aggregate.refresh_requested` — emitted when a manual refresh is triggered for one or more pre-aggregate definitions.

Pre-aggregate routing metadata is also now included on `query.executed` events via a new `PreAggregateAnalyticsProperties` type, surfacing whether the query was eligible for pre-aggregation, whether it hit a pre-aggregate, the pre-aggregate name, any miss reason, and the routing mode (`required` or `opportunistic`). This metadata is passed through the async query execution pipeline for metric queries, saved chart queries, and dashboard chart queries.