### PR TITLE
fix(formula): default window function ORDER BY to query sort fields

### DIFF
--- a/packages/backend/src/queryCompiler.ts
+++ b/packages/backend/src/queryCompiler.ts
@@ -184,6 +184,21 @@ const compileTableCalculation = (
                     columns[dep.name] = dep.name;
                 }
             }
+            // Filter out sorts on table calculations: a formula table calc
+            // and its siblings are projected in the same SELECT, so ordering
+            // by a sibling alias inside its OVER clause self-references
+            // within that SELECT and every warehouse rejects it.
+            const validFieldIdsForSort = new Set(validFieldIds);
+            const defaultOrderBy = sortFields
+                .filter((s) => validFieldIdsForSort.has(s.fieldId))
+                .map((s) => ({
+                    column: customBinDimensionIds.has(s.fieldId)
+                        ? `${s.fieldId}_order`
+                        : s.fieldId,
+                    direction: (s.descending ? 'DESC' : 'ASC') as
+                        | 'ASC'
+                        | 'DESC',
+                }));
             // Table calcs land in a post-aggregation SELECT alongside non-
             // aggregate dimension columns, so bare SQL aggregates would be
             // rejected by the warehouse. Wrapping as `AGG(x) OVER ()` turns
@@ -193,6 +208,7 @@ const compileTableCalculation = (
                 dialect,
                 columns,
                 renderAggregate: (inner) => `${inner} OVER ()`,
+                defaultOrderBy,
             });
             return {
                 ...tableCalculation,

--- a/packages/formula-tests/cases/window.cases.ts
+++ b/packages/formula-tests/cases/window.cases.ts
@@ -406,6 +406,126 @@ export const windowCases: TestCase[] = [
         tags: ['window'],
     },
 
+    // ── defaultOrderBy fallback ───────────────────────────────────
+    // These exercise the compile-time `defaultOrderBy` option, which
+    // queryCompiler.ts passes from the containing query's sort fields.
+    // BigQuery and Snowflake reject analytic functions with no ORDER BY
+    // ("Window ORDER BY is required for analytic function lag"), so these
+    // cases regress-guard the fallback that keeps `=LAG(A)` working when
+    // the user hasn't written an explicit ORDER BY in the formula.
+
+    {
+        id: 'window/lag-default-order',
+        formula: '=LAG(A)',
+        description:
+            'LAG with no formula-level ORDER BY picks up defaultOrderBy (mirrors window/lag)',
+        columns: { A: 'amount' },
+        sourceTable: 'test_window',
+        orderBy: 'id',
+        defaultOrderBy: [{ column: 'id', direction: 'ASC' }],
+        expectedRows: [
+            { result: null },
+            { result: 100.00 },
+            { result: 200.00 },
+            { result: 150.00 },
+            { result: 300.00 },
+            { result: 250.00 },
+            { result: 50.00 },
+            { result: 75.00 },
+            { result: 60.00 },
+            { result: 90.00 },
+            { result: 80.00 },
+            { result: 500.00 },
+            { result: 400.00 },
+            { result: 450.00 },
+            { result: 350.00 },
+            { result: 550.00 },
+            { result: 10.00 },
+            { result: 20.00 },
+            { result: 15.00 },
+            { result: 25.00 },
+        ],
+        warehouses: ALL_WAREHOUSES,
+        tier: 1,
+        tags: ['window'],
+    },
+    {
+        id: 'window/lag-user-partition-default-order',
+        formula: '=LAG(A, PARTITION BY B)',
+        description:
+            'User PARTITION BY combines with defaultOrderBy (mirrors window/lag-partitioned)',
+        columns: { A: 'amount', B: 'category' },
+        sourceTable: 'test_window',
+        orderBy: 'id',
+        defaultOrderBy: [{ column: 'id', direction: 'ASC' }],
+        expectedRows: [
+            { result: null }, { result: 100.00 }, { result: 200.00 }, { result: 150.00 }, { result: 300.00 },
+            { result: null }, { result: 50.00 }, { result: 75.00 }, { result: 60.00 }, { result: 90.00 },
+            { result: null }, { result: 500.00 }, { result: 400.00 }, { result: 450.00 }, { result: 350.00 },
+            { result: null }, { result: 10.00 }, { result: 20.00 }, { result: 15.00 }, { result: 25.00 },
+        ],
+        warehouses: ALL_WAREHOUSES,
+        tier: 1,
+        tags: ['window'],
+    },
+    {
+        id: 'window/lag-user-order-wins-over-default',
+        formula: '=LAG(A, ORDER BY B)',
+        description:
+            'Explicit ORDER BY in the formula always wins over defaultOrderBy',
+        columns: { A: 'amount', B: 'id' },
+        sourceTable: 'test_window',
+        orderBy: 'id',
+        // defaultOrderBy below would sort by amount DESC if honoured; the
+        // expected rows match window/lag (ORDER BY id), proving the user's
+        // explicit clause wins.
+        defaultOrderBy: [{ column: 'amount', direction: 'DESC' }],
+        expectedRows: [
+            { result: null },
+            { result: 100.00 },
+            { result: 200.00 },
+            { result: 150.00 },
+            { result: 300.00 },
+            { result: 250.00 },
+            { result: 50.00 },
+            { result: 75.00 },
+            { result: 60.00 },
+            { result: 90.00 },
+            { result: 80.00 },
+            { result: 500.00 },
+            { result: 400.00 },
+            { result: 450.00 },
+            { result: 350.00 },
+            { result: 550.00 },
+            { result: 10.00 },
+            { result: 20.00 },
+            { result: 15.00 },
+            { result: 25.00 },
+        ],
+        warehouses: ALL_WAREHOUSES,
+        tier: 1,
+        tags: ['window'],
+    },
+    {
+        id: 'window/row-number-default-order',
+        formula: '=ROW_NUMBER()',
+        description:
+            'ROW_NUMBER with no formula-level window clause picks up defaultOrderBy (BigQuery/Snowflake reject OVER () otherwise)',
+        columns: {},
+        sourceTable: 'test_window',
+        orderBy: 'id',
+        defaultOrderBy: [{ column: 'id', direction: 'ASC' }],
+        expectedRows: [
+            { result: 1 }, { result: 2 }, { result: 3 }, { result: 4 }, { result: 5 },
+            { result: 6 }, { result: 7 }, { result: 8 }, { result: 9 }, { result: 10 },
+            { result: 11 }, { result: 12 }, { result: 13 }, { result: 14 }, { result: 15 },
+            { result: 16 }, { result: 17 }, { result: 18 }, { result: 19 }, { result: 20 },
+        ],
+        warehouses: ALL_WAREHOUSES,
+        tier: 1,
+        tags: ['window'],
+    },
+
     // ── LEAD ──────────────────────────────────────────────────────
 
     {

--- a/packages/formula-tests/runner/executor.ts
+++ b/packages/formula-tests/runner/executor.ts
@@ -77,6 +77,7 @@ export async function runTestCase(
         sql = compile(testCase.formula, {
             dialect: warehouse.dialect,
             columns: testCase.columns,
+            defaultOrderBy: testCase.defaultOrderBy,
         });
     } catch (e: unknown) {
         const message = e instanceof Error ? e.message : String(e);

--- a/packages/formula-tests/types.ts
+++ b/packages/formula-tests/types.ts
@@ -7,6 +7,12 @@ export interface TestCase {
     columns: Record<string, string>;
     sourceTable: string;
     orderBy?: string;
+    // Passed through to compile() as `defaultOrderBy`. Exercises the
+    // fallback ORDER BY that queryCompiler.ts injects from the containing
+    // query's sort fields, so formulas like `=LAG(A)` (no explicit ORDER BY)
+    // generate valid SQL on BigQuery/Snowflake and pick the visually-previous
+    // row on every dialect.
+    defaultOrderBy?: { column: string; direction?: 'ASC' | 'DESC' }[];
     expectedRows: Record<string, any>[];
     expectedError?: string;
     warehouses: WarehouseType[];

--- a/packages/formula/src/codegen/generator.ts
+++ b/packages/formula/src/codegen/generator.ts
@@ -458,6 +458,14 @@ export class SqlGenerator {
     // callers that need per-function argument transforms (e.g. AVG's
     // precision-preserving cast on Redshift) build the call via their own
     // emitter and still share the PARTITION BY / ORDER BY / frame plumbing.
+    //
+    // When the formula has no explicit ORDER BY in its OVER clause we fall
+    // back to `options.defaultOrderBy` (if set). That option carries the
+    // containing query's visual sort order, so `LAG(x)` without an explicit
+    // ORDER BY picks the row the user sees immediately above the current
+    // one in the rendered table. It also makes BigQuery and Snowflake
+    // accept `LAG`/`LEAD`/`ROW_NUMBER`/... which reject an OVER clause with
+    // no ORDER BY. An explicit ORDER BY in the formula always wins.
     protected appendOverClause(
         funcCall: string,
         node: { windowClause?: WindowClauseNode | null },
@@ -474,6 +482,19 @@ export class SqlGenerator {
             overParts.push(
                 `ORDER BY ${this.generate(wc.orderBy.column)}${dir}`,
             );
+        } else {
+            const defaultOrder = this.options.defaultOrderBy;
+            if (defaultOrder && defaultOrder.length > 0) {
+                const cols = defaultOrder
+                    .map((entry) => {
+                        const dir = entry.direction
+                            ? ` ${entry.direction}`
+                            : '';
+                        return `${this.quoteIdentifier(entry.column)}${dir}`;
+                    })
+                    .join(', ');
+                overParts.push(`ORDER BY ${cols}`);
+            }
         }
 
         const framePart = frameClause ? ` ${frameClause}` : '';

--- a/packages/formula/src/types.ts
+++ b/packages/formula/src/types.ts
@@ -28,6 +28,18 @@ export interface CompileOptions {
     // Callers that compose their own GROUP BY around the output leave this
     // unset. The formula package has no opinion on embedding context.
     renderAggregate?: (innerSql: string) => string;
+    // Fallback ORDER BY for window functions (LAG/LEAD, ROW_NUMBER, FIRST/LAST,
+    // RUNNING_TOTAL, MOVING_*, NTILE, RANK/DENSE_RANK) whose formula has no
+    // explicit ORDER BY in its OVER clause. Lets the caller inject the
+    // containing query's visual sort order so `LAG(x)` picks the row the user
+    // sees immediately above the current one in the rendered table — and so
+    // BigQuery/Snowflake don't reject `OVER ()` where they require an
+    // analytic ORDER BY. Columns are raw SQL identifiers and the compiler
+    // quotes them with the dialect's quoting rules.
+    defaultOrderBy?: ReadonlyArray<{
+        column: string;
+        direction?: 'ASC' | 'DESC';
+    }>;
 }
 
 // AST Node Types

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -451,4 +451,151 @@ describe('codegen', () => {
             expect(calls).toEqual([]);
         });
     });
+
+    describe('defaultOrderBy', () => {
+        // defaultOrderBy backfills the OVER clause ORDER BY when the formula
+        // has none. Callers pass their containing query's visual sort order so
+        // `LAG(x)` picks the row rendered immediately above the current one —
+        // and so BigQuery/Snowflake accept analytic functions that reject a
+        // bare `OVER ()`.
+
+        it('injects ORDER BY into LAG when formula has no explicit ordering', () => {
+            expect(
+                compile('=LAG(revenue)', {
+                    dialect: 'bigquery',
+                    columns,
+                    defaultOrderBy: [{ column: 'order_date', direction: 'DESC' }],
+                }),
+            ).toBe('LAG(`revenue`) OVER (ORDER BY `order_date` DESC)');
+        });
+
+        it('respects user ORDER BY when formula has one, ignoring defaultOrderBy', () => {
+            expect(
+                compile('=LAG(revenue, ORDER BY region)', {
+                    dialect: 'postgres',
+                    columns,
+                    defaultOrderBy: [{ column: 'order_date', direction: 'DESC' }],
+                }),
+            ).toBe('LAG("revenue") OVER (ORDER BY "region")');
+        });
+
+        it('combines user PARTITION BY with default ORDER BY', () => {
+            expect(
+                compile('=LAG(revenue, PARTITION BY region)', {
+                    dialect: 'postgres',
+                    columns,
+                    defaultOrderBy: [{ column: 'order_date', direction: 'ASC' }],
+                }),
+            ).toBe(
+                'LAG("revenue") OVER (PARTITION BY "region" ORDER BY "order_date" ASC)',
+            );
+        });
+
+        it('emits multiple default sort columns in order, each with its direction', () => {
+            expect(
+                compile('=LAG(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    defaultOrderBy: [
+                        { column: 'order_date', direction: 'DESC' },
+                        { column: 'region', direction: 'ASC' },
+                    ],
+                }),
+            ).toBe(
+                'LAG("revenue") OVER (ORDER BY "order_date" DESC, "region" ASC)',
+            );
+        });
+
+        it('omits direction when not set', () => {
+            expect(
+                compile('=LAG(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    defaultOrderBy: [{ column: 'order_date' }],
+                }),
+            ).toBe('LAG("revenue") OVER (ORDER BY "order_date")');
+        });
+
+        it('is a no-op when defaultOrderBy is empty', () => {
+            expect(
+                compile('=LAG(revenue)', {
+                    dialect: 'postgres',
+                    columns,
+                    defaultOrderBy: [],
+                }),
+            ).toBe('LAG("revenue") OVER ()');
+        });
+
+        it('applies to other window functions that need an order (ROW_NUMBER, FIRST, RUNNING_TOTAL)', () => {
+            expect(
+                compile('=ROW_NUMBER()', {
+                    dialect: 'bigquery',
+                    columns,
+                    defaultOrderBy: [{ column: 'order_date', direction: 'DESC' }],
+                }),
+            ).toBe('ROW_NUMBER() OVER (ORDER BY `order_date` DESC)');
+
+            expect(
+                compile('=FIRST(revenue)', {
+                    dialect: 'bigquery',
+                    columns,
+                    defaultOrderBy: [{ column: 'order_date', direction: 'DESC' }],
+                }),
+            ).toBe(
+                'FIRST_VALUE(`revenue`) OVER (ORDER BY `order_date` DESC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)',
+            );
+
+            expect(
+                compile('=RUNNING_TOTAL(revenue)', {
+                    dialect: 'bigquery',
+                    columns,
+                    defaultOrderBy: [{ column: 'order_date', direction: 'ASC' }],
+                }),
+            ).toBe(
+                'SUM(`revenue`) OVER (ORDER BY `order_date` ASC ROWS UNBOUNDED PRECEDING)',
+            );
+        });
+
+        it('does not touch `OVER ()` emitted by renderAggregate (aggregate whole-result wrapping is intentionally unordered)', () => {
+            expect(
+                compile('=SUM(revenue)', {
+                    dialect: 'bigquery',
+                    columns,
+                    renderAggregate: (inner) => `${inner} OVER ()`,
+                    defaultOrderBy: [{ column: 'order_date', direction: 'DESC' }],
+                }),
+            ).toBe('SUM(`revenue`) OVER ()');
+        });
+
+        it('quotes default sort columns using the dialect — BigQuery backticks', () => {
+            expect(
+                compile('=LAG(revenue)', {
+                    dialect: 'bigquery',
+                    columns,
+                    defaultOrderBy: [
+                        {
+                            column: 'organizations_daily_date_day',
+                            direction: 'DESC',
+                        },
+                    ],
+                }),
+            ).toBe(
+                'LAG(`revenue`) OVER (ORDER BY `organizations_daily_date_day` DESC)',
+            );
+        });
+
+        it('flows through dialect LAG hooks — Redshift 3-arg COALESCE wrapper still gets the default order', () => {
+            // Redshift's generateLagLead rewrites to COALESCE(LAG(a, b), default);
+            // the inner LAG should still pick up the default ORDER BY.
+            expect(
+                compile('=LAG(revenue, 1, 0)', {
+                    dialect: 'redshift',
+                    columns,
+                    defaultOrderBy: [{ column: 'order_date', direction: 'DESC' }],
+                }),
+            ).toBe(
+                'COALESCE(LAG("revenue", 1) OVER (ORDER BY "order_date" DESC), 0)',
+            );
+        });
+    });
 });


### PR DESCRIPTION
## Summary

Window functions (`LAG`, `LEAD`, `ROW_NUMBER`, `RANK`/`DENSE_RANK`, `FIRST`/`LAST`, `RUNNING_TOTAL`, `MOVING_SUM`/`MOVING_AVG`, `NTILE`) with no explicit `ORDER BY` in the formula now inherit the containing query's sort fields as a fallback. Fixes BigQuery's `Window ORDER BY is required for analytic function lag` error and makes `LAG(x)` semantically pick the row immediately above the current one in the rendered table on every warehouse.

Closes **PROD-7080**.

### Before / After

Given a query sorted by `users_user_created_ts_month ASC`, a formula table calc like `=LAG(Total users)` previously compiled to:

```sql
LAG(`users_count_user_ids`) OVER ()
-- BigQuery: Window ORDER BY is required for analytic function lag
```

It now compiles to:

```sql
LAG(`users_count_user_ids`) OVER (ORDER BY `users_user_created_ts_month` ASC)
```

Explicit clauses in the formula still win — `=LAG(Total users, PARTITION BY App version, ORDER BY User created month)` compiles unchanged. The fallback only fills in the missing `ORDER BY`, so `=LAG(Total users, PARTITION BY App version)` composes the user's partition with the injected order:

```sql
LAG(`users_count_user_ids`) OVER (
    PARTITION BY `users_app_version_latest`
    ORDER BY `users_user_created_ts_month` ASC
)
```

### Design

A new compile option on `@lightdash/formula` — `defaultOrderBy: { column: string; direction?: 'ASC' | 'DESC' }[]` — lets callers supply a fallback ORDER BY. The formula compiler uses it only when the formula's OVER clause has no explicit `ORDER BY`; an explicit one always wins. Data shape (not a callback) because this is descriptive input to the compiler, not an embedding decision the caller needs to make — same pattern as the existing `columns: Record<string, string>` option. Quoting and direction formatting stay internal to the formula package so they follow the dialect's rules consistently.

The wiring:

1. `packages/formula/src/types.ts` — new `defaultOrderBy` on `CompileOptions`.
2. `packages/formula/src/codegen/generator.ts` — `appendOverClause` emits the default ORDER BY into every window function's OVER clause when the formula didn't specify one. Flows through every dialect-specific LAG/LEAD hook (Redshift's 3-arg COALESCE wrapper, ClickHouse's `lagInFrame`) automatically — they all route back through `emitWindow → generateWindowFunction → appendOverClause`.
3. `packages/backend/src/queryCompiler.ts` — the only caller that sets `defaultOrderBy`; it passes `metricQuery.sorts`, mirroring the existing `MetricQueryBuilder.buildWindowOrderByClause` that's already used for post-calculation metrics (`RUNNING_TOTAL`, `PERCENT_OF_PREVIOUS`). Custom bin dimensions get their `_order` suffix so the window order matches the table's numeric-bin order.

### Scope notes

- Sorts on table calculations are filtered out of the default. Formula table calcs and their siblings are projected in the same `SELECT` (the `table_calculations` CTE), and referencing a sibling in an OVER clause self-references within that SELECT — every warehouse rejects it. Users sorting by a table calc still need an explicit `ORDER BY` in the formula; this PR doesn't make that case worse than today.
- `nullsFirst` on sorts is ignored in the injected clause (matches `buildWindowOrderByClause`). Follow-up if anyone hits it — ClickHouse's syntax diverges and deserves a focused change.
- No change to formulas that had explicit `ORDER BY` or to the `renderAggregate` `OVER ()` wrap for whole-result-set aggregates (intentionally unordered).

## Test plan

- [x] `pnpm -F formula test` — 149 unit tests pass, including 11 new `defaultOrderBy` cases (fallback, user-ORDER-BY-wins precedence, partition + default, multi-field, empty option, BigQuery quoting, Redshift 3-arg COALESCE wrapper, `renderAggregate` untouched, `ROW_NUMBER`/`FIRST`/`RUNNING_TOTAL`).
- [x] `pnpm formula:test:fast` — 311/311 on DuckDB (4 new end-to-end cases: `window/lag-default-order`, `window/lag-user-partition-default-order`, `window/lag-user-order-wins-over-default`, `window/row-number-default-order`).
- [x] `pnpm formula:test:tier2 --warehouse bigquery` — 311/311 on real BigQuery, end-to-end verification on the warehouse whose strict ORDER-BY requirement surfaced the bug.
- [x] `pnpm -F backend typecheck` — clean.
- [x] Manual verification on a real BigQuery project with `=ROW_NUMBER()`, `=LAG(Total users)`, and `=ROUND((A - LAG(A, PARTITION BY V)) / COALESCE(LAG(A, PARTITION BY V), 1), 2)` — compiled SQL shows the injected `ORDER BY` exactly as expected, composes correctly with explicit `PARTITION BY`.
- [x] CI tier1 + tier2 across Postgres / Redshift / Snowflake / Databricks / ClickHouse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)