### PR TITLE
fix: preserve user-entered name when AI generates a formula

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -284,7 +284,9 @@ const TableCalculationModal: FC<Props> = ({
     const handleFormulaAiApply = useCallback(
         (result: GeneratedFormulaTableCalculation) => {
             form.setFieldValue('formula', result.formula);
-            form.setFieldValue('name', result.displayName);
+            if (!form.values.name.trim()) {
+                form.setFieldValue('name', result.displayName);
+            }
             if (result.type) {
                 form.setFieldValue('type', result.type);
             }


### PR DESCRIPTION
## Summary

When a user opens the Table Calculation modal with an existing name (either by editing an existing calc, or having typed one for a new one) and then uses the AI formula generator, the generated `displayName` no longer overwrites the name they already chose.

Closes **PROD-7079**.

## Before / After

- **Before:** `handleFormulaAiApply` unconditionally called `form.setFieldValue('name', result.displayName)`. Users would watch their chosen name get clobbered by a long, auto-generated title.
- **After:** the name is only filled in when the field is empty. Formula, type, and format are still populated from the AI result as before — only the name is now user-owned.

The fix is one `if (!form.values.name.trim())` guard around the name assignment in `packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx`.

## Test plan

- [x] `pnpm -F frontend typecheck` — clean.
- [ ] Manual: open Table Calculation modal, type a name, use the AI prompt to generate a formula — name stays as typed; formula/type/format populate from AI.
- [ ] Manual: open Table Calculation modal with no name, use the AI prompt — name is filled in from `result.displayName` (existing behaviour preserved for the empty case).
- [ ] Manual: edit an existing table calc, use the AI prompt — name stays as-is; formula/type/format update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)