### PR TITLE
fix: submit AI table-calculation prompt on Enter

### DIFF
--- a/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiPromptInput/AiPromptEditor.tsx
+++ b/packages/frontend/src/ee/features/ambientAi/components/tableCalculation/components/AiPromptInput/AiPromptEditor.tsx
@@ -10,7 +10,7 @@ import Mention from '@tiptap/extension-mention';
 import Placeholder from '@tiptap/extension-placeholder';
 import { useEditor, type Editor } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
-import { useEffect, useMemo, type FC } from 'react';
+import { useEffect, useMemo, useRef, type FC } from 'react';
 import {
     generateFieldSuggestion,
     type FieldSuggestionItem,
@@ -52,6 +52,11 @@ export const AiPromptEditor: FC<Props> = ({
     onCleared,
     disabled,
 }) => {
+    // Refs so handleKeyDown (configured once at editor mount) always reaches the live values.
+    const onSubmitRef = useRef(onSubmit);
+    onSubmitRef.current = onSubmit;
+    const editorRef = useRef<Editor | null>(null);
+
     // Build field suggestions from itemsMap
     const fieldSuggestions: FieldSuggestionItem[] = useMemo(() => {
         if (!explore) return [];
@@ -116,12 +121,12 @@ export const AiPromptEditor: FC<Props> = ({
         },
         editorProps: {
             handleKeyDown: (_, event) => {
-                // Submit on Enter (without shift)
                 if (event.key === 'Enter' && !event.shiftKey) {
-                    const text = editor?.getText() ?? '';
-                    if (text.trim() && onSubmit) {
+                    const text = editorRef.current?.getText() ?? '';
+                    const submit = onSubmitRef.current;
+                    if (text.trim() && submit) {
                         event.preventDefault();
-                        onSubmit(text);
+                        submit(text);
                         return true;
                     }
                 }
@@ -129,6 +134,8 @@ export const AiPromptEditor: FC<Props> = ({
             },
         },
     });
+
+    editorRef.current = editor;
 
     // Clear editor when shouldClear changes to true
     useEffect(() => {


### PR DESCRIPTION
## Summary

Pressing **Enter** in the AI prompt input of the Table Calculation modal did nothing. It should submit the prompt and trigger formula generation.

Closes **PROD-7078**.

## Root cause

`AiPromptEditor.tsx` already had an Enter-to-submit handler:

```ts
editorProps: {
    handleKeyDown: (_, event) => {
        if (event.key === 'Enter' && !event.shiftKey) {
            const text = editor?.getText() ?? '';
            if (text.trim() && onSubmit) {
                event.preventDefault();
                onSubmit(text);
                return true;
            }
        }
        return false;
    },
},
```

But this reaches `editor` through a closure captured from the render in which `useEditor(...)` was called. `@tiptap/react`'s `useEditor` returns `null` on the initial render and the `Editor` instance only on a subsequent render. Since Tiptap configures `editorProps.handleKeyDown` exactly once (at editor-mount time), the closure permanently held `editor === null`, so `editor?.getText()` returned `''`, `text.trim()` was falsy, and the handler fell through to `return false` — letting the contenteditable insert a newline instead of submitting.

Same latent trap for `onSubmit`: if the parent passed a non-stable callback, the handler would be frozen to the first render's reference.

## Fix

Route both lookups through refs (`editorRef`, `onSubmitRef`) kept in sync with the current render. The handler now reads the actual current Editor and the latest callback, regardless of how many renders have occurred since `useEditor` was invoked.

```ts
handleKeyDown: (_, event) => {
    if (event.key === 'Enter' && !event.shiftKey) {
        const text = editorRef.current?.getText() ?? '';
        const submit = onSubmitRef.current;
        if (text.trim() && submit) {
            event.preventDefault();
            submit(text);
            return true;
        }
    }
    return false;
},
```

Shift+Enter still passes through as a newline (unchanged).

## Test plan

- [x] `pnpm -F frontend typecheck` — clean.
- [ ] Manual: open Table Calculation modal, switch to Formula tab, type a prompt, press **Enter** → generates.
- [ ] Manual: same modal, type a prompt, press **Shift+Enter** → inserts newline (no submission).
- [ ] Manual: click the send button instead of Enter → still generates (existing code path untouched).
- [ ] Manual: with a `@field` mention open, pressing Enter selects the mention (Tiptap's own handler wins before ours, as expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)