### PR TITLE
fix: stop explore jitter when AI generates table calc formula

### DIFF
--- a/packages/frontend/src/components/Explorer/FormatForm/getFormatSummary.ts
+++ b/packages/frontend/src/components/Explorer/FormatForm/getFormatSummary.ts
@@ -1,0 +1,78 @@
+import {
+    CustomFormatType,
+    findCompactConfig,
+    type CustomFormat,
+} from '@lightdash/common';
+
+export const getFormatTypeLabel = (type: CustomFormatType): string => {
+    switch (type) {
+        case CustomFormatType.BYTES_SI:
+            return 'Bytes (SI)';
+        case CustomFormatType.BYTES_IEC:
+            return 'Bytes (IEC)';
+        case CustomFormatType.DATE:
+            return 'Date';
+        case CustomFormatType.TIMESTAMP:
+            return 'Timestamp';
+        case CustomFormatType.DEFAULT:
+            return 'Default';
+        case CustomFormatType.PERCENT:
+            return 'Percent';
+        case CustomFormatType.CURRENCY:
+            return 'Currency';
+        case CustomFormatType.NUMBER:
+            return 'Number';
+        case CustomFormatType.CUSTOM:
+            return 'Custom';
+        default:
+            return type;
+    }
+};
+
+export const getFormatSummary = (format: CustomFormat): string => {
+    const type = format.type ?? CustomFormatType.DEFAULT;
+
+    if (type === CustomFormatType.DEFAULT) {
+        return 'Default';
+    }
+
+    const parts: string[] = [];
+
+    if (type === CustomFormatType.CURRENCY && format.currency) {
+        parts.push(format.currency);
+    } else {
+        parts.push(getFormatTypeLabel(type));
+    }
+
+    const supportsRound =
+        type === CustomFormatType.PERCENT ||
+        type === CustomFormatType.CURRENCY ||
+        type === CustomFormatType.NUMBER ||
+        type === CustomFormatType.BYTES_SI ||
+        type === CustomFormatType.BYTES_IEC;
+
+    if (supportsRound && format.round !== undefined && format.round !== null) {
+        parts.push(`${format.round} decimal${format.round === 1 ? '' : 's'}`);
+    }
+
+    if (format.compact) {
+        const compactConfig = findCompactConfig(format.compact);
+        if (compactConfig) parts.push(compactConfig.label.toLowerCase());
+    }
+
+    if (type === CustomFormatType.NUMBER) {
+        if (format.prefix) parts.push(`prefix "${format.prefix}"`);
+        if (format.suffix) parts.push(`suffix "${format.suffix}"`);
+    }
+
+    if (
+        (type === CustomFormatType.CUSTOM ||
+            type === CustomFormatType.DATE ||
+            type === CustomFormatType.TIMESTAMP) &&
+        format.custom
+    ) {
+        parts.push(format.custom);
+    }
+
+    return parts.join(' · ');
+};

--- a/packages/frontend/src/components/Explorer/FormatForm/index.tsx
+++ b/packages/frontend/src/components/Explorer/FormatForm/index.tsx
@@ -36,6 +36,7 @@ import { useMemo, type FC } from 'react';
 import { type ValueOf } from 'type-fest';
 import MantineIcon from '../../common/MantineIcon';
 import { PolymorphicPaperButton } from '../../common/PolymorphicPaperButton';
+import { getFormatTypeLabel } from './getFormatSummary';
 
 type Props = {
     formatInputProps: (
@@ -64,31 +65,6 @@ const dateFormatTypeOptions = [
     CustomFormatType.DATE,
     CustomFormatType.TIMESTAMP,
 ];
-
-const getFormatTypeLabel = (type: CustomFormatType): string => {
-    switch (type) {
-        case CustomFormatType.BYTES_SI:
-            return 'Bytes (SI)';
-        case CustomFormatType.BYTES_IEC:
-            return 'Bytes (IEC)';
-        case CustomFormatType.DATE:
-            return 'Date';
-        case CustomFormatType.TIMESTAMP:
-            return 'Timestamp';
-        case CustomFormatType.DEFAULT:
-            return 'Default';
-        case CustomFormatType.PERCENT:
-            return 'Percent';
-        case CustomFormatType.CURRENCY:
-            return 'Currency';
-        case CustomFormatType.NUMBER:
-            return 'Number';
-        case CustomFormatType.CUSTOM:
-            return 'Custom';
-        default:
-            return type;
-    }
-};
 
 const formatSeparatorOptions = [
     {

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaEditor.tsx
@@ -209,6 +209,15 @@ export const FormulaEditor: FC<Props> = ({
         }
     }, [editor, editorRef]);
 
+    // Sync new `initialContent` into the existing editor; equality guard breaks the typing loop.
+    useEffect(() => {
+        if (!editor || initialContent === undefined) return;
+        if (editor.getText() === initialContent) return;
+        editor.commands.setContent(
+            buildInitialContent(initialContent, fieldSuggestions),
+        );
+    }, [editor, initialContent, fieldSuggestions]);
+
     // Update field suggestions when fields change
     useEffect(() => {
         if (editor && fieldSuggestions.length > 0) {

--- a/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaForm.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/FormulaForm/FormulaForm.module.css
@@ -1,4 +1,6 @@
 .container {
+    flex: 1;
+    min-height: 0;
     display: flex;
     flex-direction: column;
     border: 1px solid var(--mantine-color-ldGray-3);

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.module.css
@@ -128,6 +128,28 @@
     gap: var(--mantine-spacing-sm);
 }
 
+.formatAccordionItem {
+    border: 1px solid var(--mantine-color-ldGray-2);
+    border-radius: var(--mantine-radius-md);
+    background-color: transparent;
+
+    @mixin dark {
+        border-color: var(--mantine-color-ldDark-4);
+    }
+}
+
+.formatAccordionControl {
+    padding-block: var(--mantine-spacing-xs);
+    padding-inline: var(--mantine-spacing-md);
+    border-radius: var(--mantine-radius-md);
+}
+
+.formatAccordionContent {
+    padding-block-start: var(--mantine-spacing-md);
+    padding-inline: var(--mantine-spacing-md);
+    padding-block-end: var(--mantine-spacing-md);
+}
+
 @media (max-width: 48em) {
     .inputModeHeader {
         align-items: flex-start;

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -14,6 +14,7 @@ import {
 } from '@lightdash/common';
 import { SUPPORTED_DIALECTS, type Dialect } from '@lightdash/formula';
 import {
+    Accordion,
     ActionIcon,
     Badge,
     Box,
@@ -54,6 +55,7 @@ import { type ValueOf } from 'type-fest';
 import MantineIcon from '../../../components/common/MantineIcon';
 import MantineModal from '../../../components/common/MantineModal';
 import { FormatForm } from '../../../components/Explorer/FormatForm';
+import { getFormatSummary } from '../../../components/Explorer/FormatForm/getFormatSummary';
 import {
     selectCustomDimensions,
     selectMetricQuery,
@@ -538,7 +540,6 @@ const TableCalculationModal: FC<Props> = ({
             cancelLabel="Cancel"
             modalRootProps={{
                 closeOnClickOutside: false,
-                centered: false,
                 styles: isExpanded
                     ? {
                           content: {
@@ -661,11 +662,40 @@ const TableCalculationModal: FC<Props> = ({
                     </Box>
                 </Stack>
 
-                <FormatForm
-                    formatInputProps={getFormatInputProps}
-                    setFormatFieldValue={setFormatFieldValue}
-                    format={form.values.format}
-                />
+                <Accordion
+                    variant="default"
+                    chevronPosition="right"
+                    defaultValue={
+                        form.values.format.type !== CustomFormatType.DEFAULT
+                            ? 'format'
+                            : null
+                    }
+                    classNames={{
+                        item: classes.formatAccordionItem,
+                        control: classes.formatAccordionControl,
+                        content: classes.formatAccordionContent,
+                    }}
+                >
+                    <Accordion.Item value="format">
+                        <Accordion.Control>
+                            <Group gap="md" wrap="nowrap">
+                                <Text size="sm" fw={500}>
+                                    Formatting
+                                </Text>
+                                <Text size="xs" c="dimmed" truncate>
+                                    {getFormatSummary(form.values.format)}
+                                </Text>
+                            </Group>
+                        </Accordion.Control>
+                        <Accordion.Panel>
+                            <FormatForm
+                                formatInputProps={getFormatInputProps}
+                                setFormatFieldValue={setFormatFieldValue}
+                                format={form.values.format}
+                            />
+                        </Accordion.Panel>
+                    </Accordion.Item>
+                </Accordion>
             </Stack>
         </MantineModal>
     );

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -266,9 +266,6 @@ const TableCalculationModal: FC<Props> = ({
 
     const [sqlGeneratedByAi, setSqlGeneratedByAi] = useState(false);
     const [formulaGeneratedByAi, setFormulaGeneratedByAi] = useState(false);
-    // Tiptap reads `initialContent` once at mount — when the AI replaces the
-    // formula we bump this key to force a remount so the new content renders.
-    const [formulaKey, setFormulaKey] = useState(0);
 
     useEffect(() => {
         if (opened) {
@@ -293,7 +290,6 @@ const TableCalculationModal: FC<Props> = ({
             if (result.format) {
                 form.setFieldValue('format', result.format);
             }
-            setFormulaKey((k) => k + 1);
             setFormulaGeneratedByAi(true);
         },
         [form],
@@ -542,6 +538,7 @@ const TableCalculationModal: FC<Props> = ({
             cancelLabel="Cancel"
             modalRootProps={{
                 closeOnClickOutside: false,
+                centered: false,
                 styles: isExpanded
                     ? {
                           content: {
@@ -624,7 +621,6 @@ const TableCalculationModal: FC<Props> = ({
                             />
                         ) : editMode === EditMode.FORMULA ? (
                             <FormulaForm
-                                key={formulaKey}
                                 explore={explore}
                                 metricQuery={metricQuery}
                                 formula={form.values.formula}


### PR DESCRIPTION
## Summary

Two changes that together stop the Explore page behind the Table Calculation modal from visibly jittering when the AI generates a formula:

1. **Stop remounting the formula editor on AI apply.** Previously `handleFormulaAiApply` bumped a key prop on `FormulaForm` so Tiptap would re-read `initialContent`, which destroyed and rebuilt the ProseMirror view on every AI result. Replaced with an in-place `editor.commands.setContent(...)` triggered by an `initialContent` effect in `FormulaEditor`. An equality guard (`editor.getText() === initialContent`) keeps normal typing a no-op.
2. **Anchor the modal to the top (`centered: false`).** When the AI result includes a `format`, the `FormatForm` reveals additional controls and the modal body grows. With `centered: true` (Mantine's default), the modal re-centered vertically on every growth — which is what reads as "Explore jittering" behind it. With the modal anchored at the top, growth only pushes content down; the modal frame's position stays put.

Closes **PROD-7077**.

## Follow-up

The format section itself still expands/contracts when AI sets a non-default format — that shift is visible _inside_ the modal. This PR only stops it from rippling into the Explore behind. Making the format section's reveal feel smoother is worth doing separately.

## Test plan

- [x] `pnpm -F frontend typecheck` — clean.
- [ ] Manual: AI-generate a formula, including one that sets a format (currency / percent) — Explore no longer jitters; modal body grows downward without re-centering.
- [ ] Manual: type in the formula editor — text flows normally, no flicker or sync loops.
- [ ] Manual: edit an existing formula calc — formula seeds as before.
- [ ] Manual: other modals (unchanged) still center vertically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)