### PR TITLE
feat: allow switching existing SQL table calc to formula

### DIFF
--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -155,9 +155,9 @@ const TableCalculationModal: FC<Props> = ({
     const hasFormula = tableCalculation
         ? isFormulaTableCalculation(tableCalculation)
         : false;
-    // Editing an existing calc: lock to its own mode (can't map SQL back to
-    // formula, and switching would throw away the user's work). New calc:
-    // Formula when the warehouse supports it, SQL otherwise.
+    const hasSql = tableCalculation
+        ? isSqlTableCalculation(tableCalculation)
+        : false;
     const defaultMode = tableCalculation
         ? hasFormula
             ? EditMode.FORMULA
@@ -168,6 +168,9 @@ const TableCalculationModal: FC<Props> = ({
           ? EditMode.FORMULA
           : EditMode.SQL;
     const [editMode, setEditMode] = useState<EditMode>(defaultMode);
+    // Switching an existing SQL calc to Formula preserves its fieldId; Formula → SQL is not offered.
+    const canSwitchInputMode =
+        isFormulaSupported && (isNewCalculation || hasSql);
 
     useEffect(() => {
         if (isNewCalculation && isFormulaSupported) {
@@ -585,7 +588,7 @@ const TableCalculationModal: FC<Props> = ({
                         <Text fz="sm" fw={600}>
                             Input mode
                         </Text>
-                        {isNewCalculation && isFormulaSupported && (
+                        {canSwitchInputMode && (
                             <SegmentedControl
                                 classNames={{
                                     root: classes.inputModeControl,


### PR DESCRIPTION
## Summary

In the Table Calculation edit modal, users editing an existing **SQL** table calc can now switch it to **Formula** mode directly, without deleting the calc and recreating it. The fieldId is preserved, so charts / sorts / column order / downstream table calcs that reference the calc by name keep working.

Closes **PROD-7083**.

## Change

Input-mode `SegmentedControl` in `TableCalculationModal` was previously gated on `isNewCalculation && isFormulaSupported`. Now it's gated on:

```ts
isFormulaSupported && (isNewCalculation || hasSql)
```

When the user switches to Formula mode and saves, the existing calc is replaced in place by `explorerActions.updateTableCalculation({ oldName, tableCalculation: value })` (unchanged). That reducer matches by `oldName`, replaces the element at the same index, and rewrites any sorts / column order entries that reference it — the fieldId is preserved whether the new shape is SQL, Formula, or Template.

## Scope

- **SQL → Formula**: now allowed. The formula field starts empty; the user writes their new formula (or uses the AI prompt if the workspace has ambient AI). On save the calc becomes a Formula calc with the same name.
- **Formula → SQL**: intentionally not offered. It would either discard the user's formula or require a formula→SQL conversion we don't have.
- **Template → anything**: unchanged (only formula / SQL modes have the toggle).
- **Warehouse doesn't support formula**: the toggle stays hidden.

No conversion happens — Oliver explicitly said "even if the formula was blank" was fine. If ambient AI later gets a SQL→formula prompt action, it plugs in on top of this without further plumbing.

## Test plan

- [x] `pnpm -F frontend typecheck` — clean.
- [ ] Manual: open an existing SQL table calc referenced by a chart filter / sort / column → switch to Formula → write a new formula → save. The calc renders as a formula, and the chart's references still resolve.
- [ ] Manual: open an existing Formula calc → toggle is hidden (one-way only).
- [ ] Manual: open an existing Template calc → toggle is hidden (unchanged).
- [ ] Manual: create a new calc on a warehouse that supports Formula → toggle works both ways (unchanged).
- [ ] Manual: create or edit on a warehouse that doesn't support Formula → toggle is hidden (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)