### PR TITLE
chore: add `moment` and `moment-timezone` as SDK dependencies

### DIFF
--- a/packages/frontend/sdk/package.json
+++ b/packages/frontend/sdk/package.json
@@ -18,6 +18,10 @@
             "default": "./dist/sdk.cjs.js"
         }
     },
+    "dependencies": {
+        "moment": "2.29.4",
+        "moment-timezone": "0.5.45"
+    },
     "peerDependencies": {
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1394,6 +1394,12 @@ importers:
 
   packages/frontend/sdk:
     dependencies:
+      moment:
+        specifier: 2.29.4
+        version: 2.29.4
+      moment-timezone:
+        specifier: 0.5.45
+        version: 0.5.45
       react:
         specifier: ^18.x || ^19.x
         version: 19.0.0


### PR DESCRIPTION
### Description:

Adds `moment` (2.29.4) and `moment-timezone` (0.5.45) as dependencies to the frontend SDK package.