### PR TITLE
refactor(timezone): consolidate timezone resolution in AsyncQueryService

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1779,6 +1779,7 @@ describe('AsyncQueryService', () => {
                     pivotConfiguration: undefined,
                     originalColumns: undefined,
                     queryCreatedAt: new Date(),
+                    displayTimezone: null,
                 };
 
                 // WHEN: runAsyncWarehouseQuery is called
@@ -1875,6 +1876,7 @@ describe('AsyncQueryService', () => {
                 pivotConfiguration: undefined,
                 originalColumns: undefined,
                 queryCreatedAt: new Date(),
+                displayTimezone: null,
             };
 
             // WHEN: runAsyncWarehouseQuery is called

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -362,6 +362,7 @@ describe('AsyncQueryService', () => {
                     fields: {},
                     missingParameterReferences: [],
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 { query: metricQueryMock },
             );
@@ -454,6 +455,7 @@ describe('AsyncQueryService', () => {
                     fields: {},
                     missingParameterReferences: [],
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 { query: metricQueryMock },
             );
@@ -555,6 +557,7 @@ describe('AsyncQueryService', () => {
                     fields: {},
                     missingParameterReferences: [],
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 { query: metricQueryMock },
             );
@@ -651,6 +654,7 @@ describe('AsyncQueryService', () => {
                     fields: {},
                     missingParameterReferences: [],
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 { query: metricQueryMock },
             );
@@ -743,6 +747,7 @@ describe('AsyncQueryService', () => {
                         'another_missing_param',
                     ],
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 { query: metricQueryMock },
             );
@@ -821,6 +826,7 @@ describe('AsyncQueryService', () => {
                     },
                     availableParameterDefinitions: {},
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 { query: metricQueryMock },
             );
@@ -891,6 +897,7 @@ describe('AsyncQueryService', () => {
                     },
                     availableParameterDefinitions: {},
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 {
                     query: {
@@ -971,6 +978,7 @@ describe('AsyncQueryService', () => {
                     },
                     availableParameterDefinitions: {},
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 {
                     query: {
@@ -1052,6 +1060,7 @@ describe('AsyncQueryService', () => {
                     },
                     availableParameterDefinitions: {},
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 { query: metricQueryMock },
             );
@@ -1695,6 +1704,7 @@ describe('AsyncQueryService', () => {
                     originalColumns: mockOriginalColumns,
                     missingParameterReferences: [],
                     displayTimezone: null,
+                    useTimezoneAwareDateTrunc: false,
                 },
                 { query: metricQueryMock },
             );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -361,6 +361,7 @@ describe('AsyncQueryService', () => {
                     sql: 'SELECT * FROM test',
                     fields: {},
                     missingParameterReferences: [],
+                    displayTimezone: null,
                 },
                 { query: metricQueryMock },
             );
@@ -452,6 +453,7 @@ describe('AsyncQueryService', () => {
                     sql: 'SELECT * FROM test',
                     fields: {},
                     missingParameterReferences: [],
+                    displayTimezone: null,
                 },
                 { query: metricQueryMock },
             );
@@ -552,6 +554,7 @@ describe('AsyncQueryService', () => {
                     sql: 'SELECT * FROM test',
                     fields: {},
                     missingParameterReferences: [],
+                    displayTimezone: null,
                 },
                 { query: metricQueryMock },
             );
@@ -647,6 +650,7 @@ describe('AsyncQueryService', () => {
                     sql: 'SELECT * FROM test',
                     fields: {},
                     missingParameterReferences: [],
+                    displayTimezone: null,
                 },
                 { query: metricQueryMock },
             );
@@ -738,6 +742,7 @@ describe('AsyncQueryService', () => {
                         'missing_param',
                         'another_missing_param',
                     ],
+                    displayTimezone: null,
                 },
                 { query: metricQueryMock },
             );
@@ -815,6 +820,7 @@ describe('AsyncQueryService', () => {
                         intrinsicUserAttributes: {},
                     },
                     availableParameterDefinitions: {},
+                    displayTimezone: null,
                 },
                 { query: metricQueryMock },
             );
@@ -884,6 +890,7 @@ describe('AsyncQueryService', () => {
                         intrinsicUserAttributes: {},
                     },
                     availableParameterDefinitions: {},
+                    displayTimezone: null,
                 },
                 {
                     query: {
@@ -963,6 +970,7 @@ describe('AsyncQueryService', () => {
                         intrinsicUserAttributes: {},
                     },
                     availableParameterDefinitions: {},
+                    displayTimezone: null,
                 },
                 {
                     query: {
@@ -1043,6 +1051,7 @@ describe('AsyncQueryService', () => {
                         intrinsicUserAttributes: {},
                     },
                     availableParameterDefinitions: {},
+                    displayTimezone: null,
                 },
                 { query: metricQueryMock },
             );
@@ -1685,6 +1694,7 @@ describe('AsyncQueryService', () => {
                     fields: {},
                     originalColumns: mockOriginalColumns,
                     missingParameterReferences: [],
+                    displayTimezone: null,
                 },
                 { query: metricQueryMock },
             );

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2872,6 +2872,7 @@ export class AsyncQueryService extends ProjectService {
             originalColumns?: ResultColumns;
             missingParameterReferences: string[];
             timezone?: string;
+            displayTimezone: string | null;
             routingTarget?: PreAggregationRoutingDecision['target'];
             preAggregationRoute?: PreAggregationRoute;
             userAccessControls?: UserAccessControls;
@@ -2899,6 +2900,7 @@ export class AsyncQueryService extends ProjectService {
                     pivotConfiguration,
                     parameters,
                     timezone,
+                    displayTimezone,
                     routingTarget,
                     preAggregationRoute,
                     userAccessControls,
@@ -3149,15 +3151,7 @@ export class AsyncQueryService extends ProjectService {
                         } satisfies ExecuteAsyncQueryReturn;
                     }
 
-                    const {
-                        displayTimezone,
-                        enabled: useTimezoneAwareDateTrunc,
-                    } = await this.resolveTimezoneContext({
-                        projectUuid,
-                        organizationUuid,
-                        userUuid: account.user.id,
-                        metricQuery,
-                    });
+                    const useTimezoneAwareDateTrunc = displayTimezone !== null;
 
                     const resolveStart = Date.now();
                     const executionPlan =
@@ -3419,6 +3413,7 @@ export class AsyncQueryService extends ProjectService {
             originalColumns?: ResultColumns;
             missingParameterReferences: string[];
             timezone?: string;
+            displayTimezone: string | null;
             routingTarget?: PreAggregationRoutingDecision['target'];
             preAggregationRoute?: PreAggregationRoute;
             userAccessControls?: UserAccessControls;
@@ -3638,6 +3633,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns: undefined,
                 missingParameterReferences,
                 timezone: resolvedTimezone,
+                displayTimezone,
                 pivotConfiguration,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
@@ -3736,17 +3732,22 @@ export class AsyncQueryService extends ProjectService {
             parameters,
         );
 
-        const { sql, fields, missingParameterReferences, resolvedTimezone } =
-            await this.prepareMetricQueryAsyncQueryArgs({
-                account,
-                metricQuery,
-                explore,
-                warehouseSqlBuilder,
-                parameters: combinedParameters,
-                projectUuid,
-                userAttributeOverrides,
-                dataTimezone: warehouseCredentials.dataTimezone,
-            });
+        const {
+            sql,
+            fields,
+            missingParameterReferences,
+            resolvedTimezone,
+            displayTimezone,
+        } = await this.prepareMetricQueryAsyncQueryArgs({
+            account,
+            metricQuery,
+            explore,
+            warehouseSqlBuilder,
+            parameters: combinedParameters,
+            projectUuid,
+            userAttributeOverrides,
+            dataTimezone: warehouseCredentials.dataTimezone,
+        });
 
         const requestParameters: ExecuteAsyncFieldValueSearchRequestParams = {
             context,
@@ -3774,6 +3775,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns: undefined,
                 missingParameterReferences,
                 timezone: resolvedTimezone,
+                displayTimezone,
                 routingTarget: 'warehouse',
             },
             requestParameters,
@@ -4026,6 +4028,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns: undefined,
                 missingParameterReferences,
                 timezone: resolvedTimezone,
+                displayTimezone,
                 pivotConfiguration,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
@@ -4350,6 +4353,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns: undefined,
                 missingParameterReferences,
                 timezone: resolvedTimezone,
+                displayTimezone,
                 pivotConfiguration,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
@@ -4648,6 +4652,7 @@ export class AsyncQueryService extends ProjectService {
                     originalColumns: undefined,
                     missingParameterReferences,
                     timezone: resolvedTimezone,
+                    displayTimezone,
                 },
                 requestParameters,
             );
@@ -4732,6 +4737,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns,
                 missingParameterReferences,
                 pivotConfiguration,
+                displayTimezone: null,
             },
             {
                 query: metricQuery,
@@ -5080,6 +5086,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns,
                 missingParameterReferences,
                 pivotConfiguration,
+                displayTimezone: null,
             },
             {
                 query: metricQuery,
@@ -5177,6 +5184,7 @@ export class AsyncQueryService extends ProjectService {
                 originalColumns,
                 missingParameterReferences,
                 pivotConfiguration,
+                displayTimezone: null,
             },
             {
                 query: metricQuery,
@@ -5390,6 +5398,7 @@ export class AsyncQueryService extends ProjectService {
             userAccessControls: resolvedUserAccessControls,
             availableParameterDefinitions,
             resolvedTimezone,
+            displayTimezone,
         } = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery,
@@ -5433,6 +5442,7 @@ export class AsyncQueryService extends ProjectService {
                     originalColumns: undefined,
                     missingParameterReferences,
                     timezone: resolvedTimezone,
+                    displayTimezone,
                     routingTarget: routingDecision.target,
                     ...(routingDecision.target === 'pre_aggregate' && {
                         preAggregationRoute: routingDecision.route,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2859,6 +2859,7 @@ export class AsyncQueryService extends ProjectService {
             availableParameterDefinitions,
             resolvedTimezone,
             displayTimezone,
+            useTimezoneAwareDateTrunc,
         };
     }
 
@@ -2873,6 +2874,7 @@ export class AsyncQueryService extends ProjectService {
             missingParameterReferences: string[];
             timezone?: string;
             displayTimezone: string | null;
+            useTimezoneAwareDateTrunc: boolean;
             routingTarget?: PreAggregationRoutingDecision['target'];
             preAggregationRoute?: PreAggregationRoute;
             userAccessControls?: UserAccessControls;
@@ -2901,6 +2903,7 @@ export class AsyncQueryService extends ProjectService {
                     parameters,
                     timezone,
                     displayTimezone,
+                    useTimezoneAwareDateTrunc,
                     routingTarget,
                     preAggregationRoute,
                     userAccessControls,
@@ -3150,8 +3153,6 @@ export class AsyncQueryService extends ProjectService {
                             },
                         } satisfies ExecuteAsyncQueryReturn;
                     }
-
-                    const useTimezoneAwareDateTrunc = displayTimezone !== null;
 
                     const resolveStart = Date.now();
                     const executionPlan =
@@ -3414,6 +3415,7 @@ export class AsyncQueryService extends ProjectService {
             missingParameterReferences: string[];
             timezone?: string;
             displayTimezone: string | null;
+            useTimezoneAwareDateTrunc: boolean;
             routingTarget?: PreAggregationRoutingDecision['target'];
             preAggregationRoute?: PreAggregationRoute;
             userAccessControls?: UserAccessControls;
@@ -3578,6 +3580,7 @@ export class AsyncQueryService extends ProjectService {
             availableParameterDefinitions,
             resolvedTimezone,
             displayTimezone,
+            useTimezoneAwareDateTrunc,
         } = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery,
@@ -3634,6 +3637,7 @@ export class AsyncQueryService extends ProjectService {
                 missingParameterReferences,
                 timezone: resolvedTimezone,
                 displayTimezone,
+                useTimezoneAwareDateTrunc,
                 pivotConfiguration,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
@@ -3738,6 +3742,7 @@ export class AsyncQueryService extends ProjectService {
             missingParameterReferences,
             resolvedTimezone,
             displayTimezone,
+            useTimezoneAwareDateTrunc,
         } = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery,
@@ -3776,6 +3781,7 @@ export class AsyncQueryService extends ProjectService {
                 missingParameterReferences,
                 timezone: resolvedTimezone,
                 displayTimezone,
+                useTimezoneAwareDateTrunc,
                 routingTarget: 'warehouse',
             },
             requestParameters,
@@ -3978,6 +3984,7 @@ export class AsyncQueryService extends ProjectService {
             availableParameterDefinitions,
             resolvedTimezone,
             displayTimezone,
+            useTimezoneAwareDateTrunc,
         } = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery: metricQueryWithLimit,
@@ -4029,6 +4036,7 @@ export class AsyncQueryService extends ProjectService {
                 missingParameterReferences,
                 timezone: resolvedTimezone,
                 displayTimezone,
+                useTimezoneAwareDateTrunc,
                 pivotConfiguration,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
@@ -4301,6 +4309,7 @@ export class AsyncQueryService extends ProjectService {
             availableParameterDefinitions,
             resolvedTimezone,
             displayTimezone,
+            useTimezoneAwareDateTrunc,
         } = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery: metricQueryWithLimit,
@@ -4354,6 +4363,7 @@ export class AsyncQueryService extends ProjectService {
                 missingParameterReferences,
                 timezone: resolvedTimezone,
                 displayTimezone,
+                useTimezoneAwareDateTrunc,
                 pivotConfiguration,
                 routingTarget: routingDecision.target,
                 ...(routingDecision.target === 'pre_aggregate' && {
@@ -4625,6 +4635,7 @@ export class AsyncQueryService extends ProjectService {
             responseMetricQuery,
             resolvedTimezone,
             displayTimezone,
+            useTimezoneAwareDateTrunc,
         } = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery: underlyingDataMetricQueryWithLimit,
@@ -4653,6 +4664,7 @@ export class AsyncQueryService extends ProjectService {
                     missingParameterReferences,
                     timezone: resolvedTimezone,
                     displayTimezone,
+                    useTimezoneAwareDateTrunc,
                 },
                 requestParameters,
             );
@@ -4738,6 +4750,7 @@ export class AsyncQueryService extends ProjectService {
                 missingParameterReferences,
                 pivotConfiguration,
                 displayTimezone: null,
+                useTimezoneAwareDateTrunc: false,
             },
             {
                 query: metricQuery,
@@ -5087,6 +5100,7 @@ export class AsyncQueryService extends ProjectService {
                 missingParameterReferences,
                 pivotConfiguration,
                 displayTimezone: null,
+                useTimezoneAwareDateTrunc: false,
             },
             {
                 query: metricQuery,
@@ -5185,6 +5199,7 @@ export class AsyncQueryService extends ProjectService {
                 missingParameterReferences,
                 pivotConfiguration,
                 displayTimezone: null,
+                useTimezoneAwareDateTrunc: false,
             },
             {
                 query: metricQuery,
@@ -5399,6 +5414,7 @@ export class AsyncQueryService extends ProjectService {
             availableParameterDefinitions,
             resolvedTimezone,
             displayTimezone,
+            useTimezoneAwareDateTrunc,
         } = await this.prepareMetricQueryAsyncQueryArgs({
             account,
             metricQuery,
@@ -5443,6 +5459,7 @@ export class AsyncQueryService extends ProjectService {
                     missingParameterReferences,
                     timezone: resolvedTimezone,
                     displayTimezone,
+                    useTimezoneAwareDateTrunc,
                     routingTarget: routingDecision.target,
                     ...(routingDecision.target === 'pre_aggregate' && {
                         preAggregationRoute: routingDecision.route,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -753,20 +753,12 @@ export class AsyncQueryService extends ProjectService {
             throw new ResultsExpiredError();
         }
 
-        const projectTimezone = queryHistory.projectUuid
-            ? await this.getQueryTimezoneForProject(queryHistory.projectUuid)
-            : 'UTC';
-        const resolvedTimezone = resolveQueryTimezone(
-            queryHistory.metricQuery,
-            projectTimezone,
-        );
-        const isTimezoneSupportEnabled = await this.isTimezoneSupportEnabled({
-            userUuid: account.user.id,
+        const { displayTimezone } = await this.resolveTimezoneContext({
+            projectUuid: queryHistory.projectUuid,
             organizationUuid: account.organization.organizationUuid,
+            userUuid: account.user.id,
+            metricQuery: queryHistory.metricQuery,
         });
-        const displayTimezone = isTimezoneSupportEnabled
-            ? resolvedTimezone
-            : undefined;
 
         const defaultedPageSize =
             pageSize ??
@@ -786,7 +778,7 @@ export class AsyncQueryService extends ProjectService {
                 queryHistory.fields,
                 queryHistory.pivotValuesColumns,
                 undefined,
-                displayTimezone,
+                displayTimezone ?? undefined,
             );
 
         const {
@@ -1486,7 +1478,7 @@ export class AsyncQueryService extends ProjectService {
         pivotConfiguration?: PivotConfiguration;
         itemsMap: ItemsMap;
         dataTimezone?: string;
-        displayTimezone?: string;
+        displayTimezone: string | null;
     }): Promise<{
         columns: ResultColumns;
         warehouseResults: WarehouseExecuteAsyncQuery;
@@ -1593,7 +1585,7 @@ export class AsyncQueryService extends ProjectService {
                                         row[c.reference],
                                         false,
                                         undefined,
-                                        displayTimezone,
+                                        displayTimezone ?? undefined,
                                     )
                                   : String(rawValue);
                               return {
@@ -2377,20 +2369,43 @@ export class AsyncQueryService extends ProjectService {
         }
     }
 
-    private async resolveDisplayTimezoneFromHistory(
-        query: QueryHistory,
-        actor: { userUuid: string },
-    ): Promise<string | undefined> {
-        if (!query.projectUuid || !query.organizationUuid) return undefined;
-        const enabled = await this.isTimezoneSupportEnabled({
-            userUuid: actor.userUuid,
-            organizationUuid: query.organizationUuid,
-        });
-        if (!enabled) return undefined;
-        const projectTimezone = await this.getQueryTimezoneForProject(
-            query.projectUuid,
+    /**
+     * Resolves both the honest `resolvedTimezone` (always a valid TZ string,
+     * used for SQL compilation + cache keys) and the flag-gated
+     * `displayTimezone` (null when timezone-aware DATE_TRUNC is off — this is
+     * what reaches API responses and the row formatter).
+     */
+    private async resolveTimezoneContext({
+        projectUuid,
+        organizationUuid,
+        userUuid,
+        metricQuery,
+    }: {
+        projectUuid: string | null;
+        organizationUuid: string;
+        userUuid: string;
+        metricQuery: MetricQuery;
+    }): Promise<{
+        resolvedTimezone: string;
+        displayTimezone: string | null;
+        enabled: boolean;
+    }> {
+        const projectTimezone = projectUuid
+            ? await this.getQueryTimezoneForProject(projectUuid)
+            : 'UTC';
+        const resolvedTimezone = resolveQueryTimezone(
+            metricQuery,
+            projectTimezone,
         );
-        return resolveQueryTimezone(query.metricQuery, projectTimezone);
+        const enabled = await this.isTimezoneSupportEnabled({
+            userUuid,
+            organizationUuid,
+        });
+        return {
+            resolvedTimezone,
+            displayTimezone: enabled ? resolvedTimezone : null,
+            enabled,
+        };
     }
 
     private async buildWarehouseQueryArgs(
@@ -2401,10 +2416,12 @@ export class AsyncQueryService extends ProjectService {
         const queryTags = AsyncQueryService.buildQueryTags(query);
         const warehouseCredentialsOverrides =
             await this.deriveWarehouseCredentialsOverrides(query);
-        const displayTimezone = await this.resolveDisplayTimezoneFromHistory(
-            query,
-            actor,
-        );
+        const { displayTimezone } = await this.resolveTimezoneContext({
+            projectUuid: query.projectUuid,
+            organizationUuid: query.organizationUuid,
+            userUuid: actor.userUuid,
+            metricQuery: query.metricQuery,
+        });
 
         return {
             projectUuid: query.projectUuid ?? '',
@@ -2440,10 +2457,12 @@ export class AsyncQueryService extends ProjectService {
         const queryTags = AsyncQueryService.buildQueryTags(query);
         const warehouseCredentialsOverrides =
             await this.deriveWarehouseCredentialsOverrides(query);
-        const displayTimezone = await this.resolveDisplayTimezoneFromHistory(
-            query,
-            actor,
-        );
+        const { displayTimezone } = await this.resolveTimezoneContext({
+            projectUuid: query.projectUuid,
+            organizationUuid: query.organizationUuid,
+            userUuid: actor.userUuid,
+            metricQuery: query.metricQuery,
+        });
 
         return {
             projectUuid: query.projectUuid ?? '',
@@ -2769,16 +2788,15 @@ export class AsyncQueryService extends ProjectService {
             explore,
         );
 
-        const projectTimezone =
-            await this.getQueryTimezoneForProject(projectUuid);
-        const resolvedTimezone = resolveQueryTimezone(
-            metricQuery,
-            projectTimezone,
-        );
-
-        const useTimezoneAwareDateTrunc = await this.isTimezoneSupportEnabled({
-            userUuid: account.user.id,
+        const {
+            resolvedTimezone,
+            displayTimezone,
+            enabled: useTimezoneAwareDateTrunc,
+        } = await this.resolveTimezoneContext({
+            projectUuid,
             organizationUuid: account.organization.organizationUuid,
+            userUuid: account.user.id,
+            metricQuery,
         });
 
         const fullQuery = await ProjectService._compileQuery({
@@ -2826,13 +2844,6 @@ export class AsyncQueryService extends ProjectService {
         );
 
         const responseMetricQuery = metricQuery;
-
-        // displayTimezone is the flag-gated value returned to API consumers;
-        // resolvedTimezone stays internal so SQL generation always has the real
-        // TZ available for tz-aware DATE_TRUNC roundtripping.
-        const displayTimezone = useTimezoneAwareDateTrunc
-            ? resolvedTimezone
-            : null;
 
         return {
             sql: fullQuery.query,
@@ -3138,12 +3149,15 @@ export class AsyncQueryService extends ProjectService {
                         } satisfies ExecuteAsyncQueryReturn;
                     }
 
-                    const useTimezoneAwareDateTrunc =
-                        await this.isTimezoneSupportEnabled({
-                            userUuid: account.user.id,
-                            organizationUuid:
-                                account.organization.organizationUuid,
-                        });
+                    const {
+                        displayTimezone,
+                        enabled: useTimezoneAwareDateTrunc,
+                    } = await this.resolveTimezoneContext({
+                        projectUuid,
+                        organizationUuid,
+                        userUuid: account.user.id,
+                        metricQuery,
+                    });
 
                     const resolveStart = Date.now();
                     const executionPlan =
@@ -3233,9 +3247,7 @@ export class AsyncQueryService extends ProjectService {
                         cacheKey,
                         originalColumns,
                         queryCreatedAt,
-                        displayTimezone: useTimezoneAwareDateTrunc
-                            ? timezone
-                            : undefined,
+                        displayTimezone,
                     };
 
                     if (executionPlan.target === 'pre_aggregate') {

--- a/packages/backend/src/services/AsyncQueryService/types.ts
+++ b/packages/backend/src/services/AsyncQueryService/types.ts
@@ -201,7 +201,7 @@ export type RunAsyncWarehouseQueryArgs = {
     originalColumns?: ResultColumns;
     query: string;
     queryCreatedAt: Date;
-    displayTimezone?: string;
+    displayTimezone: string | null;
 };
 
 export type RunAsyncPreAggregateQueryArgs = Omit<


### PR DESCRIPTION
## What

Tidies up how timezone context is resolved inside `AsyncQueryService`. One helper now does what five separate code paths were each doing.

## Why

After the parent PR landed, `displayTimezone` plumbing was sprinkled across several methods — each one independently called `getQueryTimezoneForProject`, `resolveQueryTimezone`, and `isTimezoneSupportEnabled`, then applied the flag gate inline. The `null`/`undefined` choice for "flag off" was inconsistent, and reviewers had to trace each site to confirm the feature was still fully gated.