### PR TITLE
chore(scim): add drift-detection warn and auth-middleware info logs

### DIFF
--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -279,6 +279,14 @@ export class ScimService extends BaseService {
             return this.convertLightdashUserToScimUser(user, userRoles);
         } catch (error) {
             if (error instanceof NotFoundError) {
+                this.logger.warn(
+                    'SCIM: user lookup failed — possible IdP cache drift',
+                    {
+                        userUuid,
+                        organizationUuid,
+                        operation: 'getUser',
+                    },
+                );
                 throw new ScimError({
                     detail: `User with UUID ${userUuid} not found`,
                     status: 404,
@@ -767,6 +775,14 @@ export class ScimService extends BaseService {
                 });
             }
             if (error instanceof NotFoundError) {
+                this.logger.warn(
+                    'SCIM: user lookup failed — possible IdP cache drift',
+                    {
+                        userUuid,
+                        organizationUuid,
+                        operation: 'updateUser',
+                    },
+                );
                 throw new ScimError({
                     detail: `User with UUID ${userUuid} not found`,
                     status: 404,
@@ -899,6 +915,14 @@ export class ScimService extends BaseService {
                             scimType: 'invalidValue',
                         });
                     case NotFoundError:
+                        this.logger.warn(
+                            'SCIM: user lookup failed — possible IdP cache drift',
+                            {
+                                userUuid,
+                                organizationUuid,
+                                operation: 'patchUser',
+                            },
+                        );
                         throw new ScimError({
                             detail: `User with UUID ${userUuid} not found`,
                             status: 404,
@@ -997,6 +1021,14 @@ export class ScimService extends BaseService {
                 });
             }
             if (error instanceof NotFoundError) {
+                this.logger.warn(
+                    'SCIM: user lookup failed — possible IdP cache drift',
+                    {
+                        userUuid,
+                        organizationUuid,
+                        operation: 'deleteUser',
+                    },
+                );
                 throw new ScimError({
                     detail: `User with UUID ${userUuid} not found`,
                     status: 404,

--- a/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
+++ b/packages/backend/src/ee/services/ServiceAccountService/ServiceAccountService.ts
@@ -285,6 +285,13 @@ export class ServiceAccountService extends BaseService {
                     return null;
                 }
 
+                this.logger.info('SCIM: access token authenticated', {
+                    serviceAccountUuid: dbToken.uuid,
+                    organizationUuid: dbToken.organizationUuid,
+                    description: dbToken.description,
+                    requestMethod: request.method,
+                    requestRoutePath: request.routePath,
+                });
                 this.analytics.track<ScimAccessTokenAuthenticationEvent>({
                     event: 'scim_access_token.authenticated',
                     anonymousId: LightdashAnalytics.anonymousId,


### PR DESCRIPTION
## Problem

After the recent debug→info promotion in `ScimService.ts`, the SCIM surface now emits structured logs for happy-path state transitions. But two forensically important signals are still missing:

1. **There's no explicit signal when a SCIM lookup 404s due to an IdP cache holding a stale `user_uuid`.** The `NotFoundError` catch blocks in `getUser` / `updateUser` / `patchUser` / `deleteUser` currently throw `ScimError` 404 without logging — operators have to infer drift by grepping the HTTP envelope and cross-referencing uuids.

2. **The SCIM auth middleware emits nothing on successful auth.** When an org has multiple SCIM integrations configured on the IdP side, it's currently impossible to tell from logs which SCIM token served a given request.

## Change

### 1. `ScimService.ts` — warn-level log on 404 paths (4 call-sites)

Adds `this.logger.warn('SCIM: user lookup failed — possible IdP cache drift', { userUuid, organizationUuid, operation })` before the existing `throw new ScimError(...)` in the `NotFoundError` branches of `getUser`, `updateUser`, `patchUser`, and `deleteUser`. Same message string across all four, with `operation` distinguishing the caller so a single grep catches every drift signal across endpoints.

### 2. `ServiceAccountService.ts` — info-level log on successful SCIM auth

Adds `this.logger.info('SCIM: access token authenticated', { serviceAccountUuid, organizationUuid, description, requestMethod, requestRoutePath })` inside `authenticateScim`, right after token validation and before the existing analytics call. Only fires on successful auth; invalid tokens still return `null` silently as before.

## Test plan

- [ ] Unit tests pass unchanged (no tests currently assert on logger calls for these paths).
- [ ] Locally trigger each flow against the dev SCIM endpoint and confirm the lines appear in `pnpm pm2:logs:api`:
  - `GET /Users/<made-up-uuid>` → `warn` with `operation: "getUser"`
  - `PATCH /Users/<made-up-uuid>` → `warn` with `operation: "updateUser"`
  - SCIM PATCH op → `warn` with `operation: "patchUser"`
  - `DELETE /Users/<made-up-uuid>` → `warn` with `operation: "deleteUser"`
  - Any authenticated SCIM request → `info` `"SCIM: access token authenticated"` with token uuid + description.
- [ ] No changelog / docs entry — internal observability change only.

## Non-goals

- Does not change any HTTP response shape.
- Does not add warn logs to group/role endpoints (same `NotFoundError` handling exists there; left out for scope tightness since the stale-cache drift pattern is user-scoped in practice).
- Does not add provenance tracking to `UserModel.createUser` / `delete` — that's a larger follow-up that would give us an audit trail for the origin of drift events, not just their detection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)