### PR TITLE
fix: upload image to s3 with correct credentials

### DIFF
--- a/packages/backend/src/clients/Aws/S3BaseClient.ts
+++ b/packages/backend/src/clients/Aws/S3BaseClient.ts
@@ -28,6 +28,80 @@ export type S3BaseConfiguration =
     | undefined;
 
 /**
+ * Resolves S3 credentials from explicit keys, a credential chain, or SDK defaults.
+ * Returns the credentials property to assign to an S3ClientConfig, or undefined
+ * to let the SDK use its default resolution.
+ */
+export function resolveS3Credentials(config: {
+    accessKey?: string;
+    secretKey?: string;
+    useCredentialsFrom?: string[];
+}): S3ClientConfig['credentials'] | undefined {
+    if (config.accessKey && config.secretKey) {
+        Logger.debug('Using S3 storage with access key credentials');
+        return {
+            accessKeyId: config.accessKey,
+            secretAccessKey: config.secretKey,
+        };
+    }
+
+    const requestedSources = config.useCredentialsFrom;
+    const providerLabels: string[] = [];
+    const providers: Array<ReturnType<typeof fromEnv>> = [];
+
+    if (requestedSources && requestedSources.length > 0) {
+        for (const srcRaw of requestedSources) {
+            const src = srcRaw.toLowerCase();
+            switch (src) {
+                case 'env':
+                    providers.push(fromEnv());
+                    providerLabels.push('env');
+                    break;
+                case 'token_file':
+                case 'tokenfile':
+                    providers.push(fromTokenFile());
+                    providerLabels.push('token_file');
+                    break;
+                case 'ini':
+                case 'init': // support common typo
+                    providers.push(fromIni());
+                    providerLabels.push('ini');
+                    break;
+                case 'container_metadata':
+                case 'ecs':
+                    providers.push(fromContainerMetadata());
+                    providerLabels.push('container_metadata');
+                    break;
+                case 'instance_metadata':
+                case 'ec2':
+                    providers.push(fromInstanceMetadata());
+                    providerLabels.push('instance_metadata');
+                    break;
+                default:
+                    Logger.warn(
+                        `S3_USE_CREDENTIALS_FROM includes unknown source: ${srcRaw} - ignoring`,
+                    );
+            }
+        }
+    }
+
+    if (providers.length > 0) {
+        Logger.debug(
+            `Using S3 storage with IAM role credentials (credential chain): ${providerLabels.join(
+                ' -> ',
+            )}`,
+        );
+        return createCredentialChain(...providers);
+    }
+
+    // Do not set credentials to preserve default AWS SDK resolution
+    Logger.debug(
+        'Using S3 storage with default AWS SDK credential resolution (no explicit chain); set S3_USE_CREDENTIALS_FROM to customize',
+    );
+    return undefined;
+}
+
+/**
  * Base class that sets up the AWS S3 client and handles credentials logic.
  * - If explicit accessKey/secretKey are provided, uses them.
  * - Else, if useCredentialsFrom is provided and has valid entries, builds an explicit credential chain in that order.
@@ -47,8 +121,7 @@ export class S3BaseClient {
             return;
         }
 
-        const { endpoint, region, accessKey, secretKey, forcePathStyle } =
-            configuration;
+        const { endpoint, region, forcePathStyle } = configuration;
 
         const s3Config: S3ClientConfig = {
             region,
@@ -57,70 +130,9 @@ export class S3BaseClient {
             forcePathStyle,
         };
 
-        if (accessKey && secretKey) {
-            Object.assign(s3Config, {
-                credentials: {
-                    accessKeyId: accessKey,
-                    secretAccessKey: secretKey,
-                },
-            });
-            Logger.debug('Using S3 storage with access key credentials');
-        } else {
-            const requestedSources = configuration.useCredentialsFrom;
-            const providerLabels: string[] = [];
-            const providers: Array<ReturnType<typeof fromEnv>> = [];
-
-            if (requestedSources && requestedSources.length > 0) {
-                for (const srcRaw of requestedSources) {
-                    const src = srcRaw.toLowerCase();
-                    switch (src) {
-                        case 'env':
-                            providers.push(fromEnv());
-                            providerLabels.push('env');
-                            break;
-                        case 'token_file':
-                        case 'tokenfile':
-                            providers.push(fromTokenFile());
-                            providerLabels.push('token_file');
-                            break;
-                        case 'ini':
-                        case 'init': // support common typo
-                            providers.push(fromIni());
-                            providerLabels.push('ini');
-                            break;
-                        case 'container_metadata':
-                        case 'ecs':
-                            providers.push(fromContainerMetadata());
-                            providerLabels.push('container_metadata');
-                            break;
-                        case 'instance_metadata':
-                        case 'ec2':
-                            providers.push(fromInstanceMetadata());
-                            providerLabels.push('instance_metadata');
-                            break;
-                        default:
-                            Logger.warn(
-                                `S3_USE_CREDENTIALS_FROM includes unknown source: ${srcRaw} - ignoring`,
-                            );
-                    }
-                }
-            }
-
-            if (providers.length > 0) {
-                Object.assign(s3Config, {
-                    credentials: createCredentialChain(...providers),
-                });
-                Logger.debug(
-                    `Using S3 storage with IAM role credentials (credential chain): ${providerLabels.join(
-                        ' -> ',
-                    )}`,
-                );
-            } else {
-                // Do not set credentials to preserve default AWS SDK resolution
-                Logger.debug(
-                    'Using S3 storage with default AWS SDK credential resolution (no explicit chain); set S3_USE_CREDENTIALS_FROM to customize',
-                );
-            }
+        const credentials = resolveS3Credentials(configuration);
+        if (credentials) {
+            s3Config.credentials = credentials;
         }
 
         this.s3 = new S3(s3Config);

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -22,6 +22,7 @@ import { extract, type Headers } from 'tar-stream';
 import { validate as isValidUuid, v4 as uuidv4 } from 'uuid';
 import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { fromSession } from '../../../auth/account';
+import { resolveS3Credentials } from '../../../clients/Aws/S3BaseClient';
 import { LightdashConfig } from '../../../config/parseConfig';
 import {
     APP_VERSION_STAGE_ORDER,
@@ -121,11 +122,9 @@ export class AppGenerateService extends BaseService {
             forcePathStyle: s3Config.forcePathStyle ?? false,
         };
 
-        if (s3Config.accessKey && s3Config.secretKey) {
-            config.credentials = {
-                accessKeyId: s3Config.accessKey,
-                secretAccessKey: s3Config.secretKey,
-            };
+        const credentials = resolveS3Credentials(s3Config);
+        if (credentials) {
+            config.credentials = credentials;
         }
 
         return {


### PR DESCRIPTION
### Description:
Summary
  - Image uploads for data apps fail in production with SignatureDoesNotMatch (HTTP 403) from GCS
  - Root cause: AppGenerateService.getS3Client() only uses explicit accessKey/secretKey for credentials, ignoring the useCredentialsFrom credential chain that production relies on (e.g., env, container_metadata,
  instance_metadata)
  - Tarball uploads work because runPipeline() executes on the scheduler worker pod, while uploadImage() runs on the API server pod — the two pods have different credential environments
  - Extracted resolveS3Credentials() from S3BaseClient into a reusable function and wired it into AppGenerateService.getS3Client() so it resolves credentials the same way all other S3 clients do

  Why only images?

  The app generation pipeline (runPipeline) runs on the scheduler worker pod via Graphile Worker, while image uploads (uploadImage) run on the API server pod handling the HTTP request. Both use the same getS3Client()
  code, but the scheduler worker pod has credentials that happen to work with the old code path, while the API server pod requires the useCredentialsFrom credential chain.

  Changes

  - packages/backend/src/clients/Aws/S3BaseClient.ts — Extract credential resolution logic into a standalone resolveS3Credentials() function. S3BaseClient now calls it internally (pure refactor, no behavior change).
  - packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts — getS3Client() now uses resolveS3Credentials() instead of only checking explicit keys.
