### PR TITLE
feat(data-apps): enable moving apps between spaces

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -16,6 +16,7 @@ import {
     type SessionUser,
 } from '@lightdash/common';
 import { ALL_TRAFFIC, Sandbox } from 'e2b';
+import { Knex } from 'knex';
 import { performance } from 'node:perf_hooks';
 import { PassThrough, Readable } from 'node:stream';
 import { extract, type Headers } from 'tar-stream';
@@ -2339,6 +2340,81 @@ export class AppGenerateService extends BaseService {
             name: updatedApp.name,
             description: updatedApp.description,
         };
+    }
+
+    /**
+     * Move a data app from one space to another.
+     *
+     * Implements the shared `BulkActionable` interface so `ContentService`
+     * can dispatch move requests uniformly alongside dashboards and charts.
+     * Only space → space moves are supported for now: personal apps (no
+     * source space) and moves to `null` (unassigning) are rejected.
+     */
+    async moveToSpace(
+        user: SessionUser,
+        {
+            projectUuid,
+            itemUuid: appUuid,
+            targetSpaceUuid,
+        }: {
+            projectUuid: string;
+            itemUuid: string;
+            targetSpaceUuid: string | null;
+        },
+        {
+            tx,
+            checkForAccess = true,
+            trackEvent = true,
+        }: {
+            tx?: Knex;
+            checkForAccess?: boolean;
+            trackEvent?: boolean;
+        } = {},
+    ): Promise<void> {
+        await this.assertDataAppsEnabled(user);
+
+        if (targetSpaceUuid === null) {
+            throw new ParameterError(
+                'You cannot move a data app outside of a space',
+            );
+        }
+
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+
+        if (app.space_uuid === null) {
+            throw new ParameterError(
+                'You cannot move a personal data app between spaces',
+            );
+        }
+
+        if (checkForAccess) {
+            this.assertDataAppAbility(
+                user,
+                'manage',
+                app.organization_uuid,
+                projectUuid,
+                'Insufficient permissions to move data apps',
+            );
+        }
+
+        await this.appModel.moveToSpace(
+            { appId: appUuid, projectUuid, targetSpaceUuid },
+            { tx },
+        );
+
+        if (trackEvent) {
+            this.analytics.track({
+                event: 'data_app.moved',
+                userId: user.userUuid,
+                properties: {
+                    organizationId: app.organization_uuid,
+                    projectId: projectUuid,
+                    appUuid,
+                    sourceSpaceUuid: app.space_uuid,
+                    targetSpaceUuid,
+                },
+            });
+        }
     }
 
     private static async extractAndUploadToS3(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8644,11 +8644,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9126,11 +9126,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9145,11 +9145,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9164,11 +9164,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9183,11 +9183,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9202,11 +9202,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -28756,6 +28756,16 @@ const models: TsoaRoute.Models = {
                     nestedProperties: {
                         contentType: {
                             ref: 'ContentType.SPACE',
+                            required: true,
+                        },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        contentType: {
+                            ref: 'ContentType.DATA_APP',
                             required: true,
                         },
                         uuid: { dataType: 'string', required: true },

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10099,6 +10099,19 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
+                                                            "error",
+                                                            "success"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
                                                             "success",
                                                             "error"
                                                         ]
@@ -29987,6 +30000,18 @@
                         },
                         "required": ["contentType", "uuid"],
                         "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contentType": {
+                                "$ref": "#/components/schemas/ContentType.DATA_APP"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["contentType", "uuid"],
+                        "type": "object"
                     }
                 ]
             },
@@ -30527,7 +30552,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2780.0",
+        "version": "0.2782.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -15,6 +15,7 @@ import {
 } from '../database/entities/apps';
 import { OrganizationTableName } from '../database/entities/organizations';
 import { ProjectTableName } from '../database/entities/projects';
+import { SpaceTableName } from '../database/entities/spaces';
 import KnexPaginate from '../database/pagination';
 
 type AppModelArguments = {
@@ -304,6 +305,42 @@ export class AppModel {
             throw new NotFoundError(`App not found: ${appId}`);
         }
         return row;
+    }
+
+    async moveToSpace(
+        {
+            appId,
+            projectUuid,
+            targetSpaceUuid,
+        }: {
+            appId: string;
+            projectUuid: string;
+            targetSpaceUuid: string;
+        },
+        { tx = this.database }: { tx?: Knex } = {},
+    ): Promise<void> {
+        const space = await tx(SpaceTableName)
+            .select(`${SpaceTableName}.space_uuid`)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_id`,
+                `${SpaceTableName}.project_id`,
+            )
+            .where(`${SpaceTableName}.space_uuid`, targetSpaceUuid)
+            .andWhere(`${ProjectTableName}.project_uuid`, projectUuid)
+            .whereNull(`${SpaceTableName}.deleted_at`)
+            .first();
+        if (!space) {
+            throw new NotFoundError('Space not found');
+        }
+
+        const updated = await tx(AppsTableName)
+            .where({ app_id: appId, project_uuid: projectUuid })
+            .whereNull('deleted_at')
+            .update({ space_uuid: targetSpaceUuid });
+        if (updated === 0) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
     }
 
     async listMyApps(

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -3,6 +3,7 @@ import {
     ApiContentActionBody,
     ApiContentBulkActionBody,
     assertUnreachable,
+    BulkActionable,
     ChartSourceType,
     ContentActionMove,
     ContentType,
@@ -13,10 +14,12 @@ import {
     KnexPaginateArgs,
     KnexPaginatedData,
     NotFoundError,
+    ParameterError,
     SessionUser,
     SpaceContentBase,
     SummaryContent,
 } from '@lightdash/common';
+import { Knex } from 'knex';
 import { intersection } from 'lodash';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { ContentModel } from '../../models/ContentModel/ContentModel';
@@ -44,6 +47,7 @@ type ContentServiceArguments = {
     savedChartService: SavedChartService;
     savedSqlService: SavedSqlService;
     spacePermissionService: SpacePermissionService;
+    appMoveService: BulkActionable<Knex> | undefined;
 };
 
 export class ContentService extends BaseService {
@@ -65,6 +69,8 @@ export class ContentService extends BaseService {
 
     spacePermissionService: SpacePermissionService;
 
+    appMoveService: BulkActionable<Knex> | undefined;
+
     constructor(args: ContentServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -78,6 +84,14 @@ export class ContentService extends BaseService {
         this.savedChartService = args.savedChartService;
         this.savedSqlService = args.savedSqlService;
         this.spacePermissionService = args.spacePermissionService;
+        this.appMoveService = args.appMoveService;
+    }
+
+    private getAppMoveService(): BulkActionable<Knex> {
+        if (!this.appMoveService) {
+            throw new ParameterError('Data apps are not available');
+        }
+        return this.appMoveService;
     }
 
     async find(
@@ -272,6 +286,12 @@ export class ContentService extends BaseService {
                             moveToSpaceArgs,
                             moveToSpaceOptions,
                         );
+                    case ContentType.DATA_APP:
+                        return this.getAppMoveService().moveToSpace(
+                            user,
+                            moveToSpaceArgs,
+                            moveToSpaceOptions,
+                        );
                     default:
                         return assertUnreachable(c, 'Unknown content type');
                 }
@@ -358,6 +378,12 @@ export class ContentService extends BaseService {
                 );
             case ContentType.SPACE:
                 return this.spaceService.moveToSpace(
+                    user,
+                    moveToSpaceArgs,
+                    moveToSpaceOptions,
+                );
+            case ContentType.DATA_APP:
+                return this.getAppMoveService().moveToSpace(
                     user,
                     moveToSpaceArgs,
                     moveToSpaceOptions,

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1,4 +1,5 @@
-import { MissingConfigError } from '@lightdash/common';
+import { BulkActionable, MissingConfigError } from '@lightdash/common';
+import { Knex } from 'knex';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { ClientRepository } from '../clients/ClientRepository';
 import { LightdashConfig } from '../config/parseConfig';
@@ -1057,6 +1058,11 @@ export class ServiceRepository
                     savedChartService: this.getSavedChartService(),
                     savedSqlService: this.getSavedSqlService(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    // Only wired when EE license is active. Core builds get
+                    // undefined and fail DATA_APP moves with a clear error.
+                    appMoveService: this.providers.appGenerateService
+                        ? this.getAppGenerateService<BulkActionable<Knex>>()
+                        : undefined,
                 }),
         );
     }

--- a/packages/common/src/types/content.ts
+++ b/packages/common/src/types/content.ts
@@ -154,6 +154,10 @@ type ItemPayload =
     | {
           uuid: string;
           contentType: ContentType.SPACE;
+      }
+    | {
+          uuid: string;
+          contentType: ContentType.DATA_APP;
       };
 
 export type ContentAction = ContentActionMove | ContentActionDelete;

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTable.tsx
@@ -835,10 +835,12 @@ const InfiniteResourceTable = ({
                                     },
                                 ];
                             case ContentType.DATA_APP:
-                                // Moving data apps between spaces is not
-                                // supported yet; skip them in bulk-move
-                                // payloads.
-                                return [];
+                                return [
+                                    {
+                                        uuid: item.data.uuid,
+                                        contentType: ContentType.DATA_APP,
+                                    },
+                                ];
                             default:
                                 return assertUnreachable(
                                     item,

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -127,8 +127,16 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                         },
                     });
                 case ResourceViewItemType.DATA_APP:
-                    // Moving data apps between spaces is not supported yet
-                    return Promise.resolve();
+                    return contentAction({
+                        action: {
+                            type: 'move',
+                            targetSpaceUuid: spaceUuid,
+                        },
+                        item: {
+                            uuid: item.data.uuid,
+                            contentType: ContentType.DATA_APP,
+                        },
+                    });
                 default:
                     return assertUnreachable(
                         item,

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -206,10 +206,16 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
             break;
         }
         case ResourceViewItemType.DATA_APP: {
-            // Write-path space permissions for data apps land in a later PR.
-            // For now this menu only shows manage-gated actions (move, delete,
-            // verify) which aren't supported for data apps yet, so hide them.
-            userCanManage = false;
+            // Data apps are admin-only for now (manage:DataApp). Space-aware
+            // write permissions will land in a later PR.
+            userCanManage =
+                user.data?.ability?.can(
+                    'manage',
+                    subject('DataApp', {
+                        organizationUuid,
+                        projectUuid,
+                    }),
+                ) === true;
             break;
         }
         default:
@@ -468,23 +474,19 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 display={isSqlChart ? 'none' : 'block'}
                             />
 
-                            {item.type !== ResourceViewItemType.DATA_APP && (
-                                <Menu.Item
-                                    component="button"
-                                    role="menuitem"
-                                    leftSection={
-                                        <IconFolderSymlink size={18} />
-                                    }
-                                    onClick={() => {
-                                        onAction({
-                                            type: ResourceViewItemAction.TRANSFER_TO_SPACE,
-                                            item,
-                                        });
-                                    }}
-                                >
-                                    Move
-                                </Menu.Item>
-                            )}
+                            <Menu.Item
+                                component="button"
+                                role="menuitem"
+                                leftSection={<IconFolderSymlink size={18} />}
+                                onClick={() => {
+                                    onAction({
+                                        type: ResourceViewItemAction.TRANSFER_TO_SPACE,
+                                        item,
+                                    });
+                                }}
+                            >
+                                Move
+                            </Menu.Item>
 
                             {item.type === ResourceViewItemType.SPACE && (
                                 <Menu.Item

--- a/packages/frontend/src/components/common/ResourceView/types.ts
+++ b/packages/frontend/src/components/common/ResourceView/types.ts
@@ -1,6 +1,7 @@
 import {
     type ResourceViewChartItem,
     type ResourceViewDashboardItem,
+    type ResourceViewDataAppItem,
     type ResourceViewItem,
     type ResourceViewSpaceItem,
 } from '@lightdash/common';
@@ -61,7 +62,8 @@ export type ResourceViewItemActionState =
           item:
               | ResourceViewChartItem
               | ResourceViewDashboardItem
-              | ResourceViewSpaceItem;
+              | ResourceViewSpaceItem
+              | ResourceViewDataAppItem;
       }
     | {
           type: ResourceViewItemAction.SHARE;


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-316/add-apps-to-spaces

### Description:
Wire data apps into the shared move-to-space flow alongside dashboards and charts. Admin-only via manage:DataApp; space-aware write permissions will land in a later PR.