### PR TITLE
fix: buffer whole image to verify correctly

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -288,6 +288,16 @@ export class AppGenerateService extends BaseService {
                 mimeType,
             );
 
+        // Buffer the stream so the AWS SDK can compute a content hash for
+        // S3v4 signing. Streaming bodies use chunked signing which GCS's
+        // S3-compatible API doesn't handle reliably. Safe here because
+        // images are capped at 10 MB above.
+        const chunks: Buffer[] = [];
+        for await (const chunk of validatedBody) {
+            chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+        }
+        const bufferedBody = Buffer.concat(chunks);
+
         const { client: s3Client, bucket } = this.getS3Client();
         const imageId = uuidv4();
         const s3Key = AppGenerateService.imageStagingKey(appUuid, imageId);
@@ -296,8 +306,8 @@ export class AppGenerateService extends BaseService {
             new PutObjectCommand({
                 Bucket: bucket,
                 Key: s3Key,
-                Body: validatedBody,
-                ContentLength: contentLength,
+                Body: bufferedBody,
+                ContentLength: bufferedBody.length,
                 ContentType: mimeType,
             }),
         );


### PR DESCRIPTION
### Description:
Fix image uploads by putting them in memory for verification. There is a bit of a tradeoff here that we are loading 10MB at a time into memory for this, but it should be extremely transient and I dont expect much concurrency. 

  - Image uploads for data apps fail in production with SignatureDoesNotMatch (HTTP 403) from GCS, while tarball uploads work fine
  - Root cause: image uploads stream a PassThrough body to S3, which forces the AWS SDK to use chunked signing (STREAMING-AWS4-HMAC-SHA256-PAYLOAD). GCS's S3-compatible API doesn't handle this reliably. Tarball uploads
  work because they send Buffer bodies, which the SDK can hash directly for standard S3v4 signing.
  - Fix: buffer the validated image stream into a Buffer before sending to S3. Safe because images are already capped at 10MB. The buffer is short-lived (released after the PUT completes).
  - Also extracted resolveS3Credentials() from S3BaseClient into a reusable helper and wired it into AppGenerateService.getS3Client(), which was ignoring the useCredentialsFrom credential chain. This was a latent bug —
  the apps S3 client would fail in any environment that relies on credential chain resolution instead of explicit HMAC keys.
