### PR TITLE
refactor: migrate OrganizationWarehouseCredentialsService to audited ability

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -101,6 +101,7 @@ module.exports = {
             // Error on direct ability checks in fully migrated services
             files: [
                 'src/ee/services/AiAgentService/**/*.ts',
+                'src/ee/services/OrganizationWarehouseCredentialsService.ts',
                 'src/services/AnalyticsService/**/*.ts',
                 'src/services/AsyncQueryService/**/*.ts',
                 'src/services/CatalogService/**/*.ts',

--- a/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
+++ b/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
@@ -43,14 +43,16 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         this.userModel = userModel;
     }
 
-    // eslint-disable-next-line class-methods-use-this
-    private canManage(account: Account) {
+    async getAll(
+        account: Account,
+    ): Promise<OrganizationWarehouseCredentials[]> {
+        const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('User must be in an organization');
         }
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('OrganizationWarehouseCredentials', {
                     organizationUuid,
@@ -61,13 +63,6 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
                 'You do not have permission to manage organization warehouse credentials',
             );
         }
-    }
-
-    async getAll(
-        account: Account,
-    ): Promise<OrganizationWarehouseCredentials[]> {
-        this.canManage(account);
-        const organizationUuid = account.organization.organizationUuid!;
         return this.organizationWarehouseCredentialsModel.getAllByOrganizationUuid(
             organizationUuid,
         );
@@ -81,13 +76,14 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     async getAllSummaries(
         account: Account,
     ): Promise<OrganizationWarehouseCredentialsSummary[]> {
+        const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = account.organization;
         if (!organizationUuid) {
             throw new ForbiddenError('User must be in an organization');
         }
 
         if (
-            account.user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('OrganizationWarehouseCredentials', {
                     organizationUuid,
@@ -118,8 +114,23 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         account: Account,
         credentialsUuid: string,
     ): Promise<OrganizationWarehouseCredentials> {
-        this.canManage(account);
-        const organizationUuid = account.organization.organizationUuid!;
+        const auditedAbility = this.createAuditedAbility(account);
+        const { organizationUuid } = account.organization;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User must be in an organization');
+        }
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('OrganizationWarehouseCredentials', {
+                    organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage organization warehouse credentials',
+            );
+        }
 
         const credentials =
             await this.organizationWarehouseCredentialsModel.getByUuid(
@@ -174,8 +185,23 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         account: Account,
         data: CreateOrganizationWarehouseCredentials,
     ): Promise<OrganizationWarehouseCredentials> {
-        this.canManage(account);
-        const organizationUuid = account.organization.organizationUuid!;
+        const auditedAbility = this.createAuditedAbility(account);
+        const { organizationUuid } = account.organization;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User must be in an organization');
+        }
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('OrganizationWarehouseCredentials', {
+                    organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage organization warehouse credentials',
+            );
+        }
         const userUuid = account.user.id;
         const credentialsWithTokens = await this.updateCredentialTokens(
             userUuid,
@@ -207,8 +233,23 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         credentialsUuid: string,
         data: UpdateOrganizationWarehouseCredentials,
     ): Promise<OrganizationWarehouseCredentials> {
-        this.canManage(account);
-        const organizationUuid = account.organization.organizationUuid!;
+        const auditedAbility = this.createAuditedAbility(account);
+        const { organizationUuid } = account.organization;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User must be in an organization');
+        }
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('OrganizationWarehouseCredentials', {
+                    organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage organization warehouse credentials',
+            );
+        }
         const userUuid = account.user.id;
 
         // Verify ownership before update
@@ -249,8 +290,23 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async delete(account: Account, credentialsUuid: string): Promise<void> {
-        this.canManage(account);
-        const organizationUuid = account.organization.organizationUuid!;
+        const auditedAbility = this.createAuditedAbility(account);
+        const { organizationUuid } = account.organization;
+        if (!organizationUuid) {
+            throw new ForbiddenError('User must be in an organization');
+        }
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('OrganizationWarehouseCredentials', {
+                    organizationUuid,
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                'You do not have permission to manage organization warehouse credentials',
+            );
+        }
         const userUuid = account.user.id;
 
         // Verify ownership before delete

--- a/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
+++ b/packages/backend/src/ee/services/OrganizationWarehouseCredentialsService.ts
@@ -43,9 +43,7 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         this.userModel = userModel;
     }
 
-    async getAll(
-        account: Account,
-    ): Promise<OrganizationWarehouseCredentials[]> {
+    private canManage(account: Account) {
         const auditedAbility = this.createAuditedAbility(account);
         const { organizationUuid } = account.organization;
         if (!organizationUuid) {
@@ -63,6 +61,13 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
                 'You do not have permission to manage organization warehouse credentials',
             );
         }
+    }
+
+    async getAll(
+        account: Account,
+    ): Promise<OrganizationWarehouseCredentials[]> {
+        this.canManage(account);
+        const organizationUuid = account.organization.organizationUuid!;
         return this.organizationWarehouseCredentialsModel.getAllByOrganizationUuid(
             organizationUuid,
         );
@@ -114,23 +119,8 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         account: Account,
         credentialsUuid: string,
     ): Promise<OrganizationWarehouseCredentials> {
-        const auditedAbility = this.createAuditedAbility(account);
-        const { organizationUuid } = account.organization;
-        if (!organizationUuid) {
-            throw new ForbiddenError('User must be in an organization');
-        }
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('OrganizationWarehouseCredentials', {
-                    organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'You do not have permission to manage organization warehouse credentials',
-            );
-        }
+        this.canManage(account);
+        const organizationUuid = account.organization.organizationUuid!;
 
         const credentials =
             await this.organizationWarehouseCredentialsModel.getByUuid(
@@ -185,23 +175,8 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         account: Account,
         data: CreateOrganizationWarehouseCredentials,
     ): Promise<OrganizationWarehouseCredentials> {
-        const auditedAbility = this.createAuditedAbility(account);
-        const { organizationUuid } = account.organization;
-        if (!organizationUuid) {
-            throw new ForbiddenError('User must be in an organization');
-        }
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('OrganizationWarehouseCredentials', {
-                    organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'You do not have permission to manage organization warehouse credentials',
-            );
-        }
+        this.canManage(account);
+        const organizationUuid = account.organization.organizationUuid!;
         const userUuid = account.user.id;
         const credentialsWithTokens = await this.updateCredentialTokens(
             userUuid,
@@ -233,23 +208,8 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
         credentialsUuid: string,
         data: UpdateOrganizationWarehouseCredentials,
     ): Promise<OrganizationWarehouseCredentials> {
-        const auditedAbility = this.createAuditedAbility(account);
-        const { organizationUuid } = account.organization;
-        if (!organizationUuid) {
-            throw new ForbiddenError('User must be in an organization');
-        }
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('OrganizationWarehouseCredentials', {
-                    organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'You do not have permission to manage organization warehouse credentials',
-            );
-        }
+        this.canManage(account);
+        const organizationUuid = account.organization.organizationUuid!;
         const userUuid = account.user.id;
 
         // Verify ownership before update
@@ -290,23 +250,8 @@ export class OrganizationWarehouseCredentialsService extends BaseService {
     }
 
     async delete(account: Account, credentialsUuid: string): Promise<void> {
-        const auditedAbility = this.createAuditedAbility(account);
-        const { organizationUuid } = account.organization;
-        if (!organizationUuid) {
-            throw new ForbiddenError('User must be in an organization');
-        }
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('OrganizationWarehouseCredentials', {
-                    organizationUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'You do not have permission to manage organization warehouse credentials',
-            );
-        }
+        this.canManage(account);
+        const organizationUuid = account.organization.organizationUuid!;
         const userUuid = account.user.id;
 
         // Verify ownership before delete


### PR DESCRIPTION
## Summary
- Replaced direct `account.user.ability.cannot()` calls with `auditedAbility.cannot()` using `this.createAuditedAbility(account)` in `OrganizationWarehouseCredentialsService`
- Two call sites changed: `canManage()` (manage check) and `getAllSummaries()` (view check)
- Added `OrganizationWarehouseCredentialsService.ts` to the `no-direct-ability-check: error` list in `.eslintrc.js`

## Test plan
- [x] `pnpm -F backend lint` — no new errors
- [x] `pnpm -F backend typecheck` — no new errors
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)