### PR TITLE
feat(echarts): shift time-axis values to project timezone wall-clock

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -4621,6 +4621,7 @@ export class AsyncQueryService extends ProjectService {
             limit: 500,
             tableCalculations: [],
             additionalMetrics: [],
+            timezone: metricQuery.timezone,
         };
 
         const underlyingDataMetricQueryWithLimit = applyMetricQueryLimit(

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -158,6 +158,7 @@ export function formatTimestamp(
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,
     convertToUTC: boolean = false,
     timezone?: string,
+    displayTimezone?: string,
 ): string {
     let momentDate;
     if (timezone) {
@@ -170,6 +171,19 @@ export function formatTimestamp(
 
     if (!momentDate.isValid()) {
         return 'NaT';
+    }
+
+    // Chart hooks that pre-shift values into project-tz-as-UTC for ECharts
+    // pass `timezone: undefined` (so we don't double-convert) but still want
+    // the offset annotation to reflect the project tz, not `(+00:00)`.
+    // `displayTimezone` overrides the `(Z)` token with the named tz's offset.
+    if (!timezone && displayTimezone) {
+        const offset = moment.tz(value, displayTimezone).format('Z');
+        const formatStr = getTimeFormat(timeInterval).replace(
+            '(Z)',
+            `[(${offset})]`,
+        );
+        return momentDate.format(formatStr);
     }
 
     return momentDate.format(getTimeFormat(timeInterval));
@@ -789,6 +803,7 @@ export function formatItemValue(
     convertToUTC?: boolean,
     parameters?: Record<string, unknown>,
     timezone?: string,
+    displayTimezone?: string,
 ): string {
     if (value === null) return '∅';
     if (value === undefined) return '-';
@@ -867,6 +882,7 @@ export function formatItemValue(
                               isDimension(item) ? item.timeInterval : undefined,
                               convertToUTC,
                               timezone,
+                              displayTimezone,
                           )
                         : 'NaT';
                 case MetricType.MAX:
@@ -877,6 +893,7 @@ export function formatItemValue(
                             isDimension(item) ? item.timeInterval : undefined,
                             convertToUTC,
                             timezone,
+                            displayTimezone,
                         );
                     }
                     break;

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -174,12 +174,10 @@ export function formatTimestamp(
     }
 
     if (!timezone && displayTimezone) {
-        const offset = moment.tz(value, displayTimezone).format('Z');
-        const formatStr = getTimeFormat(timeInterval).replace(
-            '(Z)',
-            `[(${offset})]`,
-        );
-        return momentDate.format(formatStr);
+        const offsetMinutes = moment.tz(value, displayTimezone).utcOffset();
+        return momentDate
+            .utcOffset(offsetMinutes, true)
+            .format(getTimeFormat(timeInterval));
     }
 
     return momentDate.format(getTimeFormat(timeInterval));

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -173,10 +173,6 @@ export function formatTimestamp(
         return 'NaT';
     }
 
-    // Chart hooks that pre-shift values into project-tz-as-UTC for ECharts
-    // pass `timezone: undefined` (so we don't double-convert) but still want
-    // the offset annotation to reflect the project tz, not `(+00:00)`.
-    // `displayTimezone` overrides the `(Z)` token with the named tz's offset.
     if (!timezone && displayTimezone) {
         const offset = moment.tz(value, displayTimezone).format('Z');
         const formatStr = getTimeFormat(timeInterval).replace(

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -153,6 +153,9 @@ export function formatDate(
     return momentDate.format(getDateFormat(timeInterval));
 }
 
+// `displayTimezone`: when `value` is already wall-clock-shifted (e.g. echarts
+// axis under the synthetic-dim shift), swaps the (Z) suffix to that tz's
+// offset without re-converting the value. Ignored if `timezone` is set.
 export function formatTimestamp(
     value: MomentInput,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -153,9 +153,7 @@ export function formatDate(
     return momentDate.format(getDateFormat(timeInterval));
 }
 
-// `displayTimezone`: when `value` is already wall-clock-shifted (e.g. echarts
-// axis under the synthetic-dim shift), swaps the (Z) suffix to that tz's
-// offset without re-converting the value. Ignored if `timezone` is set.
+// displayTimezone: relabels a pre-shifted value with that tz's offset suffix without re-converting.
 export function formatTimestamp(
     value: MomentInput,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -153,7 +153,9 @@ export function formatDate(
     return momentDate.format(getDateFormat(timeInterval));
 }
 
-// displayTimezone: relabels a pre-shifted value with that tz's offset suffix without re-converting.
+// `timezone` converts the UTC value into that zone. `displayTimezone` assumes the
+// value is already a wall-clock ms in that zone (pre-shifted) and only appends the
+// offset suffix. Pass at most one.
 export function formatTimestamp(
     value: MomentInput,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -153,9 +153,9 @@ export function formatDate(
     return momentDate.format(getDateFormat(timeInterval));
 }
 
-// `timezone` converts the UTC value into that zone. `displayTimezone` assumes the
-// value is already a wall-clock ms in that zone (pre-shifted) and only appends the
-// offset suffix. Pass at most one.
+// Pass `timezone` to convert the UTC value into that zone. Pass `displayTimezone`
+// when the value is already wall-clock in that zone — it only appends the offset
+// suffix. Pass at most one.
 export function formatTimestamp(
     value: MomentInput,
     timeInterval: TimeFrames | undefined = TimeFrames.MILLISECOND,

--- a/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
+++ b/packages/common/src/visualizations/helpers/getCartesianAxisFormatterConfig.ts
@@ -28,6 +28,7 @@ export const getCartesianAxisFormatterConfig = ({
     show,
     parameters,
     timezone,
+    displayTimezone,
 }: {
     axisItem: ItemsMap[string] | undefined;
     longestLabelWidth?: number;
@@ -36,6 +37,7 @@ export const getCartesianAxisFormatterConfig = ({
     show?: boolean;
     parameters?: Record<string, unknown>;
     timezone?: string;
+    displayTimezone?: string;
 }) => {
     // Remove axis labels, lines, and ticks if the axis is not shown
     // This is done to prevent the grid from disappearing when the axis is not shown
@@ -74,7 +76,14 @@ export const getCartesianAxisFormatterConfig = ({
     if (axisItem && (hasFormattingConfig || axisMinInterval)) {
         axisConfig.axisLabel = {
             formatter: (value: AnyType) =>
-                formatItemValue(axisItem, value, true, parameters, timezone),
+                formatItemValue(
+                    axisItem,
+                    value,
+                    true,
+                    parameters,
+                    timezone,
+                    displayTimezone,
+                ),
         };
         axisConfig.axisPointer = {
             label: {
@@ -89,6 +98,7 @@ export const getCartesianAxisFormatterConfig = ({
                               true,
                               parameters,
                               timezone,
+                              displayTimezone,
                           )
                         : undefined,
             },
@@ -115,6 +125,7 @@ export const getCartesianAxisFormatterConfig = ({
                               true,
                               parameters,
                               timezone,
+                              displayTimezone,
                           )
                         : undefined,
             },

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -350,31 +350,54 @@ const getHeader = (
 ): string => {
     const firstParam = params[0];
 
-    // When a project timezone is supplied, skip echarts' axisValueLabel
-    // (which uses useUTC:true semantics) and format the raw axis value
-    // ourselves so the header matches project-TZ display.
+    // When a project timezone is supplied (non-shift), skip echarts'
+    // axisValueLabel (which uses useUTC:true semantics) and format the raw
+    // UTC value ourselves so the header matches project-TZ display. Walk
+    // axisValue → value[0] → dataset row to cover stack100 per-item fires
+    // where axisValue may be undefined.
     const rawAxisValue = firstParam?.axisValue;
-    if (timezone && itemsMap && xFieldId && rawAxisValue != null) {
-        return getFormattedValue(
-            rawAxisValue,
-            xFieldId,
-            itemsMap,
-            true,
-            undefined,
-            undefined,
-            timezone,
-        );
+    if (timezone && itemsMap && xFieldId) {
+        const formatViaTz = (v: unknown) =>
+            getFormattedValue(
+                v,
+                xFieldId,
+                itemsMap,
+                true,
+                undefined,
+                undefined,
+                timezone,
+            );
+        if (rawAxisValue != null) return formatViaTz(rawAxisValue);
+        if (Array.isArray(firstParam?.value) && firstParam.value[0] != null) {
+            return formatViaTz(firstParam.value[0]);
+        }
+        const datasetValue =
+            firstParam?.value &&
+            typeof firstParam.value === 'object' &&
+            !Array.isArray(firstParam.value)
+                ? (firstParam.value as Record<string, unknown>)[xFieldId]
+                : undefined;
+        if (datasetValue != null) return formatViaTz(datasetValue);
     }
 
-    // Shift case (axis tz swapped to displayTimezone): axis-trigger tooltips
-    // carry a pre-shifted wall-clock ms that displayTimezone's shift-aware
-    // formatter branch relabels; item-trigger tooltips (e.g. scatter) have
-    // axisValue=undefined, so read the pristine UTC from the dataset row and
-    // format through displayTimezone as the true tz.
+    // Shift case: axisValue / value[0] are pre-shifted ms (displayTimezone's
+    // shift-aware branch relabels); dataset row[xFieldId] is pristine UTC.
     if (displayTimezone && itemsMap && xFieldId) {
         if (rawAxisValue != null) {
             return getFormattedValue(
                 rawAxisValue,
+                xFieldId,
+                itemsMap,
+                true,
+                undefined,
+                undefined,
+                undefined,
+                displayTimezone,
+            );
+        }
+        if (Array.isArray(firstParam?.value) && firstParam.value[0] != null) {
+            return getFormattedValue(
+                firstParam.value[0],
                 xFieldId,
                 itemsMap,
                 true,
@@ -566,12 +589,12 @@ export function createStack100TooltipFormatter(
 
         let header: string;
         const firstParam = params[0];
-        const rawDatasetValue = (
-            firstParam?.value as Record<string, unknown> | undefined
-        )?.[xAxisField];
 
         if (xAxisDateFormat) {
             // Format from the raw data value to avoid timezone double-parsing.
+            const rawDatasetValue = (
+                firstParam?.value as Record<string, unknown> | undefined
+            )?.[xAxisField];
             const rawValue = rawDatasetValue ?? firstParam?.axisValue;
             header =
                 rawValue != null
@@ -586,24 +609,6 @@ export function createStack100TooltipFormatter(
                           timezone,
                           displayTimezone,
                       );
-        } else if (
-            (timezone || displayTimezone) &&
-            itemsMap &&
-            rawDatasetValue != null
-        ) {
-            // Per-item tooltip fires can have axisValue=undefined. Read the
-            // raw UTC value straight from the dataset row and format honestly
-            // through the tz (treat displayTimezone as the true tz here since
-            // we're starting from unshifted data).
-            header = getFormattedValue(
-                rawDatasetValue,
-                xAxisField,
-                itemsMap,
-                true,
-                undefined,
-                undefined,
-                timezone ?? displayTimezone,
-            );
         } else {
             header = getHeader(
                 params,

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -346,6 +346,7 @@ const getHeader = (
     itemsMap?: ItemsMap,
     xFieldId?: string,
     timezone?: string,
+    displayTimezone?: string,
 ): string => {
     const firstParam = params[0];
 
@@ -378,7 +379,16 @@ const getHeader = (
     // This handles cases where ECharts couldn't format the value properly
     if (rawAxisValue !== undefined && rawAxisValue !== null) {
         if (itemsMap && xFieldId) {
-            return getFormattedValue(rawAxisValue, xFieldId, itemsMap, true);
+            return getFormattedValue(
+                rawAxisValue,
+                xFieldId,
+                itemsMap,
+                true,
+                undefined,
+                undefined,
+                undefined,
+                displayTimezone,
+            );
         }
         return String(rawAxisValue);
     }
@@ -398,6 +408,7 @@ const getHeader = (
                     undefined,
                     undefined,
                     timezone,
+                    displayTimezone,
                 );
             }
             return String(xValue);
@@ -868,6 +879,7 @@ export const buildCartesianTooltipFormatter =
         parameters,
         rows,
         timezone,
+        displayTimezone,
     }: {
         itemsMap?: ItemsMap;
         stackValue: string | boolean | undefined;
@@ -883,6 +895,7 @@ export const buildCartesianTooltipFormatter =
         parameters?: ParametersValuesMap;
         rows?: (ResultRow | Record<string, unknown>)[];
         timezone?: string;
+        displayTimezone?: string;
     }): TooltipComponentFormatterCallback<
         TooltipFormatterParams | TooltipFormatterParams[]
     > =>
@@ -911,7 +924,13 @@ export const buildCartesianTooltipFormatter =
             )(params as TooltipParam[]);
         }
 
-        const header = getHeader(params, itemsMap, xFieldId, timezone);
+        const header = getHeader(
+            params,
+            itemsMap,
+            xFieldId,
+            timezone,
+            displayTimezone,
+        );
 
         const sortedParams = sortTooltipParams(
             params,
@@ -1247,6 +1266,8 @@ export const buildCartesianTooltipFormatter =
                             undefined,
                             pivotValuesColumnsMap,
                             parameters,
+                            timezone,
+                            displayTimezone,
                         );
                         tooltipHtml = tooltipHtml.replace(field, formatted);
                     } else {
@@ -1315,6 +1336,8 @@ export const buildCartesianTooltipFormatter =
                         undefined,
                         pivotValuesColumnsMap,
                         parameters,
+                        timezone,
+                        displayTimezone,
                     );
                     tooltipHtml = tooltipHtml.replace(field, formatted);
                 });
@@ -1364,6 +1387,7 @@ export const buildCartesianTooltipFormatter =
                               pivotValuesColumnsMap,
                               parameters,
                               timezone,
+                              displayTimezone,
                           )
                         : header;
                 return `${formatTooltipHeader(

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -349,11 +349,11 @@ const getHeader = (
     displayTimezone?: string,
 ): string => {
     const firstParam = params[0];
-    const rawAxisValue = firstParam?.axisValue;
 
     // When a project timezone is supplied, skip echarts' axisValueLabel
     // (which uses useUTC:true semantics) and format the raw axis value
     // ourselves so the header matches project-TZ display.
+    const rawAxisValue = firstParam?.axisValue;
     if (timezone && itemsMap && xFieldId && rawAxisValue != null) {
         return getFormattedValue(
             rawAxisValue,
@@ -366,47 +366,41 @@ const getHeader = (
         );
     }
 
-    // Shift case: axisValue is a pre-shifted wall-clock ms. Format it through
-    // our own formatter so the header shows the date, not the raw number.
-    if (displayTimezone && itemsMap && xFieldId && rawAxisValue != null) {
-        return getFormattedValue(
-            rawAxisValue,
-            xFieldId,
-            itemsMap,
-            true,
-            undefined,
-            undefined,
-            undefined,
-            displayTimezone,
-        );
-    }
-
-    // Item-trigger tooltips (e.g. scatter) fire per-point with axisValue=undefined.
-    // Read the raw UTC value straight from the dataset row and format through
-    // the tz (shifted path: treat displayTimezone as the true tz since we're
-    // starting from unshifted data).
-    const rawDatasetValue =
-        xFieldId &&
-        firstParam?.value &&
-        typeof firstParam.value === 'object' &&
-        !Array.isArray(firstParam.value)
-            ? (firstParam.value as Record<string, unknown>)[xFieldId]
-            : undefined;
-    if (
-        (timezone || displayTimezone) &&
-        itemsMap &&
-        xFieldId &&
-        rawDatasetValue != null
-    ) {
-        return getFormattedValue(
-            rawDatasetValue,
-            xFieldId,
-            itemsMap,
-            true,
-            undefined,
-            undefined,
-            timezone ?? displayTimezone,
-        );
+    // Shift case (axis tz swapped to displayTimezone): axis-trigger tooltips
+    // carry a pre-shifted wall-clock ms that displayTimezone's shift-aware
+    // formatter branch relabels; item-trigger tooltips (e.g. scatter) have
+    // axisValue=undefined, so read the pristine UTC from the dataset row and
+    // format through displayTimezone as the true tz.
+    if (displayTimezone && itemsMap && xFieldId) {
+        if (rawAxisValue != null) {
+            return getFormattedValue(
+                rawAxisValue,
+                xFieldId,
+                itemsMap,
+                true,
+                undefined,
+                undefined,
+                undefined,
+                displayTimezone,
+            );
+        }
+        const datasetValue =
+            firstParam?.value &&
+            typeof firstParam.value === 'object' &&
+            !Array.isArray(firstParam.value)
+                ? (firstParam.value as Record<string, unknown>)[xFieldId]
+                : undefined;
+        if (datasetValue != null) {
+            return getFormattedValue(
+                datasetValue,
+                xFieldId,
+                itemsMap,
+                true,
+                undefined,
+                undefined,
+                displayTimezone,
+            );
+        }
     }
 
     // First try the standard axisValueLabel or name
@@ -422,16 +416,7 @@ const getHeader = (
     // This handles cases where ECharts couldn't format the value properly
     if (rawAxisValue !== undefined && rawAxisValue !== null) {
         if (itemsMap && xFieldId) {
-            return getFormattedValue(
-                rawAxisValue,
-                xFieldId,
-                itemsMap,
-                true,
-                undefined,
-                undefined,
-                undefined,
-                displayTimezone,
-            );
+            return getFormattedValue(rawAxisValue, xFieldId, itemsMap, true);
         }
         return String(rawAxisValue);
     }
@@ -451,7 +436,6 @@ const getHeader = (
                     undefined,
                     undefined,
                     timezone,
-                    displayTimezone,
                 );
             }
             return String(xValue);

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -350,11 +350,9 @@ const getHeader = (
 ): string => {
     const firstParam = params[0];
 
-    // When a project timezone is supplied (non-shift), skip echarts'
-    // axisValueLabel (which uses useUTC:true semantics) and format the raw
-    // UTC value ourselves so the header matches project-TZ display. Walk
-    // axisValue → value[0] → dataset row to cover stack100 per-item fires
-    // where axisValue may be undefined.
+    // Format the raw UTC value through the project timezone. axisValue is
+    // undefined on some stack100 tooltip fires, so fall back to value[0] and
+    // then to the dataset row.
     const rawAxisValue = firstParam?.axisValue;
     if (timezone && itemsMap && xFieldId) {
         const formatViaTz = (v: unknown) =>
@@ -380,8 +378,10 @@ const getHeader = (
         if (datasetValue != null) return formatViaTz(datasetValue);
     }
 
-    // Shift case: axisValue / value[0] are pre-shifted ms (displayTimezone's
-    // shift-aware branch relabels); dataset row[xFieldId] is pristine UTC.
+    // When the x-axis values were shifted to project-timezone wall-clock,
+    // axisValue and value[0] are already wall-clock (only need the offset
+    // suffix), while the dataset row still holds the original UTC value
+    // (needs the full conversion).
     if (displayTimezone && itemsMap && xFieldId) {
         if (rawAxisValue != null) {
             return getFormattedValue(

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -350,10 +350,19 @@ const getHeader = (
 ): string => {
     const firstParam = params[0];
 
+    // Prefer raw row value: true UTC even when the axis uses a shifted synthetic dim.
+    const dataXValue =
+        xFieldId &&
+        firstParam?.data &&
+        typeof firstParam.data === 'object' &&
+        !Array.isArray(firstParam.data)
+            ? (firstParam.data as Record<string, unknown>)[xFieldId]
+            : undefined;
+    const rawAxisValue = dataXValue ?? firstParam?.axisValue;
+
     // When a project timezone is supplied, skip echarts' axisValueLabel
     // (which uses useUTC:true semantics) and format the raw axis value
     // ourselves so the header matches project-TZ display.
-    const rawAxisValue = firstParam?.axisValue;
     if (timezone && itemsMap && xFieldId && rawAxisValue != null) {
         return getFormattedValue(
             rawAxisValue,

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -349,16 +349,7 @@ const getHeader = (
     displayTimezone?: string,
 ): string => {
     const firstParam = params[0];
-
-    // Prefer raw row value: true UTC even when the axis uses a shifted synthetic dim.
-    const dataXValue =
-        xFieldId &&
-        firstParam?.data &&
-        typeof firstParam.data === 'object' &&
-        !Array.isArray(firstParam.data)
-            ? (firstParam.data as Record<string, unknown>)[xFieldId]
-            : undefined;
-    const rawAxisValue = dataXValue ?? firstParam?.axisValue;
+    const rawAxisValue = firstParam?.axisValue;
 
     // When a project timezone is supplied, skip echarts' axisValueLabel
     // (which uses useUTC:true semantics) and format the raw axis value
@@ -372,6 +363,21 @@ const getHeader = (
             undefined,
             undefined,
             timezone,
+        );
+    }
+
+    // Shift case: axisValue is a pre-shifted wall-clock ms. Format it through
+    // our own formatter so the header shows the date, not the raw number.
+    if (displayTimezone && itemsMap && xFieldId && rawAxisValue != null) {
+        return getFormattedValue(
+            rawAxisValue,
+            xFieldId,
+            itemsMap,
+            true,
+            undefined,
+            undefined,
+            undefined,
+            displayTimezone,
         );
     }
 
@@ -540,27 +546,60 @@ export function createStack100TooltipFormatter(
     xAxisField: string,
     itemsMap?: ItemsMap,
     xAxisDateFormat?: string,
+    timezone?: string,
+    displayTimezone?: string,
 ) {
     return (params: TooltipParams) => {
         if (!Array.isArray(params)) return '';
 
         let header: string;
+        const firstParam = params[0];
+        const rawDatasetValue = (
+            firstParam?.value as Record<string, unknown> | undefined
+        )?.[xAxisField];
+
         if (xAxisDateFormat) {
             // Format from the raw data value to avoid timezone double-parsing.
-            const firstParam = params[0];
-            const rawValue =
-                (firstParam?.value as Record<string, unknown> | undefined)?.[
-                    xAxisField
-                ] ?? firstParam?.axisValue;
+            const rawValue = rawDatasetValue ?? firstParam?.axisValue;
             header =
                 rawValue != null
                     ? formatDateWithPattern(
                           rawValue as string | number,
                           xAxisDateFormat,
                       )
-                    : getHeader(params, itemsMap, xAxisField);
+                    : getHeader(
+                          params,
+                          itemsMap,
+                          xAxisField,
+                          timezone,
+                          displayTimezone,
+                      );
+        } else if (
+            (timezone || displayTimezone) &&
+            itemsMap &&
+            rawDatasetValue != null
+        ) {
+            // Per-item tooltip fires can have axisValue=undefined. Read the
+            // raw UTC value straight from the dataset row and format honestly
+            // through the tz (treat displayTimezone as the true tz here since
+            // we're starting from unshifted data).
+            header = getFormattedValue(
+                rawDatasetValue,
+                xAxisField,
+                itemsMap,
+                true,
+                undefined,
+                undefined,
+                timezone ?? displayTimezone,
+            );
         } else {
-            header = getHeader(params, itemsMap, xAxisField);
+            header = getHeader(
+                params,
+                itemsMap,
+                xAxisField,
+                timezone,
+                displayTimezone,
+            );
         }
 
         const rowsHtml = params
@@ -930,6 +969,9 @@ export const buildCartesianTooltipFormatter =
                 },
                 xFieldId,
                 itemsMap,
+                undefined,
+                timezone,
+                displayTimezone,
             )(params as TooltipParam[]);
         }
 

--- a/packages/common/src/visualizations/helpers/tooltipFormatter.ts
+++ b/packages/common/src/visualizations/helpers/tooltipFormatter.ts
@@ -381,6 +381,34 @@ const getHeader = (
         );
     }
 
+    // Item-trigger tooltips (e.g. scatter) fire per-point with axisValue=undefined.
+    // Read the raw UTC value straight from the dataset row and format through
+    // the tz (shifted path: treat displayTimezone as the true tz since we're
+    // starting from unshifted data).
+    const rawDatasetValue =
+        xFieldId &&
+        firstParam?.value &&
+        typeof firstParam.value === 'object' &&
+        !Array.isArray(firstParam.value)
+            ? (firstParam.value as Record<string, unknown>)[xFieldId]
+            : undefined;
+    if (
+        (timezone || displayTimezone) &&
+        itemsMap &&
+        xFieldId &&
+        rawDatasetValue != null
+    ) {
+        return getFormattedValue(
+            rawDatasetValue,
+            xFieldId,
+            itemsMap,
+            true,
+            undefined,
+            undefined,
+            timezone ?? displayTimezone,
+        );
+    }
+
     // First try the standard axisValueLabel or name
     const standardHeader = firstParam?.axisValueLabel ?? firstParam?.name;
 

--- a/packages/common/src/visualizations/helpers/valueFormatter.ts
+++ b/packages/common/src/visualizations/helpers/valueFormatter.ts
@@ -12,10 +12,18 @@ export const getFormattedValue = (
     pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
     parameters?: ParametersValuesMap,
     timezone?: string,
+    displayTimezone?: string,
 ): string => {
     const pivotValuesColumn = pivotValuesColumnsMap?.[key];
     const item = itemsMap[pivotValuesColumn?.referenceField ?? key];
-    return formatItemValue(item, value, convertToUTC, parameters, timezone);
+    return formatItemValue(
+        item,
+        value,
+        convertToUTC,
+        parameters,
+        timezone,
+        displayTimezone,
+    );
 };
 
 export const valueFormatter =
@@ -25,6 +33,7 @@ export const valueFormatter =
         pivotValuesColumnsMap?: Record<string, PivotValuesColumn> | null,
         parameters?: ParametersValuesMap,
         timezone?: string,
+        displayTimezone?: string,
     ) =>
     (rawValue: AnyType) =>
         getFormattedValue(
@@ -35,4 +44,5 @@ export const valueFormatter =
             pivotValuesColumnsMap,
             parameters,
             timezone,
+            displayTimezone,
         );

--- a/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
+++ b/packages/frontend/src/components/VisualizationConfigs/ChartConfigPanel/Series/GroupedSeriesConfiguration.tsx
@@ -23,6 +23,7 @@ import { Box, Checkbox, Group, Select, Stack, Switch } from '@mantine/core';
 import React, { useCallback, type FC } from 'react';
 import { createPortal } from 'react-dom';
 import type useCartesianChartConfig from '../../../../hooks/cartesianChartConfig/useCartesianChartConfig';
+import { useVisualizationContext } from '../../../LightdashVisualization/useVisualizationContext';
 import { Config } from '../../common/Config';
 import { GrabIcon } from '../../common/GrabIcon';
 import { ChartTypeSelect } from './ChartTypeSelect';
@@ -51,9 +52,10 @@ const getFormatterValue = (
     value: any,
     key: string,
     items: Array<Field | TableCalculation | CustomDimension>,
+    timezone?: string,
 ) => {
     const item = items.find((i) => getItemId(i) === key);
-    return formatItemValue(item, value, true);
+    return formatItemValue(item, value, true, undefined, timezone);
 };
 
 type DraggablePortalHandlerProps = {
@@ -94,6 +96,8 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
     updateSeries,
     series,
 }) => {
+    const { resolvedTimezone } = useVisualizationContext();
+
     const [openSeriesId, setOpenSeriesId] = React.useState<
         string | undefined
     >();
@@ -308,6 +312,7 @@ const GroupedSeriesConfiguration: FC<GroupedSeriesConfigurationProps> = ({
                                                             value,
                                                             field,
                                                             items,
+                                                            resolvedTimezone,
                                                         );
                                                     return acc
                                                         ? `${acc} - ${formattedValue}`

--- a/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.test.ts
@@ -1,0 +1,515 @@
+import {
+    DimensionType,
+    FieldType,
+    TimeFrames,
+    type CartesianChart,
+    type ItemsMap,
+} from '@lightdash/common';
+import { describe, expect, test } from 'vitest';
+import {
+    applyTimezoneShiftToEchartsOptions,
+    resolveAxisTimezone,
+    type EchartsOptionsShape,
+    type TimezoneShiftedField,
+} from './timezoneShift';
+
+// Asia/Tokyo is UTC+9 year-round with no DST, so offsets are stable.
+const TZ = 'Asia/Tokyo';
+const TZ_OFFSET_MS = 9 * 60 * 60 * 1000;
+
+// 2024-01-15T12:00:00Z
+const UTC_MS = 1705320000000;
+const SHIFTED_MS = UTC_MS + TZ_OFFSET_MS;
+
+const makeTimeDimension = (
+    name: string,
+    timeInterval: TimeFrames | undefined,
+): ItemsMap[string] =>
+    ({
+        compiledSql: '',
+        tablesReferences: [],
+        fieldType: FieldType.DIMENSION,
+        hidden: false,
+        label: name,
+        name,
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '',
+        type: DimensionType.TIMESTAMP,
+        timeInterval,
+    }) as ItemsMap[string];
+
+const makeMetric = (name: string): ItemsMap[string] =>
+    ({
+        compiledSql: '',
+        tablesReferences: [],
+        fieldType: FieldType.METRIC,
+        hidden: false,
+        label: name,
+        name,
+        table: 'orders',
+        tableLabel: 'Orders',
+        sql: '',
+        type: DimensionType.NUMBER,
+    }) as ItemsMap[string];
+
+const makeCartesian = (overrides: {
+    xField?: string;
+    yField?: string[];
+    flipAxes?: boolean;
+}): CartesianChart => ({
+    layout: {
+        xField: overrides.xField,
+        yField: overrides.yField,
+        flipAxes: overrides.flipAxes,
+    },
+    eChartsConfig: {},
+});
+
+describe('resolveAxisTimezone', () => {
+    const itemsMap: ItemsMap = {
+        orders_created_day: makeTimeDimension(
+            'orders_created_day',
+            TimeFrames.DAY,
+        ),
+        orders_created_month: makeTimeDimension(
+            'orders_created_month',
+            TimeFrames.MONTH,
+        ),
+        orders_created_no_interval: makeTimeDimension(
+            'orders_created_no_interval',
+            undefined,
+        ),
+        orders_total: makeMetric('orders_total'),
+    };
+
+    test('no shift when resolvedTimezone is undefined', () => {
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_day',
+            }),
+            itemsMap,
+            resolvedTimezone: undefined,
+        });
+        expect(result).toEqual({
+            shiftedField: undefined,
+            axisTimezone: undefined,
+            axisDisplayTimezone: undefined,
+        });
+    });
+
+    test('no shift when resolvedTimezone is UTC', () => {
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_day',
+            }),
+            itemsMap,
+            resolvedTimezone: 'UTC',
+        });
+        expect(result.shiftedField).toBeUndefined();
+        expect(result.axisTimezone).toBe('UTC');
+        expect(result.axisDisplayTimezone).toBeUndefined();
+    });
+
+    test('no shift when validCartesianConfig is missing', () => {
+        const result = resolveAxisTimezone({
+            validCartesianConfig: undefined,
+            itemsMap,
+            resolvedTimezone: TZ,
+        });
+        expect(result.shiftedField).toBeUndefined();
+        expect(result.axisTimezone).toBe(TZ);
+    });
+
+    test('no shift when itemsMap is missing', () => {
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_day',
+            }),
+            itemsMap: undefined,
+            resolvedTimezone: TZ,
+        });
+        expect(result.shiftedField).toBeUndefined();
+    });
+
+    test('no shift when the axis field is not a dimension', () => {
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({ xField: 'orders_total' }),
+            itemsMap,
+            resolvedTimezone: TZ,
+        });
+        expect(result.shiftedField).toBeUndefined();
+    });
+
+    test('no shift when the dimension has no timeInterval', () => {
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({
+                xField: 'orders_created_no_interval',
+            }),
+            itemsMap,
+            resolvedTimezone: TZ,
+        });
+        expect(result.shiftedField).toBeUndefined();
+    });
+
+    test.each([
+        TimeFrames.WEEK,
+        TimeFrames.MONTH,
+        TimeFrames.QUARTER,
+        TimeFrames.YEAR,
+    ])('no shift for category-axis interval %s', (interval) => {
+        const fieldId = `orders_created_${interval.toLowerCase()}`;
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({ xField: fieldId }),
+            itemsMap: {
+                ...itemsMap,
+                [fieldId]: makeTimeDimension(fieldId, interval),
+            },
+            resolvedTimezone: TZ,
+        });
+        expect(result.shiftedField).toBeUndefined();
+        expect(result.axisTimezone).toBe(TZ);
+    });
+
+    test.each([
+        TimeFrames.SECOND,
+        TimeFrames.MINUTE,
+        TimeFrames.HOUR,
+        TimeFrames.DAY,
+    ])('shifts for time-axis interval %s', (interval) => {
+        const fieldId = `orders_created_${interval.toLowerCase()}`;
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({ xField: fieldId }),
+            itemsMap: {
+                ...itemsMap,
+                [fieldId]: makeTimeDimension(fieldId, interval),
+            },
+            resolvedTimezone: TZ,
+        });
+        expect(result.shiftedField).toEqual({
+            fieldId,
+            timezone: TZ,
+            flipAxes: false,
+        });
+        expect(result.axisTimezone).toBeUndefined();
+        expect(result.axisDisplayTimezone).toBe(TZ);
+    });
+
+    test('uses yField[0] when flipAxes is true', () => {
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({
+                yField: ['orders_created_day', 'other'],
+                flipAxes: true,
+            }),
+            itemsMap,
+            resolvedTimezone: TZ,
+        });
+        expect(result.shiftedField).toEqual({
+            fieldId: 'orders_created_day',
+            timezone: TZ,
+            flipAxes: true,
+        });
+    });
+
+    test('returns no shift when the target field id is missing', () => {
+        const result = resolveAxisTimezone({
+            validCartesianConfig: makeCartesian({ xField: undefined }),
+            itemsMap,
+            resolvedTimezone: TZ,
+        });
+        expect(result.shiftedField).toBeUndefined();
+    });
+});
+
+describe('applyTimezoneShiftToEchartsOptions', () => {
+    const shifted: TimezoneShiftedField = {
+        fieldId: 'orders_created_day',
+        timezone: TZ,
+        flipAxes: false,
+    };
+    const shiftedDim = 'orders_created_day_ld_tz_shifted';
+
+    test('appends a shifted column to each dataset row', () => {
+        const options: EchartsOptionsShape = {
+            dataset: {
+                source: [
+                    { orders_created_day: UTC_MS, orders_total: 10 },
+                    {
+                        orders_created_day: '2024-01-15T12:00:00Z',
+                        orders_total: 20,
+                    },
+                    { orders_created_day: new Date(UTC_MS), orders_total: 30 },
+                ],
+            },
+            series: [],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.dataset).toEqual({
+            source: [
+                {
+                    orders_created_day: UTC_MS,
+                    orders_total: 10,
+                    [shiftedDim]: SHIFTED_MS,
+                },
+                {
+                    orders_created_day: '2024-01-15T12:00:00Z',
+                    orders_total: 20,
+                    [shiftedDim]: SHIFTED_MS,
+                },
+                {
+                    orders_created_day: new Date(UTC_MS),
+                    orders_total: 30,
+                    [shiftedDim]: SHIFTED_MS,
+                },
+            ],
+        });
+    });
+
+    test('falls back to the raw value when it cannot be parsed to a number', () => {
+        const options: EchartsOptionsShape = {
+            dataset: {
+                source: [{ orders_created_day: 'not-a-date', orders_total: 1 }],
+            },
+            series: [],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.dataset).toEqual({
+            source: [
+                {
+                    orders_created_day: 'not-a-date',
+                    orders_total: 1,
+                    [shiftedDim]: 'not-a-date',
+                },
+            ],
+        });
+    });
+
+    test('uses null when the raw value is null or undefined', () => {
+        const options: EchartsOptionsShape = {
+            dataset: {
+                source: [
+                    { orders_created_day: null, orders_total: 1 },
+                    { orders_total: 2 },
+                ],
+            },
+            series: [],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.dataset).toEqual({
+            source: [
+                {
+                    orders_created_day: null,
+                    orders_total: 1,
+                    [shiftedDim]: null,
+                },
+                { orders_total: 2, [shiftedDim]: null },
+            ],
+        });
+    });
+
+    test('preserves dataset array shape', () => {
+        const options: EchartsOptionsShape = {
+            dataset: [
+                { source: [{ orders_created_day: UTC_MS, orders_total: 1 }] },
+                { source: [{ orders_created_day: UTC_MS, orders_total: 2 }] },
+            ],
+            series: [],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(Array.isArray(result.dataset)).toBe(true);
+        expect(result.dataset).toHaveLength(2);
+    });
+
+    test('leaves non-object rows unchanged', () => {
+        const options: EchartsOptionsShape = {
+            dataset: { source: [[UTC_MS, 10]] },
+            series: [],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.dataset).toEqual({ source: [[UTC_MS, 10]] });
+    });
+
+    test('renames x encoding and dimensions on matching series (flipAxes=false)', () => {
+        const options: EchartsOptionsShape = {
+            dataset: {
+                source: [{ orders_created_day: UTC_MS, orders_total: 1 }],
+            },
+            series: [
+                {
+                    encode: { x: 'orders_created_day', y: 'orders_total' },
+                    dimensions: [
+                        'orders_created_day',
+                        { name: 'orders_total' },
+                    ],
+                },
+            ],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.series?.[0].encode).toEqual({
+            x: shiftedDim,
+            y: 'orders_total',
+        });
+        expect(result.series?.[0].dimensions).toEqual([
+            shiftedDim,
+            { name: 'orders_total' },
+        ]);
+    });
+
+    test('renames y encoding when flipAxes is true', () => {
+        const options: EchartsOptionsShape = {
+            dataset: {
+                source: [{ orders_created_day: UTC_MS, orders_total: 1 }],
+            },
+            series: [
+                {
+                    encode: { x: 'orders_total', y: 'orders_created_day' },
+                    dimensions: ['orders_total', 'orders_created_day'],
+                },
+            ],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, {
+            ...shifted,
+            flipAxes: true,
+        });
+
+        expect(result.series?.[0].encode).toEqual({
+            x: 'orders_total',
+            y: shiftedDim,
+        });
+        expect(result.series?.[0].dimensions).toEqual([
+            'orders_total',
+            shiftedDim,
+        ]);
+    });
+
+    test('leaves series whose encoding does not match the shifted field', () => {
+        const options: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [
+                {
+                    encode: { x: 'other_field', y: 'orders_total' },
+                    dimensions: ['other_field', 'orders_total'],
+                },
+            ],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.series?.[0].encode).toEqual({
+            x: 'other_field',
+            y: 'orders_total',
+        });
+        expect(result.series?.[0].dimensions).toEqual([
+            'other_field',
+            'orders_total',
+        ]);
+    });
+
+    test('shifts tuple-mode series data at the renamed dimension slot', () => {
+        const options: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [
+                {
+                    encode: { x: 'orders_created_day', y: 'orders_total' },
+                    dimensions: ['orders_created_day', 'orders_total'],
+                    data: [{ value: [UTC_MS, 10] }, { value: [UTC_MS, 20] }],
+                },
+            ],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.series?.[0].data).toEqual([
+            { value: [SHIFTED_MS, 10] },
+            { value: [SHIFTED_MS, 20] },
+        ]);
+    });
+
+    test('shifts bare-array series data at axis slot 0 (flipAxes=false)', () => {
+        const options: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [
+                {
+                    // No encode/dimensions — simulates a synthetic stack-total label series.
+                    data: [
+                        [UTC_MS, 100],
+                        [UTC_MS, 200],
+                    ],
+                },
+            ],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.series?.[0].data).toEqual([
+            [SHIFTED_MS, 100],
+            [SHIFTED_MS, 200],
+        ]);
+    });
+
+    test('shifts bare-array series data at axis slot 1 (flipAxes=true)', () => {
+        const options: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [
+                {
+                    data: [
+                        [100, UTC_MS],
+                        [200, UTC_MS],
+                    ],
+                },
+            ],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, {
+            ...shifted,
+            flipAxes: true,
+        });
+
+        expect(result.series?.[0].data).toEqual([
+            [100, SHIFTED_MS],
+            [200, SHIFTED_MS],
+        ]);
+    });
+
+    test('leaves bare-array series data unchanged when the axis slot is not a date', () => {
+        const data = [
+            ['category-a', 100],
+            ['category-b', 200],
+        ];
+        const options: EchartsOptionsShape = {
+            dataset: { source: [] },
+            series: [{ data }],
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.series?.[0].data).toBe(data);
+    });
+
+    test('preserves unrelated options keys', () => {
+        const options = {
+            dataset: { source: [{ orders_created_day: UTC_MS }] },
+            series: [],
+            xAxis: { type: 'time' as const },
+            yAxis: { type: 'value' as const },
+        };
+
+        const result = applyTimezoneShiftToEchartsOptions(options, shifted);
+
+        expect(result.xAxis).toEqual({ type: 'time' });
+        expect(result.yAxis).toEqual({ type: 'value' });
+    });
+});

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -11,6 +11,8 @@ import utcPlugin from 'dayjs/plugin/utc';
 dayjs.extend(utcPlugin);
 dayjs.extend(timezonePlugin);
 
+// Time intervals that benefit from category axis in bar charts.
+// These must match intervals handled by getCategoryDateAxisConfig.
 export const TIME_INTERVALS_FOR_CATEGORY_AXIS: TimeFrames[] = [
     TimeFrames.WEEK,
     TimeFrames.MONTH,
@@ -26,8 +28,15 @@ export type TimezoneShiftedField = {
 const getTimezoneOffsetMs = (ms: number, timezone: string): number =>
     dayjs(ms).tz(timezone).utcOffset() * 60_000;
 
-const shiftMsToTimezoneWallClock = (ms: number, timezone: string): number =>
-    ms + getTimezoneOffsetMs(ms, timezone);
+const shiftRawToTimezoneWallClockMs = (
+    raw: unknown,
+    timezone: string,
+): number | undefined => {
+    if (raw === null || raw === undefined) return undefined;
+    const ms = typeof raw === 'number' ? raw : new Date(String(raw)).getTime();
+    if (!Number.isFinite(ms)) return undefined;
+    return ms + getTimezoneOffsetMs(ms, timezone);
+};
 
 export const detectTimezoneShiftedField = ({
     validCartesianConfig,
@@ -65,29 +74,116 @@ export const detectTimezoneShiftedField = ({
     return { fieldId: timeFieldId, timezone: resolvedTimezone };
 };
 
-type ShiftableCell = { value?: { raw?: unknown } } | undefined;
-type ShiftableRow = Record<string, ShiftableCell>;
+const SHIFTED_DIM_SUFFIX = '__shifted';
 
-export const applyTimezoneShiftToRows = <R extends ShiftableRow>(
-    rows: R[],
-    fieldId: string,
-    timezone: string,
-): R[] =>
-    rows.map((row) => {
-        const cell = row[fieldId];
-        const raw = cell?.value?.raw;
-        if (raw === null || raw === undefined) return row;
-        const ms =
-            typeof raw === 'number' ? raw : new Date(String(raw)).getTime();
-        if (!Number.isFinite(ms)) return row;
+type EchartsDimension = string | { name?: string; [key: string]: unknown };
+
+type EchartsSeriesShape = {
+    encode?: { x?: unknown; y?: unknown; [key: string]: unknown };
+    dimensions?: EchartsDimension[];
+    data?: unknown[];
+    [key: string]: unknown;
+};
+
+type EchartsDataset = {
+    source?: unknown[];
+    [key: string]: unknown;
+};
+
+type EchartsOptionsShape = {
+    dataset?: EchartsDataset | EchartsDataset[];
+    series?: EchartsSeriesShape[];
+    [key: string]: unknown;
+};
+
+const isPlainObject = (v: unknown): v is Record<string, unknown> =>
+    typeof v === 'object' && v !== null && !Array.isArray(v);
+
+const getDimensionName = (dim: EchartsDimension): string | undefined =>
+    typeof dim === 'string' ? dim : dim?.name;
+
+const renameDimension = (
+    dim: EchartsDimension,
+    from: string,
+    to: string,
+): EchartsDimension => {
+    if (typeof dim === 'string') return dim === from ? to : dim;
+    return dim?.name === from ? { ...dim, name: to } : dim;
+};
+
+// Terminal post-processor; keeps the rest of the cartesian pipeline in true UTC.
+export const applyTimezoneShiftToEchartsOptions = <
+    O extends EchartsOptionsShape,
+>(
+    options: O,
+    shifted: TimezoneShiftedField,
+    flipAxes: boolean,
+): O => {
+    const { fieldId, timezone } = shifted;
+    const shiftedDim = `${fieldId}${SHIFTED_DIM_SUFFIX}`;
+
+    const datasetWasArray = Array.isArray(options.dataset);
+    let datasets: EchartsDataset[] = [];
+    if (Array.isArray(options.dataset)) datasets = options.dataset;
+    else if (options.dataset) datasets = [options.dataset];
+
+    const newDatasets: EchartsDataset[] = datasets.map((ds) => {
+        if (!Array.isArray(ds.source)) return ds;
+        const newSource = ds.source.map((row) => {
+            if (!isPlainObject(row)) return row;
+            const shiftedMs = shiftRawToTimezoneWallClockMs(
+                row[fieldId],
+                timezone,
+            );
+            return {
+                ...row,
+                [shiftedDim]: shiftedMs ?? row[fieldId] ?? null,
+            };
+        });
+        return { ...ds, source: newSource };
+    });
+
+    const which: 'x' | 'y' = flipAxes ? 'y' : 'x';
+    const seriesList = options.series ?? [];
+
+    const newSeries: EchartsSeriesShape[] = seriesList.map((s) => {
+        if (s.encode?.[which] !== fieldId) return s;
+
+        const newEncode = { ...s.encode, [which]: shiftedDim };
+        const newDimensions = s.dimensions?.map((d) =>
+            renameDimension(d, fieldId, shiftedDim),
+        );
+
+        let newData = s.data;
+        if (Array.isArray(s.data) && newDimensions) {
+            const slotIdx = newDimensions
+                .map(getDimensionName)
+                .indexOf(shiftedDim);
+            if (slotIdx >= 0) {
+                newData = s.data.map((d) => {
+                    if (!isPlainObject(d) || !Array.isArray(d.value)) return d;
+                    const newValue = [...d.value];
+                    const shiftedMs = shiftRawToTimezoneWallClockMs(
+                        newValue[slotIdx],
+                        timezone,
+                    );
+                    if (shiftedMs !== undefined) newValue[slotIdx] = shiftedMs;
+                    return { ...d, value: newValue };
+                });
+            }
+        }
+
         return {
-            ...row,
-            [fieldId]: {
-                ...cell,
-                value: {
-                    ...cell?.value,
-                    raw: shiftMsToTimezoneWallClock(ms, timezone),
-                },
-            },
+            ...s,
+            encode: newEncode,
+            dimensions: newDimensions,
+            data: newData,
         };
     });
+
+    return {
+        ...options,
+        dataset: datasetWasArray ? newDatasets : newDatasets[0],
+        series: newSeries,
+    };
+};

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -1,0 +1,93 @@
+import {
+    isDimension,
+    TimeFrames,
+    type CartesianChart,
+    type ItemsMap,
+} from '@lightdash/common';
+import dayjs from 'dayjs';
+import timezonePlugin from 'dayjs/plugin/timezone';
+import utcPlugin from 'dayjs/plugin/utc';
+
+dayjs.extend(utcPlugin);
+dayjs.extend(timezonePlugin);
+
+export const TIME_INTERVALS_FOR_CATEGORY_AXIS: TimeFrames[] = [
+    TimeFrames.WEEK,
+    TimeFrames.MONTH,
+    TimeFrames.QUARTER,
+    TimeFrames.YEAR,
+];
+
+export type TimezoneShiftedField = {
+    fieldId: string;
+    timezone: string;
+};
+
+const getTimezoneOffsetMs = (ms: number, timezone: string): number =>
+    dayjs(ms).tz(timezone).utcOffset() * 60_000;
+
+const shiftMsToTimezoneWallClock = (ms: number, timezone: string): number =>
+    ms + getTimezoneOffsetMs(ms, timezone);
+
+export const detectTimezoneShiftedField = ({
+    validCartesianConfig,
+    itemsMap,
+    resolvedTimezone,
+}: {
+    validCartesianConfig: CartesianChart | undefined;
+    itemsMap: ItemsMap | undefined;
+    resolvedTimezone: string | undefined;
+}): TimezoneShiftedField | undefined => {
+    if (
+        !resolvedTimezone ||
+        resolvedTimezone === 'UTC' ||
+        !validCartesianConfig ||
+        !itemsMap
+    ) {
+        return undefined;
+    }
+    const flipAxes = !!validCartesianConfig.layout?.flipAxes;
+    const timeFieldId = flipAxes
+        ? validCartesianConfig.layout?.yField?.[0]
+        : validCartesianConfig.layout?.xField;
+    if (!timeFieldId) return undefined;
+    const field = itemsMap[timeFieldId];
+    if (!field || !isDimension(field) || !field.timeInterval) {
+        return undefined;
+    }
+    if (
+        TIME_INTERVALS_FOR_CATEGORY_AXIS.includes(
+            field.timeInterval as TimeFrames,
+        )
+    ) {
+        return undefined;
+    }
+    return { fieldId: timeFieldId, timezone: resolvedTimezone };
+};
+
+type ShiftableCell = { value?: { raw?: unknown } } | undefined;
+type ShiftableRow = Record<string, ShiftableCell>;
+
+export const applyTimezoneShiftToRows = <R extends ShiftableRow>(
+    rows: R[],
+    fieldId: string,
+    timezone: string,
+): R[] =>
+    rows.map((row) => {
+        const cell = row[fieldId];
+        const raw = cell?.value?.raw;
+        if (raw === null || raw === undefined) return row;
+        const ms =
+            typeof raw === 'number' ? raw : new Date(String(raw)).getTime();
+        if (!Number.isFinite(ms)) return row;
+        return {
+            ...row,
+            [fieldId]: {
+                ...cell,
+                value: {
+                    ...cell?.value,
+                    raw: shiftMsToTimezoneWallClock(ms, timezone),
+                },
+            },
+        };
+    });

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -23,6 +23,15 @@ export const TIME_INTERVALS_FOR_CATEGORY_AXIS: TimeFrames[] = [
 export type TimezoneShiftedField = {
     fieldId: string;
     timezone: string;
+    flipAxes: boolean;
+};
+
+// When shifted, axisTimezone is undefined and axisDisplayTimezone holds the tz.
+// Otherwise the swap is reversed. Callers shouldn't compute this themselves.
+export type AxisTimezoneConfig = {
+    shiftedField: TimezoneShiftedField | undefined;
+    axisTimezone: string | undefined;
+    axisDisplayTimezone: string | undefined;
 };
 
 const getTimezoneOffsetMs = (ms: number, timezone: string): number =>
@@ -33,12 +42,15 @@ const shiftRawToTimezoneWallClockMs = (
     timezone: string,
 ): number | undefined => {
     if (raw === null || raw === undefined) return undefined;
-    const ms = typeof raw === 'number' ? raw : new Date(String(raw)).getTime();
+    let ms: number;
+    if (typeof raw === 'number') ms = raw;
+    else if (raw instanceof Date) ms = raw.getTime();
+    else ms = new Date(String(raw)).getTime();
     if (!Number.isFinite(ms)) return undefined;
     return ms + getTimezoneOffsetMs(ms, timezone);
 };
 
-export const detectTimezoneShiftedField = ({
+const detectTimezoneShiftedField = ({
     validCartesianConfig,
     itemsMap,
     resolvedTimezone,
@@ -61,20 +73,36 @@ export const detectTimezoneShiftedField = ({
         : validCartesianConfig.layout?.xField;
     if (!timeFieldId) return undefined;
     const field = itemsMap[timeFieldId];
-    if (!field || !isDimension(field) || !field.timeInterval) {
+    if (!field || !isDimension(field)) return undefined;
+    const timeInterval = field.timeInterval;
+    if (!timeInterval) return undefined;
+    if (TIME_INTERVALS_FOR_CATEGORY_AXIS.includes(timeInterval)) {
         return undefined;
     }
-    if (
-        TIME_INTERVALS_FOR_CATEGORY_AXIS.includes(
-            field.timeInterval as TimeFrames,
-        )
-    ) {
-        return undefined;
-    }
-    return { fieldId: timeFieldId, timezone: resolvedTimezone };
+    return { fieldId: timeFieldId, timezone: resolvedTimezone, flipAxes };
 };
 
-const SHIFTED_DIM_SUFFIX = '__shifted';
+export const resolveAxisTimezone = (params: {
+    validCartesianConfig: CartesianChart | undefined;
+    itemsMap: ItemsMap | undefined;
+    resolvedTimezone: string | undefined;
+}): AxisTimezoneConfig => {
+    const shiftedField = detectTimezoneShiftedField(params);
+    if (shiftedField) {
+        return {
+            shiftedField,
+            axisTimezone: undefined,
+            axisDisplayTimezone: shiftedField.timezone,
+        };
+    }
+    return {
+        shiftedField: undefined,
+        axisTimezone: params.resolvedTimezone,
+        axisDisplayTimezone: undefined,
+    };
+};
+
+const SHIFTED_DIM_SUFFIX = '_ld_tz_shifted';
 
 type EchartsDimension = string | { name?: string; [key: string]: unknown };
 
@@ -90,7 +118,7 @@ type EchartsDataset = {
     [key: string]: unknown;
 };
 
-type EchartsOptionsShape = {
+export type EchartsOptionsShape = {
     dataset?: EchartsDataset | EchartsDataset[];
     series?: EchartsSeriesShape[];
     [key: string]: unknown;
@@ -111,79 +139,128 @@ const renameDimension = (
     return dim?.name === from ? { ...dim, name: to } : dim;
 };
 
-// Terminal post-processor; keeps the rest of the cartesian pipeline in true UTC.
-export const applyTimezoneShiftToEchartsOptions = <
-    O extends EchartsOptionsShape,
->(
-    options: O,
+// Preserves the input's array-vs-single shape.
+const mapDatasets = (
+    dataset: EchartsDataset | EchartsDataset[] | undefined,
+    fn: (ds: EchartsDataset) => EchartsDataset,
+): EchartsDataset | EchartsDataset[] | undefined => {
+    if (Array.isArray(dataset)) return dataset.map(fn);
+    if (dataset) return fn(dataset);
+    return dataset;
+};
+
+// Appends a `<fieldId>__shifted` column to every source row.
+const shiftDatasetSources = (
+    dataset: EchartsOptionsShape['dataset'],
     shifted: TimezoneShiftedField,
-    flipAxes: boolean,
-): O => {
-    const { fieldId, timezone } = shifted;
-    const shiftedDim = `${fieldId}${SHIFTED_DIM_SUFFIX}`;
-
-    const datasetWasArray = Array.isArray(options.dataset);
-    let datasets: EchartsDataset[] = [];
-    if (Array.isArray(options.dataset)) datasets = options.dataset;
-    else if (options.dataset) datasets = [options.dataset];
-
-    const newDatasets: EchartsDataset[] = datasets.map((ds) => {
+    shiftedDim: string,
+): EchartsOptionsShape['dataset'] =>
+    mapDatasets(dataset, (ds) => {
         if (!Array.isArray(ds.source)) return ds;
         const newSource = ds.source.map((row) => {
             if (!isPlainObject(row)) return row;
             const shiftedMs = shiftRawToTimezoneWallClockMs(
-                row[fieldId],
-                timezone,
+                row[shifted.fieldId],
+                shifted.timezone,
             );
             return {
                 ...row,
-                [shiftedDim]: shiftedMs ?? row[fieldId] ?? null,
+                [shiftedDim]: shiftedMs ?? row[shifted.fieldId] ?? null,
             };
         });
         return { ...ds, source: newSource };
     });
 
-    const which: 'x' | 'y' = flipAxes ? 'y' : 'x';
-    const seriesList = options.series ?? [];
+// Tuple-mode (e.g. stacked bars) data points carry a value array indexed by
+// dimension order; overwrite the slot at the shifted dim.
+const shiftSeriesTupleData = (
+    series: EchartsSeriesShape,
+    shifted: TimezoneShiftedField,
+    shiftedDim: string,
+): EchartsSeriesShape => {
+    if (!Array.isArray(series.data) || !series.dimensions) return series;
+    const slotIdx = series.dimensions.map(getDimensionName).indexOf(shiftedDim);
+    if (slotIdx < 0) return series;
 
-    const newSeries: EchartsSeriesShape[] = seriesList.map((s) => {
-        if (s.encode?.[which] !== fieldId) return s;
-
-        const newEncode = { ...s.encode, [which]: shiftedDim };
-        const newDimensions = s.dimensions?.map((d) =>
-            renameDimension(d, fieldId, shiftedDim),
+    const newData = series.data.map((d) => {
+        if (!isPlainObject(d) || !Array.isArray(d.value)) return d;
+        const newValue = [...d.value];
+        const shiftedMs = shiftRawToTimezoneWallClockMs(
+            newValue[slotIdx],
+            shifted.timezone,
         );
-
-        let newData = s.data;
-        if (Array.isArray(s.data) && newDimensions) {
-            const slotIdx = newDimensions
-                .map(getDimensionName)
-                .indexOf(shiftedDim);
-            if (slotIdx >= 0) {
-                newData = s.data.map((d) => {
-                    if (!isPlainObject(d) || !Array.isArray(d.value)) return d;
-                    const newValue = [...d.value];
-                    const shiftedMs = shiftRawToTimezoneWallClockMs(
-                        newValue[slotIdx],
-                        timezone,
-                    );
-                    if (shiftedMs !== undefined) newValue[slotIdx] = shiftedMs;
-                    return { ...d, value: newValue };
-                });
-            }
-        }
-
-        return {
-            ...s,
-            encode: newEncode,
-            dimensions: newDimensions,
-            data: newData,
-        };
+        if (shiftedMs !== undefined) newValue[slotIdx] = shiftedMs;
+        return { ...d, value: newValue };
     });
+    return { ...series, data: newData };
+};
 
+// Repoints series encoded on `fieldId` to the shifted dim.
+const renameSeriesEncoding = (
+    series: EchartsSeriesShape[] | undefined,
+    shifted: TimezoneShiftedField,
+    shiftedDim: string,
+): EchartsSeriesShape[] => {
+    const which: 'x' | 'y' = shifted.flipAxes ? 'y' : 'x';
+    return (series ?? []).map((s) => {
+        if (s.encode?.[which] !== shifted.fieldId) return s;
+        const renamed: EchartsSeriesShape = {
+            ...s,
+            encode: { ...s.encode, [which]: shiftedDim },
+            dimensions: s.dimensions?.map((d) =>
+                renameDimension(d, shifted.fieldId, shiftedDim),
+            ),
+        };
+        return shiftSeriesTupleData(renamed, shifted, shiftedDim);
+    });
+};
+
+// Some synthetic series (e.g. stack-total label series) use bare-array tuples
+// as `series.data` with no encode/dimensions, so the regular shift paths miss
+// them. They live on the same axis as the shifted bars, so shift the axis slot
+// (index 0, or 1 when flipAxes) in-place to keep labels aligned with bars.
+const shiftBareArraySeriesData = (
+    series: EchartsSeriesShape[] | undefined,
+    shifted: TimezoneShiftedField,
+): EchartsSeriesShape[] => {
+    if (!series) return [];
+    const axisSlot = shifted.flipAxes ? 1 : 0;
+    return series.map((s) => {
+        if (!Array.isArray(s.data)) return s;
+        let mutated = false;
+        const newData = s.data.map((d) => {
+            if (!Array.isArray(d)) return d;
+            const shiftedMs = shiftRawToTimezoneWallClockMs(
+                d[axisSlot],
+                shifted.timezone,
+            );
+            if (shiftedMs === undefined) return d;
+            mutated = true;
+            const next = [...d];
+            next[axisSlot] = shiftedMs;
+            return next;
+        });
+        return mutated ? { ...s, data: newData } : s;
+    });
+};
+
+// Terminal post-processor; rest of the cartesian pipeline stays in true UTC.
+// Generic preserves the caller's inferred option type for downstream destructuring.
+export const applyTimezoneShiftToEchartsOptions = <
+    O extends EchartsOptionsShape,
+>(
+    options: O,
+    shifted: TimezoneShiftedField,
+): O => {
+    const shiftedDim = `${shifted.fieldId}${SHIFTED_DIM_SUFFIX}`;
+    const renamedSeries = renameSeriesEncoding(
+        options.series,
+        shifted,
+        shiftedDim,
+    );
     return {
         ...options,
-        dataset: datasetWasArray ? newDatasets : newDatasets[0],
-        series: newSeries,
+        dataset: shiftDatasetSources(options.dataset, shifted, shiftedDim),
+        series: shiftBareArraySeriesData(renamedSeries, shifted),
     };
 };

--- a/packages/frontend/src/hooks/echarts/timezoneShift.ts
+++ b/packages/frontend/src/hooks/echarts/timezoneShift.ts
@@ -26,8 +26,8 @@ export type TimezoneShiftedField = {
     flipAxes: boolean;
 };
 
-// When shifted, axisTimezone is undefined and axisDisplayTimezone holds the tz.
-// Otherwise the swap is reversed. Callers shouldn't compute this themselves.
+// Exactly one of axisTimezone / axisDisplayTimezone is set: axisDisplayTimezone
+// when values are shifted to wall-clock, axisTimezone otherwise.
 export type AxisTimezoneConfig = {
     shiftedField: TimezoneShiftedField | undefined;
     axisTimezone: string | undefined;
@@ -149,7 +149,7 @@ const mapDatasets = (
     return dataset;
 };
 
-// Appends a `<fieldId>__shifted` column to every source row.
+// Adds a shifted-wall-clock column alongside the original UTC column on every row.
 const shiftDatasetSources = (
     dataset: EchartsOptionsShape['dataset'],
     shifted: TimezoneShiftedField,
@@ -171,8 +171,8 @@ const shiftDatasetSources = (
         return { ...ds, source: newSource };
     });
 
-// Tuple-mode (e.g. stacked bars) data points carry a value array indexed by
-// dimension order; overwrite the slot at the shifted dim.
+// For series whose data points are tuples indexed by dimension order (e.g.
+// stacked bars), overwrite the slot at the shifted dimension.
 const shiftSeriesTupleData = (
     series: EchartsSeriesShape,
     shifted: TimezoneShiftedField,
@@ -195,7 +195,8 @@ const shiftSeriesTupleData = (
     return { ...series, data: newData };
 };
 
-// Repoints series encoded on `fieldId` to the shifted dim.
+// Point series that were reading the original field at their encoded axis to
+// the shifted column instead.
 const renameSeriesEncoding = (
     series: EchartsSeriesShape[] | undefined,
     shifted: TimezoneShiftedField,
@@ -215,10 +216,9 @@ const renameSeriesEncoding = (
     });
 };
 
-// Some synthetic series (e.g. stack-total label series) use bare-array tuples
-// as `series.data` with no encode/dimensions, so the regular shift paths miss
-// them. They live on the same axis as the shifted bars, so shift the axis slot
-// (index 0, or 1 when flipAxes) in-place to keep labels aligned with bars.
+// Some synthetic series (e.g. stack-total labels) carry bare-array data with
+// no encode/dimensions, so the dimension-based shift above misses them. Shift
+// their axis slot in place so the labels stay aligned with the shifted bars.
 const shiftBareArraySeriesData = (
     series: EchartsSeriesShape[] | undefined,
     shifted: TimezoneShiftedField,
@@ -244,8 +244,7 @@ const shiftBareArraySeriesData = (
     });
 };
 
-// Terminal post-processor; rest of the cartesian pipeline stays in true UTC.
-// Generic preserves the caller's inferred option type for downstream destructuring.
+// Run last on the built echarts options — the rest of the pipeline stays in UTC.
 export const applyTimezoneShiftToEchartsOptions = <
     O extends EchartsOptionsShape,
 >(

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -75,11 +75,16 @@ import {
 import { getLegendStyle } from '@lightdash/common/src/visualizations/helpers/styles/legendStyles';
 import { useMantineTheme } from '@mantine/core';
 import dayjs from 'dayjs';
+import timezonePlugin from 'dayjs/plugin/timezone';
+import utcPlugin from 'dayjs/plugin/utc';
 import {
     type DefaultLabelFormatterCallbackParams,
     type TooltipComponentFormatterCallback,
     type TooltipComponentOption,
 } from 'echarts';
+
+dayjs.extend(utcPlugin);
+dayjs.extend(timezonePlugin);
 import groupBy from 'lodash/groupBy';
 import maxBy from 'lodash/maxBy';
 import toNumber from 'lodash/toNumber';
@@ -2517,32 +2522,8 @@ const useEchartsCartesianConfig = (
         );
         if (!timezoneShiftedField) return sliced;
         const { fieldId, timezone } = timezoneShiftedField;
-        const dtf = new Intl.DateTimeFormat('en-US', {
-            timeZone: timezone,
-            hour12: false,
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-            hour: '2-digit',
-            minute: '2-digit',
-            second: '2-digit',
-        });
-        const tzOffsetMs = (ms: number): number => {
-            const parts: Record<string, string> = {};
-            for (const p of dtf.formatToParts(new Date(ms))) {
-                if (p.type !== 'literal') parts[p.type] = p.value;
-            }
-            const hour = parts.hour === '24' ? 0 : Number(parts.hour);
-            const asUtc = Date.UTC(
-                Number(parts.year),
-                Number(parts.month) - 1,
-                Number(parts.day),
-                hour,
-                Number(parts.minute),
-                Number(parts.second),
-            );
-            return asUtc - ms;
-        };
+        const tzOffsetMs = (ms: number): number =>
+            dayjs(ms).tz(timezone).utcOffset() * 60_000;
         return sliced.map((row) => {
             const cell = row[fieldId];
             const raw = cell?.value?.raw;

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -103,7 +103,7 @@ import { type InfiniteQueryResults } from '../useQueryResults';
 import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import { getCartesianConditionalFormattingColor } from './cartesianConditionalFormatting';
 import {
-    applyTimezoneShiftToRows,
+    applyTimezoneShiftToEchartsOptions,
     detectTimezoneShiftedField,
     TIME_INTERVALS_FOR_CATEGORY_AXIS,
     type TimezoneShiftedField,
@@ -193,8 +193,6 @@ export const getAxisTypeFromField = (item?: ItemsMap[string]): string => {
     }
 };
 
-// Time intervals that benefit from category axis in bar charts.
-// These must match intervals handled by getCategoryDateAxisConfig.
 type GetAxisTypeArg = {
     validCartesianConfig: CartesianChart;
     itemsMap: ItemsMap;
@@ -2428,8 +2426,11 @@ const useEchartsCartesianConfig = (
         [resolvedTimezone, validCartesianConfig, itemsMap],
     );
 
-    const chartTimezone = timezoneShiftedField ? undefined : resolvedTimezone;
-    const displayTimezone = timezoneShiftedField ? resolvedTimezone : undefined;
+    // Axis labels render pre-shifted values; the formatter just relabels via displayTimezone.
+    const axisTimezone = timezoneShiftedField ? undefined : resolvedTimezone;
+    const axisDisplayTimezone = timezoneShiftedField
+        ? resolvedTimezone
+        : undefined;
 
     const tooltipConfig = useMemo(() => {
         if (!isCartesianVisualizationConfig(visualizationConfig)) return;
@@ -2488,24 +2489,15 @@ const useEchartsCartesianConfig = (
         );
     }, [resultsData, pivotDimensions, pivotedKeys, nonPivotedKeys]);
 
-    const rows = useMemo(() => {
-        const sliced = sliceRows(
-            allRows,
-            isShowHideRowsEnabled,
-            validCartesianConfig?.rowLimit,
-        );
-        if (!timezoneShiftedField) return sliced;
-        return applyTimezoneShiftToRows(
-            sliced,
-            timezoneShiftedField.fieldId,
-            timezoneShiftedField.timezone,
-        );
-    }, [
-        allRows,
-        isShowHideRowsEnabled,
-        validCartesianConfig?.rowLimit,
-        timezoneShiftedField,
-    ]);
+    const rows = useMemo(
+        () =>
+            sliceRows(
+                allRows,
+                isShowHideRowsEnabled,
+                validCartesianConfig?.rowLimit,
+            ),
+        [allRows, isShowHideRowsEnabled, validCartesianConfig?.rowLimit],
+    );
 
     // Pivot references from hidden series, used for resolving custom tooltip references
     // to fields that are on the Y axis but have their chart series hidden.
@@ -2591,8 +2583,8 @@ const useEchartsCartesianConfig = (
                     : undefined,
             minsAndMaxes: resultsAndMinsAndMaxes.minsAndMaxes,
             parameters,
-            resolvedTimezone: chartTimezone,
-            displayTimezone,
+            resolvedTimezone: axisTimezone,
+            displayTimezone: axisDisplayTimezone,
         });
     }, [
         itemsMap,
@@ -2603,8 +2595,8 @@ const useEchartsCartesianConfig = (
         isShowHideRowsEnabled,
         resultsAndMinsAndMaxes.minsAndMaxes,
         parameters,
-        chartTimezone,
-        displayTimezone,
+        axisTimezone,
+        axisDisplayTimezone,
     ]);
 
     const stackedSeriesWithColorAssignments = useMemo(() => {
@@ -3166,8 +3158,7 @@ const useEchartsCartesianConfig = (
                 pivotValuesColumnsMap,
                 parameters,
                 rows: dataToRender,
-                timezone: chartTimezone,
-                displayTimezone,
+                timezone: resolvedTimezone,
             }),
         };
     }, [
@@ -3184,8 +3175,7 @@ const useEchartsCartesianConfig = (
         hiddenSeriesPivotRefs,
         dataToRender,
         isTouchDevice,
-        chartTimezone,
-        displayTimezone,
+        resolvedTimezone,
     ]);
 
     // Calculate max stack label padding for 100% stacking grid
@@ -3530,9 +3520,9 @@ const useEchartsCartesianConfig = (
     const eChartsOptions = useMemo(() => {
         const enableDataZoom =
             validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.enableDataZoom;
-        const flipAxes = validCartesianConfig?.layout?.flipAxes;
+        const flipAxes = !!validCartesianConfig?.layout?.flipAxes;
 
-        return {
+        const baseOptions = {
             xAxis: sortedAxes.xAxis,
             yAxis: sortedAxes.yAxis,
             useUTC: true,
@@ -3575,6 +3565,14 @@ const useEchartsCartesianConfig = (
                 ],
             }),
         };
+
+        return timezoneShiftedField
+            ? applyTimezoneShiftToEchartsOptions(
+                  baseOptions,
+                  timezoneShiftedField,
+                  flipAxes,
+              )
+            : baseOptions;
     }, [
         sortedAxes,
         sortedSeriesForChart,
@@ -3586,6 +3584,7 @@ const useEchartsCartesianConfig = (
         currentGrid,
         theme?.other.chartFont,
         validCartesianConfig,
+        timezoneShiftedField,
     ]);
 
     if (

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -1580,6 +1580,7 @@ const getEchartAxes = ({
     minsAndMaxes,
     parameters,
     resolvedTimezone,
+    displayTimezone,
 }: {
     validCartesianConfig: CartesianChart;
     itemsMap: ItemsMap;
@@ -1589,6 +1590,7 @@ const getEchartAxes = ({
     minsAndMaxes: ReturnType<typeof getResultValueArray>['minsAndMaxes'];
     parameters?: ParametersValuesMap;
     resolvedTimezone?: string;
+    displayTimezone?: string;
 }) => {
     const xAxisItemId = validCartesianConfig.layout.flipAxes
         ? validCartesianConfig.layout?.yField?.[0]
@@ -1801,6 +1803,7 @@ const getEchartAxes = ({
         show: showXAxis,
         parameters,
         timezone: resolvedTimezone,
+        displayTimezone,
     });
     const bottomAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -1822,6 +1825,7 @@ const getEchartAxes = ({
         show: showXAxis,
         parameters,
         timezone: resolvedTimezone,
+        displayTimezone,
     });
     const topAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -1842,6 +1846,7 @@ const getEchartAxes = ({
         show: showLeftYAxis,
         parameters,
         timezone: resolvedTimezone,
+        displayTimezone,
     });
     const leftAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -1862,6 +1867,7 @@ const getEchartAxes = ({
         show: showRightYAxis,
         parameters,
         timezone: resolvedTimezone,
+        displayTimezone,
     });
     const rightAxisConfigWithStyle: Record<string, unknown> = Object.assign(
         {},
@@ -2413,6 +2419,62 @@ const useEchartsCartesianConfig = (
         return visualizationConfig.chartConfig.validConfig;
     }, [visualizationConfig]);
 
+    // When a non-UTC project tz is active on a time axis, we hard-shift the
+    // `.value.raw` of the time column on every row so that ECharts
+    // (useUTC:true) positions ticks and renders default labels as if the
+    // shifted ms were UTC — which visually reads as project-tz wall-clock.
+    // The shift happens at the row boundary (see `rows` useMemo below) so
+    // dataset.source, series inline data, and tooltip row lookups all see
+    // shifted values. Downstream formatters must NOT re-apply tz conversion
+    // on shifted values — they should use `chartTimezone` (undefined while
+    // shift is active) instead of `resolvedTimezone`.
+    const timezoneShiftedField = useMemo<
+        { fieldId: string; timezone: string } | undefined
+    >(() => {
+        if (
+            !resolvedTimezone ||
+            resolvedTimezone === 'UTC' ||
+            !validCartesianConfig ||
+            !itemsMap
+        ) {
+            return undefined;
+        }
+        const flipAxes = !!validCartesianConfig.layout?.flipAxes;
+        const timeFieldId = flipAxes
+            ? validCartesianConfig.layout?.yField?.[0]
+            : validCartesianConfig.layout?.xField;
+        if (!timeFieldId) return undefined;
+        const field = itemsMap[timeFieldId];
+        if (!field || !isDimension(field) || !field.timeInterval) {
+            return undefined;
+        }
+        // Week/Month/Quarter/Year render on a category axis (string labels),
+        // not a time axis — tick placement is not ms-based, no shift needed.
+        if (
+            TIME_INTERVALS_FOR_CATEGORY_AXIS.includes(
+                field.timeInterval as TimeFrames,
+            )
+        ) {
+            return undefined;
+        }
+        return { fieldId: timeFieldId, timezone: resolvedTimezone };
+    }, [resolvedTimezone, validCartesianConfig, itemsMap]);
+
+    // Two timezones, one source of truth. Downstream formatters receive
+    // values from two paths: ECharts-supplied (shifted ms for axis ticks,
+    // tooltip param.axisValue) and raw backend metadata (pivot values in
+    // legends). They need different handling when the shift is active:
+    //   - chartTimezone: tz for value CONVERSION. `undefined` while shift
+    //     is active so formatters don't re-convert already-shifted values.
+    //     `resolvedTimezone` otherwise (normal UTC→project tz conversion).
+    //   - displayTimezone: tz for the OFFSET ANNOTATION only. Set to
+    //     `resolvedTimezone` while shift is active so the `(Z)` token in
+    //     format strings still renders as `(-11:00)` instead of `(+00:00)`.
+    // Pivot metadata (raw backend values) continues to use `resolvedTimezone`
+    // directly — those bypass the shift entirely.
+    const chartTimezone = timezoneShiftedField ? undefined : resolvedTimezone;
+    const displayTimezone = timezoneShiftedField ? resolvedTimezone : undefined;
+
     const tooltipConfig = useMemo(() => {
         if (!isCartesianVisualizationConfig(visualizationConfig)) return;
         return visualizationConfig.chartConfig.tooltip;
@@ -2470,15 +2532,64 @@ const useEchartsCartesianConfig = (
         );
     }, [resultsData, pivotDimensions, pivotedKeys, nonPivotedKeys]);
 
-    const rows = useMemo(
-        () =>
-            sliceRows(
-                allRows,
-                isShowHideRowsEnabled,
-                validCartesianConfig?.rowLimit,
-            ),
-        [allRows, isShowHideRowsEnabled, validCartesianConfig?.rowLimit],
-    );
+    const rows = useMemo(() => {
+        const sliced = sliceRows(
+            allRows,
+            isShowHideRowsEnabled,
+            validCartesianConfig?.rowLimit,
+        );
+        if (!timezoneShiftedField) return sliced;
+        const { fieldId, timezone } = timezoneShiftedField;
+        const dtf = new Intl.DateTimeFormat('en-US', {
+            timeZone: timezone,
+            hour12: false,
+            year: 'numeric',
+            month: '2-digit',
+            day: '2-digit',
+            hour: '2-digit',
+            minute: '2-digit',
+            second: '2-digit',
+        });
+        const tzOffsetMs = (ms: number): number => {
+            const parts: Record<string, string> = {};
+            for (const p of dtf.formatToParts(new Date(ms))) {
+                if (p.type !== 'literal') parts[p.type] = p.value;
+            }
+            const hour = parts.hour === '24' ? 0 : Number(parts.hour);
+            const asUtc = Date.UTC(
+                Number(parts.year),
+                Number(parts.month) - 1,
+                Number(parts.day),
+                hour,
+                Number(parts.minute),
+                Number(parts.second),
+            );
+            return asUtc - ms;
+        };
+        return sliced.map((row) => {
+            const cell = row[fieldId];
+            const raw = cell?.value?.raw;
+            if (raw === null || raw === undefined) return row;
+            const ms =
+                typeof raw === 'number' ? raw : new Date(String(raw)).getTime();
+            if (!Number.isFinite(ms)) return row;
+            return {
+                ...row,
+                [fieldId]: {
+                    ...cell,
+                    value: {
+                        ...cell.value,
+                        raw: ms + tzOffsetMs(ms),
+                    },
+                },
+            };
+        });
+    }, [
+        allRows,
+        isShowHideRowsEnabled,
+        validCartesianConfig?.rowLimit,
+        timezoneShiftedField,
+    ]);
 
     // Pivot references from hidden series, used for resolving custom tooltip references
     // to fields that are on the Y axis but have their chart series hidden.
@@ -2564,7 +2675,8 @@ const useEchartsCartesianConfig = (
                     : undefined,
             minsAndMaxes: resultsAndMinsAndMaxes.minsAndMaxes,
             parameters,
-            resolvedTimezone,
+            resolvedTimezone: chartTimezone,
+            displayTimezone,
         });
     }, [
         itemsMap,
@@ -2575,7 +2687,8 @@ const useEchartsCartesianConfig = (
         isShowHideRowsEnabled,
         resultsAndMinsAndMaxes.minsAndMaxes,
         parameters,
-        resolvedTimezone,
+        chartTimezone,
+        displayTimezone,
     ]);
 
     const stackedSeriesWithColorAssignments = useMemo(() => {
@@ -3137,7 +3250,8 @@ const useEchartsCartesianConfig = (
                 pivotValuesColumnsMap,
                 parameters,
                 rows: dataToRender,
-                timezone: resolvedTimezone,
+                timezone: chartTimezone,
+                displayTimezone,
             }),
         };
     }, [
@@ -3154,7 +3268,8 @@ const useEchartsCartesianConfig = (
         hiddenSeriesPivotRefs,
         dataToRender,
         isTouchDevice,
-        resolvedTimezone,
+        chartTimezone,
+        displayTimezone,
     ]);
 
     // Calculate max stack label padding for 100% stacking grid

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -2419,15 +2419,6 @@ const useEchartsCartesianConfig = (
         return visualizationConfig.chartConfig.validConfig;
     }, [visualizationConfig]);
 
-    // When a non-UTC project tz is active on a time axis, we hard-shift the
-    // `.value.raw` of the time column on every row so that ECharts
-    // (useUTC:true) positions ticks and renders default labels as if the
-    // shifted ms were UTC — which visually reads as project-tz wall-clock.
-    // The shift happens at the row boundary (see `rows` useMemo below) so
-    // dataset.source, series inline data, and tooltip row lookups all see
-    // shifted values. Downstream formatters must NOT re-apply tz conversion
-    // on shifted values — they should use `chartTimezone` (undefined while
-    // shift is active) instead of `resolvedTimezone`.
     const timezoneShiftedField = useMemo<
         { fieldId: string; timezone: string } | undefined
     >(() => {
@@ -2448,8 +2439,6 @@ const useEchartsCartesianConfig = (
         if (!field || !isDimension(field) || !field.timeInterval) {
             return undefined;
         }
-        // Week/Month/Quarter/Year render on a category axis (string labels),
-        // not a time axis — tick placement is not ms-based, no shift needed.
         if (
             TIME_INTERVALS_FOR_CATEGORY_AXIS.includes(
                 field.timeInterval as TimeFrames,
@@ -2460,18 +2449,6 @@ const useEchartsCartesianConfig = (
         return { fieldId: timeFieldId, timezone: resolvedTimezone };
     }, [resolvedTimezone, validCartesianConfig, itemsMap]);
 
-    // Two timezones, one source of truth. Downstream formatters receive
-    // values from two paths: ECharts-supplied (shifted ms for axis ticks,
-    // tooltip param.axisValue) and raw backend metadata (pivot values in
-    // legends). They need different handling when the shift is active:
-    //   - chartTimezone: tz for value CONVERSION. `undefined` while shift
-    //     is active so formatters don't re-convert already-shifted values.
-    //     `resolvedTimezone` otherwise (normal UTC→project tz conversion).
-    //   - displayTimezone: tz for the OFFSET ANNOTATION only. Set to
-    //     `resolvedTimezone` while shift is active so the `(Z)` token in
-    //     format strings still renders as `(-11:00)` instead of `(+00:00)`.
-    // Pivot metadata (raw backend values) continues to use `resolvedTimezone`
-    // directly — those bypass the shift entirely.
     const chartTimezone = timezoneShiftedField ? undefined : resolvedTimezone;
     const displayTimezone = timezoneShiftedField ? resolvedTimezone : undefined;
 

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -104,9 +104,8 @@ import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import { getCartesianConditionalFormattingColor } from './cartesianConditionalFormatting';
 import {
     applyTimezoneShiftToEchartsOptions,
-    detectTimezoneShiftedField,
+    resolveAxisTimezone,
     TIME_INTERVALS_FOR_CATEGORY_AXIS,
-    type TimezoneShiftedField,
 } from './timezoneShift';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
@@ -2416,21 +2415,15 @@ const useEchartsCartesianConfig = (
         return visualizationConfig.chartConfig.validConfig;
     }, [visualizationConfig]);
 
-    const timezoneShiftedField = useMemo<TimezoneShiftedField | undefined>(
+    const { shiftedField, axisTimezone, axisDisplayTimezone } = useMemo(
         () =>
-            detectTimezoneShiftedField({
+            resolveAxisTimezone({
                 validCartesianConfig,
                 itemsMap,
                 resolvedTimezone,
             }),
         [resolvedTimezone, validCartesianConfig, itemsMap],
     );
-
-    // Axis labels render pre-shifted values; the formatter just relabels via displayTimezone.
-    const axisTimezone = timezoneShiftedField ? undefined : resolvedTimezone;
-    const axisDisplayTimezone = timezoneShiftedField
-        ? resolvedTimezone
-        : undefined;
 
     const tooltipConfig = useMemo(() => {
         if (!isCartesianVisualizationConfig(visualizationConfig)) return;
@@ -3158,7 +3151,8 @@ const useEchartsCartesianConfig = (
                 pivotValuesColumnsMap,
                 parameters,
                 rows: dataToRender,
-                timezone: resolvedTimezone,
+                timezone: axisTimezone,
+                displayTimezone: axisDisplayTimezone,
             }),
         };
     }, [
@@ -3175,7 +3169,8 @@ const useEchartsCartesianConfig = (
         hiddenSeriesPivotRefs,
         dataToRender,
         isTouchDevice,
-        resolvedTimezone,
+        axisTimezone,
+        axisDisplayTimezone,
     ]);
 
     // Calculate max stack label padding for 100% stacking grid
@@ -3520,7 +3515,7 @@ const useEchartsCartesianConfig = (
     const eChartsOptions = useMemo(() => {
         const enableDataZoom =
             validCartesianConfig?.eChartsConfig?.xAxis?.[0]?.enableDataZoom;
-        const flipAxes = !!validCartesianConfig?.layout?.flipAxes;
+        const flipAxes = validCartesianConfig?.layout?.flipAxes;
 
         const baseOptions = {
             xAxis: sortedAxes.xAxis,
@@ -3566,12 +3561,8 @@ const useEchartsCartesianConfig = (
             }),
         };
 
-        return timezoneShiftedField
-            ? applyTimezoneShiftToEchartsOptions(
-                  baseOptions,
-                  timezoneShiftedField,
-                  flipAxes,
-              )
+        return shiftedField
+            ? applyTimezoneShiftToEchartsOptions(baseOptions, shiftedField)
             : baseOptions;
     }, [
         sortedAxes,
@@ -3584,7 +3575,7 @@ const useEchartsCartesianConfig = (
         currentGrid,
         theme?.other.chartFont,
         validCartesianConfig,
-        timezoneShiftedField,
+        shiftedField,
     ]);
 
     if (

--- a/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
+++ b/packages/frontend/src/hooks/echarts/useEchartsCartesianConfig.ts
@@ -75,16 +75,11 @@ import {
 import { getLegendStyle } from '@lightdash/common/src/visualizations/helpers/styles/legendStyles';
 import { useMantineTheme } from '@mantine/core';
 import dayjs from 'dayjs';
-import timezonePlugin from 'dayjs/plugin/timezone';
-import utcPlugin from 'dayjs/plugin/utc';
 import {
     type DefaultLabelFormatterCallbackParams,
     type TooltipComponentFormatterCallback,
     type TooltipComponentOption,
 } from 'echarts';
-
-dayjs.extend(utcPlugin);
-dayjs.extend(timezonePlugin);
 import groupBy from 'lodash/groupBy';
 import maxBy from 'lodash/maxBy';
 import toNumber from 'lodash/toNumber';
@@ -107,6 +102,12 @@ import {
 import { type InfiniteQueryResults } from '../useQueryResults';
 import { useServerFeatureFlag } from '../useServerOrClientFeatureFlag';
 import { getCartesianConditionalFormattingColor } from './cartesianConditionalFormatting';
+import {
+    applyTimezoneShiftToRows,
+    detectTimezoneShiftedField,
+    TIME_INTERVALS_FOR_CATEGORY_AXIS,
+    type TimezoneShiftedField,
+} from './timezoneShift';
 import { useLegendDoubleClickTooltip } from './useLegendDoubleClickTooltip';
 
 // NOTE: CallbackDataParams type doesn't have axisValue, axisValueLabel properties: https://github.com/apache/echarts/issues/17561
@@ -194,13 +195,6 @@ export const getAxisTypeFromField = (item?: ItemsMap[string]): string => {
 
 // Time intervals that benefit from category axis in bar charts.
 // These must match intervals handled by getCategoryDateAxisConfig.
-const TIME_INTERVALS_FOR_CATEGORY_AXIS: TimeFrames[] = [
-    TimeFrames.WEEK,
-    TimeFrames.MONTH,
-    TimeFrames.QUARTER,
-    TimeFrames.YEAR,
-];
-
 type GetAxisTypeArg = {
     validCartesianConfig: CartesianChart;
     itemsMap: ItemsMap;
@@ -2424,35 +2418,15 @@ const useEchartsCartesianConfig = (
         return visualizationConfig.chartConfig.validConfig;
     }, [visualizationConfig]);
 
-    const timezoneShiftedField = useMemo<
-        { fieldId: string; timezone: string } | undefined
-    >(() => {
-        if (
-            !resolvedTimezone ||
-            resolvedTimezone === 'UTC' ||
-            !validCartesianConfig ||
-            !itemsMap
-        ) {
-            return undefined;
-        }
-        const flipAxes = !!validCartesianConfig.layout?.flipAxes;
-        const timeFieldId = flipAxes
-            ? validCartesianConfig.layout?.yField?.[0]
-            : validCartesianConfig.layout?.xField;
-        if (!timeFieldId) return undefined;
-        const field = itemsMap[timeFieldId];
-        if (!field || !isDimension(field) || !field.timeInterval) {
-            return undefined;
-        }
-        if (
-            TIME_INTERVALS_FOR_CATEGORY_AXIS.includes(
-                field.timeInterval as TimeFrames,
-            )
-        ) {
-            return undefined;
-        }
-        return { fieldId: timeFieldId, timezone: resolvedTimezone };
-    }, [resolvedTimezone, validCartesianConfig, itemsMap]);
+    const timezoneShiftedField = useMemo<TimezoneShiftedField | undefined>(
+        () =>
+            detectTimezoneShiftedField({
+                validCartesianConfig,
+                itemsMap,
+                resolvedTimezone,
+            }),
+        [resolvedTimezone, validCartesianConfig, itemsMap],
+    );
 
     const chartTimezone = timezoneShiftedField ? undefined : resolvedTimezone;
     const displayTimezone = timezoneShiftedField ? resolvedTimezone : undefined;
@@ -2521,27 +2495,11 @@ const useEchartsCartesianConfig = (
             validCartesianConfig?.rowLimit,
         );
         if (!timezoneShiftedField) return sliced;
-        const { fieldId, timezone } = timezoneShiftedField;
-        const tzOffsetMs = (ms: number): number =>
-            dayjs(ms).tz(timezone).utcOffset() * 60_000;
-        return sliced.map((row) => {
-            const cell = row[fieldId];
-            const raw = cell?.value?.raw;
-            if (raw === null || raw === undefined) return row;
-            const ms =
-                typeof raw === 'number' ? raw : new Date(String(raw)).getTime();
-            if (!Number.isFinite(ms)) return row;
-            return {
-                ...row,
-                [fieldId]: {
-                    ...cell,
-                    value: {
-                        ...cell.value,
-                        raw: ms + tzOffsetMs(ms),
-                    },
-                },
-            };
-        });
+        return applyTimezoneShiftToRows(
+            sliced,
+            timezoneShiftedField.fieldId,
+            timezoneShiftedField.timezone,
+        );
     }, [
         allRows,
         isShowHideRowsEnabled,


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

Relates to: https://linear.app/lightdash/issue/GLITCH-291/update-result-formatting-to-use-resolved-project-timezone

### Description:

When project timezone is set and `EnableTimezoneSupport` is enabled, shifts the x-axis so that it can correctly plot tz formatted values

**Before**
<img width="2153" height="663" alt="image" src="https://github.com/user-attachments/assets/614e0dcc-581e-4187-bf0f-3bf1f76ba634" />

**After**
<img width="2138" height="661" alt="image" src="https://github.com/user-attachments/assets/1cc0c4db-7401-49cb-93df-1d162eda70c8" />
