### PR TITLE
feat: add dbt Cloud branch preview integration

### DIFF
--- a/packages/backend/src/clients/DbtCloud/DbtCloudRestClient.ts
+++ b/packages/backend/src/clients/DbtCloud/DbtCloudRestClient.ts
@@ -1,0 +1,169 @@
+import {
+    DEFAULT_DBT_CLOUD_BASE_URL,
+    ParameterError,
+    TERMINAL_RUN_STATUSES,
+    type DbtCloudJobResponse,
+    type DbtCloudRunStatusResponse,
+    type DbtCloudTriggerRunResponse,
+} from '@lightdash/common';
+import Logger from '../../logging/logger';
+
+const DEFAULT_POLL_INTERVAL_MS = 5_000;
+const DEFAULT_POLL_TIMEOUT_MS = 600_000; // 10 minutes
+
+type DbtCloudRestClientArgs = {
+    serviceToken: string;
+    accountId: string;
+    baseUrl?: string;
+};
+
+export class DbtCloudRestClient {
+    private readonly serviceToken: string;
+
+    private readonly accountId: string;
+
+    private readonly baseUrl: string;
+
+    constructor({ serviceToken, accountId, baseUrl }: DbtCloudRestClientArgs) {
+        if (!serviceToken) {
+            throw new ParameterError('dbt Cloud service token is required');
+        }
+        if (!accountId) {
+            throw new ParameterError('dbt Cloud account ID is required');
+        }
+        this.serviceToken = serviceToken;
+        this.accountId = accountId;
+        this.baseUrl = (baseUrl || DEFAULT_DBT_CLOUD_BASE_URL).replace(
+            /\/$/,
+            '',
+        );
+    }
+
+    private async request<T>(path: string, options?: RequestInit): Promise<T> {
+        const url = `${this.baseUrl}/api/v2/accounts/${this.accountId}${path}`;
+        const response = await fetch(url, {
+            ...options,
+            headers: {
+                Authorization: `Token ${this.serviceToken}`,
+                'Content-Type': 'application/json',
+                ...options?.headers,
+            },
+        });
+
+        if (!response.ok) {
+            const errorBody = await response.text();
+            throw new ParameterError(
+                `dbt Cloud API error (${response.status}): ${errorBody}`,
+            );
+        }
+
+        const json = (await response.json()) as { data: T };
+        return json.data;
+    }
+
+    async getJob(jobId: string): Promise<DbtCloudJobResponse> {
+        const raw = await this.request<Record<string, unknown>>(
+            `/jobs/${jobId}/`,
+        );
+        return {
+            id: raw.id as number,
+            name: raw.name as string,
+            jobType: raw.job_type as string,
+            environmentId: raw.environment_id as number,
+            executeSteps: raw.execute_steps as string[],
+            settings: raw.settings as { threads: number; targetName: string },
+            deferringEnvironmentId:
+                (raw.deferring_environment_id as number | null) ?? null,
+        };
+    }
+
+    async triggerRun({
+        jobId,
+        gitBranch,
+        cause,
+        stepsOverride,
+    }: {
+        jobId: string;
+        gitBranch: string;
+        cause?: string;
+        stepsOverride?: string[];
+    }): Promise<DbtCloudTriggerRunResponse> {
+        const body: Record<string, unknown> = {
+            cause: cause ?? `Lightdash branch preview for ${gitBranch}`,
+            git_branch: gitBranch,
+        };
+        if (stepsOverride) {
+            body.steps_override = stepsOverride;
+        }
+
+        const raw = await this.request<Record<string, unknown>>(
+            `/jobs/${jobId}/run/`,
+            {
+                method: 'POST',
+                body: JSON.stringify(body),
+            },
+        );
+        return { runId: raw.id as number };
+    }
+
+    async getRunStatus(runId: number): Promise<DbtCloudRunStatusResponse> {
+        const raw = await this.request<Record<string, unknown>>(
+            `/runs/${runId}/`,
+        );
+        return {
+            runId: raw.id as number,
+            status: raw.status as number,
+            statusHumanized: raw.status_humanized as string,
+            finishedAt: (raw.finished_at as string | null) ?? null,
+        };
+    }
+
+    async getArtifact<T = unknown>(
+        runId: number,
+        artifactPath: string,
+    ): Promise<T> {
+        return this.request<T>(`/runs/${runId}/artifacts/${artifactPath}`);
+    }
+
+    async pollRunUntilComplete(
+        runId: number,
+        options?: {
+            timeoutMs?: number;
+            intervalMs?: number;
+        },
+    ): Promise<DbtCloudRunStatusResponse> {
+        const timeoutMs = options?.timeoutMs ?? DEFAULT_POLL_TIMEOUT_MS;
+        const intervalMs = options?.intervalMs ?? DEFAULT_POLL_INTERVAL_MS;
+        const startTime = Date.now();
+
+        const poll = async (): Promise<DbtCloudRunStatusResponse> => {
+            const status = await this.getRunStatus(runId);
+
+            if (
+                TERMINAL_RUN_STATUSES.includes(
+                    status.status as (typeof TERMINAL_RUN_STATUSES)[number],
+                )
+            ) {
+                return status;
+            }
+
+            if (Date.now() - startTime > timeoutMs) {
+                throw new ParameterError(
+                    `dbt Cloud run ${runId} timed out after ${timeoutMs / 1000}s (last status: ${status.statusHumanized})`,
+                );
+            }
+
+            Logger.debug(
+                `dbt Cloud run ${runId} status: ${status.statusHumanized}, polling again in ${intervalMs / 1000}s`,
+            );
+
+            await new Promise((resolve) => {
+                setTimeout(resolve, intervalMs);
+            });
+
+            return poll();
+        };
+
+        return poll();
+    }
+}

--- a/packages/backend/src/controllers/projectController.ts
+++ b/packages/backend/src/controllers/projectController.ts
@@ -39,6 +39,8 @@ import {
     type ApiCreateDashboardResponse,
     type ApiCreateDashboardWithChartsResponse,
     type ApiCreatePreviewResults,
+    type ApiDbtCloudBranchPreviewResults,
+    type ApiDbtCloudJobValidationResults,
     type ApiGetDashboardsResponse,
     type ApiGetTagsResponse,
     type ApiRefreshResults,
@@ -1256,6 +1258,59 @@ export class ProjectController extends BaseController {
         this.setStatus(200);
         return {
             status: 'ok',
+        };
+    }
+
+    /**
+     * Validate the configured dbt Cloud preview job for branch previews
+     * @summary Validate dbt Cloud preview job
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/dbt-cloud/validate-preview-job')
+    @OperationId('validateDbtCloudPreviewJob')
+    async validateDbtCloudPreviewJob(
+        @Path() projectUuid: string,
+        @Request() req: express.Request,
+    ): Promise<ApiSuccess<ApiDbtCloudJobValidationResults>> {
+        this.setStatus(200);
+        const result = await this.services
+            .getProjectService()
+            .validateDbtCloudPreviewJob(req.user!, projectUuid);
+        return {
+            status: 'ok',
+            results: result,
+        };
+    }
+
+    /**
+     * Trigger a dbt Cloud branch preview by running dbt parse on a feature branch
+     * @summary Trigger dbt Cloud branch preview
+     */
+    @Middlewares([
+        allowApiKeyAuthentication,
+        isAuthenticated,
+        unauthorisedInDemo,
+    ])
+    @SuccessResponse('200', 'Success')
+    @Post('{projectUuid}/dbt-cloud/branch-preview')
+    @OperationId('triggerDbtCloudBranchPreview')
+    async triggerDbtCloudBranchPreview(
+        @Path() projectUuid: string,
+        @Body() body: { branch: string },
+        @Request() req: express.Request,
+    ): Promise<ApiSuccess<ApiDbtCloudBranchPreviewResults>> {
+        this.setStatus(200);
+        const result = await this.services
+            .getProjectService()
+            .triggerBranchPreview(req.user!, projectUuid, body.branch);
+        return {
+            status: 'ok',
+            results: result,
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -18055,6 +18055,7 @@ const models: TsoaRoute.Models = {
                 { dataType: 'enum', enums: ['checkForStuckJobs'] },
                 { dataType: 'enum', enums: ['cleanDeploySessions'] },
                 { dataType: 'enum', enums: ['managedAgentHeartbeat'] },
+                { dataType: 'enum', enums: ['dbtCloudBranchPreview'] },
             ],
             validators: {},
         },
@@ -19086,6 +19087,9 @@ const models: TsoaRoute.Models = {
             environment_id: { dataType: 'string', required: true },
             discovery_api_endpoint: { dataType: 'string' },
             tags: { dataType: 'array', array: { dataType: 'string' } },
+            account_id: { dataType: 'string' },
+            base_url: { dataType: 'string' },
+            preview_job_id: { dataType: 'string' },
         },
         additionalProperties: true,
     },
@@ -20572,7 +20576,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20582,7 +20586,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20592,7 +20596,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -20605,7 +20609,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21008,7 +21012,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21018,7 +21022,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -21028,7 +21032,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -21041,7 +21045,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -21520,6 +21524,109 @@ const models: TsoaRoute.Models = {
         dataType: 'refAlias',
         type: {
             ref: 'Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.tiles-or-description__',
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DbtCloudJobResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                deferringEnvironmentId: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'double' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                settings: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        targetName: { dataType: 'string', required: true },
+                        threads: { dataType: 'double', required: true },
+                    },
+                    required: true,
+                },
+                executeSteps: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                environmentId: { dataType: 'double', required: true },
+                jobType: { dataType: 'string', required: true },
+                name: { dataType: 'string', required: true },
+                id: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DbtCloudJobValidationResult: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                job: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { ref: 'DbtCloudJobResponse' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                errors: {
+                    dataType: 'array',
+                    array: { dataType: 'string' },
+                    required: true,
+                },
+                isValid: { dataType: 'boolean', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDbtCloudJobValidationResults: {
+        dataType: 'refAlias',
+        type: { ref: 'DbtCloudJobValidationResult', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_ApiDbtCloudJobValidationResults_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'ApiDbtCloudJobValidationResults',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDbtCloudBranchPreviewResults: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: { runId: { dataType: 'double', required: true } },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiSuccess_ApiDbtCloudBranchPreviewResults_: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: {
+                    ref: 'ApiDbtCloudBranchPreviewResults',
+                    required: true,
+                },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
             validators: {},
         },
     },
@@ -46829,6 +46936,133 @@ export function RegisterRoutes(app: Router) {
                     next,
                     validatedArgs,
                     successStatus: undefined,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_validateDbtCloudPreviewJob: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/dbt-cloud/validate-preview-job',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.validateDbtCloudPreviewJob,
+        ),
+
+        async function ProjectController_validateDbtCloudPreviewJob(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_validateDbtCloudPreviewJob,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'validateDbtCloudPreviewJob',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsProjectController_triggerDbtCloudBranchPreview: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        body: {
+            in: 'body',
+            name: 'body',
+            required: true,
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                branch: { dataType: 'string', required: true },
+            },
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.post(
+        '/api/v1/projects/:projectUuid/dbt-cloud/branch-preview',
+        ...fetchMiddlewares<RequestHandler>(ProjectController),
+        ...fetchMiddlewares<RequestHandler>(
+            ProjectController.prototype.triggerDbtCloudBranchPreview,
+        ),
+
+        async function ProjectController_triggerDbtCloudBranchPreview(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsProjectController_triggerDbtCloudBranchPreview,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<ProjectController>(ProjectController);
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'triggerDbtCloudBranchPreview',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
                 });
             } catch (err) {
                 return next(err);

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -19193,7 +19193,8 @@
                     "generateSlackChannelSyncJobs",
                     "checkForStuckJobs",
                     "cleanDeploySessions",
-                    "managedAgentHeartbeat"
+                    "managedAgentHeartbeat",
+                    "dbtCloudBranchPreview"
                 ]
             },
             "BaseSchedulerLog": {
@@ -20315,6 +20316,15 @@
                             "type": "string"
                         },
                         "type": "array"
+                    },
+                    "account_id": {
+                        "type": "string"
+                    },
+                    "base_url": {
+                        "type": "string"
+                    },
+                    "preview_job_id": {
+                        "type": "string"
                     }
                 },
                 "required": ["type", "api_key", "environment_id"],
@@ -21922,22 +21932,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -22284,22 +22294,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "dashboard": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_DashboardAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__dashboard_58___91_x-string_93__58__name_63_-string-or-undefined--tiles_63__58__40__type-DashboardTileTypes.SAVED_CHART-or-DashboardTileTypes.SQL_CHART--properties_58__title-string--chartName-string__-or-_type-DashboardTileTypes.MARKDOWN--properties_58__title-string--content-string__-or-_type-DashboardTileTypes.LOOM--properties_58__title-string__-or-_type-DashboardTileTypes.HEADING--properties_58__text-string___41_-Array-or-undefined--description_63_-string-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ApiDashboardAsCodeListResponse": {
@@ -22782,6 +22792,122 @@
             "Omit_DashboardAsCode.tiles-or-description_": {
                 "$ref": "#/components/schemas/Pick_DashboardAsCode.Exclude_keyofDashboardAsCode.tiles-or-description__",
                 "description": "Construct a type with the properties of T except for those in type K."
+            },
+            "DbtCloudJobResponse": {
+                "properties": {
+                    "deferringEnvironmentId": {
+                        "type": "number",
+                        "format": "double",
+                        "nullable": true
+                    },
+                    "settings": {
+                        "properties": {
+                            "targetName": {
+                                "type": "string"
+                            },
+                            "threads": {
+                                "type": "number",
+                                "format": "double"
+                            }
+                        },
+                        "required": ["targetName", "threads"],
+                        "type": "object"
+                    },
+                    "executeSteps": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "environmentId": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "jobType": {
+                        "type": "string"
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "id": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": [
+                    "deferringEnvironmentId",
+                    "settings",
+                    "executeSteps",
+                    "environmentId",
+                    "jobType",
+                    "name",
+                    "id"
+                ],
+                "type": "object"
+            },
+            "DbtCloudJobValidationResult": {
+                "properties": {
+                    "job": {
+                        "allOf": [
+                            {
+                                "$ref": "#/components/schemas/DbtCloudJobResponse"
+                            }
+                        ],
+                        "nullable": true
+                    },
+                    "errors": {
+                        "items": {
+                            "type": "string"
+                        },
+                        "type": "array"
+                    },
+                    "isValid": {
+                        "type": "boolean"
+                    }
+                },
+                "required": ["job", "errors", "isValid"],
+                "type": "object"
+            },
+            "ApiDbtCloudJobValidationResults": {
+                "$ref": "#/components/schemas/DbtCloudJobValidationResult"
+            },
+            "ApiSuccess_ApiDbtCloudJobValidationResults_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ApiDbtCloudJobValidationResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "ApiDbtCloudBranchPreviewResults": {
+                "properties": {
+                    "runId": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["runId"],
+                "type": "object"
+            },
+            "ApiSuccess_ApiDbtCloudBranchPreviewResults_": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/ApiDbtCloudBranchPreviewResults"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
             },
             "ApiRefreshResults": {
                 "properties": {
@@ -30285,7 +30411,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2769.0",
+        "version": "0.2772.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -40517,6 +40643,104 @@
                         "application/json": {
                             "schema": {
                                 "$ref": "#/components/schemas/AnyType"
+                            }
+                        }
+                    }
+                }
+            }
+        },
+        "/api/v1/projects/{projectUuid}/dbt-cloud/validate-preview-job": {
+            "post": {
+                "operationId": "validateDbtCloudPreviewJob",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccess_ApiDbtCloudJobValidationResults_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Validate the configured dbt Cloud preview job for branch previews",
+                "summary": "Validate dbt Cloud preview job",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v1/projects/{projectUuid}/dbt-cloud/branch-preview": {
+            "post": {
+                "operationId": "triggerDbtCloudBranchPreview",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiSuccess_ApiDbtCloudBranchPreviewResults_"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Trigger a dbt Cloud branch preview by running dbt parse on a feature branch",
+                "summary": "Trigger dbt Cloud branch preview",
+                "tags": ["Projects"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    }
+                ],
+                "requestBody": {
+                    "required": true,
+                    "content": {
+                        "application/json": {
+                            "schema": {
+                                "properties": {
+                                    "branch": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": ["branch"],
+                                "type": "object"
                             }
                         }
                     }

--- a/packages/backend/src/scheduler/SchedulerClient.ts
+++ b/packages/backend/src/scheduler/SchedulerClient.ts
@@ -47,6 +47,7 @@ import {
     TraceTaskBase,
     UploadMetricGsheetPayload,
     ValidateProjectPayload,
+    type DbtCloudBranchPreviewPayload,
     type DownloadAsyncQueryResultsPayload,
     type PreAggregateSchedulerDetails,
     type SchedulerCreateProjectWithCompilePayload,
@@ -1156,6 +1157,32 @@ export class SchedulerClient {
                 organizationUuid: payload.organizationUuid,
                 context: payload.context,
                 onlyValidateExploresInArgs: payload.onlyValidateExploresInArgs,
+            },
+        });
+
+        return jobId;
+    }
+
+    async dbtCloudBranchPreview(payload: DbtCloudBranchPreviewPayload) {
+        const graphileClient = await this.graphileUtils;
+        const now = new Date();
+        const jobId = await SchedulerClient.addJob(
+            graphileClient,
+            SCHEDULER_TASKS.DBT_CLOUD_BRANCH_PREVIEW,
+            payload,
+            now,
+            JobPriority.HIGH,
+        );
+
+        await this.schedulerModel.logSchedulerJob({
+            task: SCHEDULER_TASKS.DBT_CLOUD_BRANCH_PREVIEW,
+            jobId,
+            scheduledTime: now,
+            status: SchedulerJobStatus.SCHEDULED,
+            details: {
+                projectUuid: payload.projectUuid,
+                runId: payload.runId,
+                gitBranch: payload.gitBranch,
             },
         });
 

--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -90,6 +90,7 @@ import {
     WarehouseConnectionError,
     type Account as AccountType,
     type BatchDeliveryResult,
+    type DbtCloudBranchPreviewPayload,
     type DeliveryResult,
     type DownloadAsyncQueryResultsPayload,
     type EmailBatchNotificationPayload,
@@ -1916,6 +1917,58 @@ export default class SchedulerTask {
         Logger.info(
             `Scheduled ${totalScheduledJobs} pre-aggregate cron materialization job(s)`,
         );
+    }
+
+    protected async handleDbtCloudBranchPreview(
+        jobId: string,
+        scheduledTime: Date,
+        payload: DbtCloudBranchPreviewPayload,
+    ) {
+        const baseLog = {
+            task: SCHEDULER_TASKS.DBT_CLOUD_BRANCH_PREVIEW,
+            jobId,
+            scheduledTime,
+        };
+
+        await this.schedulerService.logSchedulerJob({
+            ...baseLog,
+            status: SchedulerJobStatus.STARTED,
+            details: {
+                projectUuid: payload.projectUuid,
+                runId: payload.runId,
+                gitBranch: payload.gitBranch,
+            },
+        });
+
+        try {
+            await this.projectService.pollAndCreateBranchPreview(
+                payload.projectUuid,
+                payload.runId,
+                payload.gitBranch,
+            );
+
+            await this.schedulerService.logSchedulerJob({
+                ...baseLog,
+                status: SchedulerJobStatus.COMPLETED,
+                details: {
+                    projectUuid: payload.projectUuid,
+                    runId: payload.runId,
+                    gitBranch: payload.gitBranch,
+                },
+            });
+        } catch (e) {
+            await this.schedulerService.logSchedulerJob({
+                ...baseLog,
+                status: SchedulerJobStatus.ERROR,
+                details: {
+                    projectUuid: payload.projectUuid,
+                    runId: payload.runId,
+                    gitBranch: payload.gitBranch,
+                    error: getErrorMessage(e),
+                },
+            });
+            throw e;
+        }
     }
 
     protected async validateProject(

--- a/packages/backend/src/scheduler/SchedulerTaskTracer.ts
+++ b/packages/backend/src/scheduler/SchedulerTaskTracer.ts
@@ -189,6 +189,11 @@ const getTagsForTask: {
         'project.uuid': payload.projectUuid,
     }),
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: () => ({}),
+    [SCHEDULER_TASKS.DBT_CLOUD_BRANCH_PREVIEW]: (payload) => ({
+        'organization.uuid': payload.organizationUuid,
+        'user.uuid': payload.userUuid,
+        'project.uuid': payload.projectUuid,
+    }),
 } as const;
 
 // Generic accessor function

--- a/packages/backend/src/scheduler/SchedulerWorker.ts
+++ b/packages/backend/src/scheduler/SchedulerWorker.ts
@@ -747,6 +747,24 @@ export class SchedulerWorker extends SchedulerTask {
                     },
                 );
             },
+            [SCHEDULER_TASKS.DBT_CLOUD_BRANCH_PREVIEW]: async (
+                payload,
+                helpers,
+            ) => {
+                await SchedulerClient.processJob(
+                    SCHEDULER_TASKS.DBT_CLOUD_BRANCH_PREVIEW,
+                    helpers.job.id,
+                    helpers.job.run_at,
+                    payload,
+                    async () => {
+                        await this.handleDbtCloudBranchPreview(
+                            helpers.job.id,
+                            helpers.job.run_at,
+                            payload,
+                        );
+                    },
+                );
+            },
             [SCHEDULER_TASKS.SQL_RUNNER]: async (payload, helpers) => {
                 await tryJobOrTimeout(
                     SchedulerClient.processJob(

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -43,6 +43,7 @@ import {
     DatabricksAuthenticationType,
     DatabricksTokenError,
     DateZoom,
+    DbtCloudRunStatus,
     DbtExposure,
     DbtExposureType,
     DbtManifestVersion,
@@ -175,6 +176,8 @@ import {
     type ApiCreateProjectResults,
     type CalculateSubtotalsFromQuery,
     type CreateDatabricksCredentials,
+    type DbtCloudJobResponse,
+    type DbtCloudJobValidationResult,
     type Metric,
     type ParameterDefinitions,
     type ParametersValuesMap,
@@ -205,6 +208,7 @@ import {
     ProjectEvent,
 } from '../../analytics/LightdashAnalytics';
 import { S3CacheClient } from '../../clients/Aws/S3CacheClient';
+import { DbtCloudRestClient } from '../../clients/DbtCloud/DbtCloudRestClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
 import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import type { INatsClient } from '../../clients/NatsClient';
@@ -8095,6 +8099,172 @@ export class ProjectService extends BaseService {
         return updatedCharts;
     }
 
+    async validateDbtCloudPreviewJob(
+        user: SessionUser,
+        projectUuid: string,
+    ): Promise<DbtCloudJobValidationResult> {
+        const project =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        if (project.dbtConnection.type !== DbtProjectType.DBT_CLOUD_IDE) {
+            throw new ParameterError(
+                `Project ${projectUuid} is not a dbt Cloud IDE project`,
+            );
+        }
+
+        const {
+            api_key: apiKey,
+            account_id: accountId,
+            preview_job_id: previewJobId,
+        } = project.dbtConnection;
+
+        if (!accountId || !previewJobId) {
+            throw new ParameterError(
+                'Account ID and Preview Job ID must be configured to validate the preview job',
+            );
+        }
+
+        const client = new DbtCloudRestClient({
+            serviceToken: apiKey,
+            accountId,
+            baseUrl: project.dbtConnection.base_url,
+        });
+
+        const errors: string[] = [];
+        let job: DbtCloudJobResponse | null = null;
+        try {
+            job = await client.getJob(previewJobId);
+        } catch (e) {
+            return {
+                isValid: false,
+                errors: [
+                    `Could not fetch job ${previewJobId}: ${getErrorMessage(e)}`,
+                ],
+                job: null,
+            };
+        }
+
+        if (job.jobType !== 'ci') {
+            errors.push(
+                `Job "${job.name}" is not a CI job (type: ${job.jobType}). Change job_type to "ci" in dbt Cloud.`,
+            );
+        }
+
+        if (!job.deferringEnvironmentId) {
+            errors.push(
+                `Job "${job.name}" does not defer to a production environment. Set a deferring environment in dbt Cloud.`,
+            );
+        }
+
+        const hasDbtParse = job.executeSteps.some((step) =>
+            step.includes('dbt parse'),
+        );
+        if (!hasDbtParse) {
+            errors.push(
+                `Job "${job.name}" does not include a "dbt parse" step. Add "dbt parse" to the execute steps.`,
+            );
+        }
+
+        return {
+            isValid: errors.length === 0,
+            errors,
+            job,
+        };
+    }
+
+    async triggerBranchPreview(
+        user: SessionUser,
+        projectUuid: string,
+        gitBranch: string,
+    ): Promise<{ runId: number }> {
+        const project =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        if (project.dbtConnection.type !== DbtProjectType.DBT_CLOUD_IDE) {
+            throw new ParameterError(
+                `Project ${projectUuid} is not a dbt Cloud IDE project`,
+            );
+        }
+
+        const {
+            api_key: apiKey,
+            account_id: accountId,
+            preview_job_id: previewJobId,
+        } = project.dbtConnection;
+
+        if (!accountId || !previewJobId) {
+            throw new ParameterError(
+                'Account ID and Preview Job ID must be configured to trigger branch previews',
+            );
+        }
+
+        const client = new DbtCloudRestClient({
+            serviceToken: apiKey,
+            accountId,
+            baseUrl: project.dbtConnection.base_url,
+        });
+
+        const { runId } = await client.triggerRun({
+            jobId: previewJobId,
+            gitBranch,
+            stepsOverride: ['dbt parse'],
+        });
+
+        await this.schedulerClient.dbtCloudBranchPreview({
+            projectUuid,
+            organizationUuid: project.organizationUuid,
+            userUuid: user.userUuid,
+            runId,
+            gitBranch,
+        });
+
+        return { runId };
+    }
+
+    async pollAndCreateBranchPreview(
+        projectUuid: string,
+        runId: number,
+        gitBranch: string,
+    ): Promise<string> {
+        const project =
+            await this.projectModel.getWithSensitiveFields(projectUuid);
+
+        if (project.dbtConnection.type !== DbtProjectType.DBT_CLOUD_IDE) {
+            throw new ParameterError(
+                `Project ${projectUuid} is not a dbt Cloud IDE project`,
+            );
+        }
+
+        const { api_key: apiKey, account_id: accountId } =
+            project.dbtConnection;
+
+        if (!accountId) {
+            throw new ParameterError(
+                'Account ID must be configured for branch previews',
+            );
+        }
+
+        const client = new DbtCloudRestClient({
+            serviceToken: apiKey,
+            accountId,
+            baseUrl: project.dbtConnection.base_url,
+        });
+
+        const finalStatus = await client.pollRunUntilComplete(runId);
+
+        if (finalStatus.status !== DbtCloudRunStatus.SUCCESS) {
+            throw new ParameterError(
+                `dbt Cloud run ${runId} ended with status: ${finalStatus.statusHumanized}`,
+            );
+        }
+
+        return this.createPreviewWithExplores(
+            projectUuid,
+            accountId,
+            String(runId),
+        );
+    }
+
     async createPreviewWithExplores(
         projectUuid: string,
         accountId: string,
@@ -8128,15 +8298,17 @@ export class ProjectService extends BaseService {
             project.createdByUserUuid,
         );
 
-        const response = await fetch(
-            `https://cloud.getdbt.com/api/v2/accounts/${accountId}/runs/${runId}/artifacts/manifest.json`,
-            {
-                headers: {
-                    Authorization: `Bearer ${project.dbtConnection.api_key}`,
-                },
-            },
-        );
-        const manifest = await response.json();
+        // Use stored account_id with fallback to webhook-provided value
+        const resolvedAccountId = project.dbtConnection.account_id || accountId;
+        const client = new DbtCloudRestClient({
+            serviceToken: project.dbtConnection.api_key,
+            accountId: resolvedAccountId,
+            baseUrl: project.dbtConnection.base_url,
+        });
+        const manifest = (await client.getArtifact(
+            Number(runId),
+            'manifest.json',
+        )) as AnyType;
 
         const prId = manifest.metadata.env.DBT_CLOUD_PR_ID;
         const jobId = manifest.metadata.env.DBT_CLOUD_JOB_ID;

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -106,6 +106,7 @@ export * from './types/content';
 export * from './types/contentVerification';
 export * from './types/dashboard';
 export * from './types/dbt';
+export * from './types/dbtCloud';
 export * from './types/downloadFile';
 export * from './types/email';
 export * from './types/errors';

--- a/packages/common/src/types/dbtCloud.ts
+++ b/packages/common/src/types/dbtCloud.ts
@@ -1,0 +1,59 @@
+export enum DbtCloudRunStatus {
+    QUEUED = 1,
+    STARTING = 2,
+    RUNNING = 3,
+    SUCCESS = 10,
+    ERROR = 20,
+    CANCELLED = 30,
+}
+
+export const TERMINAL_RUN_STATUSES = [
+    DbtCloudRunStatus.SUCCESS,
+    DbtCloudRunStatus.ERROR,
+    DbtCloudRunStatus.CANCELLED,
+] as const;
+
+export type DbtCloudTriggerRunRequest = {
+    jobId: string;
+    gitBranch: string;
+    cause?: string;
+    stepsOverride?: string[];
+};
+
+export type DbtCloudTriggerRunResponse = {
+    runId: number;
+};
+
+export type DbtCloudRunStatusResponse = {
+    runId: number;
+    status: DbtCloudRunStatus;
+    statusHumanized: string;
+    finishedAt: string | null;
+};
+
+export type DbtCloudJobResponse = {
+    id: number;
+    name: string;
+    jobType: string;
+    environmentId: number;
+    executeSteps: string[];
+    settings: {
+        threads: number;
+        targetName: string;
+    };
+    deferringEnvironmentId: number | null;
+};
+
+export type DbtCloudJobValidationResult = {
+    isValid: boolean;
+    errors: string[];
+    job: DbtCloudJobResponse | null;
+};
+
+export type ApiDbtCloudJobValidationResults = DbtCloudJobValidationResult;
+
+export type ApiDbtCloudBranchPreviewResults = {
+    runId: number;
+};
+
+export const DEFAULT_DBT_CLOUD_BASE_URL = 'https://cloud.getdbt.com';

--- a/packages/common/src/types/projects.ts
+++ b/packages/common/src/types/projects.ts
@@ -473,6 +473,9 @@ export interface DbtCloudIDEProjectConfig extends DbtProjectConfigBase {
     environment_id: string;
     discovery_api_endpoint?: string;
     tags?: string[];
+    account_id?: string;
+    base_url?: string;
+    preview_job_id?: string;
 }
 
 export interface DbtGithubProjectConfig extends DbtProjectCompilerBase {

--- a/packages/common/src/types/scheduler.ts
+++ b/packages/common/src/types/scheduler.ts
@@ -660,6 +660,11 @@ export type CompileProjectPayload = TraceTaskBase & {
     isPreview: boolean;
 };
 
+export type DbtCloudBranchPreviewPayload = TraceTaskBase & {
+    runId: number;
+    gitBranch: string;
+};
+
 export type PreAggregateMaterializationTrigger =
     | 'compile'
     | 'cron'

--- a/packages/common/src/types/schedulerTaskList.ts
+++ b/packages/common/src/types/schedulerTaskList.ts
@@ -12,6 +12,7 @@ import { type UploadMetricGsheetPayload } from './gdrive';
 import { type RenameResourcesPayload } from './rename';
 import {
     type CompileProjectPayload,
+    type DbtCloudBranchPreviewPayload,
     type DownloadAsyncQueryResultsPayload,
     type EmailBatchNotificationPayload,
     type EmailNotificationPayload,
@@ -87,6 +88,7 @@ export const SCHEDULER_TASKS = {
     CHECK_FOR_STUCK_JOBS: 'checkForStuckJobs',
     CLEAN_DEPLOY_SESSIONS: 'cleanDeploySessions',
     MANAGED_AGENT_HEARTBEAT: 'managedAgentHeartbeat',
+    DBT_CLOUD_BRANCH_PREVIEW: 'dbtCloudBranchPreview',
     ...EE_SCHEDULER_TASKS,
 } as const;
 
@@ -133,6 +135,7 @@ export interface TaskPayloadMap {
     [SCHEDULER_TASKS.GENERATE_ARTIFACT_QUESTION]: GenerateArtifactQuestionJobPayload;
     [SCHEDULER_TASKS.APP_GENERATE_PIPELINE]: AppGeneratePipelineJobPayload;
     [SCHEDULER_TASKS.SWEEP_STALE_APP_LOCKS]: TraceTaskBase;
+    [SCHEDULER_TASKS.DBT_CLOUD_BRANCH_PREVIEW]: DbtCloudBranchPreviewPayload;
 }
 
 export interface EETaskPayloadMap {

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/DbtCloudForm.tsx
@@ -89,6 +89,33 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                 />
             )}
             <TextInput
+                name="dbt.account_id"
+                {...form.getInputProps('dbt.account_id')}
+                label="Account ID"
+                description={
+                    <p>
+                        Your dbt Cloud account ID. You can find this in the URL
+                        when logged in to dbt Cloud (e.g.
+                        cloud.getdbt.com/deploy/<b>12345</b>/...).
+                    </p>
+                }
+                disabled={disabled}
+            />
+            <TextInput
+                name="dbt.base_url"
+                {...form.getInputProps('dbt.base_url')}
+                label="Base URL"
+                description={
+                    <p>
+                        The base URL for your dbt Cloud instance. Only change
+                        this if you are on a non-US region or single-tenant
+                        deployment.
+                    </p>
+                }
+                placeholder="https://cloud.getdbt.com"
+                disabled={disabled}
+            />
+            <TextInput
                 name="dbt.discovery_api_endpoint"
                 {...form.getInputProps('dbt.discovery_api_endpoint')}
                 label="Discovery API endpoint"
@@ -106,6 +133,20 @@ const DbtCloudForm: FC<{ disabled: boolean }> = ({ disabled }) => {
                     </p>
                 }
                 placeholder="https://metadata.cloud.getdbt.com/graphql"
+                disabled={disabled}
+            />
+            <TextInput
+                name="dbt.preview_job_id"
+                {...form.getInputProps('dbt.preview_job_id')}
+                label="Preview Job ID"
+                description={
+                    <p>
+                        The ID of a CI job in dbt Cloud to use for branch
+                        previews. The job should run <b>dbt parse</b> and defer
+                        to your production environment.
+                        <DocumentationHelpButton href="https://docs.getdbt.com/docs/deploy/ci-jobs" />
+                    </p>
+                }
                 disabled={disabled}
             />
             <MultiSelect

--- a/packages/frontend/src/components/ProjectConnection/DbtForms/defaultValues.tsx
+++ b/packages/frontend/src/components/ProjectConnection/DbtForms/defaultValues.tsx
@@ -69,6 +69,9 @@ const dbtCloudIdeDefaultValues: DbtCloudIDEProjectConfig = {
     environment_id: '',
     discovery_api_endpoint: '',
     tags: [],
+    account_id: '',
+    base_url: '',
+    preview_job_id: '',
 } as const;
 
 // Local


### PR DESCRIPTION
## Summary

- Add active branch preview support for dbt Cloud IDE projects
- New config fields (`account_id`, `base_url`, `preview_job_id`) with frontend form inputs
- `DbtCloudRestClient` for dbt Cloud v2 REST API (trigger runs, poll status, fetch artifacts)
- Job validation endpoint (`POST .../dbt-cloud/validate-preview-job`) — checks job type, deferring env, execute steps
- Branch preview trigger endpoint (`POST .../dbt-cloud/branch-preview`) — triggers `dbt parse` on a feature branch
- Background Graphile Worker job polls for run completion and creates/updates preview project
- Refactors `createPreviewWithExplores` to use REST client instead of hardcoded `cloud.getdbt.com` URL

## Test plan

- [ ] Configure a dbt Cloud IDE project with `account_id`, `base_url`, `preview_job_id`
- [ ] Validate preview job endpoint returns actionable errors for misconfigured jobs
- [ ] Trigger branch preview and verify run is created in dbt Cloud
- [ ] Verify background job polls and creates preview project on success
- [ ] Verify existing webhook flow still works (backward compat)
- [ ] `pnpm -F common typecheck && pnpm -F backend typecheck && pnpm -F frontend typecheck`