### PR TITLE
feat(data-apps): track app views

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -3,6 +3,8 @@ import {
     AiAgentReasoningTableName,
 } from '../database/entities/aiAgentReasoning';
 import {
+    AnalyticsAppViews,
+    AnalyticsAppViewsTableName,
     AnalyticsChartViews,
     AnalyticsChartViewsTableName,
     AnalyticsDashboardViews,
@@ -413,6 +415,7 @@ declare module 'knex/types/tables' {
         [SlackChannelsTableName]: SlackChannelsTable;
         [AnalyticsChartViewsTableName]: AnalyticsChartViews;
         [AnalyticsDashboardViewsTableName]: AnalyticsDashboardViews;
+        [AnalyticsAppViewsTableName]: AnalyticsAppViews;
         [PinnedListTableName]: PinnedListTable;
         [PinnedChartTableName]: PinnedChartTable;
         [PinnedDashboardTableName]: PinnedDashboardTable;

--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -1244,13 +1244,24 @@ export type DataAppImageUploadedEvent = BaseTrack & {
     };
 };
 
+export type DataAppViewedEvent = BaseTrack & {
+    event: 'data_app.view';
+    userId: string;
+    properties: {
+        organizationId: string;
+        projectId: string;
+        appUuid: string;
+    };
+};
+
 export type DataAppEvent =
     | DataAppCreatedEvent
     | DataAppIteratedEvent
     | DataAppVersionCancelledEvent
     | DataAppVersionCompletedEvent
     | DataAppVersionFailedEvent
-    | DataAppImageUploadedEvent;
+    | DataAppImageUploadedEvent
+    | DataAppViewedEvent;
 
 export type CommentsEvent = BaseTrack & {
     event: 'comment.created' | 'comment.deleted' | 'comment.resolved';

--- a/packages/backend/src/database/entities/analytics.ts
+++ b/packages/backend/src/database/entities/analytics.ts
@@ -4,6 +4,7 @@ import { Knex } from 'knex';
 export const AnalyticsChartViewsTableName = 'analytics_chart_views';
 export const AnalyticsDashboardViewsTableName = 'analytics_dashboard_views';
 export const AnalyticsSqlChartViewsTableName = 'analytics_sql_chart_views';
+export const AnalyticsAppViewsTableName = 'analytics_app_views';
 
 export type DbAnalyticsChartViews = {
     chart_uuid: string;
@@ -17,6 +18,11 @@ export type DbAnalyticsDashboardViews = {
     timestamp: Date;
     context: Record<string, AnyType> | null;
 };
+export type DbAnalyticsAppViews = {
+    app_id: string;
+    user_uuid: string | null;
+    timestamp: Date;
+};
 
 export type AnalyticsDashboardViews = Knex.CompositeTableType<
     DbAnalyticsDashboardViews,
@@ -26,4 +32,9 @@ export type AnalyticsDashboardViews = Knex.CompositeTableType<
 export type AnalyticsChartViews = Knex.CompositeTableType<
     DbAnalyticsChartViews,
     Pick<DbAnalyticsChartViews, 'chart_uuid' | 'user_uuid'>
+>;
+
+export type AnalyticsAppViews = Knex.CompositeTableType<
+    DbAnalyticsAppViews,
+    Pick<DbAnalyticsAppViews, 'app_id' | 'user_uuid'>
 >;

--- a/packages/backend/src/database/entities/apps.ts
+++ b/packages/backend/src/database/entities/apps.ts
@@ -22,6 +22,7 @@ export type DbApp = {
     created_by_user_uuid: string;
     deleted_at: Date | null;
     deleted_by_user_uuid: string | null;
+    views_count: number;
 };
 
 export type AppsTable = Knex.CompositeTableType<
@@ -42,6 +43,7 @@ export type AppsTable = Knex.CompositeTableType<
             | 'sandbox_id'
             | 'deleted_at'
             | 'deleted_by_user_uuid'
+            | 'views_count'
         >
     >
 >;

--- a/packages/backend/src/database/migrations/20260423120000_add_app_views.ts
+++ b/packages/backend/src/database/migrations/20260423120000_add_app_views.ts
@@ -1,0 +1,39 @@
+import { Knex } from 'knex';
+
+const ANALYTICS_APP_VIEWS_TABLE_NAME = 'analytics_app_views';
+const APPS_TABLE_NAME = 'apps';
+
+export async function up(knex: Knex): Promise<void> {
+    await knex.schema.table(APPS_TABLE_NAME, (table) => {
+        table.integer('views_count').defaultTo(0).notNullable();
+    });
+
+    await knex.schema.createTable(
+        ANALYTICS_APP_VIEWS_TABLE_NAME,
+        (tableBuilder) => {
+            tableBuilder
+                .uuid('user_uuid')
+                .nullable()
+                .references('user_uuid')
+                .inTable('users')
+                .onDelete('SET NULL');
+            tableBuilder
+                .uuid('app_id')
+                .notNullable()
+                .references('app_id')
+                .inTable(APPS_TABLE_NAME)
+                .onDelete('CASCADE');
+            tableBuilder
+                .timestamp('timestamp', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+        },
+    );
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(ANALYTICS_APP_VIEWS_TABLE_NAME);
+    await knex.schema.table(APPS_TABLE_NAME, (table) => {
+        table.dropColumn('views_count');
+    });
+}

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -80,6 +80,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                 new AppGenerateService({
                     lightdashConfig: context.lightdashConfig,
                     analytics: context.lightdashAnalytics,
+                    analyticsModel: models.getAnalyticsModel(),
                     catalogModel: models.getCatalogModel(),
                     appModel: models.getAppModel(),
                     featureFlagModel: models.getFeatureFlagModel(),

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -31,6 +31,7 @@ import {
     type AppVersionStatus,
     type DbApp,
 } from '../../../database/entities/apps';
+import { AnalyticsModel } from '../../../models/AnalyticsModel';
 import { AppModel } from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
 import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
@@ -44,6 +45,7 @@ import type { CommercialSchedulerClient } from '../../scheduler/SchedulerClient'
 type AppGenerateServiceDeps = {
     lightdashConfig: LightdashConfig;
     analytics: LightdashAnalytics;
+    analyticsModel: AnalyticsModel;
     catalogModel: CatalogModel;
     appModel: AppModel;
     featureFlagModel: FeatureFlagModel;
@@ -63,6 +65,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly analytics: LightdashAnalytics;
 
+    private readonly analyticsModel: AnalyticsModel;
+
     private readonly catalogModel: CatalogModel;
 
     private readonly appModel: AppModel;
@@ -80,6 +84,7 @@ export class AppGenerateService extends BaseService {
     constructor({
         lightdashConfig,
         analytics,
+        analyticsModel,
         catalogModel,
         appModel,
         featureFlagModel,
@@ -91,6 +96,7 @@ export class AppGenerateService extends BaseService {
         super();
         this.lightdashConfig = lightdashConfig;
         this.analytics = analytics;
+        this.analyticsModel = analyticsModel;
         this.catalogModel = catalogModel;
         this.appModel = appModel;
         this.featureFlagModel = featureFlagModel;
@@ -2228,6 +2234,18 @@ export class AppGenerateService extends BaseService {
             project_uuid: projectUuid,
             space_uuid: spaceUuid,
             organization_uuid: organizationUuid,
+        });
+
+        await this.analyticsModel.addAppViewEvent(appUuid, user.userUuid);
+
+        this.analytics.track({
+            event: 'data_app.view',
+            userId: user.userUuid,
+            properties: {
+                organizationId: organizationUuid,
+                projectId: projectUuid,
+                appUuid,
+            },
         });
 
         return {

--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -9,9 +9,11 @@ import {
 import * as Sentry from '@sentry/node';
 import { Knex } from 'knex';
 import {
+    AnalyticsAppViewsTableName,
     AnalyticsChartViewsTableName,
     AnalyticsDashboardViewsTableName,
 } from '../database/entities/analytics';
+import { AppsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
@@ -153,6 +155,22 @@ export class AnalyticsModel {
                     ) as unknown as Date, // update first_viewed_at if it is null
                 })
                 .where('dashboard_uuid', dashboardUuid);
+        });
+    }
+
+    async addAppViewEvent(appId: string, userUuid: string): Promise<void> {
+        await this.database.transaction(async (trx) => {
+            await trx(AnalyticsAppViewsTableName).insert({
+                app_id: appId,
+                user_uuid: userUuid,
+            });
+            await trx(AppsTableName)
+                .update({
+                    views_count: trx.raw(
+                        'views_count + 1',
+                    ) as unknown as number,
+                })
+                .where('app_id', appId);
         });
     }
 


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-355/add-app-viewed-tracking

### Description:
Records a row in the new analytics_app_views table and increments apps.views_count on every GET /apps/{appUuid}, mirroring the existing dashboard view tracking. Also emits a data_app.view Rudderstack event for product analytics.
