### PR TITLE
feat(data-apps): show type and view count in space listings

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -114,8 +114,10 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     `last_updated_by_user.first_name       as last_updated_by_user_first_name`,
                     `last_updated_by_user.last_name        as last_updated_by_user_last_name`,
 
-                    knex.raw(`0 as views`),
-                    knex.raw(`NULL::timestamp as first_viewed_at`),
+                    `${AppsTableName}.views_count as views`,
+                    knex.raw(
+                        `${AppsTableName}.created_at::timestamp as first_viewed_at`,
+                    ),
                     knex.raw(
                         `${AppsTableName}.deleted_at::timestamp as deleted_at`,
                     ),

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -97,6 +97,8 @@ export type ResourceViewDataAppItem = {
             firstName: string;
             lastName: string;
         } | null;
+        views: number;
+        firstViewedAt: Date | null;
         latestVersionNumber: number | null;
         latestVersionStatus: AppVersionStatus | null;
     };
@@ -261,6 +263,8 @@ export const contentToResourceViewItem = (content: SummaryContent) => {
                           lastName: updatedByUser.lastName,
                       }
                     : null,
+                views: content.views,
+                firstViewedAt: content.firstViewedAt,
                 latestVersionNumber: content.latestVersionNumber,
                 latestVersionStatus: content.latestVersionStatus,
             };

--- a/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
+++ b/packages/frontend/src/components/common/ResourceView/InfiniteResourceTableColumnName.tsx
@@ -1,4 +1,5 @@
 import {
+    isResourceViewDataAppItem,
     isResourceViewItemChart,
     isResourceViewItemDashboard,
     isResourceViewSpaceItem,
@@ -148,6 +149,8 @@ const InfiniteResourceTableColumnName = ({
     const isSpace = isResourceViewSpaceItem(item);
     const isChartOrDashboard =
         isResourceViewItemChart(item) || isResourceViewItemDashboard(item);
+    const showTypeAndViews =
+        isChartOrDashboard || isResourceViewDataAppItem(item);
 
     const hasValidationErrors =
         isChartOrDashboard &&
@@ -212,7 +215,7 @@ const InfiniteResourceTableColumnName = ({
                                 </Box>
                             )}
                     </Group>
-                    {isChartOrDashboard && (
+                    {showTypeAndViews && (
                         <Text fz={12} c="ldGray.6">
                             {getResourceTypeName(item)} •{' '}
                             <Tooltip

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -114,9 +114,10 @@ export const getResourceViewsSinceWhenDescription = (
 ) => {
     if (
         item.type !== ResourceViewItemType.CHART &&
-        item.type !== ResourceViewItemType.DASHBOARD
+        item.type !== ResourceViewItemType.DASHBOARD &&
+        item.type !== ResourceViewItemType.DATA_APP
     ) {
-        throw new Error('Only supported for charts and dashboards');
+        throw new Error('Only supported for charts, dashboards and data apps');
     }
 
     return item.data.firstViewedAt


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-316/add-apps-to-spaces

### Description:
Render "Data app • N views" under app names in the space content table, matching the subtitle charts and dashboards already have.

<img width="885" height="302" alt="image" src="https://github.com/user-attachments/assets/9ee92aa9-7f7d-445b-97ad-0505c110ebbe" />


