### PR TITLE
feat(data-apps): enable rename from space listings

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -22,6 +22,7 @@ import { useSpacePinningMutation } from '../../../hooks/pinning/useSpaceMutation
 import { useContentAction } from '../../../hooks/useContent';
 import { useSpace } from '../../../hooks/useSpaces';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
+import AppUpdateModal from '../modal/AppUpdateModal';
 import ChartDeleteModal from '../modal/ChartDeleteModal';
 import ChartDuplicateModal from '../modal/ChartDuplicateModal';
 import ChartUpdateModal from '../modal/ChartUpdateModal';
@@ -225,8 +226,18 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                         />
                     );
                 case ResourceViewItemType.DATA_APP:
-                    // Update via this modal isn't supported for data apps yet
-                    return null;
+                    return (
+                        <AppUpdateModal
+                            opened
+                            uuid={action.item.data.uuid}
+                            initialName={action.item.data.name}
+                            initialDescription={
+                                action.item.data.description ?? ''
+                            }
+                            onClose={handleReset}
+                            onConfirm={handleReset}
+                        />
+                    );
                 default:
                     return assertUnreachable(
                         action.item,

--- a/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
@@ -1,0 +1,108 @@
+import {
+    Button,
+    Stack,
+    Textarea,
+    TextInput,
+    type ModalProps,
+} from '@mantine-8/core';
+import { useForm } from '@mantine/form';
+import { IconAppWindow } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useUpdateApp } from '../../../features/apps/hooks/useUpdateApp';
+import { useProjectUuid } from '../../../hooks/useProjectUuid';
+import MantineModal from '../MantineModal';
+
+interface AppUpdateModalProps {
+    opened: ModalProps['opened'];
+    onClose: ModalProps['onClose'];
+    uuid: string;
+    initialName: string;
+    initialDescription: string;
+    onConfirm?: () => void;
+}
+
+type FormState = {
+    name: string;
+    description: string;
+};
+
+const AppUpdateModal: FC<AppUpdateModalProps> = ({
+    uuid,
+    initialName,
+    initialDescription,
+    onConfirm,
+    ...modalProps
+}) => {
+    const projectUuid = useProjectUuid();
+    const { mutateAsync, isLoading: isUpdating } = useUpdateApp();
+
+    const form = useForm<FormState>({
+        initialValues: {
+            name: initialName,
+            description: initialDescription,
+        },
+    });
+
+    if (!projectUuid) {
+        return null;
+    }
+
+    const handleConfirm = form.onSubmit(async (data) => {
+        const trimmedName = data.name.trim();
+        const trimmedDescription = data.description.trim();
+        const patch: { name?: string; description?: string } = {};
+        if (trimmedName !== initialName) patch.name = trimmedName;
+        if (trimmedDescription !== initialDescription) {
+            patch.description = trimmedDescription;
+        }
+        if (Object.keys(patch).length > 0) {
+            await mutateAsync({
+                projectUuid,
+                appUuid: uuid,
+                ...patch,
+            });
+        }
+        onConfirm?.();
+    });
+
+    return (
+        <MantineModal
+            title="Update Data App"
+            {...modalProps}
+            icon={IconAppWindow}
+            actions={
+                <Button
+                    disabled={!form.isValid() || !form.values.name.trim()}
+                    loading={isUpdating}
+                    type="submit"
+                    form="update-app"
+                >
+                    Save
+                </Button>
+            }
+        >
+            <form id="update-app" onSubmit={handleConfirm}>
+                <Stack>
+                    <TextInput
+                        label="Name"
+                        required
+                        placeholder="eg. Sales insights"
+                        disabled={isUpdating}
+                        {...form.getInputProps('name')}
+                    />
+
+                    <Textarea
+                        label="Description"
+                        placeholder="A few words to give your team some context"
+                        disabled={isUpdating}
+                        autosize
+                        maxRows={3}
+                        {...form.getInputProps('description')}
+                    />
+                </Stack>
+            </form>
+        </MantineModal>
+    );
+};
+
+export default AppUpdateModal;

--- a/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
+++ b/packages/frontend/src/components/common/modal/AppUpdateModal.tsx
@@ -5,9 +5,10 @@ import {
     TextInput,
     type ModalProps,
 } from '@mantine-8/core';
-import { useForm } from '@mantine/form';
+import { useForm, zodResolver } from '@mantine/form';
 import { IconAppWindow } from '@tabler/icons-react';
 import { type FC } from 'react';
+import { z } from 'zod';
 import { useUpdateApp } from '../../../features/apps/hooks/useUpdateApp';
 import { useProjectUuid } from '../../../hooks/useProjectUuid';
 import MantineModal from '../MantineModal';
@@ -21,10 +22,12 @@ interface AppUpdateModalProps {
     onConfirm?: () => void;
 }
 
-type FormState = {
-    name: string;
-    description: string;
-};
+const updateAppSchema = z.object({
+    name: z.string().trim().min(1, { message: 'Name is required' }),
+    description: z.string(),
+});
+
+type FormState = z.infer<typeof updateAppSchema>;
 
 const AppUpdateModal: FC<AppUpdateModalProps> = ({
     uuid,
@@ -41,6 +44,8 @@ const AppUpdateModal: FC<AppUpdateModalProps> = ({
             name: initialName,
             description: initialDescription,
         },
+        validate: zodResolver(updateAppSchema),
+        validateInputOnChange: true,
     });
 
     if (!projectUuid) {
@@ -72,7 +77,7 @@ const AppUpdateModal: FC<AppUpdateModalProps> = ({
             icon={IconAppWindow}
             actions={
                 <Button
-                    disabled={!form.isValid() || !form.values.name.trim()}
+                    disabled={!form.isValid()}
                     loading={isUpdating}
                     type="submit"
                     form="update-app"

--- a/packages/frontend/src/features/apps/hooks/useUpdateApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useUpdateApp.ts
@@ -6,6 +6,7 @@ import {
 import { useMutation, useQueryClient } from '@tanstack/react-query';
 import { lightdashApi } from '../../../api';
 import useToaster from '../../../hooks/toaster/useToaster';
+import { invalidateContent } from '../../../hooks/useContent';
 
 type UpdateAppParams = {
     projectUuid: string;
@@ -36,6 +37,7 @@ export const useUpdateApp = () => {
             void queryClient.invalidateQueries({
                 queryKey: ['app', variables.projectUuid, variables.appUuid],
             });
+            void invalidateContent(queryClient, variables.projectUuid);
             const field = variables.name
                 ? 'name'
                 : variables.description


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-316/add-apps-to-spaces


### Description:
Wire the Rename menu action for data apps to a new AppUpdateModal that reuses the existing PATCH /ee/projects/:projectUuid/apps/:appUuid endpoint. Admin-only via manage:DataApp, matching the Move action.


https://github.com/user-attachments/assets/02fa5e45-2bcd-437c-b789-a0def7fe1985


