### PR TITLE
feat(timezone): thread displayTimezone through CSV and pivot CSV exports

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1103,6 +1103,14 @@ export class AsyncQueryService extends ProjectService {
             throw new ForbiddenError();
         }
 
+        const { displayTimezone } = await this.resolveTimezoneContext({
+            projectUuid: queryHistory.projectUuid,
+            organizationUuid: queryHistory.organizationUuid,
+            userUuid:
+                AsyncQueryService.getQueryHistoryActor(queryHistory).userUuid,
+            metricQuery: queryHistory.metricQuery,
+        });
+
         const { status, resultsFileName, fields, columns } = queryHistory;
         const resultsStorageClient = this.getResultsStorageClientForContext(
             queryHistory.context,
@@ -1227,6 +1235,7 @@ export class AsyncQueryService extends ProjectService {
                             ? null
                             : account.user.userUuid,
                         expirationSecondsOverride,
+                        timezone: displayTimezone ?? undefined,
                     });
                 }
                 return this.downloadAsyncQueryResultsAsFormattedFile(
@@ -1255,6 +1264,7 @@ export class AsyncQueryService extends ProjectService {
                         fileType: DownloadFileType.CSV,
                         expirationSecondsOverride,
                     },
+                    displayTimezone ?? undefined,
                 );
             case DownloadFileType.XLSX: {
                 // Check if this is a pivot table download
@@ -1349,6 +1359,7 @@ export class AsyncQueryService extends ProjectService {
                 sortedFieldIds: string[],
                 headers: string[],
                 streams: { readStream: Readable; writeStream: Writable },
+                timezone?: string,
             ) => Promise<{ truncated: boolean }>;
         },
         options?: {
@@ -1367,6 +1378,7 @@ export class AsyncQueryService extends ProjectService {
             fileType: DownloadFileType;
             expirationSecondsOverride?: number;
         },
+        timezone?: string,
     ): Promise<{ fileUrl: string; truncated: boolean }> {
         // Generate a unique filename
         const formattedFileName = service.generateFileId(resultsFileName);
@@ -1410,6 +1422,7 @@ export class AsyncQueryService extends ProjectService {
                         readStream,
                         writeStream,
                     },
+                    timezone,
                 );
 
                 return {

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -1,3 +1,9 @@
+import {
+    DimensionType,
+    FieldType,
+    ItemsMap,
+    type Dimension,
+} from '@lightdash/common';
 import * as fs from 'fs/promises';
 import moment from 'moment';
 import { Readable, Writable } from 'stream';
@@ -247,9 +253,8 @@ $4.00,value_4,2020-03-16
         expect(csv).toEqual(['$1.00', 'value_1', '2020-03-16 11:32:55.123']);
     });
 
-    it('accepts a timezone argument and forwards it to formatItemValue', async () => {
+    it('Should shift timestamp dimensions into the provided timezone', async () => {
         const row = {
-            column_number: 1,
             column_string: `value_1`,
             column_timestamp: '2020-03-16T11:32:55.123Z',
         };
@@ -258,13 +263,61 @@ $4.00,value_4,2020-03-16
             row,
             itemMap,
             false,
-            ['column_number', 'column_string', 'column_timestamp'],
+            ['column_string', 'column_timestamp'],
             'America/New_York',
         );
 
-        expect(csv[0]).toBe('$1.00');
-        expect(csv[1]).toBe('value_1');
-        expect(typeof csv[2]).toBe('string');
+        expect(csv).toEqual(['value_1', '2020-03-16 07:32:55.123']);
+    });
+
+    it('Should not shift raw date dimensions (no TIMESTAMP base)', async () => {
+        const row = {
+            column_string: `value_1`,
+            column_date: '2020-03-16T02:32:55.000Z',
+        };
+
+        const csv = CsvService.convertRowToCsv(
+            row,
+            itemMap,
+            false,
+            ['column_string', 'column_date'],
+            'America/New_York',
+        );
+
+        expect(csv).toEqual(['value_1', '2020-03-16']);
+    });
+
+    it('Should shift date dimensions that are day-truncated from a TIMESTAMP base', async () => {
+        const columnDay: Dimension = {
+            name: 'column_day',
+            description: undefined,
+            type: DimensionType.DATE,
+            hidden: false,
+            table: 'table',
+            tableLabel: 'table',
+            label: 'column day',
+            fieldType: FieldType.DIMENSION,
+            sql: '${TABLE}.column_day',
+            timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+        };
+        const itemMapWithTruncatedDay: ItemsMap = {
+            ...itemMap,
+            column_day: columnDay,
+        };
+        const row = {
+            column_string: `value_1`,
+            column_day: '2020-03-16T02:32:55.000Z',
+        };
+
+        const csv = CsvService.convertRowToCsv(
+            row,
+            itemMapWithTruncatedDay,
+            false,
+            ['column_string', 'column_day'],
+            'America/New_York',
+        );
+
+        expect(csv).toEqual(['value_1', '2020-03-15']);
     });
 
     it('Should generate csv file ids', async () => {

--- a/packages/backend/src/services/CsvService/CsvService.test.ts
+++ b/packages/backend/src/services/CsvService/CsvService.test.ts
@@ -247,6 +247,26 @@ $4.00,value_4,2020-03-16
         expect(csv).toEqual(['$1.00', 'value_1', '2020-03-16 11:32:55.123']);
     });
 
+    it('accepts a timezone argument and forwards it to formatItemValue', async () => {
+        const row = {
+            column_number: 1,
+            column_string: `value_1`,
+            column_timestamp: '2020-03-16T11:32:55.123Z',
+        };
+
+        const csv = CsvService.convertRowToCsv(
+            row,
+            itemMap,
+            false,
+            ['column_number', 'column_string', 'column_timestamp'],
+            'America/New_York',
+        );
+
+        expect(csv[0]).toBe('$1.00');
+        expect(csv[1]).toBe('value_1');
+        expect(typeof csv[2]).toBe('string');
+    });
+
     it('Should generate csv file ids', async () => {
         const time = moment('2023-09-07 12:13:45.123');
         const timestamp = time.format('YYYY-MM-DD-HH-mm-ss-SSSS');

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -154,6 +154,7 @@ export class CsvService extends BaseService {
         itemMap: ItemsMap,
         onlyRaw: boolean,
         sortedFieldIds: string[],
+        timezone?: string,
     ): string | null {
         if (!line.trim()) return null;
 
@@ -164,6 +165,7 @@ export class CsvService extends BaseService {
                 itemMap,
                 onlyRaw,
                 sortedFieldIds,
+                timezone,
             );
 
             return csvRow.map(CsvService.escapeCsvValue).join(',');
@@ -235,6 +237,7 @@ export class CsvService extends BaseService {
         itemMap: ItemsMap,
         onlyRaw: boolean,
         sortedFieldIds: string[],
+        timezone?: string,
     ) {
         return sortedFieldIds.map((id: string) => {
             const data = row[id];
@@ -256,7 +259,7 @@ export class CsvService extends BaseService {
             if (onlyRaw) return data;
 
             // Use standard Lightdash formatting based on the item formatting configuration
-            return formatItemValue(item, data);
+            return formatItemValue(item, data, undefined, undefined, timezone);
         });
     }
 
@@ -293,6 +296,7 @@ export class CsvService extends BaseService {
             readStream: Readable;
             writeStream: Writable;
         },
+        timezone?: string,
     ): Promise<void> {
         // Create csv-stringify stringifier with clean configuration
         const stringifier = stringify({
@@ -313,6 +317,7 @@ export class CsvService extends BaseService {
                     itemMap,
                     onlyRaw,
                     sortedFieldIds,
+                    timezone,
                 );
 
                 // Pass data to next stream in pipeline (csv-stringify)
@@ -360,6 +365,7 @@ export class CsvService extends BaseService {
             readStream,
             writeStream,
         }: { readStream: Readable; writeStream: Writable },
+        timezone?: string,
     ): Promise<{ truncated: boolean }> {
         return new Promise((resolve, reject) => {
             // Write CSV header with BOM immediately
@@ -393,6 +399,7 @@ export class CsvService extends BaseService {
                         itemMap,
                         onlyRaw,
                         sortedFieldIds,
+                        timezone,
                     );
 
                     if (csvString) {
@@ -417,6 +424,7 @@ export class CsvService extends BaseService {
                     itemMap,
                     onlyRaw,
                     sortedFieldIds,
+                    timezone,
                 );
 
                 if (csvString) {

--- a/packages/backend/src/services/CsvService/CsvService.ts
+++ b/packages/backend/src/services/CsvService/CsvService.ts
@@ -17,6 +17,7 @@ import {
     getItemMap,
     isDashboardChartTileType,
     isDashboardSqlChartTile,
+    isDimension,
     isField,
     ItemsMap,
     MetricQuery,
@@ -249,10 +250,21 @@ export class CsvService extends BaseService {
 
             const itemIsField = isField(item);
             if (itemIsField && item.type === DimensionType.TIMESTAMP) {
-                return moment(data).format('YYYY-MM-DD HH:mm:ss.SSS');
+                const m = timezone
+                    ? moment.utc(data).tz(timezone)
+                    : moment(data);
+                return m.format('YYYY-MM-DD HH:mm:ss.SSS');
             }
             if (itemIsField && item.type === DimensionType.DATE) {
-                return moment(data).format('YYYY-MM-DD');
+                // Only TZ format dates that have timestamps as base dimensions
+                const m =
+                    timezone &&
+                    isDimension(item) &&
+                    item.timeIntervalBaseDimensionType ===
+                        DimensionType.TIMESTAMP
+                        ? moment.utc(data).tz(timezone)
+                        : moment(data);
+                return m.format('YYYY-MM-DD');
             }
 
             // Return raw value and let csv-stringify handle the rest

--- a/packages/backend/src/services/PivotTableService/PivotTableService.ts
+++ b/packages/backend/src/services/PivotTableService/PivotTableService.ts
@@ -101,6 +101,7 @@ export class PivotTableService extends BaseService {
         organizationUuid,
         createdByUserUuid,
         expirationSecondsOverride,
+        timezone,
     }: {
         resultsFileName: string;
         fields: ItemsMap;
@@ -120,6 +121,7 @@ export class PivotTableService extends BaseService {
         organizationUuid: string;
         createdByUserUuid: string | null;
         expirationSecondsOverride?: number;
+        timezone?: string;
     }): Promise<{ fileUrl: string; truncated: boolean }> {
         const { onlyRaw, customLabels, pivotConfig, attachmentDownloadName } =
             options;
@@ -173,6 +175,7 @@ export class PivotTableService extends BaseService {
             organizationUuid,
             createdByUserUuid,
             expirationSecondsOverride,
+            timezone,
         });
 
         return {


### PR DESCRIPTION
Part of https://linear.app/lightdash/issue/GLITCH-293

Threads the resolved project `displayTimezone` into the CSV export path (ad-hoc + scheduled, non-pivot + pivot) so CSV outputs match what the user sees in the UI.

Resolves the timezone once in `AsyncQueryService.downloadAsyncQueryResults` and forwards it through `CsvService` (`convertRowToCsv`, `processJsonLineToCsv`, `streamObjectRowsToFile`, `streamJsonlRowsToFile`) and `PivotTableService.downloadAsyncPivotTableCsv`.

Flag-gated end-to-end: `displayTimezone` is `null` when `EnableTimezoneSupport` is off, so formatting falls back to UTC.

Results in pago pago
<img width="834" height="422" alt="CleanShot 2026-04-23 at 17 44 00" src="https://github.com/user-attachments/assets/1048a4bd-bf80-4359-974d-67589b6cb0a5" />

**Before**
<img width="455" height="466" alt="CleanShot 2026-04-23 at 17 44 29" src="https://github.com/user-attachments/assets/18130313-acb0-4068-b8b3-e7021916822d" />

**After**
<img width="456" height="485" alt="CleanShot 2026-04-23 at 17 44 44" src="https://github.com/user-attachments/assets/065913ba-2d02-451b-9a58-bcf9f34f1a7c" />
