### PR TITLE
feat(timezone): thread displayTimezone through Excel non-pivot and pivot exports

### DIFF
--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -1291,6 +1291,7 @@ export class AsyncQueryService extends ProjectService {
                                   pivotConfig,
                                   attachmentDownloadName,
                               },
+                              timezone: displayTimezone ?? undefined,
                           })
                         : // Use direct Excel export to bypass PassThrough + Upload hanging issues
                           await ExcelService.downloadAsyncExcelDirectly(
@@ -1309,6 +1310,7 @@ export class AsyncQueryService extends ProjectService {
                                   hiddenFields,
                                   attachmentDownloadName,
                               },
+                              displayTimezone ?? undefined,
                           );
                 const xlsxPersistentUrl =
                     await this.persistentDownloadFileService.createPersistentUrl(

--- a/packages/backend/src/services/ExcelService/ExcelService.test.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.test.ts
@@ -192,6 +192,26 @@ const mockItemMapWithFormats: ItemsMap = {
 
 describe('ExcelService', () => {
     describe('convertRowToExcel', () => {
+        it('accepts a timezone argument and forwards it to formatItemValue', () => {
+            const row = {
+                number_with_usd_format: '1234.56',
+                string_column: 'test string',
+            };
+
+            const sortedFieldIds = ['number_with_usd_format', 'string_column'];
+
+            const result = ExcelService.convertRowToExcel(
+                row,
+                mockItemMapWithFormats,
+                false,
+                sortedFieldIds,
+                'America/New_York',
+            );
+
+            expect(result[0]).toBe(1234.56);
+            expect(result[1]).toBe('test string');
+        });
+
         it('should convert numeric strings to numbers when format expression is present', () => {
             const row = {
                 number_with_usd_format: '1234.56',

--- a/packages/backend/src/services/ExcelService/ExcelService.ts
+++ b/packages/backend/src/services/ExcelService/ExcelService.ts
@@ -66,6 +66,7 @@ export class ExcelService {
         itemMap: ItemsMap,
         onlyRaw: boolean,
         sortedFieldIds: string[],
+        timezone?: string,
     ): (string | number | Date | null)[] {
         return sortedFieldIds.map((fieldId) => {
             const rawValue = row[fieldId];
@@ -105,7 +106,13 @@ export class ExcelService {
             }
 
             // Otherwise, use standard Lightdash formatting as there won't be a format expression
-            return formatItemValue(item, rawValue);
+            return formatItemValue(
+                item,
+                rawValue,
+                undefined,
+                undefined,
+                timezone,
+            );
         });
     }
 
@@ -342,6 +349,7 @@ export class ExcelService {
         lightdashConfig,
         options,
         pivotDetails,
+        timezone,
     }: {
         resultsFileName: string;
         fields: ItemsMap;
@@ -359,6 +367,7 @@ export class ExcelService {
             pivotConfig: PivotConfig;
             attachmentDownloadName?: string;
         };
+        timezone?: string;
     }): Promise<{ fileUrl: string; truncated: boolean; s3Key: string }> {
         const { onlyRaw, customLabels, pivotConfig, attachmentDownloadName } =
             options;
@@ -408,6 +417,7 @@ export class ExcelService {
             maxColumnLimit: lightdashConfig.pivotTable.maxColumnLimit,
             pivotDetails,
             enableImprovedExcelDates: lightdashConfig.enableImprovedExcelDates,
+            timezone,
         });
 
         // Upload the Excel buffer to exports bucket using cross-bucket transform
@@ -460,6 +470,7 @@ export class ExcelService {
         fields: ItemsMap,
         onlyRaw: boolean,
         sortedFieldIds: string[],
+        timezone?: string,
     ): Promise<{ truncated: boolean }> {
         // Use the same approach as our working tests - direct filename instead of stream
         const workbook = new Excel.stream.xlsx.WorkbookWriter({
@@ -501,6 +512,7 @@ export class ExcelService {
                     fields,
                     onlyRaw,
                     sortedFieldIds,
+                    timezone,
                 );
 
                 if (Array.isArray(rowData) && rowData.length > 0) {
@@ -558,6 +570,7 @@ export class ExcelService {
             hiddenFields?: string[];
             attachmentDownloadName?: string;
         } = {},
+        timezone?: string,
     ): Promise<{ fileUrl: string; truncated: boolean; s3Key: string }> {
         // Handle column ordering and filtering
         const {
@@ -595,6 +608,7 @@ export class ExcelService {
                 fields,
                 onlyRaw,
                 sortedFieldIds,
+                timezone,
             );
 
             // Generate filename with truncated flag


### PR DESCRIPTION
Part of https://linear.app/lightdash/issue/GLITCH-293

Threads `displayTimezone` into the Excel export path (non-pivot + pivot), reusing the timezone resolution added in the CSV PR.

Updates `ExcelService.convertRowToExcel`, `streamJsonlToExcelFile`, `downloadAsyncPivotTableXlsx` and `downloadAsyncExcelDirectly` to accept and forward `timezone`, and passes `displayTimezone` at both `AsyncQueryService` Excel branches.

Flag-gated end-to-end: `displayTimezone` is `null` when `EnableTimezoneSupport` is off, so formatting falls back to UTC.