### PR TITLE
feat(timezone): thread displayTimezone into scheduled gsheets pivot deliveries

### DIFF
--- a/packages/backend/src/scheduler/SchedulerTask.ts
+++ b/packages/backend/src/scheduler/SchedulerTask.ts
@@ -2176,6 +2176,7 @@ export default class SchedulerTask {
                 rows,
                 fields: itemMap,
                 pivotDetails,
+                displayTimezone,
             } = await this.asyncQueryService.executeMetricQueryAndGetResults(
                 {
                     account,
@@ -2203,7 +2204,13 @@ export default class SchedulerTask {
             if (payload.pivotConfig) {
                 // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                 // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
-                const formattedRows = formatRows(rows, itemMap);
+                const formattedRows = formatRows(
+                    rows,
+                    itemMap,
+                    undefined,
+                    undefined,
+                    displayTimezone ?? undefined,
+                );
 
                 const pivotedResults = pivotResultsAsCsv({
                     pivotConfig: payload.pivotConfig,
@@ -2763,6 +2770,7 @@ export default class SchedulerTask {
                     rows,
                     fields: itemMap,
                     pivotDetails,
+                    displayTimezone,
                 } = await this.asyncQueryService.executeSavedChartQueryAndGetResults(
                     {
                         account,
@@ -2812,7 +2820,13 @@ export default class SchedulerTask {
                 ) {
                     // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                     // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
-                    const formattedRows = formatRows(rows, itemMap);
+                    const formattedRows = formatRows(
+                        rows,
+                        itemMap,
+                        undefined,
+                        undefined,
+                        displayTimezone ?? undefined,
+                    );
 
                     const pivotedResults = pivotResultsAsCsv({
                         pivotConfig,
@@ -2926,6 +2940,7 @@ export default class SchedulerTask {
                             rows,
                             fields: itemMap,
                             pivotDetails,
+                            displayTimezone,
                         } = await this.asyncQueryService.executeDashboardChartQueryAndGetResults(
                             {
                                 account: account!,
@@ -2965,7 +2980,13 @@ export default class SchedulerTask {
                         ) {
                             // PivotQueryResults expects a formatted ResultRow[] type, so we need to convert it first
                             // TODO: refactor pivotQueryResults to accept a Record<string, unknown>[] simple row type for performance
-                            const formattedRows = formatRows(rows, itemMap);
+                            const formattedRows = formatRows(
+                                rows,
+                                itemMap,
+                                undefined,
+                                undefined,
+                                displayTimezone ?? undefined,
+                            );
 
                             const pivotedResults = pivotResultsAsCsv({
                                 pivotConfig,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -2259,6 +2259,11 @@ describe('AsyncQueryService', () => {
                     pivotValuesColumns: null,
                     pivotTotalColumnCount: null,
                     originalColumns: null,
+                    projectUuid,
+                    organizationUuid: projectSummary.organizationUuid,
+                    metricQuery: metricQueryMock,
+                    createdByActorType: 'session',
+                    createdByUserUuid: 'user-uuid',
                 } satisfies Partial<QueryHistory>);
                 (
                     service.resultsStorageClient.getDownloadStream as jest.Mock
@@ -2335,6 +2340,11 @@ describe('AsyncQueryService', () => {
                     pivotValuesColumns: null,
                     pivotTotalColumnCount: null,
                     originalColumns: null,
+                    projectUuid,
+                    organizationUuid: projectSummary.organizationUuid,
+                    metricQuery: metricQueryMock,
+                    createdByActorType: 'session',
+                    createdByUserUuid: 'user-uuid',
                 } satisfies Partial<QueryHistory>);
                 (
                     service.resultsStorageClient.getDownloadStream as jest.Mock

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -5261,6 +5261,7 @@ export class AsyncQueryService extends ProjectService {
         cacheMetadata: CacheMetadata;
         fields: ItemsMap;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        displayTimezone: string | null;
     }> {
         const { account, projectUuid } = args;
 
@@ -5300,6 +5301,7 @@ export class AsyncQueryService extends ProjectService {
         cacheMetadata: CacheMetadata;
         fields: ItemsMap;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        displayTimezone: string | null;
     }> {
         const queryHistory = await this.queryHistoryModel.get(
             queryUuid,
@@ -5319,12 +5321,21 @@ export class AsyncQueryService extends ProjectService {
             },
         });
 
+        const { displayTimezone } = await this.resolveTimezoneContext({
+            projectUuid: queryHistory.projectUuid,
+            organizationUuid: queryHistory.organizationUuid,
+            userUuid:
+                AsyncQueryService.getQueryHistoryActor(queryHistory).userUuid,
+            metricQuery: queryHistory.metricQuery,
+        });
+
         return {
             rows,
             cacheMetadata,
             fields,
             pivotDetails:
                 AsyncQueryService.getPivotDetailsFromQueryHistory(queryHistory),
+            displayTimezone,
         };
     }
 
@@ -5529,6 +5540,7 @@ export class AsyncQueryService extends ProjectService {
         cacheMetadata: CacheMetadata;
         fields: ItemsMap;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        displayTimezone: string | null;
     }> {
         const { account, projectUuid } = args;
 
@@ -5614,6 +5626,7 @@ export class AsyncQueryService extends ProjectService {
         cacheMetadata: CacheMetadata;
         fields: ItemsMap;
         pivotDetails: ReadyQueryResultsPage['pivotDetails'];
+        displayTimezone: string | null;
     }> {
         const { account, projectUuid } = args;
 


### PR DESCRIPTION
Closes https://linear.app/lightdash/issue/GLITCH-293

Threads `displayTimezone` into scheduled Google Sheets pivot deliveries in `SchedulerTask`.

Exposes `displayTimezone` from `getReadyQueryResults` and the three public helpers that back the scheduler (`executeMetricQueryAndGetResults`, `executeSavedChartQueryAndGetResults`, `executeDashboardChartQueryAndGetResults`) so `SchedulerTask` can forward it into each `formatRows` call for gsheets pivot deliveries.

Flag-gated end-to-end: `displayTimezone` is `null` when `EnableTimezoneSupport` is off, so formatting falls back to UTC.