### PR TITLE
feat(data-apps): soft and hard delete

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -69,6 +69,23 @@ This means Claude can see what it built previously and make targeted changes rat
 Users can cancel a building version. This atomically marks it as `status='error'` in the database and pauses the sandbox
 (interrupting any running commands). The sandbox remains resumable for subsequent iterations.
 
+### Deletion
+
+Deleting an app goes through a single `DELETE /apps/{appUuid}` endpoint that routes to one of two modes based on the
+instance-wide `lightdashConfig.softDelete.enabled` flag — the same pattern used by charts, dashboards, spaces, and SQL
+charts.
+
+- **Soft delete** (`softDelete.enabled=true`): the `apps` row is marked with `deleted_at` and `deleted_by_user_uuid`.
+  Every read path (`getApp`, `getAppWithVersions`, `listMyApps`, `updateApp`, `moveToSpace`) already filters
+  `deleted_at IS NULL`, so the app disappears from the UI but can be restored by clearing those columns. The E2B sandbox
+  is paused so the in-flight pipeline (if any) stops against a hidden app.
+- **Hard delete** (`softDelete.enabled=false`): the `apps` row is removed; `app_versions` cascade via
+  `ON DELETE CASCADE`; the E2B sandbox is killed; and every S3 object under the `apps/{appUuid}/` prefix is
+  enumerated and deleted (staged image uploads, version source tarballs, built dist tarballs, and per-version assets).
+
+Implementation: `AppGenerateService.deleteApp` is the entry point. It delegates to `softDeleteApp` or
+`permanentDeleteApp`, which each enforce the `manage:DataApp` scope and handle sandbox/S3 cleanup.
+
 ---
 
 ## Data Model
@@ -133,6 +150,7 @@ All endpoints require the `manage:DataApp` permission and are scoped under `/api
 | `POST`  | `/projects/{projectUuid}/apps/`                                           | Create a new app from a prompt         |
 | `GET`   | `/projects/{projectUuid}/apps/{appUuid}`                                  | Get app with paginated version history |
 | `PATCH` | `/projects/{projectUuid}/apps/{appUuid}`                                  | Update name/description                |
+| `DELETE`| `/projects/{projectUuid}/apps/{appUuid}`                                  | Soft or hard delete (config-driven)    |
 | `POST`  | `/projects/{projectUuid}/apps/{appUuid}/versions`                         | Iterate with a follow-up prompt        |
 | `POST`  | `/projects/{projectUuid}/apps/{appUuid}/versions/{version}/cancel`        | Cancel a building version              |
 | `GET`   | `/projects/{projectUuid}/apps/{appUuid}/versions/{version}/preview-token` | Mint JWT for iframe preview            |

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -3,6 +3,7 @@ import {
     ParameterError,
     type ApiAppImageUploadResponse,
     type ApiCancelAppVersionResponse,
+    type ApiDeleteAppResponse,
     type ApiGenerateAppResponse,
     type ApiGetAppResponse,
     type ApiMyAppsResponse,
@@ -13,6 +14,7 @@ import {
 } from '@lightdash/common';
 import {
     Body,
+    Delete,
     Get,
     Hidden,
     Middlewares,
@@ -211,6 +213,32 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results: result,
+        };
+    }
+
+    /**
+     * Delete an app. When soft delete is enabled, the app is marked as
+     * deleted and can be restored via the admin flow. Otherwise the app
+     * row, every version, and all S3 artifacts are permanently removed.
+     * @summary Delete app
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Delete('/{appUuid}')
+    @OperationId('deleteApp')
+    async deleteApp(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<ApiDeleteAppResponse> {
+        await this.getAppGenerateService().deleteApp(
+            req.user!,
+            projectUuid,
+            appUuid,
+        );
+        return {
+            status: 'ok',
+            results: undefined,
         };
     }
 

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1,7 +1,10 @@
 import {
+    DeleteObjectsCommand,
     GetObjectCommand,
+    ListObjectsV2Command,
     PutObjectCommand,
     S3Client,
+    type ObjectIdentifier,
     type S3ClientConfig,
 } from '@aws-sdk/client-s3';
 import { subject } from '@casl/ability';
@@ -2375,6 +2378,246 @@ export class AppGenerateService extends BaseService {
             name: updatedApp.name,
             description: updatedApp.description,
         };
+    }
+
+    /**
+     * Delete a data app. Routes to soft or permanent delete based on
+     * `lightdashConfig.softDelete.enabled`.
+     *
+     * `bypassPermissions` is used by cascading deletes from `SpaceService`
+     * where the parent space already authorized the action — skipping both
+     * the feature-flag check and the CASL check.
+     */
+    async deleteApp(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+        options?: { bypassPermissions?: boolean },
+    ): Promise<void> {
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        if (options?.bypassPermissions) {
+            this.logBypassEvent(user, 'delete', {
+                type: 'DataApp',
+                metadata: { appUuid },
+                organizationUuid: app.organization_uuid,
+            });
+        } else {
+            await this.assertDataAppsEnabled(user);
+            this.assertDataAppAbility(
+                user,
+                'manage',
+                app.organization_uuid,
+                projectUuid,
+                'Insufficient permissions to delete data apps',
+            );
+        }
+
+        const softDeleteEnabled = this.lightdashConfig.softDelete.enabled;
+
+        if (softDeleteEnabled) {
+            // Pausing the sandbox interrupts any in-flight pipeline so it
+            // doesn't keep running against a now-hidden app.
+            await this.pauseSandboxIfRunning(app.sandbox_id, appUuid);
+            await this.appModel.softDelete(appUuid, projectUuid, user.userUuid);
+        } else {
+            await this.killSandboxIfExists(app.sandbox_id, appUuid);
+            await this.deleteAppS3Prefix(appUuid);
+            await this.appModel.permanentDelete(appUuid, projectUuid);
+        }
+
+        this.analytics.track({
+            event: 'data_app.deleted',
+            userId: user.userUuid,
+            properties: {
+                organizationId: app.organization_uuid,
+                projectId: projectUuid,
+                appUuid,
+                softDelete: softDeleteEnabled,
+            },
+        });
+    }
+
+    /**
+     * Restore a soft-deleted app. Used by the `SpaceService` restore cascade.
+     */
+    async restoreApp(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+        options?: { bypassPermissions?: boolean },
+    ): Promise<void> {
+        const app = await this.appModel.getAppIncludingDeleted(
+            appUuid,
+            projectUuid,
+        );
+        if (options?.bypassPermissions) {
+            this.logBypassEvent(user, 'manage', {
+                type: 'DataApp',
+                metadata: { appUuid },
+                organizationUuid: app.organization_uuid,
+            });
+        } else {
+            await this.assertDataAppsEnabled(user);
+            this.assertDataAppAbility(
+                user,
+                'manage',
+                app.organization_uuid,
+                projectUuid,
+                'Insufficient permissions to restore data apps',
+            );
+        }
+
+        await this.appModel.restore(appUuid, projectUuid);
+
+        this.analytics.track({
+            event: 'data_app.restored',
+            userId: user.userUuid,
+            properties: {
+                organizationId: app.organization_uuid,
+                projectId: projectUuid,
+                appUuid,
+            },
+        });
+    }
+
+    /**
+     * Permanently delete an app regardless of current soft-delete state.
+     * Kills the sandbox and purges the S3 prefix. Used by the `SpaceService`
+     * permanent-delete cascade (where the app is typically already
+     * soft-deleted) and by the admin recently-deleted flow.
+     */
+    async permanentDeleteApp(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+        options?: { bypassPermissions?: boolean },
+    ): Promise<void> {
+        const app = await this.appModel.getAppIncludingDeleted(
+            appUuid,
+            projectUuid,
+        );
+        if (options?.bypassPermissions) {
+            this.logBypassEvent(user, 'manage', {
+                type: 'DataApp',
+                metadata: { appUuid },
+                organizationUuid: app.organization_uuid,
+            });
+        } else {
+            await this.assertDataAppsEnabled(user);
+            this.assertDataAppAbility(
+                user,
+                'manage',
+                app.organization_uuid,
+                projectUuid,
+                'Insufficient permissions to delete data apps',
+            );
+        }
+
+        await this.killSandboxIfExists(app.sandbox_id, appUuid);
+        await this.deleteAppS3Prefix(appUuid);
+        await this.appModel.permanentDelete(appUuid, projectUuid);
+
+        this.analytics.track({
+            event: 'data_app.deleted',
+            userId: user.userUuid,
+            properties: {
+                organizationId: app.organization_uuid,
+                projectId: projectUuid,
+                appUuid,
+                softDelete: false,
+            },
+        });
+    }
+
+    private async pauseSandboxIfRunning(
+        sandboxId: string | null,
+        appUuid: string,
+    ): Promise<void> {
+        if (!sandboxId) return;
+        try {
+            const sandbox = await Sandbox.connect(sandboxId, {
+                apiKey: this.getE2bApiKey(),
+            });
+            await sandbox.pause();
+            this.logger.info(
+                `App ${appUuid}: sandbox paused during delete (sandboxId=${sandboxId})`,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: failed to pause sandbox during delete: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
+    private async killSandboxIfExists(
+        sandboxId: string | null,
+        appUuid: string,
+    ): Promise<void> {
+        if (!sandboxId) return;
+        try {
+            const sandbox = await Sandbox.connect(sandboxId, {
+                apiKey: this.getE2bApiKey(),
+            });
+            await sandbox.kill();
+            this.logger.info(
+                `App ${appUuid}: sandbox killed during hard delete (sandboxId=${sandboxId})`,
+            );
+        } catch (error) {
+            this.logger.warn(
+                `App ${appUuid}: failed to kill sandbox during hard delete: ${getErrorMessage(error)}`,
+            );
+        }
+    }
+
+    /**
+     * Purge every S3 object under `apps/{appUuid}/` — covers staged image
+     * uploads, version source tarballs, built dist tarballs, and per-version
+     * assets.
+     */
+    private async deleteAppS3Prefix(appUuid: string): Promise<void> {
+        const { client, bucket } = this.getS3Client();
+        const prefix = `apps/${appUuid}/`;
+
+        let continuationToken: string | undefined;
+        let totalDeleted = 0;
+        // S3 pagination requires sequential awaits: each list call depends on
+        // the previous call's continuation token.
+        /* eslint-disable no-await-in-loop */
+        do {
+            const listResponse = await client.send(
+                new ListObjectsV2Command({
+                    Bucket: bucket,
+                    Prefix: prefix,
+                    ContinuationToken: continuationToken,
+                }),
+            );
+
+            const objects: ObjectIdentifier[] = (listResponse.Contents ?? [])
+                .map((obj) => obj.Key)
+                .filter((key): key is string => typeof key === 'string')
+                .map((Key) => ({ Key }));
+
+            if (objects.length > 0) {
+                // DeleteObjects caps at 1000 keys per call; ListObjectsV2
+                // returns at most 1000 per page, so one batch per page is safe.
+                await client.send(
+                    new DeleteObjectsCommand({
+                        Bucket: bucket,
+                        Delete: { Objects: objects, Quiet: true },
+                    }),
+                );
+                totalDeleted += objects.length;
+            }
+
+            continuationToken = listResponse.IsTruncated
+                ? listResponse.NextContinuationToken
+                : undefined;
+        } while (continuationToken);
+        /* eslint-enable no-await-in-loop */
+
+        this.logger.info(
+            `App ${appUuid}: deleted ${totalDeleted} S3 object(s) under ${prefix}`,
+        );
     }
 
     /**

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -7062,6 +7062,11 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiDeleteAppResponse: {
+        dataType: 'refAlias',
+        type: { ref: 'ApiSuccessEmpty', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__token-string__': {
         dataType: 'refAlias',
         type: {
@@ -8699,25 +8704,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['success'],
                                                         },
                                                         {
@@ -8737,11 +8723,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8756,11 +8742,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8791,29 +8796,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 chartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -8837,6 +8819,35 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -8848,12 +8859,6 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -8969,11 +8974,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9049,29 +9054,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     chartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -9095,6 +9077,35 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
+                                                                                                    searchRank:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                        },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -9106,12 +9117,6 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    fieldType:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9143,44 +9148,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -9219,11 +9186,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9238,11 +9205,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9257,11 +9224,49 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -29423,6 +29428,75 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DeletedDataAppContentSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                organizationUuid: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                spaceName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                spaceUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                deletedBy: {
+                    dataType: 'union',
+                    subSchemas: [
+                        {
+                            dataType: 'nestedObjectLiteral',
+                            nestedProperties: {
+                                lastName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                firstName: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                                userUuid: {
+                                    dataType: 'string',
+                                    required: true,
+                                },
+                            },
+                        },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                deletedAt: { dataType: 'datetime', required: true },
+                contentType: { ref: 'ContentType.DATA_APP', required: true },
+                description: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                name: { dataType: 'string', required: true },
+                uuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'WithDescendantCounts_DeletedDataAppContentSummary.never_': {
+        dataType: 'refAlias',
+        type: { ref: 'DeletedDataAppContentSummary', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     DeletedContentWithDescendants: {
         dataType: 'refAlias',
         type: {
@@ -29439,6 +29513,9 @@ const models: TsoaRoute.Models = {
                 },
                 {
                     ref: 'WithDescendantCounts_DeletedSpaceContentSummary.nestedSpace-or-dashboard-or-chart-or-scheduler_',
+                },
+                {
+                    ref: 'WithDescendantCounts_DeletedDataAppContentSummary.never_',
                 },
             ],
             validators: {},
@@ -29528,6 +29605,16 @@ const models: TsoaRoute.Models = {
                     nestedProperties: {
                         contentType: {
                             ref: 'ContentType.SPACE',
+                            required: true,
+                        },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                },
+                {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        contentType: {
+                            ref: 'ContentType.DATA_APP',
                             required: true,
                         },
                         uuid: { dataType: 'string', required: true },
@@ -33123,6 +33210,73 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'updateApp',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_deleteApp: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.delete(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.deleteApp,
+        ),
+
+        async function AppGenerateController_deleteApp(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_deleteApp,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'deleteApp',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8451,6 +8451,9 @@
                 },
                 "type": "object"
             },
+            "ApiDeleteAppResponse": {
+                "$ref": "#/components/schemas/ApiSuccessEmpty"
+            },
             "ApiSuccess__token-string__": {
                 "properties": {
                     "results": {
@@ -10174,8 +10177,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10187,8 +10190,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -10202,15 +10205,18 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
+                                                                        "fieldType": {
+                                                                            "type": "string"
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10218,17 +10224,14 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
-                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10277,8 +10280,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -10322,15 +10325,18 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10338,17 +10344,14 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
-                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10376,8 +10379,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -30759,6 +30762,73 @@
                     }
                 ]
             },
+            "DeletedDataAppContentSummary": {
+                "properties": {
+                    "organizationUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "spaceName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "spaceUuid": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "deletedBy": {
+                        "properties": {
+                            "lastName": {
+                                "type": "string"
+                            },
+                            "firstName": {
+                                "type": "string"
+                            },
+                            "userUuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["lastName", "firstName", "userUuid"],
+                        "type": "object",
+                        "nullable": true
+                    },
+                    "deletedAt": {
+                        "type": "string",
+                        "format": "date-time"
+                    },
+                    "contentType": {
+                        "$ref": "#/components/schemas/ContentType.DATA_APP"
+                    },
+                    "description": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "name": {
+                        "type": "string"
+                    },
+                    "uuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "organizationUuid",
+                    "projectUuid",
+                    "spaceName",
+                    "spaceUuid",
+                    "deletedBy",
+                    "deletedAt",
+                    "contentType",
+                    "description",
+                    "name",
+                    "uuid"
+                ],
+                "type": "object"
+            },
+            "WithDescendantCounts_DeletedDataAppContentSummary.never_": {
+                "$ref": "#/components/schemas/DeletedDataAppContentSummary"
+            },
             "DeletedContentWithDescendants": {
                 "anyOf": [
                     {
@@ -30772,6 +30842,9 @@
                     },
                     {
                         "$ref": "#/components/schemas/WithDescendantCounts_DeletedSpaceContentSummary.nestedSpace-or-dashboard-or-chart-or-scheduler_"
+                    },
+                    {
+                        "$ref": "#/components/schemas/WithDescendantCounts_DeletedDataAppContentSummary.never_"
                     }
                 ]
             },
@@ -30855,6 +30928,18 @@
                         "properties": {
                             "contentType": {
                                 "$ref": "#/components/schemas/ContentType.SPACE"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": ["contentType", "uuid"],
+                        "type": "object"
+                    },
+                    {
+                        "properties": {
+                            "contentType": {
+                                "$ref": "#/components/schemas/ContentType.DATA_APP"
                             },
                             "uuid": {
                                 "type": "string"
@@ -30951,7 +31036,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2791.0",
+        "version": "0.2795.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -447,6 +447,79 @@ export class AppModel {
         };
     }
 
+    async softDelete(
+        appId: string,
+        projectUuid: string,
+        deletedByUserUuid: string,
+    ): Promise<void> {
+        const updated = await this.database(AppsTableName)
+            .where({ app_id: appId, project_uuid: projectUuid })
+            .whereNull('deleted_at')
+            .update({
+                deleted_at: this.database.fn.now() as unknown as Date,
+                deleted_by_user_uuid: deletedByUserUuid,
+            });
+        if (updated === 0) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
+    }
+
+    async permanentDelete(appId: string, projectUuid: string): Promise<void> {
+        // app_versions rows cascade via FK (ON DELETE CASCADE).
+        const deleted = await this.database(AppsTableName)
+            .where({ app_id: appId, project_uuid: projectUuid })
+            .delete();
+        if (deleted === 0) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
+    }
+
+    /**
+     * Fetch an app regardless of soft-delete state. Used by restore and by
+     * cascading permanent-delete (where the app row is already soft-deleted
+     * from a prior cascade step).
+     */
+    async getAppIncludingDeleted(
+        appId: string,
+        projectUuid: string,
+    ): Promise<DbApp & { organization_uuid: string }> {
+        const row = await this.database(AppsTableName)
+            .innerJoin(
+                ProjectTableName,
+                `${ProjectTableName}.project_uuid`,
+                `${AppsTableName}.project_uuid`,
+            )
+            .innerJoin(
+                OrganizationTableName,
+                `${OrganizationTableName}.organization_id`,
+                `${ProjectTableName}.organization_id`,
+            )
+            .where(`${AppsTableName}.app_id`, appId)
+            .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
+            .select<(DbApp & { organization_uuid: string })[]>(
+                `${AppsTableName}.*`,
+                `${OrganizationTableName}.organization_uuid`,
+            )
+            .first();
+        if (!row) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
+        return row;
+    }
+
+    async restore(appId: string, projectUuid: string): Promise<void> {
+        const updated = await this.database(AppsTableName)
+            .where({ app_id: appId, project_uuid: projectUuid })
+            .whereNotNull('deleted_at')
+            .update({
+                deleted_at: null,
+                deleted_by_user_uuid: null,
+            });
+        if (updated === 0) {
+            throw new NotFoundError(`Deleted app not found: ${appId}`);
+        }
+    }
+
     async updateSandboxId(
         appId: string,
         sandboxId: string | null,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -17,15 +17,9 @@ import {
 
 export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow> =
     {
-        shouldQueryBeIncluded: (filters: ContentFilters) => {
-            // Apps don't participate in the soft-delete / restore flow yet,
-            // so exclude them from the deleted-content listing.
-            if (filters.deleted) return false;
-            return (
-                !filters.contentTypes ||
-                filters.contentTypes?.includes(ContentType.DATA_APP)
-            );
-        },
+        shouldQueryBeIncluded: (filters: ContentFilters) =>
+            !filters.contentTypes ||
+            filters.contentTypes?.includes(ContentType.DATA_APP),
         getSummaryQuery: (
             knex: Knex,
             filters: ContentFilters,
@@ -49,10 +43,17 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                         );
                     }
                 })
-                // Apps without a space are personal drafts — excluded from
-                // space-based content listings. They surface only in /user/apps.
-                .whereNotNull(`${AppsTableName}.space_uuid`)
-                .innerJoin(
+                // Apps without a space are personal drafts. They're hidden
+                // from space-based content listings but surface in the
+                // recently-deleted view so admins can restore them.
+                .where((personalFilter) => {
+                    if (!filters.deleted) {
+                        void personalFilter.whereNotNull(
+                            `${AppsTableName}.space_uuid`,
+                        );
+                    }
+                })
+                .leftJoin(
                     SpaceTableName,
                     `${SpaceTableName}.space_uuid`,
                     `${AppsTableName}.space_uuid`,

--- a/packages/backend/src/models/ContentModel/ContentModel.ts
+++ b/packages/backend/src/models/ContentModel/ContentModel.ts
@@ -232,6 +232,11 @@ export class ContentModel {
                     chartCount: Number(row.metadata.chartCount ?? 0),
                     schedulerCount: Number(row.metadata.schedulerCount ?? 0),
                 };
+            case ContentType.DATA_APP:
+                return {
+                    ...base,
+                    contentType: ContentType.DATA_APP,
+                };
             default:
                 throw new Error(
                     `Unexpected content type in deleted results: ${row.content_type}`,

--- a/packages/backend/src/models/SpaceModel.ts
+++ b/packages/backend/src/models/SpaceModel.ts
@@ -15,6 +15,7 @@ import {
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
 import { Knex } from 'knex';
+import { AppsTableName } from '../database/entities/apps';
 import {
     DashboardsTableName,
     DashboardVersionsTableName,
@@ -1255,6 +1256,41 @@ export class SpaceModel {
 
         const dashboards = await query;
         return dashboards.map((d) => d.dashboard_uuid);
+    }
+
+    /**
+     * Returns apps directly assigned to a space. Used by the
+     * space-delete cascade to soft-delete apps alongside the space.
+     * Apps without a space are personal drafts and not returned here.
+     */
+    async getAppsInSpace(
+        spaceUuid: string,
+        options?: { deleted?: boolean; deletedByUserUuid?: string },
+    ): Promise<{ appUuid: string; projectUuid: string }[]> {
+        const query = this.database(AppsTableName)
+            .select(
+                `${AppsTableName}.app_id as app_uuid`,
+                `${AppsTableName}.project_uuid`,
+            )
+            .where(`${AppsTableName}.space_uuid`, spaceUuid);
+
+        if (options?.deleted) {
+            void query.whereNotNull(`${AppsTableName}.deleted_at`);
+            if (options.deletedByUserUuid) {
+                void query.where(
+                    `${AppsTableName}.deleted_by_user_uuid`,
+                    options.deletedByUserUuid,
+                );
+            }
+        } else {
+            void query.whereNull(`${AppsTableName}.deleted_at`);
+        }
+
+        const apps = await query;
+        return apps.map((a) => ({
+            appUuid: a.app_uuid,
+            projectUuid: a.project_uuid,
+        }));
     }
 
     async update(

--- a/packages/backend/src/services/ContentService/ContentService.ts
+++ b/packages/backend/src/services/ContentService/ContentService.ts
@@ -22,6 +22,7 @@ import {
 import { Knex } from 'knex';
 import { intersection } from 'lodash';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
+import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import { ContentModel } from '../../models/ContentModel/ContentModel';
 import {
     ContentArgs,
@@ -48,6 +49,7 @@ type ContentServiceArguments = {
     savedSqlService: SavedSqlService;
     spacePermissionService: SpacePermissionService;
     appMoveService: BulkActionable<Knex> | undefined;
+    appGenerateService: AppGenerateService | undefined;
 };
 
 export class ContentService extends BaseService {
@@ -71,6 +73,8 @@ export class ContentService extends BaseService {
 
     appMoveService: BulkActionable<Knex> | undefined;
 
+    appGenerateService: AppGenerateService | undefined;
+
     constructor(args: ContentServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -85,6 +89,7 @@ export class ContentService extends BaseService {
         this.savedSqlService = args.savedSqlService;
         this.spacePermissionService = args.spacePermissionService;
         this.appMoveService = args.appMoveService;
+        this.appGenerateService = args.appGenerateService;
     }
 
     private getAppMoveService(): BulkActionable<Knex> {
@@ -92,6 +97,13 @@ export class ContentService extends BaseService {
             throw new ParameterError('Data apps are not available');
         }
         return this.appMoveService;
+    }
+
+    private getAppGenerateService(): AppGenerateService {
+        if (!this.appGenerateService) {
+            throw new ParameterError('Data apps are not available');
+        }
+        return this.appGenerateService;
     }
 
     async find(
@@ -444,6 +456,7 @@ export class ContentService extends BaseService {
             ContentType.CHART,
             ContentType.DASHBOARD,
             ContentType.SPACE,
+            ContentType.DATA_APP,
         ];
 
         return this.contentModel.findDeletedContents(
@@ -502,6 +515,12 @@ export class ContentService extends BaseService {
                 return this.dashboardService.restore(user, item.uuid);
             case ContentType.SPACE:
                 return this.spaceService.restore(user, item.uuid);
+            case ContentType.DATA_APP:
+                return this.getAppGenerateService().restoreApp(
+                    user,
+                    projectUuid,
+                    item.uuid,
+                );
             default:
                 return assertUnreachable(item, 'Unknown content type');
         }
@@ -558,6 +577,12 @@ export class ContentService extends BaseService {
                 return this.dashboardService.permanentDelete(user, item.uuid);
             case ContentType.SPACE:
                 return this.spaceService.permanentDelete(user, item.uuid);
+            case ContentType.DATA_APP:
+                return this.getAppGenerateService().permanentDeleteApp(
+                    user,
+                    projectUuid,
+                    item.uuid,
+                );
             default:
                 return assertUnreachable(item, 'Unknown content type');
         }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -3,6 +3,7 @@ import { Knex } from 'knex';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import { ClientRepository } from '../clients/ClientRepository';
 import { LightdashConfig } from '../config/parseConfig';
+import { AppGenerateService } from '../ee/services/AppGenerateService/AppGenerateService';
 import { PreAggregateMaterializationService } from '../ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService';
 import { ModelRepository } from '../models/ModelRepository';
 import PrometheusMetrics from '../prometheus/PrometheusMetrics';
@@ -840,6 +841,11 @@ export class ServiceRepository
                     spacePermissionService: this.getSpacePermissionService(),
                     savedChartService: this.getSavedChartService(),
                     dashboardService: this.getDashboardService(),
+                    // Only wired when EE license is active. Core builds get
+                    // undefined and the delete cascade skips apps.
+                    appGenerateService: this.providers.appGenerateService
+                        ? this.getAppGenerateService<AppGenerateService>()
+                        : undefined,
                 }),
         );
     }
@@ -1062,6 +1068,9 @@ export class ServiceRepository
                     // undefined and fail DATA_APP moves with a clear error.
                     appMoveService: this.providers.appGenerateService
                         ? this.getAppGenerateService<BulkActionable<Knex>>()
+                        : undefined,
+                    appGenerateService: this.providers.appGenerateService
+                        ? this.getAppGenerateService<AppGenerateService>()
                         : undefined,
                 }),
         );

--- a/packages/backend/src/services/SpaceService/SpaceService.test.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.test.ts
@@ -38,6 +38,7 @@ describe('SpaceService', () => {
             } as unknown as SpacePermissionService,
             savedChartService: {} as SavedChartService,
             dashboardService: {} as DashboardService,
+            appGenerateService: undefined,
         });
     });
 
@@ -906,6 +907,7 @@ describe('SpaceService.updateSpace - permission copy on inherit toggle', () => {
                 mockSpacePermissionService as unknown as SpacePermissionService,
             savedChartService: {} as SavedChartService,
             dashboardService: {} as DashboardService,
+            appGenerateService: undefined,
         });
 
         // Default mocks

--- a/packages/backend/src/services/SpaceService/SpaceService.ts
+++ b/packages/backend/src/services/SpaceService/SpaceService.ts
@@ -19,6 +19,7 @@ import {
 import { Knex } from 'knex';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
+import type { AppGenerateService } from '../../ee/services/AppGenerateService/AppGenerateService';
 import { PinnedListModel } from '../../models/PinnedListModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SpaceModel } from '../../models/SpaceModel';
@@ -40,6 +41,9 @@ type SpaceServiceArguments = {
     spacePermissionService: SpacePermissionService;
     savedChartService: SavedChartService;
     dashboardService: DashboardService;
+    // EE-only. When the license isn't active the repository leaves this
+    // undefined and the cascade skips data apps (there are none to delete).
+    appGenerateService: AppGenerateService | undefined;
 };
 
 export const hasDirectAccessToSpace = (
@@ -88,6 +92,8 @@ export class SpaceService
 
     private readonly dashboardService: DashboardService;
 
+    private readonly appGenerateService: AppGenerateService | undefined;
+
     constructor(args: SpaceServiceArguments) {
         super();
         this.analytics = args.analytics;
@@ -98,6 +104,7 @@ export class SpaceService
         this.spacePermissionService = args.spacePermissionService;
         this.savedChartService = args.savedChartService;
         this.dashboardService = args.dashboardService;
+        this.appGenerateService = args.appGenerateService;
     }
 
     /** @internal For unit testing only */
@@ -547,6 +554,9 @@ export class SpaceService
             await this.spaceModel.getDashboardUuidsInSpace(spaceUuid);
         const childSpaceUuids =
             await this.spaceModel.getChildSpaceUuids(spaceUuid);
+        const apps = this.appGenerateService
+            ? await this.spaceModel.getAppsInSpace(spaceUuid)
+            : [];
 
         for (const chartUuid of chartUuids) {
             // eslint-disable-next-line no-await-in-loop
@@ -559,6 +569,15 @@ export class SpaceService
             await this.dashboardService.delete(user, dashboardUuid, {
                 bypassPermissions: true, // space delete authorized above
             });
+        }
+        for (const { appUuid, projectUuid } of apps) {
+            // eslint-disable-next-line no-await-in-loop
+            await this.appGenerateService!.deleteApp(
+                user,
+                projectUuid,
+                appUuid,
+                { bypassPermissions: true }, // space delete authorized above
+            );
         }
         for (const childSpaceUuid of childSpaceUuids) {
             // eslint-disable-next-line no-await-in-loop
@@ -688,6 +707,25 @@ export class SpaceService
                 });
             }
 
+            if (this.appGenerateService) {
+                const deletedApps = await this.spaceModel.getAppsInSpace(
+                    spaceUuid,
+                    {
+                        deleted: true,
+                        deletedByUserUuid: space.deletedBy.userUuid,
+                    },
+                );
+                for (const { appUuid, projectUuid } of deletedApps) {
+                    // eslint-disable-next-line no-await-in-loop
+                    await this.appGenerateService.restoreApp(
+                        user,
+                        projectUuid,
+                        appUuid,
+                        { bypassPermissions: true }, // space restore authorized above
+                    );
+                }
+            }
+
             const deletedChildSpaceUuids =
                 await this.spaceModel.getChildSpaceUuids(spaceUuid, {
                     deleted: true,
@@ -739,6 +777,30 @@ export class SpaceService
                 )
             ) {
                 throw new ForbiddenError();
+            }
+        }
+
+        // Apps' FK is ON DELETE SET NULL, so DB CASCADE doesn't clean them up.
+        // Permanent-delete them explicitly (sandbox + S3 cleanup). Include
+        // both active and soft-deleted apps: when soft-delete is disabled the
+        // cascade from delete() bypasses the soft-delete step, so apps in the
+        // space are still active at this point.
+        if (this.appGenerateService) {
+            const [deletedApps, activeApps] = await Promise.all([
+                this.spaceModel.getAppsInSpace(spaceUuid, { deleted: true }),
+                this.spaceModel.getAppsInSpace(spaceUuid),
+            ]);
+            for (const { appUuid, projectUuid } of [
+                ...deletedApps,
+                ...activeApps,
+            ]) {
+                // eslint-disable-next-line no-await-in-loop
+                await this.appGenerateService.permanentDeleteApp(
+                    user,
+                    projectUuid,
+                    appUuid,
+                    { bypassPermissions: true },
+                );
             }
         }
 

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -78,6 +78,8 @@ export type ApiUpdateAppResponse = ApiSuccess<{
 
 export type ApiCancelAppVersionResponse = ApiSuccessEmpty;
 
+export type ApiDeleteAppResponse = ApiSuccessEmpty;
+
 export type ApiAppSummary = {
     appUuid: string;
     name: string;

--- a/packages/common/src/types/softDelete.ts
+++ b/packages/common/src/types/softDelete.ts
@@ -81,10 +81,30 @@ export type DeletedSpaceContentSummary = {
     organizationUuid: string;
 };
 
+export type DeletedDataAppContentSummary = {
+    uuid: string;
+    name: string;
+    description: string | null;
+    contentType: ContentType.DATA_APP;
+    deletedAt: Date;
+    deletedBy: {
+        userUuid: string;
+        firstName: string;
+        lastName: string;
+    } | null;
+    // Apps can be personal (no space), so these are nullable unlike for
+    // dashboards/charts which always belong to a space.
+    spaceUuid: string | null;
+    spaceName: string | null;
+    projectUuid: string;
+    organizationUuid: string;
+};
+
 export type DeletedContentSummary =
     | DeletedChartContentSummary
     | DeletedDashboardContentSummary
-    | DeletedSpaceContentSummary;
+    | DeletedSpaceContentSummary
+    | DeletedDataAppContentSummary;
 
 // ---------------------------------------------------------------------------
 // Content-with-descendant-counts (returned by ContentModel / API)
@@ -99,7 +119,8 @@ export type DeletedContentWithDescendants =
     | WithDescendantCounts<
           DeletedSpaceContentSummary,
           'nestedSpace' | 'dashboard' | 'chart' | 'scheduler'
-      >;
+      >
+    | WithDescendantCounts<DeletedDataAppContentSummary, never>;
 
 export type DeletedContentFilters = {
     projectUuids: string[];
@@ -127,6 +148,10 @@ export type DeletedContentItem =
     | {
           uuid: string;
           contentType: ContentType.SPACE;
+      }
+    | {
+          uuid: string;
+          contentType: ContentType.DATA_APP;
       };
 
 export type ApiRestoreContentBody = {

--- a/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
+++ b/packages/frontend/src/components/UserSettings/MyAppsPanel/index.tsx
@@ -16,16 +16,25 @@ import {
     IconPencil,
     IconRadar,
     IconTextCaption,
+    IconTrash,
 } from '@tabler/icons-react';
 import {
     MantineReactTable,
     useMantineReactTable,
     type MRT_ColumnDef,
 } from 'mantine-react-table';
-import { useCallback, useEffect, useMemo, useRef, type FC } from 'react';
+import {
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import { Link } from 'react-router';
 import { useMyApps } from '../../../features/apps/hooks/useMyApps';
 import MantineIcon from '../../common/MantineIcon';
+import AppDeleteModal from '../../common/modal/AppDeleteModal';
 
 const statusColor = (status: string | null) => {
     switch (status) {
@@ -43,6 +52,7 @@ const statusColor = (status: string | null) => {
 const MyAppsPanel: FC = () => {
     const tableContainerRef = useRef<HTMLDivElement>(null);
     const { data, fetchNextPage, isFetching, isLoading, isError } = useMyApps();
+    const [appToDelete, setAppToDelete] = useState<ApiAppSummary | null>(null);
 
     const flatData = useMemo<ApiAppSummary[]>(
         () => data?.pages.flatMap((page) => page.data) ?? [],
@@ -206,6 +216,19 @@ const MyAppsPanel: FC = () => {
                                 >
                                     Continue building
                                 </Menu.Item>
+                                <Menu.Divider />
+                                <Menu.Item
+                                    color="red"
+                                    leftSection={
+                                        <MantineIcon
+                                            icon={IconTrash}
+                                            size={14}
+                                        />
+                                    }
+                                    onClick={() => setAppToDelete(app)}
+                                >
+                                    Delete
+                                </Menu.Item>
                             </Menu.Dropdown>
                         </Menu>
                     );
@@ -259,6 +282,16 @@ const MyAppsPanel: FC = () => {
     return (
         <Stack gap="md">
             <MantineReactTable table={table} />
+            {appToDelete && (
+                <AppDeleteModal
+                    opened
+                    projectUuid={appToDelete.projectUuid}
+                    uuid={appToDelete.appUuid}
+                    name={appToDelete.name}
+                    onClose={() => setAppToDelete(null)}
+                    onConfirm={() => setAppToDelete(null)}
+                />
+            )}
         </Stack>
     );
 };

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -22,6 +22,7 @@ import { useSpacePinningMutation } from '../../../hooks/pinning/useSpaceMutation
 import { useContentAction } from '../../../hooks/useContent';
 import { useSpace } from '../../../hooks/useSpaces';
 import AddTilesToDashboardModal from '../../SavedDashboards/AddTilesToDashboardModal';
+import AppDeleteModal from '../modal/AppDeleteModal';
 import AppUpdateModal from '../modal/AppUpdateModal';
 import ChartDeleteModal from '../modal/ChartDeleteModal';
 import ChartDuplicateModal from '../modal/ChartDuplicateModal';
@@ -292,8 +293,16 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
                         />
                     );
                 case ResourceViewItemType.DATA_APP:
-                    // Delete from this menu isn't supported for data apps yet
-                    return null;
+                    return (
+                        <AppDeleteModal
+                            opened
+                            projectUuid={projectUuid}
+                            uuid={action.item.data.uuid}
+                            name={action.item.data.name}
+                            onClose={handleReset}
+                            onConfirm={handleReset}
+                        />
+                    );
                 default:
                     return assertUnreachable(
                         action.item,

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -525,7 +525,11 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                             });
                                         }}
                                     >
-                                        Delete {item.type}
+                                        Delete{' '}
+                                        {item.type ===
+                                        ResourceViewItemType.DATA_APP
+                                            ? 'data app'
+                                            : item.type}
                                     </Menu.Item>
                                 </>
                             )}

--- a/packages/frontend/src/components/common/modal/AppDeleteModal.tsx
+++ b/packages/frontend/src/components/common/modal/AppDeleteModal.tsx
@@ -1,0 +1,53 @@
+import { type ModalProps } from '@mantine-8/core';
+import { type FC } from 'react';
+import { useDeleteApp } from '../../../features/apps/hooks/useDeleteApp';
+import useApp from '../../../providers/App/useApp';
+import MantineModal from '../MantineModal';
+
+interface AppDeleteModalProps extends Pick<ModalProps, 'opened' | 'onClose'> {
+    projectUuid: string;
+    uuid: string;
+    name: string;
+    onConfirm?: () => void;
+}
+
+const AppDeleteModal: FC<AppDeleteModalProps> = ({
+    opened,
+    onClose,
+    projectUuid,
+    uuid,
+    name,
+    onConfirm,
+}) => {
+    const { health } = useApp();
+    const softDeleteEnabled = health.data?.softDelete.enabled;
+    const retentionDays = health.data?.softDelete.retentionDays;
+
+    const { mutateAsync: deleteApp, isLoading: isDeleting } = useDeleteApp();
+
+    const handleConfirm = async () => {
+        await deleteApp({ projectUuid, appUuid: uuid });
+        onConfirm?.();
+    };
+
+    const description = softDeleteEnabled
+        ? `This app will be moved to Recently deleted and permanently removed after ${retentionDays} days.`
+        : 'This app and all of its versions will be permanently deleted, including any built artifacts in storage.';
+
+    return (
+        <MantineModal
+            opened={opened}
+            onClose={onClose}
+            title="Delete app"
+            variant="delete"
+            resourceType="app"
+            resourceLabel={name || `Untitled app ${uuid.slice(0, 8)}`}
+            description={description}
+            onConfirm={handleConfirm}
+            confirmLoading={isDeleting}
+            cancelDisabled={isDeleting}
+        />
+    );
+};
+
+export default AppDeleteModal;

--- a/packages/frontend/src/features/apps/hooks/useDeleteApp.ts
+++ b/packages/frontend/src/features/apps/hooks/useDeleteApp.ts
@@ -1,0 +1,41 @@
+import { type ApiError } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+type DeleteAppParams = {
+    projectUuid: string;
+    appUuid: string;
+};
+
+const deleteApp = async ({
+    projectUuid,
+    appUuid,
+}: DeleteAppParams): Promise<void> => {
+    await lightdashApi<undefined>({
+        method: 'DELETE',
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}`,
+    });
+};
+
+export const useDeleteApp = () => {
+    const queryClient = useQueryClient();
+    const { showToastSuccess, showToastApiError } = useToaster();
+    return useMutation<void, ApiError, DeleteAppParams>({
+        mutationFn: deleteApp,
+        onSuccess: (_data, variables) => {
+            void queryClient.invalidateQueries({ queryKey: ['myApps'] });
+            void queryClient.invalidateQueries({ queryKey: ['content'] });
+            void queryClient.invalidateQueries({
+                queryKey: ['app', variables.projectUuid, variables.appUuid],
+            });
+            showToastSuccess({ title: 'Data app deleted' });
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to delete app',
+                apiError: error,
+            });
+        },
+    });
+};

--- a/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/ContentTypeFilter.tsx
@@ -1,19 +1,22 @@
-import { ContentType } from '@lightdash/common';
+import { ContentType, FeatureFlags } from '@lightdash/common';
 import { Box, Divider, SegmentedControl, Text, Tooltip } from '@mantine-8/core';
 import {
+    IconAppWindow,
     IconChartBar,
     IconFolder,
     IconLayoutDashboard,
 } from '@tabler/icons-react';
 import type { FC } from 'react';
 import MantineIcon from '../../../components/common/MantineIcon';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import classes from './ContentTypeFilter.module.css';
 
 type DeletedContentTypeFilter =
     | 'all'
     | ContentType.CHART
     | ContentType.DASHBOARD
-    | ContentType.SPACE;
+    | ContentType.SPACE
+    | ContentType.DATA_APP;
 
 type ContentTypeFilterProps = {
     selectedContentType: DeletedContentTypeFilter;
@@ -24,6 +27,9 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
     selectedContentType,
     setSelectedContentType,
 }) => {
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const dataAppsEnabled = dataAppsFlag.data?.enabled ?? false;
+
     const iconProps = {
         style: { display: 'block' },
         size: 18,
@@ -71,6 +77,26 @@ export const ContentTypeFilter: FC<ContentTypeFilterProps> = ({
                 </Tooltip>
             ),
         },
+        ...(dataAppsEnabled
+            ? [
+                  {
+                      value: ContentType.DATA_APP,
+                      label: (
+                          <Tooltip
+                              label="Show only deleted data apps"
+                              withinPortal
+                          >
+                              <Box>
+                                  <MantineIcon
+                                      icon={IconAppWindow}
+                                      {...iconProps}
+                                  />
+                              </Box>
+                          </Tooltip>
+                      ),
+                  },
+              ]
+            : []),
         {
             value: ContentType.SPACE,
             label: (

--- a/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
+++ b/packages/frontend/src/features/recentlyDeleted/components/RecentlyDeletedPage.tsx
@@ -17,6 +17,7 @@ import {
 } from '@mantine-8/core';
 import { useDebouncedValue } from '@mantine/hooks';
 import {
+    IconAppWindow,
     IconCalendar,
     IconClock,
     IconFolder,
@@ -129,7 +130,11 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
     const retentionDays = health.data?.softDelete.retentionDays;
 
     const [selectedContentType, setSelectedContentType] = useState<
-        'all' | ContentType.CHART | ContentType.DASHBOARD | ContentType.SPACE
+        | 'all'
+        | ContentType.CHART
+        | ContentType.DASHBOARD
+        | ContentType.SPACE
+        | ContentType.DATA_APP
     >('all');
 
     const {
@@ -256,6 +261,13 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                     <IconBox
                                         icon={IconFolder}
                                         color="violet.6"
+                                    />
+                                );
+                            case ContentType.DATA_APP:
+                                return (
+                                    <IconBox
+                                        icon={IconAppWindow}
+                                        color="orange.6"
                                     />
                                 );
                             default:
@@ -398,6 +410,12 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                             contentType: item.contentType,
                                         });
                                         break;
+                                    case ContentType.DATA_APP:
+                                        restoreContent({
+                                            uuid: item.uuid,
+                                            contentType: item.contentType,
+                                        });
+                                        break;
                                     default:
                                         assertUnreachable(
                                             item,
@@ -422,6 +440,12 @@ const RecentlyDeletedPage: FC<Props> = ({ projectUuid }) => {
                                         });
                                         break;
                                     case ContentType.SPACE:
+                                        permanentlyDelete({
+                                            uuid: item.uuid,
+                                            contentType: item.contentType,
+                                        });
+                                        break;
+                                    case ContentType.DATA_APP:
                                         permanentlyDelete({
                                             uuid: item.uuid,
                                             contentType: item.contentType,

--- a/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
+++ b/packages/frontend/src/features/recentlyDeleted/hooks/useDeletedContent.ts
@@ -104,7 +104,16 @@ export function useRestoreDeletedContent(projectUuid: string) {
                                           `/projects/${projectUuid}/spaces/${item.uuid}`,
                                       ),
                               }
-                            : undefined,
+                            : item.contentType === ContentType.DATA_APP
+                              ? {
+                                    children: 'Go to app',
+                                    icon: IconArrowRight,
+                                    onClick: () =>
+                                        navigate(
+                                            `/projects/${projectUuid}/apps/${item.uuid}`,
+                                        ),
+                                }
+                              : undefined,
             });
             await invalidateContent(queryClient, projectUuid);
             await queryClient.invalidateQueries(['deletedContent']);

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -16,6 +16,7 @@ import {
     ThemeIcon,
 } from '@mantine-8/core';
 import {
+    IconAppsOff,
     IconAppWindow,
     IconArrowUp,
     IconExternalLink,
@@ -35,6 +36,7 @@ import {
 import { Panel, PanelGroup, PanelResizeHandle } from 'react-resizable-panels';
 import { Link, Navigate, useNavigate, useParams } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
+import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import { EditableText } from '../components/VisualizationConfigs/common/EditableText';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import AppResourcePicker, {
@@ -231,6 +233,7 @@ const AppGenerate: FC = () => {
     // Fetch version history (polling is handled by the Web Worker below)
     const {
         data: appData,
+        error: appError,
         fetchNextPage,
         hasNextPage,
         isFetchingNextPage,
@@ -418,6 +421,21 @@ const AppGenerate: FC = () => {
         )
     ) {
         return <Navigate to={`/projects/${projectUuid}/home`} replace />;
+    }
+
+    // Navigating to a soft-deleted (or never-existed) app's URL. Surface a
+    // not-found state instead of silently falling through to new-app mode —
+    // otherwise a follow-up prompt would try to iterate a ghost app.
+    if (urlAppUuid && appError?.error?.statusCode === 404) {
+        return (
+            <Box mt="30vh">
+                <SuboptimalState
+                    icon={IconAppsOff}
+                    title="Data app not found"
+                    description="This data app doesn't exist or has been deleted."
+                />
+            </Box>
+        );
     }
 
     if (!projectUuid) {

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,8 +1,9 @@
 import { FeatureFlags } from '@lightdash/common';
 import { ActionIcon, Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
-import { IconDots, IconPencil } from '@tabler/icons-react';
+import { IconAppsOff, IconDots, IconPencil } from '@tabler/icons-react';
 import { useCallback, useEffect, useState } from 'react';
 import { Navigate, useNavigate, useParams } from 'react-router';
+import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
@@ -78,14 +79,25 @@ export default function AppPreviewTest() {
         appQuery.isLoading || (version !== undefined && isTokenLoading);
     const error = appQuery.error ?? tokenError;
 
-    // Forbidden / not-found → render the standard no-access panel, not a
-    // "no ready version" message which would be misleading.
     const isForbidden =
         appQuery.error?.error?.statusCode === 403 ||
-        tokenError?.error?.statusCode === 403 ||
-        appQuery.error?.error?.statusCode === 404;
+        tokenError?.error?.statusCode === 403;
     if (isForbidden) {
         return <ForbiddenPanel />;
+    }
+    const isNotFound =
+        appQuery.error?.error?.statusCode === 404 ||
+        tokenError?.error?.statusCode === 404;
+    if (isNotFound) {
+        return (
+            <Box mt="30vh">
+                <SuboptimalState
+                    icon={IconAppsOff}
+                    title="Data app not found"
+                    description="This data app doesn't exist or has been deleted."
+                />
+            </Box>
+        );
     }
 
     if (


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-317/make-it-possible-to-delete-apps

### Description:
Adds a DELETE endpoint for data apps that routes to soft or permanent delete based on lightdashConfig.softDelete.enabled, matching the pattern used by charts, dashboards, and spaces.

Permanent delete also kills the E2B sandbox and purges the apps/{appUuid}/ prefix from S3 (staged uploads, version source tarballs, built dist, and per-version assets).

Wires up the delete menu item on space/resource views via a new AppDeleteModal, and consolidates the delete confirmation used by MyAppsPanel.