### PR TITLE
fix(sql-runner): allow non-admins to create/list schedulers on SQL charts (PROD-7098)

### DIFF
--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -123,8 +123,12 @@ const projectModel = {
 const spacePermissionService = {
     can: jest.fn(async () => true),
 };
-const googleDriveClient = {};
-const userService = {};
+const googleDriveClient = {
+    assertFileIsGoogleSheet: jest.fn(async () => undefined),
+};
+const userService = {
+    getRefreshToken: jest.fn(async () => 'refresh-token'),
+};
 
 jest.spyOn(analyticsMock, 'track');
 
@@ -132,8 +136,14 @@ const newSchedulerPayload = {
     name: 'Test',
     cron: '0 9 * * *',
     timezone: 'UTC',
-    format: SchedulerFormat.IMAGE,
-    options: {},
+    format: SchedulerFormat.GSHEETS,
+    options: {
+        gdriveId: 'gdrive-id',
+        gdriveName: 'sheet',
+        gdriveOrganizationName: '',
+        url: 'https://docs.google.com/spreadsheets/d/gdrive-id',
+        tabName: undefined,
+    },
     targets: [],
     includeLinks: false,
     enabled: true,
@@ -264,6 +274,18 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
                     targets: undefined as never,
                 }),
             ).rejects.toThrow('Targets is required');
+        });
+
+        it('rejects non-GSHEETS format (SQL chart schedulers are GSHEETS-only)', async () => {
+            await expect(
+                service.createScheduler(adminUser, projectUuid, savedSqlUuid, {
+                    ...newSchedulerPayload,
+                    format: SchedulerFormat.IMAGE,
+                }),
+            ).rejects.toThrow(
+                'SQL chart schedulers only support Google Sheets format',
+            );
+            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });
     });
 });

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -6,8 +6,6 @@ import {
     SchedulerFormat,
 } from '@lightdash/common';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
-import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
-import { SlackClient } from '../../clients/Slack/SlackClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -15,7 +13,6 @@ import { SavedSqlModel } from '../../models/SavedSqlModel';
 import { SchedulerModel } from '../../models/SchedulerModel';
 import { SchedulerClient } from '../../scheduler/SchedulerClient';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
-import { UserService } from '../UserService';
 import { SavedSqlService } from './SavedSqlService';
 
 const organizationUuid = 'org-uuid';
@@ -93,7 +90,7 @@ const createdScheduler = {
     name: 'Test',
     cron: '0 9 * * *',
     timezone: 'UTC',
-    format: 'image',
+    format: SchedulerFormat.IMAGE,
     savedChartUuid: null,
     dashboardUuid: null,
     savedSqlUuid,
@@ -111,39 +108,16 @@ const schedulerModel = {
     getSqlChartSchedulers: jest.fn(async () => []),
     createScheduler: jest.fn(async () => createdScheduler),
 };
-const schedulerClient = {
-    generateDailyJobsForScheduler: jest.fn(async () => undefined),
-};
-const slackClient = {
-    joinChannels: jest.fn(async () => undefined),
-};
-const projectModel = {
-    get: jest.fn(async () => ({ schedulerTimezone: 'UTC' })),
-};
 const spacePermissionService = {
     can: jest.fn(async () => true),
 };
-const googleDriveClient = {
-    assertFileIsGoogleSheet: jest.fn(async () => undefined),
-};
-const userService = {
-    getRefreshToken: jest.fn(async () => 'refresh-token'),
-};
-
-jest.spyOn(analyticsMock, 'track');
 
 const newSchedulerPayload = {
     name: 'Test',
     cron: '0 9 * * *',
     timezone: 'UTC',
-    format: SchedulerFormat.GSHEETS,
-    options: {
-        gdriveId: 'gdrive-id',
-        gdriveName: 'sheet',
-        gdriveOrganizationName: '',
-        url: 'https://docs.google.com/spreadsheets/d/gdrive-id',
-        tabName: undefined,
-    },
+    format: SchedulerFormat.IMAGE,
+    options: {},
     targets: [],
     includeLinks: false,
     enabled: true,
@@ -153,16 +127,13 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
     const service = new SavedSqlService({
         lightdashConfig: lightdashConfigMock,
         analytics: analyticsMock,
-        projectModel: projectModel as unknown as ProjectModel,
+        projectModel: {} as unknown as ProjectModel,
         savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
-        schedulerClient: schedulerClient as unknown as SchedulerClient,
+        schedulerClient: {} as unknown as SchedulerClient,
         schedulerModel: schedulerModel as unknown as SchedulerModel,
         analyticsModel: {} as unknown as AnalyticsModel,
         spacePermissionService:
             spacePermissionService as unknown as SpacePermissionService,
-        slackClient: slackClient as unknown as SlackClient,
-        googleDriveClient: googleDriveClient as unknown as GoogleDriveClient,
-        userService: userService as unknown as UserService,
     });
 
     afterEach(() => jest.clearAllMocks());
@@ -184,7 +155,6 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             await expect(
                 service.getSchedulers(viewerUser, projectUuid, savedSqlUuid),
             ).rejects.toThrow(ForbiddenError);
-            // Security invariant: deny must happen before any read
             expect(schedulerModel.getSqlChartSchedulers).not.toHaveBeenCalled();
         });
 
@@ -195,6 +165,7 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             ).rejects.toThrow(
                 "You don't have access to the space this chart belongs to",
             );
+            expect(schedulerModel.getSqlChartSchedulers).not.toHaveBeenCalled();
         });
     });
 
@@ -230,12 +201,7 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
                     newSchedulerPayload,
                 ),
             ).rejects.toThrow(ForbiddenError);
-            // Security invariant: deny must happen before any write or
-            // external side effect (Google Drive API)
             expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
-            expect(
-                googleDriveClient.assertFileIsGoogleSheet,
-            ).not.toHaveBeenCalled();
         });
 
         it('user without space access is blocked from creating scheduler', async () => {
@@ -249,39 +215,6 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
                 ),
             ).rejects.toThrow(
                 "You don't have access to the space this chart belongs to",
-            );
-            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
-            expect(
-                googleDriveClient.assertFileIsGoogleSheet,
-            ).not.toHaveBeenCalled();
-        });
-
-        it('rejects invalid cron frequency', async () => {
-            await expect(
-                service.createScheduler(adminUser, projectUuid, savedSqlUuid, {
-                    ...newSchedulerPayload,
-                    cron: '* * * * *',
-                }),
-            ).rejects.toThrow('Frequency not allowed');
-        });
-
-        it('rejects non-array targets', async () => {
-            await expect(
-                service.createScheduler(adminUser, projectUuid, savedSqlUuid, {
-                    ...newSchedulerPayload,
-                    targets: undefined as never,
-                }),
-            ).rejects.toThrow('Targets is required');
-        });
-
-        it('rejects non-GSHEETS format (SQL chart schedulers are GSHEETS-only)', async () => {
-            await expect(
-                service.createScheduler(adminUser, projectUuid, savedSqlUuid, {
-                    ...newSchedulerPayload,
-                    format: SchedulerFormat.IMAGE,
-                }),
-            ).rejects.toThrow(
-                'SQL chart schedulers only support Google Sheets format',
             );
             expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -172,9 +172,6 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             await expect(
                 service.getSchedulers(adminUser, projectUuid, savedSqlUuid),
             ).resolves.toEqual([]);
-            expect(schedulerModel.getSqlChartSchedulers).toHaveBeenCalledWith(
-                savedSqlUuid,
-            );
         });
 
         it('editor can list SQL chart schedulers (PROD-7098 regression)', async () => {
@@ -187,7 +184,6 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             await expect(
                 service.getSchedulers(viewerUser, projectUuid, savedSqlUuid),
             ).rejects.toThrow(ForbiddenError);
-            expect(schedulerModel.getSqlChartSchedulers).not.toHaveBeenCalled();
         });
 
         it('user without space access is blocked', async () => {
@@ -202,33 +198,25 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
 
     describe('createScheduler', () => {
         it('admin can create scheduler on SQL chart', async () => {
-            await service.createScheduler(
-                adminUser,
-                projectUuid,
-                savedSqlUuid,
-                newSchedulerPayload,
-            );
-            expect(schedulerModel.createScheduler).toHaveBeenCalled();
-            expect(
-                schedulerClient.generateDailyJobsForScheduler,
-            ).toHaveBeenCalled();
+            await expect(
+                service.createScheduler(
+                    adminUser,
+                    projectUuid,
+                    savedSqlUuid,
+                    newSchedulerPayload,
+                ),
+            ).resolves.toBeDefined();
         });
 
         it('editor can create scheduler on SQL chart (PROD-7098 fix)', async () => {
-            await service.createScheduler(
-                editorUser,
-                projectUuid,
-                savedSqlUuid,
-                newSchedulerPayload,
-            );
-            expect(schedulerModel.createScheduler).toHaveBeenCalled();
-            expect(slackClient.joinChannels).toHaveBeenCalled();
-            expect(
-                schedulerClient.generateDailyJobsForScheduler,
-            ).toHaveBeenCalled();
-            expect(analyticsMock.track).toHaveBeenCalledWith(
-                expect.objectContaining({ event: 'scheduler.created' }),
-            );
+            await expect(
+                service.createScheduler(
+                    editorUser,
+                    projectUuid,
+                    savedSqlUuid,
+                    newSchedulerPayload,
+                ),
+            ).resolves.toBeDefined();
         });
 
         it('viewer is blocked from creating scheduler', async () => {
@@ -240,7 +228,6 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
                     newSchedulerPayload,
                 ),
             ).rejects.toThrow(ForbiddenError);
-            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });
 
         it('user without space access is blocked from creating scheduler', async () => {
@@ -255,7 +242,6 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             ).rejects.toThrow(
                 "You don't have access to the space this chart belongs to",
             );
-            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
         });
 
         it('rejects invalid cron frequency', async () => {

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -184,6 +184,8 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             await expect(
                 service.getSchedulers(viewerUser, projectUuid, savedSqlUuid),
             ).rejects.toThrow(ForbiddenError);
+            // Security invariant: deny must happen before any read
+            expect(schedulerModel.getSqlChartSchedulers).not.toHaveBeenCalled();
         });
 
         it('user without space access is blocked', async () => {
@@ -228,6 +230,12 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
                     newSchedulerPayload,
                 ),
             ).rejects.toThrow(ForbiddenError);
+            // Security invariant: deny must happen before any write or
+            // external side effect (Google Drive API)
+            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
+            expect(
+                googleDriveClient.assertFileIsGoogleSheet,
+            ).not.toHaveBeenCalled();
         });
 
         it('user without space access is blocked from creating scheduler', async () => {
@@ -242,6 +250,10 @@ describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
             ).rejects.toThrow(
                 "You don't have access to the space this chart belongs to",
             );
+            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
+            expect(
+                googleDriveClient.assertFileIsGoogleSheet,
+            ).not.toHaveBeenCalled();
         });
 
         it('rejects invalid cron frequency', async () => {

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts
@@ -1,0 +1,269 @@
+import { Ability } from '@casl/ability';
+import {
+    ForbiddenError,
+    OrganizationMemberRole,
+    PossibleAbilities,
+    SchedulerFormat,
+} from '@lightdash/common';
+import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
+import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
+import { SlackClient } from '../../clients/Slack/SlackClient';
+import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
+import { AnalyticsModel } from '../../models/AnalyticsModel';
+import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
+import { SavedSqlModel } from '../../models/SavedSqlModel';
+import { SchedulerModel } from '../../models/SchedulerModel';
+import { SchedulerClient } from '../../scheduler/SchedulerClient';
+import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { UserService } from '../UserService';
+import { SavedSqlService } from './SavedSqlService';
+
+const organizationUuid = 'org-uuid';
+const projectUuid = 'project-uuid';
+const savedSqlUuid = 'saved-sql-uuid';
+const spaceUuid = 'space-uuid';
+
+const sqlChart = {
+    savedSqlUuid,
+    name: 'Chart',
+    organization: { organizationUuid },
+    project: { projectUuid },
+    space: { uuid: spaceUuid, name: 'Space' },
+};
+
+const baseUser = {
+    userId: 1,
+    userUuid: 'user-uuid',
+    email: 'user@test.com',
+    firstName: 'Test',
+    lastName: 'User',
+    organizationUuid,
+    organizationName: 'Test Org',
+    organizationCreatedAt: new Date(),
+    isTrackingAnonymized: false,
+    isMarketingOptedIn: false,
+    isSetupComplete: true,
+    isActive: true,
+    isPending: false,
+    abilityRules: [],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+};
+
+const adminUser = {
+    ...baseUser,
+    userUuid: 'admin-uuid',
+    role: OrganizationMemberRole.ADMIN,
+    ability: new Ability<PossibleAbilities>([
+        {
+            subject: 'ScheduledDeliveries',
+            action: 'manage',
+            conditions: { organizationUuid },
+        },
+    ]),
+};
+
+const editorUser = {
+    ...baseUser,
+    userUuid: 'editor-uuid',
+    role: OrganizationMemberRole.EDITOR,
+    ability: new Ability<PossibleAbilities>([
+        {
+            subject: 'ScheduledDeliveries',
+            action: 'create',
+            conditions: { organizationUuid },
+        },
+        {
+            subject: 'ScheduledDeliveries',
+            action: 'manage',
+            conditions: { organizationUuid, userUuid: 'editor-uuid' },
+        },
+    ]),
+};
+
+const viewerUser = {
+    ...baseUser,
+    userUuid: 'viewer-uuid',
+    role: OrganizationMemberRole.VIEWER,
+    ability: new Ability<PossibleAbilities>([]),
+};
+
+const createdScheduler = {
+    schedulerUuid: 'scheduler-uuid',
+    name: 'Test',
+    cron: '0 9 * * *',
+    timezone: 'UTC',
+    format: 'image',
+    savedChartUuid: null,
+    dashboardUuid: null,
+    savedSqlUuid,
+    createdBy: 'editor-uuid',
+    targets: [],
+    includeLinks: false,
+    enabled: true,
+    options: {},
+};
+
+const savedSqlModel = {
+    getByUuid: jest.fn(async () => sqlChart),
+};
+const schedulerModel = {
+    getSqlChartSchedulers: jest.fn(async () => []),
+    createScheduler: jest.fn(async () => createdScheduler),
+};
+const schedulerClient = {
+    generateDailyJobsForScheduler: jest.fn(async () => undefined),
+};
+const slackClient = {
+    joinChannels: jest.fn(async () => undefined),
+};
+const projectModel = {
+    get: jest.fn(async () => ({ schedulerTimezone: 'UTC' })),
+};
+const spacePermissionService = {
+    can: jest.fn(async () => true),
+};
+const googleDriveClient = {};
+const userService = {};
+
+jest.spyOn(analyticsMock, 'track');
+
+const newSchedulerPayload = {
+    name: 'Test',
+    cron: '0 9 * * *',
+    timezone: 'UTC',
+    format: SchedulerFormat.IMAGE,
+    options: {},
+    targets: [],
+    includeLinks: false,
+    enabled: true,
+};
+
+describe('SavedSqlService - Scheduler authorization (PROD-7098)', () => {
+    const service = new SavedSqlService({
+        lightdashConfig: lightdashConfigMock,
+        analytics: analyticsMock,
+        projectModel: projectModel as unknown as ProjectModel,
+        savedSqlModel: savedSqlModel as unknown as SavedSqlModel,
+        schedulerClient: schedulerClient as unknown as SchedulerClient,
+        schedulerModel: schedulerModel as unknown as SchedulerModel,
+        analyticsModel: {} as unknown as AnalyticsModel,
+        spacePermissionService:
+            spacePermissionService as unknown as SpacePermissionService,
+        slackClient: slackClient as unknown as SlackClient,
+        googleDriveClient: googleDriveClient as unknown as GoogleDriveClient,
+        userService: userService as unknown as UserService,
+    });
+
+    afterEach(() => jest.clearAllMocks());
+
+    describe('getSchedulers', () => {
+        it('admin can list SQL chart schedulers', async () => {
+            await expect(
+                service.getSchedulers(adminUser, projectUuid, savedSqlUuid),
+            ).resolves.toEqual([]);
+            expect(schedulerModel.getSqlChartSchedulers).toHaveBeenCalledWith(
+                savedSqlUuid,
+            );
+        });
+
+        it('editor can list SQL chart schedulers (PROD-7098 regression)', async () => {
+            await expect(
+                service.getSchedulers(editorUser, projectUuid, savedSqlUuid),
+            ).resolves.toEqual([]);
+        });
+
+        it('viewer is blocked from listing SQL chart schedulers', async () => {
+            await expect(
+                service.getSchedulers(viewerUser, projectUuid, savedSqlUuid),
+            ).rejects.toThrow(ForbiddenError);
+            expect(schedulerModel.getSqlChartSchedulers).not.toHaveBeenCalled();
+        });
+
+        it('user without space access is blocked', async () => {
+            spacePermissionService.can.mockResolvedValueOnce(false);
+            await expect(
+                service.getSchedulers(editorUser, projectUuid, savedSqlUuid),
+            ).rejects.toThrow(
+                "You don't have access to the space this chart belongs to",
+            );
+        });
+    });
+
+    describe('createScheduler', () => {
+        it('admin can create scheduler on SQL chart', async () => {
+            await service.createScheduler(
+                adminUser,
+                projectUuid,
+                savedSqlUuid,
+                newSchedulerPayload,
+            );
+            expect(schedulerModel.createScheduler).toHaveBeenCalled();
+            expect(
+                schedulerClient.generateDailyJobsForScheduler,
+            ).toHaveBeenCalled();
+        });
+
+        it('editor can create scheduler on SQL chart (PROD-7098 fix)', async () => {
+            await service.createScheduler(
+                editorUser,
+                projectUuid,
+                savedSqlUuid,
+                newSchedulerPayload,
+            );
+            expect(schedulerModel.createScheduler).toHaveBeenCalled();
+            expect(slackClient.joinChannels).toHaveBeenCalled();
+            expect(
+                schedulerClient.generateDailyJobsForScheduler,
+            ).toHaveBeenCalled();
+            expect(analyticsMock.track).toHaveBeenCalledWith(
+                expect.objectContaining({ event: 'scheduler.created' }),
+            );
+        });
+
+        it('viewer is blocked from creating scheduler', async () => {
+            await expect(
+                service.createScheduler(
+                    viewerUser,
+                    projectUuid,
+                    savedSqlUuid,
+                    newSchedulerPayload,
+                ),
+            ).rejects.toThrow(ForbiddenError);
+            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        it('user without space access is blocked from creating scheduler', async () => {
+            spacePermissionService.can.mockResolvedValueOnce(false);
+            await expect(
+                service.createScheduler(
+                    editorUser,
+                    projectUuid,
+                    savedSqlUuid,
+                    newSchedulerPayload,
+                ),
+            ).rejects.toThrow(
+                "You don't have access to the space this chart belongs to",
+            );
+            expect(schedulerModel.createScheduler).not.toHaveBeenCalled();
+        });
+
+        it('rejects invalid cron frequency', async () => {
+            await expect(
+                service.createScheduler(adminUser, projectUuid, savedSqlUuid, {
+                    ...newSchedulerPayload,
+                    cron: '* * * * *',
+                }),
+            ).rejects.toThrow('Frequency not allowed');
+        });
+
+        it('rejects non-array targets', async () => {
+            await expect(
+                service.createScheduler(adminUser, projectUuid, savedSqlUuid, {
+                    ...newSchedulerPayload,
+                    targets: undefined as never,
+                }),
+            ).rejects.toThrow('Targets is required');
+        });
+    });
+});

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -897,6 +897,16 @@ export class SavedSqlService
             );
         }
 
+        // Authorize before any external side-effects (Google Drive API call
+        // below). A user with the route middleware but no create:ScheduledDeliveries
+        // or space access shouldn't be able to probe the Drive API.
+        const { organizationUuid } =
+            await this.checkCreateScheduledDeliveryAccess(
+                user,
+                projectUuid,
+                savedSqlUuid,
+            );
+
         if (!isValidFrequency(newScheduler.cron)) {
             throw new ParameterError(
                 'Frequency not allowed, custom input is limited to hourly',
@@ -913,40 +923,31 @@ export class SavedSqlService
             );
         }
 
-        if (newScheduler.format === SchedulerFormat.GSHEETS) {
-            if (!isSchedulerGsheetsOptions(newScheduler.options)) {
-                throw new ParameterError(
-                    'Google Sheets format requires valid gsheets options',
-                );
-            }
-
-            try {
-                const refreshToken = await this.userService.getRefreshToken(
-                    user.userUuid,
-                );
-                await this.googleDriveClient.assertFileIsGoogleSheet(
-                    refreshToken,
-                    newScheduler.options.gdriveId,
-                );
-            } catch (error) {
-                if (error instanceof UnexpectedGoogleSheetsError) {
-                    throw error;
-                }
-                if (error instanceof GoogleSheetsTransientError) {
-                    throw error;
-                }
-                throw new MissingConfigError(
-                    'Unable to validate Google Sheets file. Please ensure you have connected your Google account.',
-                );
-            }
+        if (!isSchedulerGsheetsOptions(newScheduler.options)) {
+            throw new ParameterError(
+                'Google Sheets format requires valid gsheets options',
+            );
         }
 
-        const { organizationUuid } =
-            await this.checkCreateScheduledDeliveryAccess(
-                user,
-                projectUuid,
-                savedSqlUuid,
+        try {
+            const refreshToken = await this.userService.getRefreshToken(
+                user.userUuid,
             );
+            await this.googleDriveClient.assertFileIsGoogleSheet(
+                refreshToken,
+                newScheduler.options.gdriveId,
+            );
+        } catch (error) {
+            if (error instanceof UnexpectedGoogleSheetsError) {
+                throw error;
+            }
+            if (error instanceof GoogleSheetsTransientError) {
+                throw error;
+            }
+            throw new MissingConfigError(
+                'Unable to validate Google Sheets file. Please ensure you have connected your Google account.',
+            );
+        }
 
         const scheduler = await this.schedulerModel.createScheduler({
             ...newScheduler,

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -6,43 +6,30 @@ import {
     CreateSchedulerAndTargetsWithoutIds,
     CreateSqlChart,
     ForbiddenError,
-    getSchedulerResourceTypeAndId,
-    getTimezoneLabel,
-    GoogleSheetsTransientError,
-    isSchedulerGsheetsOptions,
-    isUserWithOrg,
     isValidFrequency,
     isValidTimezone,
     isVizBarChartConfig,
     isVizLineChartConfig,
     isVizPieChartConfig,
-    MissingConfigError,
     NotFoundError,
     Organization,
     ParameterError,
     Project,
     QueryExecutionContext,
     SchedulerAndTargets,
-    SchedulerFormat,
     SessionUser,
     SqlChart,
     SqlRunnerPivotQueryBody,
-    UnexpectedGoogleSheetsError,
     UpdateSqlChart,
     VIZ_DEFAULT_AGGREGATION,
 } from '@lightdash/common';
-import cronstrue from 'cronstrue';
 import { Knex } from 'knex';
 import { uniq } from 'lodash';
 import {
     CreateSqlChartVersionEvent,
     LightdashAnalytics,
-    SchedulerUpsertEvent,
 } from '../../analytics/LightdashAnalytics';
-import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
-import { SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
-import { getSchedulerTargetType } from '../../database/entities/scheduler';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedSqlModel } from '../../models/SavedSqlModel';
@@ -54,7 +41,6 @@ import type {
     SoftDeleteOptions,
 } from '../SoftDeletableService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
-import { UserService } from '../UserService';
 
 type SavedSqlServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -65,9 +51,6 @@ type SavedSqlServiceArguments = {
     schedulerModel: SchedulerModel;
     analyticsModel: AnalyticsModel;
     spacePermissionService: SpacePermissionService;
-    slackClient: SlackClient;
-    googleDriveClient: GoogleDriveClient;
-    userService: UserService;
 };
 
 // TODO: Rename to SqlRunnerService
@@ -92,12 +75,6 @@ export class SavedSqlService
 
     private readonly spacePermissionService: SpacePermissionService;
 
-    private readonly slackClient: SlackClient;
-
-    private readonly googleDriveClient: GoogleDriveClient;
-
-    private readonly userService: UserService;
-
     constructor(args: SavedSqlServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
@@ -108,9 +85,6 @@ export class SavedSqlService
         this.schedulerModel = args.schedulerModel;
         this.analyticsModel = args.analyticsModel;
         this.spacePermissionService = args.spacePermissionService;
-        this.slackClient = args.slackClient;
-        this.googleDriveClient = args.googleDriveClient;
-        this.userService = args.userService;
     }
 
     static getCreateVersionEventProperties(
@@ -883,29 +857,11 @@ export class SavedSqlService
         savedSqlUuid: string,
         newScheduler: CreateSchedulerAndTargetsWithoutIds,
     ): Promise<SchedulerAndTargets> {
-        if (!isUserWithOrg(user)) {
-            throw new ForbiddenError('User is not part of an organization');
-        }
-
-        // SQL chart schedulers only flow through the Google Sheets upload worker
-        // (SchedulerTask.handleGsheetsUpload). Other formats route to
-        // handleScheduledDelivery, which has no SQL-chart branch and would fail
-        // at runtime with "Chart or dashboard can't be both undefined".
-        if (newScheduler.format !== SchedulerFormat.GSHEETS) {
-            throw new ParameterError(
-                'SQL chart schedulers only support Google Sheets format',
-            );
-        }
-
-        // Authorize before any external side-effects (Google Drive API call
-        // below). A user with the route middleware but no create:ScheduledDeliveries
-        // or space access shouldn't be able to probe the Drive API.
-        const { organizationUuid } =
-            await this.checkCreateScheduledDeliveryAccess(
-                user,
-                projectUuid,
-                savedSqlUuid,
-            );
+        await this.checkCreateScheduledDeliveryAccess(
+            user,
+            projectUuid,
+            savedSqlUuid,
+        );
 
         if (!isValidFrequency(newScheduler.cron)) {
             throw new ParameterError(
@@ -917,88 +873,12 @@ export class SavedSqlService
             throw new ParameterError('Timezone string is not valid');
         }
 
-        if (!newScheduler.targets || !Array.isArray(newScheduler.targets)) {
-            throw new ParameterError(
-                'Targets is required and must be an array',
-            );
-        }
-
-        if (!isSchedulerGsheetsOptions(newScheduler.options)) {
-            throw new ParameterError(
-                'Google Sheets format requires valid gsheets options',
-            );
-        }
-
-        try {
-            const refreshToken = await this.userService.getRefreshToken(
-                user.userUuid,
-            );
-            await this.googleDriveClient.assertFileIsGoogleSheet(
-                refreshToken,
-                newScheduler.options.gdriveId,
-            );
-        } catch (error) {
-            if (error instanceof UnexpectedGoogleSheetsError) {
-                throw error;
-            }
-            if (error instanceof GoogleSheetsTransientError) {
-                throw error;
-            }
-            throw new MissingConfigError(
-                'Unable to validate Google Sheets file. Please ensure you have connected your Google account.',
-            );
-        }
-
-        const scheduler = await this.schedulerModel.createScheduler({
+        return this.schedulerModel.createScheduler({
             ...newScheduler,
             createdBy: user.userUuid,
             savedChartUuid: null,
             dashboardUuid: null,
             savedSqlUuid,
         });
-
-        const createSchedulerEventData: SchedulerUpsertEvent = {
-            userId: user.userUuid,
-            event: 'scheduler.created',
-            properties: {
-                projectId: projectUuid,
-                organizationId: organizationUuid,
-                schedulerId: scheduler.schedulerUuid,
-                ...getSchedulerResourceTypeAndId(scheduler),
-                cronExpression: scheduler.cron,
-                format: scheduler.format,
-                cronString: cronstrue.toString(scheduler.cron, {
-                    verbose: true,
-                    throwExceptionOnParseError: false,
-                }),
-                targets:
-                    scheduler.format === SchedulerFormat.GSHEETS
-                        ? []
-                        : scheduler.targets.map(getSchedulerTargetType),
-                timeZone: getTimezoneLabel(scheduler.timezone),
-                includeLinks: scheduler.includeLinks,
-            },
-        };
-        this.analytics.track(createSchedulerEventData);
-
-        await this.slackClient.joinChannels(
-            user.organizationUuid,
-            SchedulerModel.getSlackChannels(scheduler.targets),
-        );
-
-        const { schedulerTimezone: defaultTimezone } =
-            await this.projectModel.get(projectUuid);
-
-        await this.schedulerClient.generateDailyJobsForScheduler(
-            scheduler,
-            {
-                organizationUuid,
-                projectUuid,
-                userUuid: user.userUuid,
-            },
-            defaultTimezone,
-        );
-
-        return scheduler;
     }
 }

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -887,6 +887,16 @@ export class SavedSqlService
             throw new ForbiddenError('User is not part of an organization');
         }
 
+        // SQL chart schedulers only flow through the Google Sheets upload worker
+        // (SchedulerTask.handleGsheetsUpload). Other formats route to
+        // handleScheduledDelivery, which has no SQL-chart branch and would fail
+        // at runtime with "Chart or dashboard can't be both undefined".
+        if (newScheduler.format !== SchedulerFormat.GSHEETS) {
+            throw new ParameterError(
+                'SQL chart schedulers only support Google Sheets format',
+            );
+        }
+
         if (!isValidFrequency(newScheduler.cron)) {
             throw new ParameterError(
                 'Frequency not allowed, custom input is limited to hourly',

--- a/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
+++ b/packages/backend/src/services/SavedSqlService/SavedSqlService.ts
@@ -6,30 +6,43 @@ import {
     CreateSchedulerAndTargetsWithoutIds,
     CreateSqlChart,
     ForbiddenError,
+    getSchedulerResourceTypeAndId,
+    getTimezoneLabel,
+    GoogleSheetsTransientError,
+    isSchedulerGsheetsOptions,
+    isUserWithOrg,
     isValidFrequency,
     isValidTimezone,
     isVizBarChartConfig,
     isVizLineChartConfig,
     isVizPieChartConfig,
+    MissingConfigError,
     NotFoundError,
     Organization,
     ParameterError,
     Project,
     QueryExecutionContext,
     SchedulerAndTargets,
+    SchedulerFormat,
     SessionUser,
     SqlChart,
     SqlRunnerPivotQueryBody,
+    UnexpectedGoogleSheetsError,
     UpdateSqlChart,
     VIZ_DEFAULT_AGGREGATION,
 } from '@lightdash/common';
+import cronstrue from 'cronstrue';
 import { Knex } from 'knex';
 import { uniq } from 'lodash';
 import {
     CreateSqlChartVersionEvent,
     LightdashAnalytics,
+    SchedulerUpsertEvent,
 } from '../../analytics/LightdashAnalytics';
+import { GoogleDriveClient } from '../../clients/Google/GoogleDriveClient';
+import { SlackClient } from '../../clients/Slack/SlackClient';
 import { LightdashConfig } from '../../config/parseConfig';
+import { getSchedulerTargetType } from '../../database/entities/scheduler';
 import { AnalyticsModel } from '../../models/AnalyticsModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
 import { SavedSqlModel } from '../../models/SavedSqlModel';
@@ -41,6 +54,7 @@ import type {
     SoftDeleteOptions,
 } from '../SoftDeletableService';
 import { SpacePermissionService } from '../SpaceService/SpacePermissionService';
+import { UserService } from '../UserService';
 
 type SavedSqlServiceArguments = {
     lightdashConfig: LightdashConfig;
@@ -51,6 +65,9 @@ type SavedSqlServiceArguments = {
     schedulerModel: SchedulerModel;
     analyticsModel: AnalyticsModel;
     spacePermissionService: SpacePermissionService;
+    slackClient: SlackClient;
+    googleDriveClient: GoogleDriveClient;
+    userService: UserService;
 };
 
 // TODO: Rename to SqlRunnerService
@@ -75,6 +92,12 @@ export class SavedSqlService
 
     private readonly spacePermissionService: SpacePermissionService;
 
+    private readonly slackClient: SlackClient;
+
+    private readonly googleDriveClient: GoogleDriveClient;
+
+    private readonly userService: UserService;
+
     constructor(args: SavedSqlServiceArguments) {
         super();
         this.lightdashConfig = args.lightdashConfig;
@@ -85,6 +108,9 @@ export class SavedSqlService
         this.schedulerModel = args.schedulerModel;
         this.analyticsModel = args.analyticsModel;
         this.spacePermissionService = args.spacePermissionService;
+        this.slackClient = args.slackClient;
+        this.googleDriveClient = args.googleDriveClient;
+        this.userService = args.userService;
     }
 
     static getCreateVersionEventProperties(
@@ -789,20 +815,36 @@ export class SavedSqlService
         }
     }
 
-    async getSchedulers(
+    private async hasChartSpaceAccess(
+        user: SessionUser,
+        spaceUuid: string,
+    ): Promise<boolean> {
+        try {
+            return await this.spacePermissionService.can(
+                'view',
+                user,
+                spaceUuid,
+            );
+        } catch (e) {
+            return false;
+        }
+    }
+
+    private async checkCreateScheduledDeliveryAccess(
         user: SessionUser,
         projectUuid: string,
         savedSqlUuid: string,
-    ): Promise<SchedulerAndTargets[]> {
+    ): Promise<{ organizationUuid: string; spaceUuid: string }> {
         const sqlChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
             projectUuid,
         });
         const { organizationUuid } = sqlChart.organization;
+        const spaceUuid = sqlChart.space.uuid;
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
             auditedAbility.cannot(
-                'manage',
+                'create',
                 subject('ScheduledDeliveries', {
                     organizationUuid,
                     projectUuid,
@@ -813,6 +855,25 @@ export class SavedSqlService
             throw new ForbiddenError();
         }
 
+        if (!(await this.hasChartSpaceAccess(user, spaceUuid))) {
+            throw new ForbiddenError(
+                "You don't have access to the space this chart belongs to",
+            );
+        }
+
+        return { organizationUuid, spaceUuid };
+    }
+
+    async getSchedulers(
+        user: SessionUser,
+        projectUuid: string,
+        savedSqlUuid: string,
+    ): Promise<SchedulerAndTargets[]> {
+        await this.checkCreateScheduledDeliveryAccess(
+            user,
+            projectUuid,
+            savedSqlUuid,
+        );
         return this.schedulerModel.getSqlChartSchedulers(savedSqlUuid);
     }
 
@@ -822,23 +883,8 @@ export class SavedSqlService
         savedSqlUuid: string,
         newScheduler: CreateSchedulerAndTargetsWithoutIds,
     ): Promise<SchedulerAndTargets> {
-        const sqlChart = await this.savedSqlModel.getByUuid(savedSqlUuid, {
-            projectUuid,
-        });
-        const { organizationUuid } = sqlChart.organization;
-
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('ScheduledDeliveries', {
-                    organizationUuid,
-                    projectUuid,
-                    metadata: { savedSqlUuid },
-                }),
-            )
-        ) {
-            throw new ForbiddenError();
+        if (!isUserWithOrg(user)) {
+            throw new ForbiddenError('User is not part of an organization');
         }
 
         if (!isValidFrequency(newScheduler.cron)) {
@@ -851,12 +897,97 @@ export class SavedSqlService
             throw new ParameterError('Timezone string is not valid');
         }
 
-        return this.schedulerModel.createScheduler({
+        if (!newScheduler.targets || !Array.isArray(newScheduler.targets)) {
+            throw new ParameterError(
+                'Targets is required and must be an array',
+            );
+        }
+
+        if (newScheduler.format === SchedulerFormat.GSHEETS) {
+            if (!isSchedulerGsheetsOptions(newScheduler.options)) {
+                throw new ParameterError(
+                    'Google Sheets format requires valid gsheets options',
+                );
+            }
+
+            try {
+                const refreshToken = await this.userService.getRefreshToken(
+                    user.userUuid,
+                );
+                await this.googleDriveClient.assertFileIsGoogleSheet(
+                    refreshToken,
+                    newScheduler.options.gdriveId,
+                );
+            } catch (error) {
+                if (error instanceof UnexpectedGoogleSheetsError) {
+                    throw error;
+                }
+                if (error instanceof GoogleSheetsTransientError) {
+                    throw error;
+                }
+                throw new MissingConfigError(
+                    'Unable to validate Google Sheets file. Please ensure you have connected your Google account.',
+                );
+            }
+        }
+
+        const { organizationUuid } =
+            await this.checkCreateScheduledDeliveryAccess(
+                user,
+                projectUuid,
+                savedSqlUuid,
+            );
+
+        const scheduler = await this.schedulerModel.createScheduler({
             ...newScheduler,
             createdBy: user.userUuid,
             savedChartUuid: null,
             dashboardUuid: null,
             savedSqlUuid,
         });
+
+        const createSchedulerEventData: SchedulerUpsertEvent = {
+            userId: user.userUuid,
+            event: 'scheduler.created',
+            properties: {
+                projectId: projectUuid,
+                organizationId: organizationUuid,
+                schedulerId: scheduler.schedulerUuid,
+                ...getSchedulerResourceTypeAndId(scheduler),
+                cronExpression: scheduler.cron,
+                format: scheduler.format,
+                cronString: cronstrue.toString(scheduler.cron, {
+                    verbose: true,
+                    throwExceptionOnParseError: false,
+                }),
+                targets:
+                    scheduler.format === SchedulerFormat.GSHEETS
+                        ? []
+                        : scheduler.targets.map(getSchedulerTargetType),
+                timeZone: getTimezoneLabel(scheduler.timezone),
+                includeLinks: scheduler.includeLinks,
+            },
+        };
+        this.analytics.track(createSchedulerEventData);
+
+        await this.slackClient.joinChannels(
+            user.organizationUuid,
+            SchedulerModel.getSlackChannels(scheduler.targets),
+        );
+
+        const { schedulerTimezone: defaultTimezone } =
+            await this.projectModel.get(projectUuid);
+
+        await this.schedulerClient.generateDailyJobsForScheduler(
+            scheduler,
+            {
+                organizationUuid,
+                projectUuid,
+                userUuid: user.userUuid,
+            },
+            defaultTimezone,
+        );
+
+        return scheduler;
     }
 }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1040,6 +1040,9 @@ export class ServiceRepository
                     schedulerModel: this.models.getSchedulerModel(),
                     analyticsModel: this.models.getAnalyticsModel(),
                     spacePermissionService: this.getSpacePermissionService(),
+                    slackClient: this.clients.getSlackClient(),
+                    googleDriveClient: this.clients.getGoogleDriveClient(),
+                    userService: this.getUserService(),
                 }),
         );
     }

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -1040,9 +1040,6 @@ export class ServiceRepository
                     schedulerModel: this.models.getSchedulerModel(),
                     analyticsModel: this.models.getAnalyticsModel(),
                     spacePermissionService: this.getSpacePermissionService(),
-                    slackClient: this.clients.getSlackClient(),
-                    googleDriveClient: this.clients.getGoogleDriveClient(),
-                    userService: this.getUserService(),
                 }),
         );
     }


### PR DESCRIPTION
## Summary

Fixes [PROD-7098](https://linear.app/lightdash/issue/PROD-7098). Non-admin users (Editors / Developers) hit a `403 "You don't have access to this resource or action"` when opening the Google Sheets Sync modal on a SQL runner chart — both when the modal tried to list existing syncs and when submitting a new one.

Root cause: `SavedSqlService.createScheduler` and `getSchedulers` checked the `manage` action on `ScheduledDeliveries`. Non-admins' `manage` grant is self-scoped (`{ userUuid: self }`), which cannot match at creation-time (the scheduler has no identity yet) or at list-time (the subject has no `userUuid`). Only Admins, who have unconditional `manage`, passed the check. The equivalent `SavedChartService` path has always used the `create` action and worked correctly for non-admins.

## Changes

- **`manage` → `create`** on both `createScheduler` and `getSchedulers` (the fix).
- Extract a `checkCreateScheduledDeliveryAccess(user, projectUuid, savedSqlUuid)` helper that mirrors `SavedChartService.checkCreateScheduledDeliveryAccess`, shared between the two methods.
- **Add a space-access check** via `hasChartSpaceAccess`. Without this, the fix would introduce a new regression: non-admin users with `create:ScheduledDeliveries` at project level could reach SQL charts sitting in private spaces they can't view. With the check, access to a SQL chart's schedulers requires both the `create` ability and space view access — matching `SavedChartService.checkCreateScheduledDeliveryAccess`.
- Add `packages/backend/src/services/SavedSqlService/SavedSqlService.test.ts` (new) covering the auth matrix.

## Permission change

Strictly permission-additive for the create path:

- Admins pass as before. CASL's `manage` is an alias for any action so `can('manage', X)` satisfies a `can('create', X)` query — no regression.
- Editors / Developers / Interactive Viewers now pass the CASL check (the fix) and are additionally gated by `hasChartSpaceAccess` (regression prevention).
- Viewers remain correctly blocked (no `create:ScheduledDeliveries` ability).

The `getSchedulers` change does mean non-admins can now list all schedulers on a SQL chart, including those created by other users. This matches `SavedChartService.getSchedulers` behaviour and is intentional.

## Out of scope for this PR (follow-ups)

While reviewing `SavedSqlService.createScheduler` I found several pre-existing parity gaps with `SavedChartService.createScheduler` (no `schedulerClient.generateDailyJobsForScheduler` call, no `slackClient.joinChannels`, no GSHEETS options or Google Drive file validation, no analytics event, no `isUserWithOrg` guard) plus two adjacent bugs in `SchedulerService.updateScheduler` (format on a SQL-chart scheduler can be mutated away from GSHEETS, and Google Drive validation fires before the auth check). These are all pre-existing — none are caused or worsened by this PR — and deserve their own dedicated PRs. They intentionally aren't part of this diff.

## Test plan

- [x] New unit tests in `SavedSqlService.test.ts` — 8 cases covering admin/editor/viewer × `createScheduler` + `getSchedulers`, plus space-access denial. All pass.
- [x] Manual API verification with curl against a local dev instance:
  - Editor POST `/sqlRunner/saved/{uuid}/schedulers` → 201 (was 403)
  - Editor GET `/sqlRunner/saved/{uuid}/schedulers` → 200 (was 403)
  - Admin POST + GET on the same → 201 / 200 (unchanged)
  - Editor POST on the regular `/saved/{uuid}/schedulers` path → 200 (baseline, unchanged)
  - Viewer GET → 403 (still correctly blocked)
- [x] End-to-end browser repro: confirmed the customer-visible 403 no longer fires when opening the Google Sheets Sync modal as an Editor. Network tab shows the GET scheduler request returning 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)