### PR TITLE
fix: don't overwrite user-set app name/description during auto-naming

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -1771,10 +1771,17 @@ export class AppGenerateService extends BaseService {
                     anthropicApiKey,
                 );
                 if (metadata) {
-                    await this.appModel.updateApp(appUuid, projectUuid, {
-                        name: metadata.name,
-                        description: metadata.description,
-                    });
+                    // Only fills fields the user hasn't already set — the
+                    // build is async, so by the time we get here the user
+                    // may have renamed the app themselves.
+                    await this.appModel.setMetadataIfUnset(
+                        appUuid,
+                        projectUuid,
+                        {
+                            name: metadata.name,
+                            description: metadata.description,
+                        },
+                    );
                     this.logger.info(
                         `App ${appUuid}: auto-named "${metadata.name}"`,
                     );

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -307,6 +307,37 @@ export class AppModel {
         return row;
     }
 
+    /**
+     * Atomically set auto-generated name/description, but only for fields
+     * that are still at their empty-string default. Used by the background
+     * pipeline so it cannot clobber edits the user made while the build
+     * was running.
+     */
+    async setMetadataIfUnset(
+        appId: string,
+        projectUuid: string,
+        metadata: { name: string; description: string },
+    ): Promise<DbApp> {
+        const [row] = await this.database(AppsTableName)
+            .where({ app_id: appId, project_uuid: projectUuid })
+            .whereNull('deleted_at')
+            .update({
+                name: this.database.raw(
+                    `CASE WHEN ${AppsTableName}.name = '' THEN ? ELSE ${AppsTableName}.name END`,
+                    [metadata.name],
+                ) as unknown as string,
+                description: this.database.raw(
+                    `CASE WHEN ${AppsTableName}.description = '' THEN ? ELSE ${AppsTableName}.description END`,
+                    [metadata.description],
+                ) as unknown as string,
+            })
+            .returning('*');
+        if (!row) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
+        return row;
+    }
+
     async moveToSpace(
         {
             appId,


### PR DESCRIPTION
Related to: https://linear.app/lightdash/issue/GLITCH-320/generate-name-and-description-automatically

### Description:
The async auto-name step fires after the first build completes, which can be long after the app record was created. If the user renamed the app in the meantime, the unconditional update clobbered their edit. Now the update skips any field that is no longer at its empty-string default, done atomically in SQL so there is no read/write race.