### PR TITLE
feat: support custom bin dimensions in pre-aggregate matcher

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -1,8 +1,10 @@
 import {
+    BinType,
     CustomDimensionType,
     DimensionType,
     FieldType,
     FilterOperator,
+    GroupValueMatchType,
     MetricType,
     PreAggregateMissReason,
     preAggregateUtils,
@@ -161,6 +163,58 @@ const makeMetricQuery = (
         ? { customDimensions: partial.customDimensions }
         : {}),
 });
+
+const makeCustomBinDimension = (binType: BinType) => {
+    const base = {
+        id: `${binType}_bin`,
+        type: CustomDimensionType.BIN as const,
+        name: `${binType} bin`,
+        table: 'orders',
+        dimensionId: 'orders_amount',
+    };
+
+    switch (binType) {
+        case BinType.FIXED_WIDTH:
+            return {
+                ...base,
+                binType,
+                binWidth: 10,
+            };
+        case BinType.CUSTOM_RANGE:
+            return {
+                ...base,
+                binType,
+                customRange: [
+                    { from: undefined, to: 10 },
+                    { from: 10, to: undefined },
+                ],
+            };
+        case BinType.CUSTOM_GROUP:
+            return {
+                ...base,
+                binType,
+                customGroups: [
+                    {
+                        name: 'small',
+                        values: [
+                            {
+                                matchType: GroupValueMatchType.EXACT,
+                                value: '1',
+                            },
+                        ],
+                    },
+                ],
+            };
+        case BinType.FIXED_NUMBER:
+            return {
+                ...base,
+                binType,
+                binNumber: 4,
+            };
+        default:
+            throw new Error(`Unsupported bin type: ${binType}`);
+    }
+};
 
 describe('findMatch', () => {
     it('returns no_pre_aggregates_defined when explore has no pre-aggregates', () => {
@@ -1079,7 +1133,71 @@ describe('findMatch', () => {
         expect(result.hit).toBe(true);
     });
 
-    it('returns custom_dimension_present when custom dimensions exist', () => {
+    it.each([
+        BinType.FIXED_WIDTH,
+        BinType.CUSTOM_RANGE,
+        BinType.CUSTOM_GROUP,
+        BinType.FIXED_NUMBER,
+    ])(
+        'returns hit for %s custom bin dimensions when their dependency is in the pre-aggregate',
+        (binType) => {
+            const customBinDimension = makeCustomBinDimension(binType);
+            const explore = {
+                ...baseExplore(),
+                preAggregates: [
+                    {
+                        name: 'orders_summary',
+                        dimensions: ['status', 'amount'],
+                        metrics: ['order_count'],
+                    },
+                ],
+            };
+
+            const result = preAggregateUtils.findMatch(
+                makeMetricQuery({
+                    dimensions: [customBinDimension.id, 'orders_status'],
+                    metrics: ['orders_order_count'],
+                    customDimensions: [customBinDimension],
+                }),
+                explore,
+            );
+
+            expect(result).toStrictEqual({
+                hit: true,
+                preAggregateName: 'orders_summary',
+                miss: null,
+            });
+        },
+    );
+
+    it('returns dimension_not_in_pre_aggregate when a custom bin dependency is missing', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_summary',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['fixed_width_bin', 'orders_status'],
+                metrics: ['orders_order_count'],
+                customDimensions: [makeCustomBinDimension(BinType.FIXED_WIDTH)],
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+            fieldId: 'fixed_width_bin',
+        });
+    });
+
+    it('returns custom_dimension_present when a custom SQL dimension exists', () => {
         const explore = {
             ...baseExplore(),
             preAggregates: [

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -1,6 +1,8 @@
 import type { Explore } from '../../types/explore';
 import {
     convertFieldRefToFieldId,
+    isCustomBinDimension,
+    isCustomSqlDimension,
     MetricType,
     type FieldId,
 } from '../../types/field';
@@ -867,8 +869,42 @@ const getMissForDef = ({
         defDimensions.add(preAggregateDef.timeDimension);
     }
 
+    const missingCustomDimension = (metricQuery.customDimensions || []).find(
+        (customDimension) => {
+            if (isCustomSqlDimension(customDimension)) {
+                return true;
+            }
+
+            return (
+                isCustomBinDimension(customDimension) &&
+                !dimensionFieldIdMatchesDef(
+                    customDimension.dimensionId,
+                    explore,
+                    defDimensions,
+                    dimensionsByFieldId,
+                )
+            );
+        },
+    );
+    if (missingCustomDimension) {
+        if (isCustomSqlDimension(missingCustomDimension)) {
+            return {
+                reason: PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT,
+            };
+        }
+
+        return {
+            reason: PreAggregateMissReason.DIMENSION_NOT_IN_PRE_AGGREGATE,
+            fieldId: getItemId(missingCustomDimension),
+        };
+    }
+
+    const customDimensionIds = new Set(
+        (metricQuery.customDimensions || []).map(getItemId),
+    );
     const missingQueryDimensionFieldId = metricQuery.dimensions.find(
         (dimensionFieldId) =>
+            !customDimensionIds.has(dimensionFieldId) &&
             !dimensionFieldIdMatchesDef(
                 dimensionFieldId,
                 explore,
@@ -934,16 +970,6 @@ export const findMatch = (
             preAggregateName: null,
             miss: {
                 reason: PreAggregateMissReason.NO_PRE_AGGREGATES_DEFINED,
-            },
-        };
-    }
-
-    if ((metricQuery.customDimensions || []).length > 0) {
-        return {
-            hit: false,
-            preAggregateName: null,
-            miss: {
-                reason: PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT,
             },
         };
     }


### PR DESCRIPTION
Closes:  [ZAP-333: Support custom bin dimensions on pre-aggregates](https://linear.app/lightdash/issue/ZAP-333/support-custom-bin-dimensions-on-pre-aggregates)

### Description:

Previously, any query containing custom dimensions would immediately return a `custom_dimension_present` miss, preventing pre-aggregate matching entirely. This change adds proper support for custom bin dimensions in the pre-aggregate matcher.

Custom bin dimensions (`FIXED_WIDTH`, `FIXED_NUMBER`, `CUSTOM_RANGE`, `CUSTOM_GROUP`) are now resolved by checking whether their underlying `dimensionId` dependency is present in the pre-aggregate definition. If the dependency is satisfied, the query can still hit a pre-aggregate. If the dependency is missing, a `dimension_not_in_pre_aggregate` miss is returned with the relevant field ID.

Custom SQL dimensions continue to return a `custom_dimension_present` miss, as before.

The early-exit block that blanket-rejected all custom dimensions has been removed and replaced with per-dimension logic inside `getMissForDef`. Additionally, the dimension matching loop now skips IDs that belong to custom dimensions, since those are handled separately.