### PR TITLE
fix: make filter autocomplete search case-insensitive

### DIFF
--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.test.ts
@@ -49,6 +49,7 @@ describe('getFieldValuesMetricQuery', () => {
             operator: FilterOperator.INCLUDE,
             values: ['test'],
             target: { fieldId: 'a_dim1' },
+            caseSensitive: false,
         });
         expect(filterRules?.[1]).toMatchObject({
             operator: FilterOperator.NOT_NULL,

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -102,9 +102,7 @@ export async function getFieldValuesMetricQuery({
             },
             operator: FilterOperator.INCLUDE,
             values: [search],
-            // Autocomplete should always match case-insensitively so users can
-            // find values without guessing the stored casing — independent of
-            // the field's configured caseSensitive setting.
+            // Autocomplete ignores the field's caseSensitive setting.
             caseSensitive: false,
         },
         {

--- a/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
+++ b/packages/backend/src/services/ProjectService/fieldValuesQueryBuilder.ts
@@ -102,6 +102,10 @@ export async function getFieldValuesMetricQuery({
             },
             operator: FilterOperator.INCLUDE,
             values: [search],
+            // Autocomplete should always match case-insensitively so users can
+            // find values without guessing the stored casing — independent of
+            // the field's configured caseSensitive setting.
+            caseSensitive: false,
         },
         {
             id: uuidv4(),

--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -1459,6 +1459,52 @@ describe('Filter SQL', () => {
             );
             expect(sql).toContain('UPPER');
         });
+
+        test('filter-rule-level caseSensitive overrides case-sensitive field and explore', () => {
+            const fieldCaseSensitive = {
+                ...mockDimension,
+                caseSensitive: true,
+            };
+            const filterRuleOverride: FilterRule = {
+                ...caseFilter,
+                caseSensitive: false,
+            };
+            const sql = renderFilterRuleSqlFromField(
+                filterRuleOverride,
+                fieldCaseSensitive,
+                '"',
+                "'",
+                (str: string) => str,
+                WeekDay.MONDAY,
+                SupportedDbtAdapter.POSTGRES,
+                'UTC',
+                true, // explore-level is also case-sensitive
+            );
+            expect(sql).toContain('UPPER');
+        });
+
+        test('filter-rule-level caseSensitive=true overrides case-insensitive field', () => {
+            const fieldCaseInsensitive = {
+                ...mockDimension,
+                caseSensitive: false,
+            };
+            const filterRuleOverride: FilterRule = {
+                ...caseFilter,
+                caseSensitive: true,
+            };
+            const sql = renderFilterRuleSqlFromField(
+                filterRuleOverride,
+                fieldCaseInsensitive,
+                '"',
+                "'",
+                (str: string) => str,
+                WeekDay.MONDAY,
+                SupportedDbtAdapter.POSTGRES,
+                'UTC',
+                false,
+            );
+            expect(sql).not.toContain('UPPER');
+        });
     });
 
     test('should return 1=1 if filter is disabled', () => {

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -851,9 +851,11 @@ export const renderFilterRuleSqlFromField = (
         : field.compiledSql;
 
     // Determine if this filter should be case sensitive
-    // Priority: field-level setting > explore-level setting > default true
+    // Priority: filter-rule-level override > field-level setting > explore-level setting > default true
     let caseSensitive: boolean;
-    if (isMetric(field)) {
+    if (filterRule.caseSensitive !== undefined) {
+        caseSensitive = filterRule.caseSensitive;
+    } else if (isMetric(field)) {
         caseSensitive = true;
     } else if ('caseSensitive' in field && field.caseSensitive !== undefined) {
         caseSensitive = field.caseSensitive;

--- a/packages/common/src/types/filter.ts
+++ b/packages/common/src/types/filter.ts
@@ -107,6 +107,12 @@ export interface FilterRule<
     disabled?: boolean;
     /** Whether this filter is required */
     required?: boolean;
+    /**
+     * Overrides the field/explore case-sensitivity for this rule only.
+     * Used by internal features like autocomplete search that must always
+     * match case-insensitively regardless of the field's configured setting.
+     */
+    caseSensitive?: boolean;
 }
 
 /** Filter rule for metrics, targeting fields by reference */


### PR DESCRIPTION
## Summary

- Filter autocomplete dropdowns were returning zero results when the user's search didn't match the stored casing exactly (e.g. typing `talking tom gold run` against a value stored as `Talking Tom Gold Run`).
- Root cause: the autocomplete query builder uses `FilterOperator.INCLUDE`, which resolves case-sensitivity from the dimension's `caseSensitive` setting (default `true`). On a case-sensitive field, lowercase search `david` compiles to `first_name LIKE '%david%'` and does not match `David`.
- Fix: adds an optional filter-rule-level `caseSensitive` override that takes precedence over field/explore/project defaults, and sets it to `false` on the INCLUDE rule in the autocomplete query builder. End-user-authored filter rules do not set this field, so their behaviour is unchanged.

Fixes #22141

## Why the bug looked intermittent

Once the exact-case value entered the frontend's accumulated `resultsSet` (e.g. after the user guessed the casing once), Mantine's client-side `MultiSelect` default filter — which IS case-insensitive — matched subsequent lowercase searches against it. So retrying the lowercase search in step 5 of the repro appeared to work, which is why this read as a frontend-only bug to report. The backend, however, was returning zero results the whole time.

## Test plan

- [x] `pnpm -F common test filtersCompiler` — 252 passed, including new filter-rule-level override cases
- [x] `pnpm -F backend test fieldValuesQueryBuilder` — 10 passed, including updated assertion on `caseSensitive: false`
- [x] `pnpm -F common typecheck` / `pnpm -F backend typecheck` — clean
- [x] `pnpm -F common lint` / `pnpm -F backend lint` — no new warnings
- [x] Verified end-to-end against local API on the Jaffle shop demo:
  - Before fix: `search: "david"` → `results: []`, `search: "David"` → `results: ["David"]`
  - After fix: `search: "david"` → `results: ["David"]`, `search: "DaViD"` → `results: ["David"]`, empty search still returns the top-N baseline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)