### PR TITLE
feat: add fieldId to pre-aggregate miss reasons for table calculations and custom metrics

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -1261,6 +1261,7 @@ describe('findMatch', () => {
 
         expect(result.miss).toStrictEqual({
             reason: PreAggregateMissReason.TABLE_CALCULATION_PRESENT,
+            fieldId: 'calc_1',
         });
     });
 
@@ -1294,6 +1295,7 @@ describe('findMatch', () => {
 
         expect(result.miss).toStrictEqual({
             reason: PreAggregateMissReason.CUSTOM_METRIC_PRESENT,
+            fieldId: 'orders_custom',
         });
     });
 

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -980,16 +980,19 @@ export const findMatch = (
             preAggregateName: null,
             miss: {
                 reason: PreAggregateMissReason.TABLE_CALCULATION_PRESENT,
+                fieldId: getItemId(metricQuery.tableCalculations[0]),
             },
         };
     }
 
-    if ((metricQuery.additionalMetrics || []).length > 0) {
+    const firstAdditionalMetric = metricQuery.additionalMetrics?.[0];
+    if (firstAdditionalMetric) {
         return {
             hit: false,
             preAggregateName: null,
             miss: {
                 reason: PreAggregateMissReason.CUSTOM_METRIC_PRESENT,
+                fieldId: getItemId(firstAdditionalMetric),
             },
         };
     }

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -112,9 +112,11 @@ export type PreAggregateMatchMiss =
       }
     | {
           reason: PreAggregateMissReason.CUSTOM_METRIC_PRESENT;
+          fieldId: FieldId;
       }
     | {
           reason: PreAggregateMissReason.TABLE_CALCULATION_PRESENT;
+          fieldId: FieldId;
       }
     | {
           reason: PreAggregateMissReason.USER_BYPASS;

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.tsx
@@ -1,7 +1,4 @@
-import {
-    preAggregateMissReasonLabels,
-    type Dashboard,
-} from '@lightdash/common';
+import { type Dashboard } from '@lightdash/common';
 import {
     Badge,
     Box,
@@ -25,6 +22,7 @@ import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types'
 import MantineIcon from '../MantineIcon';
 import { PolymorphicGroupButton } from '../PolymorphicGroupButton';
 import classes from './PreAggregateAuditIndicator.module.css';
+import { getDetail } from './PreAggregateAuditIndicator.utils';
 
 const NONE_KEY = 'none';
 
@@ -44,16 +42,6 @@ type TabGroup = {
     misses: TilePreAggregateStatus[];
     ineligible: TilePreAggregateStatus[];
 };
-
-function getDetail(tile: TilePreAggregateStatus): string {
-    if (tile.hit && tile.preAggregateName) {
-        return tile.preAggregateName;
-    }
-    if (!tile.hit && tile.reason) {
-        return preAggregateMissReasonLabels[tile.reason.reason];
-    }
-    return '—';
-}
 
 function scrollToTile(tileUuid: string) {
     const el = document.querySelector<HTMLElement>(

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.utils.ts
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.utils.ts
@@ -1,0 +1,22 @@
+import {
+    preAggregateMissReasonLabels,
+    type PreAggregateMatchMiss,
+} from '@lightdash/common';
+import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types';
+
+function formatTileMissReason(reason: PreAggregateMatchMiss): string {
+    const label = preAggregateMissReasonLabels[reason.reason] ?? reason.reason;
+    return 'fieldId' in reason && reason.fieldId
+        ? `${label}: ${reason.fieldId}`
+        : label;
+}
+
+export function getDetail(tile: TilePreAggregateStatus): string {
+    if (tile.hit && tile.preAggregateName) {
+        return tile.preAggregateName;
+    }
+    if (!tile.hit && tile.reason) {
+        return formatTileMissReason(tile.reason);
+    }
+    return '—';
+}


### PR DESCRIPTION
Closes:

### Description:

When a pre-aggregate cache miss occurs due to a table calculation or custom metric being present, the specific field responsible for the miss is now included in the miss result. The `PreAggregateMatchMiss` type for `TABLE_CALCULATION_PRESENT` and `CUSTOM_METRIC_PRESENT` reasons now carries a `fieldId` property identifying the offending field.

This `fieldId` is surfaced in the pre-aggregate audit indicator on dashboards, so the miss reason displayed to users now includes the field name (e.g. `"Table calculation present: calc_1"`) rather than just the generic reason label.