### PR TITLE
refactor: migrate GitIntegrationService to audited ability

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -133,6 +133,7 @@ module.exports = {
                 'src/services/SlackIntegrationService/**/*.ts',
                 'src/services/SpaceService/**/*.ts',
                 'src/services/OrganizationService/**/*.ts',
+                'src/services/GitIntegrationService/**/*.ts',
                 'src/services/SpotlightService/**/*.ts',
                 'src/services/UnfurlService/**/*.ts',
                 'src/services/UserAttributesService/**/*.ts',

--- a/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
+++ b/packages/backend/src/services/GitIntegrationService/GitIntegrationService.ts
@@ -586,8 +586,9 @@ Affected charts:
 
         if (fields.length === 0) throw new ParseError(`Missing ${typeName}s`);
 
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('CustomFields', {
                     organizationUuid: user.organizationUuid!,
@@ -938,8 +939,9 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         exploreName: string,
     ): Promise<{ content: string; sha: string; filePath: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,
@@ -1010,8 +1012,9 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         projectUuid: string,
         exploreName: string,
     ): Promise<{ filePath: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,
@@ -1054,9 +1057,10 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         prTitle: string,
         prDescription: string,
     ): Promise<PullRequestCreated> {
+        const auditedAbility = this.createAuditedAbility(user);
         // PR creates its own feature branch, so always allow (isProtectedBranch: false)
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,
@@ -1222,8 +1226,9 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         user: SessionUser,
         projectUuid: string,
     ): Promise<GitBranch[]> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,
@@ -1270,8 +1275,9 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         branch: string,
         path?: string,
     ): Promise<GitFileOrDirectory> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,
@@ -1356,11 +1362,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         sha?: string,
         message?: string,
     ): Promise<{ sha: string; path: string }> {
+        const auditedAbility = this.createAuditedAbility(user);
         const protectedBranch = await this.getProtectedBranch(projectUuid);
         const isProtectedBranch = branch === protectedBranch;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,
@@ -1454,11 +1461,12 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         sha: string,
         message?: string,
     ): Promise<void> {
+        const auditedAbility = this.createAuditedAbility(user);
         const protectedBranch = await this.getProtectedBranch(projectUuid);
         const isProtectedBranch = branch === protectedBranch;
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,
@@ -1507,8 +1515,9 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         branchName: string,
         sourceBranch: string,
     ): Promise<GitBranch> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,
@@ -1577,8 +1586,9 @@ Triggered by user ${user.firstName} ${user.lastName} (${user.email})
         title: string,
         description: string,
     ): Promise<PullRequestCreated> {
+        const auditedAbility = this.createAuditedAbility(user);
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('SourceCode', {
                     organizationUuid: user.organizationUuid!,


### PR DESCRIPTION
## Summary
- Replace all `user.ability.cannot(...)` calls with `auditedAbility.cannot(...)` in GitIntegrationService (10 methods)
- Add `const auditedAbility = this.createAuditedAbility(user)` at the top of each method with ability checks
- Add `src/services/GitIntegrationService/**/*.ts` to the `no-direct-ability-check` error list in `.eslintrc.js`

## Test plan
- [x] `pnpm -F backend lint` — no new errors (only pre-existing ones)
- [x] `npx jest --testPathPattern=GitIntegration` — 2/2 tests pass
- [x] `pnpm -F backend typecheck` — no new errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)