### PR TITLE
refactor: migrate ValidationService to audited ability

### DIFF
--- a/packages/backend/.eslintrc.js
+++ b/packages/backend/.eslintrc.js
@@ -137,6 +137,7 @@ module.exports = {
                 'src/services/UnfurlService/**/*.ts',
                 'src/services/UserAttributesService/**/*.ts',
                 'src/services/UserService.ts',
+                'src/services/ValidationService/**/*.ts',
             ],
             rules: {
                 'no-direct-ability-check': 'error',

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -1058,7 +1058,7 @@ export class ValidationService extends BaseService {
             auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
-                    organizationUuid,
+                    organizationUuid: organizationUuid!,
                     projectUuid,
                 }),
             )

--- a/packages/backend/src/services/ValidationService/ValidationService.ts
+++ b/packages/backend/src/services/ValidationService/ValidationService.ts
@@ -43,8 +43,6 @@ import {
 import * as Sentry from '@sentry/node';
 import { LightdashAnalytics } from '../../analytics/LightdashAnalytics';
 import { LightdashConfig } from '../../config/parseConfig';
-import { CaslAuditWrapper } from '../../logging/caslAuditWrapper';
-import { logAuditEvent } from '../../logging/winston';
 import { DashboardModel } from '../../models/DashboardModel/DashboardModel';
 import { FeatureFlagModel } from '../../models/FeatureFlagModel/FeatureFlagModel';
 import { ProjectModel } from '../../models/ProjectModel/ProjectModel';
@@ -936,13 +934,14 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
+
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1053,13 +1052,14 @@ export class ValidationService extends BaseService {
     ): Promise<ValidationResponse[]> {
         const { organizationUuid } = user;
 
+        const auditedAbility = this.createAuditedAbility(user);
+
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1122,9 +1122,7 @@ export class ValidationService extends BaseService {
     ): Promise<ValidationResponse> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -1132,7 +1130,6 @@ export class ValidationService extends BaseService {
                 subject('Validation', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1184,9 +1181,7 @@ export class ValidationService extends BaseService {
     ): Promise<KnexPaginatedData<ValidationResponse[]>> {
         const projectSummary = await this.projectModel.getSummary(projectUuid);
 
-        const auditedAbility = new CaslAuditWrapper(user.ability, user, {
-            auditLogger: logAuditEvent,
-        });
+        const auditedAbility = this.createAuditedAbility(user);
 
         if (
             auditedAbility.cannot(
@@ -1194,7 +1189,6 @@ export class ValidationService extends BaseService {
                 subject('Validation', {
                     organizationUuid: projectSummary.organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1269,8 +1263,11 @@ export class ValidationService extends BaseService {
         const projectSummary = await this.projectModel.getSummary(
             validation.projectUuid,
         );
+
+        const auditedAbility = this.createAuditedAbility(user);
+
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid: projectSummary.organizationUuid,
@@ -1301,13 +1298,14 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
+
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1325,13 +1323,17 @@ export class ValidationService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('SavedChart', {
                     organizationUuid: chart.organizationUuid,
                     projectUuid: chart.projectUuid,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: {
+                        savedChartUuid: chartUuid,
+                        savedChartName: chart.name,
+                    },
                 }),
             )
         ) {
@@ -1381,13 +1383,14 @@ export class ValidationService extends BaseService {
         const { organizationUuid } =
             await this.projectModel.getSummary(projectUuid);
 
+        const auditedAbility = this.createAuditedAbility(user);
+
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'manage',
                 subject('Validation', {
                     organizationUuid,
                     projectUuid,
-                    metadata: { projectUuid },
                 }),
             )
         ) {
@@ -1406,13 +1409,17 @@ export class ValidationService extends BaseService {
             );
 
         if (
-            user.ability.cannot(
+            auditedAbility.cannot(
                 'view',
                 subject('Dashboard', {
                     organizationUuid: dashboard.organizationUuid,
                     projectUuid: dashboard.projectUuid,
                     inheritsFromOrgOrProject,
                     access,
+                    metadata: {
+                        dashboardUuid,
+                        dashboardName: dashboard.name,
+                    },
                 }),
             )
         ) {


### PR DESCRIPTION
## Summary
- Replaced all direct `user.ability.can/cannot(...)` calls with `this.createAuditedAbility(user)` in ValidationService
- Converted existing `new CaslAuditWrapper(...)` calls in `getById` and `getPaginated` to use `this.createAuditedAbility(user)` instead
- Removed unused `CaslAuditWrapper` and `logAuditEvent` imports
- Removed duplicate `metadata: { projectUuid }` from CASL subjects (already on the subject body)
- Added type-prefixed metadata (`savedChartUuid`, `savedChartName`, `dashboardUuid`, `dashboardName`) for entity-specific permission checks
- Added `src/services/ValidationService/**/*.ts` to the `no-direct-ability-check` error list in `.eslintrc.js`

## Test plan
- [x] `pnpm -F backend lint` — no ValidationService errors
- [x] `pnpm -F backend typecheck` — no new errors
- [x] ValidationService tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)