### PR TITLE
feat(pre-aggregates): add dashboard audit foundation types [ZAP-329]

### DIFF
--- a/packages/common/src/ee/index.ts
+++ b/packages/common/src/ee/index.ts
@@ -3,6 +3,7 @@ export * from './apps/types';
 export * from './ambientAi';
 export * from './commercialFeatureFlags';
 export * from './embed';
+export * from './preAggregates';
 export * from './preAggregates/types';
 export * as preAggregateUtils from './preAggregates/utils';
 export * from './scim/errors';

--- a/packages/common/src/ee/preAggregates/audit.ts
+++ b/packages/common/src/ee/preAggregates/audit.ts
@@ -1,0 +1,62 @@
+import { type DashboardTileTypes } from '../../types/dashboard';
+import { type PreAggregateMatchMiss } from '../../types/preAggregate';
+
+export enum TileIneligibleReason {
+    NON_CHART_TILE = 'non_chart_tile',
+    SQL_CHART = 'sql_chart',
+    ORPHANED_CHART = 'orphaned_chart',
+    EXPLORE_RESOLUTION_ERROR = 'explore_resolution_error',
+}
+
+export type TilePreAggregateAuditHit = {
+    status: 'hit';
+    tileUuid: string;
+    tileName: string;
+    tileType: DashboardTileTypes.SAVED_CHART;
+    savedChartUuid: string;
+    exploreName: string;
+    preAggregateName: string;
+};
+
+export type TilePreAggregateAuditMiss = {
+    status: 'miss';
+    tileUuid: string;
+    tileName: string;
+    tileType: DashboardTileTypes.SAVED_CHART;
+    savedChartUuid: string;
+    exploreName: string;
+    miss: PreAggregateMatchMiss;
+};
+
+export type TilePreAggregateAuditIneligible = {
+    status: 'ineligible';
+    tileUuid: string;
+    tileName: string;
+    tileType: DashboardTileTypes;
+    ineligibleReason: TileIneligibleReason;
+};
+
+export type TilePreAggregateAuditStatus =
+    | TilePreAggregateAuditHit
+    | TilePreAggregateAuditMiss
+    | TilePreAggregateAuditIneligible;
+
+export type TabAuditGroup = {
+    tabUuid: string | null;
+    tabName: string | null;
+    tiles: TilePreAggregateAuditStatus[];
+};
+
+export type DashboardPreAggregateAuditSummary = {
+    hitCount: number;
+    missCount: number;
+    ineligibleCount: number;
+};
+
+export type DashboardPreAggregateAudit = {
+    dashboardUuid: string;
+    dashboardSlug: string;
+    dashboardName: string;
+    tabs: TabAuditGroup[];
+    summary: DashboardPreAggregateAuditSummary;
+};

--- a/packages/common/src/ee/preAggregates/index.ts
+++ b/packages/common/src/ee/preAggregates/index.ts
@@ -1,0 +1,1 @@
+export * from './audit';

--- a/packages/common/src/types/api.ts
+++ b/packages/common/src/types/api.ts
@@ -36,6 +36,7 @@ import type {
     DecodedEmbed,
     EmbedUrl,
 } from '../ee';
+import type { DashboardPreAggregateAudit } from '../ee/preAggregates/audit';
 import type { PivotValuesColumn } from '../visualizations/types';
 import {
     type ApiUnusedContent,
@@ -224,6 +225,11 @@ import {
     type ValidationResponse,
 } from './validation';
 import { type ApiWarehouseTableFields } from './warehouse';
+
+export type ApiGetDashboardPreAggregateAuditResponse = {
+    status: 'ok';
+    results: DashboardPreAggregateAudit;
+};
 
 export enum RequestMethod {
     CLI = 'CLI',


### PR DESCRIPTION
## What

Part **1 of 4** in the ZAP-329 stack. Types-only foundation that the rest of the stack builds on.

Adds to `@lightdash/common`:

- **`DashboardPreAggregateAudit`** — the top-level response shape.
- **`TabAuditGroup`** — one entry per dashboard tab, plus a null-`tabUuid` entry collecting untabbed tiles. Consumers iterate a single array regardless of whether the dashboard has tabs.
- **`TilePreAggregateAuditStatus`** — discriminated union on `status ∈ 'hit' | 'miss' | 'ineligible'`. TypeScript narrows cleanly via the discriminant, and downstream code uses `assertUnreachable` in switches (per the repo's CLAUDE.md rules).
- **`TileIneligibleReason`** enum — for tiles that can't route through pre-aggregates at all: `NON_CHART_TILE` (markdown / loom / heading), `SQL_CHART`, `ORPHANED_CHART` (chart was deleted), `EXPLORE_RESOLUTION_ERROR`.
- **`ApiGetDashboardPreAggregateAuditResponse`** — API envelope matching the existing `ApiGetPreAggregateStatsResponse` pattern.

No runtime behaviour changes on its own. The next three PRs diff cleanly against this surface.

## Why

ZAP-329 exposes the in-app *Pre-aggregation audit* drawer's per-tile hit/miss signal as a scriptable API + CLI command so customers, CI pipelines, and internal tooling can verify pre-aggregate coverage without opening a browser. See the [Linear ticket](https://linear.app/lightdash/issue/ZAP-329) for the full context.

## Stack

1. **This PR — types** 👈
2. [#22307 — backend service layer](https://github.com/lightdash/lightdash/pull/22307)
3. [#22308 — REST endpoint](https://github.com/lightdash/lightdash/pull/22308)
4. [#22309 — CLI command](https://github.com/lightdash/lightdash/pull/22309)

## Testing

- [ ] `pnpm -F common typecheck` passes
- [ ] `pnpm -F common lint` passes
- [ ] Types are reachable as `import { DashboardPreAggregateAudit } from '@lightdash/common'` (verified by the next PR compiling)
