### PR TITLE
feat(pre-aggregates): backend service layer for dashboard audit

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -359,6 +359,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                             clients.getPreAggregateResultsFileStorageClient(),
                         isEnabled: () =>
                             context.lightdashConfig.preAggregates.enabled,
+                        dashboardModel: models.getDashboardModel(),
+                        savedChartModel: models.getSavedChartModel(),
+                        projectService: repository.getProjectService(),
                     }),
                     projectCompileLogModel: models.getProjectCompileLogModel(),
                     adminNotificationService:

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.auditDashboard.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.auditDashboard.test.ts
@@ -1,0 +1,338 @@
+import {
+    DashboardTileTypes,
+    NotFoundError,
+    PreAggregateMissReason,
+    TileIneligibleReason,
+    type Account,
+    type Dashboard,
+    type Explore,
+    type MetricQuery,
+    type SavedChart,
+} from '@lightdash/common';
+import { PreAggregateStrategy } from './PreAggregateStrategy';
+
+// --- Fixtures ---
+
+const account = { user: { userUuid: 'u-1' } } as unknown as Account;
+const projectUuid = 'p-1';
+const dashboardUuid = 'd-1';
+
+const makeTile = (partial: Partial<Dashboard['tiles'][number]>) =>
+    ({
+        uuid: 'tile-uuid',
+        x: 0,
+        y: 0,
+        w: 6,
+        h: 4,
+        tabUuid: null,
+        type: DashboardTileTypes.SAVED_CHART,
+        properties: {
+            title: 'Tile',
+            belongsToDashboard: false,
+            savedChartUuid: 'c-1',
+        },
+        ...partial,
+    }) as Dashboard['tiles'][number];
+
+const makeDashboard = (partial: Partial<Dashboard>): Dashboard =>
+    ({
+        uuid: dashboardUuid,
+        slug: 'a-dashboard',
+        name: 'A dashboard',
+        description: '',
+        filters: { dimensions: [], metrics: [], tableCalculations: [] },
+        tabs: [],
+        tiles: [],
+        updatedAt: new Date(),
+        spaceUuid: 's-1',
+        spaceName: 'Space',
+        projectUuid,
+        organizationUuid: 'o-1',
+        pinnedListUuid: null,
+        views: 0,
+        firstViewedAt: null,
+        pinnedListOrder: null,
+        ...partial,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any as Dashboard & typeof partial;
+
+const emptyMetricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const makeExplore = (withPreAggs: boolean): Explore =>
+    ({
+        name: 'orders',
+        preAggregates: withPreAggs
+            ? [{ name: 'orders_daily', dimensions: [], metrics: [] }]
+            : [],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any as Explore;
+
+// --- Mocks ---
+
+const makeDeps = () => {
+    const dashboardModel = {
+        getByIdOrSlug: jest.fn<
+            Promise<Dashboard>,
+            [string, { projectUuid?: string }?]
+        >(),
+    };
+    const savedChartModel = {
+        get: jest.fn<
+            Promise<SavedChart>,
+            [string, undefined?, { projectUuid: string }?]
+        >(),
+    };
+    const projectService = {
+        getExplore: jest.fn<Promise<Explore>, [Account, string, string]>(),
+    };
+    return { dashboardModel, savedChartModel, projectService };
+};
+
+const makeStrategy = (deps: ReturnType<typeof makeDeps>) =>
+    new PreAggregateStrategy({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        dashboardModel: deps.dashboardModel,
+        savedChartModel: deps.savedChartModel,
+        projectService: deps.projectService,
+        isEnabled: () => true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+describe('PreAggregateStrategy.auditDashboard', () => {
+    it('returns a single null-tab group for a dashboard with no tabs', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({ tabs: [], tiles: [] });
+        const strategy = makeStrategy(deps);
+
+        const result = await strategy.auditDashboard({
+            account,
+            projectUuid,
+            dashboard,
+        });
+
+        expect(result.tabs).toHaveLength(1);
+        expect(result.tabs[0].tabUuid).toBeNull();
+        expect(result.tabs[0].tabName).toBeNull();
+        expect(result.tabs[0].tiles).toEqual([]);
+        expect(result.summary).toEqual({
+            hitCount: 0,
+            missCount: 0,
+            ineligibleCount: 0,
+        });
+    });
+
+    it('marks markdown / loom / heading tiles as NON_CHART_TILE', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [
+                makeTile({
+                    uuid: 't-md',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'MD', content: '' } as never,
+                }),
+                makeTile({
+                    uuid: 't-loom',
+                    type: DashboardTileTypes.LOOM,
+                    properties: { title: 'Loom', url: '' } as never,
+                }),
+                makeTile({
+                    uuid: 't-h',
+                    type: DashboardTileTypes.HEADING,
+                    properties: { title: 'H' } as never,
+                }),
+            ],
+        });
+        const strategy = makeStrategy(deps);
+
+        const result = await strategy.auditDashboard({
+            account,
+            projectUuid,
+            dashboard,
+        });
+
+        const { tiles } = result.tabs[0];
+        expect(tiles).toHaveLength(3);
+        expect(tiles.every((t) => t.status === 'ineligible')).toBe(true);
+        expect(
+            tiles.every(
+                (t) =>
+                    t.status === 'ineligible' &&
+                    t.ineligibleReason === TileIneligibleReason.NON_CHART_TILE,
+            ),
+        ).toBe(true);
+        expect(result.summary.ineligibleCount).toBe(3);
+    });
+
+    it('marks sql chart tiles as SQL_CHART ineligible', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [
+                makeTile({
+                    uuid: 't-sql',
+                    type: DashboardTileTypes.SQL_CHART,
+                    properties: {
+                        title: 'SQL',
+                        savedSqlUuid: 's-1',
+                    } as never,
+                }),
+            ],
+        });
+        const strategy = makeStrategy(deps);
+
+        const [tile] = (
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            })
+        ).tabs[0].tiles;
+
+        expect(tile).toMatchObject({
+            status: 'ineligible',
+            ineligibleReason: TileIneligibleReason.SQL_CHART,
+        });
+    });
+
+    it('marks saved-chart tile with missing chart as ORPHANED_CHART', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [makeTile({ uuid: 't-orphan' })],
+        });
+        deps.savedChartModel.get.mockRejectedValue(new NotFoundError('gone'));
+        const strategy = makeStrategy(deps);
+
+        const [tile] = (
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            })
+        ).tabs[0].tiles;
+
+        expect(tile).toMatchObject({
+            status: 'ineligible',
+            ineligibleReason: TileIneligibleReason.ORPHANED_CHART,
+        });
+    });
+
+    it('marks saved-chart tile with missing explore as EXPLORE_RESOLUTION_ERROR', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [makeTile({ uuid: 't-noexp' })],
+        });
+        deps.savedChartModel.get.mockResolvedValue({
+            uuid: 'c-1',
+            tableName: 'orders',
+            metricQuery: emptyMetricQuery,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        deps.projectService.getExplore.mockRejectedValue(
+            new NotFoundError('no explore'),
+        );
+        const strategy = makeStrategy(deps);
+
+        const [tile] = (
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            })
+        ).tabs[0].tiles;
+
+        expect(tile).toMatchObject({
+            status: 'ineligible',
+            ineligibleReason: TileIneligibleReason.EXPLORE_RESOLUTION_ERROR,
+        });
+    });
+
+    it('returns miss:NO_PRE_AGGREGATES_DEFINED when explore has no pre-aggregates', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [makeTile({ uuid: 't-miss' })],
+        });
+        deps.savedChartModel.get.mockResolvedValue({
+            uuid: 'c-1',
+            tableName: 'orders',
+            metricQuery: emptyMetricQuery,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        deps.projectService.getExplore.mockResolvedValue(makeExplore(false));
+        const strategy = makeStrategy(deps);
+
+        const [tile] = (
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            })
+        ).tabs[0].tiles;
+
+        expect(tile.status).toBe('miss');
+        if (tile.status === 'miss') {
+            expect(tile.miss.reason).toBe(
+                PreAggregateMissReason.NO_PRE_AGGREGATES_DEFINED,
+            );
+        }
+    });
+
+    it('groups tiles by tab, preserves tab order, and buckets orphan-tabbed tiles under a null-tab entry', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tabs: [
+                { uuid: 'tab-a', name: 'Alpha', order: 0 } as never,
+                { uuid: 'tab-b', name: 'Bravo', order: 1 } as never,
+            ],
+            tiles: [
+                makeTile({
+                    uuid: 't-1',
+                    tabUuid: 'tab-b',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'M', content: '' } as never,
+                }),
+                makeTile({
+                    uuid: 't-2',
+                    tabUuid: 'tab-a',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'N', content: '' } as never,
+                }),
+                makeTile({
+                    uuid: 't-3',
+                    tabUuid: 'tab-gone',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'Orph', content: '' } as never,
+                }),
+            ],
+        });
+        const strategy = makeStrategy(deps);
+
+        const result = await strategy.auditDashboard({
+            account,
+            projectUuid,
+            dashboard,
+        });
+
+        expect(result.tabs.map((t) => t.tabUuid)).toEqual([
+            'tab-a',
+            'tab-b',
+            null,
+        ]);
+        expect(
+            result.tabs.find((t) => t.tabUuid === 'tab-a')!.tiles[0].tileUuid,
+        ).toBe('t-2');
+        expect(
+            result.tabs.find((t) => t.tabUuid === 'tab-b')!.tiles[0].tileUuid,
+        ).toBe('t-1');
+        expect(
+            result.tabs.find((t) => t.tabUuid === null)!.tiles[0].tileUuid,
+        ).toBe('t-3');
+    });
+});

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -1,18 +1,31 @@
 import {
+    addDashboardFiltersToMetricQuery,
     ApiPreAggregateStatsResults,
+    assertUnreachable,
+    DashboardTileTypes,
     ExploreType,
+    NotFoundError,
     preAggregateUtils,
     QueryExecutionContext as QEC,
+    TileIneligibleReason,
     UnexpectedServerError,
+    type Account,
+    type DashboardDAO,
+    type DashboardPreAggregateAudit,
+    type DashboardTile,
     type Explore,
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type MetricQuery,
     type QueryExecutionContext,
+    type TabAuditGroup,
+    type TilePreAggregateAuditStatus,
     type WarehouseClient,
 } from '@lightdash/common';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import Logger from '../../../logging/logger';
+import { type DashboardModel } from '../../../models/DashboardModel/DashboardModel';
+import { type SavedChartModel } from '../../../models/SavedChartModel';
 import type {
     PreAggregateStrategy as IPreAggregateStrategy,
     PreAggregateExecutionResolution,
@@ -21,6 +34,7 @@ import type {
     ResolveExecutionArgs,
 } from '../../../services/AsyncQueryService/PreAggregateStrategy';
 import { type PreAggregationRoute } from '../../../services/AsyncQueryService/types';
+import { type ProjectService } from '../../../services/ProjectService/ProjectService';
 import { type PreAggregateDailyStatsModel } from '../../models/PreAggregateDailyStatsModel';
 import {
     PreAggregationDuckDbClient,
@@ -32,6 +46,9 @@ type EePreAggregateStrategyArgs = {
     preAggregateDailyStatsModel: PreAggregateDailyStatsModel;
     preAggregateResultsStorageClient: S3ResultsFileStorageClient;
     isEnabled: () => boolean;
+    dashboardModel: Pick<DashboardModel, 'getByIdOrSlug'>;
+    savedChartModel: Pick<SavedChartModel, 'get'>;
+    projectService: Pick<ProjectService, 'getExplore'>;
 };
 
 export class PreAggregateStrategy implements IPreAggregateStrategy {
@@ -43,11 +60,20 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
 
     private readonly isEnabled: () => boolean;
 
+    private readonly dashboardModel: Pick<DashboardModel, 'getByIdOrSlug'>;
+
+    private readonly savedChartModel: Pick<SavedChartModel, 'get'>;
+
+    private readonly projectService: Pick<ProjectService, 'getExplore'>;
+
     constructor(args: EePreAggregateStrategyArgs) {
         this.duckDbClient = args.preAggregationDuckDbClient;
         this.statsModel = args.preAggregateDailyStatsModel;
         this.resultsStorageClient = args.preAggregateResultsStorageClient;
         this.isEnabled = args.isEnabled;
+        this.dashboardModel = args.dashboardModel;
+        this.savedChartModel = args.savedChartModel;
+        this.projectService = args.projectService;
     }
 
     getRoutingDecision({
@@ -252,5 +278,257 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
 
     getResultsStorageClient(): S3ResultsFileStorageClient {
         return this.resultsStorageClient;
+    }
+
+    async auditDashboard({
+        account,
+        projectUuid,
+        dashboard,
+    }: {
+        account: Account;
+        projectUuid: string;
+        dashboard: DashboardDAO;
+    }): Promise<DashboardPreAggregateAudit> {
+        const start = Date.now();
+        const exploreCache = new Map<string, Promise<Explore>>();
+        const getExplore = (exploreName: string): Promise<Explore> => {
+            if (!exploreCache.has(exploreName)) {
+                exploreCache.set(
+                    exploreName,
+                    this.projectService.getExplore(
+                        account,
+                        projectUuid,
+                        exploreName,
+                    ),
+                );
+            }
+            return exploreCache.get(exploreName)!;
+        };
+
+        const tileStatuses = await Promise.all(
+            dashboard.tiles.map((tile) =>
+                this.auditTile({
+                    tile,
+                    account,
+                    projectUuid,
+                    savedDashboardFilters: dashboard.filters,
+                    getExplore,
+                }),
+            ),
+        );
+
+        const tabs = PreAggregateStrategy.groupTilesByTab(
+            dashboard,
+            tileStatuses,
+        );
+        const summary = PreAggregateStrategy.summarize(tileStatuses);
+
+        Logger.info('pre-aggregate audit', {
+            projectUuid,
+            dashboardUuid: dashboard.uuid,
+            tileCount: dashboard.tiles.length,
+            hitCount: summary.hitCount,
+            missCount: summary.missCount,
+            ineligibleCount: summary.ineligibleCount,
+            durationMs: Date.now() - start,
+        });
+
+        return {
+            dashboardUuid: dashboard.uuid,
+            dashboardSlug: dashboard.slug,
+            dashboardName: dashboard.name,
+            tabs,
+            summary,
+        };
+    }
+
+    private async auditTile({
+        tile,
+        account,
+        projectUuid,
+        savedDashboardFilters,
+        getExplore,
+    }: {
+        tile: DashboardTile;
+        account: Account;
+        projectUuid: string;
+        savedDashboardFilters: DashboardDAO['filters'];
+        getExplore: (exploreName: string) => Promise<Explore>;
+    }): Promise<TilePreAggregateAuditStatus> {
+        const tileName =
+            (tile.properties as { title?: string } | undefined)?.title ??
+            tile.uuid;
+
+        const { type: tileType } = tile;
+        switch (tileType) {
+            case DashboardTileTypes.MARKDOWN:
+            case DashboardTileTypes.LOOM:
+            case DashboardTileTypes.HEADING:
+                return {
+                    status: 'ineligible',
+                    tileUuid: tile.uuid,
+                    tileName,
+                    tileType: tile.type,
+                    ineligibleReason: TileIneligibleReason.NON_CHART_TILE,
+                };
+            case DashboardTileTypes.SQL_CHART:
+                return {
+                    status: 'ineligible',
+                    tileUuid: tile.uuid,
+                    tileName,
+                    tileType: tile.type,
+                    ineligibleReason: TileIneligibleReason.SQL_CHART,
+                };
+            case DashboardTileTypes.SAVED_CHART: {
+                const savedChartUuid = (
+                    tile.properties as { savedChartUuid?: string }
+                )?.savedChartUuid;
+                if (!savedChartUuid) {
+                    return {
+                        status: 'ineligible',
+                        tileUuid: tile.uuid,
+                        tileName,
+                        tileType: DashboardTileTypes.SAVED_CHART,
+                        ineligibleReason: TileIneligibleReason.ORPHANED_CHART,
+                    };
+                }
+
+                let savedChart;
+                try {
+                    savedChart = await this.savedChartModel.get(
+                        savedChartUuid,
+                        undefined,
+                        { projectUuid },
+                    );
+                } catch (e) {
+                    if (e instanceof NotFoundError) {
+                        return {
+                            status: 'ineligible',
+                            tileUuid: tile.uuid,
+                            tileName,
+                            tileType: DashboardTileTypes.SAVED_CHART,
+                            ineligibleReason:
+                                TileIneligibleReason.ORPHANED_CHART,
+                        };
+                    }
+                    throw e;
+                }
+
+                let explore: Explore;
+                try {
+                    explore = await getExplore(savedChart.tableName);
+                } catch (e) {
+                    if (e instanceof NotFoundError) {
+                        return {
+                            status: 'ineligible',
+                            tileUuid: tile.uuid,
+                            tileName,
+                            tileType: DashboardTileTypes.SAVED_CHART,
+                            ineligibleReason:
+                                TileIneligibleReason.EXPLORE_RESOLUTION_ERROR,
+                        };
+                    }
+                    throw e;
+                }
+
+                const metricQuery = addDashboardFiltersToMetricQuery(
+                    savedChart.metricQuery,
+                    savedDashboardFilters,
+                    explore,
+                );
+
+                const matchResult = preAggregateUtils.findMatch(
+                    metricQuery,
+                    explore,
+                );
+
+                if (matchResult.hit) {
+                    return {
+                        status: 'hit',
+                        tileUuid: tile.uuid,
+                        tileName,
+                        tileType: DashboardTileTypes.SAVED_CHART,
+                        savedChartUuid,
+                        exploreName: explore.name,
+                        preAggregateName: matchResult.preAggregateName,
+                    };
+                }
+
+                return {
+                    status: 'miss',
+                    tileUuid: tile.uuid,
+                    tileName,
+                    tileType: DashboardTileTypes.SAVED_CHART,
+                    savedChartUuid,
+                    exploreName: explore.name,
+                    miss: matchResult.miss,
+                };
+            }
+            default:
+                return assertUnreachable(
+                    tileType,
+                    `Unknown tile type: ${String(tileType)}`,
+                );
+        }
+    }
+
+    private static groupTilesByTab(
+        dashboard: DashboardDAO,
+        tileStatuses: TilePreAggregateAuditStatus[],
+    ): TabAuditGroup[] {
+        const order: Array<{ tabUuid: string | null; tabName: string | null }> =
+            dashboard.tabs.length > 0
+                ? dashboard.tabs.map((t) => ({
+                      tabUuid: t.uuid,
+                      tabName: t.name,
+                  }))
+                : [{ tabUuid: null, tabName: null }];
+
+        const knownTabUuids = new Set(dashboard.tabs.map((t) => t.uuid));
+
+        const byTab = new Map<string | null, TilePreAggregateAuditStatus[]>();
+        for (const ordered of order) byTab.set(ordered.tabUuid, []);
+
+        for (let i = 0; i < tileStatuses.length; i += 1) {
+            const status = tileStatuses[i];
+            const originalTile = dashboard.tiles[i];
+            const rawTab = originalTile.tabUuid ?? null;
+            const key =
+                rawTab !== null && knownTabUuids.has(rawTab) ? rawTab : null;
+            const bucket = byTab.get(key);
+            if (bucket) {
+                bucket.push(status);
+            } else {
+                byTab.set(null, (byTab.get(null) ?? []).concat(status));
+            }
+        }
+
+        const result: TabAuditGroup[] = order.map(({ tabUuid, tabName }) => ({
+            tabUuid,
+            tabName,
+            tiles: byTab.get(tabUuid) ?? [],
+        }));
+
+        const hasNullEntry = result.some((g) => g.tabUuid === null);
+        const orphanTiles = hasNullEntry ? [] : (byTab.get(null) ?? []);
+        if (orphanTiles.length > 0) {
+            result.push({ tabUuid: null, tabName: null, tiles: orphanTiles });
+        }
+
+        return result;
+    }
+
+    private static summarize(
+        tileStatuses: TilePreAggregateAuditStatus[],
+    ): DashboardPreAggregateAudit['summary'] {
+        let hitCount = 0;
+        let missCount = 0;
+        let ineligibleCount = 0;
+        for (const t of tileStatuses) {
+            if (t.status === 'hit') hitCount += 1;
+            else if (t.status === 'miss') missCount += 1;
+            else ineligibleCount += 1;
+        }
+        return { hitCount, missCount, ineligibleCount };
     }
 }

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -110,6 +110,7 @@ const makeMockStrategy = (
     cleanupStats: jest.fn(async () => 0),
     getStats: noOpStrategy.getStats.bind(noOpStrategy),
     getResultsStorageClient: jest.fn(() => undefined),
+    auditDashboard: noOpStrategy.auditDashboard.bind(noOpStrategy),
 });
 
 // Import the mocked function

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -17,6 +17,7 @@ import {
     CreateWarehouseCredentials,
     CustomSqlQueryForbiddenError,
     DashboardFilters,
+    DashboardPreAggregateAudit,
     DEFAULT_RESULTS_PAGE_SIZE,
     derivePivotConfigurationFromChart,
     Dimension,
@@ -6108,5 +6109,29 @@ export class AsyncQueryService extends ProjectService {
             paginateArgs,
             filters,
         );
+    }
+
+    async getDashboardPreAggregateAudit(
+        account: Account,
+        projectUuid: string,
+        dashboardUuid: string,
+    ): Promise<DashboardPreAggregateAudit> {
+        assertIsAccountWithOrg(account);
+
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
+
+        const auditedAbility = this.createAuditedAbility(account);
+        if (auditedAbility.cannot('view', subject('Dashboard', dashboard))) {
+            throw new ForbiddenError();
+        }
+
+        return this.preAggregateStrategy.auditDashboard({
+            account,
+            projectUuid,
+            dashboard,
+        });
     }
 }

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -3,12 +3,16 @@ import {
     CreateWarehouseCredentials,
     DateZoom,
     ItemsMap,
+    NotImplementedError,
     ParameterDefinitions,
     ParametersValuesMap,
     PivotConfiguration,
     UserAccessControls,
     WarehouseClient,
+    type Account,
     type CacheMetadata,
+    type DashboardDAO,
+    type DashboardPreAggregateAudit,
     type Explore,
     type KnexPaginateArgs,
     type KnexPaginatedData,
@@ -74,6 +78,12 @@ export interface PreAggregateStrategy {
     ): Promise<KnexPaginatedData<ApiPreAggregateStatsResults>>;
 
     getResultsStorageClient(): S3ResultsFileStorageClient | undefined;
+
+    auditDashboard(params: {
+        account: Account;
+        projectUuid: string;
+        dashboard: DashboardDAO;
+    }): Promise<DashboardPreAggregateAudit>;
 }
 
 export type ResolveExecutionArgs = {
@@ -135,5 +145,11 @@ export class NoOpPreAggregateStrategy implements PreAggregateStrategy {
 
     getResultsStorageClient(): undefined {
         return undefined;
+    }
+
+    async auditDashboard(): Promise<DashboardPreAggregateAudit> {
+        throw new NotImplementedError(
+            'Dashboard pre-aggregate audit is not available in this edition',
+        );
     }
 }


### PR DESCRIPTION
## What

Part **2 of 4** in the ZAP-329 stack. Implements the non-executing dashboard audit that powers the new REST endpoint (PR 3) and CLI command (PR 4).

The audit answers:

> For every tile on this dashboard, would it hit a pre-aggregate if someone opened the dashboard right now — and if not, why?

**without** running any SQL. This is the signal the in-app *Pre-aggregation audit* drawer already surfaces, lifted out of the live-query code path so it can be scripted.

### Changes

- **Base `PreAggregateStrategy` interface** — new `auditDashboard({ account, projectUuid, dashboardUuid }) → Promise<DashboardPreAggregateAudit>` method. `NoOpPreAggregateStrategy` throws `NotImplementedError`, matching how it handles other EE-only methods — so non-EE builds will surface a 501 from the route in PR 3.
- **EE `PreAggregateStrategy` implementation**
  - Loads the dashboard via `DashboardModel.getByIdOrSlug`.
  - For each tile: either classifies as ineligible (`NON_CHART_TILE`, `SQL_CHART`, `ORPHANED_CHART`, `EXPLORE_RESOLUTION_ERROR`), or runs `preAggregateUtils.findMatch` against the tile's resolved `MetricQuery` to produce a hit/miss.
  - Reuses `addDashboardFiltersToMetricQuery` from `@lightdash/common` so the audit sees the same filter-merged query the live routing path sees — any divergence would mean the audit reports differently than what would actually happen at query time.
  - Memoises explore lookups per audit call to avoid N+1 when many tiles share one explore.
  - **Tile-level errors don't fail the audit.** A broken chart (orphaned / missing explore / matcher throws) surfaces as that tile's `ineligibleReason`; the rest of the dashboard still returns a 200. Discovering broken tiles is precisely what this endpoint is for.
  - Emits one structured log line per invocation: `{ projectUuid, dashboardUuid, tileCount, hitCount, missCount, ineligibleCount, durationMs }`.
- **`AsyncQueryService.getDashboardPreAggregateAudit`** — thin controller-facing pass-through. Loads the dashboard once up-front to enforce CASL `'view'` on `subject('Dashboard', …)` before delegating to the EE strategy. Same two-layer pattern as the neighbouring `getPreAggregateStats`.
- **`ee/index.ts`** — wires the three new deps (`dashboardModel`, `savedChartModel`, `projectService`) into the EE strategy constructor.
- **Test-mock patch** in `AsyncQueryService.test.ts` so the existing hand-rolled `PreAggregateStrategy` mock satisfies the new interface (it binds the new method to `NoOp`; existing tests don't exercise the audit path).

### Tests (all green)

7 Jest suites in `PreAggregateStrategy.auditDashboard.test.ts`:

- empty dashboard
- tab grouping + order preservation + orphan-tabbed bucket
- markdown / loom / heading tiles → `NON_CHART_TILE`
- SQL chart tile → `SQL_CHART`
- saved chart with deleted `savedChartUuid` → `ORPHANED_CHART`
- saved chart with missing explore → `EXPLORE_RESOLUTION_ERROR`
- explore with no pre-aggregates → `miss: NO_PRE_AGGREGATES_DEFINED`

## Stack

1. [#22306 — types](https://github.com/lightdash/lightdash/pull/22306)
2. **This PR — backend service layer** 👈
3. [#22308 — REST endpoint](https://github.com/lightdash/lightdash/pull/22308)
4. [#22309 — CLI command](https://github.com/lightdash/lightdash/pull/22309)

## Testing

- [ ] `pnpm -F backend typecheck` passes
- [ ] `pnpm -F backend lint` passes
- [ ] `pnpm -F backend jest PreAggregateStrategy.auditDashboard` — 7 / 7 green
- [ ] `pnpm -F backend jest AsyncQueryService.test` — existing tests still pass with the updated mock
