### PR TITLE
feat(pre-aggregates): expose dashboard audit via REST 

### DIFF
--- a/examples/api/ai.http
+++ b/examples/api/ai.http
@@ -17,3 +17,4 @@ Content-Type: application/json
 {
     "context": "say something interesting"
 }
+

--- a/examples/api/pre-aggregates.http
+++ b/examples/api/pre-aggregates.http
@@ -1,0 +1,25 @@
+### Login
+// @no-log
+POST http://localhost:8080/api/v1/login
+Content-Type: application/json
+
+{
+    "email": "demo@lightdash.com",
+    "password": "demo_password!"
+}
+
+
+### Refresh all pre-aggregates (v1) — async, returns jobIds
+POST http://localhost:8080/api/v1/projects/{{projectUuid}}/pre-aggregates/refresh
+
+### Refresh one pre-aggregate by definition name (v1)
+POST http://localhost:8080/api/v1/projects/{{projectUuid}}/pre-aggregates/definitions/orders_daily_avg_demo/refresh
+
+### List materializations (v2) — poll after refresh to see status
+GET http://localhost:8080/api/v2/projects/{{projectUuid}}/pre-aggregates/materializations
+
+### Stats (v2) — historical hit/miss counts per chart
+GET http://localhost:8080/api/v2/projects/{{projectUuid}}/pre-aggregates/stats
+
+### Dashboard audit (v2) — ZAP-329, per-tile hit/miss/ineligible decision
+GET http://localhost:8080/api/v2/projects/{{projectUuid}}/pre-aggregates/dashboards/{{dashboardUuid}}/audit

--- a/packages/backend/src/ee/controllers/PreAggregateController.ts
+++ b/packages/backend/src/ee/controllers/PreAggregateController.ts
@@ -1,5 +1,6 @@
 import {
     ApiErrorPayload,
+    type ApiGetDashboardPreAggregateAuditResponse,
     type ApiGetPreAggregateMaterializationsResponse,
     type ApiGetPreAggregateStatsResponse,
 } from '@lightdash/common';
@@ -64,6 +65,35 @@ export class PreAggregateController extends BaseController {
             status: 'ok',
             results,
         };
+    }
+
+    /**
+     * Audits pre-aggregate hit/miss coverage for every tile on a dashboard
+     * without executing the queries. Returns a per-tile breakdown grouped
+     * by tab, suitable for CI coverage checks and pre-aggregate tuning.
+     * @summary Get dashboard pre-aggregate audit
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Get('/dashboards/{dashboardUuidOrSlug}/audit')
+    @OperationId('getDashboardPreAggregateAudit')
+    async getDashboardPreAggregateAudit(
+        @Path() projectUuid: string,
+        @Path() dashboardUuidOrSlug: string,
+        @Request() req: express.Request,
+    ): Promise<ApiGetDashboardPreAggregateAuditResponse> {
+        this.setStatus(200);
+        const dashboard = await this.services
+            .getDashboardService()
+            .getByIdOrSlug(req.user!, dashboardUuidOrSlug, { projectUuid });
+        const results = await this.services
+            .getAsyncQueryService()
+            .getDashboardPreAggregateAudit(
+                req.account!,
+                projectUuid,
+                dashboard.uuid,
+            );
+        return { status: 'ok', results };
     }
 
     /**

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -359,6 +359,9 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                             clients.getPreAggregateResultsFileStorageClient(),
                         isEnabled: () =>
                             context.lightdashConfig.preAggregates.enabled,
+                        dashboardModel: models.getDashboardModel(),
+                        savedChartModel: models.getSavedChartModel(),
+                        projectService: repository.getProjectService(),
                     }),
                     projectCompileLogModel: models.getProjectCompileLogModel(),
                     adminNotificationService:

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.auditDashboard.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.auditDashboard.test.ts
@@ -1,0 +1,338 @@
+import {
+    DashboardTileTypes,
+    NotFoundError,
+    PreAggregateMissReason,
+    TileIneligibleReason,
+    type Account,
+    type Dashboard,
+    type Explore,
+    type MetricQuery,
+    type SavedChart,
+} from '@lightdash/common';
+import { PreAggregateStrategy } from './PreAggregateStrategy';
+
+// --- Fixtures ---
+
+const account = { user: { userUuid: 'u-1' } } as unknown as Account;
+const projectUuid = 'p-1';
+const dashboardUuid = 'd-1';
+
+const makeTile = (partial: Partial<Dashboard['tiles'][number]>) =>
+    ({
+        uuid: 'tile-uuid',
+        x: 0,
+        y: 0,
+        w: 6,
+        h: 4,
+        tabUuid: null,
+        type: DashboardTileTypes.SAVED_CHART,
+        properties: {
+            title: 'Tile',
+            belongsToDashboard: false,
+            savedChartUuid: 'c-1',
+        },
+        ...partial,
+    }) as Dashboard['tiles'][number];
+
+const makeDashboard = (partial: Partial<Dashboard>): Dashboard =>
+    ({
+        uuid: dashboardUuid,
+        slug: 'a-dashboard',
+        name: 'A dashboard',
+        description: '',
+        filters: { dimensions: [], metrics: [], tableCalculations: [] },
+        tabs: [],
+        tiles: [],
+        updatedAt: new Date(),
+        spaceUuid: 's-1',
+        spaceName: 'Space',
+        projectUuid,
+        organizationUuid: 'o-1',
+        pinnedListUuid: null,
+        views: 0,
+        firstViewedAt: null,
+        pinnedListOrder: null,
+        ...partial,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any as Dashboard & typeof partial;
+
+const emptyMetricQuery: MetricQuery = {
+    exploreName: 'orders',
+    dimensions: [],
+    metrics: [],
+    filters: {},
+    sorts: [],
+    limit: 500,
+    tableCalculations: [],
+};
+
+const makeExplore = (withPreAggs: boolean): Explore =>
+    ({
+        name: 'orders',
+        preAggregates: withPreAggs
+            ? [{ name: 'orders_daily', dimensions: [], metrics: [] }]
+            : [],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    }) as any as Explore;
+
+// --- Mocks ---
+
+const makeDeps = () => {
+    const dashboardModel = {
+        getByIdOrSlug: jest.fn<
+            Promise<Dashboard>,
+            [string, { projectUuid?: string }?]
+        >(),
+    };
+    const savedChartModel = {
+        get: jest.fn<
+            Promise<SavedChart>,
+            [string, undefined?, { projectUuid: string }?]
+        >(),
+    };
+    const projectService = {
+        getExplore: jest.fn<Promise<Explore>, [Account, string, string]>(),
+    };
+    return { dashboardModel, savedChartModel, projectService };
+};
+
+const makeStrategy = (deps: ReturnType<typeof makeDeps>) =>
+    new PreAggregateStrategy({
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        ...({} as any),
+        dashboardModel: deps.dashboardModel,
+        savedChartModel: deps.savedChartModel,
+        projectService: deps.projectService,
+        isEnabled: () => true,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any);
+
+describe('PreAggregateStrategy.auditDashboard', () => {
+    it('returns a single null-tab group for a dashboard with no tabs', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({ tabs: [], tiles: [] });
+        const strategy = makeStrategy(deps);
+
+        const result = await strategy.auditDashboard({
+            account,
+            projectUuid,
+            dashboard,
+        });
+
+        expect(result.tabs).toHaveLength(1);
+        expect(result.tabs[0].tabUuid).toBeNull();
+        expect(result.tabs[0].tabName).toBeNull();
+        expect(result.tabs[0].tiles).toEqual([]);
+        expect(result.summary).toEqual({
+            hitCount: 0,
+            missCount: 0,
+            ineligibleCount: 0,
+        });
+    });
+
+    it('marks markdown / loom / heading tiles as NON_CHART_TILE', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [
+                makeTile({
+                    uuid: 't-md',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'MD', content: '' } as never,
+                }),
+                makeTile({
+                    uuid: 't-loom',
+                    type: DashboardTileTypes.LOOM,
+                    properties: { title: 'Loom', url: '' } as never,
+                }),
+                makeTile({
+                    uuid: 't-h',
+                    type: DashboardTileTypes.HEADING,
+                    properties: { title: 'H' } as never,
+                }),
+            ],
+        });
+        const strategy = makeStrategy(deps);
+
+        const result = await strategy.auditDashboard({
+            account,
+            projectUuid,
+            dashboard,
+        });
+
+        const { tiles } = result.tabs[0];
+        expect(tiles).toHaveLength(3);
+        expect(tiles.every((t) => t.status === 'ineligible')).toBe(true);
+        expect(
+            tiles.every(
+                (t) =>
+                    t.status === 'ineligible' &&
+                    t.ineligibleReason === TileIneligibleReason.NON_CHART_TILE,
+            ),
+        ).toBe(true);
+        expect(result.summary.ineligibleCount).toBe(3);
+    });
+
+    it('marks sql chart tiles as SQL_CHART ineligible', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [
+                makeTile({
+                    uuid: 't-sql',
+                    type: DashboardTileTypes.SQL_CHART,
+                    properties: {
+                        title: 'SQL',
+                        savedSqlUuid: 's-1',
+                    } as never,
+                }),
+            ],
+        });
+        const strategy = makeStrategy(deps);
+
+        const [tile] = (
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            })
+        ).tabs[0].tiles;
+
+        expect(tile).toMatchObject({
+            status: 'ineligible',
+            ineligibleReason: TileIneligibleReason.SQL_CHART,
+        });
+    });
+
+    it('marks saved-chart tile with missing chart as ORPHANED_CHART', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [makeTile({ uuid: 't-orphan' })],
+        });
+        deps.savedChartModel.get.mockRejectedValue(new NotFoundError('gone'));
+        const strategy = makeStrategy(deps);
+
+        const [tile] = (
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            })
+        ).tabs[0].tiles;
+
+        expect(tile).toMatchObject({
+            status: 'ineligible',
+            ineligibleReason: TileIneligibleReason.ORPHANED_CHART,
+        });
+    });
+
+    it('marks saved-chart tile with missing explore as EXPLORE_RESOLUTION_ERROR', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [makeTile({ uuid: 't-noexp' })],
+        });
+        deps.savedChartModel.get.mockResolvedValue({
+            uuid: 'c-1',
+            tableName: 'orders',
+            metricQuery: emptyMetricQuery,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        deps.projectService.getExplore.mockRejectedValue(
+            new NotFoundError('no explore'),
+        );
+        const strategy = makeStrategy(deps);
+
+        const [tile] = (
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            })
+        ).tabs[0].tiles;
+
+        expect(tile).toMatchObject({
+            status: 'ineligible',
+            ineligibleReason: TileIneligibleReason.EXPLORE_RESOLUTION_ERROR,
+        });
+    });
+
+    it('returns miss:NO_PRE_AGGREGATES_DEFINED when explore has no pre-aggregates', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tiles: [makeTile({ uuid: 't-miss' })],
+        });
+        deps.savedChartModel.get.mockResolvedValue({
+            uuid: 'c-1',
+            tableName: 'orders',
+            metricQuery: emptyMetricQuery,
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any);
+        deps.projectService.getExplore.mockResolvedValue(makeExplore(false));
+        const strategy = makeStrategy(deps);
+
+        const [tile] = (
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            })
+        ).tabs[0].tiles;
+
+        expect(tile.status).toBe('miss');
+        if (tile.status === 'miss') {
+            expect(tile.miss.reason).toBe(
+                PreAggregateMissReason.NO_PRE_AGGREGATES_DEFINED,
+            );
+        }
+    });
+
+    it('groups tiles by tab, preserves tab order, and buckets orphan-tabbed tiles under a null-tab entry', async () => {
+        const deps = makeDeps();
+        const dashboard = makeDashboard({
+            tabs: [
+                { uuid: 'tab-a', name: 'Alpha', order: 0 } as never,
+                { uuid: 'tab-b', name: 'Bravo', order: 1 } as never,
+            ],
+            tiles: [
+                makeTile({
+                    uuid: 't-1',
+                    tabUuid: 'tab-b',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'M', content: '' } as never,
+                }),
+                makeTile({
+                    uuid: 't-2',
+                    tabUuid: 'tab-a',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'N', content: '' } as never,
+                }),
+                makeTile({
+                    uuid: 't-3',
+                    tabUuid: 'tab-gone',
+                    type: DashboardTileTypes.MARKDOWN,
+                    properties: { title: 'Orph', content: '' } as never,
+                }),
+            ],
+        });
+        const strategy = makeStrategy(deps);
+
+        const result = await strategy.auditDashboard({
+            account,
+            projectUuid,
+            dashboard,
+        });
+
+        expect(result.tabs.map((t) => t.tabUuid)).toEqual([
+            'tab-a',
+            'tab-b',
+            null,
+        ]);
+        expect(
+            result.tabs.find((t) => t.tabUuid === 'tab-a')!.tiles[0].tileUuid,
+        ).toBe('t-2');
+        expect(
+            result.tabs.find((t) => t.tabUuid === 'tab-b')!.tiles[0].tileUuid,
+        ).toBe('t-1');
+        expect(
+            result.tabs.find((t) => t.tabUuid === null)!.tiles[0].tileUuid,
+        ).toBe('t-3');
+    });
+});

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -1,18 +1,31 @@
 import {
+    addDashboardFiltersToMetricQuery,
     ApiPreAggregateStatsResults,
+    assertUnreachable,
+    DashboardTileTypes,
     ExploreType,
+    NotFoundError,
     preAggregateUtils,
     QueryExecutionContext as QEC,
+    TileIneligibleReason,
     UnexpectedServerError,
+    type Account,
+    type DashboardDAO,
+    type DashboardPreAggregateAudit,
+    type DashboardTile,
     type Explore,
     type KnexPaginateArgs,
     type KnexPaginatedData,
     type MetricQuery,
     type QueryExecutionContext,
+    type TabAuditGroup,
+    type TilePreAggregateAuditStatus,
     type WarehouseClient,
 } from '@lightdash/common';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import Logger from '../../../logging/logger';
+import { type DashboardModel } from '../../../models/DashboardModel/DashboardModel';
+import { type SavedChartModel } from '../../../models/SavedChartModel';
 import type {
     PreAggregateStrategy as IPreAggregateStrategy,
     PreAggregateExecutionResolution,
@@ -21,6 +34,7 @@ import type {
     ResolveExecutionArgs,
 } from '../../../services/AsyncQueryService/PreAggregateStrategy';
 import { type PreAggregationRoute } from '../../../services/AsyncQueryService/types';
+import { type ProjectService } from '../../../services/ProjectService/ProjectService';
 import { type PreAggregateDailyStatsModel } from '../../models/PreAggregateDailyStatsModel';
 import {
     PreAggregationDuckDbClient,
@@ -32,6 +46,9 @@ type EePreAggregateStrategyArgs = {
     preAggregateDailyStatsModel: PreAggregateDailyStatsModel;
     preAggregateResultsStorageClient: S3ResultsFileStorageClient;
     isEnabled: () => boolean;
+    dashboardModel: Pick<DashboardModel, 'getByIdOrSlug'>;
+    savedChartModel: Pick<SavedChartModel, 'get'>;
+    projectService: Pick<ProjectService, 'getExplore'>;
 };
 
 export class PreAggregateStrategy implements IPreAggregateStrategy {
@@ -43,11 +60,20 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
 
     private readonly isEnabled: () => boolean;
 
+    private readonly dashboardModel: Pick<DashboardModel, 'getByIdOrSlug'>;
+
+    private readonly savedChartModel: Pick<SavedChartModel, 'get'>;
+
+    private readonly projectService: Pick<ProjectService, 'getExplore'>;
+
     constructor(args: EePreAggregateStrategyArgs) {
         this.duckDbClient = args.preAggregationDuckDbClient;
         this.statsModel = args.preAggregateDailyStatsModel;
         this.resultsStorageClient = args.preAggregateResultsStorageClient;
         this.isEnabled = args.isEnabled;
+        this.dashboardModel = args.dashboardModel;
+        this.savedChartModel = args.savedChartModel;
+        this.projectService = args.projectService;
     }
 
     getRoutingDecision({
@@ -252,5 +278,257 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
 
     getResultsStorageClient(): S3ResultsFileStorageClient {
         return this.resultsStorageClient;
+    }
+
+    async auditDashboard({
+        account,
+        projectUuid,
+        dashboard,
+    }: {
+        account: Account;
+        projectUuid: string;
+        dashboard: DashboardDAO;
+    }): Promise<DashboardPreAggregateAudit> {
+        const start = Date.now();
+        const exploreCache = new Map<string, Promise<Explore>>();
+        const getExplore = (exploreName: string): Promise<Explore> => {
+            if (!exploreCache.has(exploreName)) {
+                exploreCache.set(
+                    exploreName,
+                    this.projectService.getExplore(
+                        account,
+                        projectUuid,
+                        exploreName,
+                    ),
+                );
+            }
+            return exploreCache.get(exploreName)!;
+        };
+
+        const tileStatuses = await Promise.all(
+            dashboard.tiles.map((tile) =>
+                this.auditTile({
+                    tile,
+                    account,
+                    projectUuid,
+                    savedDashboardFilters: dashboard.filters,
+                    getExplore,
+                }),
+            ),
+        );
+
+        const tabs = PreAggregateStrategy.groupTilesByTab(
+            dashboard,
+            tileStatuses,
+        );
+        const summary = PreAggregateStrategy.summarize(tileStatuses);
+
+        Logger.info('pre-aggregate audit', {
+            projectUuid,
+            dashboardUuid: dashboard.uuid,
+            tileCount: dashboard.tiles.length,
+            hitCount: summary.hitCount,
+            missCount: summary.missCount,
+            ineligibleCount: summary.ineligibleCount,
+            durationMs: Date.now() - start,
+        });
+
+        return {
+            dashboardUuid: dashboard.uuid,
+            dashboardSlug: dashboard.slug,
+            dashboardName: dashboard.name,
+            tabs,
+            summary,
+        };
+    }
+
+    private async auditTile({
+        tile,
+        account,
+        projectUuid,
+        savedDashboardFilters,
+        getExplore,
+    }: {
+        tile: DashboardTile;
+        account: Account;
+        projectUuid: string;
+        savedDashboardFilters: DashboardDAO['filters'];
+        getExplore: (exploreName: string) => Promise<Explore>;
+    }): Promise<TilePreAggregateAuditStatus> {
+        const tileName =
+            (tile.properties as { title?: string } | undefined)?.title ??
+            tile.uuid;
+
+        const { type: tileType } = tile;
+        switch (tileType) {
+            case DashboardTileTypes.MARKDOWN:
+            case DashboardTileTypes.LOOM:
+            case DashboardTileTypes.HEADING:
+                return {
+                    status: 'ineligible',
+                    tileUuid: tile.uuid,
+                    tileName,
+                    tileType: tile.type,
+                    ineligibleReason: TileIneligibleReason.NON_CHART_TILE,
+                };
+            case DashboardTileTypes.SQL_CHART:
+                return {
+                    status: 'ineligible',
+                    tileUuid: tile.uuid,
+                    tileName,
+                    tileType: tile.type,
+                    ineligibleReason: TileIneligibleReason.SQL_CHART,
+                };
+            case DashboardTileTypes.SAVED_CHART: {
+                const savedChartUuid = (
+                    tile.properties as { savedChartUuid?: string }
+                )?.savedChartUuid;
+                if (!savedChartUuid) {
+                    return {
+                        status: 'ineligible',
+                        tileUuid: tile.uuid,
+                        tileName,
+                        tileType: DashboardTileTypes.SAVED_CHART,
+                        ineligibleReason: TileIneligibleReason.ORPHANED_CHART,
+                    };
+                }
+
+                let savedChart;
+                try {
+                    savedChart = await this.savedChartModel.get(
+                        savedChartUuid,
+                        undefined,
+                        { projectUuid },
+                    );
+                } catch (e) {
+                    if (e instanceof NotFoundError) {
+                        return {
+                            status: 'ineligible',
+                            tileUuid: tile.uuid,
+                            tileName,
+                            tileType: DashboardTileTypes.SAVED_CHART,
+                            ineligibleReason:
+                                TileIneligibleReason.ORPHANED_CHART,
+                        };
+                    }
+                    throw e;
+                }
+
+                let explore: Explore;
+                try {
+                    explore = await getExplore(savedChart.tableName);
+                } catch (e) {
+                    if (e instanceof NotFoundError) {
+                        return {
+                            status: 'ineligible',
+                            tileUuid: tile.uuid,
+                            tileName,
+                            tileType: DashboardTileTypes.SAVED_CHART,
+                            ineligibleReason:
+                                TileIneligibleReason.EXPLORE_RESOLUTION_ERROR,
+                        };
+                    }
+                    throw e;
+                }
+
+                const metricQuery = addDashboardFiltersToMetricQuery(
+                    savedChart.metricQuery,
+                    savedDashboardFilters,
+                    explore,
+                );
+
+                const matchResult = preAggregateUtils.findMatch(
+                    metricQuery,
+                    explore,
+                );
+
+                if (matchResult.hit) {
+                    return {
+                        status: 'hit',
+                        tileUuid: tile.uuid,
+                        tileName,
+                        tileType: DashboardTileTypes.SAVED_CHART,
+                        savedChartUuid,
+                        exploreName: explore.name,
+                        preAggregateName: matchResult.preAggregateName,
+                    };
+                }
+
+                return {
+                    status: 'miss',
+                    tileUuid: tile.uuid,
+                    tileName,
+                    tileType: DashboardTileTypes.SAVED_CHART,
+                    savedChartUuid,
+                    exploreName: explore.name,
+                    miss: matchResult.miss,
+                };
+            }
+            default:
+                return assertUnreachable(
+                    tileType,
+                    `Unknown tile type: ${String(tileType)}`,
+                );
+        }
+    }
+
+    private static groupTilesByTab(
+        dashboard: DashboardDAO,
+        tileStatuses: TilePreAggregateAuditStatus[],
+    ): TabAuditGroup[] {
+        const order: Array<{ tabUuid: string | null; tabName: string | null }> =
+            dashboard.tabs.length > 0
+                ? dashboard.tabs.map((t) => ({
+                      tabUuid: t.uuid,
+                      tabName: t.name,
+                  }))
+                : [{ tabUuid: null, tabName: null }];
+
+        const knownTabUuids = new Set(dashboard.tabs.map((t) => t.uuid));
+
+        const byTab = new Map<string | null, TilePreAggregateAuditStatus[]>();
+        for (const ordered of order) byTab.set(ordered.tabUuid, []);
+
+        for (let i = 0; i < tileStatuses.length; i += 1) {
+            const status = tileStatuses[i];
+            const originalTile = dashboard.tiles[i];
+            const rawTab = originalTile.tabUuid ?? null;
+            const key =
+                rawTab !== null && knownTabUuids.has(rawTab) ? rawTab : null;
+            const bucket = byTab.get(key);
+            if (bucket) {
+                bucket.push(status);
+            } else {
+                byTab.set(null, (byTab.get(null) ?? []).concat(status));
+            }
+        }
+
+        const result: TabAuditGroup[] = order.map(({ tabUuid, tabName }) => ({
+            tabUuid,
+            tabName,
+            tiles: byTab.get(tabUuid) ?? [],
+        }));
+
+        const hasNullEntry = result.some((g) => g.tabUuid === null);
+        const orphanTiles = hasNullEntry ? [] : (byTab.get(null) ?? []);
+        if (orphanTiles.length > 0) {
+            result.push({ tabUuid: null, tabName: null, tiles: orphanTiles });
+        }
+
+        return result;
+    }
+
+    private static summarize(
+        tileStatuses: TilePreAggregateAuditStatus[],
+    ): DashboardPreAggregateAudit['summary'] {
+        let hitCount = 0;
+        let missCount = 0;
+        let ineligibleCount = 0;
+        for (const t of tileStatuses) {
+            if (t.status === 'hit') hitCount += 1;
+            else if (t.status === 'miss') missCount += 1;
+            else ineligibleCount += 1;
+        }
+        return { hitCount, missCount, ineligibleCount };
     }
 }

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -1955,6 +1955,7 @@ const models: TsoaRoute.Models = {
             settings: { ref: 'AnyType' },
             disabled: { dataType: 'boolean' },
             required: { dataType: 'boolean' },
+            caseSensitive: { dataType: 'boolean' },
         },
         additionalProperties: true,
     },
@@ -2849,6 +2850,7 @@ const models: TsoaRoute.Models = {
             settings: { ref: 'AnyType' },
             disabled: { dataType: 'boolean' },
             required: { dataType: 'boolean' },
+            caseSensitive: { dataType: 'boolean' },
         },
         additionalProperties: true,
     },
@@ -3051,6 +3053,7 @@ const models: TsoaRoute.Models = {
             settings: { ref: 'AnyType' },
             disabled: { dataType: 'boolean' },
             required: { dataType: 'boolean' },
+            caseSensitive: { dataType: 'boolean' },
         },
         additionalProperties: true,
     },
@@ -5470,6 +5473,7 @@ const models: TsoaRoute.Models = {
             settings: { ref: 'AnyType' },
             disabled: { dataType: 'boolean' },
             required: { dataType: 'boolean' },
+            caseSensitive: { dataType: 'boolean' },
         },
         additionalProperties: true,
     },
@@ -6352,6 +6356,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        fieldId: { ref: 'FieldId', required: true },
                         reason: {
                             ref: 'PreAggregateMissReason.CUSTOM_METRIC_PRESENT',
                             required: true,
@@ -6361,6 +6366,7 @@ const models: TsoaRoute.Models = {
                 {
                     dataType: 'nestedObjectLiteral',
                     nestedProperties: {
+                        fieldId: { ref: 'FieldId', required: true },
                         reason: {
                             ref: 'PreAggregateMissReason.TABLE_CALCULATION_PRESENT',
                             required: true,
@@ -8712,11 +8718,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8731,11 +8737,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8750,11 +8756,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8785,29 +8791,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 searchRank:
                                                                                                     {
                                                                                                         dataType:
@@ -8831,11 +8814,28 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
                                                                                                     },
                                                                                                 tableName:
                                                                                                     {
@@ -8848,6 +8848,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -8963,11 +8969,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9043,29 +9049,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    chartUsage:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     searchRank:
                                                                                                         {
                                                                                                             dataType:
@@ -9089,11 +9072,28 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
                                                                                                         },
                                                                                                     tableName:
                                                                                                         {
@@ -9106,6 +9106,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9137,11 +9143,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9156,11 +9162,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -10717,6 +10723,172 @@ const models: TsoaRoute.Models = {
                     ref: 'KnexPaginatedData_ApiPreAggregateStatsResults_',
                     required: true,
                 },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TilePreAggregateAuditHit: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                preAggregateName: { dataType: 'string', required: true },
+                exploreName: { dataType: 'string', required: true },
+                savedChartUuid: { dataType: 'string', required: true },
+                tileType: {
+                    ref: 'DashboardTileTypes.SAVED_CHART',
+                    required: true,
+                },
+                tileName: { dataType: 'string', required: true },
+                tileUuid: { dataType: 'string', required: true },
+                status: { dataType: 'enum', enums: ['hit'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TilePreAggregateAuditMiss: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                miss: { ref: 'PreAggregateMatchMiss', required: true },
+                exploreName: { dataType: 'string', required: true },
+                savedChartUuid: { dataType: 'string', required: true },
+                tileType: {
+                    ref: 'DashboardTileTypes.SAVED_CHART',
+                    required: true,
+                },
+                tileName: { dataType: 'string', required: true },
+                tileUuid: { dataType: 'string', required: true },
+                status: { dataType: 'enum', enums: ['miss'], required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TileIneligibleReason: {
+        dataType: 'refEnum',
+        enums: [
+            'non_chart_tile',
+            'sql_chart',
+            'orphaned_chart',
+            'explore_resolution_error',
+        ],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TilePreAggregateAuditIneligible: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                ineligibleReason: {
+                    ref: 'TileIneligibleReason',
+                    required: true,
+                },
+                tileType: { ref: 'DashboardTileTypes', required: true },
+                tileName: { dataType: 'string', required: true },
+                tileUuid: { dataType: 'string', required: true },
+                status: {
+                    dataType: 'enum',
+                    enums: ['ineligible'],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TilePreAggregateAuditStatus: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'union',
+            subSchemas: [
+                { ref: 'TilePreAggregateAuditHit' },
+                { ref: 'TilePreAggregateAuditMiss' },
+                { ref: 'TilePreAggregateAuditIneligible' },
+            ],
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TabAuditGroup: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                tiles: {
+                    dataType: 'array',
+                    array: {
+                        dataType: 'refAlias',
+                        ref: 'TilePreAggregateAuditStatus',
+                    },
+                    required: true,
+                },
+                tabName: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+                tabUuid: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'string' },
+                        { dataType: 'enum', enums: [null] },
+                    ],
+                    required: true,
+                },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardPreAggregateAuditSummary: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                ineligibleCount: { dataType: 'double', required: true },
+                missCount: { dataType: 'double', required: true },
+                hitCount: { dataType: 'double', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    DashboardPreAggregateAudit: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                summary: {
+                    ref: 'DashboardPreAggregateAuditSummary',
+                    required: true,
+                },
+                tabs: {
+                    dataType: 'array',
+                    array: { dataType: 'refAlias', ref: 'TabAuditGroup' },
+                    required: true,
+                },
+                dashboardName: { dataType: 'string', required: true },
+                dashboardSlug: { dataType: 'string', required: true },
+                dashboardUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiGetDashboardPreAggregateAuditResponse: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'DashboardPreAggregateAudit', required: true },
                 status: { dataType: 'enum', enums: ['ok'], required: true },
             },
             validators: {},
@@ -20466,6 +20638,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                caseSensitive: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 operator: { ref: 'FilterOperator', required: true },
                 values: {
                     dataType: 'union',
@@ -20635,7 +20814,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
+    'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20645,7 +20824,7 @@ const models: TsoaRoute.Models = {
             },
         },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
+    'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__':
         {
             dataType: 'refAlias',
             type: {
@@ -20655,7 +20834,7 @@ const models: TsoaRoute.Models = {
                         dataType: 'union',
                         subSchemas: [
                             {
-                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
+                                ref: 'PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__',
                             },
                             { dataType: 'undefined' },
                         ],
@@ -20668,7 +20847,7 @@ const models: TsoaRoute.Models = {
     'PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__': {
         dataType: 'refAlias',
         type: {
-            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
+            ref: 'PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__',
             validators: {},
         },
     },
@@ -20966,6 +21145,13 @@ const models: TsoaRoute.Models = {
                     ],
                 },
                 required: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
+                caseSensitive: {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'boolean' },
@@ -24862,6 +25048,13 @@ const models: TsoaRoute.Models = {
                         { dataType: 'undefined' },
                     ],
                 },
+                caseSensitive: {
+                    dataType: 'union',
+                    subSchemas: [
+                        { dataType: 'boolean' },
+                        { dataType: 'undefined' },
+                    ],
+                },
                 groupLabel: {
                     dataType: 'union',
                     subSchemas: [
@@ -24900,13 +25093,6 @@ const models: TsoaRoute.Models = {
                     dataType: 'union',
                     subSchemas: [
                         { dataType: 'string' },
-                        { dataType: 'undefined' },
-                    ],
-                },
-                caseSensitive: {
-                    dataType: 'union',
-                    subSchemas: [
-                        { dataType: 'boolean' },
                         { dataType: 'undefined' },
                     ],
                 },
@@ -36524,6 +36710,73 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'getPreAggregateStats',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsPreAggregateController_getDashboardPreAggregateAudit: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        dashboardUuidOrSlug: {
+            in: 'path',
+            name: 'dashboardUuidOrSlug',
+            required: true,
+            dataType: 'string',
+        },
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+    };
+    app.get(
+        '/api/v2/projects/:projectUuid/pre-aggregates/dashboards/:dashboardUuidOrSlug/audit',
+        ...fetchMiddlewares<RequestHandler>(PreAggregateController),
+        ...fetchMiddlewares<RequestHandler>(
+            PreAggregateController.prototype.getDashboardPreAggregateAudit,
+        ),
+
+        async function PreAggregateController_getDashboardPreAggregateAudit(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsPreAggregateController_getDashboardPreAggregateAudit,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<PreAggregateController>(
+                        PreAggregateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'getDashboardPreAggregateAudit',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -2106,6 +2106,10 @@
                     "required": {
                         "type": "boolean",
                         "description": "Whether this filter is required"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean",
+                        "description": "Overrides the field/explore case-sensitivity for this rule only.\nUsed by internal features like autocomplete search that must always\nmatch case-insensitively regardless of the field's configured setting."
                     }
                 },
                 "required": ["operator", "id", "target"],
@@ -3192,6 +3196,10 @@
                     "required": {
                         "type": "boolean",
                         "description": "Whether this filter is required"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean",
+                        "description": "Overrides the field/explore case-sensitivity for this rule only.\nUsed by internal features like autocomplete search that must always\nmatch case-insensitively regardless of the field's configured setting."
                     }
                 },
                 "required": ["operator", "id", "target"],
@@ -3508,6 +3516,10 @@
                     "required": {
                         "type": "boolean",
                         "description": "Whether this filter is required"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean",
+                        "description": "Overrides the field/explore case-sensitivity for this rule only.\nUsed by internal features like autocomplete search that must always\nmatch case-insensitively regardless of the field's configured setting."
                     }
                 },
                 "required": ["operator", "id", "target"],
@@ -6526,6 +6538,10 @@
                     "required": {
                         "type": "boolean",
                         "description": "Whether this filter is required"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean",
+                        "description": "Overrides the field/explore case-sensitivity for this rule only.\nUsed by internal features like autocomplete search that must always\nmatch case-insensitively regardless of the field's configured setting."
                     }
                 },
                 "required": ["operator", "id", "target"],
@@ -7616,20 +7632,26 @@
                     },
                     {
                         "properties": {
+                            "fieldId": {
+                                "$ref": "#/components/schemas/FieldId"
+                            },
                             "reason": {
                                 "$ref": "#/components/schemas/PreAggregateMissReason.CUSTOM_METRIC_PRESENT"
                             }
                         },
-                        "required": ["reason"],
+                        "required": ["fieldId", "reason"],
                         "type": "object"
                     },
                     {
                         "properties": {
+                            "fieldId": {
+                                "$ref": "#/components/schemas/FieldId"
+                            },
                             "reason": {
                                 "$ref": "#/components/schemas/PreAggregateMissReason.TABLE_CALCULATION_PRESENT"
                             }
                         },
-                        "required": ["reason"],
+                        "required": ["fieldId", "reason"],
                         "type": "object"
                     },
                     {
@@ -10162,23 +10184,33 @@
                                             },
                                             {
                                                 "properties": {
+                                                    "status": {
+                                                        "type": "string",
+                                                        "enum": [
+                                                            "success",
+                                                            "error"
+                                                        ]
+                                                    }
+                                                },
+                                                "required": ["status"],
+                                                "type": "object"
+                                            },
+                                            {
+                                                "properties": {
                                                     "ranking": {
                                                         "properties": {
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10186,14 +10218,17 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10242,8 +10277,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10287,18 +10322,15 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10306,14 +10338,17 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10341,8 +10376,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -11709,6 +11744,213 @@
                 "properties": {
                     "results": {
                         "$ref": "#/components/schemas/KnexPaginatedData_ApiPreAggregateStatsResults_"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
+            },
+            "TilePreAggregateAuditHit": {
+                "properties": {
+                    "preAggregateName": {
+                        "type": "string"
+                    },
+                    "exploreName": {
+                        "type": "string"
+                    },
+                    "savedChartUuid": {
+                        "type": "string"
+                    },
+                    "tileType": {
+                        "$ref": "#/components/schemas/DashboardTileTypes.SAVED_CHART"
+                    },
+                    "tileName": {
+                        "type": "string"
+                    },
+                    "tileUuid": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["hit"],
+                        "nullable": false
+                    }
+                },
+                "required": [
+                    "preAggregateName",
+                    "exploreName",
+                    "savedChartUuid",
+                    "tileType",
+                    "tileName",
+                    "tileUuid",
+                    "status"
+                ],
+                "type": "object"
+            },
+            "TilePreAggregateAuditMiss": {
+                "properties": {
+                    "miss": {
+                        "$ref": "#/components/schemas/PreAggregateMatchMiss"
+                    },
+                    "exploreName": {
+                        "type": "string"
+                    },
+                    "savedChartUuid": {
+                        "type": "string"
+                    },
+                    "tileType": {
+                        "$ref": "#/components/schemas/DashboardTileTypes.SAVED_CHART"
+                    },
+                    "tileName": {
+                        "type": "string"
+                    },
+                    "tileUuid": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["miss"],
+                        "nullable": false
+                    }
+                },
+                "required": [
+                    "miss",
+                    "exploreName",
+                    "savedChartUuid",
+                    "tileType",
+                    "tileName",
+                    "tileUuid",
+                    "status"
+                ],
+                "type": "object"
+            },
+            "TileIneligibleReason": {
+                "enum": [
+                    "non_chart_tile",
+                    "sql_chart",
+                    "orphaned_chart",
+                    "explore_resolution_error"
+                ],
+                "type": "string"
+            },
+            "TilePreAggregateAuditIneligible": {
+                "properties": {
+                    "ineligibleReason": {
+                        "$ref": "#/components/schemas/TileIneligibleReason"
+                    },
+                    "tileType": {
+                        "$ref": "#/components/schemas/DashboardTileTypes"
+                    },
+                    "tileName": {
+                        "type": "string"
+                    },
+                    "tileUuid": {
+                        "type": "string"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ineligible"],
+                        "nullable": false
+                    }
+                },
+                "required": [
+                    "ineligibleReason",
+                    "tileType",
+                    "tileName",
+                    "tileUuid",
+                    "status"
+                ],
+                "type": "object"
+            },
+            "TilePreAggregateAuditStatus": {
+                "anyOf": [
+                    {
+                        "$ref": "#/components/schemas/TilePreAggregateAuditHit"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TilePreAggregateAuditMiss"
+                    },
+                    {
+                        "$ref": "#/components/schemas/TilePreAggregateAuditIneligible"
+                    }
+                ]
+            },
+            "TabAuditGroup": {
+                "properties": {
+                    "tiles": {
+                        "items": {
+                            "$ref": "#/components/schemas/TilePreAggregateAuditStatus"
+                        },
+                        "type": "array"
+                    },
+                    "tabName": {
+                        "type": "string",
+                        "nullable": true
+                    },
+                    "tabUuid": {
+                        "type": "string",
+                        "nullable": true
+                    }
+                },
+                "required": ["tiles", "tabName", "tabUuid"],
+                "type": "object"
+            },
+            "DashboardPreAggregateAuditSummary": {
+                "properties": {
+                    "ineligibleCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "missCount": {
+                        "type": "number",
+                        "format": "double"
+                    },
+                    "hitCount": {
+                        "type": "number",
+                        "format": "double"
+                    }
+                },
+                "required": ["ineligibleCount", "missCount", "hitCount"],
+                "type": "object"
+            },
+            "DashboardPreAggregateAudit": {
+                "properties": {
+                    "summary": {
+                        "$ref": "#/components/schemas/DashboardPreAggregateAuditSummary"
+                    },
+                    "tabs": {
+                        "items": {
+                            "$ref": "#/components/schemas/TabAuditGroup"
+                        },
+                        "type": "array"
+                    },
+                    "dashboardName": {
+                        "type": "string"
+                    },
+                    "dashboardSlug": {
+                        "type": "string"
+                    },
+                    "dashboardUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "summary",
+                    "tabs",
+                    "dashboardName",
+                    "dashboardSlug",
+                    "dashboardUuid"
+                ],
+                "type": "object"
+            },
+            "ApiGetDashboardPreAggregateAuditResponse": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/DashboardPreAggregateAudit"
                     },
                     "status": {
                         "type": "string",
@@ -21800,6 +22042,10 @@
                         "type": "boolean",
                         "description": "Whether this filter is required"
                     },
+                    "caseSensitive": {
+                        "type": "boolean",
+                        "description": "Overrides the field/explore case-sensitivity for this rule only.\nUsed by internal features like autocomplete search that must always\nmatch case-insensitively regardless of the field's configured setting."
+                    },
                     "operator": {
                         "$ref": "#/components/schemas/FilterOperator",
                         "description": "Filter operator"
@@ -21974,22 +22220,22 @@
                     }
                 ]
             },
-            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
+            "PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__": {
                 "properties": {},
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
-            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
+            "PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__": {
                 "properties": {
                     "chart": {
-                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
+                        "$ref": "#/components/schemas/PartialObjectDeep___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined__._recurseIntoArrays-true__"
                     }
                 },
                 "type": "object",
                 "description": "Same as `PartialDeep`, but accepts only `object`s as inputs. Internal helper for `PartialDeep`."
             },
             "PartialDeep_ChartAsCodeLanguageMap._recurseIntoArrays-true__": {
-                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
+                "$ref": "#/components/schemas/PartialObjectDeep__chart_58___91_x-string_93__58__name_63_-string-or-undefined--description_63_-string-or-undefined--chartConfig_63__58__type-ChartType.CARTESIAN--config_63__58__eChartsConfig_58__series_63__58__name_63_-string-or-undefined--markLine_63__58__data_58__name_63_-string-or-undefined_-Array_-or-undefined_-Array-or-undefined--xAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined--yAxis_63__58__name_63_-string-or-undefined_-Array-or-undefined__-or-undefined_-or-_type-ChartType.PIE--config_63__58__groupLabelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.FUNNEL--config_63__58__labelOverrides_63_-Record_string.string_-or-undefined_-or-undefined_-or-_type-ChartType.BIG_NUMBER--config_63__58__label_63_-string-or-undefined--comparisonLabel_63_-string-or-undefined--comparisonField_63_-string-or-undefined_-or-undefined_-or-_type-ChartType.TABLE--config_63__58__columns_63_-Record_string._name-string__-or-undefined_-or-undefined_-or-_type-ChartType.CUSTOM--config_63__58__spec_63_-Record_string.unknown_-or-undefined_-or-undefined_-or-undefined___._recurseIntoArrays-true__",
                 "description": "Create a type from another type with all keys and nested keys set to optional.\n\nUse-cases:\n- Merging a default settings/config object with another object, the second object would be a deep partial of the default object.\n- Mocking and testing complex entities, where populating an entire object with its keys would be redundant in terms of the mock or test."
             },
             "ContentAsCodeType.SPACE": {
@@ -22241,6 +22487,10 @@
                     "required": {
                         "type": "boolean",
                         "description": "Whether this filter is required"
+                    },
+                    "caseSensitive": {
+                        "type": "boolean",
+                        "description": "Overrides the field/explore case-sensitivity for this rule only.\nUsed by internal features like autocomplete search that must always\nmatch case-insensitively regardless of the field's configured setting."
                     },
                     "operator": {
                         "$ref": "#/components/schemas/FilterOperator",
@@ -26084,6 +26334,9 @@
                     "warehouse": {
                         "type": "string"
                     },
+                    "caseSensitive": {
+                        "type": "boolean"
+                    },
                     "groupLabel": {
                         "type": "string"
                     },
@@ -26114,9 +26367,6 @@
                     },
                     "sqlPath": {
                         "type": "string"
-                    },
-                    "caseSensitive": {
-                        "type": "boolean"
                     },
                     "aiHint": {
                         "anyOf": [
@@ -30701,7 +30951,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2789.0",
+        "version": "0.2791.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"
@@ -32181,6 +32431,55 @@
                         "schema": {
                             "type": "string",
                             "enum": ["chart", "dashboard", "explorer"]
+                        }
+                    }
+                ]
+            }
+        },
+        "/api/v2/projects/{projectUuid}/pre-aggregates/dashboards/{dashboardUuidOrSlug}/audit": {
+            "get": {
+                "operationId": "getDashboardPreAggregateAudit",
+                "responses": {
+                    "200": {
+                        "description": "Success",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiGetDashboardPreAggregateAuditResponse"
+                                }
+                            }
+                        }
+                    },
+                    "default": {
+                        "description": "Error",
+                        "content": {
+                            "application/json": {
+                                "schema": {
+                                    "$ref": "#/components/schemas/ApiErrorPayload"
+                                }
+                            }
+                        }
+                    }
+                },
+                "description": "Audits pre-aggregate hit/miss coverage for every tile on a dashboard\nwithout executing the queries. Returns a per-tile breakdown grouped\nby tab, suitable for CI coverage checks and pre-aggregate tuning.",
+                "summary": "Get dashboard pre-aggregate audit",
+                "tags": ["v2", "Pre-Aggregates"],
+                "security": [],
+                "parameters": [
+                    {
+                        "in": "path",
+                        "name": "projectUuid",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
+                        }
+                    },
+                    {
+                        "in": "path",
+                        "name": "dashboardUuidOrSlug",
+                        "required": true,
+                        "schema": {
+                            "type": "string"
                         }
                     }
                 ]

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -110,6 +110,7 @@ const makeMockStrategy = (
     cleanupStats: jest.fn(async () => 0),
     getStats: noOpStrategy.getStats.bind(noOpStrategy),
     getResultsStorageClient: jest.fn(() => undefined),
+    auditDashboard: noOpStrategy.auditDashboard.bind(noOpStrategy),
 });
 
 // Import the mocked function

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -17,6 +17,7 @@ import {
     CreateWarehouseCredentials,
     CustomSqlQueryForbiddenError,
     DashboardFilters,
+    DashboardPreAggregateAudit,
     DEFAULT_RESULTS_PAGE_SIZE,
     derivePivotConfigurationFromChart,
     Dimension,
@@ -6108,5 +6109,29 @@ export class AsyncQueryService extends ProjectService {
             paginateArgs,
             filters,
         );
+    }
+
+    async getDashboardPreAggregateAudit(
+        account: Account,
+        projectUuid: string,
+        dashboardUuid: string,
+    ): Promise<DashboardPreAggregateAudit> {
+        assertIsAccountWithOrg(account);
+
+        const dashboard = await this.dashboardModel.getByIdOrSlug(
+            dashboardUuid,
+            { projectUuid },
+        );
+
+        const auditedAbility = this.createAuditedAbility(account);
+        if (auditedAbility.cannot('view', subject('Dashboard', dashboard))) {
+            throw new ForbiddenError();
+        }
+
+        return this.preAggregateStrategy.auditDashboard({
+            account,
+            projectUuid,
+            dashboard,
+        });
     }
 }

--- a/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -3,12 +3,16 @@ import {
     CreateWarehouseCredentials,
     DateZoom,
     ItemsMap,
+    NotImplementedError,
     ParameterDefinitions,
     ParametersValuesMap,
     PivotConfiguration,
     UserAccessControls,
     WarehouseClient,
+    type Account,
     type CacheMetadata,
+    type DashboardDAO,
+    type DashboardPreAggregateAudit,
     type Explore,
     type KnexPaginateArgs,
     type KnexPaginatedData,
@@ -74,6 +78,12 @@ export interface PreAggregateStrategy {
     ): Promise<KnexPaginatedData<ApiPreAggregateStatsResults>>;
 
     getResultsStorageClient(): S3ResultsFileStorageClient | undefined;
+
+    auditDashboard(params: {
+        account: Account;
+        projectUuid: string;
+        dashboard: DashboardDAO;
+    }): Promise<DashboardPreAggregateAudit>;
 }
 
 export type ResolveExecutionArgs = {
@@ -135,5 +145,11 @@ export class NoOpPreAggregateStrategy implements PreAggregateStrategy {
 
     getResultsStorageClient(): undefined {
         return undefined;
+    }
+
+    async auditDashboard(): Promise<DashboardPreAggregateAudit> {
+        throw new NotImplementedError(
+            'Dashboard pre-aggregate audit is not available in this edition',
+        );
     }
 }


### PR DESCRIPTION
## What

Part **3 of 4** in the ZAP-329 stack. Exposes the audit service from PR 2 as a REST endpoint:

```
GET /api/v2/projects/{projectUuid}/pre-aggregates/dashboards/{dashboardUuid}/audit
```

Response shape: `DashboardPreAggregateAudit` — the per-tile discriminated-union structure grouped by tab, plus a hit / miss / ineligible summary. **No SQL is executed.** The response reflects the routing decision the matcher *would* make if the dashboard were opened right now.

### Example response (abridged)

```json
{
  "status": "ok",
  "results": {
    "dashboardUuid": "…",
    "dashboardSlug": "weekly-sales",
    "dashboardName": "Weekly Sales",
    "tabs": [
      {
        "tabUuid": "…",
        "tabName": "Overview",
        "tiles": [
          { "status": "hit",  "tileName": "Revenue by region",
            "preAggregateName": "daily_revenue_by_region", … },
          { "status": "miss", "tileName": "Revenue by SKU",
            "miss": { "reason": "dimension_not_in_pre_aggregate", … } }
        ]
      }
    ],
    "summary": { "hitCount": 12, "missCount": 3, "ineligibleCount": 2 }
  }
}
```

### Why a new endpoint rather than reusing the drawer's data path

The drawer accumulates its state from live query responses as the dashboard loads, so it's only available to someone who has the dashboard open in a browser. ZAP-329 exists to make that signal scriptable — CI pre-deploy checks, the `lightdash pre-aggregate-audit` CLI (PR 4), and customer-self-serve coverage tuning.

### Shape and surface

- Registered on the existing `PreAggregateController`, landing as a sibling of `/stats` and `/materializations`. EE-gated like the rest of the pre-aggregate surface — non-EE builds surface **501** via the NoOp strategy.
- Auth middleware: `[allowApiKeyAuthentication, isAuthenticated]` — accepts both session cookies and `Authorization: ApiKey <token>`, matching `/stats`.
- Authorization: the upstream service enforces CASL `'view'` on `subject('Dashboard', …)`. A user who can see the dashboard in the UI can audit it; one who can't, can't. **Not** a project-wide `view Project` check.
- No query parameters in v1. Filter-override (`?filters=…`) is deferred until a concrete use case lands — rationale in `docs/superpowers/specs/…-design.md`.

### Generated files

`packages/backend/src/generated/routes.ts` and `swagger.json` are regenerated via `pnpm generate-api`.

## Stack

1. [#22306 — types](https://github.com/lightdash/lightdash/pull/22306)
2. [#22307 — backend service layer](https://github.com/lightdash/lightdash/pull/22307)
3. **This PR — REST endpoint** 👈
4. [#22309 — CLI command](https://github.com/lightdash/lightdash/pull/22309)

## Testing

- [ ] `pnpm -F backend typecheck` passes
- [ ] `pnpm generate-api` is idempotent (no new diffs after running again)
- [ ] **Manual smoke** against local dev (steps in `docs/superpowers/plans/…-api-cli.md` Task 8):
  ```bash
  curl -H "Authorization: ApiKey $LDPAT" \
    "$SITE_URL/api/v2/projects/$PROJECT/pre-aggregates/dashboards/$DASHBOARD/audit" \
    | jq '.results.summary'
  ```
- [ ] 403 when auth'd as a user without `view Dashboard`
- [ ] 404 for an unknown `dashboardUuid`
- [ ] 501 on non-EE builds
