### PR TITLE
chore: remove `moment` and `moment-timezone` from SDK dependencies

### DIFF
--- a/packages/frontend/sdk/package.json
+++ b/packages/frontend/sdk/package.json
@@ -18,10 +18,6 @@
             "default": "./dist/sdk.cjs.js"
         }
     },
-    "dependencies": {
-        "moment": "2.29.4",
-        "moment-timezone": "0.5.45"
-    },
     "peerDependencies": {
         "react": "^18.x || ^19.x",
         "react-dom": "^18.x || ^19.x"

--- a/packages/frontend/vite.config.sdk.ts
+++ b/packages/frontend/vite.config.sdk.ts
@@ -40,6 +40,7 @@ export default defineConfig({
             external: [
                 'react',
                 'react-dom',
+                'react-dom/server',
                 'react/jsx-runtime',
                 'react/jsx-dev-runtime',
             ],

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1394,12 +1394,6 @@ importers:
 
   packages/frontend/sdk:
     dependencies:
-      moment:
-        specifier: 2.29.4
-        version: 2.29.4
-      moment-timezone:
-        specifier: 0.5.45
-        version: 0.5.45
       react:
         specifier: ^18.x || ^19.x
         version: 19.0.0


### PR DESCRIPTION
Related to: #22289

### Description:

Removes `moment` and `moment-timezone` as direct dependencies from the frontend SDK package, as these should not be bundled with the SDK. Additionally, marks `react-dom/server` as an external dependency in the SDK's Vite build configuration to prevent it from being included in the bundle.