### PR TITLE
fix: show different clock icon when pre-aggregate cache misses

### DIFF
--- a/packages/frontend/src/components/DashboardTiles/TileExecutionInfo.tsx
+++ b/packages/frontend/src/components/DashboardTiles/TileExecutionInfo.tsx
@@ -6,6 +6,7 @@ import {
 import { Divider, Stack } from '@mantine-8/core';
 import { ActionIcon, HoverCard } from '@mantine/core';
 import {
+    IconClock,
     IconClockBolt,
     IconClockPlay,
     IconDatabase,
@@ -108,7 +109,13 @@ const TileExecutionInfo: FC<TileExecutionInfoProps> = ({
             </HoverCard.Dropdown>
             <HoverCard.Target>
                 <ActionIcon size="sm">
-                    <MantineIcon icon={IconClockBolt} />
+                    <MantineIcon
+                        icon={
+                            cacheMetadata.preAggregate?.hit
+                                ? IconClockBolt
+                                : IconClock
+                        }
+                    />
                 </ActionIcon>
             </HoverCard.Target>
         </HoverCard>


### PR DESCRIPTION
Closes:

### Description:
Updates the execution info icon in dashboard tiles to visually differentiate between pre-aggregate cache hits and misses. When a pre-aggregate cache hit occurs, the `IconClockBolt` icon is displayed; otherwise, the standard `IconClock` icon is shown. This gives users a clearer at-a-glance indication of whether a tile's data was served from a pre-aggregated cache.