### PR TITLE
feat(ai-agent): structured wide events for Slack auth resolution (PROD-7030)

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/slackStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/slackStrategy.ts
@@ -8,6 +8,7 @@ import {
 } from '@lightdash/common';
 import { Strategy as SlackStrategy } from 'passport-slack-oauth2';
 import { lightdashConfig } from '../../../config/lightdashConfig';
+import Logger from '../../../logging/logger';
 
 export const slackPassportStrategy = !(
     lightdashConfig.slack?.clientId && lightdashConfig.slack?.clientSecret
@@ -45,6 +46,13 @@ export const slackPassportStrategy = !(
                   await req.services
                       .getUserService()
                       .linkOpenIdIdentityToUser(req.user, openIdUser);
+                  Logger.info('Slack OAuth identity link attempt', {
+                      event: 'auth.slack.identity_link',
+                      result: 'created',
+                      userUuid: req.user.userUuid,
+                      slackSubject: profile.id,
+                      slackProfileTeamId: profile.team.id,
+                  });
                   return done(null, req.user);
               } catch (e: unknown) {
                   if (
@@ -54,15 +62,23 @@ export const slackPassportStrategy = !(
                       e.code === '23505'
                   ) {
                       // Postgres duplicate key error code
-                      console.warn(
-                          `Trying to link open id to user ${req.user.userUuid} but user is already linked`,
-                      );
-                      return done(null, req.user); // Silent error if user is already linked to the identity
+                      Logger.info('Slack OAuth identity link attempt', {
+                          event: 'auth.slack.identity_link',
+                          result: 'already_linked',
+                          userUuid: req.user.userUuid,
+                          slackSubject: profile.id,
+                          slackProfileTeamId: profile.team.id,
+                      });
+                      return done(null, req.user); // Silent success — user is already linked to the identity
                   }
-                  console.error(
-                      `Unable to link open id to user ${req.user.userUuid}`,
-                      e,
-                  );
+                  Logger.info('Slack OAuth identity link attempt', {
+                      event: 'auth.slack.identity_link',
+                      result: 'failed',
+                      userUuid: req.user.userUuid,
+                      slackSubject: profile.id,
+                      slackProfileTeamId: profile.team.id,
+                      errorMessage: getErrorMessage(e),
+                  });
                   return done(new UnexpectedDatabaseError(getErrorMessage(e)));
               }
           },

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -41,6 +41,7 @@ import {
     LightdashUser,
     NotFoundError,
     NotImplementedError,
+    OpenIdIdentity,
     OpenIdIdentityIssuerType,
     ParameterError,
     parseVizConfig,
@@ -4690,46 +4691,86 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         channelId?: string;
         client: WebClient;
     }): Promise<string | undefined | null> {
-        if (!teamId) {
-            return undefined;
-        }
+        let result:
+            | 'no_team_id'
+            | 'oauth_not_required'
+            | 'authenticated'
+            | 'identity_missing' = 'no_team_id';
+        let organizationUuid: string | null = null;
+        let observedIdentity: OpenIdIdentity | null = null;
+        try {
+            if (!teamId) {
+                return undefined;
+            }
 
-        const organizationUuid =
-            await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
-                teamId,
-            );
+            organizationUuid =
+                await this.slackAuthenticationModel.getOrganizationUuidFromTeamId(
+                    teamId,
+                );
 
-        const slackSettings =
-            await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
+            const slackSettings =
+                await this.slackAuthenticationModel.getInstallationFromOrganizationUuid(
+                    organizationUuid,
+                );
+
+            if (!slackSettings?.aiRequireOAuth) {
+                result = 'oauth_not_required';
+                return organizationUuid;
+            }
+
+            // TODO: Legacy Slack-linked users can still fail here if team_id was never
+            // populated on their OpenID identity.
+            const openIdIdentity =
+                await this.openIdIdentityModel.findIdentityByOpenId(
+                    OpenIdIdentityIssuerType.SLACK,
+                    userId,
+                    teamId,
+                );
+            observedIdentity = openIdIdentity;
+            if (!observedIdentity) {
+                // Observability-only: a teamless lookup so the wide event can
+                // distinguish a truly-absent identity from one filtered out by team_id.
+                observedIdentity =
+                    await this.openIdIdentityModel.findIdentityByOpenId(
+                        OpenIdIdentityIssuerType.SLACK,
+                        userId,
+                    );
+            }
+
+            if (openIdIdentity) {
+                result = 'authenticated';
+                return organizationUuid;
+            }
+
+            result = 'identity_missing';
+            if (channelId) {
+                await client.chat.postEphemeral({
+                    channel: channelId,
+                    user: userId,
+                    text: 'You need to link your Slack account to Lightdash to vote on AI responses. Please use the AI Agent first to complete the OAuth linking process.',
+                });
+            }
+
+            return null;
+        } finally {
+            Logger.info('AI agent Slack auth check', {
+                event: 'ai_agent.slack_auth',
+                trigger: 'vote',
+                result,
                 organizationUuid,
-            );
-
-        if (!slackSettings?.aiRequireOAuth) {
-            return organizationUuid;
-        }
-
-        // TODO: Legacy Slack-linked users can still fail here if team_id was never
-        // populated on their OpenID identity.
-        const openIdIdentity =
-            await this.openIdIdentityModel.findIdentityByOpenId(
-                OpenIdIdentityIssuerType.SLACK,
-                userId,
-                teamId,
-            );
-
-        if (openIdIdentity) {
-            return organizationUuid;
-        }
-
-        if (channelId) {
-            await client.chat.postEphemeral({
-                channel: channelId,
-                user: userId,
-                text: 'You need to link your Slack account to Lightdash to vote on AI responses. Please use the AI Agent first to complete the OAuth linking process.',
+                slackUserId: userId,
+                slackUserIdFlavor: userId.startsWith('W')
+                    ? 'enterprise'
+                    : 'workspace',
+                blockActionTeamId: teamId ?? null,
+                storedTeamId: observedIdentity?.teamId ?? null,
+                hasStoredIdentity: observedIdentity != null,
+                teamIdMatchesStored:
+                    observedIdentity?.teamId && teamId
+                        ? observedIdentity.teamId === teamId
+                        : null,
             });
         }
-
-        return null;
     }
 
     public handleAgentSelection(app: App) {
@@ -5022,60 +5063,96 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         say: Function,
         client: WebClient,
     ): Promise<{ userUuid: string } | null> {
-        const aiRequireOAuth = slackSettings?.aiRequireOAuth;
-        if (!aiRequireOAuth) {
-            return {
-                userUuid:
-                    await this.slackAuthenticationModel.getUserUuid(teamId),
-            };
-        }
+        let result:
+            | 'oauth_not_required'
+            | 'authenticated'
+            | 'identity_missing' = 'identity_missing';
+        let observedIdentity: OpenIdIdentity | null = null;
+        try {
+            const aiRequireOAuth = slackSettings?.aiRequireOAuth;
+            if (!aiRequireOAuth) {
+                result = 'oauth_not_required';
+                return {
+                    userUuid:
+                        await this.slackAuthenticationModel.getUserUuid(teamId),
+                };
+            }
 
-        const openIdIdentity =
-            await this.openIdIdentityModel.findIdentityByOpenId(
-                OpenIdIdentityIssuerType.SLACK,
-                userId,
-                teamId,
-            );
-        if (!openIdIdentity) {
-            await client.chat.postEphemeral({
-                channel: channelId,
-                user: userId,
-                text: `Hi <@${userId}>! OAuth authentication is required to use AI Agent. Please connect your Slack account to Lightdash to continue.`,
-                blocks: [
-                    {
-                        type: 'section',
-                        text: {
-                            type: 'mrkdwn',
-                            text: `Hi <@${userId}>! OAuth authentication is required to use AI Agent. Please connect your Slack account to Lightdash to continue.`,
-                        },
-                    },
-                    {
-                        type: 'actions',
-                        elements: [
-                            {
-                                type: 'button',
-                                text: {
-                                    type: 'plain_text',
-                                    text: 'Connect your Slack account',
-                                },
-                                // Encode message info in action_id since URL isn't available in action payload
-                                action_id: `actions.oauth_button_click:${teamId}:${channelId}:${messageId}`,
-                                url: `${
-                                    this.lightdashConfig.siteUrl
-                                }/api/v1/auth/slack?team=${teamId}&channel=${channelId}&message=${messageId}${
-                                    threadTs ? `&thread_ts=${threadTs}` : ''
-                                }`,
-                                style: 'primary',
+            const openIdIdentity =
+                await this.openIdIdentityModel.findIdentityByOpenId(
+                    OpenIdIdentityIssuerType.SLACK,
+                    userId,
+                    teamId,
+                );
+            observedIdentity = openIdIdentity;
+            if (!observedIdentity) {
+                // Observability-only: a teamless lookup so the wide event can
+                // distinguish a truly-absent identity from one filtered out by team_id.
+                observedIdentity =
+                    await this.openIdIdentityModel.findIdentityByOpenId(
+                        OpenIdIdentityIssuerType.SLACK,
+                        userId,
+                    );
+            }
+
+            if (!openIdIdentity) {
+                await client.chat.postEphemeral({
+                    channel: channelId,
+                    user: userId,
+                    text: `Hi <@${userId}>! OAuth authentication is required to use AI Agent. Please connect your Slack account to Lightdash to continue.`,
+                    blocks: [
+                        {
+                            type: 'section',
+                            text: {
+                                type: 'mrkdwn',
+                                text: `Hi <@${userId}>! OAuth authentication is required to use AI Agent. Please connect your Slack account to Lightdash to continue.`,
                             },
-                        ],
-                    },
-                ],
+                        },
+                        {
+                            type: 'actions',
+                            elements: [
+                                {
+                                    type: 'button',
+                                    text: {
+                                        type: 'plain_text',
+                                        text: 'Connect your Slack account',
+                                    },
+                                    // Encode message info in action_id since URL isn't available in action payload
+                                    action_id: `actions.oauth_button_click:${teamId}:${channelId}:${messageId}`,
+                                    url: `${
+                                        this.lightdashConfig.siteUrl
+                                    }/api/v1/auth/slack?team=${teamId}&channel=${channelId}&message=${messageId}${
+                                        threadTs ? `&thread_ts=${threadTs}` : ''
+                                    }`,
+                                    style: 'primary',
+                                },
+                            ],
+                        },
+                    ],
+                });
+
+                return null;
+            }
+
+            result = 'authenticated';
+            return { userUuid: openIdIdentity.userUuid };
+        } finally {
+            Logger.info('AI agent Slack auth check', {
+                event: 'ai_agent.slack_auth',
+                trigger: 'app_mention',
+                result,
+                slackUserId: userId,
+                slackUserIdFlavor: userId.startsWith('W')
+                    ? 'enterprise'
+                    : 'workspace',
+                blockActionTeamId: teamId,
+                storedTeamId: observedIdentity?.teamId ?? null,
+                hasStoredIdentity: observedIdentity != null,
+                teamIdMatchesStored: observedIdentity?.teamId
+                    ? observedIdentity.teamId === teamId
+                    : null,
             });
-
-            return null;
         }
-
-        return { userUuid: openIdIdentity.userUuid };
     }
 
     /**

--- a/packages/backend/src/models/OpenIdIdentitiesModel.ts
+++ b/packages/backend/src/models/OpenIdIdentitiesModel.ts
@@ -36,6 +36,7 @@ export class OpenIdIdentityModel {
             createdAt: identity.created_at,
             userUuid: identity.user_uuid,
             email: identity.email,
+            teamId: identity.team_id,
         };
     }
 
@@ -49,6 +50,7 @@ export class OpenIdIdentityModel {
                 'openid_identities.created_at',
                 'users.user_uuid',
                 'openid_identities.email',
+                'openid_identities.team_id',
             );
     }
 


### PR DESCRIPTION
## Summary

Observability-only PR for [PROD-7030](https://linear.app/lightdash/issue/PROD-7030/). Emits structured wide events so we can validate, at query time, which of three theories is driving the bug report (AI agent feedback buttons say "please link your Slack account" even for users who are already linked).

This PR **does not change behavior** — it only adds logging. A follow-up PR will drop the `team_id` filter in the identity lookup, which the data gathered from these events will justify.

### Wide events

1. `ai_agent.slack_auth` — fired on every invocation of `getSlackVoteOrganizationUuid` and `handleAiAgentAuth` via `try/finally`. Attributes:

   | Field | Meaning |
   |---|---|
   | `trigger` | `'vote'` or `'app_mention'` (literal per call site) |
   | `result` | `'no_team_id' \| 'oauth_not_required' \| 'authenticated' \| 'identity_missing'` |
   | `slackUserId` | Slack user subject (`U…` or `W…`) |
   | `slackUserIdFlavor` | `'enterprise'` (W) or `'workspace'` (U) — cheap discriminator for the enterprise-grid theory |
   | `blockActionTeamId` | The `context.teamId` Bolt gave us |
   | `storedTeamId` | `profile.team.id` as persisted on the OpenID identity row, or null |
   | `hasStoredIdentity` | Whether a Slack identity for this user exists at all |
   | `teamIdMatchesStored` | True / false / null (null when we can't evaluate it) |
   | `organizationUuid` | Org scope for per-customer slicing |

   On a miss, an extra teamless `findIdentityByOpenId(SLACK, userId)` call is made *for observability only* so the wide event can distinguish "truly absent" from "filtered out by team_id". The auth-check return value is unchanged.

2. `auth.slack.identity_link` — fired from `slackStrategy` on OAuth callback. Attributes:

   | Field | Meaning |
   |---|---|
   | `result` | `'created' \| 'already_linked' \| 'failed'` |
   | `userUuid` | The Lightdash user being linked |
   | `slackSubject` | Slack user id from OIDC profile |
   | `slackProfileTeamId` | `profile.team.id` from OIDC |

   Replaces the existing `console.warn` / `console.error` with structured `Logger.info` so gcloud log-based metrics can count `already_linked` over time — a high baseline here is itself a signal that the upcoming fix is needed.

### Theories this lets us validate

| Theory | Query-time filter |
|---|---|
| Legacy NULL team_id rows (pre-2025-07-03 migration) | `result=authenticated AND storedTeamId=null` after fix; pre-fix inferred from `hasStoredIdentity=true AND storedTeamId=null` |
| `context.teamId` ≠ stored `profile.team.id` (Enterprise Grid / Slack Connect) | `result=identity_missing AND hasStoredIdentity=true AND teamIdMatchesStored=false` |
| Enterprise user-id flavor (W… vs U…) | `slackUserIdFlavor=enterprise` |
| Fix impact, post-deploy | `auth.slack.identity_link` with `result=already_linked` should collapse from current baseline toward zero |

### Minor type change

`_parseDbIdentity` in `OpenIdIdentitiesModel` now populates `teamId` (already-optional field on `OpenIdIdentity` via `CreateOpenIdIdentity`). Purely additive; no call sites need to change.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint` — 0 errors, 42 pre-existing warnings unrelated to this change
- [x] `pnpm -F common typecheck`
- [ ] Post-deploy: run queries from the PR body against an affected customer's namespace to confirm theory distribution
- [ ] Post-deploy: confirm `already_linked` baseline count is nonzero (will justify the follow-up behavioral fix)

## Follow-up

Separate PR will: drop the `teamId` filter from the two auth-check call sites, add an OAuth button to the vote-path ephemeral, and suppress the `processPendingSlackMessage` replay when OAuth was triggered from a vote.

🤖 Generated with [Claude Code](https://claude.com/claude-code)