### PR TITLE
docs(skills): teach agents about verified field on upload

### DIFF
--- a/skills/developing-in-lightdash/resources/cli-reference.md
+++ b/skills/developing-in-lightdash/resources/cli-reference.md
@@ -108,6 +108,8 @@ lightdash upload --charts my-chart --dashboards my-dashboard
 lightdash upload --dashboards my-dashboard --include-charts
 ```
 
+**Verification on upload:** chart and dashboard YAML files include a `verified` boolean. Set `verified: true` or `verified: false` to verify/unverify on upload; omit the field to leave the current verification state unchanged. Only admins can change verification — non-admin uploads silently skip this field.
+
 ## Delete Content
 
 Permanently delete charts and dashboards from the server and remove their local YAML files.

--- a/skills/developing-in-lightdash/resources/dashboard-reference.md
+++ b/skills/developing-in-lightdash/resources/dashboard-reference.md
@@ -17,6 +17,7 @@ slug: sales-dashboard
 spaceSlug: sales
 tabs: []         # Optional tabs for organization
 tiles: []        # Chart and content tiles
+verified: true   # Optional: true/false to verify/unverify on upload, omit to leave unchanged. Admins only.
 version: 1
 ```
 


### PR DESCRIPTION
## Summary

Adds minimal guidance to the \`developing-in-lightdash\` skill so AI coding agents (Claude Code, Cursor, Codex) know that chart and dashboard YAML supports a writable \`verified\` boolean for controlling verification state via \`lightdash upload\`.

- \`cli-reference.md\` — one paragraph in the upload section explaining the three-state semantics (\`true\` / \`false\` / absent) and the admin-only constraint
- \`dashboard-reference.md\` — adds \`verified\` to the Dashboard Structure YAML example with a short inline comment

Total diff: +3 lines across 2 files. No bloat — agents reading the skill will pick this up alongside the rest of the upload reference.

## Test plan

- [ ] Skill installs cleanly via \`lightdash install-skills\`
- [ ] Diff visible in \`~/.claude/skills/developing-in-lightdash/\` after install
- [ ] Sample agent prompt ("verify my dashboard via the CLI") produces YAML with the \`verified\` field

🤖 Generated with [Claude Code](https://claude.com/claude-code)