### PR TITLE
feat(ee/mcp): expose verified content via MCP tool

### DIFF
--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -378,6 +378,8 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     analytics: context.lightdashAnalytics,
                     asyncQueryService: repository.getAsyncQueryService(),
                     catalogService: repository.getCatalogService(),
+                    contentVerificationService:
+                        repository.getContentVerificationService(),
                     projectService: repository.getProjectService(),
                     savedSqlService: repository.getSavedSqlService(),
                     schedulerService: repository.getSchedulerService(),

--- a/packages/backend/src/ee/services/McpService/McpService.ts
+++ b/packages/backend/src/ee/services/McpService/McpService.ts
@@ -64,6 +64,7 @@ import { UserAttributesModel } from '../../../models/UserAttributesModel';
 import { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
 import { BaseService } from '../../../services/BaseService';
 import { CatalogService } from '../../../services/CatalogService/CatalogService';
+import { ContentVerificationService } from '../../../services/ContentVerificationService';
 import { CsvService } from '../../../services/CsvService/CsvService';
 import { FeatureFlagService } from '../../../services/FeatureFlag/FeatureFlagService';
 import { ProjectService } from '../../../services/ProjectService/ProjectService';
@@ -128,6 +129,7 @@ export enum McpToolName {
     RUN_METRIC_QUERY = 'run_metric_query',
     RUN_SQL = 'run_sql',
     SEARCH_FIELD_VALUES = 'search_field_values',
+    LIST_VERIFIED_CONTENT = 'list_verified_content',
 }
 
 type McpServiceArguments = {
@@ -135,6 +137,7 @@ type McpServiceArguments = {
     analytics: LightdashAnalytics;
     asyncQueryService: AsyncQueryService;
     catalogService: CatalogService;
+    contentVerificationService: ContentVerificationService;
     projectModel: ProjectModel;
     projectService: ProjectService;
     savedSqlService: SavedSqlService;
@@ -170,6 +173,8 @@ export class McpService extends BaseService {
 
     private catalogService: CatalogService;
 
+    private contentVerificationService: ContentVerificationService;
+
     private projectService: ProjectService;
 
     private savedSqlService: SavedSqlService;
@@ -203,6 +208,7 @@ export class McpService extends BaseService {
         analytics,
         asyncQueryService,
         catalogService,
+        contentVerificationService,
         projectService,
         savedSqlService,
         schedulerService,
@@ -221,6 +227,7 @@ export class McpService extends BaseService {
         this.analytics = analytics;
         this.asyncQueryService = asyncQueryService;
         this.catalogService = catalogService;
+        this.contentVerificationService = contentVerificationService;
         this.projectService = projectService;
         this.savedSqlService = savedSqlService;
         this.schedulerService = schedulerService;
@@ -1523,6 +1530,46 @@ export class McpService extends BaseService {
                         isError: true,
                     };
                 }
+            },
+        );
+
+        this.mcpServer.registerTool(
+            McpToolName.LIST_VERIFIED_CONTENT,
+            {
+                description:
+                    'List all verified charts and dashboards in the active project. Verified content has been reviewed and marked as trusted — use this to discover reference examples of sanctioned metrics and visualizations when building new content. Requires an active project set via set_project. Each item includes contentType (chart or dashboard), contentUuid, name, space, and verification metadata (who verified it and when).',
+                inputSchema: {},
+                annotations: {
+                    readOnlyHint: true,
+                    destructiveHint: false,
+                    idempotentHint: true,
+                },
+            },
+            async (
+                _args: Record<string, never>,
+                extra: RequestHandlerExtra<ServerRequest, ServerNotification>,
+            ) => {
+                const { user } = this.getAccount(extra as McpProtocolContext);
+                const projectUuid = await this.resolveProjectUuid(
+                    extra as McpProtocolContext,
+                );
+
+                this.trackToolCall(
+                    extra as McpProtocolContext,
+                    McpToolName.LIST_VERIFIED_CONTENT,
+                    projectUuid,
+                );
+
+                const verifiedContent =
+                    await this.contentVerificationService.listVerifiedContent(
+                        user,
+                        projectUuid,
+                    );
+
+                return this.buildScopedResponse(
+                    extra as McpProtocolContext,
+                    JSON.stringify(verifiedContent, null, 2),
+                );
             },
         );
 


### PR DESCRIPTION
Closes: [PROD-7089](https://linear.app/lightdash/issue/PROD-7089/expose-verified-chartsdashboards-via-lightdash-mcp-tool)

### Description

Adds a new `list_verified_content` MCP tool that returns all verified charts and dashboards for the active project. Agents can use this to discover trusted reference content when building new charts/dashboards.

The tool:
- Takes no arguments (uses active project context set via `set_project`)
- Returns `VerifiedContentListItem[]` — contentType (chart/dashboard), contentUuid, name, spaceUuid/spaceName, verifiedBy, verifiedAt
- Delegates to existing `ContentVerificationService.listVerifiedContent()` so it inherits the same permission model as the HTTP endpoint

### Context

Customer ask: agents should be able to reference verified content as a trusted pattern when building new charts. Previously the MCP exposed `verifiedQuestions` (AI-agent-curated queries) but nothing for the content-verification feature (#22089 / #22124).

Per the ticket, the `developing-in-lightdash` skill is **intentionally not updated** with hard-coded "prefer verified content" guidance — that stays a customer-side prompt choice.

### Test plan

- [ ] Set a project context via `set_project`, call `list_verified_content`, verify it returns verified charts and dashboards with verifier/timestamp metadata
- [ ] Verify `ForbiddenError` when no project is set
- [ ] Verify permission check (admin/manage scope on ContentVerification) is enforced