### PR TITLE
feat(content): surface verification on Space overview

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DashboardContentConfiguration.ts
@@ -1,5 +1,6 @@
 import { ContentType, DashboardContent } from '@lightdash/common';
 import { Knex } from 'knex';
+import { ContentVerificationTableName } from '../../../database/entities/contentVerification';
 import {
     DashboardsTableName,
     DashboardVersionsTableName,
@@ -87,6 +88,25 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                     `updated_by_user.user_uuid`,
                     `last_version.updated_by_user_uuid`,
                 )
+                .leftJoin(
+                    ContentVerificationTableName,
+                    function verificationJoin() {
+                        this.on(
+                            `${ContentVerificationTableName}.content_uuid`,
+                            '=',
+                            `${DashboardsTableName}.dashboard_uuid`,
+                        ).andOn(
+                            `${ContentVerificationTableName}.content_type`,
+                            '=',
+                            knex.raw('?', [ContentType.DASHBOARD]),
+                        );
+                    },
+                )
+                .leftJoin(
+                    `${UserTableName} as verified_by_user`,
+                    `verified_by_user.user_uuid`,
+                    `${ContentVerificationTableName}.verified_by_user_uuid`,
+                )
                 .select<SummaryContentRow[]>([
                     knex.raw(`'${ContentType.DASHBOARD}' as content_type`),
                     knex.raw(
@@ -130,6 +150,10 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                     knex.raw(
                         `(SELECT last_name FROM users WHERE user_uuid = ${DashboardsTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
                     ),
+                    `${ContentVerificationTableName}.verified_at as verified_at`,
+                    `verified_by_user.user_uuid as verified_by_user_uuid`,
+                    `verified_by_user.first_name as verified_by_user_first_name`,
+                    `verified_by_user.last_name as verified_by_user_last_name`,
                     knex.raw(
                         `json_build_object(${
                             filters.includeDescendantCounts
@@ -243,7 +267,20 @@ export const dashboardContentConfiguration: ContentConfiguration<SummaryContentR
                     : null,
                 views: value.views,
                 firstViewedAt: value.first_viewed_at,
-                verification: null,
+                verification:
+                    value.verified_at !== null &&
+                    value.verified_by_user_uuid !== null &&
+                    value.verified_by_user_first_name !== null &&
+                    value.verified_by_user_last_name !== null
+                        ? {
+                              verifiedBy: {
+                                  userUuid: value.verified_by_user_uuid,
+                                  firstName: value.verified_by_user_first_name,
+                                  lastName: value.verified_by_user_last_name,
+                              },
+                              verifiedAt: value.verified_at,
+                          }
+                        : null,
             };
         },
     };

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -135,6 +135,10 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     knex.raw(
                         `(SELECT last_name FROM users WHERE user_uuid = ${AppsTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
                     ),
+                    knex.raw(`null::timestamp as verified_at`),
+                    knex.raw(`null::uuid as verified_by_user_uuid`),
+                    knex.raw(`null as verified_by_user_first_name`),
+                    knex.raw(`null as verified_by_user_last_name`),
                     knex.raw(
                         `json_build_object(
                             'latestVersionNumber', latest_version.version,

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DbtExploreChartContentConfiguration.ts
@@ -5,6 +5,7 @@ import {
     ContentType,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { ContentVerificationTableName } from '../../../database/entities/contentVerification';
 import { DashboardsTableName } from '../../../database/entities/dashboards';
 import { OrganizationTableName } from '../../../database/entities/organizations';
 import {
@@ -87,6 +88,25 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                     `${SavedChartsTableName}.last_version_updated_by_user_uuid`,
                     `updatedByUser.user_uuid`,
                 )
+                .leftJoin(
+                    ContentVerificationTableName,
+                    function verificationJoin() {
+                        this.on(
+                            `${ContentVerificationTableName}.content_uuid`,
+                            '=',
+                            `${SavedChartsTableName}.saved_query_uuid`,
+                        ).andOn(
+                            `${ContentVerificationTableName}.content_type`,
+                            '=',
+                            knex.raw('?', [ContentType.CHART]),
+                        );
+                    },
+                )
+                .leftJoin(
+                    `${UserTableName} as verifiedByUser`,
+                    `verifiedByUser.user_uuid`,
+                    `${ContentVerificationTableName}.verified_by_user_uuid`,
+                )
                 .select<SelectSavedChart[]>([
                     knex.raw(`'${ContentType.CHART}' as content_type`),
                     knex.raw(
@@ -131,6 +151,10 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                     knex.raw(
                         `(SELECT last_name FROM users WHERE user_uuid = ${SavedChartsTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
                     ),
+                    `${ContentVerificationTableName}.verified_at as verified_at`,
+                    `verifiedByUser.user_uuid as verified_by_user_uuid`,
+                    `verifiedByUser.first_name as verified_by_user_first_name`,
+                    `verifiedByUser.last_name as verified_by_user_last_name`,
                     knex.raw(`json_build_object(
                     'source','${ChartSourceType.DBT_EXPLORE}',
                     'chart_kind', ${SavedChartsTableName}.last_version_chart_kind,
@@ -249,7 +273,20 @@ export const dbtExploreChartContentConfiguration: ContentConfiguration<SelectSav
                     : null,
                 views: value.views,
                 firstViewedAt: value.first_viewed_at,
-                verification: null,
+                verification:
+                    value.verified_at !== null &&
+                    value.verified_by_user_uuid !== null &&
+                    value.verified_by_user_first_name !== null &&
+                    value.verified_by_user_last_name !== null
+                        ? {
+                              verifiedBy: {
+                                  userUuid: value.verified_by_user_uuid,
+                                  firstName: value.verified_by_user_first_name,
+                                  lastName: value.verified_by_user_last_name,
+                              },
+                              verifiedAt: value.verified_at,
+                          }
+                        : null,
             };
         },
     };

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SpaceContentConfiguration.ts
@@ -107,6 +107,10 @@ export const spaceContentConfiguration: ContentConfiguration<SpaceContentRow> =
                     `${SpaceTableName}.deleted_by_user_uuid`,
                     'deleted_by_user.first_name as deleted_by_user_first_name',
                     'deleted_by_user.last_name as deleted_by_user_last_name',
+                    knex.raw(`null::timestamp as verified_at`),
+                    knex.raw(`null::uuid as verified_by_user_uuid`),
+                    knex.raw(`null as verified_by_user_first_name`),
+                    knex.raw(`null as verified_by_user_last_name`),
                     knex.raw(`json_build_object(
                         'dashboardCount', (${
                             filters.includeDescendantCounts

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -5,6 +5,7 @@ import {
     ContentType,
 } from '@lightdash/common';
 import { Knex } from 'knex';
+import { ContentVerificationTableName } from '../../../database/entities/contentVerification';
 import { DashboardsTableName } from '../../../database/entities/dashboards';
 import { OrganizationTableName } from '../../../database/entities/organizations';
 import { ProjectTableName } from '../../../database/entities/projects';
@@ -84,6 +85,25 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                     `${SavedSqlTableName}.last_version_updated_by_user_uuid`,
                     `updatedByUser.user_uuid`,
                 )
+                .leftJoin(
+                    ContentVerificationTableName,
+                    function verificationJoin() {
+                        this.on(
+                            `${ContentVerificationTableName}.content_uuid`,
+                            '=',
+                            `${SavedSqlTableName}.saved_sql_uuid`,
+                        ).andOn(
+                            `${ContentVerificationTableName}.content_type`,
+                            '=',
+                            knex.raw('?', [ContentType.CHART]),
+                        );
+                    },
+                )
+                .leftJoin(
+                    `${UserTableName} as verifiedByUser`,
+                    `verifiedByUser.user_uuid`,
+                    `${ContentVerificationTableName}.verified_by_user_uuid`,
+                )
                 .select<SelectSavedSql[]>([
                     knex.raw(`'${ContentType.CHART}' as content_type`),
                     knex.raw(
@@ -130,6 +150,10 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                     knex.raw(
                         `(SELECT last_name FROM ${UserTableName} WHERE user_uuid = ${SavedSqlTableName}.deleted_by_user_uuid) as deleted_by_user_last_name`,
                     ),
+                    `${ContentVerificationTableName}.verified_at as verified_at`,
+                    `verifiedByUser.user_uuid as verified_by_user_uuid`,
+                    `verifiedByUser.first_name as verified_by_user_first_name`,
+                    `verifiedByUser.last_name as verified_by_user_last_name`,
                     knex.raw(`json_build_object(
                     'source','${ChartSourceType.SQL}',
                     'chart_kind', ${SavedSqlTableName}.last_version_chart_kind,
@@ -236,7 +260,20 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                     : null,
                 views: value.views,
                 firstViewedAt: value.first_viewed_at,
-                verification: null,
+                verification:
+                    value.verified_at !== null &&
+                    value.verified_by_user_uuid !== null &&
+                    value.verified_by_user_first_name !== null &&
+                    value.verified_by_user_last_name !== null
+                        ? {
+                              verifiedBy: {
+                                  userUuid: value.verified_by_user_uuid,
+                                  firstName: value.verified_by_user_first_name,
+                                  lastName: value.verified_by_user_last_name,
+                              },
+                              verifiedAt: value.verified_at,
+                          }
+                        : null,
             };
         },
     };

--- a/packages/backend/src/models/ContentModel/ContentModelTypes.ts
+++ b/packages/backend/src/models/ContentModel/ContentModelTypes.ts
@@ -73,6 +73,10 @@ export type SummaryContentRow<
     deleted_by_user_uuid: string | null;
     deleted_by_user_first_name: string | null;
     deleted_by_user_last_name: string | null;
+    verified_at: Date | null;
+    verified_by_user_uuid: string | null;
+    verified_by_user_first_name: string | null;
+    verified_by_user_last_name: string | null;
     metadata: T;
 };
 


### PR DESCRIPTION
## Summary

The verified badge appears on charts/dashboards everywhere except the Space overview page. PR #20943 added the indicator to tiles, resource browser, search, and omnibar — this fills the remaining gap.

The frontend already renders `ResourceVerifiedIndicator` in `InfiniteResourceTableColumnName` when `item.data.verification` is populated. The Space page uses `InfiniteResourceTable` → which reads from `/api/v2/content` → which runs through `ContentModel`. The gap was in the backend: `ContentConfiguration`s hardcoded \`verification: null\`.

This left-joins \`content_verification\` (and the verifying user) into the dashboard, dbt-explore chart, and SQL chart configurations, and extends \`SummaryContentRow\` with four new verification columns so all five UNION branches share the same shape (\`space\` and \`data_app\` configs emit NULLs).

Closes PROD-7090.

## Test plan

- [x] Backend typecheck, lint, \`test:dev:nowatch\` (138 tests)
- [x] Verified a chart via the chart menu → Space overview shows the green check indicator on its icon; API response includes \`verification: { verifiedBy, verifiedAt }\`
- [x] Non-verified charts on the same page return \`verification: null\` and render no badge