### PR TITLE
fix(cli): validate preview project exists before defaulting to it

### DIFF
--- a/packages/cli/src/handlers/selectProject.ts
+++ b/packages/cli/src/handlers/selectProject.ts
@@ -1,11 +1,46 @@
+import { LightdashError, Project, ProjectType } from '@lightdash/common';
 import inquirer from 'inquirer';
-import { Config } from '../config';
+import { Config, unsetPreviewProject } from '../config';
 import GlobalState from '../globalState';
 import * as styles from '../styles';
+import { lightdashApi } from './dbt/apiClient';
 
 export type ProjectSelection = {
     projectUuid: string;
     isPreview: boolean;
+};
+
+const validatePreviewProject = async (
+    previewProjectUuid: string | undefined,
+): Promise<string | undefined> => {
+    if (!previewProjectUuid) {
+        return undefined;
+    }
+
+    try {
+        const project = await lightdashApi<Project>({
+            method: 'GET',
+            url: `/api/v1/projects/${previewProjectUuid}`,
+            body: undefined,
+        });
+
+        if (project.type === ProjectType.PREVIEW) {
+            return project.projectUuid;
+        }
+
+        await unsetPreviewProject();
+        return undefined;
+    } catch (error) {
+        if (
+            error instanceof LightdashError &&
+            (error.statusCode === 403 || error.statusCode === 404)
+        ) {
+            await unsetPreviewProject();
+            return undefined;
+        }
+
+        return previewProjectUuid;
+    }
 };
 
 /**
@@ -27,7 +62,9 @@ export const selectProject = async (
     }
 
     const mainProject = config.context?.project;
-    const previewProject = config.context?.previewProject;
+    const previewProject = await validatePreviewProject(
+        config.context?.previewProject,
+    );
     const previewName = config.context?.previewName;
     const mainProjectName = config.context?.projectName;
 


### PR DESCRIPTION
Closes:

### Description:
Before selecting a preview project, the CLI now validates that the stored preview project UUID still exists and is actually a preview project type. If the project is no longer accessible (403/404) or has changed to a non-preview type, the preview project is automatically unset from the config, preventing stale or invalid preview project references from being used in subsequent commands.