### PR TITLE
feat: validate derived dimension eligibility for pre-aggregate materialization

### DIFF
--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -30,6 +30,62 @@ models:
               - total_completed_order_amount
             time_dimension: order_date
             granularity: day
+          - name: basic_sql_dimension_daily
+            dimensions:
+              - status
+              - constant_one
+            metrics:
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: table_ref_dimension_daily
+            dimensions:
+              - status
+              - table_amount
+            metrics:
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: semantic_ref_dimension_daily
+            dimensions:
+              - status
+              - semantic_amount
+            metrics:
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: mixed_expression_dimension_daily
+            dimensions:
+              - status
+              - amount_plus_shipping
+            metrics:
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: recursive_dimension_daily
+            dimensions:
+              - status
+              - amount_plus_shipping_band
+            metrics:
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: param_dimension_rejected_daily
+            dimensions:
+              - status
+              - date_dim_param_test
+            metrics:
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: user_attribute_email_rejected_daily
+            dimensions:
+              - status
+              - user_attribute_email_test
+            metrics:
+              - total_order_amount
+            time_dimension: order_date
+            granularity: day
         primary_key: order_id
         spotlight:
           categories:
@@ -190,6 +246,21 @@ models:
               filter_by: false
               segment_by: false
         type: string
+      - name: user_attribute_email_test
+        description: "Example of dimension based on a user attribute email"
+        meta:
+          dimension:
+            sql: |
+              CASE
+                WHEN ${ld.userAttributes.email} = 'demo@lightdash.com'
+                  THEN ${TABLE}.status
+                ELSE 'non-demo'
+              END
+            groups: ["pre-aggregations"]
+            spotlight:
+              filter_by: false
+              segment_by: false
+        type: string
       - name: order_date
         description: Date (UTC) that the order was placed
         config:
@@ -234,6 +305,36 @@ models:
             dimension:
               format: usd
               round: 2
+            additional_dimensions:
+              constant_one:
+                type: number
+                label: Constant One
+                groups: ["pre-aggregations"]
+                sql: "1"
+              table_amount:
+                type: number
+                label: Table Amount
+                groups: ["pre-aggregations"]
+                sql: ${TABLE}.amount
+              semantic_amount:
+                type: number
+                label: Semantic Amount
+                groups: ["pre-aggregations"]
+                sql: ${amount}
+              amount_plus_shipping:
+                type: number
+                label: Amount Plus Shipping
+                groups: ["pre-aggregations"]
+                sql: ${TABLE}.amount + ${shipping_cost}
+              amount_plus_shipping_band:
+                type: string
+                label: Amount Plus Shipping Band
+                groups: ["pre-aggregations"]
+                sql: |
+                  CASE
+                    WHEN ${amount_plus_shipping} >= 100 THEN 'high'
+                    ELSE 'low'
+                  END
             metrics:
               average_order_size:
                 type: average

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -16,12 +16,20 @@ const makeDimension = ({
     name,
     table,
     type = DimensionType.STRING,
+    sql,
+    compiledSql,
+    parameterReferences,
+    compilationError,
     timeInterval,
     timeIntervalBaseDimensionName,
 }: {
     name: string;
     table: string;
     type?: DimensionType;
+    sql?: string;
+    compiledSql?: string;
+    parameterReferences?: string[];
+    compilationError?: { message: string };
     timeInterval?: TimeFrames;
     timeIntervalBaseDimensionName?: string;
 }): CompiledDimension => ({
@@ -32,10 +40,12 @@ const makeDimension = ({
     label: name,
     table,
     tableLabel: table,
-    sql: `${table}.${name}`,
+    sql: sql ?? `${table}.${name}`,
     hidden: false,
-    compiledSql: `${table}.${name}`,
+    compiledSql: compiledSql ?? sql ?? `${table}.${name}`,
     tablesReferences: [table],
+    ...(parameterReferences ? { parameterReferences } : {}),
+    ...(compilationError ? { compilationError } : {}),
     ...(timeInterval ? { timeInterval } : {}),
     ...(timeIntervalBaseDimensionName ? { timeIntervalBaseDimensionName } : {}),
 });
@@ -316,5 +326,100 @@ describe('buildPreAggregateExplore', () => {
         });
 
         expect(result.tables.orders.metrics.order_count).toBeDefined();
+    });
+
+    it('accepts eligible derived dimensions selected by the pre-aggregate definition', () => {
+        const explore = sourceExplore();
+        explore.tables.orders.dimensions.status_label = makeDimension({
+            name: 'status_label',
+            table: 'orders',
+            sql: "concat(${status}, '-ok')",
+            compiledSql: "concat(orders.status, '-ok')",
+        });
+
+        const result = buildPreAggregateExplore(explore, {
+            name: 'derived_dimension_rollup',
+            dimensions: ['status_label'],
+            metrics: ['order_count'],
+        });
+
+        expect(result.tables.orders.dimensions.status_label).toBeDefined();
+        expect(result.tables.orders.dimensions.status_label.compiledSql).toBe(
+            'orders.orders_status_label',
+        );
+    });
+
+    it('rejects parameterized derived dimensions selected by the pre-aggregate definition', () => {
+        const explore = sourceExplore();
+        explore.tables.orders.dimensions.parameterized_status = makeDimension({
+            name: 'parameterized_status',
+            table: 'orders',
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                    ELSE NULL
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+
+        expect(() =>
+            buildPreAggregateExplore(explore, {
+                name: 'invalid_rollup',
+                dimensions: ['parameterized_status'],
+                metrics: ['order_count'],
+            }),
+        ).toThrow(
+            'Pre-aggregate "invalid_rollup" references ineligible dimension "parameterized_status": dimension "orders_parameterized_status" is not eligible for direct materialization (reason: parameter_references)',
+        );
+    });
+
+    it('rejects user-attribute derived dimensions selected by the pre-aggregate definition', () => {
+        const explore = sourceExplore();
+        explore.tables.orders.dimensions.region_aware_status = makeDimension({
+            name: 'region_aware_status',
+            table: 'orders',
+            sql: "case when ${ld.userAttributes.region} = 'EMEA' then ${TABLE}.status end",
+        });
+
+        expect(() =>
+            buildPreAggregateExplore(explore, {
+                name: 'invalid_rollup',
+                dimensions: ['region_aware_status'],
+                metrics: ['order_count'],
+            }),
+        ).toThrow(
+            'Pre-aggregate "invalid_rollup" references ineligible dimension "region_aware_status": dimension "orders_region_aware_status" is not eligible for direct materialization (reason: user_attributes)',
+        );
+    });
+
+    it('rejects derived dimensions whose recursive dependency is ineligible', () => {
+        const explore = sourceExplore();
+        explore.tables.orders.dimensions.parameterized_status = makeDimension({
+            name: 'parameterized_status',
+            table: 'orders',
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                    ELSE NULL
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+        explore.tables.orders.dimensions.status_wrapper = makeDimension({
+            name: 'status_wrapper',
+            table: 'orders',
+            sql: '${parameterized_status}',
+        });
+
+        expect(() =>
+            buildPreAggregateExplore(explore, {
+                name: 'invalid_rollup',
+                dimensions: ['status_wrapper'],
+                metrics: ['order_count'],
+            }),
+        ).toThrow(
+            'Pre-aggregate "invalid_rollup" references ineligible dimension "status_wrapper": dimension "orders_parameterized_status" is not eligible for direct materialization (reason: parameter_references)',
+        );
     });
 });

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -1,4 +1,5 @@
 import {
+    analyzePreAggregateDerivedDimensionEligibility,
     assertUnreachable,
     ExploreType,
     getItemId,
@@ -219,6 +220,77 @@ const buildDimensionSql = ({
     );
 };
 
+const getSelectedDimension = ({
+    dimensionsByReference,
+    preAggregateDef,
+    dimensionReference,
+}: {
+    dimensionsByReference: Map<string, CompiledDimension[]>;
+    preAggregateDef: PreAggregateDef;
+    dimensionReference: string;
+}): CompiledDimension => {
+    const candidates = dimensionsByReference.get(dimensionReference) || [];
+
+    if (candidates.length === 0) {
+        throw new Error(
+            `Pre-aggregate "${preAggregateDef.name}" references unknown dimension "${dimensionReference}"`,
+        );
+    }
+
+    const isTimeDimensionReference =
+        !!preAggregateDef.timeDimension &&
+        preAggregateUtils.getDimensionBaseName(candidates[0]) ===
+            preAggregateDef.timeDimension;
+
+    if (
+        isTimeDimensionReference &&
+        preAggregateDef.granularity &&
+        preAggregateDef.timeDimension
+    ) {
+        const timeGranularityDimension = candidates.find(
+            (dimension) =>
+                preAggregateUtils.getDimensionBaseName(dimension) ===
+                    preAggregateDef.timeDimension &&
+                dimension.timeInterval === preAggregateDef.granularity,
+        );
+
+        if (!timeGranularityDimension) {
+            throw new Error(
+                `Pre-aggregate "${preAggregateDef.name}" is missing time granularity field "${preAggregateDef.timeDimension}_${preAggregateDef.granularity.toLowerCase()}"`,
+            );
+        }
+
+        return timeGranularityDimension;
+    }
+
+    return (
+        candidates.find((dimension) => !dimension.timeInterval) ?? candidates[0]
+    );
+};
+
+const assertDimensionEligibleForDirectMaterialization = ({
+    sourceExplore,
+    preAggregateDef,
+    dimensionReference,
+    dimension,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+    dimensionReference: string;
+    dimension: CompiledDimension;
+}): void => {
+    const eligibility = analyzePreAggregateDerivedDimensionEligibility({
+        dimension,
+        tables: sourceExplore.tables,
+    });
+
+    if (!eligibility.isEligible) {
+        throw new Error(
+            `Pre-aggregate "${preAggregateDef.name}" references ineligible dimension "${dimensionReference}": dimension "${eligibility.ineligibleDimensionFieldId}" is not eligible for direct materialization (reason: ${eligibility.reason})`,
+        );
+    }
+};
+
 const getIncludedDimensions = (
     sourceExplore: Explore,
     preAggregateDef: PreAggregateDef,
@@ -247,6 +319,21 @@ const getIncludedDimensions = (
     ) {
         defDimensions.add(preAggregateDef.timeDimension);
     }
+
+    Array.from(defDimensions).forEach((dimensionReference) => {
+        const dimension = getSelectedDimension({
+            dimensionsByReference,
+            preAggregateDef,
+            dimensionReference,
+        });
+
+        assertDimensionEligibleForDirectMaterialization({
+            sourceExplore,
+            preAggregateDef,
+            dimensionReference,
+            dimension,
+        });
+    });
 
     const includedDimensions = Object.values(sourceExplore.tables).flatMap(
         (table) =>

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -2,14 +2,47 @@ import {
     DimensionType,
     FieldType,
     FilterOperator,
+    getParameterReferencesFromSqlAndFormat,
     MetricType,
     SupportedDbtAdapter,
     TimeFrames,
     UnitOfTime,
+    type CompiledDimension,
     type Explore,
     type PreAggregateDef,
 } from '@lightdash/common';
 import { buildMaterializationMetricQuery } from './buildMaterializationMetricQuery';
+
+const makeDimension = ({
+    name,
+    type = DimensionType.STRING,
+    sql,
+    compiledSql,
+    parameterReferences,
+    compilationError,
+}: {
+    name: string;
+    type?: DimensionType;
+    sql?: string;
+    compiledSql?: string;
+    parameterReferences?: string[];
+    compilationError?: { message: string };
+}): CompiledDimension => ({
+    fieldType: FieldType.DIMENSION,
+    type,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: sql ?? '${TABLE}.id',
+    hidden: false,
+    compiledSql: compiledSql ?? sql ?? '"orders".id',
+    parameterReferences:
+        parameterReferences ??
+        getParameterReferencesFromSqlAndFormat(sql ?? '${TABLE}.id'),
+    tablesReferences: ['orders'],
+    ...(compilationError ? { compilationError } : {}),
+});
 
 const getSourceExplore = (): Explore =>
     ({
@@ -335,6 +368,112 @@ describe('buildMaterializationMetricQuery', () => {
             }),
         ).toThrow(
             'Pre-aggregate "orders_rollup" generates duplicate materialization metric field ID "orders_avg_order_amount__sum"',
+        );
+    });
+
+    it('includes eligible derived dimensions in the materialization metric query', () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.dimensions.status_label = makeDimension({
+            name: 'status_label',
+            sql: "concat(${status}, '-ok')",
+            compiledSql: `concat("orders".status, '-ok')`,
+        });
+
+        const result = buildMaterializationMetricQuery({
+            sourceExplore,
+            preAggregateDef: {
+                name: 'orders_rollup',
+                dimensions: ['status_label'],
+                metrics: ['order_count'],
+            },
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.metricQuery.dimensions).toEqual(['orders_status_label']);
+    });
+
+    it('rejects parameterized derived dimensions in the materialization metric query', () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.dimensions.parameterized_status =
+            makeDimension({
+                name: 'parameterized_status',
+                sql: `
+                    CASE
+                        WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                        ELSE NULL
+                    END
+                `,
+                parameterReferences: ['orders.region'],
+            });
+
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore,
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['parameterized_status'],
+                    metrics: ['order_count'],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" references ineligible dimension "parameterized_status": dimension "orders_parameterized_status" is not eligible for direct materialization (reason: parameter_references)',
+        );
+    });
+
+    it('rejects user-attribute derived dimensions in the materialization metric query', () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.dimensions.region_aware_status =
+            makeDimension({
+                name: 'region_aware_status',
+                sql: "case when ${lightdash.userAttributes.region} = 'EMEA' then ${TABLE}.status end",
+            });
+
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore,
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['region_aware_status'],
+                    metrics: ['order_count'],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" references ineligible dimension "region_aware_status": dimension "orders_region_aware_status" is not eligible for direct materialization (reason: user_attributes)',
+        );
+    });
+
+    it('rejects derived dimensions when a recursive dependency is ineligible', () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.dimensions.parameterized_status =
+            makeDimension({
+                name: 'parameterized_status',
+                sql: `
+                    CASE
+                        WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                        ELSE NULL
+                    END
+                `,
+                parameterReferences: ['orders.region'],
+            });
+        sourceExplore.tables.orders.dimensions.status_wrapper = makeDimension({
+            name: 'status_wrapper',
+            sql: '${parameterized_status}',
+        });
+
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore,
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status_wrapper'],
+                    metrics: ['order_count'],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" references ineligible dimension "status_wrapper": dimension "orders_parameterized_status" is not eligible for direct materialization (reason: parameter_references)',
         );
     });
 });

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -1,4 +1,5 @@
 import {
+    analyzePreAggregateDerivedDimensionEligibility,
     assertUnreachable,
     convertFieldRefToFieldId,
     getItemId,
@@ -77,15 +78,20 @@ const assertUniqueMetricFieldId = ({
 };
 
 const getDimensionFieldId = ({
-    sourceExplore,
+    dimension,
+}: {
+    dimension: CompiledDimension;
+}): FieldId => getItemId(dimension);
+
+const getSelectedDimension = ({
+    dimensionsByReference,
     preAggregateDef,
     dimensionReference,
 }: {
-    sourceExplore: Explore;
+    dimensionsByReference: Map<string, CompiledDimension[]>;
     preAggregateDef: PreAggregateDef;
     dimensionReference: string;
-}): FieldId => {
-    const dimensionsByReference = getDimensionsByReference(sourceExplore);
+}): CompiledDimension => {
     const candidates = dimensionsByReference.get(dimensionReference) || [];
 
     if (candidates.length === 0) {
@@ -117,14 +123,37 @@ const getDimensionFieldId = ({
             );
         }
 
-        return getItemId(timeGranularityDimension);
+        return timeGranularityDimension;
     }
 
     const exactBaseDimension = candidates.find(
         (dimension) => !dimension.timeInterval,
     );
 
-    return getItemId(exactBaseDimension ?? candidates[0]);
+    return exactBaseDimension ?? candidates[0];
+};
+
+const assertDimensionEligibleForDirectMaterialization = ({
+    sourceExplore,
+    preAggregateDef,
+    dimensionReference,
+    dimension,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+    dimensionReference: string;
+    dimension: CompiledDimension;
+}): void => {
+    const eligibility = analyzePreAggregateDerivedDimensionEligibility({
+        dimension,
+        tables: sourceExplore.tables,
+    });
+
+    if (!eligibility.isEligible) {
+        throw new Error(
+            `Pre-aggregate "${preAggregateDef.name}" references ineligible dimension "${dimensionReference}": dimension "${eligibility.ineligibleDimensionFieldId}" is not eligible for direct materialization (reason: ${eligibility.reason})`,
+        );
+    }
 };
 
 const hasTimeDimensionReference = ({
@@ -202,6 +231,7 @@ export const buildMaterializationMetricQuery = ({
         tables: sourceExplore.tables,
         baseTable: sourceExplore.baseTable,
     });
+    const dimensionsByReference = getDimensionsByReference(sourceExplore);
     const dimensionReferences = [...preAggregateDef.dimensions];
 
     if (
@@ -212,13 +242,39 @@ export const buildMaterializationMetricQuery = ({
         dimensionReferences.push(preAggregateDef.timeDimension);
     }
 
+    const resolveSelectedDimension = (
+        dimensionReference: string,
+    ): CompiledDimension => {
+        const dimension = getSelectedDimension({
+            dimensionsByReference,
+            preAggregateDef,
+            dimensionReference,
+        });
+
+        assertDimensionEligibleForDirectMaterialization({
+            sourceExplore,
+            preAggregateDef,
+            dimensionReference,
+            dimension,
+        });
+
+        return dimension;
+    };
+
+    const selectedDimensions = Array.from(
+        new Map(
+            dimensionReferences.map((dimensionReference) => [
+                dimensionReference,
+                resolveSelectedDimension(dimensionReference),
+            ]),
+        ).values(),
+    );
+
     const dimensions = Array.from(
         new Set(
-            dimensionReferences.map((dimensionReference) =>
+            selectedDimensions.map((dimension) =>
                 getDimensionFieldId({
-                    sourceExplore,
-                    preAggregateDef,
-                    dimensionReference,
+                    dimension,
                 }),
             ),
         ),
@@ -227,9 +283,9 @@ export const buildMaterializationMetricQuery = ({
     const timeDimensionFieldId =
         preAggregateDef.timeDimension && preAggregateDef.granularity
             ? getDimensionFieldId({
-                  sourceExplore,
-                  preAggregateDef,
-                  dimensionReference: preAggregateDef.timeDimension,
+                  dimension: resolveSelectedDimension(
+                      preAggregateDef.timeDimension,
+                  ),
               })
             : null;
 

--- a/packages/common/src/ee/preAggregates/dimensionEligibility.test.ts
+++ b/packages/common/src/ee/preAggregates/dimensionEligibility.test.ts
@@ -1,0 +1,220 @@
+import { getParameterReferencesFromSqlAndFormat } from '../../compiler/parameters';
+import type { CompiledTable } from '../../types/explore';
+import {
+    DimensionType,
+    FieldType,
+    type CompiledDimension,
+} from '../../types/field';
+import { getItemId } from '../../utils/item';
+import {
+    analyzePreAggregateDerivedDimensionEligibility,
+    PreAggregateDerivedDimensionIneligibilityReason,
+} from './dimensionEligibility';
+
+const makeDimension = (
+    overrides: Partial<CompiledDimension> & Pick<CompiledDimension, 'name'>,
+): CompiledDimension => ({
+    ...overrides,
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.STRING,
+    name: overrides.name,
+    label: overrides.label ?? overrides.name,
+    table: overrides.table ?? 'orders',
+    tableLabel: overrides.tableLabel ?? 'Orders',
+    sql: overrides.sql ?? '${TABLE}.id',
+    compiledSql: overrides.compiledSql ?? overrides.sql ?? '"orders".id',
+    parameterReferences:
+        overrides.parameterReferences ??
+        getParameterReferencesFromSqlAndFormat(overrides.sql ?? '${TABLE}.id'),
+    tablesReferences: overrides.tablesReferences ?? ['orders'],
+    hidden: overrides.hidden ?? false,
+});
+
+const makeTables = (
+    dimensions: CompiledDimension[],
+): Record<string, Pick<CompiledTable, 'dimensions'>> =>
+    dimensions.reduce<Record<string, Pick<CompiledTable, 'dimensions'>>>(
+        (acc, dimension) => {
+            acc[dimension.table] = acc[dimension.table] ?? { dimensions: {} };
+            acc[dimension.table].dimensions[dimension.name] = dimension;
+            return acc;
+        },
+        {},
+    );
+
+describe('analyzePreAggregateDerivedDimensionEligibility', () => {
+    it('classifies a plain base dimension as eligible', () => {
+        const orderId = makeDimension({
+            name: 'order_id',
+            sql: '${TABLE}.id',
+            compiledSql: '"orders".id',
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: orderId,
+                tables: makeTables([orderId]),
+            }),
+        ).toEqual({
+            isEligible: true,
+            referencedDimensionFieldIds: [getItemId(orderId)],
+        });
+    });
+
+    it('classifies a derived dimension without runtime context as eligible', () => {
+        const status = makeDimension({
+            name: 'status',
+            sql: '${TABLE}.status',
+            compiledSql: '"orders".status',
+        });
+        const normalizedStatus = makeDimension({
+            name: 'normalized_status',
+            sql: 'upper(${status})',
+        });
+        const statusLabel = makeDimension({
+            name: 'status_label',
+            sql: "concat(${normalized_status}, '-ok')",
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: statusLabel,
+                tables: makeTables([status, normalizedStatus, statusLabel]),
+            }),
+        ).toEqual({
+            isEligible: true,
+            referencedDimensionFieldIds: [
+                getItemId(statusLabel),
+                getItemId(normalizedStatus),
+                getItemId(status),
+            ],
+        });
+    });
+
+    it('rejects when a dimension sql references a parameter directly', () => {
+        const status = makeDimension({
+            name: 'status',
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                    ELSE NULL
+                END
+            `,
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: status,
+                tables: makeTables([status]),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedDimensionIneligibilityReason.PARAMETER_REFERENCES,
+            ineligibleDimensionFieldId: getItemId(status),
+            referencedDimensionFieldIds: [getItemId(status)],
+        });
+    });
+
+    it('rejects when a recursive dependency has parameter references', () => {
+        const status = makeDimension({
+            name: 'status',
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                    ELSE NULL
+                END
+            `,
+        });
+        const filteredStatus = makeDimension({
+            name: 'filtered_status',
+            sql: '${status}',
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: filteredStatus,
+                tables: makeTables([status, filteredStatus]),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedDimensionIneligibilityReason.PARAMETER_REFERENCES,
+            ineligibleDimensionFieldId: getItemId(status),
+            referencedDimensionFieldIds: [
+                getItemId(filteredStatus),
+                getItemId(status),
+            ],
+        });
+    });
+
+    it('rejects when the dimension sql contains a direct user attribute reference', () => {
+        const regionAwareStatus = makeDimension({
+            name: 'region_aware_status',
+            sql: "case when ${ld.userAttributes.region} = 'EMEA' then ${TABLE}.status end",
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: regionAwareStatus,
+                tables: makeTables([regionAwareStatus]),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedDimensionIneligibilityReason.USER_ATTRIBUTES,
+            ineligibleDimensionFieldId: getItemId(regionAwareStatus),
+            referencedDimensionFieldIds: [getItemId(regionAwareStatus)],
+        });
+    });
+
+    it('rejects when a nested dependency has a compilation error', () => {
+        const status = makeDimension({
+            name: 'status',
+            sql: '${TABLE}.status',
+            compilationError: {
+                message: 'Cannot compile',
+            },
+        });
+        const prettyStatus = makeDimension({
+            name: 'pretty_status',
+            sql: "concat(${orders.status}, '!')",
+        });
+        const statusWrapper = makeDimension({
+            name: 'status_wrapper',
+            sql: '${pretty_status}',
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: statusWrapper,
+                tables: makeTables([status, prettyStatus, statusWrapper]),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedDimensionIneligibilityReason.COMPILATION_ERROR,
+            ineligibleDimensionFieldId: getItemId(status),
+            referencedDimensionFieldIds: [
+                getItemId(statusWrapper),
+                getItemId(prettyStatus),
+                getItemId(status),
+            ],
+        });
+    });
+
+    it('rejects circular dependencies without recursing indefinitely', () => {
+        const loop = makeDimension({
+            name: 'loop',
+            sql: '${loop}',
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: loop,
+                tables: makeTables([loop]),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedDimensionIneligibilityReason.CIRCULAR_DEPENDENCY,
+            ineligibleDimensionFieldId: getItemId(loop),
+            referencedDimensionFieldIds: [getItemId(loop)],
+        });
+    });
+});

--- a/packages/common/src/ee/preAggregates/dimensionEligibility.ts
+++ b/packages/common/src/ee/preAggregates/dimensionEligibility.ts
@@ -1,0 +1,217 @@
+import {
+    getAllReferences,
+    getParsedReference,
+} from '../../compiler/exploreCompiler';
+import type { CompiledTable } from '../../types/explore';
+import type { CompiledDimension, FieldId } from '../../types/field';
+import { getItemId } from '../../utils/item';
+
+const USER_ATTRIBUTE_REFERENCE_PREFIXES = [
+    '${ld.userAttributes.',
+    '${lightdash.userAttributes.',
+] as const;
+
+export enum PreAggregateDerivedDimensionIneligibilityReason {
+    CIRCULAR_DEPENDENCY = 'circular_dependency',
+    COMPILATION_ERROR = 'compilation_error',
+    MISSING_DEPENDENCY = 'missing_dependency',
+    PARAMETER_REFERENCES = 'parameter_references',
+    USER_ATTRIBUTES = 'user_attributes',
+}
+
+type PreAggregateDerivedDimensionEligibilityBase = {
+    referencedDimensionFieldIds: FieldId[];
+};
+
+export type PreAggregateDerivedDimensionEligibility =
+    | ({
+          isEligible: true;
+      } & PreAggregateDerivedDimensionEligibilityBase)
+    | ({
+          isEligible: false;
+          ineligibleDimensionFieldId: FieldId;
+          reason: PreAggregateDerivedDimensionIneligibilityReason;
+      } & PreAggregateDerivedDimensionEligibilityBase);
+
+type PreAggregateDimensionLookup = Record<
+    string,
+    Pick<CompiledTable, 'dimensions'>
+>;
+
+type EligibilityTraversalState = {
+    activeFieldIds: Set<FieldId>;
+    cache: Map<FieldId, PreAggregateDerivedDimensionEligibility>;
+};
+
+const mergeReferencedFieldIds = (
+    current: FieldId[],
+    next: FieldId[],
+): FieldId[] => Array.from(new Set([...current, ...next]));
+
+const hasParameterReferences = (dimension: CompiledDimension): boolean =>
+    (dimension.parameterReferences?.length ?? 0) > 0;
+
+const hasExplicitUserAttributeReference = (sql: string): boolean =>
+    // There is no shared extractor for user-attribute references today, so keep
+    // this first slice limited to explicit tokens we can detect cheaply.
+    USER_ATTRIBUTE_REFERENCE_PREFIXES.some((prefix) => sql.includes(prefix));
+
+const getReferencedDimension = ({
+    dimension,
+    ref,
+    tables,
+}: {
+    dimension: CompiledDimension;
+    ref: string;
+    tables: PreAggregateDimensionLookup;
+}): CompiledDimension | undefined => {
+    if (ref === 'TABLE') {
+        return undefined;
+    }
+
+    const { refTable, refName } = getParsedReference(ref, dimension.table);
+    return tables[refTable]?.dimensions[refName];
+};
+
+const getIneligibleResult = ({
+    fieldId,
+    reason,
+    referencedDimensionFieldIds,
+}: {
+    fieldId: FieldId;
+    reason: PreAggregateDerivedDimensionIneligibilityReason;
+    referencedDimensionFieldIds: FieldId[];
+}): PreAggregateDerivedDimensionEligibility => ({
+    isEligible: false,
+    reason,
+    ineligibleDimensionFieldId: fieldId,
+    referencedDimensionFieldIds,
+});
+
+const analyzeDimensionEligibility = ({
+    dimension,
+    tables,
+    state,
+}: {
+    dimension: CompiledDimension;
+    tables: PreAggregateDimensionLookup;
+    state: EligibilityTraversalState;
+}): PreAggregateDerivedDimensionEligibility => {
+    const currentFieldId = getItemId(dimension);
+    const cachedResult = state.cache.get(currentFieldId);
+    if (cachedResult) {
+        return cachedResult;
+    }
+
+    if (state.activeFieldIds.has(currentFieldId)) {
+        return getIneligibleResult({
+            fieldId: currentFieldId,
+            reason: PreAggregateDerivedDimensionIneligibilityReason.CIRCULAR_DEPENDENCY,
+            referencedDimensionFieldIds: [currentFieldId],
+        });
+    }
+
+    state.activeFieldIds.add(currentFieldId);
+
+    let result: PreAggregateDerivedDimensionEligibility = {
+        isEligible: true,
+        referencedDimensionFieldIds: [currentFieldId],
+    };
+
+    try {
+        if (dimension.compilationError) {
+            result = getIneligibleResult({
+                fieldId: currentFieldId,
+                reason: PreAggregateDerivedDimensionIneligibilityReason.COMPILATION_ERROR,
+                referencedDimensionFieldIds: [currentFieldId],
+            });
+            return result;
+        }
+
+        if (hasParameterReferences(dimension)) {
+            result = getIneligibleResult({
+                fieldId: currentFieldId,
+                reason: PreAggregateDerivedDimensionIneligibilityReason.PARAMETER_REFERENCES,
+                referencedDimensionFieldIds: [currentFieldId],
+            });
+            return result;
+        }
+
+        if (hasExplicitUserAttributeReference(dimension.sql)) {
+            result = getIneligibleResult({
+                fieldId: currentFieldId,
+                reason: PreAggregateDerivedDimensionIneligibilityReason.USER_ATTRIBUTES,
+                referencedDimensionFieldIds: [currentFieldId],
+            });
+            return result;
+        }
+
+        for (const ref of getAllReferences(dimension.sql)) {
+            const referencedDimension = getReferencedDimension({
+                dimension,
+                ref,
+                tables,
+            });
+
+            if (!referencedDimension) {
+                if (ref === 'TABLE') {
+                    // eslint-disable-next-line no-continue
+                    continue;
+                }
+
+                result = getIneligibleResult({
+                    fieldId: currentFieldId,
+                    reason: PreAggregateDerivedDimensionIneligibilityReason.MISSING_DEPENDENCY,
+                    referencedDimensionFieldIds:
+                        result.referencedDimensionFieldIds,
+                });
+                return result;
+            }
+
+            const referencedDimensionEligibility = analyzeDimensionEligibility({
+                dimension: referencedDimension,
+                tables,
+                state,
+            });
+
+            const referencedDimensionFieldIds = mergeReferencedFieldIds(
+                result.referencedDimensionFieldIds,
+                referencedDimensionEligibility.referencedDimensionFieldIds,
+            );
+
+            if (!referencedDimensionEligibility.isEligible) {
+                result = {
+                    ...referencedDimensionEligibility,
+                    referencedDimensionFieldIds,
+                };
+                return result;
+            }
+
+            result = {
+                isEligible: true,
+                referencedDimensionFieldIds,
+            };
+        }
+
+        return result;
+    } finally {
+        state.activeFieldIds.delete(currentFieldId);
+        state.cache.set(currentFieldId, result);
+    }
+};
+
+export const analyzePreAggregateDerivedDimensionEligibility = ({
+    dimension,
+    tables,
+}: {
+    dimension: CompiledDimension;
+    tables: PreAggregateDimensionLookup;
+}): PreAggregateDerivedDimensionEligibility =>
+    analyzeDimensionEligibility({
+        dimension,
+        tables,
+        state: {
+            activeFieldIds: new Set<FieldId>(),
+            cache: new Map<FieldId, PreAggregateDerivedDimensionEligibility>(),
+        },
+    });

--- a/packages/common/src/ee/preAggregates/index.ts
+++ b/packages/common/src/ee/preAggregates/index.ts
@@ -1,1 +1,6 @@
 export * from './audit';
+export {
+    analyzePreAggregateDerivedDimensionEligibility,
+    PreAggregateDerivedDimensionIneligibilityReason,
+    type PreAggregateDerivedDimensionEligibility,
+} from './dimensionEligibility';

--- a/packages/common/src/ee/preAggregates/utils.ts
+++ b/packages/common/src/ee/preAggregates/utils.ts
@@ -1,4 +1,9 @@
 export { getAdditivityType, isCompatible } from './additivity';
+export {
+    analyzePreAggregateDerivedDimensionEligibility,
+    PreAggregateDerivedDimensionIneligibilityReason,
+    type PreAggregateDerivedDimensionEligibility,
+} from './dimensionEligibility';
 export { applyUserBypass, findMatch } from './matcher';
 export {
     getMetricRepresentation,


### PR DESCRIPTION
Closes:

### Description:

Adds eligibility validation for derived dimensions used in pre-aggregate definitions, preventing dimensions that reference runtime context (user attributes or parameters) from being materialized.

A new `analyzePreAggregateDerivedDimensionEligibility` function recursively walks a dimension's SQL dependency graph and classifies it as eligible or ineligible for direct materialization. Ineligibility reasons include:

- `parameter_references` — the dimension or one of its dependencies references a Lightdash parameter
- `user_attributes` — the dimension SQL contains a user attribute reference (e.g. `${ld.userAttributes.*}`)
- `compilation_error` — a dependency failed to compile
- `missing_dependency` — a referenced dimension cannot be resolved
- `circular_dependency` — a cycle is detected in the dependency graph

This validation is enforced in both `buildPreAggregateExplore` and `buildMaterializationMetricQuery`, throwing a descriptive error that identifies the pre-aggregate name, the referenced dimension, and the specific ineligible field with its reason.

The jaffle shop demo has been extended with example pre-aggregate definitions covering basic SQL dimensions, table-ref dimensions, semantic-ref dimensions, mixed expressions, recursive dimensions, and rejected cases for parameterized and user-attribute dimensions.