### PR TITLE
fix(data-apps): hide promote option for data apps in space view

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -339,7 +339,8 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                                 )}
                             {userCanPromoteChart &&
                                 !isSqlChart &&
-                                item.type !== ResourceViewItemType.SPACE && (
+                                item.type !== ResourceViewItemType.SPACE &&
+                                item.type !== ResourceViewItemType.DATA_APP && (
                                     <Tooltip
                                         label="You must enable first an upstream project in settings > Data ops"
                                         disabled={


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-316/add-apps-to-spaces

### Description:
Promotion is not supported for data apps, so the menu item was showing as disabled/greyed out. Hide it entirely for DATA_APP items instead.
