### PR TITLE
feat(data-apps): add Data Apps option to space content type filter

### DIFF
--- a/packages/frontend/src/components/common/ResourceView/ContentTypeFilter.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ContentTypeFilter.tsx
@@ -24,6 +24,10 @@ const ContentTypeOptions = [
         value: ContentType.CHART,
         label: <ContentTypeSelectOption label={'Charts'} />,
     },
+    {
+        value: ContentType.DATA_APP,
+        label: <ContentTypeSelectOption label={'Data Apps'} />,
+    },
 ];
 type ContentTypeFilterProps = {
     value: ContentType | undefined;

--- a/packages/frontend/src/pages/Space.tsx
+++ b/packages/frontend/src/pages/Space.tsx
@@ -1,6 +1,7 @@
 import { subject } from '@casl/ability';
 import {
     ContentType,
+    FeatureFlags,
     LightdashMode,
     ResourceViewItemType,
     type ResourceViewSpaceItem,
@@ -37,6 +38,7 @@ import { AddToSpaceResources } from '../components/Explorer/SpaceBrowser/types';
 import ForbiddenPanel from '../components/ForbiddenPanel';
 import { useSpacePinningMutation } from '../hooks/pinning/useSpaceMutation';
 import { useContentAction } from '../hooks/useContent';
+import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useSpace } from '../hooks/useSpaces';
 import { Can } from '../providers/Ability';
 import useApp from '../providers/App/useApp';
@@ -71,6 +73,8 @@ const Space: FC = () => {
     );
 
     const isDemo = health.data?.mode === LightdashMode.DEMO;
+    const dataAppsFlag = useServerFeatureFlag(FeatureFlags.EnableDataApps);
+    const dataAppsEnabled = dataAppsFlag.data?.enabled ?? false;
     const navigate = useNavigate();
     const location = useLocation();
 
@@ -400,7 +404,13 @@ const Space: FC = () => {
                         }}
                         contentTypeFilter={{
                             defaultValue: undefined,
-                            options: [ContentType.DASHBOARD, ContentType.CHART],
+                            options: [
+                                ContentType.DASHBOARD,
+                                ContentType.CHART,
+                                ...(dataAppsEnabled
+                                    ? [ContentType.DATA_APP]
+                                    : []),
+                            ],
                         }}
                         columnVisibility={{
                             [ColumnVisibility.SPACE]: false,


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-316/add-apps-to-spaces

### Description:
Adds a filter toggle along-side All|Dashboards|Charts to filter for "Data Apps".

<img width="671" height="167" alt="image" src="https://github.com/user-attachments/assets/28a61db7-d529-4571-b25c-2f270f347029" />

