### PR TITLE
feat(explorer): show resolved timezone badge on chart card

### DIFF
--- a/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
+++ b/packages/frontend/src/components/Explorer/SavedChartsHeader/index.tsx
@@ -88,10 +88,7 @@ import { useExplorerQuery } from '../../../hooks/useExplorerQuery';
 import { useProject } from '../../../hooks/useProject';
 import { useUpdateMutation } from '../../../hooks/useSavedQuery';
 import useSearchParams from '../../../hooks/useSearchParams';
-import {
-    useClientFeatureFlag,
-    useServerFeatureFlag,
-} from '../../../hooks/useServerOrClientFeatureFlag';
+import { useServerFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
 import { Can } from '../../../providers/Ability';
 import useApp from '../../../providers/App/useApp';
 import {
@@ -122,9 +119,6 @@ import SaveChartButton from '../SaveChartButton';
 import { TitleBreadCrumbs } from './TitleBreadcrumbs';
 
 const SavedChartsHeader: FC = () => {
-    const userTimeZonesEnabled = useClientFeatureFlag(
-        FeatureFlags.EnableUserTimezones,
-    );
     const { data: changeChartExploreFlag } = useServerFeatureFlag(
         FeatureFlags.ChangeChartExplore,
     );
@@ -562,13 +556,6 @@ const SavedChartsHeader: FC = () => {
                         </>
                     )}
                 </div>
-                {userTimeZonesEnabled &&
-                    savedChart?.metricQuery.timezone &&
-                    !isEditMode && (
-                        <Text c="gray" mr="sm" fz="xs">
-                            {savedChart?.metricQuery.timezone}
-                        </Text>
-                    )}
                 {(userCanManageChart ||
                     userCanCreateDeliveriesAndAlerts ||
                     userCanManageExplore) && (

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -57,6 +57,7 @@ import { VisualizationConfigPortalId } from '../ExplorePanel/constants';
 import { DevCopyChartDebugData } from '../ExplorerHeader/DevCopyChartDebugData';
 import VisualizationConfig from '../VisualizationCard/VisualizationConfig';
 import { SeriesContextMenu } from './SeriesContextMenu';
+import VisualizationTimezone from './VisualizationTimezone';
 import VisualizationWarning from './VisualizationWarning';
 
 export type EchartsClickEvent = {
@@ -317,6 +318,14 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                     rightHeaderElement={
                         isOpen && (
                             <>
+                                <VisualizationTimezone
+                                    resolvedTimezone={
+                                        query.data?.resolvedTimezone
+                                    }
+                                    metricQueryTimezone={
+                                        query.data?.metricQuery?.timezone
+                                    }
+                                />
                                 {isEditMode ? (
                                     <Button
                                         {...COLLAPSABLE_CARD_BUTTON_PROPS}

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
@@ -31,12 +31,12 @@ const VisualizationTimezone: FC<Props> = ({
         >
             <Badge
                 leftSection={<MantineIcon icon={IconClock} size="sm" />}
-                color="gray"
+                color="ldGray.6"
                 variant="transparent"
                 size="sm"
                 tt="none"
             >
-                {getTimezoneLabel(timezone) ?? timezone}
+                {getTimezoneLabel(timezone)}
             </Badge>
         </Tooltip>
     );

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
@@ -1,0 +1,45 @@
+import { FeatureFlags, getTimezoneLabel } from '@lightdash/common';
+import { Badge, Tooltip } from '@mantine-8/core';
+import { IconClock } from '@tabler/icons-react';
+import { type FC } from 'react';
+import { useClientFeatureFlag } from '../../../hooks/useServerOrClientFeatureFlag';
+import MantineIcon from '../../common/MantineIcon';
+
+type Props = {
+    resolvedTimezone: string | null | undefined;
+    // Backwards-compat fallback: before `EnableTimezoneSupport`, the only
+    // timezone signal was the user override on the query. Remove this prop
+    // once that flag graduates and `resolvedTimezone` is always populated.
+    metricQueryTimezone: string | null | undefined;
+};
+
+const VisualizationTimezone: FC<Props> = ({
+    resolvedTimezone,
+    metricQueryTimezone,
+}) => {
+    const userTimeZonesEnabled = useClientFeatureFlag(
+        FeatureFlags.EnableUserTimezones,
+    );
+    const timezone =
+        resolvedTimezone ?? (userTimeZonesEnabled ? metricQueryTimezone : null);
+    if (!timezone) return null;
+
+    return (
+        <Tooltip
+            label="Results and chart values are rendered in this timezone"
+            position="bottom"
+        >
+            <Badge
+                leftSection={<MantineIcon icon={IconClock} size="sm" />}
+                color="gray"
+                variant="transparent"
+                size="sm"
+                tt="none"
+            >
+                {getTimezoneLabel(timezone) ?? timezone}
+            </Badge>
+        </Tooltip>
+    );
+};
+
+export default VisualizationTimezone;

--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationTimezone.tsx
@@ -26,7 +26,7 @@ const VisualizationTimezone: FC<Props> = ({
 
     return (
         <Tooltip
-            label="Results and chart values are rendered in this timezone"
+            label={`Chart and results shown in ${timezone} time zone`}
             position="bottom"
         >
             <Badge

--- a/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
+++ b/packages/frontend/src/components/SettingsQueryTimezone/index.tsx
@@ -1,4 +1,9 @@
-import { getErrorMessage, isApiError, type Project } from '@lightdash/common';
+import {
+    FeatureFlags,
+    getErrorMessage,
+    isApiError,
+    type Project,
+} from '@lightdash/common';
 import {
     Anchor,
     Button,
@@ -16,6 +21,7 @@ import {
     useProject,
     useProjectUpdateQueryTimezoneSettings,
 } from '../../hooks/useProject';
+import { useServerFeatureFlag } from '../../hooks/useServerOrClientFeatureFlag';
 import { SettingsGridCard } from '../common/Settings/SettingsCard';
 import TimeZonePicker from '../common/TimeZonePicker';
 
@@ -74,6 +80,10 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
     projectUuid,
 }) => {
     const { showToastError, showToastSuccess } = useToaster();
+    const { data: timezoneSupportFlag } = useServerFeatureFlag(
+        FeatureFlags.EnableTimezoneSupport,
+    );
+    const timezoneSupportEnabled = timezoneSupportFlag?.enabled === true;
     const { data: project, isLoading: isLoadingProject } =
         useProject(projectUuid);
     const projectMutation = useProjectUpdateQueryTimezoneSettings(projectUuid);
@@ -107,12 +117,24 @@ const SettingsQueryTimezone: FC<SettingsQueryTimezoneProps> = ({
                 <Stack gap="xs">
                     <Title order={4}>Query time zone</Title>
                     <Text c="ldGray.6" fz="sm">
-                        Controls what &quot;today&quot;, &quot;this week&quot;,
-                        and other &quot;in the current&quot; date filters mean.
-                        For example, if set to US/Eastern, &quot;today&quot;
-                        means midnight-to-midnight New York time instead of UTC.
-                        This does not change your database&apos;s session time
-                        zone.
+                        {timezoneSupportEnabled ? (
+                            <>
+                                The time zone used for date filters, time
+                                grouping, and how dates appear in charts and
+                                tables. This does not change your
+                                database&apos;s session time zone.
+                            </>
+                        ) : (
+                            <>
+                                Controls what &quot;today&quot;, &quot;this
+                                week&quot;, and other &quot;in the current&quot;
+                                date filters mean. For example, if set to
+                                US/Eastern, &quot;today&quot; means
+                                midnight-to-midnight New York time instead of
+                                UTC. This does not change your database&apos;s
+                                session time zone.
+                            </>
+                        )}
                     </Text>
                     <Text c="ldGray.6" fz="xs">
                         Learn more in our{' '}


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-332/change-project-query-timezone-setting-name-and-description

### Description:

- Changes the project query timezone setting description to describe the new behavior when flag is ON
- Adds a timezone indicator to edit/view charts. Keeping backwards compatibility with the old indicator but unifying it so it get's displayed in the chart card header

**Before**

![CleanShot 2026-04-24 at 11.00.35.png](https://app.graphite.com/user-attachments/assets/d5280128-14d9-4544-851f-f679327a8df4.png)

Only in view mode
![CleanShot 2026-04-24 at 11.00.01.png](https://app.graphite.com/user-attachments/assets/be4b99e3-1678-4c25-8d11-e092ec960051.png)

**After**

![CleanShot 2026-04-24 at 10.59.02.png](https://app.graphite.com/user-attachments/assets/0aca3d57-1314-4cb3-9b82-5dd8362a6868.png)

<img width="492" height="830" alt="CleanShot 2026-04-24 at 11 20 32" src="https://github.com/user-attachments/assets/cd6477cb-6f70-4ab6-9376-3bd4146bfd2b" />


