### PR TITLE
fix: allow template and formula table calculations in pre-aggregate matcher

### DIFF
--- a/packages/backend/src/ee/preAggregates/matcher.test.ts
+++ b/packages/backend/src/ee/preAggregates/matcher.test.ts
@@ -9,6 +9,7 @@ import {
     PreAggregateMissReason,
     preAggregateUtils,
     SupportedDbtAdapter,
+    TableCalculationTemplateType,
     TimeFrames,
     UnitOfTime,
     type CompiledDimension,
@@ -1232,7 +1233,78 @@ describe('findMatch', () => {
         });
     });
 
-    it('returns table_calculation_present when table calculations exist', () => {
+    it('returns hit when only template table calculations exist', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_summary',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                tableCalculations: [
+                    {
+                        name: 'calc_1',
+                        displayName: 'Calc',
+                        template: {
+                            type: TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL,
+                            fieldId: 'orders_order_count',
+                        },
+                    },
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('returns hit when only formula table calculations exist', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_summary',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                tableCalculations: [
+                    {
+                        name: 'calc_1',
+                        displayName: 'Calc',
+                        formula: '=orders_order_count * 2',
+                    },
+                ],
+            }),
+            explore,
+        );
+
+        expect(result).toStrictEqual({
+            hit: true,
+            preAggregateName: 'orders_summary',
+            miss: null,
+        });
+    });
+
+    it('returns table_calculation_present when a SQL table calculation exists', () => {
         const explore = {
             ...baseExplore(),
             preAggregates: [
@@ -1262,6 +1334,47 @@ describe('findMatch', () => {
         expect(result.miss).toStrictEqual({
             reason: PreAggregateMissReason.TABLE_CALCULATION_PRESENT,
             fieldId: 'calc_1',
+        });
+    });
+
+    it('returns table_calculation_present when SQL and semantic table calculations are mixed', () => {
+        const explore = {
+            ...baseExplore(),
+            preAggregates: [
+                {
+                    name: 'orders_summary',
+                    dimensions: ['status'],
+                    metrics: ['order_count'],
+                },
+            ],
+        };
+
+        const result = preAggregateUtils.findMatch(
+            makeMetricQuery({
+                dimensions: ['orders_status'],
+                metrics: ['orders_order_count'],
+                tableCalculations: [
+                    {
+                        name: 'calc_template',
+                        displayName: 'Template calc',
+                        template: {
+                            type: TableCalculationTemplateType.PERCENT_OF_COLUMN_TOTAL,
+                            fieldId: 'orders_order_count',
+                        },
+                    },
+                    {
+                        name: 'calc_sql',
+                        displayName: 'SQL calc',
+                        sql: '1',
+                    },
+                ],
+            }),
+            explore,
+        );
+
+        expect(result.miss).toStrictEqual({
+            reason: PreAggregateMissReason.TABLE_CALCULATION_PRESENT,
+            fieldId: 'calc_sql',
         });
     });
 

--- a/packages/common/src/ee/preAggregates/matcher.ts
+++ b/packages/common/src/ee/preAggregates/matcher.ts
@@ -3,6 +3,7 @@ import {
     convertFieldRefToFieldId,
     isCustomBinDimension,
     isCustomSqlDimension,
+    isSqlTableCalculation,
     MetricType,
     type FieldId,
 } from '../../types/field';
@@ -974,13 +975,16 @@ export const findMatch = (
         };
     }
 
-    if ((metricQuery.tableCalculations || []).length > 0) {
+    const sqlTableCalculation = (metricQuery.tableCalculations || []).find(
+        isSqlTableCalculation,
+    );
+    if (sqlTableCalculation) {
         return {
             hit: false,
             preAggregateName: null,
             miss: {
                 reason: PreAggregateMissReason.TABLE_CALCULATION_PRESENT,
-                fieldId: getItemId(metricQuery.tableCalculations[0]),
+                fieldId: getItemId(sqlTableCalculation),
             },
         };
     }

--- a/packages/common/src/types/preAggregate.ts
+++ b/packages/common/src/types/preAggregate.ts
@@ -191,10 +191,10 @@ export const preAggregateMissReasonLabels: Record<
         'Pre-aggregate filter not satisfied',
     [PreAggregateMissReason.GRANULARITY_TOO_FINE]: 'Granularity too fine',
     [PreAggregateMissReason.CUSTOM_DIMENSION_PRESENT]:
-        'Custom dimension present',
-    [PreAggregateMissReason.CUSTOM_METRIC_PRESENT]: 'Custom metric present',
+        'Custom dimension detected',
+    [PreAggregateMissReason.CUSTOM_METRIC_PRESENT]: 'Custom metric detected',
     [PreAggregateMissReason.TABLE_CALCULATION_PRESENT]:
-        'Table calculation present',
+        'SQL Table calculation detected',
     [PreAggregateMissReason.USER_BYPASS]: 'Bypassed by user',
     [PreAggregateMissReason.EXPLORE_RESOLUTION_ERROR]:
         'Materialized explore not found',


### PR DESCRIPTION
Closes:

### Description:

Previously, the pre-aggregate matcher would return a `table_calculation_present` miss for **any** table calculation, including template-based (e.g. percent of column total) and formula-based calculations. These types of table calculations don't use raw SQL and can safely be applied on top of pre-aggregated results.

The matcher now only blocks pre-aggregate usage when a SQL-based table calculation is present. Template and formula table calculations are treated as compatible, allowing pre-aggregate hits to still be returned in those cases. Mixed scenarios where both SQL and semantic table calculations exist will still correctly return a miss, reporting the SQL calculation as the blocking field.