### PR TITLE
fix(pre-aggregates): scope dashboard filters per-tile in audit [ZAP-329]

### DIFF
--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.auditDashboard.test.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.auditDashboard.test.ts
@@ -1,10 +1,13 @@
 import {
     DashboardTileTypes,
+    FilterOperator,
     NotFoundError,
     PreAggregateMissReason,
+    preAggregateUtils,
     TileIneligibleReason,
     type Account,
     type Dashboard,
+    type DashboardFilterRule,
     type Explore,
     type MetricQuery,
     type SavedChart,
@@ -69,6 +72,7 @@ const emptyMetricQuery: MetricQuery = {
 const makeExplore = (withPreAggs: boolean): Explore =>
     ({
         name: 'orders',
+        tables: {},
         preAggregates: withPreAggs
             ? [{ name: 'orders_daily', dimensions: [], metrics: [] }]
             : [],
@@ -334,5 +338,60 @@ describe('PreAggregateStrategy.auditDashboard', () => {
         expect(
             result.tabs.find((t) => t.tabUuid === null)!.tiles[0].tileUuid,
         ).toBe('t-3');
+    });
+
+    it('drops dashboard filter rules whose field is not in the tile explore before calling findMatch', async () => {
+        const findMatchSpy = jest.spyOn(preAggregateUtils, 'findMatch');
+        try {
+            const deps = makeDeps();
+            const offExploreFilter: DashboardFilterRule = {
+                id: 'f-off',
+                target: {
+                    fieldId: 'other_browser',
+                    tableName: 'other',
+                },
+                operator: FilterOperator.EQUALS,
+                values: ['chrome'],
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any;
+            const dashboard = makeDashboard({
+                tiles: [makeTile({ uuid: 't-1' })],
+                filters: {
+                    dimensions: [offExploreFilter],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+            });
+            deps.savedChartModel.get.mockResolvedValue({
+                uuid: 'c-1',
+                tableName: 'orders',
+                metricQuery: emptyMetricQuery,
+                // eslint-disable-next-line @typescript-eslint/no-explicit-any
+            } as any);
+            deps.projectService.getExplore.mockResolvedValue(
+                makeExplore(false),
+            );
+            const strategy = makeStrategy(deps);
+
+            await strategy.auditDashboard({
+                account,
+                projectUuid,
+                dashboard,
+            });
+
+            expect(findMatchSpy).toHaveBeenCalledTimes(1);
+            const [mqArg] = findMatchSpy.mock.calls[0] as [
+                MetricQuery,
+                Explore,
+            ];
+            const dimGroup = mqArg.filters?.dimensions as
+                | { and?: unknown[]; or?: unknown[] }
+                | undefined;
+            const dimensionFilterCount =
+                dimGroup?.and?.length ?? dimGroup?.or?.length ?? 0;
+            expect(dimensionFilterCount).toBe(0);
+        } finally {
+            findMatchSpy.mockRestore();
+        }
     });
 });

--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -4,6 +4,10 @@ import {
     assertUnreachable,
     DashboardTileTypes,
     ExploreType,
+    getDashboardFiltersForTileAndTables,
+    getDimensionMapFromTables,
+    getMetricsMapFromTables,
+    isFilterableDimension,
     NotFoundError,
     preAggregateUtils,
     QueryExecutionContext as QEC,
@@ -431,9 +435,29 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
                     throw e;
                 }
 
+                // Scope dashboard filters to this tile — mirror of the live
+                // query path in AsyncQueryService.
+                const availableFieldIds = [
+                    ...Object.entries(getDimensionMapFromTables(explore.tables))
+                        .filter(
+                            ([, field]) =>
+                                isFilterableDimension(field) && !field.hidden,
+                        )
+                        .map(([fieldId]) => fieldId),
+                    ...Object.entries(getMetricsMapFromTables(explore.tables))
+                        .filter(([, field]) => !field.hidden)
+                        .map(([fieldId]) => fieldId),
+                ];
+                const appliedDashboardFilters =
+                    getDashboardFiltersForTileAndTables(
+                        tile.uuid,
+                        availableFieldIds,
+                        savedDashboardFilters,
+                    );
+
                 const metricQuery = addDashboardFiltersToMetricQuery(
                     savedChart.metricQuery,
-                    savedDashboardFilters,
+                    appliedDashboardFilters,
                     explore,
                 );
 


### PR DESCRIPTION
## Summary

- The new \`pre-aggregate-audit\` command (and the \`/pre-aggregates/dashboards/{uuid}/audit\` endpoint behind it) was reporting false \`filter_dimension_not_in_pre_aggregate\` misses: it injected every dashboard-level dimension filter into every tile's metric query before calling \`preAggregateUtils.findMatch\`, regardless of whether the filter targeted a field in the tile's explore or was disabled for that tile via \`tileTargets\`.
- Concretely, on a dashboard whose only dimension filter was \`dbt_orders.browser\`, the CLI reported **0 hits / 16 misses** while the in-app Pre-aggregation drawer correctly reported **14 / 2** — tiles from \`dbt_users\`, \`dbt_support_requests\` and \`dbt_baskets\` were all penalised for a filter that doesn't apply to their explore.
- The live routing path in \`AsyncQueryService\` already handles this: compute the tile's \`availableFieldIds\` from the explore, call \`getDashboardFiltersForTileAndTables\` to drop inapplicable rules, then merge with \`addDashboardFiltersToMetricQuery\`. The audit path skipped the first two steps. This PR brings the audit in line with the live path so the audit signal matches what the drawer shows and what the real query would produce.

## Why this is a narrow fix

The backing commit's body (#22307) explicitly called out the risk — "reuses \`addDashboardFiltersToMetricQuery\` so the audit sees the same filter-merged query the live routing path sees (divergence would mean the audit lies)" — but missed that the live path also pre-scopes via \`getDashboardFiltersForTileAndTables\`. That scoping is exactly what was missing.

## Follow-up (not in this PR)

The "\`availableFieldIds\` → \`getDashboardFiltersForTileAndTables\` → \`addDashboardFiltersToMetricQuery\`" dance is duplicated across \`AsyncQueryService\` (3 callsites), \`ProjectService\` (1), and \`EmbedService\` (2). Worth extracting into a shared \`applyDashboardFiltersForTile(tile, metricQuery, dashboardFilters, explore)\` helper in \`@lightdash/common\` so the live and audit paths cannot drift again. Kept out of this PR to keep the diff tight and reviewable.

## Test plan

- [x] New unit test in \`PreAggregateStrategy.auditDashboard.test.ts\` asserts that a dashboard filter whose \`target.fieldId\` is not in the tile's explore does **not** leak into the metric query passed to \`preAggregateUtils.findMatch\`. Verified the test fails without the fix (\`Expected: 0, Received: 1\`) and passes with it.
- [x] \`pnpm -F backend test --testPathPattern PreAggregateStrategy.auditDashboard\` — 8/8 green.
- [x] \`pnpm -F backend typecheck\` — clean.
- [ ] Manual: once merged/deployed, re-run \`lightdash pre-aggregate-audit --dashboard 3ee80f6e-5cb2-4375-b313-d2ad9126aece\` against the repro dashboard and confirm it matches the drawer (\`14 hit / 2 miss\`).