### PR TITLE
refactor(filters): extract applyDashboardFiltersForTile helper

### DIFF
--- a/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
+++ b/packages/backend/src/ee/services/AsyncQueryService/PreAggregateStrategy.ts
@@ -1,13 +1,9 @@
 import {
-    addDashboardFiltersToMetricQuery,
     ApiPreAggregateStatsResults,
+    applyDashboardFiltersForTile,
     assertUnreachable,
     DashboardTileTypes,
     ExploreType,
-    getDashboardFiltersForTileAndTables,
-    getDimensionMapFromTables,
-    getMetricsMapFromTables,
-    isFilterableDimension,
     NotFoundError,
     preAggregateUtils,
     QueryExecutionContext as QEC,
@@ -435,31 +431,12 @@ export class PreAggregateStrategy implements IPreAggregateStrategy {
                     throw e;
                 }
 
-                // Scope dashboard filters to this tile — mirror of the live
-                // query path in AsyncQueryService.
-                const availableFieldIds = [
-                    ...Object.entries(getDimensionMapFromTables(explore.tables))
-                        .filter(
-                            ([, field]) =>
-                                isFilterableDimension(field) && !field.hidden,
-                        )
-                        .map(([fieldId]) => fieldId),
-                    ...Object.entries(getMetricsMapFromTables(explore.tables))
-                        .filter(([, field]) => !field.hidden)
-                        .map(([fieldId]) => fieldId),
-                ];
-                const appliedDashboardFilters =
-                    getDashboardFiltersForTileAndTables(
-                        tile.uuid,
-                        availableFieldIds,
-                        savedDashboardFilters,
-                    );
-
-                const metricQuery = addDashboardFiltersToMetricQuery(
-                    savedChart.metricQuery,
-                    appliedDashboardFilters,
+                const { metricQuery } = applyDashboardFiltersForTile({
+                    tileUuid: tile.uuid,
+                    metricQuery: savedChart.metricQuery,
+                    dashboardFilters: savedDashboardFilters,
                     explore,
-                );
+                });
 
                 const matchResult = preAggregateUtils.findMatch(
                     metricQuery,

--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -28,12 +28,12 @@ import {
     ForbiddenError,
     formatRawRows,
     formatRows,
+    getAvailableFilterFieldIds,
     getDashboardFiltersForTileAndTables,
     getDimensionMapFromTables,
     getDimensions,
     getFilterInteractivityValue,
     getItemId,
-    getMetrics,
     InteractivityOptions,
     IntrinsicUserAttributes,
     isChartContent,
@@ -940,14 +940,7 @@ export class EmbedService extends BaseService {
         tileUuid: string,
         dashboardFilters?: DashboardFilters,
     ) {
-        const availableFieldIds = [
-            ...getDimensions(explore)
-                .filter((f) => isFilterableDimension(f) && !f.hidden)
-                .map(getItemId),
-            ...getMetrics(explore)
-                .filter((f) => !f.hidden)
-                .map(getItemId),
-        ];
+        const availableFieldIds = getAvailableFilterFieldIds(explore);
 
         let appliedDashboardFilters = getDashboardFiltersForTileAndTables(
             tileUuid,

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -6,6 +6,7 @@ import {
     ApiExecuteAsyncDashboardSqlChartQueryResults,
     ApiExecuteAsyncSqlQueryResults,
     ApiPreAggregateStatsResults,
+    applyDashboardFiltersForTile,
     assertIsAccountWithOrg,
     assertUnreachable,
     CalculateSubtotalsFromQuery,
@@ -34,10 +35,9 @@ import {
     formatRawRows,
     formatRawValue,
     formatRow,
+    getAvailableFilterFieldIds,
     getDashboardFilterRulesForTables,
     getDashboardFilterRulesForTileAndReferences,
-    getDashboardFiltersForTileAndTables,
-    getDimensionMapFromTables,
     getDimensions,
     getDimensionsWithValidParameters,
     getErrorMessage,
@@ -46,7 +46,6 @@ import {
     getItemMap,
     getMetricOverridesWithPopInheritance,
     getMetrics,
-    getMetricsMapFromTables,
     getMetricsWithValidParameters,
     isCartesianChartConfig,
     isCustomBinDimension,
@@ -55,7 +54,6 @@ import {
     isDateItem,
     isExploreError,
     isField,
-    isFilterableDimension,
     isJwtUser,
     isMetric,
     isValidTimezone,
@@ -4181,37 +4179,16 @@ export class AsyncQueryService extends ProjectService {
             account.isRegisteredUser() ? account.user.id : null,
         );
 
-        // Use the explore's actual field ids (dimensions + metrics) as the
-        // source of truth for which dashboard filter rules apply to this tile.
-        // Matching on field id avoids the divergence between the UI and the
-        // server when a filter rule's `target.tableName` is stale (see comment
-        // on getDashboardFilterRulesForTables in @lightdash/common filters).
-        // The set is intentionally aligned with the UI's
-        // getAvailableFiltersForSavedQueries (filterable, non-hidden).
-        const availableFieldIds = [
-            ...Object.entries(getDimensionMapFromTables(explore.tables))
-                .filter(
-                    ([, field]) =>
-                        isFilterableDimension(field) && !field.hidden,
-                )
-                .map(([fieldId]) => fieldId),
-            ...Object.entries(getMetricsMapFromTables(explore.tables))
-                .filter(([, field]) => !field.hidden)
-                .map(([fieldId]) => fieldId),
-        ];
-        const appliedDashboardFilters: DashboardFilters =
-            getDashboardFiltersForTileAndTables(
+        const { metricQuery: metricQueryWithFilters, appliedDashboardFilters } =
+            applyDashboardFiltersForTile({
                 tileUuid,
-                availableFieldIds,
+                metricQuery: savedChart.metricQuery,
                 dashboardFilters,
-            );
+                explore,
+            });
 
         const metricQueryWithDashboardOverrides: MetricQuery = {
-            ...addDashboardFiltersToMetricQuery(
-                savedChart.metricQuery,
-                appliedDashboardFilters,
-                explore,
-            ),
+            ...metricQueryWithFilters,
             sorts:
                 dashboardSorts && dashboardSorts.length > 0
                     ? dashboardSorts
@@ -5807,17 +5784,7 @@ export class AsyncQueryService extends ProjectService {
             savedChart.tableName,
             organizationUuid,
         );
-        const availableFieldIds = [
-            ...Object.entries(getDimensionMapFromTables(explore.tables))
-                .filter(
-                    ([, field]) =>
-                        isFilterableDimension(field) && !field.hidden,
-                )
-                .map(([fieldId]) => fieldId),
-            ...Object.entries(getMetricsMapFromTables(explore.tables))
-                .filter(([, field]) => !field.hidden)
-                .map(([fieldId]) => fieldId),
-        ];
+        const availableFieldIds = getAvailableFilterFieldIds(explore);
 
         const appliedDashboardFilters = dashboardFilters
             ? {

--- a/packages/backend/src/services/ProjectService/ProjectService.ts
+++ b/packages/backend/src/services/ProjectService/ProjectService.ts
@@ -63,6 +63,7 @@ import {
     ForbiddenError,
     formatRows,
     getAllDimensionsMap,
+    getAvailableFilterFieldIds,
     getAvailableParametersFromTables,
     getDashboardFilterRulesForTables,
     getDimensions,
@@ -3677,18 +3678,7 @@ export class ProjectService extends BaseService {
             account.user.id,
         );
 
-        // Match dashboard filter rules by their actual field id against the
-        // explore's available fields, not by tableName. See comment on
-        // getDashboardFilterRulesForTables for the rationale. Aligned with the
-        // UI's getAvailableFiltersForSavedQueries (filterable, non-hidden).
-        const availableFieldIds = [
-            ...getDimensions(explore)
-                .filter((f) => isFilterableDimension(f) && !f.hidden)
-                .map(getItemId),
-            ...getMetrics(explore)
-                .filter((f) => !f.hidden)
-                .map(getItemId),
-        ];
+        const availableFieldIds = getAvailableFilterFieldIds(explore);
         const appliedDashboardFilters = {
             dimensions: getDashboardFilterRulesForTables(
                 availableFieldIds,

--- a/packages/common/src/utils/filters.test.ts
+++ b/packages/common/src/utils/filters.test.ts
@@ -9,10 +9,12 @@ import {
     type MetricFilterRule,
     type OrFilterGroup,
 } from '../types/filter';
+import { type MetricQuery } from '../types/metricQuery';
 import { TimeFrames } from '../types/timeFrames';
 import {
     addDashboardFiltersToMetricQuery,
     addFilterRule,
+    applyDashboardFiltersForTile,
     createFilterRuleFromModelRequiredFilterRule,
     getDashboardFilterRulesForTileAndReferences,
     isFilterRuleInQuery,
@@ -1027,5 +1029,101 @@ describe('getDashboardFilterRulesForTileAndReferences', () => {
 
         // Verify filter-3 is not included (isSqlColumn is true but fieldId doesn't match)
         expect(result).toHaveLength(0);
+    });
+});
+
+describe('applyDashboardFiltersForTile', () => {
+    const baseMetricQuery: MetricQuery = {
+        exploreName: 'test',
+        dimensions: [],
+        metrics: [],
+        filters: {},
+        sorts: [],
+        limit: 500,
+        tableCalculations: [],
+    };
+
+    const statusRule: DashboardFilterRule = {
+        id: 'f-status',
+        target: { fieldId: 'orders_status', tableName: 'orders' },
+        operator: FilterOperator.EQUALS,
+        values: [true],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    const offExploreRule: DashboardFilterRule = {
+        id: 'f-off',
+        target: { fieldId: 'other_browser', tableName: 'other' },
+        operator: FilterOperator.EQUALS,
+        values: ['chrome'],
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    } as any;
+
+    test('drops rules whose fieldId is not in the explore', () => {
+        const { metricQuery, appliedDashboardFilters } =
+            applyDashboardFiltersForTile({
+                tileUuid: 't-1',
+                metricQuery: baseMetricQuery,
+                dashboardFilters: {
+                    dimensions: [offExploreRule],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                explore: mockExplore,
+            });
+
+        expect(appliedDashboardFilters.dimensions).toEqual([]);
+        expect(
+            (metricQuery.filters.dimensions as AndFilterGroup | undefined)
+                ?.and ?? [],
+        ).toEqual([]);
+    });
+
+    test('drops rules whose tileTargets disable them for this tile', () => {
+        const disabledRule: DashboardFilterRule = {
+            ...statusRule,
+            tileTargets: { 't-1': false },
+            // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        } as any;
+        const { metricQuery, appliedDashboardFilters } =
+            applyDashboardFiltersForTile({
+                tileUuid: 't-1',
+                metricQuery: baseMetricQuery,
+                dashboardFilters: {
+                    dimensions: [disabledRule],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                explore: mockExplore,
+            });
+
+        expect(appliedDashboardFilters.dimensions).toEqual([]);
+        expect(
+            (metricQuery.filters.dimensions as AndFilterGroup | undefined)
+                ?.and ?? [],
+        ).toEqual([]);
+    });
+
+    test('merges applicable rules into the metric query', () => {
+        const { metricQuery, appliedDashboardFilters } =
+            applyDashboardFiltersForTile({
+                tileUuid: 't-1',
+                metricQuery: baseMetricQuery,
+                dashboardFilters: {
+                    dimensions: [statusRule, offExploreRule],
+                    metrics: [],
+                    tableCalculations: [],
+                },
+                explore: mockExplore,
+            });
+
+        expect(appliedDashboardFilters.dimensions).toHaveLength(1);
+        expect(appliedDashboardFilters.dimensions[0].id).toBe('f-status');
+        const merged = (metricQuery.filters.dimensions as AndFilterGroup).and;
+        expect(merged).toHaveLength(1);
+        expect(merged[0]).toMatchObject({
+            target: { fieldId: 'orders_status' },
+            values: [true],
+        });
     });
 });

--- a/packages/common/src/utils/filters.ts
+++ b/packages/common/src/utils/filters.ts
@@ -10,6 +10,7 @@ import {
     DimensionType,
     isCustomSqlDimension,
     isDimension,
+    isFilterableDimension,
     isTableCalculation,
     MetricType,
     TableCalculationType,
@@ -50,6 +51,7 @@ import { type MetricQuery } from '../types/metricQuery';
 import { type ResultColumn } from '../types/results';
 import { TimeFrames } from '../types/timeFrames';
 import assertUnreachable from './assertUnreachable';
+import { getDimensionMapFromTables, getMetricsMapFromTables } from './fields';
 import { formatDate } from './formatting';
 import { getItemId, getItemType, isDateItem } from './item';
 
@@ -1196,6 +1198,45 @@ export const addDashboardFiltersToMetricQuery = (
                 undefined,
             ),
         },
+    };
+};
+
+// Mirrors the UI's getAvailableFiltersForSavedQueries. Matching on field-id (not tableName) is the source of truth — see getDashboardFilterRulesForTables below for why.
+export const getAvailableFilterFieldIds = (explore: Explore): string[] => [
+    ...Object.entries(getDimensionMapFromTables(explore.tables))
+        .filter(([, field]) => isFilterableDimension(field) && !field.hidden)
+        .map(([fieldId]) => fieldId),
+    ...Object.entries(getMetricsMapFromTables(explore.tables))
+        .filter(([, field]) => !field.hidden)
+        .map(([fieldId]) => fieldId),
+];
+
+export const applyDashboardFiltersForTile = ({
+    tileUuid,
+    metricQuery,
+    dashboardFilters,
+    explore,
+}: {
+    tileUuid: string;
+    metricQuery: MetricQuery;
+    dashboardFilters: DashboardFilters;
+    explore: Explore;
+}): {
+    metricQuery: MetricQuery;
+    appliedDashboardFilters: DashboardFilters;
+} => {
+    const appliedDashboardFilters = getDashboardFiltersForTileAndTables(
+        tileUuid,
+        getAvailableFilterFieldIds(explore),
+        dashboardFilters,
+    );
+    return {
+        metricQuery: addDashboardFiltersToMetricQuery(
+            metricQuery,
+            appliedDashboardFilters,
+            explore,
+        ),
+        appliedDashboardFilters,
     };
 };
 


### PR DESCRIPTION
## Summary

The `availableFieldIds → getDashboardFiltersForTileAndTables → addDashboardFiltersToMetricQuery` dance lived in five callsites. Divergence between those copies is what caused the audit bug fixed in #22338 (now merged). This PR centralises the pattern in `@lightdash/common` so the live query path and the pre-aggregate audit cannot drift apart again.

## New helpers in `@lightdash/common`

- `getAvailableFilterFieldIds(explore)` — filterable non-hidden dimensions + non-hidden metrics (same set the UI uses in `getAvailableFiltersForSavedQueries`).
- `applyDashboardFiltersForTile({ tileUuid, metricQuery, dashboardFilters, explore })` — composes scope + merge and returns both the merged `metricQuery` and the scoped `appliedDashboardFilters` (the latter is consumed by analytics/audit callers).

Both live in `utils/filters.ts` alongside the existing `getDashboardFiltersForTileAndTables` and `addDashboardFiltersToMetricQuery` helpers — semantically a filter concern, not a field-shape concern.

## Callsites migrated

| Callsite | Helper used |
|---|---|
| `AsyncQueryService.executeAsyncDashboardChartQuery` | composite |
| `PreAggregateStrategy.auditTile` (from #22338) | composite |
| `ProjectService.runViewChartQuery` | `getAvailableFilterFieldIds` only (no tile) |
| `AsyncQueryService.calculateTotalFromSavedChart` | `getAvailableFilterFieldIds` only |
| `EmbedService._getAppliedDashboardFilters` | `getAvailableFilterFieldIds` only |

## Not migrated (out of scope)

`AsyncQueryService.executeAsyncDashboardSqlChartQuery` uses `getDashboardFilterRulesForTileAndReferences` scoped by raw SQL column references instead of explore field ids — different shape, not this pattern. Left alone.

## Behaviour

Pure refactor. Every migrated callsite computes the same `availableFieldIds` set, applies filters in the same order, and passes the same `explore` onward as before.

## Test plan

- [x] New unit tests in `packages/common/src/utils/filters.test.ts` cover `applyDashboardFiltersForTile`: off-explore filter dropped, `tileTargets`-disabled filter dropped, applicable filter merged.
- [x] `pnpm -F common test` — `filters.test` 31/31 green.
- [x] `pnpm -F backend test` suites around migrated callers: `PreAggregateStrategy.auditDashboard`, `AsyncQueryService`, `EmbedService`, `ProjectService` — 83/83 green.
- [x] `pnpm -F backend typecheck` — clean.