### PR TITLE
fix: improve miss reason in explorer

### DIFF
--- a/packages/frontend/src/components/PreAggregateStatusBadge.tsx
+++ b/packages/frontend/src/components/PreAggregateStatusBadge.tsx
@@ -1,7 +1,4 @@
-import {
-    PreAggregateMissReason,
-    preAggregateMissReasonLabels,
-} from '@lightdash/common';
+import { PreAggregateMissReason } from '@lightdash/common';
 import { ThemeIcon, Tooltip } from '@mantine-8/core';
 import { IconBolt, IconBoltOff } from '@tabler/icons-react';
 import { memo, useMemo, type FC } from 'react';
@@ -11,6 +8,7 @@ import {
     useExplorerSelector,
 } from '../features/explorer/store';
 import { usePreAggregateCacheEnabled } from '../hooks/usePreAggregateCacheEnabled';
+import { formatTileMissReason } from './common/Dashboard/PreAggregateAuditIndicator.utils';
 
 const PreAggregateStatusBadge: FC = memo(() => {
     const preAggregateCheck = useExplorerSelector(selectPreAggregateCheck);
@@ -63,7 +61,7 @@ const PreAggregateStatusBadge: FC = memo(() => {
 
         return {
             color: 'gray',
-            tooltip: `Cache miss: ${preAggregateMissReasonLabels[result.reason.reason]}`,
+            tooltip: `Cache miss: ${formatTileMissReason(result.reason)}`,
             icon: 'bolt',
         };
     }, [preAggVisible, preAggregateCheck, preAggCacheEnabled]);

--- a/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.utils.ts
+++ b/packages/frontend/src/components/common/Dashboard/PreAggregateAuditIndicator.utils.ts
@@ -4,7 +4,7 @@ import {
 } from '@lightdash/common';
 import { type TilePreAggregateStatus } from '../../../providers/Dashboard/types';
 
-function formatTileMissReason(reason: PreAggregateMatchMiss): string {
+export function formatTileMissReason(reason: PreAggregateMatchMiss): string {
     const label = preAggregateMissReasonLabels[reason.reason] ?? reason.reason;
     return 'fieldId' in reason && reason.fieldId
         ? `${label}: ${reason.fieldId}`


### PR DESCRIPTION
Closes:

### Description:

Exports `formatTileMissReason` from `PreAggregateAuditIndicator.utils.ts` and reuses it in `PreAggregateStatusBadge` to format cache miss tooltip messages. This ensures consistent miss reason formatting (including the optional `fieldId` suffix) across both the dashboard audit indicator and the explorer status badge, replacing the previous direct lookup via `preAggregateMissReasonLabels` which did not include the field ID context.