### PR TITLE
fix(filters): skip timestamptz literal wrap for DATE-over-DATE dimensions

### DIFF
--- a/packages/common/src/compiler/filtersCompiler.test.ts
+++ b/packages/common/src/compiler/filtersCompiler.test.ts
@@ -2526,7 +2526,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
         values: ['2024-01-15'],
     };
 
-    test('DATE filter wraps literal in project TZ when parameter is true', () => {
+    test('DATE-over-TIMESTAMP filter wraps literal in project TZ when parameter is true', () => {
         const sql = renderFilterRuleSql(
             equalsFilter,
             DimensionType.DATE,
@@ -2539,6 +2539,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             true,
             undefined,
             true,
+            DimensionType.TIMESTAMP,
         );
         expect(sql).toContain("AT TIME ZONE 'Asia/Tokyo'");
         expect(sql).toContain("'2024-01-15'::timestamp");
@@ -2558,7 +2559,26 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
         expect(sql).not.toContain('AT TIME ZONE');
     });
 
-    test('BigQuery DATE filter emits TIMESTAMP(literal, tz) instead of ::timestamp', () => {
+    test('DATE filter over a DATE base emits a bare literal even when parameter is true', () => {
+        const sql = renderFilterRuleSql(
+            equalsFilter,
+            DimensionType.DATE,
+            DimensionSqlMock,
+            "'",
+            (s: string) => s,
+            null,
+            SupportedDbtAdapter.POSTGRES,
+            'Asia/Tokyo',
+            true,
+            undefined,
+            true,
+            DimensionType.DATE,
+        );
+        expect(sql).not.toContain('AT TIME ZONE');
+        expect(sql).not.toContain('::timestamp');
+    });
+
+    test('BigQuery DATE-over-TIMESTAMP filter emits TIMESTAMP(literal, tz)', () => {
         const sql = renderFilterRuleSql(
             equalsFilter,
             DimensionType.DATE,
@@ -2571,12 +2591,32 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             true,
             undefined,
             true,
+            DimensionType.TIMESTAMP,
         );
         expect(sql).toContain("TIMESTAMP('2024-01-15', 'Asia/Tokyo')");
         expect(sql).not.toContain('::timestamp');
     });
 
-    test('ClickHouse DATE filter anchors literal with toDateTime(literal, tz)', () => {
+    test('BigQuery DATE filter over a DATE base emits a bare literal (no TIMESTAMP wrap)', () => {
+        const sql = renderFilterRuleSql(
+            equalsFilter,
+            DimensionType.DATE,
+            DimensionSqlMock,
+            "'",
+            (s: string) => s,
+            null,
+            SupportedDbtAdapter.BIGQUERY,
+            'Asia/Tokyo',
+            true,
+            undefined,
+            true,
+            DimensionType.DATE,
+        );
+        expect(sql).not.toContain('TIMESTAMP(');
+        expect(sql).toContain("'2024-01-15'");
+    });
+
+    test('ClickHouse DATE-over-TIMESTAMP filter anchors literal with toDateTime(literal, tz)', () => {
         const sql = renderFilterRuleSql(
             equalsFilter,
             DimensionType.DATE,
@@ -2589,9 +2629,28 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             true,
             undefined,
             true,
+            DimensionType.TIMESTAMP,
         );
         expect(sql).toContain("toDateTime('2024-01-15', 'Asia/Tokyo')");
         expect(sql).not.toContain('::timestamp');
+    });
+
+    test('ClickHouse DATE filter over a DATE base emits a bare literal (no toDateTime wrap)', () => {
+        const sql = renderFilterRuleSql(
+            equalsFilter,
+            DimensionType.DATE,
+            DimensionSqlMock,
+            "'",
+            (s: string) => s,
+            null,
+            SupportedDbtAdapter.CLICKHOUSE,
+            'Asia/Tokyo',
+            true,
+            undefined,
+            true,
+            DimensionType.DATE,
+        );
+        expect(sql).not.toContain('toDateTime(');
     });
 
     test('TIMESTAMP filter does not wrap literal even when parameter is true', () => {
@@ -2607,6 +2666,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             true,
             undefined,
             true,
+            DimensionType.TIMESTAMP,
         );
         expect(sql).not.toContain("AT TIME ZONE 'Asia/Tokyo'");
     });
@@ -2619,6 +2679,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
         const renderWithParam = (
             filter: FilterRule<FilterOperator, unknown>,
             useTimezoneAwareDateTrunc: boolean,
+            baseTimeIntervalDimensionType: DimensionType = DimensionType.TIMESTAMP,
         ) =>
             renderFilterRuleSql(
                 filter,
@@ -2632,6 +2693,7 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
                 true,
                 undefined,
                 useTimezoneAwareDateTrunc,
+                baseTimeIntervalDimensionType,
             );
 
         test('inThePast completed day wraps boundaries in project TZ', () => {
@@ -2682,6 +2744,31 @@ describe('useTimezoneAwareDateTrunc parameter — filter literal wrapping', () =
             };
             const sql = renderWithParam(filter, false);
             expect(sql).not.toContain('AT TIME ZONE');
+        });
+
+        test('inThePast completed weeks on a DATE-backed dimension does not wrap BigQuery literals in TIMESTAMP', () => {
+            const filter: FilterRule<FilterOperator, unknown> = {
+                id: 'id',
+                target: { fieldId: 'fieldId' },
+                operator: FilterOperator.IN_THE_PAST,
+                values: [14],
+                settings: { unitOfTime: UnitOfTime.weeks, completed: true },
+            };
+            const sql = renderFilterRuleSql(
+                filter,
+                DimensionType.DATE,
+                DimensionSqlMock,
+                "'",
+                (s: string) => s,
+                null,
+                SupportedDbtAdapter.BIGQUERY,
+                'Asia/Tokyo',
+                true,
+                undefined,
+                true,
+                DimensionType.DATE,
+            );
+            expect(sql).not.toContain('TIMESTAMP(');
         });
     });
 });

--- a/packages/common/src/compiler/filtersCompiler.ts
+++ b/packages/common/src/compiler/filtersCompiler.ts
@@ -750,6 +750,7 @@ export const renderFilterRuleSql = (
     caseSensitive: boolean = true,
     baseDimensionSql?: string,
     useTimezoneAwareDateTrunc?: boolean,
+    baseTimeIntervalDimensionType?: DimensionType,
 ): string => {
     if (filterRule.disabled) {
         return `1=1`; // When filter is disabled, we want to return all rows
@@ -788,6 +789,12 @@ export const renderFilterRuleSql = (
         }
         case DimensionType.DATE:
         case MetricType.DATE: {
+            // Only truncations over a TIMESTAMP base carry a timestamptz
+            // SQL expression; pure DATE columns stay bare DATE, so wrapping
+            // the literal would break BigQuery's DATE vs TIMESTAMP check.
+            const wrapLiteralAsTimestamptz =
+                !!useTimezoneAwareDateTrunc &&
+                baseTimeIntervalDimensionType === DimensionType.TIMESTAMP;
             return renderDateFilterSql(
                 fieldSql,
                 escapedFilterRule,
@@ -798,7 +805,7 @@ export const renderFilterRuleSql = (
                     : undefined,
                 startOfWeek,
                 baseDimensionSql,
-                useTimezoneAwareDateTrunc,
+                wrapLiteralAsTimestamptz,
             );
         }
         case DimensionType.TIMESTAMP:
@@ -863,6 +870,11 @@ export const renderFilterRuleSqlFromField = (
         caseSensitive = exploreCaseSensitive;
     }
 
+    const baseTimeIntervalDimensionType =
+        !isCompiledCustomSqlDimension(field) && !isMetric(field)
+            ? field.timeIntervalBaseDimensionType
+            : undefined;
+
     return renderFilterRuleSql(
         filterRule,
         fieldType,
@@ -875,5 +887,6 @@ export const renderFilterRuleSqlFromField = (
         caseSensitive,
         baseDimensionSql,
         useTimezoneAwareDateTrunc,
+        baseTimeIntervalDimensionType,
     );
 };


### PR DESCRIPTION
Closes GLITCH-360

## Summary

BigQuery DATE columns failed with `No matching signature for operator >=` when a dashboard had a relative DATE filter and timezone-aware `DATE_TRUNC` was enabled — the filter literal was being wrapped as `TIMESTAMP(..., tz)` even though the column was a bare DATE.

The timestamptz wrap only makes sense when the dimension is a truncation **over a TIMESTAMP base** (the `toUTC` round-trip produces a timestamptz expression). For raw DATE columns and DATE-interval-over-DATE, the SQL expression stays DATE — so the literal must stay plain.

Gate the `castValue` wrap on `baseTimeIntervalDimensionType === TIMESTAMP` (already surfaced on `CompiledDimension`; also used for pivot formatting). Boundary computation still uses project TZ unconditionally.

**Before**
<img width="2123" height="586" alt="CleanShot 2026-04-24 at 12 10 14" src="https://github.com/user-attachments/assets/e81d6ec4-aed4-414c-8348-be8c04b72fe5" />

**After**
<img width="2123" height="511" alt="CleanShot 2026-04-24 at 12 13 27" src="https://github.com/user-attachments/assets/c2e8f93f-eb3b-4cd1-955e-17561d8b8c83" />