### PR TITLE
fix: make feature flag `default_enabled` nullable

### DIFF
--- a/packages/backend/src/database/entities/featureFlags.ts
+++ b/packages/backend/src/database/entities/featureFlags.ts
@@ -5,7 +5,7 @@ export const FeatureFlagOverridesTableName = 'feature_flag_overrides';
 
 export type DbFeatureFlag = {
     flag_id: string;
-    default_enabled: boolean;
+    default_enabled: boolean | null;
     created_at: Date;
     updated_at: Date;
 };

--- a/packages/backend/src/database/migrations/20260424120000_feature_flags_nullable_default.ts
+++ b/packages/backend/src/database/migrations/20260424120000_feature_flags_nullable_default.ts
@@ -1,0 +1,17 @@
+import { type Knex } from 'knex';
+import { FeatureFlagsTableName } from '../entities/featureFlags';
+
+export const up = async (knex: Knex): Promise<void> => {
+    await knex.schema.alterTable(FeatureFlagsTableName, (table) => {
+        table.boolean('default_enabled').nullable().alter();
+    });
+};
+
+export const down = async (knex: Knex): Promise<void> => {
+    await knex(FeatureFlagsTableName)
+        .whereNull('default_enabled')
+        .update({ default_enabled: false });
+    await knex.schema.alterTable(FeatureFlagsTableName, (table) => {
+        table.boolean('default_enabled').notNullable().alter();
+    });
+};

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -449,6 +449,10 @@ export class FeatureFlagModel {
             }
         }
 
+        if (flag.default_enabled === null) {
+            return null;
+        }
+
         return { id: args.featureFlagId, enabled: flag.default_enabled };
     }
 }


### PR DESCRIPTION
Closes:

### Description:
Makes the `default_enabled` column on the `feature_flags` table nullable. When `default_enabled` is `null`, the feature flag evaluation returns `null` instead of a flag object, allowing callers to distinguish between a flag that is explicitly disabled and one that has no default set.

The migration handles rollback by setting any `null` values back to `false` before restoring the `NOT NULL` constraint.