### PR TITLE
refactor(formatting): centralise DATE-base tz gate in formatItemValue

### DIFF
--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -757,14 +757,6 @@ export function formatRow(
         const pivotValuesColumn = pivotValuesColumns?.[columnName];
         const item = itemsMap[pivotValuesColumn?.referenceField ?? columnName];
 
-        // Truncated dimensions whose base column is DATE have no time
-        // component, so applying the display timezone would shift the day.
-        const itemTimezone =
-            isDimension(item) &&
-            item.timeIntervalBaseDimensionType === DimensionType.DATE
-                ? undefined
-                : timezone;
-
         resultRow[columnName] = {
             value: {
                 raw: formatRawValue(item, value),
@@ -773,7 +765,7 @@ export function formatRow(
                     value,
                     false,
                     parameters,
-                    itemTimezone,
+                    timezone,
                 ),
             },
         };

--- a/packages/common/src/utils/formatting.test.ts
+++ b/packages/common/src/utils/formatting.test.ts
@@ -790,6 +790,40 @@ describe('Formatting', () => {
             ).toEqual('2021');
         });
 
+        test('formatItemValue DATE ignores display timezone for DATE-backed dimensions', () => {
+            const value = new Date('2026-03-03T00:00:00.000Z');
+            // DATE base: timezone must be ignored (no day-shift in negative offsets)
+            expect(
+                formatItemValue(
+                    {
+                        ...dimension,
+                        type: DimensionType.DATE,
+                        timeInterval: TimeFrames.DAY,
+                        timeIntervalBaseDimensionType: DimensionType.DATE,
+                    },
+                    value,
+                    false,
+                    undefined,
+                    'Pacific/Pago_Pago',
+                ),
+            ).toEqual('2026-03-03');
+            // TIMESTAMP base: timezone still applies
+            expect(
+                formatItemValue(
+                    {
+                        ...dimension,
+                        type: DimensionType.DATE,
+                        timeInterval: TimeFrames.DAY,
+                        timeIntervalBaseDimensionType: DimensionType.TIMESTAMP,
+                    },
+                    value,
+                    false,
+                    undefined,
+                    'Pacific/Pago_Pago',
+                ),
+            ).toEqual('2026-03-02');
+        });
+
         test('formatItemValue should return the right format when field is Metric', () => {
             expect(formatItemValue(metric, undefined)).toEqual('-');
             expect(formatItemValue(metric, null)).toEqual('∅');

--- a/packages/common/src/utils/formatting.ts
+++ b/packages/common/src/utils/formatting.ts
@@ -861,15 +861,25 @@ export function formatItemValue(
                     return formatBoolean(value);
                 case DimensionType.DATE:
                 case MetricType.DATE:
-                case TableCalculationType.DATE:
+                case TableCalculationType.DATE: {
+                    // Truncated dimensions whose base column is DATE have no
+                    // time component — applying a display timezone would
+                    // shift the calendar day (off-by-one in negative offsets).
+                    const dateTimezone =
+                        isDimension(item) &&
+                        item.timeIntervalBaseDimensionType ===
+                            DimensionType.DATE
+                            ? undefined
+                            : timezone;
                     return isMomentInput(value)
                         ? formatDate(
                               value,
                               isDimension(item) ? item.timeInterval : undefined,
                               convertToUTC,
-                              timezone,
+                              dateTimezone,
                           )
                         : 'NaT';
+                }
                 case DimensionType.TIMESTAMP:
                 case MetricType.TIMESTAMP:
                 case TableCalculationType.TIMESTAMP:


### PR DESCRIPTION
Closes GLITCH-361

## Summary

Centralise the "ignore display timezone when a DATE dimension is backed by a DATE column" gate in `formatItemValue` so every caller inherits it.

`timeIntervalBaseDimensionType` was introduced in #22286 to fix a day-shift in `formatRow` for negative-offset timezones. CSV (#22282) added its own DATE branch in parallel. The gate was not pushed into `formatItemValue` itself, so chart axis labels, echarts tooltips, pivot labels, etc. can still day-shift DATE-over-DATE dimensions in negative offsets.

Move the gate into `formatItemValue`'s DATE case. Drop the now-redundant duplicate in `formatRow`. `CsvService` keeps its own DATE branch (different wire format, not routed through `formatItemValue`).