### PR TITLE
fix(ai-agent): Slack vote OAuth + resolve identity without team filter (PROD-7030)

### DIFF
--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -17,6 +17,7 @@ declare module 'express-session' {
             channelId?: string | undefined;
             messageTs?: string | undefined;
             threadTs?: string | undefined;
+            trigger?: 'vote' | 'app_mention' | undefined;
         };
         impersonation?: {
             adminUserUuid: string;

--- a/packages/backend/src/controllers/authentication/middlewares.ts
+++ b/packages/backend/src/controllers/authentication/middlewares.ts
@@ -210,7 +210,7 @@ export const storeOIDCRedirect: RequestHandler = (req, res, next) => {
 };
 
 export const storeSlackContext: RequestHandler = (req, res, next) => {
-    const { team, channel, message, thread_ts: threadTs } = req.query;
+    const { team, channel, message, thread_ts: threadTs, trigger } = req.query;
     req.session.slack = {};
 
     if (typeof team === 'string') {
@@ -224,6 +224,9 @@ export const storeSlackContext: RequestHandler = (req, res, next) => {
     }
     if (typeof threadTs === 'string') {
         req.session.slack.threadTs = threadTs;
+    }
+    if (trigger === 'vote' || trigger === 'app_mention') {
+        req.session.slack.trigger = trigger;
     }
 
     next();

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4585,6 +4585,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 threadTs: undefined,
                 channelId: event.channel,
                 messageId: event.ts,
+                organizationUuid,
             },
             say,
             client,
@@ -4870,6 +4871,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                         threadTs,
                         channelId,
                         messageId: body.message?.ts || '',
+                        organizationUuid,
                     },
                     // Pass a no-op function for say since we'll handle responses ourselves
                     async () => {},
@@ -5085,12 +5087,14 @@ Use them as a reference, but do all the due dilligence and follow the instructio
             threadTs,
             channelId,
             messageId,
+            organizationUuid,
         }: {
             userId: string;
             teamId: string;
             threadTs: string | undefined;
             channelId: string;
             messageId: string;
+            organizationUuid: string;
         },
         say: Function,
         client: WebClient,
@@ -5163,6 +5167,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 event: 'ai_agent.slack_auth',
                 trigger: 'app_mention',
                 result,
+                organizationUuid,
                 slackUserId: userId,
                 slackUserIdFlavor: userId.startsWith('W')
                     ? 'enterprise'
@@ -5450,6 +5455,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 threadTs: event.thread_ts || event.ts, // Use event.ts for new messages to create a thread
                 channelId: event.channel,
                 messageId: event.ts,
+                organizationUuid,
             },
             say,
             client,

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -5143,7 +5143,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                                     action_id: `actions.oauth_button_click:${teamId}:${channelId}:${messageId}`,
                                     url: `${
                                         this.lightdashConfig.siteUrl
-                                    }/api/v1/auth/slack?team=${teamId}&channel=${channelId}&message=${messageId}${
+                                    }/api/v1/auth/slack?team=${teamId}&channel=${channelId}&message=${messageId}&trigger=app_mention${
                                         threadTs ? `&thread_ts=${threadTs}` : ''
                                     }`,
                                     style: 'primary',
@@ -5187,8 +5187,16 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         messageTs: string;
         threadTs?: string;
         userUuid: string;
+        trigger?: 'vote' | 'app_mention';
     }): Promise<void> {
-        const { teamId, channelId, messageTs, threadTs, userUuid } = data;
+        const {
+            teamId,
+            channelId,
+            messageTs,
+            threadTs,
+            userUuid,
+            trigger = 'app_mention',
+        } = data;
 
         Logger.info(
             `Processing pending Slack message after OAuth: team=${teamId}, channel=${channelId}, message=${messageTs}`,
@@ -5236,6 +5244,10 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 
         if (cachedResponse) {
             // Update the ephemeral message to show success, then delete after 10 seconds
+            const successText =
+                trigger === 'vote'
+                    ? '✅ Connected! Click the vote button again to submit your feedback.'
+                    : '✅ Authentication successful! Processing your request...';
             try {
                 const successResponse = await fetch(
                     cachedResponse.responseUrl,
@@ -5249,7 +5261,7 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                                     type: 'section',
                                     text: {
                                         type: 'mrkdwn',
-                                        text: '✅ Authentication successful! Processing your request...',
+                                        text: successText,
                                     },
                                 },
                             ],
@@ -5284,6 +5296,13 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                     e,
                 );
             }
+        }
+
+        // Vote-triggered OAuth: the original message is the AI's own reply, not
+        // a user prompt. Replaying it would feed the bot its own response.
+        // Auth is now established; user re-clicks the vote button to record it.
+        if (trigger === 'vote') {
+            return;
         }
 
         // Fetch the original message

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -3863,6 +3863,8 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 await ack();
                 const { user } = body;
                 const { teamId } = context;
+                const triggeringMessage =
+                    body.type === 'block_actions' ? body.message : undefined;
                 const organizationUuid =
                     await this.getSlackVoteOrganizationUuid({
                         teamId,
@@ -3871,6 +3873,8 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                             body.type === 'block_actions'
                                 ? body.channel?.id
                                 : undefined,
+                        messageId: triggeringMessage?.ts,
+                        threadTs: triggeringMessage?.thread_ts,
                         client,
                     });
 
@@ -3926,6 +3930,8 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 await ack();
                 const { user } = body;
                 const { teamId } = context;
+                const triggeringMessage =
+                    body.type === 'block_actions' ? body.message : undefined;
                 const organizationUuid =
                     await this.getSlackVoteOrganizationUuid({
                         teamId,
@@ -3934,6 +3940,8 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                             body.type === 'block_actions'
                                 ? body.channel?.id
                                 : undefined,
+                        messageId: triggeringMessage?.ts,
+                        threadTs: triggeringMessage?.thread_ts,
                         client,
                     });
 
@@ -4684,11 +4692,15 @@ Use them as a reference, but do all the due dilligence and follow the instructio
         teamId,
         userId,
         channelId,
+        messageId,
+        threadTs,
         client,
     }: {
         teamId?: string;
         userId: string;
         channelId?: string;
+        messageId?: string;
+        threadTs?: string;
         client: WebClient;
     }): Promise<string | undefined | null> {
         let result:
@@ -4732,10 +4744,42 @@ Use them as a reference, but do all the due dilligence and follow the instructio
 
             result = 'identity_missing';
             if (channelId) {
+                const text = `Hi <@${userId}>! OAuth authentication is required to vote on AI Agent responses. Please connect your Slack account to Lightdash to continue.`;
+                const blocks =
+                    teamId && messageId
+                        ? [
+                              {
+                                  type: 'section',
+                                  text: { type: 'mrkdwn', text },
+                              },
+                              {
+                                  type: 'actions',
+                                  elements: [
+                                      {
+                                          type: 'button',
+                                          text: {
+                                              type: 'plain_text',
+                                              text: 'Connect your Slack account',
+                                          },
+                                          action_id: `actions.oauth_button_click:${teamId}:${channelId}:${messageId}`,
+                                          url: `${
+                                              this.lightdashConfig.siteUrl
+                                          }/api/v1/auth/slack?team=${teamId}&channel=${channelId}&message=${messageId}&trigger=vote${
+                                              threadTs
+                                                  ? `&thread_ts=${threadTs}`
+                                                  : ''
+                                          }`,
+                                          style: 'primary',
+                                      },
+                                  ],
+                              },
+                          ]
+                        : undefined;
                 await client.chat.postEphemeral({
                     channel: channelId,
                     user: userId,
-                    text: 'You need to link your Slack account to Lightdash to vote on AI responses. Please use the AI Agent first to complete the OAuth linking process.',
+                    text,
+                    blocks,
                 });
             }
 

--- a/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
+++ b/packages/backend/src/ee/services/AiAgentService/AiAgentService.ts
@@ -4718,24 +4718,12 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 return organizationUuid;
             }
 
-            // TODO: Legacy Slack-linked users can still fail here if team_id was never
-            // populated on their OpenID identity.
             const openIdIdentity =
                 await this.openIdIdentityModel.findIdentityByOpenId(
                     OpenIdIdentityIssuerType.SLACK,
                     userId,
-                    teamId,
                 );
             observedIdentity = openIdIdentity;
-            if (!observedIdentity) {
-                // Observability-only: a teamless lookup so the wide event can
-                // distinguish a truly-absent identity from one filtered out by team_id.
-                observedIdentity =
-                    await this.openIdIdentityModel.findIdentityByOpenId(
-                        OpenIdIdentityIssuerType.SLACK,
-                        userId,
-                    );
-            }
 
             if (openIdIdentity) {
                 result = 'authenticated';
@@ -5082,18 +5070,8 @@ Use them as a reference, but do all the due dilligence and follow the instructio
                 await this.openIdIdentityModel.findIdentityByOpenId(
                     OpenIdIdentityIssuerType.SLACK,
                     userId,
-                    teamId,
                 );
             observedIdentity = openIdIdentity;
-            if (!observedIdentity) {
-                // Observability-only: a teamless lookup so the wide event can
-                // distinguish a truly-absent identity from one filtered out by team_id.
-                observedIdentity =
-                    await this.openIdIdentityModel.findIdentityByOpenId(
-                        OpenIdIdentityIssuerType.SLACK,
-                        userId,
-                    );
-            }
 
             if (!openIdIdentity) {
                 await client.chat.postEphemeral({

--- a/packages/backend/src/models/OpenIdIdentitiesModel.ts
+++ b/packages/backend/src/models/OpenIdIdentitiesModel.ts
@@ -78,17 +78,10 @@ export class OpenIdIdentityModel {
     async findIdentityByOpenId(
         issuerType: OpenIdIdentityIssuerType,
         subject: string,
-        teamId?: string,
     ): Promise<OpenIdIdentity | null> {
-        const query = this.getOpenIdQueryBuilder()
+        const [identity] = await this.getOpenIdQueryBuilder()
             .where('issuer_type', issuerType)
             .andWhere('subject', subject);
-
-        if (teamId) {
-            void query.andWhere(`${OpenIdIdentitiesTableName}.team_id`, teamId);
-        }
-
-        const [identity] = await query;
 
         if (identity === undefined) {
             return null;

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -399,6 +399,7 @@ apiV1Router.get(
                     messageTs: slackContext.messageTs,
                     threadTs: slackContext.threadTs,
                     userUuid: req.user.userUuid,
+                    trigger: slackContext.trigger,
                 })
                 .catch((err: unknown) => {
                     // Log but don't fail the redirect


### PR DESCRIPTION
## Summary

Fixes [PROD-7030](https://linear.app/lightdash/issue/PROD-7030/). Two bugs, one PR:

1. **Root cause** — `findIdentityByOpenId(SLACK, userId, teamId)` narrowed the lookup by the Bolt `context.teamId` (install team), but the stored `team_id` on `openid_identities` is `profile.team.id` from Slack's OIDC scope (user's home team). For Slack Connect / Enterprise Grid users the two differ, causing the auth check to miss even for already-linked users. The filter is dropped — `(issuer_type, subject)` is already a unique Slack-user identifier.

2. **Filed UX bug** — The feedback-vote ephemeral was plain text with no OAuth button. Now matches the `handleAiAgentAuth` pattern: a "Connect your Slack account" button whose URL carries `trigger=vote` so the OAuth callback knows not to replay the AI reply into a new `createSlackPrompt`.

## Commits

| Commit | Change |
|---|---|
| `5011297390` | Drop the `team_id` filter from `findIdentityByOpenId`; update both auth-check sites; remove the observability-only teamless fallback added in the preceding logging PR (primary lookup now does that job). |
| `23c139a45d` | Add OAuth button to the vote ephemeral; thread `body.message.ts` + `thread_ts` through the upvote/downvote handlers so the button URL is well-formed. |
| `dfd7e780fe` | Add `trigger` to the OAuth URL → session → callback → `processPendingSlackMessage`. On `trigger=vote` the callback updates the ephemeral to "Connected! Click the vote button again" and skips the app_mention replay (which would otherwise feed the bot its own reply). |
| `00c3bd6228` | Include `organizationUuid` in the `app_mention` auth wide event (previously only present on the `vote` event), so prod logs can slice by customer org on both trigger paths. |

## Evidence

Investigation pre-dates the recent logging PR and is based on direct DB queries against an affected customer's Cloud SQL instance:

- 15 Slack-linked users total. Zero rows had `team_id = NULL` — ruling out the "legacy pre-migration rows" theory.
- 11 of 15 users had `oi.team_id` ≠ the install's `slack_team_id`. These users were bouncing off the auth check on every interaction.
- Application logs showed ~40 `processPendingSlackMessage` invocations per month from the same handful of users — each one an @mention that was silently forced through the OAuth "Connect your Slack account" button before the bot would respond. The vote path exposed the same bug more starkly because its ephemeral lacked the button.

## What doesn't change

- `team_id` column on `openid_identities` stays; it's still populated on new links and remains useful as audit/display metadata.
- `OpenIdIdentity.teamId` remains on the type (still populated; consumed by the wide-event logs only).
- No API schema change — `pnpm generate-api` produces no diff for our files.
- No migration.

## Test plan

- [x] `pnpm -F backend typecheck`
- [x] `pnpm -F backend lint` — 0 errors, pre-existing warnings only
- [ ] Post-deploy to an affected customer: `ai_agent.slack_auth` wide events should show `result=authenticated` for users whose `teamIdMatchesStored=false` (previously these missed and logged `identity_missing`). The `auth.slack.identity_link` `result=already_linked` count should collapse toward zero.
- [ ] Post-deploy: click vote as an unlinked user on any `aiRequireOAuth=true` org → ephemeral shows "Connect your Slack account" button → OAuth completes → ephemeral updates to "Connected! Click the vote button again" → second vote click records the score.
- [ ] Post-deploy: as an Enterprise-Grid linked user, click vote → vote records immediately, no ephemeral.

## Risk

Dropping the team filter loosens identity resolution: a Slack user's subject is globally unique (even in Enterprise Grid, `W…` IDs are grid-wide and `U…` IDs are per-workspace-unique), so collisions are not realistically possible. The `(issuer_type, subject)` pair is effectively the primary key for identity lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Security

- **Identity uniqueness**: guaranteed by the DB primary key `openid_identities_pkey (issuer, subject)` — the dropped `team_id` filter was never doing disambiguation work. The lookup cannot return more than one row, independent of whether Slack globally guarantees subject uniqueness across unrelated workspaces (their current docs say yes for non-legacy IDs; in Enterprise Grid shared IDs across workspaces are the intended feature).
- **Authorization shift worth noting**: pre-fix, the `team_id` filter incidentally restricted votes/@mentions to users from the bot's install workspace. Post-fix, any user linked to a Lightdash account can vote on AI responses they can see in Slack. This matters in Slack Connect scenarios where a shared channel gives cross-org visibility — a user from org A with a Lightdash account can now vote on org B's AI responses in a shared channel. No existing code on this path ever enforced org-membership; the removed filter was not a real authorization boundary, just a coincidental restriction.
- **Payload integrity**: `userId`/`teamId` come from Slack's HMAC-signed block_action payload validated by Bolt. No user-controllable forgery.
- **`trigger` query param**: allowlisted at the middleware to `'vote' | 'app_mention'`; any other value is dropped. The worst-case forgery flips the post-OAuth replay behaviour, producing at most a UX glitch.
- **No new sensitive fields in logs** — wide events carry Slack user IDs, team IDs, organizationUuid. No emails, no tokens, no message content. Consistent with existing log practice.