### PR TITLE
feat(data-apps): pin data apps to the project homepage

### DIFF
--- a/packages/backend/src/@types/knex-tables.d.ts
+++ b/packages/backend/src/@types/knex-tables.d.ts
@@ -158,6 +158,8 @@ import {
     PersonalAccessTokenTableName,
 } from '../database/entities/personalAccessTokens';
 import {
+    PinnedAppTable,
+    PinnedAppTableName,
     PinnedChartTable,
     PinnedChartTableName,
     PinnedDashboardTable,
@@ -420,6 +422,7 @@ declare module 'knex/types/tables' {
         [PinnedChartTableName]: PinnedChartTable;
         [PinnedDashboardTableName]: PinnedDashboardTable;
         [PinnedSpaceTableName]: PinnedSpaceTable;
+        [PinnedAppTableName]: PinnedAppTable;
         [SchedulerTableName]: SchedulerTable;
         [SchedulerSlackTargetTableName]: SchedulerSlackTargetTable;
         [SchedulerEmailTargetTableName]: SchedulerEmailTargetTable;

--- a/packages/backend/src/database/entities/pinnedList.ts
+++ b/packages/backend/src/database/entities/pinnedList.ts
@@ -4,6 +4,7 @@ export const PinnedListTableName = 'pinned_list';
 export const PinnedChartTableName = 'pinned_chart';
 export const PinnedDashboardTableName = 'pinned_dashboard';
 export const PinnedSpaceTableName = 'pinned_space';
+export const PinnedAppTableName = 'pinned_app';
 
 export type DbPinnedList = {
     pinned_list_uuid: string;
@@ -32,8 +33,19 @@ export type DBPinnedSpace = {
     created_at: Date;
     order: number;
 };
+export type DbPinnedApp = {
+    pinned_item_uuid: string;
+    pinned_list_uuid: string;
+    app_uuid: string;
+    created_at: Date;
+    order: number;
+};
 
-export type DbPinnedItem = DbPinnedChart | DbPinnedDashboard | DBPinnedSpace;
+export type DbPinnedItem =
+    | DbPinnedChart
+    | DbPinnedDashboard
+    | DBPinnedSpace
+    | DbPinnedApp;
 
 export type CreatePinnedChart = Omit<
     DbPinnedChart,
@@ -45,6 +57,10 @@ export type CreatePinnedDashboard = Omit<
 >;
 export type CreatePinnedSpace = Omit<
     DBPinnedSpace,
+    'pinned_item_uuid' | 'created_at' | 'order'
+>;
+export type CreatePinnedApp = Omit<
+    DbPinnedApp,
     'pinned_item_uuid' | 'created_at' | 'order'
 >;
 
@@ -66,4 +82,9 @@ export type PinnedSpaceTable = Knex.CompositeTableType<
     DBPinnedSpace,
     CreatePinnedSpace,
     Pick<DBPinnedSpace, 'order'>
+>;
+export type PinnedAppTable = Knex.CompositeTableType<
+    DbPinnedApp,
+    CreatePinnedApp,
+    Pick<DbPinnedApp, 'order'>
 >;

--- a/packages/backend/src/database/migrations/20260424120000_add_pinned_app_table.ts
+++ b/packages/backend/src/database/migrations/20260424120000_add_pinned_app_table.ts
@@ -1,0 +1,38 @@
+import { Knex } from 'knex';
+
+const PinnedListTableName = 'pinned_list';
+const PinnedAppTableName = 'pinned_app';
+
+export async function up(knex: Knex): Promise<void> {
+    if (!(await knex.schema.hasTable(PinnedAppTableName))) {
+        await knex.schema.createTable(PinnedAppTableName, (table) => {
+            table
+                .uuid('pinned_item_uuid')
+                .primary()
+                .notNullable()
+                .defaultTo(knex.raw('uuid_generate_v4()'));
+            table
+                .uuid('pinned_list_uuid')
+                .references('pinned_list_uuid')
+                .inTable(PinnedListTableName)
+                .notNullable()
+                .onDelete('CASCADE');
+            table
+                .uuid('app_uuid')
+                .references('app_id')
+                .inTable('apps')
+                .notNullable()
+                .onDelete('CASCADE');
+            table.integer('order').notNullable().defaultTo(100);
+            table
+                .timestamp('created_at', { useTz: false })
+                .notNullable()
+                .defaultTo(knex.fn.now());
+            table.unique(['pinned_list_uuid', 'app_uuid']);
+        });
+    }
+}
+
+export async function down(knex: Knex): Promise<void> {
+    await knex.schema.dropTableIfExists(PinnedAppTableName);
+}

--- a/packages/backend/src/ee/controllers/appGenerateController.ts
+++ b/packages/backend/src/ee/controllers/appGenerateController.ts
@@ -8,6 +8,7 @@ import {
     type ApiGetAppResponse,
     type ApiMyAppsResponse,
     type ApiPreviewTokenResponse,
+    type ApiTogglePinnedItem,
     type ApiUpdateAppRequest,
     type ApiUpdateAppResponse,
     type GenerateAppRequestBody,
@@ -239,6 +240,30 @@ export class AppGenerateController extends BaseController {
         return {
             status: 'ok',
             results: undefined,
+        };
+    }
+
+    /**
+     * Pin or unpin an app to the project homepage. Toggles the current state.
+     * @summary Toggle app pinning
+     */
+    @Middlewares([allowApiKeyAuthentication, isAuthenticated])
+    @SuccessResponse('200', 'Success')
+    @Patch('/{appUuid}/pinning')
+    @OperationId('toggleAppPinning')
+    async toggleAppPinning(
+        @Request() req: express.Request,
+        @Path() projectUuid: string,
+        @Path() appUuid: string,
+    ): Promise<ApiTogglePinnedItem> {
+        const result = await this.getAppGenerateService().togglePinning(
+            req.user!,
+            projectUuid,
+            appUuid,
+        );
+        return {
+            status: 'ok',
+            results: result,
         };
     }
 

--- a/packages/backend/src/ee/index.ts
+++ b/packages/backend/src/ee/index.ts
@@ -84,6 +84,7 @@ export async function getEnterpriseAppArguments(): Promise<EnterpriseAppArgument
                     catalogModel: models.getCatalogModel(),
                     appModel: models.getAppModel(),
                     featureFlagModel: models.getFeatureFlagModel(),
+                    pinnedListModel: models.getPinnedListModel(),
                     projectModel: models.getProjectModel(),
                     schedulerClient:
                         clients.getSchedulerClient() as CommercialSchedulerClient,

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -17,6 +17,7 @@ import {
     type AppGeneratePipelineJobPayload,
     type ChartReference,
     type SessionUser,
+    type TogglePinnedItemInfo,
 } from '@lightdash/common';
 import { ALL_TRAFFIC, Sandbox } from 'e2b';
 import { Knex } from 'knex';
@@ -38,6 +39,7 @@ import { AnalyticsModel } from '../../../models/AnalyticsModel';
 import { AppModel } from '../../../models/AppModel';
 import { CatalogModel } from '../../../models/CatalogModel/CatalogModel';
 import { FeatureFlagModel } from '../../../models/FeatureFlagModel/FeatureFlagModel';
+import { PinnedListModel } from '../../../models/PinnedListModel';
 import { ProjectModel } from '../../../models/ProjectModel/ProjectModel';
 import { mintPreviewToken } from '../../../routers/appPreviewToken';
 import { BaseService } from '../../../services/BaseService';
@@ -52,6 +54,7 @@ type AppGenerateServiceDeps = {
     catalogModel: CatalogModel;
     appModel: AppModel;
     featureFlagModel: FeatureFlagModel;
+    pinnedListModel: PinnedListModel;
     projectModel: ProjectModel;
     schedulerClient: CommercialSchedulerClient;
     savedChartService: SavedChartService;
@@ -76,6 +79,8 @@ export class AppGenerateService extends BaseService {
 
     private readonly featureFlagModel: FeatureFlagModel;
 
+    private readonly pinnedListModel: PinnedListModel;
+
     private readonly projectModel: ProjectModel;
 
     private readonly schedulerClient: CommercialSchedulerClient;
@@ -91,6 +96,7 @@ export class AppGenerateService extends BaseService {
         catalogModel,
         appModel,
         featureFlagModel,
+        pinnedListModel,
         projectModel,
         schedulerClient,
         savedChartService,
@@ -103,6 +109,7 @@ export class AppGenerateService extends BaseService {
         this.catalogModel = catalogModel;
         this.appModel = appModel;
         this.featureFlagModel = featureFlagModel;
+        this.pinnedListModel = pinnedListModel;
         this.projectModel = projectModel;
         this.schedulerClient = schedulerClient;
         this.savedChartService = savedChartService;
@@ -2219,6 +2226,8 @@ export class AppGenerateService extends BaseService {
         description: string;
         createdByUserUuid: string;
         spaceUuid: string | null;
+        pinnedListUuid: string | null;
+        pinnedListOrder: number | null;
         versions: {
             version: number;
             prompt: string;
@@ -2236,6 +2245,8 @@ export class AppGenerateService extends BaseService {
             createdByUserUuid,
             organizationUuid,
             spaceUuid,
+            pinnedListUuid,
+            pinnedListOrder,
             versions,
             hasMore,
         } = await this.appModel.getAppWithVersions(appUuid, projectUuid, opts);
@@ -2264,6 +2275,8 @@ export class AppGenerateService extends BaseService {
             description,
             createdByUserUuid,
             spaceUuid,
+            pinnedListUuid,
+            pinnedListOrder,
             versions: versions.map((v) => ({
                 version: v.version,
                 prompt: v.prompt,
@@ -2319,6 +2332,110 @@ export class AppGenerateService extends BaseService {
                 lastVersionStatus: row.lastVersion?.status ?? null,
             })),
             pagination: result.pagination,
+        };
+    }
+
+    /**
+     * Pin/unpin a data app to the project homepage.
+     *
+     * Personal (spaceless) apps cannot be pinned — the pinned panel is a
+     * project-wide surface, so pinning an app only visible to its creator
+     * would leak its presence to everyone else.
+     */
+    async togglePinning(
+        user: SessionUser,
+        projectUuid: string,
+        appUuid: string,
+    ): Promise<TogglePinnedItemInfo> {
+        await this.assertDataAppsEnabled(user);
+
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+
+        this.assertDataAppAbility(
+            user,
+            'manage',
+            app.organization_uuid,
+            projectUuid,
+            'Insufficient permissions to pin data apps',
+            { metadata: { appUuid } },
+        );
+
+        if (!app.space_uuid) {
+            throw new ParameterError('Personal data apps cannot be pinned');
+        }
+
+        const { inheritsFromOrgOrProject, access } =
+            await this.spacePermissionService.getSpaceAccessContext(
+                user.userUuid,
+                app.space_uuid,
+            );
+
+        const auditedAbility = this.createAuditedAbility(user);
+        if (
+            auditedAbility.cannot(
+                'manage',
+                subject('PinnedItems', {
+                    organizationUuid: app.organization_uuid,
+                    projectUuid,
+                    metadata: { appUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError();
+        }
+
+        if (
+            auditedAbility.cannot(
+                'view',
+                subject('DataApp', {
+                    organizationUuid: app.organization_uuid,
+                    projectUuid,
+                    spaceUuid: app.space_uuid,
+                    inheritsFromOrgOrProject,
+                    access,
+                    metadata: { appUuid },
+                }),
+            )
+        ) {
+            throw new ForbiddenError(
+                "You don't have access to the space this data app belongs to",
+            );
+        }
+
+        if (app.pinned_list_uuid) {
+            await this.pinnedListModel.deleteItem({
+                pinnedListUuid: app.pinned_list_uuid,
+                appUuid,
+            });
+        } else {
+            await this.pinnedListModel.addItem({
+                projectUuid,
+                appUuid,
+            });
+        }
+
+        const pinnedList =
+            await this.pinnedListModel.getPinnedListAndItems(projectUuid);
+
+        this.analytics.track({
+            event: 'pinned_list.updated',
+            userId: user.userUuid,
+            properties: {
+                projectId: projectUuid,
+                organizationId: app.organization_uuid,
+                location: 'homepage',
+                pinnedListId: pinnedList.pinnedListUuid,
+                pinnedItems: pinnedList.items,
+            },
+        });
+
+        return {
+            projectUuid,
+            spaceUuid: app.space_uuid,
+            pinnedListUuid: pinnedList.pinnedListUuid,
+            isPinned: !!pinnedList.items.find(
+                (item) => item.appUuid === appUuid,
+            ),
         };
     }
 

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -6967,7 +6967,7 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
+    'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__':
         {
             dataType: 'refAlias',
             type: {
@@ -6983,6 +6983,22 @@ const models: TsoaRoute.Models = {
                                     dataType: 'refAlias',
                                     ref: 'ApiAppVersionSummary',
                                 },
+                                required: true,
+                            },
+                            pinnedListOrder: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { dataType: 'double' },
+                                    { dataType: 'enum', enums: [null] },
+                                ],
+                                required: true,
+                            },
+                            pinnedListUuid: {
+                                dataType: 'union',
+                                subSchemas: [
+                                    { dataType: 'string' },
+                                    { dataType: 'enum', enums: [null] },
+                                ],
                                 required: true,
                             },
                             spaceUuid: {
@@ -7012,7 +7028,7 @@ const models: TsoaRoute.Models = {
     ApiGetAppResponse: {
         dataType: 'refAlias',
         type: {
-            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
+            ref: 'ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__',
             validators: {},
         },
     },
@@ -7065,6 +7081,32 @@ const models: TsoaRoute.Models = {
     ApiDeleteAppResponse: {
         dataType: 'refAlias',
         type: { ref: 'ApiSuccessEmpty', validators: {} },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    TogglePinnedItemInfo: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                isPinned: { dataType: 'boolean', required: true },
+                spaceUuid: { dataType: 'string', required: true },
+                projectUuid: { dataType: 'string', required: true },
+                pinnedListUuid: { dataType: 'string', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ApiTogglePinnedItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                results: { ref: 'TogglePinnedItemInfo', required: true },
+                status: { dataType: 'enum', enums: ['ok'], required: true },
+            },
+            validators: {},
+        },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     'ApiSuccess__token-string__': {
@@ -8704,25 +8746,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -8742,11 +8765,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8761,11 +8784,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8796,29 +8838,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                chartUsage:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 searchRank:
                                                                                                     {
                                                                                                         dataType:
@@ -8842,11 +8861,28 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
-                                                                                                fieldType:
+                                                                                                chartUsage:
                                                                                                     {
                                                                                                         dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
                                                                                                     },
                                                                                                 tableName:
                                                                                                     {
@@ -8859,6 +8895,12 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -8974,11 +9016,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9054,29 +9096,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    chartUsage:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     searchRank:
                                                                                                         {
                                                                                                             dataType:
@@ -9100,11 +9119,28 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
-                                                                                                    fieldType:
+                                                                                                    chartUsage:
                                                                                                         {
                                                                                                             dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
                                                                                                         },
                                                                                                     tableName:
                                                                                                         {
@@ -9117,6 +9153,12 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9148,44 +9190,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['success'],
                                                         },
                                                         {
@@ -9224,11 +9228,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9243,11 +9247,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9262,11 +9266,49 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -22663,6 +22705,106 @@ const models: TsoaRoute.Models = {
         },
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    'ResourceViewItemType.DATA_APP': {
+        dataType: 'refEnum',
+        enums: ['data_app'],
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    ResourceViewDataAppItem: {
+        dataType: 'refAlias',
+        type: {
+            dataType: 'nestedObjectLiteral',
+            nestedProperties: {
+                category: { ref: 'ResourceItemCategory' },
+                data: {
+                    dataType: 'nestedObjectLiteral',
+                    nestedProperties: {
+                        pinnedListOrder: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'double' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        pinnedListUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        latestVersionStatus: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { ref: 'AppVersionStatus' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        latestVersionNumber: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'double' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        firstViewedAt: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'datetime' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        views: { dataType: 'double', required: true },
+                        updatedByUser: {
+                            dataType: 'union',
+                            subSchemas: [
+                                {
+                                    dataType: 'nestedObjectLiteral',
+                                    nestedProperties: {
+                                        lastName: {
+                                            dataType: 'string',
+                                            required: true,
+                                        },
+                                        firstName: {
+                                            dataType: 'string',
+                                            required: true,
+                                        },
+                                        userUuid: {
+                                            dataType: 'string',
+                                            required: true,
+                                        },
+                                    },
+                                },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
+                        updatedAt: { dataType: 'datetime', required: true },
+                        spaceUuid: { dataType: 'string', required: true },
+                        description: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'undefined' },
+                            ],
+                            required: true,
+                        },
+                        name: { dataType: 'string', required: true },
+                        uuid: { dataType: 'string', required: true },
+                    },
+                    required: true,
+                },
+                type: { ref: 'ResourceViewItemType.DATA_APP', required: true },
+            },
+            validators: {},
+        },
+    },
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
     PinnedItems: {
         dataType: 'refAlias',
         type: {
@@ -22673,6 +22815,7 @@ const models: TsoaRoute.Models = {
                     { ref: 'ResourceViewDashboardItem' },
                     { ref: 'ResourceViewChartItem' },
                     { ref: 'ResourceViewSpaceItem' },
+                    { ref: 'ResourceViewDataAppItem' },
                 ],
             },
             validators: {},
@@ -22696,7 +22839,7 @@ const models: TsoaRoute.Models = {
         enums: ['chart', 'dashboard', 'space', 'data_app'],
     },
     // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data.uuid-or-pinnedListOrder_':
+    'Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data-or-ResourceViewDataAppItem-at-data.uuid-or-pinnedListOrder_':
         {
             dataType: 'refAlias',
             type: {
@@ -22722,7 +22865,7 @@ const models: TsoaRoute.Models = {
             dataType: 'nestedObjectLiteral',
             nestedProperties: {
                 data: {
-                    ref: 'Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data.uuid-or-pinnedListOrder_',
+                    ref: 'Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data-or-ResourceViewDataAppItem-at-data.uuid-or-pinnedListOrder_',
                     required: true,
                 },
                 type: { ref: 'ResourceViewItemType', required: true },
@@ -24596,90 +24739,6 @@ const models: TsoaRoute.Models = {
                 userIdFieldId: { dataType: 'string', required: true },
                 timestampFieldId: { dataType: 'string', required: true },
                 exploreName: { dataType: 'string', required: true },
-            },
-            validators: {},
-        },
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    'ResourceViewItemType.DATA_APP': {
-        dataType: 'refEnum',
-        enums: ['data_app'],
-    },
-    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
-    ResourceViewDataAppItem: {
-        dataType: 'refAlias',
-        type: {
-            dataType: 'nestedObjectLiteral',
-            nestedProperties: {
-                category: { ref: 'ResourceItemCategory' },
-                data: {
-                    dataType: 'nestedObjectLiteral',
-                    nestedProperties: {
-                        latestVersionStatus: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { ref: 'AppVersionStatus' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        latestVersionNumber: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'double' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        firstViewedAt: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'datetime' },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        views: { dataType: 'double', required: true },
-                        updatedByUser: {
-                            dataType: 'union',
-                            subSchemas: [
-                                {
-                                    dataType: 'nestedObjectLiteral',
-                                    nestedProperties: {
-                                        lastName: {
-                                            dataType: 'string',
-                                            required: true,
-                                        },
-                                        firstName: {
-                                            dataType: 'string',
-                                            required: true,
-                                        },
-                                        userUuid: {
-                                            dataType: 'string',
-                                            required: true,
-                                        },
-                                    },
-                                },
-                                { dataType: 'enum', enums: [null] },
-                            ],
-                            required: true,
-                        },
-                        updatedAt: { dataType: 'datetime', required: true },
-                        spaceUuid: { dataType: 'string', required: true },
-                        description: {
-                            dataType: 'union',
-                            subSchemas: [
-                                { dataType: 'string' },
-                                { dataType: 'undefined' },
-                            ],
-                            required: true,
-                        },
-                        name: { dataType: 'string', required: true },
-                        uuid: { dataType: 'string', required: true },
-                    },
-                    required: true,
-                },
-                type: { ref: 'ResourceViewItemType.DATA_APP', required: true },
             },
             validators: {},
         },
@@ -28980,6 +29039,7 @@ const models: TsoaRoute.Models = {
                     {
                         dataType: 'nestedObjectLiteral',
                         nestedProperties: {
+                            order: { dataType: 'double', required: true },
                             uuid: { dataType: 'string', required: true },
                         },
                     },
@@ -33304,6 +33364,73 @@ export function RegisterRoutes(app: Router) {
 
                 await templateService.apiHandler({
                     methodName: 'deleteApp',
+                    controller,
+                    response,
+                    next,
+                    validatedArgs,
+                    successStatus: 200,
+                });
+            } catch (err) {
+                return next(err);
+            }
+        },
+    );
+    // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+    const argsAppGenerateController_toggleAppPinning: Record<
+        string,
+        TsoaRoute.ParameterSchema
+    > = {
+        req: { in: 'request', name: 'req', required: true, dataType: 'object' },
+        projectUuid: {
+            in: 'path',
+            name: 'projectUuid',
+            required: true,
+            dataType: 'string',
+        },
+        appUuid: {
+            in: 'path',
+            name: 'appUuid',
+            required: true,
+            dataType: 'string',
+        },
+    };
+    app.patch(
+        '/api/v1/ee/projects/:projectUuid/apps/:appUuid/pinning',
+        ...fetchMiddlewares<RequestHandler>(AppGenerateController),
+        ...fetchMiddlewares<RequestHandler>(
+            AppGenerateController.prototype.toggleAppPinning,
+        ),
+
+        async function AppGenerateController_toggleAppPinning(
+            request: ExRequest,
+            response: ExResponse,
+            next: any,
+        ) {
+            // WARNING: This file was auto-generated with tsoa. Please do not modify it. Re-run tsoa to re-generate this file: https://github.com/lukeautry/tsoa
+
+            let validatedArgs: any[] = [];
+            try {
+                validatedArgs = templateService.getValidatedArgs({
+                    args: argsAppGenerateController_toggleAppPinning,
+                    request,
+                    response,
+                });
+
+                const container: IocContainer =
+                    typeof iocContainer === 'function'
+                        ? (iocContainer as IocContainerFactory)(request)
+                        : iocContainer;
+
+                const controller: any =
+                    await container.get<AppGenerateController>(
+                        AppGenerateController,
+                    );
+                if (typeof controller['setStatus'] === 'function') {
+                    controller.setStatus(undefined);
+                }
+
+                await templateService.apiHandler({
+                    methodName: 'toggleAppPinning',
                     controller,
                     response,
                     next,

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -8355,7 +8355,7 @@
                 ],
                 "type": "object"
             },
-            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
+            "ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__": {
                 "properties": {
                     "results": {
                         "properties": {
@@ -8367,6 +8367,15 @@
                                     "$ref": "#/components/schemas/ApiAppVersionSummary"
                                 },
                                 "type": "array"
+                            },
+                            "pinnedListOrder": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            },
+                            "pinnedListUuid": {
+                                "type": "string",
+                                "nullable": true
                             },
                             "spaceUuid": {
                                 "type": "string",
@@ -8388,6 +8397,8 @@
                         "required": [
                             "hasMore",
                             "versions",
+                            "pinnedListOrder",
+                            "pinnedListUuid",
                             "spaceUuid",
                             "createdByUserUuid",
                             "description",
@@ -8406,7 +8417,7 @@
                 "type": "object"
             },
             "ApiGetAppResponse": {
-                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
+                "$ref": "#/components/schemas/ApiSuccess__appUuid-string--name-string--description-string--createdByUserUuid-string--spaceUuid-string-or-null--pinnedListUuid-string-or-null--pinnedListOrder-number-or-null--versions-ApiAppVersionSummary-Array--hasMore-boolean__"
             },
             "ApiCancelAppVersionResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"
@@ -8453,6 +8464,43 @@
             },
             "ApiDeleteAppResponse": {
                 "$ref": "#/components/schemas/ApiSuccessEmpty"
+            },
+            "TogglePinnedItemInfo": {
+                "properties": {
+                    "isPinned": {
+                        "type": "boolean"
+                    },
+                    "spaceUuid": {
+                        "type": "string"
+                    },
+                    "projectUuid": {
+                        "type": "string"
+                    },
+                    "pinnedListUuid": {
+                        "type": "string"
+                    }
+                },
+                "required": [
+                    "isPinned",
+                    "spaceUuid",
+                    "projectUuid",
+                    "pinnedListUuid"
+                ],
+                "type": "object"
+            },
+            "ApiTogglePinnedItem": {
+                "properties": {
+                    "results": {
+                        "$ref": "#/components/schemas/TogglePinnedItemInfo"
+                    },
+                    "status": {
+                        "type": "string",
+                        "enum": ["ok"],
+                        "nullable": false
+                    }
+                },
+                "required": ["results", "status"],
+                "type": "object"
             },
             "ApiSuccess__token-string__": {
                 "properties": {
@@ -10177,8 +10225,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -10190,8 +10238,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10205,18 +10253,15 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
-                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10224,14 +10269,17 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
+                                                                        "fieldType": {
+                                                                            "type": "string"
+                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
-                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
+                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10280,8 +10328,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10325,18 +10373,15 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
-                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10344,14 +10389,17 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
+                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
-                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
+                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10379,8 +10427,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -23923,6 +23971,107 @@
                 "required": ["data", "type"],
                 "type": "object"
             },
+            "ResourceViewItemType.DATA_APP": {
+                "enum": ["data_app"],
+                "type": "string"
+            },
+            "ResourceViewDataAppItem": {
+                "properties": {
+                    "category": {
+                        "$ref": "#/components/schemas/ResourceItemCategory"
+                    },
+                    "data": {
+                        "properties": {
+                            "pinnedListOrder": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            },
+                            "pinnedListUuid": {
+                                "type": "string",
+                                "nullable": true
+                            },
+                            "latestVersionStatus": {
+                                "allOf": [
+                                    {
+                                        "$ref": "#/components/schemas/AppVersionStatus"
+                                    }
+                                ],
+                                "nullable": true
+                            },
+                            "latestVersionNumber": {
+                                "type": "number",
+                                "format": "double",
+                                "nullable": true
+                            },
+                            "firstViewedAt": {
+                                "type": "string",
+                                "format": "date-time",
+                                "nullable": true
+                            },
+                            "views": {
+                                "type": "number",
+                                "format": "double"
+                            },
+                            "updatedByUser": {
+                                "properties": {
+                                    "lastName": {
+                                        "type": "string"
+                                    },
+                                    "firstName": {
+                                        "type": "string"
+                                    },
+                                    "userUuid": {
+                                        "type": "string"
+                                    }
+                                },
+                                "required": [
+                                    "lastName",
+                                    "firstName",
+                                    "userUuid"
+                                ],
+                                "type": "object",
+                                "nullable": true
+                            },
+                            "updatedAt": {
+                                "type": "string",
+                                "format": "date-time"
+                            },
+                            "spaceUuid": {
+                                "type": "string"
+                            },
+                            "description": {
+                                "type": "string"
+                            },
+                            "name": {
+                                "type": "string"
+                            },
+                            "uuid": {
+                                "type": "string"
+                            }
+                        },
+                        "required": [
+                            "pinnedListOrder",
+                            "pinnedListUuid",
+                            "latestVersionStatus",
+                            "latestVersionNumber",
+                            "firstViewedAt",
+                            "views",
+                            "updatedByUser",
+                            "updatedAt",
+                            "spaceUuid",
+                            "name",
+                            "uuid"
+                        ],
+                        "type": "object"
+                    },
+                    "type": {
+                        "$ref": "#/components/schemas/ResourceViewItemType.DATA_APP"
+                    }
+                },
+                "required": ["data", "type"],
+                "type": "object"
+            },
             "PinnedItems": {
                 "items": {
                     "anyOf": [
@@ -23934,6 +24083,9 @@
                         },
                         {
                             "$ref": "#/components/schemas/ResourceViewSpaceItem"
+                        },
+                        {
+                            "$ref": "#/components/schemas/ResourceViewDataAppItem"
                         }
                     ]
                 },
@@ -23957,7 +24109,7 @@
                 "enum": ["chart", "dashboard", "space", "data_app"],
                 "type": "string"
             },
-            "Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data.uuid-or-pinnedListOrder_": {
+            "Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data-or-ResourceViewDataAppItem-at-data.uuid-or-pinnedListOrder_": {
                 "properties": {
                     "uuid": {
                         "type": "string"
@@ -23975,7 +24127,7 @@
             "UpdatePinnedItemOrder": {
                 "properties": {
                     "data": {
-                        "$ref": "#/components/schemas/Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data.uuid-or-pinnedListOrder_"
+                        "$ref": "#/components/schemas/Pick_ResourceViewChartItem-at-data-or-ResourceViewDashboardItem-at-data-or-ResourceViewSpaceItem-at-data-or-ResourceViewDataAppItem-at-data.uuid-or-pinnedListOrder_"
                     },
                     "type": {
                         "$ref": "#/components/schemas/ResourceViewItemType"
@@ -25932,96 +26084,6 @@
                     "timestampFieldId",
                     "exploreName"
                 ],
-                "type": "object"
-            },
-            "ResourceViewItemType.DATA_APP": {
-                "enum": ["data_app"],
-                "type": "string"
-            },
-            "ResourceViewDataAppItem": {
-                "properties": {
-                    "category": {
-                        "$ref": "#/components/schemas/ResourceItemCategory"
-                    },
-                    "data": {
-                        "properties": {
-                            "latestVersionStatus": {
-                                "allOf": [
-                                    {
-                                        "$ref": "#/components/schemas/AppVersionStatus"
-                                    }
-                                ],
-                                "nullable": true
-                            },
-                            "latestVersionNumber": {
-                                "type": "number",
-                                "format": "double",
-                                "nullable": true
-                            },
-                            "firstViewedAt": {
-                                "type": "string",
-                                "format": "date-time",
-                                "nullable": true
-                            },
-                            "views": {
-                                "type": "number",
-                                "format": "double"
-                            },
-                            "updatedByUser": {
-                                "properties": {
-                                    "lastName": {
-                                        "type": "string"
-                                    },
-                                    "firstName": {
-                                        "type": "string"
-                                    },
-                                    "userUuid": {
-                                        "type": "string"
-                                    }
-                                },
-                                "required": [
-                                    "lastName",
-                                    "firstName",
-                                    "userUuid"
-                                ],
-                                "type": "object",
-                                "nullable": true
-                            },
-                            "updatedAt": {
-                                "type": "string",
-                                "format": "date-time"
-                            },
-                            "spaceUuid": {
-                                "type": "string"
-                            },
-                            "description": {
-                                "type": "string"
-                            },
-                            "name": {
-                                "type": "string"
-                            },
-                            "uuid": {
-                                "type": "string"
-                            }
-                        },
-                        "required": [
-                            "latestVersionStatus",
-                            "latestVersionNumber",
-                            "firstViewedAt",
-                            "views",
-                            "updatedByUser",
-                            "updatedAt",
-                            "spaceUuid",
-                            "name",
-                            "uuid"
-                        ],
-                        "type": "object"
-                    },
-                    "type": {
-                        "$ref": "#/components/schemas/ResourceViewItemType.DATA_APP"
-                    }
-                },
-                "required": ["data", "type"],
                 "type": "object"
             },
             "FavoriteItems": {
@@ -30275,11 +30337,15 @@
                     },
                     "pinnedList": {
                         "properties": {
+                            "order": {
+                                "type": "number",
+                                "format": "double"
+                            },
                             "uuid": {
                                 "type": "string"
                             }
                         },
-                        "required": ["uuid"],
+                        "required": ["order", "uuid"],
                         "type": "object",
                         "nullable": true
                     },
@@ -31083,7 +31149,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2795.0",
+        "version": "0.2799.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -14,6 +14,7 @@ import {
     type DbAppVersion,
 } from '../database/entities/apps';
 import { OrganizationTableName } from '../database/entities/organizations';
+import { PinnedAppTableName } from '../database/entities/pinnedList';
 import { ProjectTableName } from '../database/entities/projects';
 import { SpaceTableName } from '../database/entities/spaces';
 import KnexPaginate from '../database/pagination';
@@ -124,7 +125,13 @@ export class AppModel {
     async getApp(
         appId: string,
         projectUuid: string,
-    ): Promise<DbApp & { organization_uuid: string }> {
+    ): Promise<
+        DbApp & {
+            organization_uuid: string;
+            pinned_list_uuid: string | null;
+            pinned_list_order: number | null;
+        }
+    > {
         const row = await this.database(AppsTableName)
             .innerJoin(
                 ProjectTableName,
@@ -136,12 +143,25 @@ export class AppModel {
                 `${OrganizationTableName}.organization_id`,
                 `${ProjectTableName}.organization_id`,
             )
+            .leftJoin(
+                PinnedAppTableName,
+                `${PinnedAppTableName}.app_uuid`,
+                `${AppsTableName}.app_id`,
+            )
             .where(`${AppsTableName}.app_id`, appId)
             .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
             .whereNull(`${AppsTableName}.deleted_at`)
-            .select<(DbApp & { organization_uuid: string })[]>(
+            .select<
+                (DbApp & {
+                    organization_uuid: string;
+                    pinned_list_uuid: string | null;
+                    pinned_list_order: number | null;
+                })[]
+            >(
                 `${AppsTableName}.*`,
                 `${OrganizationTableName}.organization_uuid`,
+                `${PinnedAppTableName}.pinned_list_uuid`,
+                `${PinnedAppTableName}.order as pinned_list_order`,
             )
             .first();
         if (!row) {
@@ -203,6 +223,8 @@ export class AppModel {
         createdByUserUuid: string;
         organizationUuid: string;
         spaceUuid: string | null;
+        pinnedListUuid: string | null;
+        pinnedListOrder: number | null;
         versions: DbAppVersion[];
         hasMore: boolean;
     }> {
@@ -223,6 +245,11 @@ export class AppModel {
                 `${AppsTableName}.app_id`,
                 `${AppVersionsTableName}.app_id`,
             )
+            .leftJoin(
+                PinnedAppTableName,
+                `${PinnedAppTableName}.app_uuid`,
+                `${AppsTableName}.app_id`,
+            )
             .where(`${AppsTableName}.app_id`, appId)
             .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
             .whereNull(`${AppsTableName}.deleted_at`)
@@ -233,6 +260,8 @@ export class AppModel {
                 `${AppsTableName}.created_by_user_uuid`,
                 `${AppsTableName}.space_uuid`,
                 `${OrganizationTableName}.organization_uuid`,
+                `${PinnedAppTableName}.pinned_list_uuid`,
+                `${PinnedAppTableName}.order as pinned_list_order`,
             )
             .orderBy(`${AppVersionsTableName}.version`, 'desc')
             .limit(limit + 1);
@@ -251,6 +280,8 @@ export class AppModel {
             created_by_user_uuid: string;
             space_uuid: string | null;
             organization_uuid: string;
+            pinned_list_uuid: string | null;
+            pinned_list_order: number | null;
         })[] = await query;
 
         // Left join: if app doesn't exist, zero rows → 404
@@ -265,6 +296,8 @@ export class AppModel {
             created_by_user_uuid: createdByUserUuid,
             space_uuid: spaceUuid,
             organization_uuid: organizationUuid,
+            pinned_list_uuid: pinnedListUuid,
+            pinned_list_order: pinnedListOrder,
         } = rows[0];
 
         // If app exists but no versions match, we get one row with all nulls
@@ -277,6 +310,8 @@ export class AppModel {
                 created_by_user_uuid: string;
                 space_uuid: string | null;
                 organization_uuid: string;
+                pinned_list_uuid: string | null;
+                pinned_list_order: number | null;
             } => r.version !== null,
         );
         const hasMore = versions.length > limit;
@@ -286,6 +321,8 @@ export class AppModel {
             createdByUserUuid,
             organizationUuid,
             spaceUuid,
+            pinnedListUuid,
+            pinnedListOrder,
             versions: versions.slice(0, limit),
             hasMore,
         };

--- a/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/DataAppContentConfiguration.ts
@@ -5,6 +5,7 @@ import {
     AppVersionsTableName,
 } from '../../../database/entities/apps';
 import { OrganizationTableName } from '../../../database/entities/organizations';
+import { PinnedAppTableName } from '../../../database/entities/pinnedList';
 import { ProjectTableName } from '../../../database/entities/projects';
 import { SpaceTableName } from '../../../database/entities/spaces';
 import { UserTableName } from '../../../database/entities/users';
@@ -83,6 +84,11 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     `last_updated_by_user.user_uuid`,
                     `latest_version.created_by_user_uuid`,
                 )
+                .leftJoin(
+                    PinnedAppTableName,
+                    `${PinnedAppTableName}.app_uuid`,
+                    `${AppsTableName}.app_id`,
+                )
                 .select<SummaryContentRow[]>([
                     knex.raw(`'${ContentType.DATA_APP}' as content_type`),
                     knex.raw(
@@ -103,7 +109,7 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     `${ProjectTableName}.name as project_name`,
                     `${OrganizationTableName}.organization_uuid`,
                     `${OrganizationTableName}.organization_name`,
-                    knex.raw(`NULL::uuid as pinned_list_uuid`),
+                    `${PinnedAppTableName}.pinned_list_uuid as pinned_list_uuid`,
                     knex.raw(
                         `${AppsTableName}.created_at::timestamp as created_at`,
                     ),
@@ -132,7 +138,8 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     knex.raw(
                         `json_build_object(
                             'latestVersionNumber', latest_version.version,
-                            'latestVersionStatus', latest_version.status
+                            'latestVersionStatus', latest_version.status,
+                            'pinnedListOrder', ${PinnedAppTableName}.order
                         ) as metadata`,
                     ),
                 ])
@@ -215,7 +222,15 @@ export const dataAppContentConfiguration: ContentConfiguration<SummaryContentRow
                     uuid: value.space_uuid,
                     name: value.space_name,
                 },
-                pinnedList: null,
+                pinnedList: value.pinned_list_uuid
+                    ? {
+                          uuid: value.pinned_list_uuid,
+                          order:
+                              (value.metadata.pinnedListOrder as
+                                  | number
+                                  | null) ?? 0,
+                      }
+                    : null,
                 views: value.views,
                 firstViewedAt: value.first_viewed_at,
                 verification: null,

--- a/packages/backend/src/models/PinnedListModel.ts
+++ b/packages/backend/src/models/PinnedListModel.ts
@@ -1,8 +1,10 @@
 import {
     CreatePinnedItem,
     DeletePinnedItem,
+    isCreateAppPinnedItem,
     isCreateChartPinnedItem,
     isCreateSpacePinnedItem,
+    isDeleteAppPinnedItem,
     isDeleteChartPinnedItem,
     isDeleteSpacePinnedItem,
     NotFoundError,
@@ -16,12 +18,14 @@ import { Knex } from 'knex';
 import {
     DbPinnedItem,
     DbPinnedList,
+    PinnedAppTableName,
     PinnedChartTableName,
     PinnedDashboardTableName,
     PinnedListTableName,
     PinnedSpaceTableName,
 } from '../database/entities/pinnedList';
 import {
+    isDbPinnedApp,
     isDbPinnedChart,
     isDbPinnedDashboard,
     isDbPinnedSpace,
@@ -70,6 +74,11 @@ export class PinnedListModel {
                 pinned_list_uuid: results.pinnedListUuid,
                 space_uuid: item.spaceUuid,
             });
+        } else if (isCreateAppPinnedItem(item)) {
+            await this.database(PinnedAppTableName).insert({
+                pinned_list_uuid: results.pinnedListUuid,
+                app_uuid: item.appUuid,
+            });
         } else {
             await this.database(PinnedDashboardTableName).insert({
                 pinned_list_uuid: results.pinnedListUuid,
@@ -88,6 +97,11 @@ export class PinnedListModel {
             await this.database(PinnedSpaceTableName)
                 .delete()
                 .where('space_uuid', item.spaceUuid)
+                .andWhere('pinned_list_uuid', item.pinnedListUuid);
+        } else if (isDeleteAppPinnedItem(item)) {
+            await this.database(PinnedAppTableName)
+                .delete()
+                .where('app_uuid', item.appUuid)
                 .andWhere('pinned_list_uuid', item.pinnedListUuid);
         } else {
             await this.database(PinnedDashboardTableName)
@@ -115,6 +129,7 @@ export class PinnedListModel {
                 ? data.dashboard_uuid
                 : undefined,
             spaceUuid: isDbPinnedSpace(data) ? data.space_uuid : undefined,
+            appUuid: isDbPinnedApp(data) ? data.app_uuid : undefined,
             createdAt: data.created_at,
         };
     }
@@ -159,12 +174,23 @@ export class PinnedListModel {
             )
             .where('pinned_list_uuid', list.pinned_list_uuid)
             .orderBy('order');
+        const pinnedApps = await this.database(PinnedAppTableName)
+            .select(
+                'pinned_list_uuid',
+                'pinned_item_uuid',
+                'app_uuid',
+                'created_at',
+                'order',
+            )
+            .where('pinned_list_uuid', list.pinned_list_uuid)
+            .orderBy('order');
 
         const pinnedList = PinnedListModel.convertPinnedList(list);
         const pinnedItems = [
             ...pinnedCharts,
             ...pinnedDashboards,
             ...pinnedSpaces,
+            ...pinnedApps,
         ].map(PinnedListModel.convertPinnedItem);
 
         return { ...pinnedList, items: pinnedItems };
@@ -203,6 +229,15 @@ export class PinnedListModel {
                                 .update('order', item.data.pinnedListOrder)
                                 .where('pinned_list_uuid', pinnedListUuid)
                                 .andWhere('space_uuid', item.data.uuid),
+                        );
+                        break;
+                    }
+                    case ResourceViewItemType.DATA_APP: {
+                        promises.push(
+                            trx(PinnedAppTableName)
+                                .update('order', item.data.pinnedListOrder)
+                                .where('pinned_list_uuid', pinnedListUuid)
+                                .andWhere('app_uuid', item.data.uuid),
                         );
                         break;
                     }

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -2,14 +2,16 @@ import {
     AnyType,
     ResourceViewChartItem,
     ResourceViewDashboardItem,
+    ResourceViewDataAppItem,
     ResourceViewItemType,
     ResourceViewSpaceItem,
 } from '@lightdash/common';
 import { Knex } from 'knex';
-import { AppsTableName } from '../database/entities/apps';
+import { AppsTableName, AppVersionsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { OrganizationTableName } from '../database/entities/organizations';
 import {
+    PinnedAppTableName,
     PinnedListTableName,
     PinnedSpaceTableName,
 } from '../database/entities/pinnedList';
@@ -192,6 +194,103 @@ const getDashboards = async (
     return items;
 };
 
+const getApps = async (
+    knex: Knex,
+    projectUuid: string,
+    pinnedListUuid: string,
+    allowedSpaceUuids: string[],
+): Promise<ResourceViewDataAppItem[]> => {
+    if (allowedSpaceUuids.length === 0) {
+        return [];
+    }
+    // Latest version per app — mirrors DataAppContentConfiguration
+    const latestVersion = knex(AppVersionsTableName)
+        .distinctOn('app_id')
+        .orderBy('app_id')
+        .orderBy('version', 'desc')
+        .select(
+            'app_id',
+            'version',
+            'status',
+            'created_at as updated_at',
+            'created_by_user_uuid',
+        )
+        .as('lv');
+
+    const rows = (await knex(PinnedListTableName)
+        .innerJoin(
+            PinnedAppTableName,
+            `${PinnedListTableName}.pinned_list_uuid`,
+            `${PinnedAppTableName}.pinned_list_uuid`,
+        )
+        .innerJoin(AppsTableName, function nonDeletedAppJoin() {
+            this.on(
+                `${PinnedAppTableName}.app_uuid`,
+                '=',
+                `${AppsTableName}.app_id`,
+            ).andOnNull(`${AppsTableName}.deleted_at`);
+        })
+        .innerJoin(
+            SpaceTableName,
+            `${AppsTableName}.space_uuid`,
+            `${SpaceTableName}.space_uuid`,
+        )
+        .leftJoin(latestVersion, 'lv.app_id', `${AppsTableName}.app_id`)
+        .leftJoin(UserTableName, 'lv.created_by_user_uuid', 'users.user_uuid')
+        .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
+        .whereNull(`${SpaceTableName}.deleted_at`)
+        .andWhere(`${PinnedListTableName}.pinned_list_uuid`, pinnedListUuid)
+        .andWhere(`${PinnedListTableName}.project_uuid`, projectUuid)
+        .select({
+            pinned_list_uuid: `${PinnedListTableName}.pinned_list_uuid`,
+            order: `${PinnedAppTableName}.order`,
+            space_uuid: `${SpaceTableName}.space_uuid`,
+            app_uuid: `${AppsTableName}.app_id`,
+            name: `${AppsTableName}.name`,
+            description: `${AppsTableName}.description`,
+            views: `${AppsTableName}.views_count`,
+            first_viewed_at: knex.raw(`${AppsTableName}.created_at`),
+            updated_at: knex.raw(
+                `COALESCE(lv.updated_at, ${AppsTableName}.created_at)`,
+            ),
+            updated_by_user_uuid: 'users.user_uuid',
+            updated_by_user_first_name: 'users.first_name',
+            updated_by_user_last_name: 'users.last_name',
+            latest_version_number: 'lv.version',
+            latest_version_status: 'lv.status',
+        })
+        .orderBy(`${PinnedAppTableName}.order`, 'asc')) as Record<
+        string,
+        AnyType
+    >[];
+
+    const resourceType: ResourceViewItemType.DATA_APP =
+        ResourceViewItemType.DATA_APP;
+    return rows.map((row) => ({
+        type: resourceType,
+        data: {
+            uuid: row.app_uuid,
+            name: row.name,
+            description: row.description || undefined,
+            spaceUuid: row.space_uuid,
+            updatedAt: row.updated_at,
+            updatedByUser: row.updated_by_user_uuid
+                ? {
+                      userUuid: row.updated_by_user_uuid,
+                      firstName: row.updated_by_user_first_name,
+                      lastName: row.updated_by_user_last_name,
+                  }
+                : null,
+            views: Number(row.views ?? 0),
+            firstViewedAt: row.first_viewed_at,
+            latestVersionNumber: row.latest_version_number ?? null,
+            latestVersionStatus: row.latest_version_status ?? null,
+            pinnedListUuid: row.pinned_list_uuid,
+            pinnedListOrder: row.order,
+        },
+    }));
+};
+
 // Intermediate type returned by the model (without access data).
 // PinningService enriches these with access data from SpacePermissionService.
 export type ResourceViewSpaceItemBase = Omit<ResourceViewSpaceItem, 'data'> & {
@@ -333,6 +432,7 @@ export class ResourceViewItemModel {
     ): Promise<{
         dashboards: ResourceViewDashboardItem[];
         charts: ResourceViewChartItem[];
+        apps: ResourceViewDataAppItem[];
     }> {
         const results = await this.database.transaction(async (trx) => {
             const dashboards = await getDashboards(
@@ -347,9 +447,16 @@ export class ResourceViewItemModel {
                 pinnedListUuid,
                 allowedSpacesUuids,
             );
+            const apps = await getApps(
+                trx,
+                projectUuid,
+                pinnedListUuid,
+                allowedSpacesUuids,
+            );
             return {
                 dashboards,
                 charts,
+                apps,
             };
         });
         return results;

--- a/packages/backend/src/models/UserFavoritesModel.ts
+++ b/packages/backend/src/models/UserFavoritesModel.ts
@@ -9,6 +9,7 @@ import { type Knex } from 'knex';
 import { AppsTableName, AppVersionsTableName } from '../database/entities/apps';
 import { DashboardsTableName } from '../database/entities/dashboards';
 import { OrganizationTableName } from '../database/entities/organizations';
+import { PinnedAppTableName } from '../database/entities/pinnedList';
 import { ProjectTableName } from '../database/entities/projects';
 import { SavedChartsTableName } from '../database/entities/savedCharts';
 import { SpaceTableName } from '../database/entities/spaces';
@@ -259,6 +260,11 @@ export class UserFavoritesModel {
                 'last_updated_by_user.user_uuid',
                 'latest_version.created_by_user_uuid',
             )
+            .leftJoin(
+                PinnedAppTableName,
+                `${PinnedAppTableName}.app_uuid`,
+                `${AppsTableName}.app_id`,
+            )
             .whereIn(`${AppsTableName}.app_id`, appUuids)
             .andWhere(`${AppsTableName}.project_uuid`, projectUuid)
             .whereIn(`${SpaceTableName}.space_uuid`, allowedSpaceUuids)
@@ -287,6 +293,8 @@ export class UserFavoritesModel {
                 updated_by_user_uuid: 'last_updated_by_user.user_uuid',
                 updated_by_user_first_name: 'last_updated_by_user.first_name',
                 updated_by_user_last_name: 'last_updated_by_user.last_name',
+                pinned_list_uuid: `${PinnedAppTableName}.pinned_list_uuid`,
+                pinned_list_order: `${PinnedAppTableName}.order`,
             })) as Record<string, AnyType>[];
 
         return rows.map<ResourceViewDataAppItem>((row) => ({
@@ -308,6 +316,8 @@ export class UserFavoritesModel {
                 firstViewedAt: row.created_at,
                 latestVersionNumber: row.latest_version_number ?? null,
                 latestVersionStatus: row.latest_version_status ?? null,
+                pinnedListUuid: row.pinned_list_uuid ?? null,
+                pinnedListOrder: row.pinned_list_order ?? null,
             },
         }));
     }

--- a/packages/backend/src/services/PinningService/PinningService.ts
+++ b/packages/backend/src/services/PinningService/PinningService.ts
@@ -129,14 +129,22 @@ export class PinningService extends BaseService {
                 };
             });
 
-        const { charts: allowedCharts, dashboards: allowedDashboards } =
-            await this.resourceViewItemModel.getAllowedChartsAndDashboards(
-                projectUuid,
-                pinnedListUuid,
-                allowedSpaceUuids,
-            );
+        const {
+            charts: allowedCharts,
+            dashboards: allowedDashboards,
+            apps: allowedApps,
+        } = await this.resourceViewItemModel.getAllowedChartsAndDashboards(
+            projectUuid,
+            pinnedListUuid,
+            allowedSpaceUuids,
+        );
 
-        return [...allowedPinnedSpaces, ...allowedCharts, ...allowedDashboards];
+        return [
+            ...allowedPinnedSpaces,
+            ...allowedCharts,
+            ...allowedDashboards,
+            ...allowedApps,
+        ];
     }
 
     async updatePinnedItemsOrder(

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -5,6 +5,7 @@ import { generateKeyPair } from 'crypto';
 import { parseKey } from 'sshpk';
 import { Worker } from 'worker_threads';
 import {
+    DbPinnedApp,
     DbPinnedChart,
     DbPinnedDashboard,
     DbPinnedItem,
@@ -22,6 +23,9 @@ export const isDbPinnedDashboard = (
 
 export const isDbPinnedSpace = (data: DbPinnedItem): data is DBPinnedSpace =>
     'space_uuid' in data && !!data.space_uuid;
+
+export const isDbPinnedApp = (data: DbPinnedItem): data is DbPinnedApp =>
+    'app_uuid' in data && !!data.app_uuid;
 
 export const wrapSentryTransaction = <T>(
     name: string,

--- a/packages/common/src/ee/apps/types.ts
+++ b/packages/common/src/ee/apps/types.ts
@@ -61,6 +61,8 @@ export type ApiGetAppResponse = ApiSuccess<{
     description: string;
     createdByUserUuid: string;
     spaceUuid: string | null;
+    pinnedListUuid: string | null;
+    pinnedListOrder: number | null;
     versions: ApiAppVersionSummary[];
     hasMore: boolean;
 }>;

--- a/packages/common/src/types/content.ts
+++ b/packages/common/src/types/content.ts
@@ -84,6 +84,10 @@ export interface DataAppContent extends Content {
     contentType: ContentType.DATA_APP;
     latestVersionNumber: number | null;
     latestVersionStatus: AppVersionStatus | null;
+    pinnedList: {
+        uuid: string;
+        order: number;
+    } | null;
 }
 
 export interface SpaceContentBase extends Content {

--- a/packages/common/src/types/pinning.ts
+++ b/packages/common/src/types/pinning.ts
@@ -1,6 +1,7 @@
 import {
     type ResourceViewChartItem,
     type ResourceViewDashboardItem,
+    type ResourceViewDataAppItem,
     type ResourceViewItemType,
     type ResourceViewSpaceItem,
 } from './resourceViewItem';
@@ -16,6 +17,7 @@ export type PinnedItem = {
     savedChartUuid?: string;
     dashboardUuid?: string;
     spaceUuid?: string;
+    appUuid?: string;
     createdAt: Date;
 };
 
@@ -38,6 +40,11 @@ export type CreateSpacePinnedItem = {
     spaceUuid: string;
 };
 
+export type CreateAppPinnedItem = {
+    projectUuid: string;
+    appUuid: string;
+};
+
 export type DeleteChartPinnedItem = {
     pinnedListUuid: string;
     savedChartUuid: string;
@@ -53,22 +60,30 @@ export type DeleteSpacePinnedItem = {
     spaceUuid: string;
 };
 
+export type DeleteAppPinnedItem = {
+    pinnedListUuid: string;
+    appUuid: string;
+};
+
 export type DeletePinnedItem =
     | DeleteChartPinnedItem
     | DeleteDashboardPinnedItem
-    | DeleteSpacePinnedItem;
+    | DeleteSpacePinnedItem
+    | DeleteAppPinnedItem;
 
 export type CreatePinnedItem =
     | CreateChartPinnedItem
     | CreateDashboardPinnedItem
-    | CreateSpacePinnedItem;
+    | CreateSpacePinnedItem
+    | CreateAppPinnedItem;
 
 export type UpdatePinnedItemOrder = {
     type: ResourceViewItemType;
     data: Pick<
         | ResourceViewChartItem['data']
         | ResourceViewDashboardItem['data']
-        | ResourceViewSpaceItem['data'],
+        | ResourceViewSpaceItem['data']
+        | ResourceViewDataAppItem['data'],
         'uuid' | 'pinnedListOrder'
     >;
 };
@@ -91,13 +106,24 @@ export const isDeleteSpacePinnedItem = (
     item: DeletePinnedItem,
 ): item is DeleteSpacePinnedItem => 'spaceUuid' in item && !!item.spaceUuid;
 
+export const isCreateAppPinnedItem = (
+    item: CreatePinnedItem,
+): item is CreateAppPinnedItem => 'appUuid' in item && !!item.appUuid;
+
+export const isDeleteAppPinnedItem = (
+    item: DeletePinnedItem,
+): item is DeleteAppPinnedItem => 'appUuid' in item && !!item.appUuid;
+
 export type ApiPinnedItems = {
     status: 'ok';
     results: PinnedItems;
 };
 
 export type PinnedItems = Array<
-    ResourceViewDashboardItem | ResourceViewChartItem | ResourceViewSpaceItem
+    | ResourceViewDashboardItem
+    | ResourceViewChartItem
+    | ResourceViewSpaceItem
+    | ResourceViewDataAppItem
 >;
 
 export type TogglePinnedItemInfo = {

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -102,6 +102,8 @@ export type ResourceViewDataAppItem = {
         firstViewedAt: Date | null;
         latestVersionNumber: number | null;
         latestVersionStatus: AppVersionStatus | null;
+        pinnedListUuid: string | null;
+        pinnedListOrder: number | null;
     };
     category?: ResourceItemCategory;
 };
@@ -269,6 +271,8 @@ export const contentToResourceViewItem = (content: SummaryContent) => {
                 firstViewedAt: content.firstViewedAt,
                 latestVersionNumber: content.latestVersionNumber,
                 latestVersionStatus: content.latestVersionStatus,
+                pinnedListUuid: content.pinnedList?.uuid || null,
+                pinnedListOrder: content.pinnedList?.order || null,
             };
             return wrapResource(dataAppViewItem, ResourceViewItemType.DATA_APP);
         default:

--- a/packages/frontend/src/components/PinnedAndFavoritesSection/index.tsx
+++ b/packages/frontend/src/components/PinnedAndFavoritesSection/index.tsx
@@ -93,7 +93,7 @@ const PinnedAndFavoritesSection: FC<Props> = ({
                         name: userCanManage ? 'Pinned items' : 'Pinned for you',
                         icon: <MantineIcon icon={IconPin} size="sm" />,
                         infoTooltipText: userCanManage
-                            ? 'Pin Spaces, Dashboards and Charts to the top of the homepage to guide your business users to the right content.'
+                            ? 'Pin Spaces, Dashboards, Charts and Data apps to the top of the homepage to guide your business users to the right content.'
                             : 'Your data team have pinned these items to help guide you towards the most relevant content!',
                         hasReorder: userCanManage,
                         filter: (item) =>

--- a/packages/frontend/src/components/PinnedItemsPanel/index.tsx
+++ b/packages/frontend/src/components/PinnedItemsPanel/index.tsx
@@ -27,13 +27,14 @@ const PinnedItemsPanel: FC<Props> = ({ pinnedItems, isEnabled }) => {
                     [
                         ResourceViewItemType.DASHBOARD,
                         ResourceViewItemType.CHART,
+                        ResourceViewItemType.DATA_APP,
                     ],
                 ],
             }}
             headerProps={{
                 title: userCanManage ? 'Pinned items' : 'Pinned for you',
                 description: userCanManage
-                    ? 'Pin Spaces, Dashboards and Charts to the top of the homepage to guide your business users to the right content.'
+                    ? 'Pin Spaces, Dashboards, Charts and Data apps to the top of the homepage to guide your business users to the right content.'
                     : 'Your data team have pinned these items to help guide you towards the most relevant content!',
             }}
         />

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionHandlers.tsx
@@ -15,6 +15,7 @@ import {
 } from '@tabler/icons-react';
 import { useCallback, useEffect, type FC } from 'react';
 import { useParams } from 'react-router';
+import { useAppPinningMutation } from '../../../features/apps/hooks/useAppPinningMutation';
 import { DeleteSqlChartModal } from '../../../features/sqlRunner/components/DeleteSqlChartModal';
 import { useChartPinningMutation } from '../../../hooks/pinning/useChartPinningMutation';
 import { useDashboardPinningMutation } from '../../../hooks/pinning/useDashboardPinningMutation';
@@ -85,6 +86,7 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
     const { mutate: pinChart } = useChartPinningMutation();
     const { mutate: pinDashboard } = useDashboardPinningMutation();
     const { mutate: pinSpace } = useSpacePinningMutation(projectUuid);
+    const { mutate: pinApp } = useAppPinningMutation();
 
     const handleReset = useCallback(() => {
         onAction({ type: ResourceViewItemAction.CLOSE });
@@ -170,15 +172,18 @@ const ResourceActionHandlers: FC<ResourceActionHandlersProps> = ({
             case ResourceViewItemType.SPACE:
                 return pinSpace(action.item.data.uuid);
             case ResourceViewItemType.DATA_APP:
-                // Pinning data apps is not supported yet
-                return undefined;
+                if (!projectUuid) return undefined;
+                return pinApp({
+                    projectUuid,
+                    appUuid: action.item.data.uuid,
+                });
             default:
                 return assertUnreachable(
                     action.item,
                     'Resource type not supported',
                 );
         }
-    }, [action, pinChart, pinDashboard, pinSpace]);
+    }, [action, pinChart, pinDashboard, pinSpace, pinApp, projectUuid]);
 
     useEffect(() => {
         if (action.type === ResourceViewItemAction.PIN_TO_HOMEPAGE) {

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -81,9 +81,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
     const { data: project } = useProject(projectUuid);
     const organizationUuid = user.data?.organizationUuid;
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
-    const isPinned =
-        item.type !== ResourceViewItemType.DATA_APP &&
-        !!item.data.pinnedListUuid;
+    const isPinned = !!item.data.pinnedListUuid;
     const isDashboardPage = location.pathname.includes('/dashboards');
 
     const isChartOrDashboard =

--- a/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceViewGrid/index.tsx
@@ -315,16 +315,13 @@ const ResourceViewGrid: FC<ResourceViewGridProps> = ({
     const pinnedItemsOrder = useCallback(
         (data: ResourceViewGridGroup[]): PinnedItems =>
             data.flatMap((group) =>
-                group.items.flatMap((item, index) => {
-                    // Data apps don't participate in pinning
-                    if (item.type === ResourceViewItemType.DATA_APP) return [];
-                    return [
-                        {
+                group.items.map(
+                    (item, index) =>
+                        ({
                             type: item.type,
                             data: { ...item.data, pinnedListOrder: index },
-                        } as PinnedItems[number],
-                    ];
-                }),
+                        }) as PinnedItems[number],
+                ),
             ),
         [],
     );

--- a/packages/frontend/src/features/apps/hooks/useAppPinningMutation.ts
+++ b/packages/frontend/src/features/apps/hooks/useAppPinningMutation.ts
@@ -1,0 +1,60 @@
+import { type ApiError, type TogglePinnedItemInfo } from '@lightdash/common';
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { lightdashApi } from '../../../api';
+import useToaster from '../../../hooks/toaster/useToaster';
+
+const updateAppPinning = async ({
+    projectUuid,
+    appUuid,
+}: {
+    projectUuid: string;
+    appUuid: string;
+}) =>
+    lightdashApi<TogglePinnedItemInfo>({
+        url: `/ee/projects/${projectUuid}/apps/${appUuid}/pinning`,
+        method: 'PATCH',
+        body: JSON.stringify({}),
+    });
+
+export const useAppPinningMutation = () => {
+    const queryClient = useQueryClient();
+    const { showToastApiError, showToastSuccess } = useToaster();
+    return useMutation<
+        TogglePinnedItemInfo,
+        ApiError,
+        { projectUuid: string; appUuid: string }
+    >(updateAppPinning, {
+        mutationKey: ['app_pinning_update'],
+        onSuccess: async (app, variables) => {
+            await queryClient.invalidateQueries([
+                'app',
+                variables.projectUuid,
+                variables.appUuid,
+            ]);
+            await queryClient.invalidateQueries(['pinned_items']);
+            await queryClient.invalidateQueries(['spaces']);
+            await queryClient.invalidateQueries([
+                'space',
+                app.projectUuid,
+                app.spaceUuid,
+            ]);
+            await queryClient.invalidateQueries(['content']);
+
+            if (app.isPinned) {
+                showToastSuccess({
+                    title: 'Success! Data app was pinned to homepage',
+                });
+            } else {
+                showToastSuccess({
+                    title: 'Success! Data app was unpinned from homepage',
+                });
+            }
+        },
+        onError: ({ error }) => {
+            showToastApiError({
+                title: 'Failed to pin data app',
+                apiError: error,
+            });
+        },
+    });
+};


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-316/add-apps-to-spaces

### Description:
Mirrors the existing per-resource pin pattern used by charts, dashboards, and spaces. Adds a pinned_app table, extends PinnedListModel with app branches, exposes PATCH /ee/projects/{projectUuid}/apps/{appUuid}/pinning, and renders pinned data apps in the homepage pinned panel alongside charts and dashboards. Personal (spaceless) apps cannot be pinned since the pinned panel is a project-wide surface.

<img width="929" height="523" alt="image" src="https://github.com/user-attachments/assets/ca57f942-454a-4fd5-8868-0f4b3d3e8b78" />
