### PR TITLE
feat: validate custom sql metric eligibility for pre-aggregation

### DIFF
--- a/docs/preagg-derived-sql-materialization.md
+++ b/docs/preagg-derived-sql-materialization.md
@@ -48,7 +48,7 @@ region_scoped_label:
   type: string
   sql: |
     CASE
-      WHEN ${ld.userAttributes.region} = 'US' THEN ${us_team_name}
+      WHEN ${ld.attr.region} = 'US' THEN ${us_team_name}
       ELSE ${global_team_name}
     END
 ```

--- a/examples/full-jaffle-shop-demo/dbt/models/orders.yml
+++ b/examples/full-jaffle-shop-demo/dbt/models/orders.yml
@@ -30,44 +30,20 @@ models:
               - total_completed_order_amount
             time_dimension: order_date
             granularity: day
-          - name: basic_sql_dimension_daily
+          - name: sql_fields_daily
             dimensions:
               - status
               - constant_one
-            metrics:
-              - total_order_amount
-            time_dimension: order_date
-            granularity: day
-          - name: table_ref_dimension_daily
-            dimensions:
-              - status
               - table_amount
-            metrics:
-              - total_order_amount
-            time_dimension: order_date
-            granularity: day
-          - name: semantic_ref_dimension_daily
-            dimensions:
-              - status
               - semantic_amount
-            metrics:
-              - total_order_amount
-            time_dimension: order_date
-            granularity: day
-          - name: mixed_expression_dimension_daily
-            dimensions:
-              - status
               - amount_plus_shipping
-            metrics:
-              - total_order_amount
-            time_dimension: order_date
-            granularity: day
-          - name: recursive_dimension_daily
-            dimensions:
-              - status
               - amount_plus_shipping_band
             metrics:
-              - total_order_amount
+              - basic_sql_metric
+              - table_ref_metric
+              - semantic_ref_metric
+              - mixed_expression_metric
+              - average_expression_metric
             time_dimension: order_date
             granularity: day
           - name: param_dimension_rejected_daily
@@ -84,6 +60,27 @@ models:
               - user_attribute_email_test
             metrics:
               - total_order_amount
+            time_dimension: order_date
+            granularity: day
+          - name: param_metric_rejected_daily
+            dimensions:
+              - status
+            metrics:
+              - parameterized_metric_test
+            time_dimension: order_date
+            granularity: day
+          - name: user_attribute_metric_rejected_daily
+            dimensions:
+              - status
+            metrics:
+              - user_attribute_email_metric_test
+            time_dimension: order_date
+            granularity: day
+          - name: param_filter_metric_rejected_daily
+            dimensions:
+              - status
+            metrics:
+              - param_filter_metric_test
             time_dimension: order_date
             granularity: day
         primary_key: order_id
@@ -252,7 +249,7 @@ models:
           dimension:
             sql: |
               CASE
-                WHEN ${ld.userAttributes.email} = 'demo@lightdash.com'
+                WHEN ${ld.user.email} = 'demo@lightdash.com'
                   THEN ${TABLE}.status
                 ELSE 'non-demo'
               END
@@ -401,6 +398,58 @@ models:
                 type: number
                 format: "$#,##0.00"
                 sql: ${total_order_amount}-${total_completed_order_amount}
+              basic_sql_metric:
+                type: sum
+                label: Basic SQL Metric
+                groups: ["pre-aggregations"]
+                sql: "1"
+              table_ref_metric:
+                type: sum
+                label: Table Ref Metric
+                groups: ["pre-aggregations"]
+                sql: ${TABLE}.amount
+              semantic_ref_metric:
+                type: sum
+                label: Semantic Ref Metric
+                groups: ["pre-aggregations"]
+                sql: ${amount}
+              mixed_expression_metric:
+                type: sum
+                label: Mixed Expression Metric
+                groups: ["pre-aggregations"]
+                sql: ${TABLE}.amount + ${shipping_cost}
+              average_expression_metric:
+                type: average
+                label: Average Expression Metric
+                groups: ["pre-aggregations"]
+                sql: ${TABLE}.amount + ${shipping_cost}
+              parameterized_metric_test:
+                type: sum
+                label: Parameterized Metric Test
+                groups: ["pre-aggregations"]
+                sql: |
+                  CASE
+                    WHEN ${lightdash.parameters.date_dim_parameter} IS NOT NULL
+                      THEN ${TABLE}.amount
+                    ELSE 0
+                  END
+              user_attribute_email_metric_test:
+                type: sum
+                label: User Attribute Email Metric Test
+                groups: ["pre-aggregations"]
+                sql: |
+                  CASE
+                    WHEN ${ld.user.email} = 'demo@lightdash.com'
+                      THEN ${TABLE}.amount
+                    ELSE 0
+                  END
+              param_filter_metric_test:
+                type: sum
+                label: Param Filter Metric Test
+                groups: ["pre-aggregations"]
+                sql: ${amount}
+                filters:
+                  - date_dim_param_test: "param is greater"
         meta:
           dimension:
             type: number

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.test.ts
@@ -2,6 +2,7 @@ import {
     DimensionType,
     ExploreType,
     FieldType,
+    FilterOperator,
     MetricType,
     PRE_AGGREGATE_MATERIALIZED_TABLE_PLACEHOLDER,
     SupportedDbtAdapter,
@@ -70,6 +71,41 @@ const makeMetric = ({
     hidden: false,
     compiledSql: `${table}.${name}`,
     tablesReferences: [table],
+});
+
+const makeCustomMetric = ({
+    name,
+    table,
+    type,
+    sql,
+    compiledSql,
+    parameterReferences,
+    compilationError,
+    filters,
+}: {
+    name: string;
+    table: string;
+    type: MetricType;
+    sql?: string;
+    compiledSql?: string;
+    parameterReferences?: string[];
+    compilationError?: { message: string };
+    filters?: CompiledMetric['filters'];
+}): CompiledMetric => ({
+    index: 0,
+    fieldType: FieldType.METRIC,
+    type,
+    name,
+    label: name,
+    table,
+    tableLabel: table,
+    sql: sql ?? `${table}.${name}`,
+    hidden: false,
+    compiledSql: compiledSql ?? sql ?? `${table}.${name}`,
+    tablesReferences: [table],
+    ...(parameterReferences ? { parameterReferences } : {}),
+    ...(compilationError ? { compilationError } : {}),
+    ...(filters ? { filters } : {}),
 });
 
 const sourceExplore = (): Explore => ({
@@ -379,7 +415,7 @@ describe('buildPreAggregateExplore', () => {
         explore.tables.orders.dimensions.region_aware_status = makeDimension({
             name: 'region_aware_status',
             table: 'orders',
-            sql: "case when ${ld.userAttributes.region} = 'EMEA' then ${TABLE}.status end",
+            sql: "case when ${ld.attr.region} = 'EMEA' then ${TABLE}.status end",
         });
 
         expect(() =>
@@ -420,6 +456,103 @@ describe('buildPreAggregateExplore', () => {
             }),
         ).toThrow(
             'Pre-aggregate "invalid_rollup" references ineligible dimension "status_wrapper": dimension "orders_parameterized_status" is not eligible for direct materialization (reason: parameter_references)',
+        );
+    });
+
+    it('accepts eligible custom sql metrics selected by the pre-aggregate definition', () => {
+        const explore = sourceExplore();
+        explore.tables.orders.dimensions.amount = makeDimension({
+            name: 'amount',
+            table: 'orders',
+            type: DimensionType.NUMBER,
+            sql: '${TABLE}.amount',
+            compiledSql: 'orders.amount',
+        });
+        explore.tables.orders.metrics.order_revenue = makeCustomMetric({
+            name: 'order_revenue',
+            table: 'orders',
+            type: MetricType.SUM,
+            sql: '${amount}',
+            compiledSql: 'SUM(orders.amount)',
+        });
+
+        const result = buildPreAggregateExplore(explore, {
+            name: 'metric_rollup',
+            dimensions: ['status'],
+            metrics: ['order_revenue'],
+        });
+
+        expect(result.tables.orders.metrics.order_revenue).toBeDefined();
+        expect(result.tables.orders.metrics.order_revenue.compiledSql).toBe(
+            'SUM(orders.orders_order_revenue)',
+        );
+    });
+
+    it('rejects parameterized custom sql metrics selected by the pre-aggregate definition', () => {
+        const explore = sourceExplore();
+        explore.tables.orders.metrics.parameterized_revenue = makeCustomMetric({
+            name: 'parameterized_revenue',
+            table: 'orders',
+            type: MetricType.SUM,
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.amount
+                    ELSE 0
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+
+        expect(() =>
+            buildPreAggregateExplore(explore, {
+                name: 'invalid_rollup',
+                dimensions: ['status'],
+                metrics: ['parameterized_revenue'],
+            }),
+        ).toThrow(
+            'Pre-aggregate "invalid_rollup" references ineligible metric "parameterized_revenue": metric "orders_parameterized_revenue" is not eligible for pre-aggregation (reason: parameter_references)',
+        );
+    });
+
+    it('rejects custom sql metrics whose filter dimension is ineligible', () => {
+        const explore = sourceExplore();
+        explore.tables.orders.dimensions.parameterized_status = makeDimension({
+            name: 'parameterized_status',
+            table: 'orders',
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                    ELSE NULL
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+        explore.tables.orders.metrics.filtered_revenue = makeCustomMetric({
+            name: 'filtered_revenue',
+            table: 'orders',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+            compiledSql: 'SUM(orders.amount)',
+            filters: [
+                {
+                    id: 'metric-filter',
+                    target: {
+                        fieldRef: 'parameterized_status',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+        });
+
+        expect(() =>
+            buildPreAggregateExplore(explore, {
+                name: 'invalid_rollup',
+                dimensions: ['status'],
+                metrics: ['filtered_revenue'],
+            }),
+        ).toThrow(
+            'Pre-aggregate "invalid_rollup" references ineligible metric "filtered_revenue": dimension "orders_parameterized_status" is not eligible for pre-aggregation metric filters (reason: parameter_references)',
         );
     });
 });

--- a/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
+++ b/packages/backend/src/ee/preAggregates/buildPreAggregateExplore.ts
@@ -1,5 +1,4 @@
 import {
-    analyzePreAggregateDerivedDimensionEligibility,
     assertUnreachable,
     ExploreType,
     getItemId,
@@ -22,6 +21,10 @@ import {
     type PreAggregateDef,
     type TimeFrames,
 } from '@lightdash/common';
+import {
+    assertDimensionEligibleForDirectMaterialization,
+    assertMetricEligibleForPreAggregation,
+} from './eligibility';
 
 const isFinerGranularity = (
     candidateGranularity: TimeFrames,
@@ -268,29 +271,6 @@ const getSelectedDimension = ({
     );
 };
 
-const assertDimensionEligibleForDirectMaterialization = ({
-    sourceExplore,
-    preAggregateDef,
-    dimensionReference,
-    dimension,
-}: {
-    sourceExplore: Explore;
-    preAggregateDef: PreAggregateDef;
-    dimensionReference: string;
-    dimension: CompiledDimension;
-}): void => {
-    const eligibility = analyzePreAggregateDerivedDimensionEligibility({
-        dimension,
-        tables: sourceExplore.tables,
-    });
-
-    if (!eligibility.isEligible) {
-        throw new Error(
-            `Pre-aggregate "${preAggregateDef.name}" references ineligible dimension "${dimensionReference}": dimension "${eligibility.ineligibleDimensionFieldId}" is not eligible for direct materialization (reason: ${eligibility.reason})`,
-        );
-    }
-};
-
 const getIncludedDimensions = (
     sourceExplore: Explore,
     preAggregateDef: PreAggregateDef,
@@ -399,6 +379,13 @@ const getIncludedMetrics = (
         }
 
         const { fieldId, metric } = metricLookup;
+
+        assertMetricEligibleForPreAggregation({
+            sourceExplore,
+            preAggregateDef,
+            metricReference,
+            metric,
+        });
 
         if (!preAggregateUtils.isSupportedMetricType(metric.type)) {
             unsupportedMetrics.push({

--- a/packages/backend/src/ee/preAggregates/eligibility.ts
+++ b/packages/backend/src/ee/preAggregates/eligibility.ts
@@ -1,0 +1,72 @@
+import {
+    analyzePreAggregateDerivedDimensionEligibility,
+    analyzePreAggregateDerivedMetricEligibility,
+    ParameterError,
+    PreAggregateDerivedMetricIneligibilityReason,
+    type CompiledDimension,
+    type CompiledMetric,
+    type Explore,
+    type PreAggregateDef,
+} from '@lightdash/common';
+
+export const assertDimensionEligibleForDirectMaterialization = ({
+    sourceExplore,
+    preAggregateDef,
+    dimensionReference,
+    dimension,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+    dimensionReference: string;
+    dimension: CompiledDimension;
+}): void => {
+    const eligibility = analyzePreAggregateDerivedDimensionEligibility({
+        dimension,
+        tables: sourceExplore.tables,
+    });
+
+    if (!eligibility.isEligible) {
+        throw new ParameterError(
+            `Pre-aggregate "${preAggregateDef.name}" references ineligible dimension "${dimensionReference}": dimension "${eligibility.ineligibleDimensionFieldId}" is not eligible for direct materialization (reason: ${eligibility.reason})`,
+        );
+    }
+};
+
+export const assertMetricEligibleForPreAggregation = ({
+    sourceExplore,
+    preAggregateDef,
+    metricReference,
+    metric,
+}: {
+    sourceExplore: Explore;
+    preAggregateDef: PreAggregateDef;
+    metricReference: string;
+    metric: CompiledMetric;
+}): void => {
+    const eligibility = analyzePreAggregateDerivedMetricEligibility({
+        metric,
+        tables: sourceExplore.tables,
+    });
+
+    if (!eligibility.isEligible) {
+        if (
+            eligibility.reason ===
+                PreAggregateDerivedMetricIneligibilityReason.FILTER_DIMENSION_INELIGIBLE ||
+            eligibility.reason ===
+                PreAggregateDerivedMetricIneligibilityReason.DIMENSION_DEPENDENCY_INELIGIBLE
+        ) {
+            throw new ParameterError(
+                `Pre-aggregate "${preAggregateDef.name}" references ineligible metric "${metricReference}": dimension "${eligibility.ineligibleDimensionFieldId}" is not eligible for pre-aggregation${
+                    eligibility.reason ===
+                    PreAggregateDerivedMetricIneligibilityReason.FILTER_DIMENSION_INELIGIBLE
+                        ? ' metric filters'
+                        : ''
+                } (reason: ${eligibility.ineligibleDimensionReason})`,
+            );
+        }
+
+        throw new ParameterError(
+            `Pre-aggregate "${preAggregateDef.name}" references ineligible metric "${metricReference}": metric "${eligibility.ineligibleMetricFieldId}" is not eligible for pre-aggregation (reason: ${eligibility.reason})`,
+        );
+    }
+};

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.test.ts
@@ -8,6 +8,7 @@ import {
     TimeFrames,
     UnitOfTime,
     type CompiledDimension,
+    type CompiledMetric,
     type Explore,
     type PreAggregateDef,
 } from '@lightdash/common';
@@ -41,6 +42,40 @@ const makeDimension = ({
         parameterReferences ??
         getParameterReferencesFromSqlAndFormat(sql ?? '${TABLE}.id'),
     tablesReferences: ['orders'],
+    ...(compilationError ? { compilationError } : {}),
+});
+
+const makeMetric = ({
+    name,
+    type,
+    sql,
+    compiledSql,
+    parameterReferences,
+    compilationError,
+    filters,
+}: {
+    name: string;
+    type: MetricType;
+    sql?: string;
+    compiledSql?: string;
+    parameterReferences?: string[];
+    compilationError?: { message: string };
+    filters?: CompiledMetric['filters'];
+}): CompiledMetric => ({
+    fieldType: FieldType.METRIC,
+    type,
+    name,
+    label: name,
+    table: 'orders',
+    tableLabel: 'Orders',
+    sql: sql ?? 'count(*)',
+    hidden: false,
+    compiledSql: compiledSql ?? sql ?? 'count(*)',
+    parameterReferences:
+        parameterReferences ??
+        getParameterReferencesFromSqlAndFormat(sql ?? 'count(*)'),
+    tablesReferences: ['orders'],
+    ...(filters ? { filters } : {}),
     ...(compilationError ? { compilationError } : {}),
 });
 
@@ -426,7 +461,7 @@ describe('buildMaterializationMetricQuery', () => {
         sourceExplore.tables.orders.dimensions.region_aware_status =
             makeDimension({
                 name: 'region_aware_status',
-                sql: "case when ${lightdash.userAttributes.region} = 'EMEA' then ${TABLE}.status end",
+                sql: "case when ${lightdash.attribute.region} = 'EMEA' then ${TABLE}.status end",
             });
 
         expect(() =>
@@ -474,6 +509,116 @@ describe('buildMaterializationMetricQuery', () => {
             }),
         ).toThrow(
             'Pre-aggregate "orders_rollup" references ineligible dimension "status_wrapper": dimension "orders_parameterized_status" is not eligible for direct materialization (reason: parameter_references)',
+        );
+    });
+
+    it('includes eligible custom sql sum metrics in the materialization metric query', () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.dimensions.amount = makeDimension({
+            name: 'amount',
+            type: DimensionType.NUMBER,
+            sql: '${TABLE}.amount',
+            compiledSql: '"orders".amount',
+        });
+        sourceExplore.tables.orders.metrics.order_revenue = makeMetric({
+            name: 'order_revenue',
+            type: MetricType.SUM,
+            sql: '${amount}',
+            compiledSql: 'SUM("orders".amount)',
+        });
+
+        const result = buildMaterializationMetricQuery({
+            sourceExplore,
+            preAggregateDef: {
+                name: 'orders_rollup',
+                dimensions: ['status'],
+                metrics: ['order_revenue'],
+            },
+            materializationConfig: { maxRows: null },
+        });
+
+        expect(result.metricQuery.metrics).toEqual(['orders_order_revenue']);
+        expect(result.metricComponents).toEqual({
+            orders_order_revenue: [
+                {
+                    componentFieldId: 'orders_order_revenue',
+                    aggregation: MetricType.SUM,
+                },
+            ],
+        });
+    });
+
+    it('rejects parameterized custom sql metrics in the materialization metric query', () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.metrics.parameterized_revenue = makeMetric({
+            name: 'parameterized_revenue',
+            type: MetricType.SUM,
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.amount
+                    ELSE 0
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore,
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['parameterized_revenue'],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" references ineligible metric "parameterized_revenue": metric "orders_parameterized_revenue" is not eligible for pre-aggregation (reason: parameter_references)',
+        );
+    });
+
+    it('rejects custom sql metrics whose filter dimension is ineligible', () => {
+        const sourceExplore = getSourceExplore();
+        sourceExplore.tables.orders.dimensions.parameterized_status =
+            makeDimension({
+                name: 'parameterized_status',
+                sql: `
+                    CASE
+                        WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                        ELSE NULL
+                    END
+                `,
+                parameterReferences: ['orders.region'],
+            });
+        sourceExplore.tables.orders.metrics.filtered_revenue = makeMetric({
+            name: 'filtered_revenue',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+            compiledSql: 'SUM("orders".amount)',
+            filters: [
+                {
+                    id: 'metric-filter',
+                    target: {
+                        fieldRef: 'parameterized_status',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+        });
+
+        expect(() =>
+            buildMaterializationMetricQuery({
+                sourceExplore,
+                preAggregateDef: {
+                    name: 'orders_rollup',
+                    dimensions: ['status'],
+                    metrics: ['filtered_revenue'],
+                },
+                materializationConfig: { maxRows: null },
+            }),
+        ).toThrow(
+            'Pre-aggregate "orders_rollup" references ineligible metric "filtered_revenue": dimension "orders_parameterized_status" is not eligible for pre-aggregation metric filters (reason: parameter_references)',
         );
     });
 });

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/buildMaterializationMetricQuery.ts
@@ -1,5 +1,4 @@
 import {
-    analyzePreAggregateDerivedDimensionEligibility,
     assertUnreachable,
     convertFieldRefToFieldId,
     getItemId,
@@ -18,6 +17,10 @@ import {
     type MetricQuery,
     type PreAggregateDef,
 } from '@lightdash/common';
+import {
+    assertDimensionEligibleForDirectMaterialization,
+    assertMetricEligibleForPreAggregation,
+} from '../../preAggregates/eligibility';
 
 const getDimensionsByReference = (sourceExplore: Explore) =>
     Object.values(sourceExplore.tables).reduce<
@@ -131,29 +134,6 @@ const getSelectedDimension = ({
     );
 
     return exactBaseDimension ?? candidates[0];
-};
-
-const assertDimensionEligibleForDirectMaterialization = ({
-    sourceExplore,
-    preAggregateDef,
-    dimensionReference,
-    dimension,
-}: {
-    sourceExplore: Explore;
-    preAggregateDef: PreAggregateDef;
-    dimensionReference: string;
-    dimension: CompiledDimension;
-}): void => {
-    const eligibility = analyzePreAggregateDerivedDimensionEligibility({
-        dimension,
-        tables: sourceExplore.tables,
-    });
-
-    if (!eligibility.isEligible) {
-        throw new Error(
-            `Pre-aggregate "${preAggregateDef.name}" references ineligible dimension "${dimensionReference}": dimension "${eligibility.ineligibleDimensionFieldId}" is not eligible for direct materialization (reason: ${eligibility.reason})`,
-        );
-    }
 };
 
 const hasTimeDimensionReference = ({
@@ -299,6 +279,13 @@ export const buildMaterializationMetricQuery = ({
                 `Pre-aggregate "${preAggregateDef.name}" references unknown metric "${metricReference}"`,
             );
         }
+
+        assertMetricEligibleForPreAggregation({
+            sourceExplore,
+            preAggregateDef,
+            metricReference,
+            metric: metricLookup.metric,
+        });
 
         acc.set(metricLookup.fieldId, metricLookup.metric);
 

--- a/packages/backend/src/utils/QueryBuilder/utils.ts
+++ b/packages/backend/src/utils/QueryBuilder/utils.ts
@@ -21,8 +21,10 @@ import {
     getDateDimension,
     getDimensionMapFromTables,
     getFixedWidthBinSelectSql,
+    getIntrinsicUserAttributeRegex,
     getItemId,
     getSqlForTruncatedDate,
+    getUserAttributeRegex,
     IntrinsicUserAttributes,
     isCompiledCustomSqlDimension,
     JoinRelationship,
@@ -237,14 +239,9 @@ export const replaceUserAttributes = (
     quoteChar: string,
     wrapChar: string,
 ): string => {
-    const userAttributeRegex =
-        /\$\{(?:lightdash|ld)\.(?:attribute|attributes|attr)\.(\w+)\}/g;
-    const intrinsicUserAttributeRegex =
-        /\$\{(?:lightdash|ld)\.(?:user)\.(\w+)\}/g;
-
     // Replace user attributes in the SQL filter
     const { replacedSql: replacedSqlFilter } = replaceLightdashValues(
-        userAttributeRegex,
+        getUserAttributeRegex(),
         sql,
         userAttributes,
         quoteChar,
@@ -253,7 +250,7 @@ export const replaceUserAttributes = (
 
     // Replace intrinsic user attributes in the SQL filter
     const { replacedSql } = replaceLightdashValues(
-        intrinsicUserAttributeRegex,
+        getIntrinsicUserAttributeRegex(),
         replacedSqlFilter,
         intrinsicUserAttributes,
         quoteChar,

--- a/packages/common/src/compiler/exploreCompiler.ts
+++ b/packages/common/src/compiler/exploreCompiler.ts
@@ -49,6 +49,10 @@ import {
     validateParameterNames,
     validateParameterReferences,
 } from './parameters';
+import {
+    getReferencedDimensionCaseInsensitive,
+    getReferencedTable,
+} from './referenceLookup';
 
 // exclude lightdash prefix from variable pattern
 export const lightdashVariablePattern =
@@ -194,19 +198,7 @@ const getDimensionFromRequiredFilter = ({
         requiredFilter.target.fieldRef,
         baseTable,
     );
-    const table = tables[refTable];
-
-    if (!table) {
-        return undefined;
-    }
-
-    // Keep required/default filter reference matching case-insensitive,
-    // consistent with metric filter dimension matching in this compiler.
-    const dimensionRefName = Object.keys(table.dimensions).find(
-        (key) => key.toLowerCase() === refName.toLowerCase(),
-    );
-
-    return dimensionRefName ? table.dimensions[dimensionRefName] : undefined;
+    return getReferencedDimensionCaseInsensitive(refTable, refName, tables);
 };
 
 const getHiddenRequiredFilterRefs = ({
@@ -267,18 +259,6 @@ export type UncompiledExplore = {
     preAggregates?: PreAggregateDef[];
     caseSensitive?: boolean;
     projectDefaults?: LightdashProjectConfig['defaults'];
-};
-
-const getReferencedTable = (
-    refTable: string,
-    tables: Record<string, Table>,
-) => {
-    if (tables[refTable]) {
-        return tables[refTable];
-    }
-    return Object.values(tables).find(
-        (table) => table.name === refTable || table.originalName === refTable,
-    );
 };
 
 /**
@@ -1102,7 +1082,7 @@ export class ExploreCompiler {
                     metric.table,
                 );
 
-                const table = tables[refTable];
+                const table = getReferencedTable(refTable, tables);
 
                 if (!table) {
                     throw new CompileError(
@@ -1110,14 +1090,11 @@ export class ExploreCompiler {
                     );
                 }
 
-                // NOTE: date dimensions from explores have their time format uppercased (e.g. order_date_DAY) - see ticket: https://github.com/lightdash/lightdash/issues/5998
-                const dimensionRefName = Object.keys(table.dimensions).find(
-                    (key) => key.toLowerCase() === refName.toLowerCase(),
+                const dimensionField = getReferencedDimensionCaseInsensitive(
+                    refTable,
+                    refName,
+                    tables,
                 );
-
-                const dimensionField = dimensionRefName
-                    ? table.dimensions[dimensionRefName]
-                    : undefined;
 
                 if (!dimensionField) {
                     throw new CompileError(

--- a/packages/common/src/compiler/referenceLookup.ts
+++ b/packages/common/src/compiler/referenceLookup.ts
@@ -1,0 +1,74 @@
+import type { Table } from '../types/explore';
+import type {
+    CompiledDimension,
+    CompiledMetric,
+    Dimension,
+    Metric,
+} from '../types/field';
+
+type TableWithName = Pick<Table, 'name' | 'originalName'>;
+type TableWithDimensions<TDimension extends Dimension | CompiledDimension> =
+    TableWithName & {
+        dimensions: Record<string, TDimension>;
+    };
+type TableWithMetrics<TMetric extends Metric | CompiledMetric> =
+    TableWithName & {
+        metrics: Record<string, TMetric>;
+    };
+
+export const getReferencedTable = <TTable extends TableWithName>(
+    refTable: string,
+    tables: Record<string, TTable>,
+): TTable | undefined => {
+    if (tables[refTable]) {
+        return tables[refTable];
+    }
+
+    return Object.values(tables).find(
+        (table) => table.name === refTable || table.originalName === refTable,
+    );
+};
+
+export const getReferencedDimension = <
+    TTable extends TableWithDimensions<TDimension>,
+    TDimension extends Dimension | CompiledDimension,
+>(
+    refTable: string,
+    refName: string,
+    tables: Record<string, TTable>,
+): TDimension | undefined =>
+    getReferencedTable(refTable, tables)?.dimensions[refName];
+
+export const getReferencedMetric = <
+    TTable extends TableWithMetrics<TMetric>,
+    TMetric extends Metric | CompiledMetric,
+>(
+    refTable: string,
+    refName: string,
+    tables: Record<string, TTable>,
+): TMetric | undefined =>
+    getReferencedTable(refTable, tables)?.metrics[refName];
+
+export const getReferencedDimensionCaseInsensitive = <
+    TTable extends TableWithDimensions<TDimension>,
+    TDimension extends Dimension | CompiledDimension,
+>(
+    refTable: string,
+    refName: string,
+    tables: Record<string, TTable>,
+): TDimension | undefined => {
+    const table = tables[refTable];
+
+    if (!table) {
+        return undefined;
+    }
+
+    // NOTE: date dimensions from explores have their time format uppercased
+    // (e.g. order_date_DAY) - see ticket:
+    // https://github.com/lightdash/lightdash/issues/5998
+    const dimensionRefName = Object.keys(table.dimensions).find(
+        (key) => key.toLowerCase() === refName.toLowerCase(),
+    );
+
+    return dimensionRefName ? table.dimensions[dimensionRefName] : undefined;
+};

--- a/packages/common/src/ee/preAggregates/dimensionEligibility.test.ts
+++ b/packages/common/src/ee/preAggregates/dimensionEligibility.test.ts
@@ -32,15 +32,28 @@ const makeDimension = (
 
 const makeTables = (
     dimensions: CompiledDimension[],
-): Record<string, Pick<CompiledTable, 'dimensions'>> =>
-    dimensions.reduce<Record<string, Pick<CompiledTable, 'dimensions'>>>(
-        (acc, dimension) => {
-            acc[dimension.table] = acc[dimension.table] ?? { dimensions: {} };
-            acc[dimension.table].dimensions[dimension.name] = dimension;
-            return acc;
-        },
-        {},
-    );
+): Record<
+    string,
+    Pick<CompiledTable, 'name' | 'originalName' | 'dimensions' | 'metrics'>
+> =>
+    dimensions.reduce<
+        Record<
+            string,
+            Pick<
+                CompiledTable,
+                'name' | 'originalName' | 'dimensions' | 'metrics'
+            >
+        >
+    >((acc, dimension) => {
+        acc[dimension.table] = acc[dimension.table] ?? {
+            name: dimension.table,
+            originalName: dimension.table === 'cstmr' ? 'customers' : undefined,
+            dimensions: {},
+            metrics: {},
+        };
+        acc[dimension.table].dimensions[dimension.name] = dimension;
+        return acc;
+    }, {});
 
 describe('analyzePreAggregateDerivedDimensionEligibility', () => {
     it('classifies a plain base dimension as eligible', () => {
@@ -87,6 +100,32 @@ describe('analyzePreAggregateDerivedDimensionEligibility', () => {
                 getItemId(statusLabel),
                 getItemId(normalizedStatus),
                 getItemId(status),
+            ],
+        });
+    });
+
+    it('resolves references through a joined table original name', () => {
+        const customerFirstName = makeDimension({
+            name: 'first_name',
+            table: 'cstmr',
+            sql: '${TABLE}.first_name',
+            compiledSql: '"customers".first_name',
+        });
+        const customerGreeting = makeDimension({
+            name: 'customer_greeting',
+            sql: "concat(${customers.first_name}, ' hi')",
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: customerGreeting,
+                tables: makeTables([customerFirstName, customerGreeting]),
+            }),
+        ).toEqual({
+            isEligible: true,
+            referencedDimensionFieldIds: [
+                getItemId(customerGreeting),
+                getItemId(customerFirstName),
             ],
         });
     });
@@ -149,7 +188,7 @@ describe('analyzePreAggregateDerivedDimensionEligibility', () => {
     it('rejects when the dimension sql contains a direct user attribute reference', () => {
         const regionAwareStatus = makeDimension({
             name: 'region_aware_status',
-            sql: "case when ${ld.userAttributes.region} = 'EMEA' then ${TABLE}.status end",
+            sql: "case when ${ld.attr.region} = 'EMEA' then ${TABLE}.status end",
         });
 
         expect(
@@ -162,6 +201,25 @@ describe('analyzePreAggregateDerivedDimensionEligibility', () => {
             reason: PreAggregateDerivedDimensionIneligibilityReason.USER_ATTRIBUTES,
             ineligibleDimensionFieldId: getItemId(regionAwareStatus),
             referencedDimensionFieldIds: [getItemId(regionAwareStatus)],
+        });
+    });
+
+    it('rejects when the dimension sql contains a direct intrinsic user reference', () => {
+        const emailAwareStatus = makeDimension({
+            name: 'email_aware_status',
+            sql: "case when ${lightdash.user.email} = 'demo@lightdash.com' then ${TABLE}.status end",
+        });
+
+        expect(
+            analyzePreAggregateDerivedDimensionEligibility({
+                dimension: emailAwareStatus,
+                tables: makeTables([emailAwareStatus]),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedDimensionIneligibilityReason.USER_ATTRIBUTES,
+            ineligibleDimensionFieldId: getItemId(emailAwareStatus),
+            referencedDimensionFieldIds: [getItemId(emailAwareStatus)],
         });
     });
 

--- a/packages/common/src/ee/preAggregates/dimensionEligibility.ts
+++ b/packages/common/src/ee/preAggregates/dimensionEligibility.ts
@@ -2,14 +2,11 @@ import {
     getAllReferences,
     getParsedReference,
 } from '../../compiler/exploreCompiler';
+import { getReferencedDimension } from '../../compiler/referenceLookup';
 import type { CompiledTable } from '../../types/explore';
 import type { CompiledDimension, FieldId } from '../../types/field';
 import { getItemId } from '../../utils/item';
-
-const USER_ATTRIBUTE_REFERENCE_PREFIXES = [
-    '${ld.userAttributes.',
-    '${lightdash.userAttributes.',
-] as const;
+import { hasLightdashUserContextVariableReference } from '../../utils/lightdashSqlVariables';
 
 export enum PreAggregateDerivedDimensionIneligibilityReason {
     CIRCULAR_DEPENDENCY = 'circular_dependency',
@@ -35,7 +32,7 @@ export type PreAggregateDerivedDimensionEligibility =
 
 type PreAggregateDimensionLookup = Record<
     string,
-    Pick<CompiledTable, 'dimensions'>
+    Pick<CompiledTable, 'name' | 'originalName' | 'dimensions'>
 >;
 
 type EligibilityTraversalState = {
@@ -52,11 +49,9 @@ const hasParameterReferences = (dimension: CompiledDimension): boolean =>
     (dimension.parameterReferences?.length ?? 0) > 0;
 
 const hasExplicitUserAttributeReference = (sql: string): boolean =>
-    // There is no shared extractor for user-attribute references today, so keep
-    // this first slice limited to explicit tokens we can detect cheaply.
-    USER_ATTRIBUTE_REFERENCE_PREFIXES.some((prefix) => sql.includes(prefix));
+    hasLightdashUserContextVariableReference(sql);
 
-const getReferencedDimension = ({
+const getReferencedDimensionForEligibility = ({
     dimension,
     ref,
     tables,
@@ -70,7 +65,7 @@ const getReferencedDimension = ({
     }
 
     const { refTable, refName } = getParsedReference(ref, dimension.table);
-    return tables[refTable]?.dimensions[refName];
+    return getReferencedDimension(refTable, refName, tables);
 };
 
 const getIneligibleResult = ({
@@ -147,7 +142,7 @@ const analyzeDimensionEligibility = ({
         }
 
         for (const ref of getAllReferences(dimension.sql)) {
-            const referencedDimension = getReferencedDimension({
+            const referencedDimension = getReferencedDimensionForEligibility({
                 dimension,
                 ref,
                 tables,

--- a/packages/common/src/ee/preAggregates/index.ts
+++ b/packages/common/src/ee/preAggregates/index.ts
@@ -4,3 +4,8 @@ export {
     PreAggregateDerivedDimensionIneligibilityReason,
     type PreAggregateDerivedDimensionEligibility,
 } from './dimensionEligibility';
+export {
+    analyzePreAggregateDerivedMetricEligibility,
+    PreAggregateDerivedMetricIneligibilityReason,
+    type PreAggregateDerivedMetricEligibility,
+} from './metricEligibility';

--- a/packages/common/src/ee/preAggregates/metricEligibility.test.ts
+++ b/packages/common/src/ee/preAggregates/metricEligibility.test.ts
@@ -1,0 +1,458 @@
+import { getParameterReferencesFromSqlAndFormat } from '../../compiler/parameters';
+import type { CompiledTable } from '../../types/explore';
+import {
+    DimensionType,
+    FieldType,
+    MetricType,
+    type CompiledDimension,
+    type CompiledMetric,
+} from '../../types/field';
+import { FilterOperator } from '../../types/filter';
+import { getItemId } from '../../utils/item';
+import { PreAggregateDerivedDimensionIneligibilityReason } from './dimensionEligibility';
+import {
+    analyzePreAggregateDerivedMetricEligibility,
+    PreAggregateDerivedMetricIneligibilityReason,
+} from './metricEligibility';
+
+const makeDimension = (
+    overrides: Partial<CompiledDimension> & Pick<CompiledDimension, 'name'>,
+): CompiledDimension => ({
+    ...overrides,
+    fieldType: FieldType.DIMENSION,
+    type: DimensionType.NUMBER,
+    name: overrides.name,
+    label: overrides.label ?? overrides.name,
+    table: overrides.table ?? 'orders',
+    tableLabel: overrides.tableLabel ?? 'Orders',
+    sql: overrides.sql ?? '${TABLE}.amount',
+    compiledSql: overrides.compiledSql ?? overrides.sql ?? '"orders".amount',
+    parameterReferences:
+        overrides.parameterReferences ??
+        getParameterReferencesFromSqlAndFormat(
+            overrides.sql ?? '${TABLE}.amount',
+        ),
+    tablesReferences: overrides.tablesReferences ?? ['orders'],
+    hidden: overrides.hidden ?? false,
+});
+
+const makeMetric = (
+    overrides: Partial<CompiledMetric> & Pick<CompiledMetric, 'name' | 'type'>,
+): CompiledMetric => ({
+    ...overrides,
+    fieldType: FieldType.METRIC,
+    type: overrides.type,
+    name: overrides.name,
+    label: overrides.label ?? overrides.name,
+    table: overrides.table ?? 'orders',
+    tableLabel: overrides.tableLabel ?? 'Orders',
+    sql: overrides.sql ?? 'sum(${TABLE}.amount)',
+    compiledSql:
+        overrides.compiledSql ?? overrides.sql ?? 'SUM("orders".amount)',
+    parameterReferences:
+        overrides.parameterReferences ??
+        getParameterReferencesFromSqlAndFormat(
+            overrides.sql ?? 'sum(${TABLE}.amount)',
+        ),
+    tablesReferences: overrides.tablesReferences ?? ['orders'],
+    hidden: overrides.hidden ?? false,
+});
+
+const makeTables = ({
+    dimensions,
+    metrics,
+}: {
+    dimensions: CompiledDimension[];
+    metrics: CompiledMetric[];
+}): Record<
+    string,
+    Pick<CompiledTable, 'name' | 'originalName' | 'dimensions' | 'metrics'>
+> =>
+    [...dimensions, ...metrics].reduce<
+        Record<
+            string,
+            Pick<
+                CompiledTable,
+                'name' | 'originalName' | 'dimensions' | 'metrics'
+            >
+        >
+    >((acc, field) => {
+        acc[field.table] = acc[field.table] ?? {
+            name: field.table,
+            originalName: field.table === 'cstmr' ? 'customers' : undefined,
+            dimensions: {},
+            metrics: {},
+        };
+
+        if (field.fieldType === FieldType.DIMENSION) {
+            acc[field.table].dimensions[field.name] = field;
+        } else {
+            acc[field.table].metrics[field.name] = field;
+        }
+
+        return acc;
+    }, {});
+
+describe('analyzePreAggregateDerivedMetricEligibility', () => {
+    it('classifies a custom sql metric over eligible dimensions as eligible', () => {
+        const amount = makeDimension({
+            name: 'amount',
+            sql: '${TABLE}.amount',
+            compiledSql: '"orders".amount',
+        });
+        const shippingCost = makeDimension({
+            name: 'shipping_cost',
+            sql: '${TABLE}.shipping_cost',
+            compiledSql: '"orders".shipping_cost',
+        });
+        const totalValue = makeMetric({
+            name: 'total_value',
+            type: MetricType.SUM,
+            sql: '${amount} + ${shipping_cost}',
+            compiledSql: 'SUM("orders".amount + "orders".shipping_cost)',
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: totalValue,
+                tables: makeTables({
+                    dimensions: [amount, shippingCost],
+                    metrics: [totalValue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: true,
+            referencedDimensionFieldIds: [
+                getItemId(amount),
+                getItemId(shippingCost),
+            ],
+            referencedMetricFieldIds: [getItemId(totalValue)],
+        });
+    });
+
+    it('classifies a metric with recursive metric dependencies as eligible when all dependencies are safe', () => {
+        const amount = makeDimension({
+            name: 'amount',
+            sql: '${TABLE}.amount',
+            compiledSql: '"orders".amount',
+        });
+        const orderValue = makeMetric({
+            name: 'order_value',
+            type: MetricType.SUM,
+            sql: '${amount}',
+            compiledSql: 'SUM("orders".amount)',
+        });
+        const doubledOrderValue = makeMetric({
+            name: 'doubled_order_value',
+            type: MetricType.NUMBER,
+            sql: '${order_value} * 2',
+            compiledSql: '(SUM("orders".amount)) * 2',
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: doubledOrderValue,
+                tables: makeTables({
+                    dimensions: [amount],
+                    metrics: [orderValue, doubledOrderValue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: true,
+            referencedDimensionFieldIds: [getItemId(amount)],
+            referencedMetricFieldIds: [
+                getItemId(doubledOrderValue),
+                getItemId(orderValue),
+            ],
+        });
+    });
+
+    it('resolves metric references through a joined table original name', () => {
+        const customerFirstName = makeDimension({
+            name: 'first_name',
+            table: 'cstmr',
+            sql: '${TABLE}.first_name',
+            compiledSql: '"customers".first_name',
+        });
+        const customerNameCount = makeMetric({
+            name: 'customer_name_count',
+            table: 'orders',
+            type: MetricType.COUNT,
+            sql: '${customers.first_name}',
+            compiledSql: 'COUNT("customers".first_name)',
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: customerNameCount,
+                tables: makeTables({
+                    dimensions: [customerFirstName],
+                    metrics: [customerNameCount],
+                }),
+            }),
+        ).toEqual({
+            isEligible: true,
+            referencedDimensionFieldIds: [getItemId(customerFirstName)],
+            referencedMetricFieldIds: [getItemId(customerNameCount)],
+        });
+    });
+
+    it('rejects when a metric references a parameter directly', () => {
+        const regionAwareRevenue = makeMetric({
+            name: 'region_aware_revenue',
+            type: MetricType.SUM,
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.amount
+                    ELSE 0
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: regionAwareRevenue,
+                tables: makeTables({
+                    dimensions: [],
+                    metrics: [regionAwareRevenue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedMetricIneligibilityReason.PARAMETER_REFERENCES,
+            ineligibleMetricFieldId: getItemId(regionAwareRevenue),
+            referencedDimensionFieldIds: [],
+            referencedMetricFieldIds: [getItemId(regionAwareRevenue)],
+        });
+    });
+
+    it('rejects when a metric sql contains a direct user attribute reference', () => {
+        const regionAwareRevenue = makeMetric({
+            name: 'region_aware_revenue',
+            type: MetricType.SUM,
+            sql: `
+                CASE
+                    WHEN \${lightdash.attributes.region} = 'EMEA' THEN \${TABLE}.amount
+                    ELSE 0
+                END
+            `,
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: regionAwareRevenue,
+                tables: makeTables({
+                    dimensions: [],
+                    metrics: [regionAwareRevenue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedMetricIneligibilityReason.USER_ATTRIBUTES,
+            ineligibleMetricFieldId: getItemId(regionAwareRevenue),
+            referencedDimensionFieldIds: [],
+            referencedMetricFieldIds: [getItemId(regionAwareRevenue)],
+        });
+    });
+
+    it('rejects when a metric sql contains a direct intrinsic user reference', () => {
+        const emailAwareRevenue = makeMetric({
+            name: 'email_aware_revenue',
+            type: MetricType.SUM,
+            sql: `
+                CASE
+                    WHEN \${ld.user.email} IS NOT NULL THEN \${TABLE}.amount
+                    ELSE 0
+                END
+            `,
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: emailAwareRevenue,
+                tables: makeTables({
+                    dimensions: [],
+                    metrics: [emailAwareRevenue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedMetricIneligibilityReason.USER_ATTRIBUTES,
+            ineligibleMetricFieldId: getItemId(emailAwareRevenue),
+            referencedDimensionFieldIds: [],
+            referencedMetricFieldIds: [getItemId(emailAwareRevenue)],
+        });
+    });
+
+    it('rejects when a referenced dimension is ineligible', () => {
+        const parameterizedAmount = makeDimension({
+            name: 'parameterized_amount',
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.amount
+                    ELSE NULL
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+        const revenue = makeMetric({
+            name: 'revenue',
+            type: MetricType.SUM,
+            sql: '${parameterized_amount}',
+            compiledSql: 'SUM(CASE WHEN ... END)',
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: revenue,
+                tables: makeTables({
+                    dimensions: [parameterizedAmount],
+                    metrics: [revenue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedMetricIneligibilityReason.DIMENSION_DEPENDENCY_INELIGIBLE,
+            ineligibleMetricFieldId: getItemId(revenue),
+            ineligibleDimensionFieldId: getItemId(parameterizedAmount),
+            ineligibleDimensionReason:
+                PreAggregateDerivedDimensionIneligibilityReason.PARAMETER_REFERENCES,
+            referencedDimensionFieldIds: [getItemId(parameterizedAmount)],
+            referencedMetricFieldIds: [getItemId(revenue)],
+        });
+    });
+
+    it('rejects when a recursive metric dependency is ineligible', () => {
+        const parameterizedRevenue = makeMetric({
+            name: 'parameterized_revenue',
+            type: MetricType.SUM,
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.amount
+                    ELSE 0
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+        const doubledRevenue = makeMetric({
+            name: 'doubled_revenue',
+            type: MetricType.NUMBER,
+            sql: '${parameterized_revenue} * 2',
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: doubledRevenue,
+                tables: makeTables({
+                    dimensions: [],
+                    metrics: [parameterizedRevenue, doubledRevenue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedMetricIneligibilityReason.METRIC_DEPENDENCY_INELIGIBLE,
+            ineligibleMetricFieldId: getItemId(parameterizedRevenue),
+            referencedDimensionFieldIds: [],
+            referencedMetricFieldIds: [
+                getItemId(doubledRevenue),
+                getItemId(parameterizedRevenue),
+            ],
+        });
+    });
+
+    it('rejects when a metric filter references an ineligible dimension', () => {
+        const amount = makeDimension({
+            name: 'amount',
+            sql: '${TABLE}.amount',
+            compiledSql: '"orders".amount',
+        });
+        const parameterizedStatus = makeDimension({
+            name: 'parameterized_status',
+            sql: `
+                CASE
+                    WHEN \${lightdash.parameters.orders.region} = 'EMEA' THEN \${TABLE}.status
+                    ELSE NULL
+                END
+            `,
+            parameterReferences: ['orders.region'],
+        });
+        const filteredRevenue = makeMetric({
+            name: 'filtered_revenue',
+            type: MetricType.SUM,
+            sql: '${amount}',
+            compiledSql: 'SUM("orders".amount)',
+            filters: [
+                {
+                    id: 'metric-filter',
+                    target: {
+                        fieldRef: 'parameterized_status',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['completed'],
+                },
+            ],
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: filteredRevenue,
+                tables: makeTables({
+                    dimensions: [amount, parameterizedStatus],
+                    metrics: [filteredRevenue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: false,
+            reason: PreAggregateDerivedMetricIneligibilityReason.FILTER_DIMENSION_INELIGIBLE,
+            ineligibleMetricFieldId: getItemId(filteredRevenue),
+            ineligibleDimensionFieldId: getItemId(parameterizedStatus),
+            ineligibleDimensionReason:
+                PreAggregateDerivedDimensionIneligibilityReason.PARAMETER_REFERENCES,
+            referencedDimensionFieldIds: [
+                getItemId(amount),
+                getItemId(parameterizedStatus),
+            ],
+            referencedMetricFieldIds: [getItemId(filteredRevenue)],
+        });
+    });
+
+    it('resolves metric filter dimensions case-insensitively', () => {
+        const orderDateDay = makeDimension({
+            name: 'order_date_day',
+            table: 'orders',
+            sql: '${TABLE}.order_date',
+            compiledSql: 'DATE_TRUNC(\'DAY\', "orders".order_date)',
+        });
+        const filteredRevenue = makeMetric({
+            name: 'filtered_revenue',
+            type: MetricType.SUM,
+            sql: '${TABLE}.amount',
+            compiledSql: 'SUM("orders".amount)',
+            filters: [
+                {
+                    id: 'metric-filter',
+                    target: {
+                        fieldRef: 'order_date_DAY',
+                    },
+                    operator: FilterOperator.EQUALS,
+                    values: ['2024-01-01'],
+                },
+            ],
+        });
+
+        expect(
+            analyzePreAggregateDerivedMetricEligibility({
+                metric: filteredRevenue,
+                tables: makeTables({
+                    dimensions: [orderDateDay],
+                    metrics: [filteredRevenue],
+                }),
+            }),
+        ).toEqual({
+            isEligible: true,
+            referencedDimensionFieldIds: [getItemId(orderDateDay)],
+            referencedMetricFieldIds: [getItemId(filteredRevenue)],
+        });
+    });
+});

--- a/packages/common/src/ee/preAggregates/metricEligibility.ts
+++ b/packages/common/src/ee/preAggregates/metricEligibility.ts
@@ -1,0 +1,405 @@
+import {
+    getAllReferences,
+    getParsedReference,
+} from '../../compiler/exploreCompiler';
+import {
+    getReferencedDimension,
+    getReferencedDimensionCaseInsensitive,
+    getReferencedMetric,
+} from '../../compiler/referenceLookup';
+import type { CompiledTable } from '../../types/explore';
+import type {
+    CompiledDimension,
+    CompiledMetric,
+    FieldId,
+} from '../../types/field';
+import { getItemId } from '../../utils/item';
+import { hasLightdashUserContextVariableReference } from '../../utils/lightdashSqlVariables';
+import {
+    analyzePreAggregateDerivedDimensionEligibility,
+    type PreAggregateDerivedDimensionEligibility,
+    type PreAggregateDerivedDimensionIneligibilityReason,
+} from './dimensionEligibility';
+
+export enum PreAggregateDerivedMetricIneligibilityReason {
+    CIRCULAR_DEPENDENCY = 'circular_dependency',
+    COMPILATION_ERROR = 'compilation_error',
+    DIMENSION_DEPENDENCY_INELIGIBLE = 'dimension_dependency_ineligible',
+    FILTER_DIMENSION_INELIGIBLE = 'filter_dimension_ineligible',
+    METRIC_DEPENDENCY_INELIGIBLE = 'metric_dependency_ineligible',
+    MISSING_DEPENDENCY = 'missing_dependency',
+    PARAMETER_REFERENCES = 'parameter_references',
+    USER_ATTRIBUTES = 'user_attributes',
+}
+
+type PreAggregateMetricLookup = Record<
+    string,
+    Pick<CompiledTable, 'name' | 'originalName' | 'dimensions' | 'metrics'>
+>;
+
+type PreAggregateDerivedMetricEligibilityBase = {
+    referencedDimensionFieldIds: FieldId[];
+    referencedMetricFieldIds: FieldId[];
+};
+
+export type PreAggregateDerivedMetricEligibility =
+    | ({
+          isEligible: true;
+      } & PreAggregateDerivedMetricEligibilityBase)
+    | ({
+          isEligible: false;
+          ineligibleMetricFieldId: FieldId;
+          ineligibleDimensionFieldId?: FieldId;
+          ineligibleDimensionReason?: PreAggregateDerivedDimensionIneligibilityReason;
+          reason: PreAggregateDerivedMetricIneligibilityReason;
+      } & PreAggregateDerivedMetricEligibilityBase);
+
+type EligibilityTraversalState = {
+    activeFieldIds: Set<FieldId>;
+    cache: Map<FieldId, PreAggregateDerivedMetricEligibility>;
+};
+
+const mergeFieldIds = (current: FieldId[], next: FieldId[]): FieldId[] =>
+    Array.from(new Set([...current, ...next]));
+
+const hasParameterReferences = (metric: CompiledMetric): boolean =>
+    (metric.parameterReferences?.length ?? 0) > 0;
+
+const hasExplicitUserAttributeReference = (sql: string): boolean =>
+    hasLightdashUserContextVariableReference(sql);
+
+const getReferencedDimensionForEligibility = ({
+    metric,
+    ref,
+    tables,
+}: {
+    metric: CompiledMetric;
+    ref: string;
+    tables: PreAggregateMetricLookup;
+}): CompiledDimension | undefined => {
+    if (ref === 'TABLE') {
+        return undefined;
+    }
+
+    const { refTable, refName } = getParsedReference(ref, metric.table);
+    return getReferencedDimension(refTable, refName, tables);
+};
+
+const getReferencedMetricForEligibility = ({
+    metric,
+    ref,
+    tables,
+}: {
+    metric: CompiledMetric;
+    ref: string;
+    tables: PreAggregateMetricLookup;
+}): CompiledMetric | undefined => {
+    if (ref === 'TABLE') {
+        return undefined;
+    }
+
+    const { refTable, refName } = getParsedReference(ref, metric.table);
+    return getReferencedMetric(refTable, refName, tables);
+};
+
+const getReferencedFilterDimension = ({
+    metric,
+    fieldRef,
+    tables,
+}: {
+    metric: CompiledMetric;
+    fieldRef: string;
+    tables: PreAggregateMetricLookup;
+}): CompiledDimension | undefined => {
+    const { refTable, refName } = getParsedReference(fieldRef, metric.table);
+    return getReferencedDimensionCaseInsensitive(refTable, refName, tables);
+};
+
+const getIneligibleMetricResult = ({
+    metricFieldId,
+    reason,
+    referencedDimensionFieldIds,
+    referencedMetricFieldIds,
+    ineligibleDimensionFieldId,
+    ineligibleDimensionReason,
+}: {
+    metricFieldId: FieldId;
+    reason: PreAggregateDerivedMetricIneligibilityReason;
+    referencedDimensionFieldIds: FieldId[];
+    referencedMetricFieldIds: FieldId[];
+    ineligibleDimensionFieldId?: FieldId;
+    ineligibleDimensionReason?: PreAggregateDerivedDimensionIneligibilityReason;
+}): PreAggregateDerivedMetricEligibility => ({
+    isEligible: false,
+    reason,
+    ineligibleMetricFieldId: metricFieldId,
+    ...(ineligibleDimensionFieldId ? { ineligibleDimensionFieldId } : {}),
+    ...(ineligibleDimensionReason ? { ineligibleDimensionReason } : {}),
+    referencedDimensionFieldIds,
+    referencedMetricFieldIds,
+});
+
+const mergeDimensionEligibility = ({
+    result,
+    eligibility,
+}: {
+    result: PreAggregateDerivedMetricEligibilityBase;
+    eligibility: PreAggregateDerivedDimensionEligibility;
+}): PreAggregateDerivedMetricEligibilityBase => ({
+    referencedDimensionFieldIds: mergeFieldIds(
+        result.referencedDimensionFieldIds,
+        eligibility.referencedDimensionFieldIds,
+    ),
+    referencedMetricFieldIds: result.referencedMetricFieldIds,
+});
+
+const analyzeMetricEligibility = ({
+    metric,
+    tables,
+    state,
+}: {
+    metric: CompiledMetric;
+    tables: PreAggregateMetricLookup;
+    state: EligibilityTraversalState;
+}): PreAggregateDerivedMetricEligibility => {
+    const currentFieldId = getItemId(metric);
+    const cachedResult = state.cache.get(currentFieldId);
+    if (cachedResult) {
+        return cachedResult;
+    }
+
+    if (state.activeFieldIds.has(currentFieldId)) {
+        return getIneligibleMetricResult({
+            metricFieldId: currentFieldId,
+            reason: PreAggregateDerivedMetricIneligibilityReason.CIRCULAR_DEPENDENCY,
+            referencedDimensionFieldIds: [],
+            referencedMetricFieldIds: [currentFieldId],
+        });
+    }
+
+    state.activeFieldIds.add(currentFieldId);
+
+    let result: PreAggregateDerivedMetricEligibility = {
+        isEligible: true,
+        referencedDimensionFieldIds: [],
+        referencedMetricFieldIds: [currentFieldId],
+    };
+
+    try {
+        if (metric.compilationError) {
+            result = getIneligibleMetricResult({
+                metricFieldId: currentFieldId,
+                reason: PreAggregateDerivedMetricIneligibilityReason.COMPILATION_ERROR,
+                referencedDimensionFieldIds: [],
+                referencedMetricFieldIds: [currentFieldId],
+            });
+            return result;
+        }
+
+        if (hasParameterReferences(metric)) {
+            result = getIneligibleMetricResult({
+                metricFieldId: currentFieldId,
+                reason: PreAggregateDerivedMetricIneligibilityReason.PARAMETER_REFERENCES,
+                referencedDimensionFieldIds: [],
+                referencedMetricFieldIds: [currentFieldId],
+            });
+            return result;
+        }
+
+        if (hasExplicitUserAttributeReference(metric.sql)) {
+            result = getIneligibleMetricResult({
+                metricFieldId: currentFieldId,
+                reason: PreAggregateDerivedMetricIneligibilityReason.USER_ATTRIBUTES,
+                referencedDimensionFieldIds: [],
+                referencedMetricFieldIds: [currentFieldId],
+            });
+            return result;
+        }
+
+        for (const ref of getAllReferences(metric.sql)) {
+            if (ref === 'TABLE') {
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            const referencedDimension = getReferencedDimensionForEligibility({
+                metric,
+                ref,
+                tables,
+            });
+
+            if (referencedDimension) {
+                const dimensionEligibility =
+                    analyzePreAggregateDerivedDimensionEligibility({
+                        dimension: referencedDimension,
+                        tables,
+                    });
+                const mergedResult = mergeDimensionEligibility({
+                    result,
+                    eligibility: dimensionEligibility,
+                });
+
+                if (!dimensionEligibility.isEligible) {
+                    result = getIneligibleMetricResult({
+                        metricFieldId: currentFieldId,
+                        reason: PreAggregateDerivedMetricIneligibilityReason.DIMENSION_DEPENDENCY_INELIGIBLE,
+                        ineligibleDimensionFieldId:
+                            dimensionEligibility.ineligibleDimensionFieldId,
+                        ineligibleDimensionReason: dimensionEligibility.reason,
+                        referencedDimensionFieldIds:
+                            mergedResult.referencedDimensionFieldIds,
+                        referencedMetricFieldIds:
+                            mergedResult.referencedMetricFieldIds,
+                    });
+                    return result;
+                }
+
+                result = {
+                    isEligible: true,
+                    referencedDimensionFieldIds:
+                        mergedResult.referencedDimensionFieldIds,
+                    referencedMetricFieldIds:
+                        mergedResult.referencedMetricFieldIds,
+                };
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            const referencedMetric = getReferencedMetricForEligibility({
+                metric,
+                ref,
+                tables,
+            });
+
+            if (referencedMetric) {
+                const metricEligibility = analyzeMetricEligibility({
+                    metric: referencedMetric,
+                    tables,
+                    state,
+                });
+                const mergedDimensionFieldIds = mergeFieldIds(
+                    result.referencedDimensionFieldIds,
+                    metricEligibility.referencedDimensionFieldIds,
+                );
+                const mergedMetricFieldIds = mergeFieldIds(
+                    result.referencedMetricFieldIds,
+                    metricEligibility.referencedMetricFieldIds,
+                );
+
+                if (!metricEligibility.isEligible) {
+                    result = {
+                        isEligible: false,
+                        reason: PreAggregateDerivedMetricIneligibilityReason.METRIC_DEPENDENCY_INELIGIBLE,
+                        ineligibleMetricFieldId:
+                            metricEligibility.ineligibleMetricFieldId,
+                        ...(metricEligibility.ineligibleDimensionFieldId
+                            ? {
+                                  ineligibleDimensionFieldId:
+                                      metricEligibility.ineligibleDimensionFieldId,
+                              }
+                            : {}),
+                        referencedDimensionFieldIds: mergedDimensionFieldIds,
+                        referencedMetricFieldIds: mergedMetricFieldIds,
+                    };
+                    return result;
+                }
+
+                result = {
+                    isEligible: true,
+                    referencedDimensionFieldIds: mergedDimensionFieldIds,
+                    referencedMetricFieldIds: mergedMetricFieldIds,
+                };
+                // eslint-disable-next-line no-continue
+                continue;
+            }
+
+            result = getIneligibleMetricResult({
+                metricFieldId: currentFieldId,
+                reason: PreAggregateDerivedMetricIneligibilityReason.MISSING_DEPENDENCY,
+                referencedDimensionFieldIds: result.referencedDimensionFieldIds,
+                referencedMetricFieldIds: result.referencedMetricFieldIds,
+            });
+            return result;
+        }
+
+        if (metric.filters) {
+            for (const filter of metric.filters) {
+                const fieldRef =
+                    // @ts-expect-error This fallback is to support old metric filters in yml. We can delete this after a few months since we can assume all projects have been redeployed
+                    (filter.target.fieldRef || filter.target.fieldId) as string;
+
+                const referencedDimension = getReferencedFilterDimension({
+                    metric,
+                    fieldRef,
+                    tables,
+                });
+
+                if (!referencedDimension) {
+                    result = getIneligibleMetricResult({
+                        metricFieldId: currentFieldId,
+                        reason: PreAggregateDerivedMetricIneligibilityReason.MISSING_DEPENDENCY,
+                        referencedDimensionFieldIds:
+                            result.referencedDimensionFieldIds,
+                        referencedMetricFieldIds:
+                            result.referencedMetricFieldIds,
+                    });
+                    return result;
+                }
+
+                const dimensionEligibility =
+                    analyzePreAggregateDerivedDimensionEligibility({
+                        dimension: referencedDimension,
+                        tables,
+                    });
+                const mergedResult = mergeDimensionEligibility({
+                    result,
+                    eligibility: dimensionEligibility,
+                });
+
+                if (!dimensionEligibility.isEligible) {
+                    result = getIneligibleMetricResult({
+                        metricFieldId: currentFieldId,
+                        reason: PreAggregateDerivedMetricIneligibilityReason.FILTER_DIMENSION_INELIGIBLE,
+                        ineligibleDimensionFieldId:
+                            dimensionEligibility.ineligibleDimensionFieldId,
+                        ineligibleDimensionReason: dimensionEligibility.reason,
+                        referencedDimensionFieldIds:
+                            mergedResult.referencedDimensionFieldIds,
+                        referencedMetricFieldIds:
+                            mergedResult.referencedMetricFieldIds,
+                    });
+                    return result;
+                }
+
+                result = {
+                    isEligible: true,
+                    referencedDimensionFieldIds:
+                        mergedResult.referencedDimensionFieldIds,
+                    referencedMetricFieldIds:
+                        mergedResult.referencedMetricFieldIds,
+                };
+            }
+        }
+
+        return result;
+    } finally {
+        state.activeFieldIds.delete(currentFieldId);
+        state.cache.set(currentFieldId, result);
+    }
+};
+
+export const analyzePreAggregateDerivedMetricEligibility = ({
+    metric,
+    tables,
+}: {
+    metric: CompiledMetric;
+    tables: PreAggregateMetricLookup;
+}): PreAggregateDerivedMetricEligibility =>
+    analyzeMetricEligibility({
+        metric,
+        tables,
+        state: {
+            activeFieldIds: new Set<FieldId>(),
+            cache: new Map<FieldId, PreAggregateDerivedMetricEligibility>(),
+        },
+    });

--- a/packages/common/src/ee/preAggregates/utils.ts
+++ b/packages/common/src/ee/preAggregates/utils.ts
@@ -4,6 +4,11 @@ export {
     PreAggregateDerivedDimensionIneligibilityReason,
     type PreAggregateDerivedDimensionEligibility,
 } from './dimensionEligibility';
+export {
+    analyzePreAggregateDerivedMetricEligibility,
+    PreAggregateDerivedMetricIneligibilityReason,
+    type PreAggregateDerivedMetricEligibility,
+} from './metricEligibility';
 export { applyUserBypass, findMatch } from './matcher';
 export {
     getMetricRepresentation,

--- a/packages/common/src/index.ts
+++ b/packages/common/src/index.ts
@@ -203,6 +203,7 @@ export * from './utils/i18n/merge';
 export * from './utils/i18n/types';
 export * from './utils/item';
 export * from './utils/loadLightdashProjectConfig';
+export * from './utils/lightdashSqlVariables';
 export * from './utils/metricsExplorer';
 export * from './utils/oauth';
 export * from './utils/organization';

--- a/packages/common/src/utils/lightdashSqlVariables.ts
+++ b/packages/common/src/utils/lightdashSqlVariables.ts
@@ -1,0 +1,10 @@
+export const getUserAttributeRegex = () =>
+    /\$\{(?:lightdash|ld)\.(?:attribute|attributes|attr)\.(\w+)\}/g;
+export const getIntrinsicUserAttributeRegex = () =>
+    /\$\{(?:lightdash|ld)\.user\.(\w+)\}/g;
+
+export const hasLightdashUserContextVariableReference = (
+    sql: string,
+): boolean =>
+    sql.match(getUserAttributeRegex()) !== null ||
+    sql.match(getIntrinsicUserAttributeRegex()) !== null;


### PR DESCRIPTION
Closes: <!-- reference the related issue e.g. #150 -->

### Description:

Adds eligibility analysis for custom SQL metrics in pre-aggregate materialization, blocking metrics that reference parameters, user attributes, or ineligible dimensions from being included in pre-aggregate definitions.

A new `metricEligibility.ts` module introduces `analyzePreAggregateDerivedMetricEligibility`, which traverses a metric's SQL references and metric filters to determine whether it can safely be materialized. The analysis catches:

- Direct parameter references in metric SQL
- Direct user attribute or intrinsic user references in metric SQL (e.g. `${ld.attr.region}`, `${lightdash.user.email}`)
- Dimension dependencies that are themselves ineligible (e.g. parameterized dimensions)
- Recursive metric dependencies that are ineligible
- Metric filters targeting ineligible dimensions

The eligibility check is enforced in both `buildPreAggregateExplore` and `buildMaterializationMetricQuery`, replacing duplicated inline `assertDimensionEligibleForDirectMaterialization` implementations with a shared version extracted to a new `eligibility.ts` file.

User attribute and intrinsic user attribute reference regexes are consolidated into a shared `lightdashSqlVariables.ts` utility, replacing previously scattered inline regex definitions. The dimension eligibility check is updated to use this shared utility, which also correctly covers the `${ld.user.*}` intrinsic reference pattern that was previously missed.