### PR TITLE
fix: attach only valid pre-aggregates to base explore and add feature flag guard

### DIFF
--- a/packages/backend/src/ee/preAggregates/generatePreAggregateExplores.ts
+++ b/packages/backend/src/ee/preAggregates/generatePreAggregateExplores.ts
@@ -17,6 +17,10 @@ export const generatePreAggregateExplores = ({
     compiledExplores: Array<Explore | ExploreError>;
     parsedPreAggregates: PreAggregateDef[];
 }): Array<Explore | ExploreError> => {
+    if (process.env.PRE_AGGREGATES_ENABLED !== 'true') {
+        return compiledExplores;
+    }
+
     if (parsedPreAggregates.length === 0) {
         return compiledExplores;
     }
@@ -30,6 +34,7 @@ export const generatePreAggregateExplores = ({
         }
 
         const generatedPreAggregateExplores: Explore[] = [];
+        const validPreAggregates: PreAggregateDef[] = [];
         const generationErrors: string[] = [];
 
         parsedPreAggregates.forEach((preAggregateDef) => {
@@ -37,6 +42,7 @@ export const generatePreAggregateExplores = ({
                 generatedPreAggregateExplores.push(
                     buildPreAggregateExplore(compiled, preAggregateDef),
                 );
+                validPreAggregates.push(preAggregateDef);
             } catch (error) {
                 generationErrors.push(
                     error instanceof Error
@@ -47,12 +53,19 @@ export const generatePreAggregateExplores = ({
         });
 
         if (generationErrors.length === 0) {
-            return [compiled, ...generatedPreAggregateExplores];
+            return [
+                {
+                    ...compiled,
+                    preAggregates: validPreAggregates,
+                },
+                ...generatedPreAggregateExplores,
+            ];
         }
 
         return [
             {
                 ...compiled,
+                preAggregates: validPreAggregates,
                 warnings: [
                     ...(compiled.warnings || []),
                     ...generationErrors.map((message) => ({

--- a/packages/backend/src/ee/preAggregates/postProcessor.test.ts
+++ b/packages/backend/src/ee/preAggregates/postProcessor.test.ts
@@ -404,4 +404,57 @@ describe('pre-aggregate virtual explore generation', () => {
                 'Pre-aggregate "broken_rollup" references unsupported metrics: "myTable_user_count" (count_distinct). Supported metric types: sum, count, min, max, average',
         });
     });
+
+    it('keeps only successfully generated pre-aggregates on the base explore', async () => {
+        process.env.PRE_AGGREGATES_ENABLED = 'true';
+
+        const explores = await convertExplores(
+            [
+                {
+                    ...MODEL_WITH_METRIC,
+                    meta: {
+                        pre_aggregates: [
+                            {
+                                name: 'valid_rollup',
+                                dimensions: ['user_id'],
+                                metrics: [
+                                    'myTable_total_num_participating_athletes',
+                                ],
+                            },
+                            {
+                                name: 'invalid_rollup',
+                                dimensions: ['user_id'],
+                                metrics: ['missing_metric'],
+                            },
+                        ],
+                    },
+                },
+            ],
+            false,
+            SupportedDbtAdapter.POSTGRES,
+            [],
+            warehouseClientMock,
+            {
+                spotlight: DEFAULT_SPOTLIGHT_CONFIG,
+            },
+            { postProcessors: [preAggregatePostProcessor] },
+        );
+
+        const baseExplore = explores.find(
+            (explore) => !('errors' in explore) && explore.name === 'myTable',
+        ) as Explore;
+
+        expect(baseExplore.preAggregates).toStrictEqual([
+            {
+                name: 'valid_rollup',
+                dimensions: ['user_id'],
+                metrics: ['myTable_total_num_participating_athletes'],
+            },
+        ]);
+        expect(baseExplore.warnings).toContainEqual({
+            type: InlineErrorType.FIELD_ERROR,
+            message:
+                'Pre-aggregate "invalid_rollup" references unknown metric "missing_metric"',
+        });
+    });
 });


### PR DESCRIPTION
Closes:

### Description:

Adds a `PRE_AGGREGATES_ENABLED` environment variable flag that must be set to `'true'` for pre-aggregate explore generation to run. When disabled, the original compiled explores are returned unchanged.

Additionally, the base explore now tracks which pre-aggregates were successfully generated via a `preAggregates` field. When some pre-aggregates fail to generate, only the valid ones are attached to the base explore, while the failures are surfaced as warnings. Previously, no pre-aggregate definitions were stored on the base explore regardless of success or failure.