### PR TITLE
feat(data-apps): enable saving apps to spaces

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2739,12 +2739,12 @@ export class AppGenerateService extends BaseService {
     }
 
     /**
-     * Move a data app from one space to another.
+     * Move a data app into a space, or between spaces.
      *
      * Implements the shared `BulkActionable` interface so `ContentService`
      * can dispatch move requests uniformly alongside dashboards and charts.
-     * Only space → space moves are supported for now: personal apps (no
-     * source space) and moves to `null` (unassigning) are rejected.
+     * Moves to `null` (unassigning back to personal) are rejected — once
+     * shared to a space, an app stays in a space.
      */
     async moveToSpace(
         user: SessionUser,
@@ -2776,12 +2776,6 @@ export class AppGenerateService extends BaseService {
         }
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
-
-        if (app.space_uuid === null) {
-            throw new ParameterError(
-                'You cannot move a personal data app between spaces',
-            );
-        }
 
         if (checkForAccess) {
             this.assertDataAppAbility(

--- a/packages/backend/src/generated/routes.ts
+++ b/packages/backend/src/generated/routes.ts
@@ -8746,25 +8746,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['success'],
                                                         },
                                                         {
@@ -8784,11 +8765,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8803,11 +8784,30 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['error'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -8838,29 +8838,6 @@ const models: TsoaRoute.Models = {
                                                                                             'nestedObjectLiteral',
                                                                                         nestedProperties:
                                                                                             {
-                                                                                                searchRank:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'union',
-                                                                                                        subSchemas:
-                                                                                                            [
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'double',
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'enum',
-                                                                                                                    enums: [
-                                                                                                                        null,
-                                                                                                                    ],
-                                                                                                                },
-                                                                                                                {
-                                                                                                                    dataType:
-                                                                                                                        'undefined',
-                                                                                                                },
-                                                                                                            ],
-                                                                                                    },
                                                                                                 chartUsage:
                                                                                                     {
                                                                                                         dataType:
@@ -8884,6 +8861,35 @@ const models: TsoaRoute.Models = {
                                                                                                                 },
                                                                                                             ],
                                                                                                     },
+                                                                                                searchRank:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'union',
+                                                                                                        subSchemas:
+                                                                                                            [
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'double',
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'enum',
+                                                                                                                    enums: [
+                                                                                                                        null,
+                                                                                                                    ],
+                                                                                                                },
+                                                                                                                {
+                                                                                                                    dataType:
+                                                                                                                        'undefined',
+                                                                                                                },
+                                                                                                            ],
+                                                                                                    },
+                                                                                                fieldType:
+                                                                                                    {
+                                                                                                        dataType:
+                                                                                                            'string',
+                                                                                                        required: true,
+                                                                                                    },
                                                                                                 tableName:
                                                                                                     {
                                                                                                         dataType:
@@ -8895,12 +8901,6 @@ const models: TsoaRoute.Models = {
                                                                                                         'string',
                                                                                                     required: true,
                                                                                                 },
-                                                                                                fieldType:
-                                                                                                    {
-                                                                                                        dataType:
-                                                                                                            'string',
-                                                                                                        required: true,
-                                                                                                    },
                                                                                                 name: {
                                                                                                     dataType:
                                                                                                         'string',
@@ -9016,11 +9016,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9096,29 +9096,6 @@ const models: TsoaRoute.Models = {
                                                                                                 'nestedObjectLiteral',
                                                                                             nestedProperties:
                                                                                                 {
-                                                                                                    searchRank:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'union',
-                                                                                                            subSchemas:
-                                                                                                                [
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'double',
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'enum',
-                                                                                                                        enums: [
-                                                                                                                            null,
-                                                                                                                        ],
-                                                                                                                    },
-                                                                                                                    {
-                                                                                                                        dataType:
-                                                                                                                            'undefined',
-                                                                                                                    },
-                                                                                                                ],
-                                                                                                        },
                                                                                                     chartUsage:
                                                                                                         {
                                                                                                             dataType:
@@ -9142,6 +9119,35 @@ const models: TsoaRoute.Models = {
                                                                                                                     },
                                                                                                                 ],
                                                                                                         },
+                                                                                                    searchRank:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'union',
+                                                                                                            subSchemas:
+                                                                                                                [
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'double',
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'enum',
+                                                                                                                        enums: [
+                                                                                                                            null,
+                                                                                                                        ],
+                                                                                                                    },
+                                                                                                                    {
+                                                                                                                        dataType:
+                                                                                                                            'undefined',
+                                                                                                                    },
+                                                                                                                ],
+                                                                                                        },
+                                                                                                    fieldType:
+                                                                                                        {
+                                                                                                            dataType:
+                                                                                                                'string',
+                                                                                                            required: true,
+                                                                                                        },
                                                                                                     tableName:
                                                                                                         {
                                                                                                             dataType:
@@ -9153,12 +9159,6 @@ const models: TsoaRoute.Models = {
                                                                                                             'string',
                                                                                                         required: true,
                                                                                                     },
-                                                                                                    fieldType:
-                                                                                                        {
-                                                                                                            dataType:
-                                                                                                                'string',
-                                                                                                            required: true,
-                                                                                                        },
                                                                                                     name: {
                                                                                                         dataType:
                                                                                                             'string',
@@ -9190,44 +9190,6 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['success'],
-                                                        },
-                                                        {
-                                                            dataType: 'enum',
-                                                            enums: ['error'],
-                                                        },
-                                                    ],
-                                                    required: true,
-                                                },
-                                            },
-                                        },
-                                        {
-                                            dataType: 'nestedObjectLiteral',
-                                            nestedProperties: {
-                                                status: {
-                                                    dataType: 'union',
-                                                    subSchemas: [
-                                                        {
-                                                            dataType: 'enum',
                                                             enums: ['error'],
                                                         },
                                                         {
@@ -9266,11 +9228,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9285,11 +9247,11 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['success'],
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -9304,11 +9266,49 @@ const models: TsoaRoute.Models = {
                                                     subSchemas: [
                                                         {
                                                             dataType: 'enum',
-                                                            enums: ['error'],
+                                                            enums: ['success'],
                                                         },
                                                         {
                                                             dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
                                                             enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
+                                                        },
+                                                    ],
+                                                    required: true,
+                                                },
+                                            },
+                                        },
+                                        {
+                                            dataType: 'nestedObjectLiteral',
+                                            nestedProperties: {
+                                                status: {
+                                                    dataType: 'union',
+                                                    subSchemas: [
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['success'],
+                                                        },
+                                                        {
+                                                            dataType: 'enum',
+                                                            enums: ['error'],
                                                         },
                                                     ],
                                                     required: true,
@@ -22785,7 +22785,14 @@ const models: TsoaRoute.Models = {
                             required: true,
                         },
                         updatedAt: { dataType: 'datetime', required: true },
-                        spaceUuid: { dataType: 'string', required: true },
+                        spaceUuid: {
+                            dataType: 'union',
+                            subSchemas: [
+                                { dataType: 'string' },
+                                { dataType: 'enum', enums: [null] },
+                            ],
+                            required: true,
+                        },
                         description: {
                             dataType: 'union',
                             subSchemas: [

--- a/packages/backend/src/generated/swagger.json
+++ b/packages/backend/src/generated/swagger.json
@@ -10225,8 +10225,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "error",
-                                                            "success"
+                                                            "success",
+                                                            "error"
                                                         ]
                                                     }
                                                 },
@@ -10238,8 +10238,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -10253,15 +10253,18 @@
                                                             "topMatchingFields": {
                                                                 "items": {
                                                                     "properties": {
+                                                                        "chartUsage": {
+                                                                            "type": "number",
+                                                                            "format": "double",
+                                                                            "nullable": true
+                                                                        },
                                                                         "searchRank": {
                                                                             "type": "number",
                                                                             "format": "double",
                                                                             "nullable": true
                                                                         },
-                                                                        "chartUsage": {
-                                                                            "type": "number",
-                                                                            "format": "double",
-                                                                            "nullable": true
+                                                                        "fieldType": {
+                                                                            "type": "string"
                                                                         },
                                                                         "tableName": {
                                                                             "type": "string"
@@ -10269,17 +10272,14 @@
                                                                         "label": {
                                                                             "type": "string"
                                                                         },
-                                                                        "fieldType": {
-                                                                            "type": "string"
-                                                                        },
                                                                         "name": {
                                                                             "type": "string"
                                                                         }
                                                                     },
                                                                     "required": [
+                                                                        "fieldType",
                                                                         "tableName",
                                                                         "label",
-                                                                        "fieldType",
                                                                         "name"
                                                                     ],
                                                                     "type": "object"
@@ -10328,8 +10328,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -10373,15 +10373,18 @@
                                                                         "results": {
                                                                             "items": {
                                                                                 "properties": {
+                                                                                    "chartUsage": {
+                                                                                        "type": "number",
+                                                                                        "format": "double",
+                                                                                        "nullable": true
+                                                                                    },
                                                                                     "searchRank": {
                                                                                         "type": "number",
                                                                                         "format": "double",
                                                                                         "nullable": true
                                                                                     },
-                                                                                    "chartUsage": {
-                                                                                        "type": "number",
-                                                                                        "format": "double",
-                                                                                        "nullable": true
+                                                                                    "fieldType": {
+                                                                                        "type": "string"
                                                                                     },
                                                                                     "tableName": {
                                                                                         "type": "string"
@@ -10389,17 +10392,14 @@
                                                                                     "label": {
                                                                                         "type": "string"
                                                                                     },
-                                                                                    "fieldType": {
-                                                                                        "type": "string"
-                                                                                    },
                                                                                     "name": {
                                                                                         "type": "string"
                                                                                     }
                                                                                 },
                                                                                 "required": [
+                                                                                    "fieldType",
                                                                                     "tableName",
                                                                                     "label",
-                                                                                    "fieldType",
                                                                                     "name"
                                                                                 ],
                                                                                 "type": "object"
@@ -10427,8 +10427,8 @@
                                                     "status": {
                                                         "type": "string",
                                                         "enum": [
-                                                            "success",
-                                                            "error"
+                                                            "error",
+                                                            "success"
                                                         ]
                                                     }
                                                 },
@@ -24038,7 +24038,8 @@
                                 "format": "date-time"
                             },
                             "spaceUuid": {
-                                "type": "string"
+                                "type": "string",
+                                "nullable": true
                             },
                             "description": {
                                 "type": "string"
@@ -31149,7 +31150,7 @@
     },
     "info": {
         "title": "Lightdash API",
-        "version": "0.2799.0",
+        "version": "0.2805.0",
         "description": "Open API documentation for all public Lightdash API endpoints. # Authentication Before you get started, you might need to create a Personal Access Token to authenticate via the API. You can create a token by following this guide: https://docs.lightdash.com/references/personal_tokens\n",
         "license": {
             "name": "MIT"

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -91,7 +91,7 @@ export type ResourceViewDataAppItem = {
         uuid: string;
         name: string;
         description: string | undefined;
-        spaceUuid: string;
+        spaceUuid: string | null;
         updatedAt: Date;
         updatedByUser: {
             userUuid: string;

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -204,8 +204,6 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
             break;
         }
         case ResourceViewItemType.DATA_APP: {
-            // Data apps are admin-only for now (manage:DataApp). Space-aware
-            // write permissions will land in a later PR.
             userCanManage =
                 user.data?.ability?.can(
                     'manage',

--- a/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
+++ b/packages/frontend/src/components/common/TransferItemsModal/TransferItemsModal.tsx
@@ -71,8 +71,9 @@ const TransferItemsModal = <R extends ResourceViewItem, T extends Array<R>>({
                 return item.data.parentSpaceUuid ?? undefined;
             case ResourceViewItemType.CHART:
             case ResourceViewItemType.DASHBOARD:
-            case ResourceViewItemType.DATA_APP:
                 return item.data.spaceUuid;
+            case ResourceViewItemType.DATA_APP:
+                return item.data.spaceUuid ?? undefined;
             default:
                 return assertUnreachable(item, 'Invalid item type');
         }

--- a/packages/frontend/src/hooks/useContent.ts
+++ b/packages/frontend/src/hooks/useContent.ts
@@ -1,12 +1,12 @@
 import {
     assertUnreachable,
+    ContentType,
     type ApiContentActionBody,
     type ApiContentBulkActionBody,
     type ApiContentResponse,
     type ApiError,
     type ApiSuccessEmpty,
     type ContentSortByColumns,
-    type ContentType,
 } from '@lightdash/common';
 import { IconArrowRight } from '@tabler/icons-react';
 import {
@@ -32,6 +32,9 @@ export type ContentArgs = {
     sortBy?: ContentSortByColumns;
     sortDirection?: 'asc' | 'desc';
 };
+
+const contentTypeLabel = (contentType: ContentType): string =>
+    contentType === ContentType.DATA_APP ? 'data app' : contentType;
 
 function createQueryString(params: Record<string, any>): string {
     const query = new URLSearchParams();
@@ -169,7 +172,9 @@ export const useContentAction = (
             switch (action.type) {
                 case 'move':
                     return showToastSuccess({
-                        title: `Successfully moved ${variables.item.contentType} to a space`,
+                        title: `Successfully moved ${contentTypeLabel(
+                            variables.item.contentType,
+                        )} to a space`,
                         action: {
                             children: 'Go to space',
                             icon: IconArrowRight,
@@ -185,7 +190,9 @@ export const useContentAction = (
                 case 'delete':
                     await queryClient.invalidateQueries(['deletedContent']);
                     return showToastSuccess({
-                        title: `Successfully deleted ${item.contentType}.`,
+                        title: `Successfully deleted ${contentTypeLabel(
+                            item.contentType,
+                        )}.`,
                         action: isSoftDeleteEnabled
                             ? {
                                   children: 'Go to recently deleted',

--- a/packages/frontend/src/pages/AppGenerate.module.css
+++ b/packages/frontend/src/pages/AppGenerate.module.css
@@ -237,7 +237,7 @@
     display: flex;
     align-items: center;
     gap: var(--mantine-spacing-sm);
-    padding: var(--mantine-spacing-xs) var(--mantine-spacing-md);
+    padding: var(--mantine-spacing-md);
     border-bottom: 1px solid;
 
     @mixin light {
@@ -253,7 +253,7 @@
 .previewHeaderInfo {
     display: flex;
     flex-direction: column;
-    gap: 0;
+    gap: 2px;
     min-width: 0;
     flex: 1;
 }

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -1,8 +1,10 @@
 import { subject } from '@casl/ability';
 import {
     ChartKind,
+    ContentType,
     FeatureFlags,
     isAppVersionInProgress,
+    ResourceViewItemType,
     type ApiAppVersionSummary,
 } from '@lightdash/common';
 import {
@@ -11,17 +13,24 @@ import {
     Group,
     Image,
     Loader,
+    Menu,
     Text,
     Textarea,
     ThemeIcon,
+    Title,
 } from '@mantine-8/core';
 import {
     IconAppsOff,
     IconAppWindow,
     IconArrowUp,
+    IconDots,
     IconExternalLink,
+    IconFolderPlus,
+    IconFolderSymlink,
+    IconPencil,
     IconPlayerStop,
     IconSparkles,
+    IconTrash,
 } from '@tabler/icons-react';
 import { useQueryClient } from '@tanstack/react-query';
 import ReactMarkdownPreview from '@uiw/react-markdown-preview';
@@ -42,9 +51,11 @@ import {
     useParams,
 } from 'react-router';
 import { v4 as uuid4 } from 'uuid';
+import AppDeleteModal from '../components/common/modal/AppDeleteModal';
+import AppUpdateModal from '../components/common/modal/AppUpdateModal';
 import { ChartIcon } from '../components/common/ResourceIcon';
 import SuboptimalState from '../components/common/SuboptimalState/SuboptimalState';
-import { EditableText } from '../components/VisualizationConfigs/common/EditableText';
+import TransferItemsModal from '../components/common/TransferItemsModal/TransferItemsModal';
 import AppIframePreview from '../features/apps/AppIframePreview';
 import {
     ImageButton,
@@ -62,8 +73,8 @@ import { useCancelAppVersion } from '../features/apps/hooks/useCancelAppVersion'
 import { useGenerateApp } from '../features/apps/hooks/useGenerateApp';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useIterateApp } from '../features/apps/hooks/useIterateApp';
-import { useUpdateApp } from '../features/apps/hooks/useUpdateApp';
 import QueryInspector from '../features/apps/QueryInspector';
+import { useContentAction } from '../hooks/useContent';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
 import useApp from '../providers/App/useApp';
@@ -241,7 +252,6 @@ const AppGenerate: FC = () => {
         isLoading: isIterating,
         reset: resetIterate,
     } = useIterateApp();
-    const { mutate: updateAppMutate } = useUpdateApp();
     const { mutate: cancelMutate, isLoading: isCancelling } =
         useCancelAppVersion();
     const { mutateAsync: uploadImage } = useAppImageUpload();
@@ -260,21 +270,16 @@ const AppGenerate: FC = () => {
         isFetchingNextPage,
     } = useGetApp(projectUuid, activeAppUuid ?? urlAppUuid);
 
-    // Derive app name/description from fetched data
+    // Derive app name/description/space from fetched data
     const appName = appData?.pages?.[0]?.name ?? '';
     const appDescription = appData?.pages?.[0]?.description ?? '';
+    const appSpaceUuid = appData?.pages?.[0]?.spaceUuid ?? null;
 
-    // Draft state for inline editing (synced from server, saved on blur)
-    const [draftName, setDraftName] = useState(appName);
-    const [draftDescription, setDraftDescription] = useState(appDescription);
-    const isEditingName = useRef(false);
-    const isEditingDescription = useRef(false);
-    useEffect(() => {
-        if (!isEditingName.current) setDraftName(appName);
-    }, [appName]);
-    useEffect(() => {
-        if (!isEditingDescription.current) setDraftDescription(appDescription);
-    }, [appDescription]);
+    const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
+    const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
+    const [isDeleteModalOpen, setIsDeleteModalOpen] = useState(false);
+    const { mutateAsync: contentAction, isLoading: isMovingToSpace } =
+        useContentAction(projectUuid);
 
     // Accumulate all versions ever seen in this session. Refetches may lose
     // older versions when new ones shift pagination boundaries, but we keep
@@ -985,77 +990,170 @@ const AppGenerate: FC = () => {
                         {activeAppUuid && (
                             <Box className={classes.previewHeader}>
                                 <Box className={classes.previewHeaderInfo}>
-                                    <EditableText
-                                        value={draftName}
-                                        placeholder="Untitled app"
-                                        fw={600}
-                                        size="md"
-                                        onFocus={() => {
-                                            isEditingName.current = true;
-                                        }}
-                                        onChange={(e) =>
-                                            setDraftName(e.currentTarget.value)
-                                        }
-                                        onBlur={() => {
-                                            isEditingName.current = false;
-                                            const trimmed = draftName.trim();
-                                            if (
-                                                trimmed &&
-                                                trimmed !== appName
-                                            ) {
-                                                updateAppMutate({
-                                                    projectUuid,
-                                                    appUuid: activeAppUuid,
-                                                    name: trimmed,
-                                                });
-                                            } else {
-                                                setDraftName(appName);
-                                            }
-                                        }}
-                                    />
-                                    <EditableText
-                                        value={draftDescription}
-                                        placeholder="Add a description..."
-                                        lighter
-                                        onFocus={() => {
-                                            isEditingDescription.current = true;
-                                        }}
-                                        onChange={(e) =>
-                                            setDraftDescription(
-                                                e.currentTarget.value,
-                                            )
-                                        }
-                                        onBlur={() => {
-                                            isEditingDescription.current = false;
-                                            const trimmed =
-                                                draftDescription.trim();
-                                            if (trimmed !== appDescription) {
-                                                updateAppMutate({
-                                                    projectUuid,
-                                                    appUuid: activeAppUuid,
-                                                    description: trimmed,
-                                                });
-                                            } else {
-                                                setDraftDescription(
-                                                    appDescription,
-                                                );
-                                            }
-                                        }}
-                                    />
+                                    <Title order={6} fw={600} lineClamp={1}>
+                                        {appName || 'Untitled app'}
+                                    </Title>
+                                    {appDescription && (
+                                        <Text
+                                            size="xs"
+                                            c="dimmed"
+                                            lineClamp={1}
+                                        >
+                                            {appDescription}
+                                        </Text>
+                                    )}
                                 </Box>
-                                {previewApp && (
-                                    <ActionIcon
-                                        component={Link}
-                                        to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/preview`}
-                                        target="_blank"
-                                        variant="subtle"
-                                        size="sm"
-                                        ml="auto"
-                                    >
-                                        <IconExternalLink size={14} />
-                                    </ActionIcon>
-                                )}
+                                <Menu
+                                    position="bottom-end"
+                                    shadow="md"
+                                    withinPortal
+                                    withArrow
+                                    arrowPosition="center"
+                                >
+                                    <Menu.Target>
+                                        <ActionIcon
+                                            variant="subtle"
+                                            size="sm"
+                                            color="ldGray.6"
+                                            ml="auto"
+                                            aria-label="App actions"
+                                        >
+                                            <IconDots size={16} />
+                                        </ActionIcon>
+                                    </Menu.Target>
+                                    <Menu.Dropdown>
+                                        {previewApp && (
+                                            <Menu.Item
+                                                component={Link}
+                                                to={`/projects/${projectUuid}/apps/${previewApp.appUuid}/preview`}
+                                                target="_blank"
+                                                leftSection={
+                                                    <IconExternalLink
+                                                        size={14}
+                                                    />
+                                                }
+                                            >
+                                                Preview latest
+                                            </Menu.Item>
+                                        )}
+                                        {previewApp && <Menu.Divider />}
+                                        <Menu.Item
+                                            leftSection={
+                                                <IconPencil size={14} />
+                                            }
+                                            onClick={() =>
+                                                setIsUpdateModalOpen(true)
+                                            }
+                                        >
+                                            Rename
+                                        </Menu.Item>
+                                        <Menu.Item
+                                            leftSection={
+                                                appSpaceUuid ? (
+                                                    <IconFolderSymlink
+                                                        size={14}
+                                                    />
+                                                ) : (
+                                                    <IconFolderPlus size={14} />
+                                                )
+                                            }
+                                            onClick={() =>
+                                                setIsMoveToSpaceOpen(true)
+                                            }
+                                        >
+                                            {appSpaceUuid
+                                                ? 'Move'
+                                                : 'Add to space'}
+                                        </Menu.Item>
+                                        <Menu.Divider />
+                                        <Menu.Item
+                                            color="red"
+                                            leftSection={
+                                                <IconTrash size={14} />
+                                            }
+                                            onClick={() =>
+                                                setIsDeleteModalOpen(true)
+                                            }
+                                        >
+                                            Delete
+                                        </Menu.Item>
+                                    </Menu.Dropdown>
+                                </Menu>
                             </Box>
+                        )}
+                        {isMoveToSpaceOpen && activeAppUuid && (
+                            <TransferItemsModal
+                                projectUuid={projectUuid}
+                                opened
+                                onClose={() => setIsMoveToSpaceOpen(false)}
+                                items={[
+                                    {
+                                        type: ResourceViewItemType.DATA_APP,
+                                        data: {
+                                            uuid: activeAppUuid,
+                                            name: appName,
+                                            description:
+                                                appDescription || undefined,
+                                            spaceUuid: appSpaceUuid,
+                                            updatedAt: new Date(),
+                                            updatedByUser: null,
+                                            views: 0,
+                                            firstViewedAt: null,
+                                            latestVersionNumber: null,
+                                            latestVersionStatus: null,
+                                            pinnedListUuid: null,
+                                            pinnedListOrder: null,
+                                        },
+                                    },
+                                ]}
+                                isLoading={isMovingToSpace}
+                                onConfirm={async (targetSpaceUuid) => {
+                                    if (!targetSpaceUuid) return;
+                                    await contentAction({
+                                        action: {
+                                            type: 'move',
+                                            targetSpaceUuid,
+                                        },
+                                        item: {
+                                            uuid: activeAppUuid,
+                                            contentType: ContentType.DATA_APP,
+                                        },
+                                    });
+                                    await queryClient.invalidateQueries({
+                                        queryKey: [
+                                            'app',
+                                            projectUuid,
+                                            activeAppUuid,
+                                        ],
+                                    });
+                                    setIsMoveToSpaceOpen(false);
+                                }}
+                            />
+                        )}
+                        {isUpdateModalOpen && activeAppUuid && (
+                            <AppUpdateModal
+                                opened
+                                uuid={activeAppUuid}
+                                initialName={appName}
+                                initialDescription={appDescription}
+                                onClose={() => setIsUpdateModalOpen(false)}
+                                onConfirm={() => setIsUpdateModalOpen(false)}
+                            />
+                        )}
+                        {isDeleteModalOpen && activeAppUuid && (
+                            <AppDeleteModal
+                                opened
+                                projectUuid={projectUuid}
+                                uuid={activeAppUuid}
+                                name={appName}
+                                onClose={() => setIsDeleteModalOpen(false)}
+                                onConfirm={() => {
+                                    setIsDeleteModalOpen(false);
+                                    void navigate(
+                                        `/projects/${projectUuid}/apps/generate`,
+                                    );
+                                }}
+                            />
                         )}
 
                         <Box className={classes.previewContent}>


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-316/add-apps-to-spaces

### Description:
Unblock the personal → space move on the backend and surface the action via a burger menu on the app page alongside rename and delete.


Add to space:
<img width="247" height="174" alt="image" src="https://github.com/user-attachments/assets/86c2654a-e2d8-4466-9258-eb7a1281e50c" />


Move to a different space:
<img width="255" height="186" alt="image" src="https://github.com/user-attachments/assets/a9ec4bb6-0ddb-4a11-a3af-8470bfafb247" />

