### PR TITLE
fix: delegate screenshot readiness to chart-level callbacks in Explorer

### DIFF
--- a/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
+++ b/packages/frontend/src/components/Explorer/VisualizationCard/VisualizationCard.tsx
@@ -68,9 +68,16 @@ export type EchartsClickEvent = {
 
 type Props = {
     projectUuid?: string;
+    onScreenshotReady?: () => void;
+    onScreenshotError?: () => void;
 };
 
-const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
+const VisualizationCard: FC<Props> = memo((props) => {
+    const {
+        projectUuid: fallBackUUid,
+        onScreenshotReady,
+        onScreenshotError,
+    } = props;
     const { health } = useApp();
     const { data: org } = useOrganization();
     const { colorScheme } = useMantineColorScheme();
@@ -396,6 +403,8 @@ const VisualizationCard: FC<Props> = memo(({ projectUuid: fallBackUUid }) => {
                         ref={measureRef}
                         className="sentry-block ph-no-capture"
                         data-testid="visualization"
+                        onScreenshotReady={onScreenshotReady}
+                        onScreenshotError={onScreenshotError}
                     />
                     <SeriesContextMenu
                         echartsSeriesClickEvent={echartsClickEvent?.event}

--- a/packages/frontend/src/components/Explorer/index.tsx
+++ b/packages/frontend/src/components/Explorer/index.tsx
@@ -1,7 +1,15 @@
 import { subject } from '@casl/ability';
 import { getAvailableParametersFromTables } from '@lightdash/common';
 import { Stack } from '@mantine-8/core';
-import { memo, useEffect, useMemo, useRef, useState, type FC } from 'react';
+import {
+    memo,
+    useCallback,
+    useEffect,
+    useMemo,
+    useRef,
+    useState,
+    type FC,
+} from 'react';
 import {
     explorerActions,
     selectAdditionalMetricModal,
@@ -77,32 +85,43 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
         const { query, queryResults } = useExplorerQuery();
         const queryUuid = query.data?.queryUuid;
 
-        // Screenshot readiness tracking for EXPLORE pages (Slack unfurls)
-        const isLoadingQueryResults =
-            query.isFetching ||
-            queryResults.isFetchingRows ||
-            !query.data?.queryUuid ||
-            queryResults.queryUuid !== query.data.queryUuid;
+        // Screenshot readiness tracking for EXPLORE pages (Slack unfurls).
+        // We flip ready only when the rendered chart signals back via
+        // onScreenshotReady — the chart-level gate already waits for all
+        // rows (setFetchAll) and chart-type-specific work (e.g. map tiles).
+        // A container-level gate would race against the chart's own
+        // setFetchAll(true) mount effect.
         const hasQueryError = !!query.error || !!queryResults.error;
 
         const [isScreenshotReady, setIsScreenshotReady] = useState(false);
+        const [screenshotErrored, setScreenshotErrored] = useState(false);
         const hasSignaledReady = useRef(false);
+
+        const handleScreenshotReady = useCallback(() => {
+            if (hasSignaledReady.current) return;
+            hasSignaledReady.current = true;
+            setIsScreenshotReady(true);
+        }, []);
+
+        const handleScreenshotError = useCallback(() => {
+            if (hasSignaledReady.current) return;
+            hasSignaledReady.current = true;
+            setScreenshotErrored(true);
+            setIsScreenshotReady(true);
+        }, []);
 
         const { data: explore } = useExplore(tableName);
 
+        // Fallback: if the query itself errors, no chart mounts and neither
+        // onScreenshotReady nor onScreenshotError will fire. Signal ready
+        // with error status so the unfurl captures the error state.
         useEffect(() => {
             if (hasSignaledReady.current) return;
-            if (!tableName) return;
-            if (!explore) return;
-
-            const isSuccessfullyLoaded = !isLoadingQueryResults;
-            if (!isSuccessfullyLoaded && !hasQueryError) {
-                return;
-            }
-
-            setIsScreenshotReady(true);
+            if (!hasQueryError) return;
             hasSignaledReady.current = true;
-        }, [tableName, isLoadingQueryResults, hasQueryError, explore]);
+            setScreenshotErrored(true);
+            setIsScreenshotReady(true);
+        }, [hasQueryError]);
 
         const { data: { parameterReferences } = {}, isError } = useCompiledSql({
             enabled: !!tableName,
@@ -222,7 +241,11 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
 
                     <FiltersCard />
 
-                    <VisualizationCard projectUuid={projectUuid} />
+                    <VisualizationCard
+                        projectUuid={projectUuid}
+                        onScreenshotReady={handleScreenshotReady}
+                        onScreenshotError={handleScreenshotError}
+                    />
 
                     <ResultsCard />
 
@@ -255,8 +278,8 @@ const Explorer: FC<{ hideHeader?: boolean }> = memo(
                 {isScreenshotReady && (
                     <ScreenshotReadyIndicator
                         tilesTotal={1}
-                        tilesReady={hasQueryError ? 0 : 1}
-                        tilesErrored={hasQueryError ? 1 : 0}
+                        tilesReady={screenshotErrored ? 0 : 1}
+                        tilesErrored={screenshotErrored ? 1 : 0}
                     />
                 )}
             </MetricQueryDataProvider>


### PR DESCRIPTION
Closes:

### Description:

Previously, the screenshot readiness signal for Explore pages (used by Slack unfurls) was determined at the container level by watching query loading state. This created a race condition where the container-level gate could fire before the chart had a chance to call `setFetchAll(true)` or complete chart-type-specific work (e.g. map tile loading).

The readiness signal is now driven by the chart itself via two new callbacks — `onScreenshotReady` and `onScreenshotError` — passed down through `VisualizationCard`. The `Explorer` component listens to these callbacks and flips `isScreenshotReady` only when the chart signals back, ensuring all chart-level work is complete before the screenshot is taken.

A fallback `useEffect` is retained to handle the case where a query error prevents any chart from mounting, meaning neither callback would ever fire. In that case, the error state is captured directly so the unfurl still reflects the correct outcome.