### PR TITLE
fix(data-apps): track data app views on iframe load, not on version polling

### DIFF
--- a/packages/backend/src/App.ts
+++ b/packages/backend/src/App.ts
@@ -514,11 +514,27 @@ export default class App {
         // is available regardless of whether the feature is enabled via
         // APPS_RUNTIME_ENABLED env var or the enable-data-apps feature flag.
         if (this.lightdashConfig.appRuntime.s3) {
+            const analyticsModel = this.models.getAnalyticsModel();
             expressApp.use(
                 '/api/apps',
                 createAppPreviewRouter(
                     this.lightdashConfig.appRuntime,
                     this.lightdashConfig.lightdashSecret,
+                    (p) => {
+                        void analyticsModel.addAppViewEvent(
+                            p.appUuid,
+                            p.userUuid,
+                        );
+                        this.analytics.track({
+                            event: 'data_app.view',
+                            userId: p.userUuid,
+                            properties: {
+                                organizationId: p.organizationUuid,
+                                projectId: p.projectUuid,
+                                appUuid: p.appUuid,
+                            },
+                        });
+                    },
                 ),
             );
         }

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -2258,18 +2258,6 @@ export class AppGenerateService extends BaseService {
             organization_uuid: organizationUuid,
         });
 
-        await this.analyticsModel.addAppViewEvent(appUuid, user.userUuid);
-
-        this.analytics.track({
-            event: 'data_app.view',
-            userId: user.userUuid,
-            properties: {
-                organizationId: organizationUuid,
-                projectId: projectUuid,
-                appUuid,
-            },
-        });
-
         return {
             appUuid,
             name,

--- a/packages/backend/src/routers/appPreviewRouter.ts
+++ b/packages/backend/src/routers/appPreviewRouter.ts
@@ -8,6 +8,7 @@ import {
     PREVIEW_COOKIE_NAME,
     PREVIEW_TOKEN_MAX_AGE_SECONDS,
     verifyPreviewToken,
+    type PreviewTokenPayload,
 } from './appPreviewToken';
 
 const CONTENT_TYPE_BY_EXT: Record<string, string> = {
@@ -88,6 +89,7 @@ const injectTokenIntoAssetUrls = (html: string, token: string): string =>
 export const createAppPreviewRouter = (
     config: AppRuntimeConfig,
     lightdashSecret: string,
+    onPreviewView?: (payload: PreviewTokenPayload) => void,
 ): Router => {
     const router = express.Router({ strict: true });
 
@@ -245,6 +247,7 @@ export const createAppPreviewRouter = (
             return;
         }
 
+        res.locals.previewTokenPayload = result.payload;
         next();
     };
 
@@ -324,6 +327,10 @@ export const createAppPreviewRouter = (
             setSecurityHeaders(res);
             res.setHeader('Content-Type', 'text/html; charset=utf-8');
             res.setHeader('Cache-Control', 'no-store');
+
+            onPreviewView?.(
+                res.locals.previewTokenPayload as PreviewTokenPayload,
+            );
 
             if (token) {
                 const html = await bufferS3Body(result.body);


### PR DESCRIPTION
### Description:
The view counter was incrementing on every call to GET /apps/{appUuid}, which is the same endpoint useAppBuildPoller hits every 3s during a build — so a 30s build added ~10 phantom views before the user saw anything. Move the view tracking to the appPreviewRouter index.html handler so it correlates with actual iframe mounts.
