### PR TITLE
feat: add executionSource to query analytics events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -250,6 +250,7 @@ type QueryExecutionEvent = BaseTrack & {
         context: QueryExecutionContext;
         organizationId: string;
         projectId: string;
+        executionSource?: QueryExecutionSource;
         cacheMetadata?: CacheMetadata;
     } & (
         | PaginatedMetricQueryExecutionProperties
@@ -258,12 +259,15 @@ type QueryExecutionEvent = BaseTrack & {
     );
 };
 
+type QueryExecutionSource = 'warehouse' | 'pre_aggregate_duckdb';
+
 type QueryReadyEvent = BaseTrack & {
     event: 'query.ready';
     properties: {
         queryId: string;
         projectId: string;
         warehouseType: WarehouseTypes;
+        executionSource: QueryExecutionSource;
         warehouseExecutionTimeMs: number | null;
         totalRowCount: number | null;
         columnsCount: number | null;
@@ -276,6 +280,7 @@ type QueryErrorEvent = BaseTrack & {
         queryId: string;
         projectId: string;
         warehouseType: WarehouseTypes | undefined;
+        executionSource: QueryExecutionSource;
     };
 };
 
@@ -313,6 +318,7 @@ type ResultsCacheWriteEvent = BaseTrack & {
         queryId: string;
         projectId: string;
         cacheKey: string;
+        executionSource: QueryExecutionSource;
         totalRowCount: number | null;
     };
 };

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -2189,6 +2189,7 @@ export class AsyncQueryService extends ProjectService {
                     queryId: queryUuid,
                     projectId: projectUuid,
                     warehouseType: warehouseClient.credentials.type,
+                    executionSource,
                     warehouseExecutionTimeMs: durationMs,
                     columnsCount:
                         pivotDetails?.totalColumnCount ??
@@ -2249,6 +2250,7 @@ export class AsyncQueryService extends ProjectService {
                         queryId: queryUuid,
                         projectId: projectUuid,
                         cacheKey,
+                        executionSource,
                         totalRowCount: pivotDetails?.totalRows ?? totalRows,
                         pivotTotalColumnCount: pivotDetails?.totalColumnCount,
                         isPivoted: pivotDetails !== null,
@@ -2342,6 +2344,7 @@ export class AsyncQueryService extends ProjectService {
                     queryId: queryUuid,
                     projectId: projectUuid,
                     warehouseType: warehouseCredentialsType,
+                    executionSource,
                     ...(isRegisteredUser
                         ? undefined
                         : { externalId: userUuid }),
@@ -3058,35 +3061,41 @@ export class AsyncQueryService extends ProjectService {
                         QueryHistoryStatus.PENDING,
                         context,
                     );
-
-                    this.analytics.trackAccount(account, {
-                        event: 'query.executed',
-                        properties: {
-                            organizationId: organizationUuid,
-                            projectId: projectUuid,
-                            context,
-                            queryId: queryHistoryUuid,
-                            warehouseType: warehouseCredentialsType,
-                            ...ProjectService.getMetricQueryExecutionProperties(
-                                {
-                                    metricQuery,
-                                    queryTags,
-                                    dateZoom,
-                                    chartUuid:
-                                        'chartUuid' in requestParameters
-                                            ? requestParameters.chartUuid
-                                            : undefined,
-                                    explore,
-                                    parameters: requestParameters.parameters,
-                                },
-                            ),
-                            cacheMetadata: {
-                                cacheHit: resultsCache.cacheHit || false,
-                                cacheUpdatedTime: resultsCache.updatedAt,
-                                cacheExpiresAt: resultsCache.expiresAt,
-                            },
+                    const queryExecutedProperties = {
+                        organizationId: organizationUuid,
+                        projectId: projectUuid,
+                        context,
+                        queryId: queryHistoryUuid,
+                        warehouseType: warehouseCredentialsType,
+                        ...ProjectService.getMetricQueryExecutionProperties({
+                            metricQuery,
+                            queryTags,
+                            dateZoom,
+                            chartUuid:
+                                'chartUuid' in requestParameters
+                                    ? requestParameters.chartUuid
+                                    : undefined,
+                            explore,
+                            parameters: requestParameters.parameters,
+                        }),
+                        cacheMetadata: {
+                            cacheHit: resultsCache.cacheHit || false,
+                            cacheUpdatedTime: resultsCache.updatedAt,
+                            cacheExpiresAt: resultsCache.expiresAt,
                         },
-                    });
+                    };
+                    const trackQueryExecuted = (
+                        executionSource?: 'warehouse' | 'pre_aggregate_duckdb',
+                    ) =>
+                        this.analytics.trackAccount(account, {
+                            event: 'query.executed',
+                            properties: {
+                                ...queryExecutedProperties,
+                                ...(executionSource
+                                    ? { executionSource }
+                                    : undefined),
+                            },
+                        });
 
                     // Track cache hit/miss
                     this.prometheusMetrics?.incrementQueryCacheHit(
@@ -3096,6 +3105,7 @@ export class AsyncQueryService extends ProjectService {
                     );
 
                     if (resultsCache.cacheHit) {
+                        trackQueryExecuted();
                         if (this.lightdashConfig.natsWorker.enabled) {
                             await this.queryHistoryModel.updateStatusToExecuting(
                                 queryHistoryUuid,
@@ -3146,6 +3156,7 @@ export class AsyncQueryService extends ProjectService {
                     }
 
                     if (missingParameterReferences.length > 0) {
+                        trackQueryExecuted();
                         await this.queryHistoryModel.updateStatusToError(
                             queryHistoryUuid,
                             projectUuid,
@@ -3221,6 +3232,7 @@ export class AsyncQueryService extends ProjectService {
                     }
 
                     if (executionPlan.target === 'error') {
+                        trackQueryExecuted();
                         await this.queryHistoryModel.updateStatusToError(
                             queryHistoryUuid,
                             projectUuid,
@@ -3245,6 +3257,12 @@ export class AsyncQueryService extends ProjectService {
                             },
                         } satisfies ExecuteAsyncQueryReturn;
                     }
+
+                    trackQueryExecuted(
+                        executionPlan.target === 'pre_aggregate'
+                            ? 'pre_aggregate_duckdb'
+                            : 'warehouse',
+                    );
 
                     const warehouseArgs: RunAsyncWarehouseQueryArgs = {
                         userUuid: account.user.id,


### PR DESCRIPTION
Closes:

### Description:
Adds an `executionSource` field to query analytics events (`query.ready`, `query.error`, and `results_cache.write`) to track whether a query was executed against the warehouse directly or via pre-aggregate DuckDB. This allows us to distinguish between the two execution paths in our analytics data.