### PR TITLE
fix: prevent preview projects from being set as default in `set-project`

### DIFF
--- a/packages/cli/src/handlers/selectProject.test.ts
+++ b/packages/cli/src/handlers/selectProject.test.ts
@@ -1,0 +1,75 @@
+import { ProjectType } from '@lightdash/common';
+import { Config } from '../config';
+import { lightdashApi } from './dbt/apiClient';
+import { selectProject } from './selectProject';
+
+jest.mock('inquirer');
+jest.mock('../analytics/analytics');
+jest.mock('./dbt/apiClient', () => ({
+    lightdashApi: jest.fn(),
+}));
+jest.mock('../config', () => ({
+    unsetPreviewProject: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockLightdashApi = lightdashApi as jest.MockedFunction<
+    typeof lightdashApi
+>;
+
+const PREVIEW_UUID = '00000000-0000-0000-0000-000000000001';
+const MAIN_UUID = '00000000-0000-0000-0000-000000000002';
+
+const mockPreviewProjectResponse = (uuid: string) => {
+    mockLightdashApi.mockResolvedValueOnce({
+        projectUuid: uuid,
+        type: ProjectType.PREVIEW,
+        // The rest of the Project shape is irrelevant for this test
+    } as never);
+};
+
+describe('selectProject', () => {
+    afterEach(() => {
+        jest.clearAllMocks();
+    });
+
+    it('returns the preview project (without prompting) when the stored main and preview UUIDs are the same', async () => {
+        // This is the misconfigured state produced by an older `set-project`
+        // that allowed selecting a preview project as the default. Both
+        // entries point at the same preview UUID, so the prompt would
+        // otherwise label the same project as both "Preview" and "Production".
+        mockPreviewProjectResponse(PREVIEW_UUID);
+
+        const config: Config = {
+            context: {
+                project: PREVIEW_UUID,
+                projectName: 'my-preview',
+                previewProject: PREVIEW_UUID,
+                previewName: 'my-preview',
+            },
+        };
+
+        const result = await selectProject(config);
+
+        expect(result).toEqual({
+            projectUuid: PREVIEW_UUID,
+            isPreview: true,
+        });
+    });
+
+    it('returns the main project when only the main project is configured', async () => {
+        const config: Config = {
+            context: {
+                project: MAIN_UUID,
+                projectName: 'main',
+            },
+        };
+
+        const result = await selectProject(config);
+
+        expect(result).toEqual({
+            projectUuid: MAIN_UUID,
+            isPreview: false,
+        });
+        expect(mockLightdashApi).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cli/src/handlers/selectProject.ts
+++ b/packages/cli/src/handlers/selectProject.ts
@@ -83,6 +83,14 @@ export const selectProject = async (
         return { projectUuid: mainProject, isPreview: false };
     }
 
+    // If the stored main project is the same UUID as the preview project,
+    // the config was set up incorrectly (e.g. an older `set-project` allowed
+    // selecting a preview). Treat the project as a preview only — otherwise
+    // the prompt would show the same project under both labels.
+    if (mainProject && previewProject && mainProject === previewProject) {
+        return { projectUuid: previewProject, isPreview: true };
+    }
+
     // Both are available - need to choose
     if (mainProject && previewProject) {
         // In non-interactive mode, default to preview project

--- a/packages/cli/src/handlers/setProject.test.ts
+++ b/packages/cli/src/handlers/setProject.test.ts
@@ -1,0 +1,85 @@
+import { OrganizationProject, ProjectType } from '@lightdash/common';
+import inquirer from 'inquirer';
+import { setProject as setProjectConfig } from '../config';
+import GlobalState from '../globalState';
+import { lightdashApi } from './dbt/apiClient';
+import { setProjectCommand } from './setProject';
+
+jest.mock('inquirer');
+jest.mock('../analytics/analytics');
+jest.mock('./dbt/apiClient', () => ({
+    lightdashApi: jest.fn(),
+}));
+jest.mock('../config', () => ({
+    getConfig: jest.fn().mockResolvedValue({ context: {} }),
+    setProject: jest.fn().mockResolvedValue(undefined),
+    unsetProject: jest.fn().mockResolvedValue(undefined),
+}));
+
+const mockLightdashApi = lightdashApi as jest.MockedFunction<
+    typeof lightdashApi
+>;
+const mockInquirer = inquirer as jest.Mocked<typeof inquirer>;
+const mockSetProjectConfig = setProjectConfig as jest.MockedFunction<
+    typeof setProjectConfig
+>;
+
+const MAIN_UUID = '00000000-0000-0000-0000-000000000001';
+const PREVIEW_UUID = '00000000-0000-0000-0000-000000000002';
+
+const buildProjects = (): OrganizationProject[] =>
+    [
+        {
+            projectUuid: MAIN_UUID,
+            name: 'main-project',
+            type: ProjectType.DEFAULT,
+        },
+        {
+            projectUuid: PREVIEW_UUID,
+            name: 'a-preview',
+            type: ProjectType.PREVIEW,
+        },
+    ] as OrganizationProject[];
+
+describe('setProjectCommand', () => {
+    const originalIsNonInteractive = GlobalState.isNonInteractive;
+
+    beforeEach(() => {
+        jest.clearAllMocks();
+        GlobalState.isNonInteractive = jest.fn().mockReturnValue(false);
+    });
+
+    afterAll(() => {
+        GlobalState.isNonInteractive = originalIsNonInteractive;
+    });
+
+    it('does not offer preview projects in the interactive list', async () => {
+        mockLightdashApi.mockResolvedValueOnce(buildProjects() as never);
+        const promptMock = jest
+            .fn()
+            .mockResolvedValueOnce({ project: MAIN_UUID });
+        mockInquirer.prompt = promptMock as never;
+
+        await setProjectCommand();
+
+        const promptArgs = promptMock.mock.calls[0][0];
+        const choices = promptArgs[0].choices.map(
+            (c: { name: string; value: string }) => c.value,
+        );
+        expect(choices).toContain(MAIN_UUID);
+        expect(choices).not.toContain(PREVIEW_UUID);
+        expect(mockSetProjectConfig).toHaveBeenCalledWith(
+            MAIN_UUID,
+            'main-project',
+        );
+    });
+
+    it('throws when --uuid points to a preview project', async () => {
+        mockLightdashApi.mockResolvedValueOnce(buildProjects() as never);
+
+        await expect(
+            setProjectCommand(undefined, PREVIEW_UUID),
+        ).rejects.toThrow(/preview project/);
+        expect(mockSetProjectConfig).not.toHaveBeenCalled();
+    });
+});

--- a/packages/cli/src/handlers/setProject.ts
+++ b/packages/cli/src/handlers/setProject.ts
@@ -1,4 +1,4 @@
-import { OrganizationProject } from '@lightdash/common';
+import { OrganizationProject, ProjectType } from '@lightdash/common';
 import inquirer from 'inquirer';
 import { URL } from 'url';
 import { LightdashAnalytics } from '../analytics/analytics';
@@ -26,18 +26,32 @@ export const setProjectCommand = async (
         `> Set project returned response: ${JSON.stringify(projects)}`,
     );
 
+    // `set-project` configures the default (production) project. Preview
+    // projects are managed separately via `start-preview`/`stop-preview`,
+    // and storing one here causes the download prompt to show the same
+    // project under both "Preview" and "Production" labels.
+    const nonPreviewProjects = projects.filter(
+        (project) => project.type !== ProjectType.PREVIEW,
+    );
+
     if (projects.length === 0) return 'empty';
 
     let selectedProject: OrganizationProject | undefined;
 
     // --uuid or --name options
     if (uuid !== undefined || name !== undefined) {
-        selectedProject = projects.find(
+        const matchedProject = projects.find(
             (project) => project.name === name || project.projectUuid === uuid,
         );
+        if (matchedProject?.type === ProjectType.PREVIEW) {
+            throw new Error(
+                `Project "${matchedProject.name}" is a preview project and cannot be set as the default project. Use \`lightdash start-preview\` to work with preview projects.`,
+            );
+        }
+        selectedProject = matchedProject;
     } else if (GlobalState.isNonInteractive()) {
         GlobalState.debug('> Non-interactive mode: selecting first project');
-        [selectedProject] = projects;
+        [selectedProject] = nonPreviewProjects;
     } else {
         const SKIP_VALUE = '__skip__';
         const answers = await inquirer.prompt([
@@ -49,7 +63,7 @@ export const setProjectCommand = async (
                         name: "Don't select a project",
                         value: SKIP_VALUE,
                     },
-                    ...projects.map((project) => ({
+                    ...nonPreviewProjects.map((project) => ({
                         name: project.name,
                         value: project.projectUuid,
                     })),
@@ -62,7 +76,7 @@ export const setProjectCommand = async (
             return 'skipped';
         }
 
-        selectedProject = projects.find(
+        selectedProject = nonPreviewProjects.find(
             (project) => project.projectUuid === answers.project,
         );
     }


### PR DESCRIPTION
Closes: [https://linear.app/lightdash/issue/PROD-7126/cli-shows-the-same-preview-project-as-both-preview-and-production-in](https://linear.app/lightdash/issue/PROD-7126/cli-shows-the-same-preview-project-as-both-preview-and-production-in)



Before



set-project --uuid \<preview-uuid>:  silently overwrites context.project with the preview UUID





![CleanShot 2026-04-27 at 12.09.53.png](https://app.graphite.com/user-attachments/assets/5a16cf25-19e5-445f-8513-efbb5b0bc44c.png)



After



![CleanShot 2026-04-27 at 12.17.03.png](https://app.graphite.com/user-attachments/assets/5cc6ede7-e1fc-4b4a-842a-3e1cfe5e2dbb.png)



### Description:

Prevents preview projects from being stored as the default project via `set-project`, which previously caused the download prompt to display the same project under both "Preview" and "Production" labels.

**`setProject`:**

- Preview projects are now filtered out of the interactive selection list.
- When using `--uuid` or `--name`, an error is thrown if the matched project is a preview project.
- In non-interactive mode, the first non-preview project is selected instead of the first project overall.

**`selectProject`:**

- Adds a guard for misconfigured state where the stored main project UUID and preview project UUID are identical (produced by older versions of `set-project`). In this case, the project is treated as a preview only, avoiding the duplicate label issue.

Tests are added for both handlers covering the new filtering/validation behaviour and the misconfigured UUID edge case.