### PR TITLE
fix(data-apps): heartbeat status_updated_at to avoid stale-lock race

### DIFF
--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -66,6 +66,11 @@ type GenerateAppResult = {
     version: number;
 };
 
+// Wall-clock heartbeat to bump status_updated_at while the pipeline is
+// running, independent of any per-stage progress updates. Must stay well
+// under STALE_THRESHOLD (5 minutes) in sweepStaleLocks.
+const HEARTBEAT_INTERVAL_MS = 60 * 1000;
+
 export class AppGenerateService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
 
@@ -1579,6 +1584,20 @@ export class AppGenerateService extends BaseService {
             }
         }
 
+        // Wall-clock heartbeat: bumps status_updated_at every minute so a
+        // long-running stage (e.g. Claude composing one big Write tool call)
+        // doesn't trip sweepStaleLocks and get force-released to a duplicate
+        // executor while we're still alive.
+        const heartbeat = setInterval(() => {
+            void this.appModel
+                .touchVersionIfInProgress(appUuid, version)
+                .catch((e) => {
+                    this.logger.warn(
+                        `App ${appUuid}: heartbeat failed: ${getErrorMessage(e)}`,
+                    );
+                });
+        }, HEARTBEAT_INTERVAL_MS);
+
         try {
             await this.runPipelineStages(
                 sandbox,
@@ -1594,6 +1613,7 @@ export class AppGenerateService extends BaseService {
                 chartReferences,
             );
         } finally {
+            clearInterval(heartbeat);
             await this.pauseSandbox(sandbox, appUuid);
         }
     }

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -106,6 +106,26 @@ export class AppModel {
             });
     }
 
+    /**
+     * Bump status_updated_at without changing any other fields, but only if
+     * the version is still in progress. Used as a wall-clock heartbeat so
+     * that releaseStaleLocks doesn't force-release a healthy job whose
+     * current stage has gone quiet (e.g. Claude composing a single large
+     * Write tool call). Returns true if the row was bumped.
+     */
+    async touchVersionIfInProgress(
+        appId: string,
+        version: number,
+    ): Promise<boolean> {
+        const updatedRows = await this.database(AppVersionsTableName)
+            .where({ app_id: appId, version })
+            .whereNotIn('status', [...APP_VERSION_TERMINAL_STATUSES])
+            .update({
+                status_updated_at: this.database.fn.now() as unknown as Date,
+            });
+        return updatedRows > 0;
+    }
+
     async getVersionStatus(
         appId: string,
         version: number,


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-359/unknown-terminated-error-investigation

### Description:
When Claude composes a single large Write tool call it can go silent for several minutes; sweepStaleLocks then force-releases the Graphile job and a duplicate executor resumes the same sandbox. When the original worker finishes and pauses the sandbox, the duplicate's in-flight RPC dies with "2: [unknown] terminated".

Add a 1-minute wall-clock heartbeat scoped to runPipelineStages that bumps status_updated_at independent of per-stage progress, so a healthy worker is no longer mistaken for a dead one.