### PR TITLE
fix(saved-charts): don't crash listing when a SQL chart has an unknown chartKind

### DIFF
--- a/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
+++ b/packages/backend/src/models/ContentModel/ContentConfigurations/SqlChartContentConfiguration.ts
@@ -20,10 +20,17 @@ import {
 
 type SelectSavedSql = SummaryContentRow<{
     source: ChartSourceType.SQL;
-    chart_kind: ChartKind;
+    chart_kind: string;
     dashboard_uuid: string | null;
     dashboard_name: string | null;
 }>;
+
+const VALID_CHART_KINDS = new Set<string>(Object.values(ChartKind));
+
+const coerceChartKind = (value: string): ChartKind =>
+    VALID_CHART_KINDS.has(value)
+        ? (value as ChartKind)
+        : ChartKind.VERTICAL_BAR;
 
 export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> =
     {
@@ -211,7 +218,7 @@ export const sqlChartContentConfiguration: ContentConfiguration<SelectSavedSql> 
                     name: value.organization_name,
                 },
                 source: value.metadata.source,
-                chartKind: value.metadata.chart_kind,
+                chartKind: coerceChartKind(value.metadata.chart_kind),
                 space: {
                     uuid: value.space_uuid,
                     name: value.space_name,

--- a/packages/frontend/src/components/common/ResourceIcon/utils.ts
+++ b/packages/frontend/src/components/common/ResourceIcon/utils.ts
@@ -1,4 +1,4 @@
-import { assertUnreachable, ChartKind } from '@lightdash/common';
+import { ChartKind } from '@lightdash/common';
 import {
     IconChartArea,
     IconChartAreaLine,
@@ -50,9 +50,6 @@ export const getChartIcon = (chartKind: ChartKind | undefined) => {
         case ChartKind.SANKEY:
             return IconGitMerge;
         default:
-            return assertUnreachable(
-                chartKind,
-                `Chart type ${chartKind} not supported`,
-            );
+            return IconChartBar;
     }
 };

--- a/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
+++ b/packages/frontend/src/components/common/ResourceView/resourceUtils.ts
@@ -50,10 +50,7 @@ export const getResourceTypeName = (item: ResourceViewItem) => {
                 case ChartKind.SANKEY:
                     return 'Sankey';
                 default:
-                    return assertUnreachable(
-                        item.data.chartKind,
-                        `Chart type ${item.data.chartKind} not supported`,
-                    );
+                    return 'Chart';
             }
         default:
             return assertUnreachable(item, 'Resource type not supported');


### PR DESCRIPTION
Closes: PROD-7147

### Description

The saved-charts page (`/projects/:id/spaces` chart list, omnibar, etc.) crashes if any SQL chart has a `chart_kind` value the frontend doesn't recognise. The list iterates every chart and renders an icon + type label; both renderers used `assertUnreachable` in their `default` branch and threw on unknown values, taking down the whole page.

`chart_kind` is stored as a plain `varchar` on `saved_sql.last_version_chart_kind` with no enum constraint, so any legacy/renamed/typo value (e.g. an old chart kind that has since been removed) is enough to break the list.

### Fix

**Frontend (the actual page-crash fix)** — replace the throwing `default` with a safe fallback:
- `getChartIcon` → `IconChartBar`
- `getResourceTypeName` → `'Chart'`

`assertUnreachable` is the wrong tool here because the input crosses a runtime boundary (DB → JSON → API), so the `ChartKind` type isn't actually narrowed at runtime.

**Backend (defense-in-depth)** — `SqlChartContentConfiguration` now coerces `metadata.chart_kind` against the `ChartKind` enum and falls back to `VERTICAL_BAR` (matches the column's DB default), keeping the `ChartContent.chartKind: ChartKind` API contract honest. The internal row type was loosened from `ChartKind` to `string` to reflect what's actually in the DB.

### Test plan

- [ ] Manually set `saved_sql.last_version_chart_kind` to a bogus value (e.g. `'bogus_kind'`) and confirm the saved-charts page renders with the row showing the default bar icon + `'Chart'` label instead of erroring
- [ ] Existing valid chart kinds still render their correct icon and label
- [ ] CI passes (typecheck + lint already green locally)