### PR TITLE
feat: add impersonation context to audit logs

### DIFF
--- a/packages/backend/src/@types/express-session.d.ts
+++ b/packages/backend/src/@types/express-session.d.ts
@@ -22,6 +22,10 @@ declare module 'express-session' {
         impersonation?: {
             adminUserUuid: string;
             adminName: string;
+            adminEmail: string;
+            adminFirstName?: string;
+            adminLastName?: string;
+            adminRole: string;
             targetUserUuid: string;
             startedAt: string;
         };

--- a/packages/backend/src/logging/caslAuditWrapper.test.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.test.ts
@@ -1,9 +1,15 @@
 import { defineAbility, subject } from '@casl/ability';
 import { ForcedSubject, type AnyObject } from '@casl/ability/dist/types/types';
-import { CaslSubjectNames, OrganizationMemberRole } from '@lightdash/common';
+import {
+    CaslSubjectNames,
+    OrganizationMemberRole,
+    type Account,
+    type ImpersonationContext,
+} from '@lightdash/common';
 import { type AuditLogEvent } from './auditLog';
 import {
     CaslAuditWrapper,
+    createActorFromAccount,
     type AuditableUser,
     type AuditLogger,
 } from './caslAuditWrapper';
@@ -523,6 +529,92 @@ describe('CaslAuditWrapper', () => {
 
             expect(wrapper.can('read', 'Dashboard')).toBe(true);
             expect(throwingLogger).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('createActorFromAccount impersonation', () => {
+        const impersonation: ImpersonationContext = {
+            adminId: 'admin-001',
+            adminEmail: 'admin@example.com',
+            adminFirstName: 'Jane',
+            adminLastName: 'Admin',
+            adminRole: OrganizationMemberRole.ADMIN,
+        };
+
+        const buildSessionAccount = (overrides: {
+            authType: 'session' | 'pat' | 'oauth' | 'service-account';
+            withImpersonation: boolean;
+        }): Account =>
+            ({
+                authentication: { type: overrides.authType, source: 'src' },
+                organization: { organizationUuid: 'org-uuid' },
+                user: {
+                    id: 'user-789',
+                    type: 'registered',
+                    userUuid: 'user-789',
+                    email: 'user@example.com',
+                    firstName: 'Target',
+                    lastName: 'User',
+                    role: OrganizationMemberRole.VIEWER,
+                    ...(overrides.withImpersonation ? { impersonation } : {}),
+                },
+                isAnonymousUser: () => false,
+                isServiceAccount: () =>
+                    overrides.authType === 'service-account',
+            }) as unknown as Account;
+
+        it('should populate impersonatedBy on session actor when impersonation is present', () => {
+            const account = buildSessionAccount({
+                authType: 'session',
+                withImpersonation: true,
+            });
+            const actor = createActorFromAccount(account);
+
+            expect(actor.type).toBe('session');
+            if (actor.type !== 'session') return;
+            expect(actor.impersonatedBy).toEqual({
+                uuid: 'admin-001',
+                email: 'admin@example.com',
+                firstName: 'Jane',
+                lastName: 'Admin',
+                role: OrganizationMemberRole.ADMIN,
+            });
+        });
+
+        it('should omit impersonatedBy on session actor when impersonation is absent', () => {
+            const account = buildSessionAccount({
+                authType: 'session',
+                withImpersonation: false,
+            });
+            const actor = createActorFromAccount(account);
+
+            expect(actor.type).toBe('session');
+            if (actor.type !== 'session') return;
+            expect(actor.impersonatedBy).toBeUndefined();
+        });
+
+        it('should not propagate impersonation onto PAT actors', () => {
+            const account = buildSessionAccount({
+                authType: 'pat',
+                withImpersonation: true,
+            });
+            const actor = createActorFromAccount(account);
+
+            expect(actor.type).toBe('pat');
+            if (actor.type !== 'pat') return;
+            expect(actor.impersonatedBy).toBeUndefined();
+        });
+
+        it('should not propagate impersonation onto OAuth actors', () => {
+            const account = buildSessionAccount({
+                authType: 'oauth',
+                withImpersonation: true,
+            });
+            const actor = createActorFromAccount(account);
+
+            expect(actor.type).toBe('oauth');
+            if (actor.type !== 'oauth') return;
+            expect(actor.impersonatedBy).toBeUndefined();
         });
     });
 });

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -33,6 +33,7 @@ export type AuditableUser = Pick<
     | 'lastName'
     | 'organizationUuid'
     | 'role'
+    | 'impersonation'
 >;
 
 type AuditableCaslSubjectObject = ForcedSubject<CaslSubjectNames> & {
@@ -130,17 +131,32 @@ export const createActorFromAccount = (account: Account): AuditActor => {
  * Creates an audit actor from a SessionUser (legacy support)
  * @deprecated Prefer createActorFromAccount with Account type
  */
-export const createActorFromUser = (user: AuditableUser): AuditActor => ({
-    type: 'session' as const,
-    uuid: user.userUuid,
-    email: user.email || '',
-    firstName: user.firstName || '',
-    lastName: user.lastName || '',
-    organizationUuid: user.organizationUuid || '',
-    organizationRole: user.role || 'unknown',
-    // TODO: Add group memberships
-    groupMemberships: [],
-});
+export const createActorFromUser = (user: AuditableUser): AuditActor => {
+    // Impersonation is only attached to session users; PAT/OAuth/service-account
+    // sessions cannot be impersonated.
+    const impersonatedBy = user.impersonation
+        ? {
+              uuid: user.impersonation.adminId,
+              email: user.impersonation.adminEmail,
+              firstName: user.impersonation.adminFirstName,
+              lastName: user.impersonation.adminLastName,
+              role: user.impersonation.adminRole,
+          }
+        : undefined;
+
+    return {
+        type: 'session' as const,
+        uuid: user.userUuid,
+        email: user.email || '',
+        firstName: user.firstName || '',
+        lastName: user.lastName || '',
+        organizationUuid: user.organizationUuid || '',
+        organizationRole: user.role || 'unknown',
+        // TODO: Add group memberships
+        groupMemberships: [],
+        ...(impersonatedBy && { impersonatedBy }),
+    };
+};
 
 const createResourceFromSubject = (
     subjectArg: AuditableCaslSubject,

--- a/packages/backend/src/logging/caslAuditWrapper.ts
+++ b/packages/backend/src/logging/caslAuditWrapper.ts
@@ -5,6 +5,7 @@ import {
     CaslSubjectNames,
     type Account,
     type AnonymousAccount,
+    type ImpersonationContext,
     type SessionUser,
 } from '@lightdash/common';
 import {
@@ -95,7 +96,21 @@ export const createActorFromAccount = (account: Account): AuditActor => {
         email?: string;
         role?: string;
         id: string;
+        impersonation?: ImpersonationContext;
     };
+
+    // Impersonation is only attached to session users; PAT/OAuth/service-account
+    // sessions cannot be impersonated.
+    const impersonatedBy =
+        actorType === 'session' && user.impersonation
+            ? {
+                  uuid: user.impersonation.adminId,
+                  email: user.impersonation.adminEmail,
+                  firstName: user.impersonation.adminFirstName,
+                  lastName: user.impersonation.adminLastName,
+                  role: user.impersonation.adminRole,
+              }
+            : undefined;
 
     return {
         type: actorType,
@@ -107,6 +122,7 @@ export const createActorFromAccount = (account: Account): AuditActor => {
         organizationRole: user.role || 'unknown',
         // TODO: Add group memberships
         groupMemberships: [],
+        ...(impersonatedBy && { impersonatedBy }),
     };
 };
 

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1678,7 +1678,15 @@ export class UserService extends BaseService {
     async resolveSessionUser(
         passportUser: { id: string; organization: string },
         impersonation:
-            | { targetUserUuid: string; startedAt: string }
+            | {
+                  adminUserUuid: string;
+                  adminEmail: string;
+                  adminFirstName?: string;
+                  adminLastName?: string;
+                  adminRole: string;
+                  targetUserUuid: string;
+                  startedAt: string;
+              }
             | undefined,
         clearImpersonation: () => void,
     ): Promise<SessionUser> {
@@ -1744,7 +1752,16 @@ export class UserService extends BaseService {
             return requestUser;
         }
 
-        return targetUser;
+        return {
+            ...targetUser,
+            impersonation: {
+                adminId: impersonation.adminUserUuid,
+                adminEmail: impersonation.adminEmail,
+                adminFirstName: impersonation.adminFirstName,
+                adminLastName: impersonation.adminLastName,
+                adminRole: impersonation.adminRole,
+            },
+        };
     }
 
     static async generateGoogleAccessToken(
@@ -2335,6 +2352,10 @@ export class UserService extends BaseService {
             setImpersonation: (data: {
                 adminUserUuid: string;
                 adminName: string;
+                adminEmail: string;
+                adminFirstName?: string;
+                adminLastName?: string;
+                adminRole: string;
                 targetUserUuid: string;
                 startedAt: string;
             }) => void;
@@ -2385,6 +2406,10 @@ export class UserService extends BaseService {
         setImpersonation({
             adminUserUuid: adminUser.userUuid,
             adminName: `${adminUser.firstName} ${adminUser.lastName}`,
+            adminEmail: adminUser.email ?? '',
+            adminFirstName: adminUser.firstName,
+            adminLastName: adminUser.lastName,
+            adminRole: adminUser.role ?? 'unknown',
             targetUserUuid,
             startedAt: new Date().toISOString(),
         });

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -53,6 +53,8 @@ export interface LightdashSessionUser extends AccountUser {
     updatedAt: Date;
     /* Whether the user doesn't have an authentication method (password or openId) */
     isPending?: boolean;
+    /* Set only when an admin is impersonating this user via session auth */
+    impersonation?: ImpersonationContext;
 }
 
 export interface ExternalUser extends AccountUser {
@@ -75,6 +77,16 @@ export interface LightdashUserWithAbilityRules extends LightdashUser {
 
 export interface SessionUser extends LightdashUserWithAbilityRules {
     ability: MemberAbility;
+    /* Set only when an admin is impersonating this user via session auth */
+    impersonation?: ImpersonationContext;
+}
+
+export interface ImpersonationContext {
+    adminId: string;
+    adminEmail: string;
+    adminFirstName?: string;
+    adminLastName?: string;
+    adminRole: string;
 }
 
 export interface UpdatedByUser {


### PR DESCRIPTION
## Summary
- Adds an optional `ImpersonationContext` to `SessionUser` / `LightdashSessionUser` so the impersonating admin is carried on the per-request user object.
- `UserService.startImpersonation` now writes admin email / name / role into the express session, and `resolveSessionUser` attaches that context onto the returned target user (only when impersonation is active and still valid).
- `createActorFromAccount` (used by the CASL audit wrapper) maps the new field into `actor.impersonatedBy` for session actors. PAT, OAuth, service-account, and anonymous actors never carry it, even if the field is present on the underlying object.

## How it surfaces in audit logs
When an admin is impersonating a user, audit events now include:

```json
"actor": {
  "type": "session",
  "uuid": "user-789",
  "email": "user@example.com",
  "organizationRole": "viewer",
  "impersonatedBy": {
    "uuid": "admin-001",
    "email": "admin@example.com",
    "firstName": "Jane",
    "lastName": "Admin",
    "role": "admin"
  }
}
```

The acting user remains the *target* — `impersonatedBy` is metadata identifying the responsible admin.

## Notes / follow-up
- The "audit logs must always show the **true actor (admin)** when impersonating" requirement is intentionally out of scope here and will land in a follow-up branch, per the original ticket.
- Existing in-flight sessions written before this deploy lack the new admin email / role fields. The 15-minute impersonation TTL clears them quickly, so the worst case is a short window of audit events with empty admin email/role strings.

## Test plan
- [x] `pnpm -F common typecheck` / `pnpm -F backend typecheck`
- [x] `pnpm -F common lint` / `pnpm -F backend lint`
- [x] `npx jest src/logging/caslAuditWrapper.test.ts` (4 new cases for impersonation mapping, all pass)
- [x] `npx jest src/auth/account/account.test.ts`
- [x] Manual smoke: start impersonation as admin, perform an action, confirm audit log entry shows `impersonatedBy`

🤖 Generated with [Claude Code](https://claude.com/claude-code)