### PR TITLE
refactor(formula): tighten AST — WindowClause out of union, typed MovingWindowFn

### DIFF
--- a/packages/formula/src/ast.ts
+++ b/packages/formula/src/ast.ts
@@ -34,6 +34,7 @@ export const isAggregateCall = (node: ASTNode): boolean => {
         case 'ZeroArgFn':
         case 'VariadicFn':
         case 'WindowFn':
+        case 'MovingWindowFn':
         case 'DateFn':
         case 'ColumnRef':
         case 'NumberLiteral':
@@ -41,7 +42,6 @@ export const isAggregateCall = (node: ASTNode): boolean => {
         case 'BooleanLiteral':
         case 'Comparison':
         case 'Logical':
-        case 'WindowClause':
             return false;
         default:
             return assertUnreachable(node, `Unknown AST node type`);
@@ -84,19 +84,25 @@ export const extractColumnRefs = (node: ASTNode): string[] => {
             return node.args.flatMap(extractColumnRefs);
         case 'WindowFn': {
             const argRefs = node.args.flatMap(extractColumnRefs);
-            const clauseRefs = node.windowClause
-                ? extractColumnRefs(node.windowClause)
+            const wc = node.windowClause;
+            const orderRefs = wc?.orderBy
+                ? extractColumnRefs(wc.orderBy.column)
                 : [];
-            return [...argRefs, ...clauseRefs];
+            const partitionRefs = wc?.partitionBy
+                ? extractColumnRefs(wc.partitionBy)
+                : [];
+            return [...argRefs, ...orderRefs, ...partitionRefs];
         }
-        case 'WindowClause': {
-            const orderRefs = node.orderBy
-                ? extractColumnRefs(node.orderBy.column)
+        case 'MovingWindowFn': {
+            const argRefs = extractColumnRefs(node.arg);
+            const wc = node.windowClause;
+            const orderRefs = wc?.orderBy
+                ? extractColumnRefs(wc.orderBy.column)
                 : [];
-            const partitionRefs = node.partitionBy
-                ? extractColumnRefs(node.partitionBy)
+            const partitionRefs = wc?.partitionBy
+                ? extractColumnRefs(wc.partitionBy)
                 : [];
-            return [...orderRefs, ...partitionRefs];
+            return [...argRefs, ...orderRefs, ...partitionRefs];
         }
         case 'ZeroArgFn':
         case 'NumberLiteral':

--- a/packages/formula/src/codegen/generator.ts
+++ b/packages/formula/src/codegen/generator.ts
@@ -12,6 +12,7 @@ import type {
     DateUnit,
     IfNode,
     LogicalNode,
+    MovingWindowFnNode,
     NumberLiteralNode,
     OneOrTwoArgFnNode,
     SingleArgFnNode,
@@ -75,6 +76,8 @@ export class SqlGenerator {
                 return this.generateVariadicFn(node);
             case 'WindowFn':
                 return this.generateWindowFn(node);
+            case 'MovingWindowFn':
+                return this.generateMovingWindowFn(node);
             case 'DateFn':
                 return this.generateDateFn(node);
             case 'ColumnRef':
@@ -89,10 +92,6 @@ export class SqlGenerator {
                 return this.generateComparison(node);
             case 'Logical':
                 return this.generateLogical(node);
-            case 'WindowClause':
-                throw new Error(
-                    'WindowClause should not be generated directly',
-                );
             default:
                 return assertUnreachable(
                     node,
@@ -318,33 +317,31 @@ export class SqlGenerator {
             case 'LAG':
             case 'LEAD':
                 return this.dispatchLagLead(node.name, args, node);
-            // TODO: unsafe cast — MOVING_SUM/MOVING_AVG assume second arg is a NumberLiteral
-            // but the grammar accepts any Expression. Fix by adding a grammar rule that
-            // enforces NumberLiteral in the second position (same pattern as BooleanExpression).
-            case 'MOVING_SUM': {
-                const preceding = (node.args[1] as NumberLiteralNode).value;
-                return this.generateWindowFunction(
-                    'SUM',
-                    [args[0]],
-                    node,
-                    `ROWS BETWEEN ${preceding} PRECEDING AND CURRENT ROW`,
-                );
-            }
-            case 'MOVING_AVG': {
-                const preceding = (node.args[1] as NumberLiteralNode).value;
-                // Route through generateAvg so dialects that need to
-                // preserve precision across the AVG division (Redshift)
-                // can inject a cast on the value argument.
-                return this.appendOverClause(
-                    this.generateAvg(args[0]),
-                    node,
-                    `ROWS BETWEEN ${preceding} PRECEDING AND CURRENT ROW`,
-                );
-            }
             default:
                 return assertUnreachable(
                     node.name,
                     `Unknown window function: ${node.name}`,
+                );
+        }
+    }
+
+    protected generateMovingWindowFn(node: MovingWindowFnNode): string {
+        const arg = this.generate(node.arg);
+        const frame = `ROWS BETWEEN ${node.preceding} PRECEDING AND CURRENT ROW`;
+        switch (node.name) {
+            case 'MOVING_SUM':
+                return this.generateWindowFunction('SUM', [arg], node, frame);
+            case 'MOVING_AVG':
+                // Route through generateAvg so Redshift's DOUBLE PRECISION cast applies.
+                return this.appendOverClause(
+                    this.generateAvg(arg),
+                    node,
+                    frame,
+                );
+            default:
+                return assertUnreachable(
+                    node.name,
+                    `Unknown moving-window function: ${node.name}`,
                 );
         }
     }

--- a/packages/formula/src/functions.ts
+++ b/packages/formula/src/functions.ts
@@ -38,9 +38,11 @@ export const WINDOW_FNS = [
     'LAST',
     'LAG',
     'LEAD',
-    'MOVING_SUM',
-    'MOVING_AVG',
 ] as const;
+
+// Window functions whose `preceding` count is a parse-time integer literal,
+// validated and lifted onto the AST node like DateFn's unit.
+export const MOVING_WINDOW_FNS = ['MOVING_SUM', 'MOVING_AVG'] as const;
 
 export const CONDITIONAL_AGG_FNS = ['SUMIF', 'AVERAGEIF'] as const;
 
@@ -65,6 +67,7 @@ export type OneOrTwoArgFnName = (typeof ONE_OR_TWO_ARG_FNS)[number];
 export type ZeroOrOneArgFnName = (typeof ZERO_OR_ONE_ARG_FNS)[number];
 export type VariadicFnName = (typeof VARIADIC_FNS)[number];
 export type WindowFnName = (typeof WINDOW_FNS)[number];
+export type MovingWindowFnName = (typeof MOVING_WINDOW_FNS)[number];
 export type ConditionalAggFnName = (typeof CONDITIONAL_AGG_FNS)[number];
 export type DateFnName = (typeof DATE_FNS)[number];
 // DATE_SUB desugars to DATE_ADD at parse time, so it never appears in the AST.
@@ -77,6 +80,7 @@ export const ALL_FUNCTION_NAMES = [
     ...ZERO_OR_ONE_ARG_FNS,
     ...VARIADIC_FNS,
     ...WINDOW_FNS,
+    ...MOVING_WINDOW_FNS,
     ...CONDITIONAL_AGG_FNS,
     ...DATE_FNS,
     'COUNTIF',
@@ -201,6 +205,7 @@ export function getParserOptions() {
         zeroOrOneArgFns: ZERO_OR_ONE_ARG_FNS,
         variadicFns: VARIADIC_FNS,
         windowFns: WINDOW_FNS,
+        movingWindowFns: MOVING_WINDOW_FNS,
         conditionalAggFns: CONDITIONAL_AGG_FNS,
         dateFns: DATE_FNS,
         dateUnits: DATE_UNITS,

--- a/packages/formula/src/grammar/formula.pegjs
+++ b/packages/formula/src/grammar/formula.pegjs
@@ -5,6 +5,7 @@
   const zeroOrOneArgFns = options.zeroOrOneArgFns;
   const variadicFns = options.variadicFns;
   const windowFns = options.windowFns;
+  const movingWindowFns = options.movingWindowFns;
   const conditionalAggFns = options.conditionalAggFns;
   const dateFns = options.dateFns;
   const dateUnits = options.dateUnits;
@@ -104,6 +105,7 @@ Primary
   / DateTruncExpr
   / DateAddOrSubExpr
   / DateDiffExpr
+  / MovingWindowFn
   / ZeroArgFn
   / SingleArgFn
   / OneOrTwoArgFn
@@ -183,6 +185,23 @@ DateDiffExpr
         error('DATE_DIFF unit must be one of: ' + dateUnits.join(', ') + '. Got: "' + unitArg.value + '"');
       }
       return { type: "DateFn", name: "DATE_DIFF", unit, args: [start, end] };
+    }
+
+// `n` is a parse-time positive integer literal, lifted onto `preceding`.
+MovingWindowFn
+  = name:Identifier &{ return movingWindowFns.includes(name.toUpperCase()); }
+    _ "(" _ arg:Expression _ "," _ n:Expression rest:WindowClausePart* _ ")" {
+      const fnName = name.toUpperCase();
+      if (n.type !== "NumberLiteral" || !Number.isInteger(n.value) || n.value <= 0) {
+        error(fnName + ' second argument must be a positive integer literal');
+      }
+      const node = { type: "MovingWindowFn", name: fnName, arg, preceding: n.value, windowClause: null };
+      for (const p of rest) {
+        if (!node.windowClause) node.windowClause = { type: "WindowClause" };
+        if (p.orderBy) node.windowClause.orderBy = p.orderBy;
+        if (p.partitionBy) node.windowClause.partitionBy = p.partitionBy;
+      }
+      return node;
     }
 
 ZeroArgFn

--- a/packages/formula/src/types.ts
+++ b/packages/formula/src/types.ts
@@ -2,6 +2,7 @@ import type {
     ConditionalAggFnName,
     DateFnAstName,
     FunctionName,
+    MovingWindowFnName,
     OneOrTwoArgFnName,
     SingleArgFnName,
     VariadicFnName,
@@ -59,7 +60,8 @@ export interface CompileOptions {
     weekStartDay?: WeekDay;
 }
 
-// AST Node Types
+// WindowClauseNode is intentionally not in this union — it only ever appears as
+// a child of WindowFnNode and is never dispatched on its own.
 export type ASTNode =
     | BinaryOpNode
     | UnaryOpNode
@@ -72,14 +74,14 @@ export type ASTNode =
     | ZeroOrOneArgFnNode
     | VariadicFnNode
     | WindowFnNode
+    | MovingWindowFnNode
     | DateFnNode
     | ColumnRefNode
     | NumberLiteralNode
     | StringLiteralNode
     | BooleanLiteralNode
     | ComparisonNode
-    | LogicalNode
-    | WindowClauseNode;
+    | LogicalNode;
 
 export interface BinaryOpNode {
     type: 'BinaryOp';
@@ -146,6 +148,15 @@ export interface WindowFnNode {
     type: 'WindowFn';
     name: WindowFnName;
     args: ASTNode[];
+    windowClause: WindowClauseNode | null;
+}
+
+// `preceding` is a parse-time positive integer, lifted off `args` like DateFn.unit.
+export interface MovingWindowFnNode {
+    type: 'MovingWindowFn';
+    name: MovingWindowFnName;
+    arg: ASTNode;
+    preceding: number;
     windowClause: WindowClauseNode | null;
 }
 

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -677,6 +677,55 @@ describe('codegen', () => {
         });
     });
 
+    describe('MOVING_SUM / MOVING_AVG', () => {
+        it('MOVING_SUM emits SUM with ROWS BETWEEN N PRECEDING frame', () => {
+            expect(
+                compile('=MOVING_SUM(revenue, 3, ORDER BY order_date)', {
+                    dialect: 'postgres',
+                    columns,
+                }),
+            ).toBe(
+                'SUM("revenue") OVER (ORDER BY "order_date" ROWS BETWEEN 3 PRECEDING AND CURRENT ROW)',
+            );
+        });
+
+        it('MOVING_AVG routes through generateAvg (Postgres adds DOUBLE PRECISION cast)', () => {
+            expect(
+                compile('=MOVING_AVG(revenue, 7, ORDER BY order_date)', {
+                    dialect: 'postgres',
+                    columns,
+                }),
+            ).toBe(
+                'AVG("revenue"::DOUBLE PRECISION) OVER (ORDER BY "order_date" ROWS BETWEEN 7 PRECEDING AND CURRENT ROW)',
+            );
+        });
+
+        it('MOVING_AVG without dialect AVG override emits bare AVG', () => {
+            expect(
+                compile('=MOVING_AVG(revenue, 4, ORDER BY order_date)', {
+                    dialect: 'bigquery',
+                    columns,
+                }),
+            ).toBe(
+                'AVG(`revenue`) OVER (ORDER BY `order_date` ROWS BETWEEN 4 PRECEDING AND CURRENT ROW)',
+            );
+        });
+
+        it('MOVING_SUM picks up defaultOrderBy when no explicit ORDER BY', () => {
+            expect(
+                compile('=MOVING_SUM(revenue, 2)', {
+                    dialect: 'postgres',
+                    columns,
+                    defaultOrderBy: [
+                        { column: 'order_date', direction: 'ASC' },
+                    ],
+                }),
+            ).toBe(
+                'SUM("revenue") OVER (ORDER BY "order_date" ASC ROWS BETWEEN 2 PRECEDING AND CURRENT ROW)',
+            );
+        });
+    });
+
     describe('renderAggregate invocation protocol', () => {
         // Identity renderer used to observe invocation count and order
         // without changing the generated SQL.

--- a/packages/formula/tests/grammar.test.ts
+++ b/packages/formula/tests/grammar.test.ts
@@ -321,6 +321,94 @@ describe('Formula Grammar', () => {
                 arg: { type: 'ColumnRef', name: 'A' },
             });
         });
+
+        it('parses MOVING_SUM as a MovingWindowFn with typed preceding count', () => {
+            const ast = parse('=MOVING_SUM(A, 3)');
+            expect(ast).toEqual({
+                type: 'MovingWindowFn',
+                name: 'MOVING_SUM',
+                arg: { type: 'ColumnRef', name: 'A' },
+                preceding: 3,
+                windowClause: null,
+            });
+        });
+
+        it('parses MOVING_AVG as a MovingWindowFn with typed preceding count', () => {
+            const ast = parse('=MOVING_AVG(A, 5)');
+            expect(ast).toEqual({
+                type: 'MovingWindowFn',
+                name: 'MOVING_AVG',
+                arg: { type: 'ColumnRef', name: 'A' },
+                preceding: 5,
+                windowClause: null,
+            });
+        });
+
+        it('parses MOVING_SUM with an ORDER BY clause', () => {
+            const ast = parse('=MOVING_SUM(A, 3, ORDER BY date DESC)');
+            expect(ast).toEqual({
+                type: 'MovingWindowFn',
+                name: 'MOVING_SUM',
+                arg: { type: 'ColumnRef', name: 'A' },
+                preceding: 3,
+                windowClause: {
+                    type: 'WindowClause',
+                    orderBy: {
+                        column: { type: 'ColumnRef', name: 'date' },
+                        direction: 'DESC',
+                    },
+                },
+            });
+        });
+
+        it('parses MOVING_SUM with PARTITION BY and ORDER BY', () => {
+            const ast = parse(
+                '=MOVING_SUM(A, 3, PARTITION BY region, ORDER BY date)',
+            );
+            expect(ast).toEqual({
+                type: 'MovingWindowFn',
+                name: 'MOVING_SUM',
+                arg: { type: 'ColumnRef', name: 'A' },
+                preceding: 3,
+                windowClause: {
+                    type: 'WindowClause',
+                    partitionBy: { type: 'ColumnRef', name: 'region' },
+                    orderBy: {
+                        column: { type: 'ColumnRef', name: 'date' },
+                    },
+                },
+            });
+        });
+
+        it('rejects MOVING_SUM with a non-literal second argument', () => {
+            expect(() => parse('=MOVING_SUM(A, B)')).toThrow(
+                /MOVING_SUM second argument must be a positive integer/,
+            );
+        });
+
+        it('rejects MOVING_SUM with a non-integer second argument', () => {
+            expect(() => parse('=MOVING_SUM(A, 3.5)')).toThrow(
+                /MOVING_SUM second argument must be a positive integer/,
+            );
+        });
+
+        it('rejects MOVING_SUM with a zero or negative count', () => {
+            expect(() => parse('=MOVING_SUM(A, 0)')).toThrow(
+                /MOVING_SUM second argument must be a positive integer/,
+            );
+        });
+
+        it('rejects MOVING_AVG with a non-literal second argument', () => {
+            expect(() => parse('=MOVING_AVG(A, B)')).toThrow(
+                /MOVING_AVG second argument must be a positive integer/,
+            );
+        });
+
+        it('rejects MOVING_SUM with wrong arg count', () => {
+            expect(() => parse('=MOVING_SUM(A)')).toThrow(
+                /MOVING_SUM called with wrong number of arguments/,
+            );
+        });
     });
 
     describe('comparisons', () => {


### PR DESCRIPTION
## Summary

Two AST cleanups that close known weak spots in `packages/formula/`. **No user-facing surface change. No generated SQL changes.** Pure type-tightening + earlier validation.

## 1. `WindowClauseNode` out of the `ASTNode` union

`WindowClauseNode` only ever appears as a child of `WindowFnNode`; it's never dispatched on its own. The codegen switch carried an unreachable `case 'WindowClause'` that just threw.

- Lifted out of the union.
- `extractColumnRefs` now inlines the `WindowClause` walk into the `WindowFn` case rather than recursing through the dispatcher.
- The "this should never happen" branch is gone.

## 2. `MOVING_SUM` / `MOVING_AVG` as a typed `MovingWindowFnNode`

The generator carried `(node.args[1] as NumberLiteralNode).value` — the grammar accepted any `Expression` in arg position 2 even though codegen required a literal. The pre-existing `TODO` in the source flagged it.

Mirrors the `DateFn` pattern from this stack:

- **Dedicated grammar rule** validates the literal at parse time and lifts it onto a typed `preceding: number` field on the new `MovingWindowFnNode`.
- Non-literal / non-integer / zero-or-negative second arg now fails at parse with a specific message.
- `generateMovingWindowFn` handles SUM/AVG paths on its own; the cases in `generateWindowFn` are removed, the cast and `TODO` with them.
- `MOVING_SUM` / `MOVING_AVG` move from `WINDOW_FNS` to a new `MOVING_WINDOW_FNS` list. Both still appear in `ALL_FUNCTION_NAMES` and `FUNCTION_DEFINITIONS`, so the function catalog surfaced to consumers (frontend autocomplete, docs) is unchanged.

## Test plan

- [x] Grammar — 9 new tests: valid usage, `ORDER BY` / `PARTITION BY` tails, rejection of non-literal / non-integer / non-positive / wrong arg count
- [x] Codegen — 4 new tests locking SQL output across dialects, including the Postgres `DOUBLE PRECISION` cast routing through `MOVING_AVG`
- [x] `pnpm -F formula test`
- [x] `pnpm formula:test:fast`
- [ ] `pnpm formula:test:tier1`

Stacked on #22379.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
