### PR TITLE
fix: don't check for tz support feature flag in embed service

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -868,12 +868,8 @@ export class EmbedService extends BaseService {
             filteredExplore,
         );
 
-        const useTimezoneAwareDateTrunc =
-            await this.projectService.isTimezoneSupportEnabled({
-                userUuid: account.user.id,
-                organizationUuid: account.organization.organizationUuid,
-            });
-
+        // Explicit false for now, need to check db without userUuid which the `FeatureFlagModel` doesn't support (account.user.id is external, otherwise we need a db lookup)
+        const useTimezoneAwareDateTrunc = false;
         const compiledQuery = await ProjectService._compileQuery({
             metricQuery,
             explore: filteredExplore,
@@ -1187,11 +1183,8 @@ export class EmbedService extends BaseService {
             projectTimezone,
         );
 
-        const isTimezoneSupportEnabled =
-            await this.projectService.isTimezoneSupportEnabled({
-                userUuid: user?.userUuid ?? account.user.id,
-                organizationUuid,
-            });
+        // Explicit false for now, need to check db without userUuid which the `FeatureFlagModel` doesn't support (account.user.id is external, otherwise we need a db lookup)
+        const isTimezoneSupportEnabled = false;
         const displayTimezone = isTimezoneSupportEnabled ? timezone : undefined;
 
         const { rows, cacheMetadata, fields } = await this._runEmbedQuery({


### PR DESCRIPTION
<!-- Thanks so much for your PR, your contribution is appreciated! ❤️ -->

### Description:

Passes false for `EnableTimezoneSupport` flag in `embedService. There should be a follow up ticket to make `userUuid`optional in`FeatureFlagModel` so that we can optionally NOT check for user while keeping the org check.