### PR TITLE
feat(data-apps): inherit edit/admin permissions from the app's space

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -145,16 +145,16 @@ All endpoints require the `manage:DataApp` permission and are scoped under `/api
 
 ### App CRUD
 
-| Method  | Path                                                                      | Description                            |
-| ------- | ------------------------------------------------------------------------- | -------------------------------------- |
-| `POST`  | `/projects/{projectUuid}/apps/`                                           | Create a new app from a prompt         |
-| `GET`   | `/projects/{projectUuid}/apps/{appUuid}`                                  | Get app with paginated version history |
-| `PATCH` | `/projects/{projectUuid}/apps/{appUuid}`                                  | Update name/description                |
-| `DELETE`| `/projects/{projectUuid}/apps/{appUuid}`                                  | Soft or hard delete (config-driven)    |
-| `POST`  | `/projects/{projectUuid}/apps/{appUuid}/versions`                         | Iterate with a follow-up prompt        |
-| `POST`  | `/projects/{projectUuid}/apps/{appUuid}/versions/{version}/cancel`        | Cancel a building version              |
-| `GET`   | `/projects/{projectUuid}/apps/{appUuid}/versions/{version}/preview-token` | Mint JWT for iframe preview            |
-| `GET`   | `/user/apps`                                                              | List current user's apps (paginated)   |
+| Method   | Path                                                                      | Description                            |
+| -------- | ------------------------------------------------------------------------- | -------------------------------------- |
+| `POST`   | `/projects/{projectUuid}/apps/`                                           | Create a new app from a prompt         |
+| `GET`    | `/projects/{projectUuid}/apps/{appUuid}`                                  | Get app with paginated version history |
+| `PATCH`  | `/projects/{projectUuid}/apps/{appUuid}`                                  | Update name/description                |
+| `DELETE` | `/projects/{projectUuid}/apps/{appUuid}`                                  | Soft or hard delete (config-driven)    |
+| `POST`   | `/projects/{projectUuid}/apps/{appUuid}/versions`                         | Iterate with a follow-up prompt        |
+| `POST`   | `/projects/{projectUuid}/apps/{appUuid}/versions/{version}/cancel`        | Cancel a building version              |
+| `GET`    | `/projects/{projectUuid}/apps/{appUuid}/versions/{version}/preview-token` | Mint JWT for iframe preview            |
+| `GET`    | `/user/apps`                                                              | List current user's apps (paginated)   |
 
 ### Preview Serving (token-based, not session-based)
 
@@ -340,9 +340,38 @@ S3 credentials are configured through the existing `S3_*` environment variables 
 
 ## Permissions
 
-Data apps use a single CASL scope: `manage:DataApp`, defined in `packages/common/src/authorization/scopes.ts`.
+Data apps follow the same space-based permission model as charts and dashboards. Three CASL scopes, all defined in
+`packages/common/src/authorization/scopes.ts`:
 
-This scope gates all operations — creation, iteration, cancellation, viewing, and listing. It is checked at both the
-controller level (via TSOA middleware) and the service level (via explicit `user.ability.cannot()` checks).
+| Scope                  | Granted to          | Effect                                                                                                           |
+| ---------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------- |
+| `view:DataApp`         | viewer+             | View any app whose space the user can view (or where the project inherits org/project access).                   |
+| `manage:DataApp@space` | interactive_viewer+ | Iterate, edit, cancel, pin, move, and delete apps in spaces where the user has the `EDITOR` or `ADMIN` role.     |
+| `manage:DataApp`       | admin               | Project-wide manage — covers all apps including personal (spaceless) ones, and gates restore + permanent-delete. |
 
-The scope is enterprise-only and must be granted to users through their role or custom role configuration.
+### Permission matrix
+
+| Action                                          | Project admin | Space admin/editor | Space viewer |
+| ----------------------------------------------- | ------------- | ------------------ | ------------ |
+| View an app in a space                          | ✓             | ✓                  | ✓            |
+| View a personal (spaceless) app                 | ✓             | —                  | —            |
+| Iterate / cancel / update / pin / move / delete | ✓             | ✓                  | ✗            |
+| Restore / permanently delete                    | ✓             | ✗                  | ✗            |
+| Create a new app                                | ✓             | ✗                  | ✗            |
+
+Permission checks live in the service layer, not the controller — TSOA middleware only handles authentication. Two
+helpers in `AppGenerateService.ts` carry the space-aware logic:
+
+- `assertCanViewApp(user, app)` — used by `getAppVersions`, `getPreviewToken`. Builds a CASL subject that includes the
+  app's space access context (or an empty context for personal apps), then checks the `view` action.
+- `assertCanManageApp(user, app, msg)` — used by `iterateApp`, `cancelVersion`, `updateApp`, `togglePinning`,
+  `deleteApp`, `moveToSpace`, and `uploadImage` (when the app exists). Same space-context shape, but checks the
+  `manage` action so space editors/admins match.
+
+`restoreApp` and `permanentDeleteApp` deliberately bypass the space-aware helper and use the bare project-wide
+`manage:DataApp` check, since restoring deleted content is an admin-only recovery flow.
+
+`moveToSpace` runs the manage check twice — once on the source app (its current space) and once on the target space —
+so a user can't move an app into a space they don't own.
+
+The scopes are enterprise-only and must be granted to users through their role or custom role configuration.

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -193,6 +193,38 @@ export class AppGenerateService extends BaseService {
         );
     }
 
+    /**
+     * Permission check for editing/deleting/iterating on an existing data app.
+     *
+     * Mirrors `assertCanManageApp`'s shape for charts/dashboards: space
+     * editors and admins inherit manage access via the space context, while
+     * personal (spaceless) apps fall back to the project-wide
+     * `manage:DataApp` rule that only project admins hold.
+     */
+    private async assertCanManageApp(
+        user: SessionUser,
+        app: Pick<DbApp, 'project_uuid' | 'space_uuid'> & {
+            organization_uuid: string;
+        },
+        errorMessage: string,
+        extraContext: Record<string, unknown> = {},
+    ): Promise<void> {
+        const spaceContext = app.space_uuid
+            ? await this.spacePermissionService.getSpaceAccessContext(
+                  user.userUuid,
+                  app.space_uuid,
+              )
+            : {};
+        this.assertDataAppAbility(
+            user,
+            'manage',
+            app.organization_uuid,
+            app.project_uuid,
+            errorMessage,
+            { ...spaceContext, ...extraContext },
+        );
+    }
+
     private getAnthropicApiKey(): string {
         const key = this.lightdashConfig.ai.copilot.providers.anthropic?.apiKey;
         if (!key) {
@@ -355,14 +387,29 @@ export class AppGenerateService extends BaseService {
         appUuid: string,
     ): Promise<{ imageId: string }> {
         await this.assertDataAppsEnabled(user);
-        const organizationUuid = await this.getProjectOrgUuid(projectUuid);
-        this.assertDataAppAbility(
-            user,
-            'manage',
-            organizationUuid,
-            projectUuid,
-            'Insufficient permissions to upload app images',
-        );
+
+        // For iterations the app already exists — use its space context so a
+        // space editor can attach an image. For initial creation the appUuid
+        // is generated client-side and the app row doesn't exist yet, so we
+        // fall back to the project-wide manage check (the create permission
+        // is enforced by `generateApp` itself).
+        const app = await this.appModel.findApp(appUuid, projectUuid);
+        if (app) {
+            await this.assertCanManageApp(
+                user,
+                app,
+                'Insufficient permissions to upload app images',
+            );
+        } else {
+            const organizationUuid = await this.getProjectOrgUuid(projectUuid);
+            this.assertDataAppAbility(
+                user,
+                'manage',
+                organizationUuid,
+                projectUuid,
+                'Insufficient permissions to upload app images',
+            );
+        }
 
         const validTypes = [
             'image/png',
@@ -2079,26 +2126,17 @@ export class AppGenerateService extends BaseService {
         chartUuids?: string[],
     ): Promise<GenerateAppResult> {
         await this.assertDataAppsEnabled(user);
-        const auditedAbility = this.createAuditedAbility(user);
-        if (
-            auditedAbility.cannot(
-                'manage',
-                subject('DataApp', {
-                    organizationUuid: user.organizationUuid!,
-                    projectUuid,
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                'Insufficient permissions to modify data apps',
-            );
-        }
 
         if (imageId !== undefined && !isValidUuid(imageId)) {
             throw new ParameterError('Invalid imageId: must be a valid UUID');
         }
 
-        await this.appModel.getApp(appUuid, projectUuid); // validates app exists
+        const app = await this.appModel.getApp(appUuid, projectUuid);
+        await this.assertCanManageApp(
+            user,
+            app,
+            'Insufficient permissions to modify data apps',
+        );
 
         const latestVersion = await this.appModel.getLatestVersion(appUuid);
         if (
@@ -2170,11 +2208,9 @@ export class AppGenerateService extends BaseService {
     ): Promise<void> {
         await this.assertDataAppsEnabled(user);
         const app = await this.appModel.getApp(appUuid, projectUuid);
-        this.assertDataAppAbility(
+        await this.assertCanManageApp(
             user,
-            'manage',
-            app.organization_uuid,
-            projectUuid,
+            app,
             'Insufficient permissions to cancel app generation',
         );
 
@@ -2360,24 +2396,16 @@ export class AppGenerateService extends BaseService {
 
         const app = await this.appModel.getApp(appUuid, projectUuid);
 
-        this.assertDataAppAbility(
-            user,
-            'manage',
-            app.organization_uuid,
-            projectUuid,
-            'Insufficient permissions to pin data apps',
-            { metadata: { appUuid } },
-        );
-
         if (!app.space_uuid) {
             throw new ParameterError('Personal data apps cannot be pinned');
         }
 
-        const { inheritsFromOrgOrProject, access } =
-            await this.spacePermissionService.getSpaceAccessContext(
-                user.userUuid,
-                app.space_uuid,
-            );
+        await this.assertCanManageApp(
+            user,
+            app,
+            'Insufficient permissions to pin data apps',
+            { metadata: { appUuid } },
+        );
 
         const auditedAbility = this.createAuditedAbility(user);
         if (
@@ -2391,24 +2419,6 @@ export class AppGenerateService extends BaseService {
             )
         ) {
             throw new ForbiddenError();
-        }
-
-        if (
-            auditedAbility.cannot(
-                'view',
-                subject('DataApp', {
-                    organizationUuid: app.organization_uuid,
-                    projectUuid,
-                    spaceUuid: app.space_uuid,
-                    inheritsFromOrgOrProject,
-                    access,
-                    metadata: { appUuid },
-                }),
-            )
-        ) {
-            throw new ForbiddenError(
-                "You don't have access to the space this data app belongs to",
-            );
         }
 
         if (app.pinned_list_uuid) {
@@ -2456,11 +2466,9 @@ export class AppGenerateService extends BaseService {
     ): Promise<{ appUuid: string; name: string; description: string }> {
         await this.assertDataAppsEnabled(user);
         const app = await this.appModel.getApp(appUuid, projectUuid);
-        this.assertDataAppAbility(
+        await this.assertCanManageApp(
             user,
-            'manage',
-            app.organization_uuid,
-            projectUuid,
+            app,
             'Insufficient permissions to manage data apps',
         );
 
@@ -2529,11 +2537,9 @@ export class AppGenerateService extends BaseService {
             });
         } else {
             await this.assertDataAppsEnabled(user);
-            this.assertDataAppAbility(
+            await this.assertCanManageApp(
                 user,
-                'manage',
-                app.organization_uuid,
-                projectUuid,
+                app,
                 'Insufficient permissions to delete data apps',
             );
         }
@@ -2786,12 +2792,27 @@ export class AppGenerateService extends BaseService {
         const app = await this.appModel.getApp(appUuid, projectUuid);
 
         if (checkForAccess) {
+            // Manage on the source app (where it currently lives) — space
+            // editors/admins of the source space can move it out.
+            await this.assertCanManageApp(
+                user,
+                app,
+                'Insufficient permissions to move data apps',
+            );
+            // …and manage on the target space, otherwise a user could move an
+            // app into a space they don't own.
+            const targetSpaceContext =
+                await this.spacePermissionService.getSpaceAccessContext(
+                    user.userUuid,
+                    targetSpaceUuid,
+                );
             this.assertDataAppAbility(
                 user,
                 'manage',
                 app.organization_uuid,
                 projectUuid,
-                'Insufficient permissions to move data apps',
+                "You don't have access to the space this data app is being moved to",
+                targetSpaceContext,
             );
         }
 

--- a/packages/backend/src/models/AppModel.ts
+++ b/packages/backend/src/models/AppModel.ts
@@ -152,7 +152,25 @@ export class AppModel {
             pinned_list_order: number | null;
         }
     > {
-        const row = await this.database(AppsTableName)
+        const row = await this.findApp(appId, projectUuid);
+        if (!row) {
+            throw new NotFoundError(`App not found: ${appId}`);
+        }
+        return row;
+    }
+
+    async findApp(
+        appId: string,
+        projectUuid: string,
+    ): Promise<
+        | (DbApp & {
+              organization_uuid: string;
+              pinned_list_uuid: string | null;
+              pinned_list_order: number | null;
+          })
+        | undefined
+    > {
+        return this.database(AppsTableName)
             .innerJoin(
                 ProjectTableName,
                 `${ProjectTableName}.project_uuid`,
@@ -184,10 +202,6 @@ export class AppModel {
                 `${PinnedAppTableName}.order as pinned_list_order`,
             )
             .first();
-        if (!row) {
-            throw new NotFoundError(`App not found: ${appId}`);
-        }
-        return row;
     }
 
     async getVersion(

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -182,6 +182,24 @@ const applyOrganizationMemberStaticAbilities: Record<
                 },
             },
         });
+        can('manage', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            access: {
+                $elemMatch: {
+                    userUuid: member.userUuid,
+                    role: SpaceMemberRole.EDITOR,
+                },
+            },
+        });
+        can('manage', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            access: {
+                $elemMatch: {
+                    userUuid: member.userUuid,
+                    role: SpaceMemberRole.ADMIN,
+                },
+            },
+        });
 
         can('manage', 'Space', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -146,6 +146,24 @@ export const projectMemberAbilities: Record<
                 },
             },
         });
+        can('manage', 'DataApp', {
+            projectUuid: member.projectUuid,
+            access: {
+                $elemMatch: {
+                    userUuid: member.userUuid,
+                    role: SpaceMemberRole.EDITOR,
+                },
+            },
+        });
+        can('manage', 'DataApp', {
+            projectUuid: member.projectUuid,
+            access: {
+                $elemMatch: {
+                    userUuid: member.userUuid,
+                    role: SpaceMemberRole.ADMIN,
+                },
+            },
+        });
 
         can('manage', 'Space', {
             projectUuid: member.projectUuid,

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -46,6 +46,7 @@ const BASE_ROLE_SCOPES = {
         // Space-level content management (requires space admin/editor role)
         'manage:Dashboard@space', // Via space access
         'manage:SavedChart@space', // Via space access
+        'manage:DataApp@space', // Via space access
         'manage:Space@assigned', // Via space access (admin role)
 
         // Enterprise scopes
@@ -173,6 +174,7 @@ export const getNonEnterpriseScopesForRole = (
         'manage:ContentAsCode',
         'view:DataApp',
         'manage:DataApp',
+        'manage:DataApp@space',
         'manage:PersonalAccessToken',
         'manage:PreAggregation',
     ]);

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -716,6 +716,17 @@ const scopes: Scope[] = [
         group: ScopeGroup.AI,
         getConditions: addDefaultUuidCondition,
     },
+    {
+        name: 'manage:DataApp@space',
+        description:
+            'Create, edit, and delete data apps in spaces where you have editor or admin access',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        getConditions: (context) => [
+            addAccessCondition(context, SpaceMemberRole.EDITOR),
+            addAccessCondition(context, SpaceMemberRole.ADMIN),
+        ],
+    },
 
     // Spotlight Scopes
     {

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -204,12 +204,16 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
             break;
         }
         case ResourceViewItemType.DATA_APP: {
+            const userAccess = spaces.find(
+                (space) => space.uuid === item.data.spaceUuid,
+            )?.userAccess;
             userCanManage =
                 user.data?.ability?.can(
                     'manage',
                     subject('DataApp', {
                         organizationUuid,
                         projectUuid,
+                        access: userAccess ? [userAccess] : [],
                     }),
                 ) === true;
             break;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -76,6 +76,7 @@ import { useIterateApp } from '../features/apps/hooks/useIterateApp';
 import QueryInspector from '../features/apps/QueryInspector';
 import { useContentAction } from '../hooks/useContent';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { useSpaceSummaries } from '../hooks/useSpaces';
 import { useAbilityContext } from '../providers/Ability/useAbilityContext';
 import useApp from '../providers/App/useApp';
 import classes from './AppGenerate.module.css';
@@ -265,6 +266,7 @@ const AppGenerate: FC = () => {
     const {
         data: appData,
         error: appError,
+        isLoading: isLoadingApp,
         fetchNextPage,
         hasNextPage,
         isFetchingNextPage,
@@ -274,6 +276,10 @@ const AppGenerate: FC = () => {
     const appName = appData?.pages?.[0]?.name ?? '';
     const appDescription = appData?.pages?.[0]?.description ?? '';
     const appSpaceUuid = appData?.pages?.[0]?.spaceUuid ?? null;
+
+    // Used to resolve the user's space role when checking manage rights for
+    // an existing app — space editors/admins inherit manage on its data app.
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
 
     const [isMoveToSpaceOpen, setIsMoveToSpaceOpen] = useState(false);
     const [isUpdateModalOpen, setIsUpdateModalOpen] = useState(false);
@@ -437,12 +443,25 @@ const AppGenerate: FC = () => {
         return <Navigate to={`/projects/${projectUuid}/home`} replace />;
     }
 
+    // For an existing app, manage rights flow through the app's space — a
+    // space editor/admin can iterate on it. For a brand-new app (no
+    // urlAppUuid), space context isn't available, so we fall back to the
+    // project-wide manage check (admin only today).
+    // Wait for the app to load before deciding — without the spaceUuid we
+    // can't tell whether a non-admin space editor should be allowed in.
+    if (urlAppUuid && isLoadingApp) {
+        return null;
+    }
+    const userSpaceAccess = appSpaceUuid
+        ? spaces.find((s) => s.uuid === appSpaceUuid)?.userAccess
+        : undefined;
     if (
         !ability.can(
             'manage',
             subject('DataApp', {
                 organizationUuid: user.data?.organizationUuid,
                 projectUuid,
+                access: userSpaceAccess ? [userSpaceAccess] : [],
             }),
         )
     ) {

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -1,3 +1,4 @@
+import { subject } from '@casl/ability';
 import { FeatureFlags } from '@lightdash/common';
 import { ActionIcon, Box, Loader, Menu, Stack, Text } from '@mantine-8/core';
 import { IconAppsOff, IconDots, IconPencil } from '@tabler/icons-react';
@@ -9,6 +10,7 @@ import AppIframePreview from '../features/apps/AppIframePreview';
 import { useAppPreviewToken } from '../features/apps/hooks/useAppPreviewToken';
 import { useGetApp } from '../features/apps/hooks/useGetApp';
 import { useServerFeatureFlag } from '../hooks/useServerOrClientFeatureFlag';
+import { useSpaceSummaries } from '../hooks/useSpaces';
 import useApp from '../providers/App/useApp';
 import classes from './AppPreviewTest.module.css';
 
@@ -38,9 +40,20 @@ export default function AppPreviewTest() {
         (v) => v.status === 'ready',
     )?.version;
 
-    const createdByUserUuid = appQuery.data?.pages[0]?.createdByUserUuid;
-    const isCreator =
-        !!user.data?.userUuid && user.data.userUuid === createdByUserUuid;
+    const appSpaceUuid = appQuery.data?.pages[0]?.spaceUuid ?? null;
+    const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
+    const userSpaceAccess = appSpaceUuid
+        ? spaces.find((s) => s.uuid === appSpaceUuid)?.userAccess
+        : undefined;
+    const canEditApp =
+        user.data?.ability?.can(
+            'manage',
+            subject('DataApp', {
+                organizationUuid: user.data?.organizationUuid,
+                projectUuid,
+                access: userSpaceAccess ? [userSpaceAccess] : [],
+            }),
+        ) === true;
 
     const version = explicitVersion ?? latestReadyVersion;
 
@@ -146,7 +159,7 @@ export default function AppPreviewTest() {
 
     return (
         <Box className={classes.previewContainer}>
-            {isCreator && (
+            {canEditApp && (
                 <Box className={classes.menuOverlay}>
                     <Menu
                         position="bottom-end"


### PR DESCRIPTION
Relates to: https://linear.app/lightdash/issue/GLITCH-321/apps-permissions-structure

### Description:
Space editors and admins on the space an app belongs to can now iterate, update, cancel, pin, move, and delete that app — mirroring the model charts and dashboards already use. Project admins keep full access; the view path was already space-aware. Personal (spaceless) apps stay admin-only.

Adds `assertCanManageApp` server-side and threads space access into the matching frontend gates (resource action menu, generate page guard, and the preview "Continue building" menu, which previously only appeared for the creator).
