### PR TITLE
fix: clear pending highlight timer and dispatch downplay on chart mouseout

### DIFF
--- a/packages/frontend/src/components/SimpleChart/index.tsx
+++ b/packages/frontend/src/components/SimpleChart/index.tsx
@@ -286,6 +286,10 @@ const SimpleChart: FC<SimpleChartProps> = memo(
         const mouseOverTimer = useRef<
             ReturnType<typeof setTimeout> | undefined
         >(undefined);
+        const highlightTimer = useRef<
+            ReturnType<typeof setTimeout> | undefined
+        >(undefined);
+        const hasDispatchedHighlight = useRef(false);
 
         const handleOnMouseOver = useCallback(
             (params: any) => {
@@ -413,11 +417,16 @@ const SimpleChart: FC<SimpleChartProps> = memo(
                         }
                     }
                     // Wait for tooltip to change from `axis` to `item` and keep hovered on item highlighted
-                    setTimeout(() => {
+                    if (highlightTimer.current) {
+                        clearTimeout(highlightTimer.current);
+                    }
+                    highlightTimer.current = setTimeout(() => {
                         eCharts.dispatchAction({
                             type: 'highlight',
                             seriesIndex: params.seriesIndex,
                         });
+                        hasDispatchedHighlight.current = true;
+                        highlightTimer.current = undefined;
                     }, 100);
                 }
             },
@@ -425,19 +434,40 @@ const SimpleChart: FC<SimpleChartProps> = memo(
         );
 
         const handleOnMouseOut = useCallback(() => {
+            // Cancel any pending highlight that hasn't fired yet so we don't
+            // re-highlight after the cursor has already left the chart area.
+            if (highlightTimer.current) {
+                clearTimeout(highlightTimer.current);
+                highlightTimer.current = undefined;
+            }
+            // Explicitly clear emphasis state, but only if we previously
+            // dispatched a manual `highlight`. That manual dispatch bypasses
+            // ECharts' automatic mouseout downplay, so without this mirror
+            // the focused series stays blurred-focused when the cursor leaves.
+            // When no manual highlight was dispatched (e.g. fast hovers under
+            // the 100ms threshold), ECharts' built-in mouseout handles cleanup
+            // and dispatching downplay here interferes with internal state on
+            // mixed charts during rapid bar↔line transitions.
+            if (hasDispatchedHighlight.current) {
+                const eCharts = chartRef.current?.getEchartsInstance();
+                if (eCharts) {
+                    eCharts.dispatchAction({ type: 'downplay' });
+                }
+                hasDispatchedHighlight.current = false;
+            }
             // Debounce the reset to prevent rapid axis<->item tooltip flicker
             // when moving between adjacent series elements in mixed charts
             if (mouseOverTimer.current) {
                 clearTimeout(mouseOverTimer.current);
             }
             mouseOverTimer.current = setTimeout(() => {
-                const eCharts = chartRef.current?.getEchartsInstance();
-                if (eCharts) {
+                const echartsInstance = chartRef.current?.getEchartsInstance();
+                if (echartsInstance) {
                     isItemTooltipActive.current = false;
                     const tooltipOptions =
                         resolvedEChartsOptions?.tooltip ??
                         eChartsOptions?.tooltip;
-                    eCharts.setOption(
+                    echartsInstance.setOption(
                         {
                             tooltip: tooltipOptions,
                         },


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7121/grouped-and-stacked-bar-charts-focus-on-a-single-series-value-gets

Before

<img width="1895" height="904" alt="CleanShot 2026-04-27 at 12 46 49" src="https://github.com/user-attachments/assets/eabaca6d-1a2d-4a88-b67b-d26cd60fddda" />

After

can't reproduce


 Where the bug is: packages/frontend/src/components/SimpleChart/index.tsx, in handleOnMouseOver (line 419).

  The mouseover handler explicitly dispatches eCharts.dispatchAction({ type: 'highlight', seriesIndex }) via a 100ms setTimeout (it's needed to keep
  the hover focus visible after switching the tooltip from axis mode to item mode). But there are two race conditions:

  1. The pending highlight fires after mouseout. If you hover briefly (<100ms) and leave, the setTimeout is never cancelled — it fires the highlight
  AFTER the cursor has already left.
  2. No mirror downplay. Manually-dispatched highlight bypasses ECharts' automatic mouseout downplay. So even when the highlight fires while the
  cursor is on the chart and you leave, nothing tells ECharts "release the focus".

  This was a regression from PR #20164 (commit 19123ec162, Feb 2026) — the previous code had emphasis: { disabled: true } on mouseout that cleared
  this. That PR removed it to fix tooltip flicker on mixed charts but didn't replace the highlight-clearing path.

  My fix in handleOnMouseOut:
  1. Cancel the pending highlight setTimeout (kills race #1).
  2. Dispatch { type: 'downplay' } (kills race #2).
  
---

## # Description:




Fixes a bug where a chart series would remain in a highlighted/blurred state after the cursor leaves the chart area.

When a `highlight` action is manually dispatched via `setTimeout` in the mouseover handler, ECharts' automatic `downplay` on mouseout no longer fires correctly, leaving the focused series visually stuck in an emphasized state.

To fix this:
- A `highlightTimer` ref is introduced to track the pending `highlight` dispatch. If the cursor leaves before the timer fires, the pending highlight is cancelled so it never applies.
- On mouseout, a `downplay` action is explicitly dispatched to clear any emphasis state that was already applied by a previous `highlight` dispatch.