### PR TITLE
fix(formula): preserve decimals in Redshift ROUND by pinning numeric scale

### DIFF
--- a/packages/formula/src/codegen/dialects.ts
+++ b/packages/formula/src/codegen/dialects.ts
@@ -201,6 +201,15 @@ const POSTGRES_CONFIG: DialectConfig = {
 const REDSHIFT_CONFIG: DialectConfig = {
     ...POSTGRES_CONFIG,
     generateStringLiteral: ansiQuoteWithEscapedBackslashesStringLiteral,
+    // Redshift's bare `(x)::numeric` defaults to `numeric(18, 0)` and
+    // truncates the input to an integer before rounding, so e.g.
+    // `ROUND(50.5::numeric, 1)` returns 50, not 50.5. Postgres' unbounded
+    // numeric keeps full precision and isn't affected. Pin precision/scale
+    // so ROUND(x, n) keeps decimals on Redshift.
+    generateRound: (value, digits) =>
+        digits !== undefined
+            ? `ROUND((${value})::numeric(38, 10), ${digits})`
+            : `ROUND(${value})`,
     generateLagLead: ({ sqlFunc, args, emitWindow }) => {
         if (args.length >= 3) {
             const [value, offset, defaultValue] = args;

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -270,13 +270,17 @@ describe('codegen', () => {
             ).toBe('ROUND(("revenue")::numeric, 2)');
         });
 
-        it('casts value to numeric on Redshift for the 2-arg form', () => {
+        it('pins numeric precision on Redshift so ROUND keeps decimals', () => {
+            // Bare `(x)::numeric` on Redshift means numeric(18, 0) — the
+            // input is truncated to an integer before ROUND runs, so
+            // ROUND(50.5, 1) returns 50. Pinning to numeric(38, 10) keeps
+            // the decimal payload through ROUND.
             expect(
                 compile('=ROUND(revenue, 2)', {
                     dialect: 'redshift',
                     columns,
                 }),
-            ).toBe('ROUND(("revenue")::numeric, 2)');
+            ).toBe('ROUND(("revenue")::numeric(38, 10), 2)');
         });
 
         it('leaves the 1-arg form uncast on Postgres', () => {


### PR DESCRIPTION
## Summary

Redshift's bare `(x)::numeric` defaults to `numeric(18, 0)` — the input is truncated to an integer **before** ROUND runs, so e.g.

```sql
ROUND(50.5::numeric, 1)  -- returns 50, not 50.5
```

Postgres's unbounded `numeric` keeps full precision, so the same codegen works there. This was masked because nothing in the codegen unit tests exercised the cast against a real Redshift cluster — the SQL shape was fine, the runtime semantics weren't.

Surfaced by existing `math/round`, `math/round-two-decimals`, and `edge/deeply-nested` integration tests, which had been red on Redshift since their inception (the previous tier1 run on this stack showed Redshift at 331/334 instead of 334/334).

## Fix

Override `generateRound` for Redshift to pin the cast to `numeric(38, 10)` — preserves up to 10 decimal places of input precision, well beyond what a realistic ROUND digit count would demand.

Postgres / DuckDB paths unchanged. The 1-arg `ROUND(x)` form is unchanged on every dialect (it doesn't need the cast).

## Test plan

- [x] `pnpm -F formula test` — codegen unit tests, including the new Redshift assertion
- [x] `pnpm formula:test:fast` — DuckDB integration
- [x] `pnpm formula:test:tier1` — DuckDB + Postgres + Redshift, 1002/1002 ✓ (previously 999/1002)
- [x] `pnpm formula:test:tier2` — BigQuery + Databricks + ClickHouse unaffected, 1002/1002 ✓

Stacked on #22380.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
