### PR TITLE
fix: calculate subtotals using cached results in explore edit

### DIFF
--- a/packages/backend/src/ee/services/EmbedService/EmbedService.ts
+++ b/packages/backend/src/ee/services/EmbedService/EmbedService.ts
@@ -1484,6 +1484,7 @@ export class EmbedService extends BaseService {
             dashboardUuid,
             combinedParameters,
             dateZoom,
+            invalidateCache,
         );
     }
 
@@ -1499,6 +1500,7 @@ export class EmbedService extends BaseService {
         dashboardUuid?: string,
         combinedParameters?: ParametersValuesMap,
         dateZoom?: DateZoom,
+        invalidateCache?: boolean,
     ) {
         // Use the shared utility to prepare dimension groups
         const { dimensionGroupsToSubtotal, analyticsData } =
@@ -1549,6 +1551,7 @@ export class EmbedService extends BaseService {
             pivotDimensions,
             parameters: combinedParameters,
             dateZoom,
+            invalidateCache,
             userAccessControls: {
                 userAttributes,
                 intrinsicUserAttributes,
@@ -1683,6 +1686,7 @@ export class EmbedService extends BaseService {
             undefined, // no dashboardUuid for raw query
             combinedParameters,
             data.dateZoom,
+            data.invalidateCache,
         );
     }
 

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -5726,6 +5726,7 @@ export class AsyncQueryService extends ProjectService {
         pivotDimensions,
         parameters,
         dateZoom,
+        invalidateCache,
         userAccessControls,
     }: {
         account: Account;
@@ -5744,6 +5745,7 @@ export class AsyncQueryService extends ProjectService {
         pivotDimensions?: string[];
         parameters?: ParametersValuesMap;
         dateZoom?: ExecuteAsyncMetricQueryArgs['dateZoom'];
+        invalidateCache?: boolean;
         userAccessControls?: UserAccessControls;
     }) {
         const { dimensionGroupsToSubtotal } =
@@ -5777,6 +5779,7 @@ export class AsyncQueryService extends ProjectService {
                         queryTags,
                         parameters,
                         dateZoom,
+                        invalidateCache,
                         userAccessControls,
                     });
 
@@ -6087,6 +6090,7 @@ export class AsyncQueryService extends ProjectService {
             pivotDimensions: data.pivotDimensions,
             parameters: combinedParameters,
             dateZoom: data.dateZoom,
+            invalidateCache: data.invalidateCache,
         });
     }
 

--- a/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
+++ b/packages/frontend/src/hooks/tableVisualization/useTableConfig.ts
@@ -260,6 +260,7 @@ const useTableConfig = (
                   embedToken,
                   parameters,
                   dateZoom,
+                  invalidateCache,
               },
     );
 

--- a/packages/frontend/src/hooks/useCalculateSubtotals.ts
+++ b/packages/frontend/src/hooks/useCalculateSubtotals.ts
@@ -23,6 +23,7 @@ const calculateSubtotalsFromQuery = async (
     pivotDimensions?: string[],
     parameters?: ParametersValuesMap,
     dateZoom?: DateZoom,
+    invalidateCache?: boolean,
 ): Promise<ApiCalculateSubtotalsResponse['results']> => {
     const timezoneFixPayload: CalculateSubtotalsFromQuery = {
         explore: explore,
@@ -34,6 +35,7 @@ const calculateSubtotalsFromQuery = async (
         pivotDimensions,
         parameters,
         dateZoom,
+        invalidateCache,
     };
     return lightdashApi<ApiCalculateSubtotalsResponse['results']>({
         url: `/projects/${projectUuid}/calculate-subtotals`,
@@ -83,6 +85,7 @@ const postCalculateSubtotalsFromQueryForEmbed = async (
     pivotDimensions?: string[],
     parameters?: ParametersValuesMap,
     dateZoom?: DateZoom,
+    invalidateCache?: boolean,
 ): Promise<ApiCalculateSubtotalsResponse['results']> => {
     const timezoneFixPayload: CalculateSubtotalsFromQuery = {
         explore,
@@ -94,6 +97,7 @@ const postCalculateSubtotalsFromQueryForEmbed = async (
         pivotDimensions,
         parameters,
         dateZoom,
+        invalidateCache,
     };
     return lightdashApi<ApiCalculateSubtotalsResponse['results']>({
         url: `/embed/${projectUuid}/calculate-subtotals`,
@@ -171,6 +175,7 @@ export const useCalculateSubtotals = ({
                         pivotDimensions,
                         parameters,
                         dateZoom,
+                        invalidateCache,
                     )
                   : // Regular mode with raw query
                     projectUuid && metricQuery && explore && columnOrder
@@ -182,6 +187,7 @@ export const useCalculateSubtotals = ({
                           pivotDimensions,
                           parameters,
                           dateZoom,
+                          invalidateCache,
                       )
                     : Promise.reject(),
         {

--- a/packages/frontend/src/hooks/useExplorerQuery.ts
+++ b/packages/frontend/src/hooks/useExplorerQuery.ts
@@ -54,6 +54,10 @@ export const useExplorerQuery = () => {
             queryKey: ['calculate_total'],
             exact: false,
         });
+        queryClient.removeQueries({
+            queryKey: ['calculate_subtotals'],
+            exact: false,
+        });
     }, [queryClient, dispatch]);
 
     // Action: Fetch results (force refresh - bypasses auto-fetch setting)


### PR DESCRIPTION
Relates to: https://github.com/lightdash/lightdash/issues/22332

### Description:

Propagates the `invalidateCache` flag through the subtotals calculation pipeline, ensuring cache invalidation is respected when calculating subtotals — both in regular and embed query flows.

### How to test
1. Enable `RESULTS_CACHE_ENABLED`
2. Open explore
2. Select 2 dimensions and 1 metric, choose table viz
3. Add subtotals
4. Check the table data
5. Mutate the data and call `dbt run`
6. Check the table data again

**Data mutation**
```diff
diff --git a/examples/full-jaffle-shop-demo/dbt/models/payments.sql b/examples/full-jaffle-shop-demo/dbt/models/payments.sql
index cbe6a96b76..d556f59530 100755
--- a/examples/full-jaffle-shop-demo/dbt/models/payments.sql
+++ b/examples/full-jaffle-shop-demo/dbt/models/payments.sql
@@ -1 +1 @@
-select * from {{ ref('stg_payments') }}
+select * from {{ ref('stg_payments') }} where amount > 10
```

**Before**

Initial query
<img width="789" height="307" alt="subtotals_before_data_mutation" src="https://github.com/user-attachments/assets/55a857a4-e079-471f-bd2f-1419ff26b5f0" />


After changing data - notice subtotals are the same even though the rows have changed
<img width="789" height="298" alt="subtotals_after_data_mutation" src="https://github.com/user-attachments/assets/8eaa608f-b840-4170-8c6a-420afbceedba" />


**After**

Initial query
<img width="789" height="307" alt="subtotals_before_data_mutation" src="https://github.com/user-attachments/assets/f278cf3b-9777-4866-a62a-ce96d8c91079" />


After changing data
<img width="788" height="302" alt="subtotals_fix" src="https://github.com/user-attachments/assets/0bceb4d3-8226-4add-ab37-f567c0e2ec4d" />
