### PR TITLE
fix: add links to dashboards and charts in user activity page

### DIFF
--- a/packages/backend/src/models/AnalyticsModel.ts
+++ b/packages/backend/src/models/AnalyticsModel.ts
@@ -222,6 +222,7 @@ export class AnalyticsModel {
                 user_uuid: string;
                 first_name: string;
                 last_name: string;
+                dashboard_uuid: string;
                 dashboard_name: string;
                 count: number;
             }[];
@@ -267,6 +268,7 @@ export class AnalyticsModel {
                     firstName: row.first_name,
                     lastName: row.last_name,
                     count: row.count,
+                    dashboardUuid: row.dashboard_uuid,
                     dashboardName: row.dashboard_name,
                 }),
             ),

--- a/packages/backend/src/models/AnalyticsModelSql.ts
+++ b/packages/backend/src/models/AnalyticsModelSql.ts
@@ -235,6 +235,7 @@ WITH RankedResults AS (
       u.user_uuid,
       u.first_name,
       u.last_name,
+      d.dashboard_uuid,
       d."name" AS dashboard_name,
       COUNT(dv.dashboard_uuid) AS dashboard_count,
       ROW_NUMBER() OVER (PARTITION BY u.first_name ORDER BY COUNT(dv.dashboard_uuid) DESC) AS rank
@@ -245,12 +246,13 @@ WITH RankedResults AS (
   left join projects on projects.project_id = s.project_id
   WHERE projects.project_uuid = '${projectUuid}'
     AND u.user_uuid IS NOT NULL
-  GROUP BY u.user_uuid, u.first_name, u.last_name, d."name"
+  GROUP BY u.user_uuid, u.first_name, u.last_name, d.dashboard_uuid, d."name"
 )
 SELECT
   user_uuid,
   first_name,
   last_name,
+  dashboard_uuid,
   dashboard_name,
   dashboard_count as count
 FROM RankedResults

--- a/packages/common/src/types/analytics.ts
+++ b/packages/common/src/types/analytics.ts
@@ -30,7 +30,10 @@ export type UserActivity = {
         average_number_of_weekly_queries_per_user: string;
     }[];
     dashboardViews: ActivityViews[];
-    userMostViewedDashboards: (UserWithCount & { dashboardName: string })[];
+    userMostViewedDashboards: (UserWithCount & {
+        dashboardName: string;
+        dashboardUuid: string;
+    })[];
     chartViews: ActivityViews[];
 };
 

--- a/packages/frontend/src/pages/UserActivity.tsx
+++ b/packages/frontend/src/pages/UserActivity.tsx
@@ -4,6 +4,7 @@ import {
     type UserWithCount,
 } from '@lightdash/common';
 import {
+    Anchor,
     Box,
     Button,
     Card,
@@ -16,7 +17,7 @@ import {
 } from '@mantine/core';
 import { IconUsers } from '@tabler/icons-react';
 import { type FC } from 'react';
-import { useParams } from 'react-router';
+import { Link, useParams } from 'react-router';
 import MantineIcon from '../components/common/MantineIcon';
 import Page from '../components/common/Page/Page';
 import PageBreadcrumbs from '../components/common/PageBreadcrumbs';
@@ -74,13 +75,37 @@ const BigNumberVis: FC<{ value: number | string; label: string }> = ({
     );
 };
 
-const showTableViews = (key: string, views: ActivityViews[]) => {
+const getDashboardLink = (projectUuid: string, dashboardUuid: string) =>
+    `/projects/${projectUuid}/dashboards/${dashboardUuid}`;
+
+const getChartLink = (projectUuid: string, chartUuid: string) =>
+    `/projects/${projectUuid}/saved/${chartUuid}`;
+
+const showTableViews = ({
+    key,
+    projectUuid,
+    type,
+    views,
+}: {
+    key: string;
+    projectUuid: string;
+    type: 'chart' | 'dashboard';
+    views: ActivityViews[];
+}) => {
     return (
         <tbody>
             {views.map((view) => {
+                const to =
+                    type === 'dashboard'
+                        ? getDashboardLink(projectUuid, view.uuid)
+                        : getChartLink(projectUuid, view.uuid);
                 return (
                     <tr key={`${key}-${view.uuid}`}>
-                        <td>{view.name}</td>
+                        <td>
+                            <Anchor component={Link} to={to}>
+                                {view.name}
+                            </Anchor>
+                        </td>
                         <td>{view.count}</td>
                     </tr>
                 );
@@ -194,11 +219,12 @@ const UserActivity: FC = () => {
         useDownloadUserActivityCsv();
 
     const { data, isInitialLoading } = useUserActivity(params.projectUuid);
+    const projectUuid = params.projectUuid;
     if (sessionUser.data?.ability?.cannot('view', 'Analytics')) {
         return <ForbiddenPanel />;
     }
 
-    if (isInitialLoading || data === undefined) {
+    if (projectUuid === undefined || isInitialLoading || data === undefined) {
         return (
             <div style={{ marginTop: '20px' }}>
                 <SuboptimalState title="Loading..." loading />
@@ -423,7 +449,17 @@ const UserActivity: FC = () => {
                                     >
                                         <td>{user.firstName} </td>
                                         <td>{user.lastName}</td>
-                                        <td>{user.dashboardName}</td>
+                                        <td>
+                                            <Anchor
+                                                component={Link}
+                                                to={getDashboardLink(
+                                                    projectUuid,
+                                                    user.dashboardUuid,
+                                                )}
+                                            >
+                                                {user.dashboardName}
+                                            </Anchor>
+                                        </td>
 
                                         <td>{user.count}</td>
                                     </tr>
@@ -445,10 +481,12 @@ const UserActivity: FC = () => {
                                         <th>Views</th>
                                     </tr>
                                 </thead>
-                                {showTableViews(
-                                    'dashboard-views',
-                                    data.dashboardViews,
-                                )}
+                                {showTableViews({
+                                    key: 'dashboard-views',
+                                    projectUuid,
+                                    type: 'dashboard',
+                                    views: data.dashboardViews,
+                                })}
                             </Table>
                         </VisualizationCard>
                         <VisualizationCard
@@ -462,7 +500,12 @@ const UserActivity: FC = () => {
                                         <th>Views</th>
                                     </tr>
                                 </thead>
-                                {showTableViews('chart-views', data.chartViews)}
+                                {showTableViews({
+                                    key: 'chart-views',
+                                    projectUuid,
+                                    type: 'chart',
+                                    views: data.chartViews,
+                                })}
                             </Table>
                         </VisualizationCard>
                     </>


### PR DESCRIPTION
Closes:

### Description:

Dashboard and chart names in the User Activity page are now clickable links that navigate directly to the respective dashboard or chart. This applies to the "Most Viewed Dashboards" table, the dashboard views table, and the chart views table.

To support linking to dashboards from the "User Most Viewed Dashboards" table, `dashboard_uuid` is now included in the analytics query results and returned as part of the `userMostViewedDashboards` response.