### PR TITLE
feat(data-apps): let interactive viewers create personal apps

### DIFF
--- a/docs/data-apps.md
+++ b/docs/data-apps.md
@@ -12,7 +12,7 @@ the hood, Claude Code runs inside an isolated sandbox, reads the project's dbt m
 builds it with Vite, and deploys the artifacts to S3. The resulting app is served in a sandboxed iframe and can query
 Lightdash metrics through a secure postMessage bridge.
 
-The feature is enterprise-only, gated behind the `APP_RUNTIME_ENABLED` flag and the `manage:DataApp` permission scope.
+The feature is enterprise-only, gated behind the `APP_RUNTIME_ENABLED` flag and the `view:DataApp` / `create:DataApp` / `manage:DataApp` permission scopes (see [Permissions](#permissions) below).
 
 ---
 
@@ -84,7 +84,8 @@ charts.
   enumerated and deleted (staged image uploads, version source tarballs, built dist tarballs, and per-version assets).
 
 Implementation: `AppGenerateService.deleteApp` is the entry point. It delegates to `softDeleteApp` or
-`permanentDeleteApp`, which each enforce the `manage:DataApp` scope and handle sandbox/S3 cleanup.
+`permanentDeleteApp`, which each enforce the appropriate manage scope (see [Permissions](#permissions) below) and
+handle sandbox/S3 cleanup.
 
 ---
 
@@ -141,7 +142,9 @@ type DbAppVersion = {
 
 ## API Endpoints
 
-All endpoints require the `manage:DataApp` permission and are scoped under `/api/v1/ee/`.
+All endpoints are scoped under `/api/v1/ee/`. The required scope per endpoint follows the model in
+[Permissions](#permissions) — `create:DataApp` for creation, `view:DataApp` (with space or self context) for reads,
+and `manage:DataApp` (with space or self context) for mutations.
 
 ### App CRUD
 
@@ -262,7 +265,8 @@ could read arbitrary S3 objects.
 
 - **Allowed MIME types**: `image/png`, `image/jpeg`, `image/gif`, `image/webp`
 - **Max size**: 10 MB (validated via `Content-Length` header before streaming)
-- **Permission**: Requires `manage:DataApp` scope (same as all app operations)
+- **Permission**: For an existing app, the standard manage check applies (space role, self for personal apps, or
+  project admin). For an upload tied to a not-yet-created app (initial creation flow), `create:DataApp` is required.
 
 ---
 
@@ -340,35 +344,48 @@ S3 credentials are configured through the existing `S3_*` environment variables 
 
 ## Permissions
 
-Data apps follow the same space-based permission model as charts and dashboards. Three CASL scopes, all defined in
-`packages/common/src/authorization/scopes.ts`:
+Data apps follow the same space-based permission model as charts and dashboards, with one extra wrinkle: an app can
+exist as **personal** (`space_uuid IS NULL`) before its creator decides to share it by moving it into a space. The
+scopes, all defined in `packages/common/src/authorization/scopes.ts`:
 
-| Scope                  | Granted to          | Effect                                                                                                           |
-| ---------------------- | ------------------- | ---------------------------------------------------------------------------------------------------------------- |
-| `view:DataApp`         | viewer+             | View any app whose space the user can view (or where the project inherits org/project access).                   |
-| `manage:DataApp@space` | interactive_viewer+ | Iterate, edit, cancel, pin, move, and delete apps in spaces where the user has the `EDITOR` or `ADMIN` role.     |
-| `manage:DataApp`       | admin               | Project-wide manage — covers all apps including personal (spaceless) ones, and gates restore + permanent-delete. |
+| Scope                  | Granted to          | Effect                                                                                                       |
+| ---------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------ |
+| `view:DataApp`         | viewer+             | View any app whose space the user can view (or where the project inherits org/project access).               |
+| `create:DataApp`       | interactive_viewer+ | Start a new app from a prompt. Newly-created apps are personal until moved into a space.                     |
+| `view:DataApp@self`    | interactive_viewer+ | View own personal apps (matched on `createdByUserUuid`).                                                     |
+| `manage:DataApp@self`  | interactive_viewer+ | Iterate, edit, pin (n/a for personal), move, and delete own personal apps.                                   |
+| `manage:DataApp@space` | interactive_viewer+ | Iterate, edit, cancel, pin, move, and delete apps in spaces where the user has the `EDITOR` or `ADMIN` role. |
+| `manage:DataApp`       | admin               | Project-wide manage — covers any app, and gates restore + permanent-delete.                                  |
 
 ### Permission matrix
 
-| Action                                          | Project admin | Space admin/editor | Space viewer |
-| ----------------------------------------------- | ------------- | ------------------ | ------------ |
-| View an app in a space                          | ✓             | ✓                  | ✓            |
-| View a personal (spaceless) app                 | ✓             | —                  | —            |
-| Iterate / cancel / update / pin / move / delete | ✓             | ✓                  | ✗            |
-| Restore / permanently delete                    | ✓             | ✗                  | ✗            |
-| Create a new app                                | ✓             | ✗                  | ✗            |
+| Action                                       | Project admin | Space admin/editor | Space viewer | App creator (personal app) |
+| -------------------------------------------- | ------------- | ------------------ | ------------ | -------------------------- |
+| View an app in a space                       | ✓             | ✓                  | ✓            | (creator viewed via space) |
+| View own personal app                        | ✓             | —                  | —            | ✓                          |
+| View someone else's personal app             | ✓             | —                  | —            | —                          |
+| Create a new app                             | ✓             | ✓                  | ✗            | n/a                        |
+| Iterate / cancel / update / move / delete    | ✓             | ✓ (in their space) | ✗            | ✓ (own personal app)       |
+| Pin to homepage                              | ✓             | ✓ (in their space) | ✗            | — (personal apps can't be pinned) |
+| Restore / permanently delete                 | ✓             | ✗                  | ✗            | ✗                          |
+
+The "App creator" column applies while an app is still personal (`space_uuid IS NULL`). Once moved into a space, the
+app's permissions follow the space — the creator no longer has special rights unless they also have a space role.
+
+### Implementation
 
 Permission checks live in the service layer, not the controller — TSOA middleware only handles authentication. Two
-helpers in `AppGenerateService.ts` carry the space-aware logic:
+helpers in `AppGenerateService.ts` carry the context-aware logic:
 
 - `assertCanViewApp(user, app)` — used by `getAppVersions`, `getPreviewToken`. Builds a CASL subject that includes the
-  app's space access context (or an empty context for personal apps), then checks the `view` action.
+  app's space access context (empty for personal apps) plus `createdByUserUuid`, then checks the `view` action.
 - `assertCanManageApp(user, app, msg)` — used by `iterateApp`, `cancelVersion`, `updateApp`, `togglePinning`,
-  `deleteApp`, `moveToSpace`, and `uploadImage` (when the app exists). Same space-context shape, but checks the
-  `manage` action so space editors/admins match.
+  `deleteApp`, `moveToSpace`, and `uploadImage` (when the app exists). Same subject shape, checks the `manage` action.
 
-`restoreApp` and `permanentDeleteApp` deliberately bypass the space-aware helper and use the bare project-wide
+`generateApp` (creation) checks the `create` action against a project-scoped subject — no app exists yet to provide
+space or creator context.
+
+`restoreApp` and `permanentDeleteApp` deliberately bypass the context-aware helper and use the bare project-wide
 `manage:DataApp` check, since restoring deleted content is an admin-only recovery flow.
 
 `moveToSpace` runs the manage check twice — once on the source app (its current space) and once on the target space —

--- a/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
+++ b/packages/backend/src/ee/services/AppGenerateService/AppGenerateService.ts
@@ -147,7 +147,7 @@ export class AppGenerateService extends BaseService {
      */
     private assertDataAppAbility(
         user: SessionUser,
-        action: 'view' | 'manage',
+        action: 'view' | 'create' | 'manage',
         organizationUuid: string,
         projectUuid: string,
         errorMessage: string,
@@ -172,15 +172,18 @@ export class AppGenerateService extends BaseService {
      * Permission check for reading a data app.
      *
      * Apps can live in two modes:
-     * - Assigned to a space → the subject carries space access context and
-     *   viewers with space access match `view:DataApp`.
-     * - Personal / unassigned → the subject has no space context, so only
-     *   the admin-level `manage:DataApp` rule (which matches any action,
-     *   including view) grants access.
+     * - Assigned to a space → the subject carries space access context, so
+     *   any user with space access matches `view:DataApp`.
+     * - Personal / unassigned → space context is empty, but
+     *   `createdByUserUuid` lets the creator match the self rule. Project
+     *   admins always match via the project-wide rule.
      */
     private async assertCanViewApp(
         user: SessionUser,
-        app: Pick<DbApp, 'project_uuid' | 'space_uuid'> & {
+        app: Pick<
+            DbApp,
+            'project_uuid' | 'space_uuid' | 'created_by_user_uuid'
+        > & {
             organization_uuid: string;
         },
     ): Promise<void> {
@@ -196,21 +199,24 @@ export class AppGenerateService extends BaseService {
             app.organization_uuid,
             app.project_uuid,
             'Insufficient permissions to access this data app',
-            spaceContext,
+            { ...spaceContext, createdByUserUuid: app.created_by_user_uuid },
         );
     }
 
     /**
      * Permission check for editing/deleting/iterating on an existing data app.
      *
-     * Mirrors `assertCanManageApp`'s shape for charts/dashboards: space
-     * editors and admins inherit manage access via the space context, while
-     * personal (spaceless) apps fall back to the project-wide
-     * `manage:DataApp` rule that only project admins hold.
+     * Mirrors the chart/dashboard pattern: space editors and admins inherit
+     * manage via the space context. For personal (spaceless) apps,
+     * `createdByUserUuid` lets the creator match the self rule. Project
+     * admins always match via the project-wide rule.
      */
     private async assertCanManageApp(
         user: SessionUser,
-        app: Pick<DbApp, 'project_uuid' | 'space_uuid'> & {
+        app: Pick<
+            DbApp,
+            'project_uuid' | 'space_uuid' | 'created_by_user_uuid'
+        > & {
             organization_uuid: string;
         },
         errorMessage: string,
@@ -228,7 +234,11 @@ export class AppGenerateService extends BaseService {
             app.organization_uuid,
             app.project_uuid,
             errorMessage,
-            { ...spaceContext, ...extraContext },
+            {
+                ...spaceContext,
+                createdByUserUuid: app.created_by_user_uuid,
+                ...extraContext,
+            },
         );
     }
 
@@ -395,11 +405,11 @@ export class AppGenerateService extends BaseService {
     ): Promise<{ imageId: string }> {
         await this.assertDataAppsEnabled(user);
 
-        // For iterations the app already exists — use its space context so a
-        // space editor can attach an image. For initial creation the appUuid
-        // is generated client-side and the app row doesn't exist yet, so we
-        // fall back to the project-wide manage check (the create permission
-        // is enforced by `generateApp` itself).
+        // For iterations the app already exists — use its space + creator
+        // context so a space editor or the creator can attach an image. For
+        // initial creation the appUuid is generated client-side and the app
+        // row doesn't exist yet, so we authorize against `create:DataApp`
+        // (anyone who can create an app can stage an image for it).
         const app = await this.appModel.findApp(appUuid, projectUuid);
         if (app) {
             await this.assertCanManageApp(
@@ -411,7 +421,7 @@ export class AppGenerateService extends BaseService {
             const organizationUuid = await this.getProjectOrgUuid(projectUuid);
             this.assertDataAppAbility(
                 user,
-                'manage',
+                'create',
                 organizationUuid,
                 projectUuid,
                 'Insufficient permissions to upload app images',
@@ -2074,7 +2084,7 @@ export class AppGenerateService extends BaseService {
         const organizationUuid = await this.getProjectOrgUuid(projectUuid);
         this.assertDataAppAbility(
             user,
-            'manage',
+            'create',
             organizationUuid,
             projectUuid,
             'Insufficient permissions to create data apps',
@@ -2359,6 +2369,7 @@ export class AppGenerateService extends BaseService {
             project_uuid: projectUuid,
             space_uuid: spaceUuid,
             organization_uuid: organizationUuid,
+            created_by_user_uuid: createdByUserUuid,
         });
 
         return {

--- a/packages/backend/src/models/ResourceViewItemModel.ts
+++ b/packages/backend/src/models/ResourceViewItemModel.ts
@@ -248,6 +248,7 @@ const getApps = async (
             app_uuid: `${AppsTableName}.app_id`,
             name: `${AppsTableName}.name`,
             description: `${AppsTableName}.description`,
+            created_by_user_uuid: `${AppsTableName}.created_by_user_uuid`,
             views: `${AppsTableName}.views_count`,
             first_viewed_at: knex.raw(`${AppsTableName}.created_at`),
             updated_at: knex.raw(
@@ -273,6 +274,7 @@ const getApps = async (
             name: row.name,
             description: row.description || undefined,
             spaceUuid: row.space_uuid,
+            createdByUserUuid: row.created_by_user_uuid,
             updatedAt: row.updated_at,
             updatedByUser: row.updated_by_user_uuid
                 ? {

--- a/packages/backend/src/models/UserFavoritesModel.ts
+++ b/packages/backend/src/models/UserFavoritesModel.ts
@@ -286,6 +286,7 @@ export class UserFavoritesModel {
                 description: `${AppsTableName}.description`,
                 space_uuid: `${SpaceTableName}.space_uuid`,
                 created_at: `${AppsTableName}.created_at`,
+                created_by_user_uuid: `${AppsTableName}.created_by_user_uuid`,
                 views: `${AppsTableName}.views_count`,
                 latest_version_number: 'latest_version.version',
                 latest_version_status: 'latest_version.status',
@@ -304,6 +305,7 @@ export class UserFavoritesModel {
                 name: row.name,
                 description: row.description ?? undefined,
                 spaceUuid: row.space_uuid,
+                createdByUserUuid: row.created_by_user_uuid ?? null,
                 updatedAt: row.latest_version_created_at ?? row.created_at,
                 updatedByUser: row.updated_by_user_uuid
                     ? {

--- a/packages/common/src/authorization/organizationMemberAbility.ts
+++ b/packages/common/src/authorization/organizationMemberAbility.ts
@@ -200,6 +200,20 @@ const applyOrganizationMemberStaticAbilities: Record<
                 },
             },
         });
+        // Create personal data apps; once created, the user can also view
+        // and manage their own. Moving an app into a space is gated
+        // separately by the target space's manage rule.
+        can('create', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+        });
+        can('view', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            createdByUserUuid: member.userUuid,
+        });
+        can('manage', 'DataApp', {
+            organizationUuid: member.organizationUuid,
+            createdByUserUuid: member.userUuid,
+        });
 
         can('manage', 'Space', {
             organizationUuid: member.organizationUuid,

--- a/packages/common/src/authorization/projectMemberAbility.ts
+++ b/packages/common/src/authorization/projectMemberAbility.ts
@@ -164,6 +164,20 @@ export const projectMemberAbilities: Record<
                 },
             },
         });
+        // Create personal data apps; once created, the user can also view
+        // and manage their own. Moving an app into a space is gated
+        // separately by the target space's manage rule.
+        can('create', 'DataApp', {
+            projectUuid: member.projectUuid,
+        });
+        can('view', 'DataApp', {
+            projectUuid: member.projectUuid,
+            createdByUserUuid: member.userUuid,
+        });
+        can('manage', 'DataApp', {
+            projectUuid: member.projectUuid,
+            createdByUserUuid: member.userUuid,
+        });
 
         can('manage', 'Space', {
             projectUuid: member.projectUuid,

--- a/packages/common/src/authorization/roleToScopeMapping.ts
+++ b/packages/common/src/authorization/roleToScopeMapping.ts
@@ -52,6 +52,9 @@ const BASE_ROLE_SCOPES = {
         // Enterprise scopes
         'view:AiAgent',
         'create:AiAgentThread',
+        'create:DataApp', // Personal apps (not yet in a space)
+        'view:DataApp@self', // Own personal apps
+        'manage:DataApp@self', // Own personal apps
     ],
 
     [ProjectMemberRole.EDITOR]: [
@@ -175,6 +178,9 @@ export const getNonEnterpriseScopesForRole = (
         'view:DataApp',
         'manage:DataApp',
         'manage:DataApp@space',
+        'create:DataApp',
+        'view:DataApp@self',
+        'manage:DataApp@self',
         'manage:PersonalAccessToken',
         'manage:PreAggregation',
     ]);

--- a/packages/common/src/authorization/scopes.ts
+++ b/packages/common/src/authorization/scopes.ts
@@ -727,6 +727,37 @@ const scopes: Scope[] = [
             addAccessCondition(context, SpaceMemberRole.ADMIN),
         ],
     },
+    {
+        name: 'create:DataApp',
+        description: 'Create new data apps',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        getConditions: addDefaultUuidCondition,
+    },
+    {
+        name: 'view:DataApp@self',
+        description: 'View own personal data apps',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        getConditions: (context) => [
+            {
+                ...addUuidCondition(context),
+                createdByUserUuid: context.userUuid || false,
+            },
+        ],
+    },
+    {
+        name: 'manage:DataApp@self',
+        description: 'Edit and delete own personal data apps',
+        isEnterprise: false,
+        group: ScopeGroup.AI,
+        getConditions: (context) => [
+            {
+                ...addUuidCondition(context),
+                createdByUserUuid: context.userUuid || false,
+            },
+        ],
+    },
 
     // Spotlight Scopes
     {

--- a/packages/common/src/types/resourceViewItem.ts
+++ b/packages/common/src/types/resourceViewItem.ts
@@ -92,6 +92,7 @@ export type ResourceViewDataAppItem = {
         name: string;
         description: string | undefined;
         spaceUuid: string | null;
+        createdByUserUuid: string | null;
         updatedAt: Date;
         updatedByUser: {
             userUuid: string;
@@ -259,6 +260,7 @@ export const contentToResourceViewItem = (content: SummaryContent) => {
                 name: content.name,
                 description: content.description || undefined,
                 spaceUuid: content.space.uuid,
+                createdByUserUuid: content.createdBy?.uuid ?? null,
                 updatedAt: content.lastUpdatedAt || content.createdAt,
                 updatedByUser: updatedByUser
                     ? {

--- a/packages/frontend/src/components/NavBar/ExploreMenu.tsx
+++ b/packages/frontend/src/components/NavBar/ExploreMenu.tsx
@@ -122,7 +122,7 @@ const ExploreMenu: FC<Props> = memo(({ projectUuid }) => {
 
                         {dataAppsFlag.data?.enabled && (
                             <Can
-                                I="manage"
+                                I="create"
                                 this={subject('DataApp', {
                                     organizationUuid:
                                         user.data?.organizationUuid,

--- a/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
+++ b/packages/frontend/src/components/common/ResourceView/ResourceActionMenu.tsx
@@ -214,6 +214,7 @@ const ResourceViewActionMenu: FC<ResourceViewActionMenuProps> = ({
                         organizationUuid,
                         projectUuid,
                         access: userAccess ? [userAccess] : [],
+                        createdByUserUuid: item.data.createdByUserUuid,
                     }),
                 ) === true;
             break;

--- a/packages/frontend/src/pages/AppGenerate.tsx
+++ b/packages/frontend/src/pages/AppGenerate.tsx
@@ -282,10 +282,11 @@ const AppGenerate: FC = () => {
         isFetchingNextPage,
     } = useGetApp(projectUuid, activeAppUuid ?? urlAppUuid);
 
-    // Derive app name/description/space from fetched data
+    // Derive app name/description/space/creator from fetched data
     const appName = appData?.pages?.[0]?.name ?? '';
     const appDescription = appData?.pages?.[0]?.description ?? '';
     const appSpaceUuid = appData?.pages?.[0]?.spaceUuid ?? null;
+    const appCreatedByUserUuid = appData?.pages?.[0]?.createdByUserUuid ?? null;
 
     // Used to resolve the user's space role when checking manage rights for
     // an existing app — space editors/admins inherit manage on its data app.
@@ -457,28 +458,36 @@ const AppGenerate: FC = () => {
         return <Navigate to={`/projects/${projectUuid}/home`} replace />;
     }
 
-    // For an existing app, manage rights flow through the app's space — a
-    // space editor/admin can iterate on it. For a brand-new app (no
-    // urlAppUuid), space context isn't available, so we fall back to the
-    // project-wide manage check (admin only today).
-    // Wait for the app to load before deciding — without the spaceUuid we
-    // can't tell whether a non-admin space editor should be allowed in.
+    // Two paths: creating a brand-new app (no urlAppUuid) → check `create`;
+    // editing an existing one → check `manage` with the app's space access
+    // and creator context (so space editors and the creator of a personal
+    // app both match).
+    // Wait for the app to load before deciding the existing-app case —
+    // without spaceUuid + createdByUserUuid we'd misjudge a non-admin user.
     if (urlAppUuid && isLoadingApp) {
         return null;
     }
     const userSpaceAccess = appSpaceUuid
         ? spaces.find((s) => s.uuid === appSpaceUuid)?.userAccess
         : undefined;
-    if (
-        !ability.can(
-            'manage',
-            subject('DataApp', {
-                organizationUuid: user.data?.organizationUuid,
-                projectUuid,
-                access: userSpaceAccess ? [userSpaceAccess] : [],
-            }),
-        )
-    ) {
+    const canAccessApp = urlAppUuid
+        ? ability.can(
+              'manage',
+              subject('DataApp', {
+                  organizationUuid: user.data?.organizationUuid,
+                  projectUuid,
+                  access: userSpaceAccess ? [userSpaceAccess] : [],
+                  createdByUserUuid: appCreatedByUserUuid,
+              }),
+          )
+        : ability.can(
+              'create',
+              subject('DataApp', {
+                  organizationUuid: user.data?.organizationUuid,
+                  projectUuid,
+              }),
+          );
+    if (!canAccessApp) {
         return <Navigate to={`/projects/${projectUuid}/home`} replace />;
     }
 
@@ -1190,6 +1199,8 @@ const AppGenerate: FC = () => {
                                             description:
                                                 appDescription || undefined,
                                             spaceUuid: appSpaceUuid,
+                                            createdByUserUuid:
+                                                appCreatedByUserUuid,
                                             updatedAt: new Date(),
                                             updatedByUser: null,
                                             views: 0,

--- a/packages/frontend/src/pages/AppPreviewTest.tsx
+++ b/packages/frontend/src/pages/AppPreviewTest.tsx
@@ -41,6 +41,8 @@ export default function AppPreviewTest() {
     )?.version;
 
     const appSpaceUuid = appQuery.data?.pages[0]?.spaceUuid ?? null;
+    const appCreatedByUserUuid =
+        appQuery.data?.pages[0]?.createdByUserUuid ?? null;
     const { data: spaces = [] } = useSpaceSummaries(projectUuid, true, {});
     const userSpaceAccess = appSpaceUuid
         ? spaces.find((s) => s.uuid === appSpaceUuid)?.userAccess
@@ -52,6 +54,7 @@ export default function AppPreviewTest() {
                 organizationUuid: user.data?.organizationUuid,
                 projectUuid,
                 access: userSpaceAccess ? [userSpaceAccess] : [],
+                createdByUserUuid: appCreatedByUserUuid,
             }),
         ) === true;
 

--- a/packages/frontend/src/pages/Settings.tsx
+++ b/packages/frontend/src/pages/Settings.tsx
@@ -246,7 +246,7 @@ const Settings: FC = () => {
                 ),
             });
         }
-        if (dataAppsFlag?.enabled && user?.ability.can('manage', 'DataApp')) {
+        if (dataAppsFlag?.enabled && user?.ability.can('create', 'DataApp')) {
             allowedRoutes.push({
                 path: '/myApps',
                 element: (
@@ -652,7 +652,7 @@ const Settings: FC = () => {
                                     />
                                 )}
                                 {dataAppsFlag?.enabled &&
-                                    user.ability.can('manage', 'DataApp') && (
+                                    user.ability.can('create', 'DataApp') && (
                                         <RouterNavLink
                                             label="My apps"
                                             exact


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/GLITCH-321/apps-permissions-structure

### Description:
Anyone with the interactive_viewer role (or higher) can now start a new data app from a prompt. Newly-created apps live as "personal" — only visible to the creator and project admins — until the creator moves them into a space, at which point the existing space-based permission model takes over.

Adds three CASL scopes — create:DataApp, view:DataApp@self, manage:DataApp@self — and threads createdByUserUuid through the permission helpers and resource items so the self rules match. Updates the editor page guard, preview "Continue building" menu, "+ New App" entry, and "My apps" settings to use the new create / self checks.
