### PR TITLE
feat(formula): add Athena dialect support

### DIFF
--- a/packages/backend/src/formulaDialectMapper.test.ts
+++ b/packages/backend/src/formulaDialectMapper.test.ts
@@ -15,12 +15,11 @@ describe('mapAdapterToFormulaDialect', () => {
         },
     );
 
-    test.each([SupportedDbtAdapter.TRINO, SupportedDbtAdapter.ATHENA])(
-        'throws for unsupported adapter %s',
-        (adapter) => {
-            expect(() => mapAdapterToFormulaDialect(adapter)).toThrow(
-                `Formula table calculations are not yet supported for ${adapter}`,
-            );
-        },
-    );
+    test('throws for unsupported adapter trino', () => {
+        expect(() =>
+            mapAdapterToFormulaDialect(SupportedDbtAdapter.TRINO),
+        ).toThrow(
+            `Formula table calculations are not yet supported for ${SupportedDbtAdapter.TRINO}`,
+        );
+    });
 });

--- a/packages/backend/src/formulaDialectMapper.ts
+++ b/packages/backend/src/formulaDialectMapper.ts
@@ -34,12 +34,13 @@ export const mapAdapterToFormulaDialect = (
             return 'databricks';
         case SupportedDbtAdapter.CLICKHOUSE:
             return 'clickhouse';
-        // Belt-and-suspenders: the frontend hides the Formula input mode
-        // on unsupported warehouses, but API clients, chart-as-code YAML,
-        // or legacy payloads can still reach this path. Fail loudly
-        // instead of producing broken SQL. TODO(ZAP-324): add these.
-        case SupportedDbtAdapter.TRINO:
         case SupportedDbtAdapter.ATHENA:
+            return 'athena';
+        // Trino support follow-up (ZAP-324). The frontend hides the Formula
+        // input mode for unsupported warehouses, but API clients, chart-as-
+        // code YAML, and legacy payloads can still reach this path. Fail
+        // loudly instead of producing broken SQL.
+        case SupportedDbtAdapter.TRINO:
             throw new Error(
                 `Formula table calculations are not yet supported for ${adapter}`,
             );

--- a/packages/formula-tests/config.ts
+++ b/packages/formula-tests/config.ts
@@ -5,7 +5,8 @@ export type WarehouseType =
     | 'snowflake'
     | 'duckdb'
     | 'databricks'
-    | 'clickhouse';
+    | 'clickhouse'
+    | 'athena';
 
 export const ALL_WAREHOUSES: WarehouseType[] = [
     'duckdb',
@@ -15,6 +16,7 @@ export const ALL_WAREHOUSES: WarehouseType[] = [
     'snowflake',
     'databricks',
     'clickhouse',
+    'athena',
 ];
 
 export type Tier = 'fast' | 'tier1' | 'tier2' | 'all';
@@ -22,13 +24,19 @@ export type Tier = 'fast' | 'tier1' | 'tier2' | 'all';
 // Redshift runs in tier1 alongside Postgres: it shares the formula-package
 // codegen with Postgres (empty subclass — zero overrides), so a tier1 run
 // catches shared-path regressions without waiting for cloud-warehouse tiers.
-// Databricks and ClickHouse run in tier2 alongside BigQuery and Snowflake:
-// cloud / self-hosted warehouses with their own connection latency and
-// infrastructure considerations.
+// Databricks, ClickHouse, Athena run in tier2 alongside BigQuery and
+// Snowflake: cloud / self-hosted warehouses with their own connection
+// latency and infrastructure considerations.
 export const TIER_WAREHOUSES: Record<Tier, WarehouseType[]> = {
     fast: ['duckdb'],
     tier1: ['duckdb', 'postgres', 'redshift'],
-    tier2: ['bigquery', 'snowflake', 'databricks', 'clickhouse'],
+    tier2: [
+        'bigquery',
+        'snowflake',
+        'databricks',
+        'clickhouse',
+        'athena',
+    ],
     all: ALL_WAREHOUSES,
 };
 
@@ -75,6 +83,33 @@ export interface WarehouseConfig {
         password: string;
         database: string;
     };
+    athena: {
+        accessKeyId: string;
+        secretAccessKey: string;
+        region: string;
+        // Athena catalog. Defaults to `AwsDataCatalog` (the Glue catalog).
+        // Surfaced for cross-account or Lake Formation setups that use a
+        // non-default catalog name.
+        catalog: string;
+        // The Glue database tables are created in. Equivalent to Lightdash
+        // project YAML's `schema:` for an Athena adapter.
+        database: string;
+        // Workgroup ('primary' is the AWS default). The workgroup must have
+        // Engine v3 enabled (Trino-based) and a result-output S3 location
+        // configured — Athena rejects every query without one.
+        workgroup: string;
+        // S3 prefix where Iceberg table data lives. Each table seeds into
+        // `s3://<bucket>/<prefix>/<table>/`. Distinct from the staging
+        // location below, which holds query result metadata only — though
+        // both can point at the same bucket with different prefixes.
+        s3Bucket: string;
+        s3Prefix: string;
+        // S3 location where Athena writes query results / metadata. Passed
+        // as `ResultConfiguration.OutputLocation` on every query so the
+        // runner doesn't depend on the workgroup having a default output
+        // location pre-configured. Format: `s3://bucket/path/`.
+        s3StagingDir: string;
+    };
 }
 
 export function getWarehouseConfig(): WarehouseConfig {
@@ -120,6 +155,18 @@ export function getWarehouseConfig(): WarehouseConfig {
             username: process.env.FORMULA_TEST_CH_USERNAME ?? 'default',
             password: process.env.FORMULA_TEST_CH_PASSWORD ?? '',
             database: process.env.FORMULA_TEST_CH_DATABASE ?? 'formula_tests',
+        },
+        athena: {
+            accessKeyId: process.env.FORMULA_TEST_AT_ACCESS_KEY_ID ?? '',
+            secretAccessKey:
+                process.env.FORMULA_TEST_AT_SECRET_ACCESS_KEY ?? '',
+            region: process.env.FORMULA_TEST_AT_REGION ?? '',
+            catalog: process.env.FORMULA_TEST_AT_CATALOG ?? '',
+            database: process.env.FORMULA_TEST_AT_DATABASE ?? '',
+            workgroup: process.env.FORMULA_TEST_AT_WORKGROUP ?? '',
+            s3Bucket: process.env.FORMULA_TEST_AT_S3_BUCKET ?? '',
+            s3Prefix: process.env.FORMULA_TEST_AT_S3_PREFIX ?? '',
+            s3StagingDir: process.env.FORMULA_TEST_AT_S3_STAGING_DIR ?? '',
         },
     };
 }

--- a/packages/formula-tests/fixtures/seed.athena.sql
+++ b/packages/formula-tests/fixtures/seed.athena.sql
@@ -1,0 +1,91 @@
+-- Athena seed. Athena's SQL Engine v3 is Trino, so the query-side syntax
+-- matches `seed.trino.sql` exactly — VALUES, INSERT, DECIMAL/DATE literals
+-- all work the same. The divergence is on the storage side: every Athena
+-- CREATE TABLE needs a backing format + LOCATION. We use Iceberg so the
+-- tables support `INSERT INTO` (Hive external tables don't).
+--
+-- The connection's seed() impl substitutes `__ATHENA_TABLE_LOCATION__` with
+-- `s3://${FORMULA_TEST_AT_S3_BUCKET}/${FORMULA_TEST_AT_S3_PREFIX}/<table>/`
+-- before executing. Each table gets its own subpath so DROP TABLE leaves
+-- the other tables' data intact.
+
+DROP TABLE IF EXISTS test_orders;
+
+CREATE TABLE test_orders (
+    id INT,
+    order_amount DECIMAL(10,2),
+    tax DECIMAL(10,2),
+    discount DECIMAL(10,2),
+    customer_name STRING,
+    category STRING,
+    order_date DATE,
+    quantity INT,
+    is_returned BOOLEAN
+)
+LOCATION '__ATHENA_TABLE_LOCATION__test_orders/'
+TBLPROPERTIES ('table_type'='ICEBERG', 'format'='PARQUET');
+
+INSERT INTO test_orders VALUES
+(1,  DECIMAL '100.00', DECIMAL '10.00', DECIMAL '5.00',  'Alice',   'Electronics', DATE '2024-01-15', 2,  FALSE),
+(2,  DECIMAL '250.50', DECIMAL '25.05', DECIMAL '12.50', 'Bob',     'Clothing',    DATE '2024-02-20', 1,  FALSE),
+(3,  DECIMAL '75.00',  DECIMAL '7.50',  DECIMAL '0.00',  'Charlie', 'Electronics', DATE '2024-03-10', 3,  TRUE),
+(4,  DECIMAL '500.00', DECIMAL '50.00', DECIMAL '25.00', 'Diana',   'Furniture',   DATE '2024-04-05', 1,  FALSE),
+(5,  DECIMAL '30.00',  DECIMAL '3.00',  DECIMAL '1.50',  'Eve',     'Clothing',    DATE '2024-05-12', 5,  FALSE),
+(6,  DECIMAL '180.00', DECIMAL '18.00', DECIMAL '9.00',  'Frank',   'Electronics', DATE '2024-06-18', 2,  TRUE),
+(7,  DECIMAL '420.00', DECIMAL '42.00', DECIMAL '21.00', 'Grace',   'Furniture',   DATE '2024-07-22', 1,  FALSE),
+(8,  DECIMAL '60.00',  DECIMAL '6.00',  DECIMAL '3.00',  'Henry',   'Clothing',    DATE '2024-08-30', 4,  FALSE),
+(9,  DECIMAL '310.00', DECIMAL '31.00', DECIMAL '15.50', 'Ivy',     'Electronics', DATE '2024-09-14', 2,  FALSE),
+(10, DECIMAL '150.00', DECIMAL '15.00', DECIMAL '7.50',  'Jack',    'Furniture',   DATE '2024-10-01', 3,  TRUE);
+
+DROP TABLE IF EXISTS test_nulls;
+
+CREATE TABLE test_nulls (
+    id INT,
+    val_a DECIMAL(10,2),
+    val_b STRING,
+    val_c INT,
+    val_d DATE
+)
+LOCATION '__ATHENA_TABLE_LOCATION__test_nulls/'
+TBLPROPERTIES ('table_type'='ICEBERG', 'format'='PARQUET');
+
+INSERT INTO test_nulls VALUES
+(1, DECIMAL '10.00', 'hello', 100, DATE '2024-01-15'),
+(2, NULL,            'world', 200, NULL),
+(3, DECIMAL '30.00', NULL,    300, DATE '2024-03-10'),
+(4, NULL,            NULL,    400, NULL),
+(5, DECIMAL '50.00', 'test',  500, DATE '2024-05-12');
+
+DROP TABLE IF EXISTS test_window;
+
+CREATE TABLE test_window (
+    id INT,
+    category STRING,
+    amount DECIMAL(10,2),
+    ts TIMESTAMP,
+    rank_val INT
+)
+LOCATION '__ATHENA_TABLE_LOCATION__test_window/'
+TBLPROPERTIES ('table_type'='ICEBERG', 'format'='PARQUET');
+
+INSERT INTO test_window VALUES
+(1,  'A', DECIMAL '100.00', TIMESTAMP '2024-01-01 10:00:00', 10),
+(2,  'A', DECIMAL '200.00', TIMESTAMP '2024-01-02 10:00:00', 20),
+(3,  'A', DECIMAL '150.00', TIMESTAMP '2024-01-03 10:00:00', 15),
+(4,  'A', DECIMAL '300.00', TIMESTAMP '2024-01-04 10:00:00', 30),
+(5,  'A', DECIMAL '250.00', TIMESTAMP '2024-01-05 10:00:00', 25),
+(6,  'B', DECIMAL '50.00',  TIMESTAMP '2024-01-01 11:00:00', 5),
+(7,  'B', DECIMAL '75.00',  TIMESTAMP '2024-01-02 11:00:00', 8),
+(8,  'B', DECIMAL '60.00',  TIMESTAMP '2024-01-03 11:00:00', 6),
+(9,  'B', DECIMAL '90.00',  TIMESTAMP '2024-01-04 11:00:00', 9),
+(10, 'B', DECIMAL '80.00',  TIMESTAMP '2024-01-05 11:00:00', 7),
+(11, 'C', DECIMAL '500.00', TIMESTAMP '2024-01-01 12:00:00', 50),
+(12, 'C', DECIMAL '400.00', TIMESTAMP '2024-01-02 12:00:00', 40),
+(13, 'C', DECIMAL '450.00', TIMESTAMP '2024-01-03 12:00:00', 45),
+(14, 'C', DECIMAL '350.00', TIMESTAMP '2024-01-04 12:00:00', 35),
+(15, 'C', DECIMAL '550.00', TIMESTAMP '2024-01-05 12:00:00', 55),
+(16, 'D', DECIMAL '10.00',  TIMESTAMP '2024-01-01 13:00:00', 1),
+(17, 'D', DECIMAL '20.00',  TIMESTAMP '2024-01-02 13:00:00', 2),
+(18, 'D', DECIMAL '15.00',  TIMESTAMP '2024-01-03 13:00:00', 3),
+(19, 'D', DECIMAL '25.00',  TIMESTAMP '2024-01-04 13:00:00', 4),
+(20, 'D', DECIMAL '30.00',  TIMESTAMP '2024-01-05 13:00:00', 5);

--- a/packages/formula-tests/package.json
+++ b/packages/formula-tests/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@lightdash/formula": "workspace:*",
+    "@aws-sdk/client-athena": "3.1000.0",
     "@clickhouse/client": "1.11.1",
     "@databricks/sql": "1.10.0",
     "@google-cloud/bigquery": "7.9.2",

--- a/packages/formula-tests/runner/executor.ts
+++ b/packages/formula-tests/runner/executor.ts
@@ -13,6 +13,13 @@ function normalizeValue(val: any): any {
     if (typeof val === 'number') return val;
     if (typeof val === 'boolean') return val;
     if (typeof val === 'string') {
+        // Athena's GetQueryResults marshals every cell as a `VarCharValue`
+        // string, including booleans. Recognise the canonical lowercase
+        // forms so a comparison query returning `true` matches the
+        // expected boolean. Other warehouses already return a typed
+        // bool/number and skip this branch.
+        if (val === 'true') return true;
+        if (val === 'false') return false;
         const num = Number(val);
         if (!isNaN(num) && val.trim() !== '') return num;
         return val;

--- a/packages/formula-tests/runner/warehouse-connections.ts
+++ b/packages/formula-tests/runner/warehouse-connections.ts
@@ -303,6 +303,185 @@ export async function createBigQueryConnection(
     };
 }
 
+export async function createAthenaConnection(
+    config: WarehouseConfig['athena'],
+): Promise<WarehouseConnection> {
+    const missing: string[] = [];
+    if (!config.accessKeyId) missing.push('FORMULA_TEST_AT_ACCESS_KEY_ID');
+    if (!config.secretAccessKey)
+        missing.push('FORMULA_TEST_AT_SECRET_ACCESS_KEY');
+    if (!config.region) missing.push('FORMULA_TEST_AT_REGION');
+    if (!config.catalog) missing.push('FORMULA_TEST_AT_CATALOG');
+    if (!config.database) missing.push('FORMULA_TEST_AT_DATABASE');
+    if (!config.workgroup) missing.push('FORMULA_TEST_AT_WORKGROUP');
+    if (!config.s3Bucket) missing.push('FORMULA_TEST_AT_S3_BUCKET');
+    if (!config.s3Prefix) missing.push('FORMULA_TEST_AT_S3_PREFIX');
+    if (!config.s3StagingDir) missing.push('FORMULA_TEST_AT_S3_STAGING_DIR');
+    if (missing.length > 0) {
+        throw new Error(
+            `Athena connection requires the following env vars: ${missing.join(', ')}`,
+        );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const {
+        AthenaClient,
+        StartQueryExecutionCommand,
+        GetQueryExecutionCommand,
+        GetQueryResultsCommand,
+    } = require('@aws-sdk/client-athena');
+
+    const client = new AthenaClient({
+        region: config.region,
+        credentials: {
+            accessKeyId: config.accessKeyId,
+            secretAccessKey: config.secretAccessKey,
+        },
+    });
+
+    // Iceberg seed paths use a `__ATHENA_TABLE_LOCATION__` placeholder —
+    // substitute with the per-table S3 path before executing CREATE TABLE.
+    const tableLocationBase = `s3://${config.s3Bucket}/${config.s3Prefix.replace(/\/$/, '')}/`;
+
+    const startQuery = async (sql: string): Promise<string> => {
+        const out = await client.send(
+            new StartQueryExecutionCommand({
+                QueryString: sql,
+                QueryExecutionContext: {
+                    Catalog: config.catalog,
+                    Database: config.database,
+                },
+                WorkGroup: config.workgroup,
+                // Always send OutputLocation so the runner works even when
+                // the workgroup has no default output location configured.
+                ResultConfiguration: {
+                    OutputLocation: config.s3StagingDir,
+                },
+            }),
+        );
+        const id = out.QueryExecutionId as string | undefined;
+        if (!id) throw new Error('Athena did not return a QueryExecutionId');
+        return id;
+    };
+
+    const waitForQuery = async (id: string): Promise<void> => {
+        // Athena queries are async: poll until SUCCEEDED / FAILED / CANCELLED.
+        // 200ms backoff matches Lightdash's production AthenaWarehouseClient
+        // poll interval.
+        const POLL_INTERVAL_MS = 200;
+        const MAX_POLL_ATTEMPTS = 1500; // 5 minutes upper bound
+        for (let i = 0; i < MAX_POLL_ATTEMPTS; i += 1) {
+            // eslint-disable-next-line no-await-in-loop
+            const status = await client.send(
+                new GetQueryExecutionCommand({ QueryExecutionId: id }),
+            );
+            const state = status.QueryExecution?.Status?.State;
+            if (state === 'SUCCEEDED') return;
+            if (state === 'FAILED' || state === 'CANCELLED') {
+                const reason =
+                    status.QueryExecution?.Status?.StateChangeReason ?? state;
+                throw new Error(`Athena query ${state}: ${reason}`);
+            }
+            // eslint-disable-next-line no-await-in-loop
+            await new Promise((r) => {
+                setTimeout(r, POLL_INTERVAL_MS);
+            });
+        }
+        throw new Error('Athena query timed out');
+    };
+
+    const fetchResults = async (
+        id: string,
+    ): Promise<Record<string, any>[]> => {
+        // Page through GetQueryResults. The first row of the first page is
+        // the column-name header per Athena's wire format — drop it.
+        let nextToken: string | undefined;
+        let columnNames: string[] | undefined;
+        const out: Record<string, any>[] = [];
+        let isFirstPage = true;
+        do {
+            // eslint-disable-next-line no-await-in-loop
+            const page = await client.send(
+                new GetQueryResultsCommand({
+                    QueryExecutionId: id,
+                    NextToken: nextToken,
+                }),
+            );
+            const rows = page.ResultSet?.Rows ?? [];
+            if (!columnNames) {
+                columnNames =
+                    page.ResultSet?.ResultSetMetadata?.ColumnInfo?.map(
+                        (c: { Name: string }) => c.Name,
+                    ) ?? [];
+            }
+            const startIdx = isFirstPage ? 1 : 0;
+            const cols = columnNames ?? [];
+            for (let i = startIdx; i < rows.length; i += 1) {
+                const cells = rows[i].Data ?? [];
+                const obj: Record<string, any> = {};
+                cols.forEach((name, j) => {
+                    obj[name] = cells[j]?.VarCharValue ?? null;
+                });
+                out.push(obj);
+            }
+            isFirstPage = false;
+            nextToken = page.NextToken;
+        } while (nextToken);
+        return out;
+    };
+
+    const execute = async (
+        sql: string,
+    ): Promise<Record<string, any>[]> => {
+        const id = await startQuery(sql);
+        await waitForQuery(id);
+        return fetchResults(id);
+    };
+
+    const executeWithoutResults = async (sql: string): Promise<void> => {
+        const id = await startQuery(sql);
+        await waitForQuery(id);
+    };
+
+    // CREATE DATABASE IF NOT EXISTS isn't a Glue catalog operation that
+    // takes a `Database:` context (you can't ask Glue for the metadata of
+    // a database that doesn't exist yet). Issue it without one.
+    const ensureDatabase = async (): Promise<void> => {
+        const out = await client.send(
+            new StartQueryExecutionCommand({
+                QueryString: `CREATE DATABASE IF NOT EXISTS ${config.database}`,
+                QueryExecutionContext: { Catalog: config.catalog },
+                WorkGroup: config.workgroup,
+                ResultConfiguration: {
+                    OutputLocation: config.s3StagingDir,
+                },
+            }),
+        );
+        const id = out.QueryExecutionId as string | undefined;
+        if (!id) throw new Error('Athena did not return a QueryExecutionId');
+        await waitForQuery(id);
+    };
+
+    return {
+        dialect: 'athena',
+        execute,
+        async seed(sql: string) {
+            await ensureDatabase();
+            const substituted = sql.replaceAll(
+                '__ATHENA_TABLE_LOCATION__',
+                tableLocationBase,
+            );
+            for (const stmt of splitSqlStatements(substituted)) {
+                // DDL/DML — no result rows to fetch.
+                await executeWithoutResults(stmt);
+            }
+        },
+        async close() {
+            client.destroy();
+        },
+    };
+}
+
 export async function createConnection(
     warehouse: WarehouseType,
     config: WarehouseConfig,
@@ -322,6 +501,8 @@ export async function createConnection(
             return createDatabricksConnection(config.databricks);
         case 'clickhouse':
             return createClickhouseConnection(config.clickhouse);
+        case 'athena':
+            return createAthenaConnection(config.athena);
         default: {
             const _exhaustive: never = warehouse;
             throw new Error(`Unknown warehouse: ${warehouse}`);

--- a/packages/formula/src/codegen/dialects.ts
+++ b/packages/formula/src/codegen/dialects.ts
@@ -106,6 +106,18 @@ const ansiQuoteWithEscapedBackslashesStringLiteral = (
     return `'${escaped}'`;
 };
 
+// Pure ANSI: only single-quote doubling, backslashes are literal. Used by
+// Trino / Athena, whose lexers do NOT support backslash escapes — `'\\'`
+// is two characters, not one. Doubling backslashes here would silently
+// corrupt user data round-trips. (Trino docs: "Escape codes are not
+// supported in string literals.")
+const ansiSingleQuoteDoubleStringLiteral = (
+    node: StringLiteralNode,
+): string => {
+    const escaped = node.value.replace(/'/g, "''");
+    return `'${escaped}'`;
+};
+
 const infixPercentModulo = (left: string, right: string): string =>
     `(${left} % ${right})`;
 
@@ -413,6 +425,57 @@ const CLICKHOUSE_CONFIG: DialectConfig = {
     },
 };
 
+// Trino / Athena config. Athena's SQL Engine v3 is Trino, and
+// `packages/common/src/utils/timeFrames.ts` wires both adapters to the
+// same `trinoConfig`. Currently only `athena` maps to this here; the
+// `trino` dialect lands in a follow-up (ZAP-324) and reuses this entry
+// unchanged. Mirrors `TrinoSqlBuilder` / `AthenaSqlBuilder` in
+// `packages/warehouses` (escapeString, getIntervalSql, getMetricSql, etc.).
+//
+// Key shape divergences from the Postgres family:
+//   - INTERVAL: `INTERVAL '<n>' <UNIT>` (value quoted, unit bare) — not
+//     `INTERVAL '<n> <unit>'`. Matches `TrinoSqlBuilder.getIntervalSql`.
+//   - DATE_ADD: `date_add('unit', n, x)` is the idiomatic form. Multiplying
+//     interval literals isn't reliable across Trino versions, and `date_add`
+//     supports `quarter` directly so the Postgres ×3-months trick isn't
+//     needed.
+//   - DATE_DIFF: `date_diff('unit', start, end)` — same shape as ClickHouse.
+//   - LAST_DAY_OF_MONTH: native in Trino since 401, available on Athena
+//     Engine v3. We emit it directly rather than composing.
+//   - AVG / ROUND: native, no cast wrappers (Trino's AVG returns DOUBLE,
+//     ROUND on DOUBLE/DECIMAL works with no precision-truncation footgun).
+const TRINO_CONFIG: DialectConfig = {
+    quoteIdentifier: doubleQuoteIdentifier,
+    // Pure single-quote doubling. Trino / Athena lexers DO NOT unescape
+    // backslashes — `'\\'` is two characters, not one — so doubling
+    // backslashes the way the Postgres-family helper does would corrupt
+    // user data on round-trip. (`TrinoSqlBuilder.escapeString` in
+    // packages/warehouses doubles backslashes too; that's a latent bug for
+    // any string with a literal `\`. We deliberately diverge from it here
+    // and use the ANSI-correct form.)
+    generateStringLiteral: ansiSingleQuoteDoubleStringLiteral,
+    // Trino / Athena `CONCAT` requires two or more arguments — calling it
+    // with a single arg fails with "There must be two or more concatenation
+    // arguments". Pass single-arg through unchanged; otherwise use the
+    // ANSI form. Postgres-family `||` would also work but `CONCAT` keeps
+    // emission identical to a metric-level concat over the same columns.
+    generateConcat: (args) =>
+        args.length === 1 ? args[0] : `CONCAT(${args.join(', ')})`,
+    generateLastDay: (arg) => `LAST_DAY_OF_MONTH(${arg})`,
+    // ANSI `DATE_TRUNC('unit', d)` with Trino-flavoured INTERVAL for
+    // non-Monday week start. Mirrors `trinoConfig.getSqlForTruncatedDate`
+    // in `packages/common/src/utils/timeFrames.ts`.
+    generateDateTrunc: (unit, arg, weekStartDay) => {
+        if (unit === 'week' && weekStartDay !== 0) {
+            return `(DATE_TRUNC('week', (${arg} - INTERVAL '${weekStartDay}' DAY)) + INTERVAL '${weekStartDay}' DAY)`;
+        }
+        return `DATE_TRUNC('${unit}', ${arg})`;
+    },
+    generateDateAdd: (unit, date, n) => `DATE_ADD('${unit}', ${n}, ${date})`,
+    generateDateDiff: (unit, start, end) =>
+        `DATE_DIFF('${unit}', ${start}, ${end})`,
+};
+
 export const DIALECTS: Record<Dialect, DialectConfig> = {
     postgres: POSTGRES_CONFIG,
     redshift: REDSHIFT_CONFIG,
@@ -421,4 +484,5 @@ export const DIALECTS: Record<Dialect, DialectConfig> = {
     duckdb: DUCKDB_CONFIG,
     databricks: DATABRICKS_CONFIG,
     clickhouse: CLICKHOUSE_CONFIG,
+    athena: TRINO_CONFIG,
 };

--- a/packages/formula/src/codegen/dialects.ts
+++ b/packages/formula/src/codegen/dialects.ts
@@ -201,6 +201,15 @@ const POSTGRES_CONFIG: DialectConfig = {
 const REDSHIFT_CONFIG: DialectConfig = {
     ...POSTGRES_CONFIG,
     generateStringLiteral: ansiQuoteWithEscapedBackslashesStringLiteral,
+    // Redshift's bare `(x)::numeric` defaults to `numeric(18, 0)` and
+    // truncates the input to an integer before rounding, so e.g.
+    // `ROUND(50.5::numeric, 1)` returns 50, not 50.5. Postgres' unbounded
+    // numeric keeps full precision and isn't affected. Pin precision/scale
+    // so ROUND(x, n) keeps decimals on Redshift.
+    generateRound: (value, digits) =>
+        digits !== undefined
+            ? `ROUND((${value})::numeric(38, 10), ${digits})`
+            : `ROUND(${value})`,
     generateLagLead: ({ sqlFunc, args, emitWindow }) => {
         if (args.length >= 3) {
             const [value, offset, defaultValue] = args;

--- a/packages/formula/src/index.ts
+++ b/packages/formula/src/index.ts
@@ -36,6 +36,7 @@ export const SUPPORTED_DIALECTS = [
     'duckdb',
     'databricks',
     'clickhouse',
+    'athena',
 ] as const satisfies readonly Dialect[];
 
 type MissingSupportedDialect = Exclude<

--- a/packages/formula/src/types.ts
+++ b/packages/formula/src/types.ts
@@ -18,7 +18,8 @@ export type Dialect =
     | 'snowflake'
     | 'duckdb'
     | 'databricks'
-    | 'clickhouse';
+    | 'clickhouse'
+    | 'athena';
 
 // Whitelisted units accepted by date functions (DATE_TRUNC today; DATE_ADD,
 // DATE_SUB, DATE_DIFF in follow-up PRs). Validated at parse time so bad units

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -270,13 +270,17 @@ describe('codegen', () => {
             ).toBe('ROUND(("revenue")::numeric, 2)');
         });
 
-        it('casts value to numeric on Redshift for the 2-arg form', () => {
+        it('pins numeric precision on Redshift so ROUND keeps decimals', () => {
+            // Bare `(x)::numeric` on Redshift means numeric(18, 0) — the
+            // input is truncated to an integer before ROUND runs, so
+            // ROUND(50.5, 1) returns 50. Pinning to numeric(38, 10) keeps
+            // the decimal payload through ROUND.
             expect(
                 compile('=ROUND(revenue, 2)', {
                     dialect: 'redshift',
                     columns,
                 }),
-            ).toBe('ROUND(("revenue")::numeric, 2)');
+            ).toBe('ROUND(("revenue")::numeric(38, 10), 2)');
         });
 
         it('leaves the 1-arg form uncast on Postgres', () => {

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -415,6 +415,94 @@ describe('codegen', () => {
         });
     });
 
+    describe('Athena dialect', () => {
+        // Athena's SQL Engine v3 is Trino. The formula package wires it
+        // through a `TRINO_CONFIG` shared with the (forthcoming) `trino`
+        // dialect. These tests pin the cross-cutting behaviour against
+        // `athena` so the codegen is locked in independently of the trino
+        // entry that will land next.
+
+        it('emits bare aggregates with double-quoted identifiers and ANSI string literals', () => {
+            expect(
+                compile('=SUMIF(revenue, region = "EU")', {
+                    dialect: 'athena',
+                    columns,
+                }),
+            ).toBe(`SUM(CASE WHEN ("region" = 'EU') THEN "revenue" END)`);
+        });
+
+        it('AVG stays bare (no DOUBLE PRECISION cast)', () => {
+            // Mirrors `AthenaSqlBuilder.getMetricSql` AVERAGE path, which
+            // defers to base `getDefaultMetricSql` returning `AVG(${sql})`.
+            expect(
+                compile('=AVG(revenue)', {
+                    dialect: 'athena',
+                    columns,
+                }),
+            ).toBe('AVG("revenue")');
+        });
+
+        it('ROUND stays bare in the 2-arg form (no numeric cast)', () => {
+            // Athena's ROUND works on DOUBLE/DECIMAL natively without the
+            // Postgres-family numeric-cast workaround.
+            expect(
+                compile('=ROUND(revenue, 2)', {
+                    dialect: 'athena',
+                    columns,
+                }),
+            ).toBe('ROUND("revenue", 2)');
+        });
+
+        it('CONCAT emits the base CONCAT(...) form for 2+ args', () => {
+            // Mirrors `AthenaSqlBuilder` falling through to
+            // `WarehouseBaseSqlBuilder.concatString`.
+            expect(
+                compile('=CONCAT(customer_name, " — ", category)', {
+                    dialect: 'athena',
+                    columns: { customer_name: 'name', category: 'cat' },
+                }),
+            ).toBe(`CONCAT("name", ' — ', "cat")`);
+        });
+
+        it('CONCAT with a single arg passes through unchanged', () => {
+            // Athena rejects `CONCAT('x')` with "There must be two or more
+            // concatenation arguments". The dialect detects the 1-arg case
+            // and emits the bare value.
+            expect(
+                compile('=CONCAT("*")', {
+                    dialect: 'athena',
+                    columns,
+                }),
+            ).toBe(`'*'`);
+        });
+
+        it('escapes single quotes by doubling them in string literals', () => {
+            // Mirrors `AthenaSqlBuilder.escapeString`. Backslashes are
+            // intentionally NOT escaped: Athena's lexer doesn't unescape
+            // `\\` so doubling them would corrupt user data on round-trip.
+            expect(
+                compile(`=IF(region = "O'Brien", 1, 0)`, {
+                    dialect: 'athena',
+                    columns: { region: 'region' },
+                }),
+            ).toBe(`CASE WHEN ("region" = 'O''Brien') THEN 1 ELSE 0 END`);
+        });
+
+        it('non-Monday weekStartDay propagates through DATE_DIFF composition', () => {
+            // Sanity-check that the DATE_TRUNC override is what
+            // generateDateDiff composes through for non-Monday weeks.
+            expect(
+                compile('=DATE_DIFF(a, b, "week")', {
+                    dialect: 'athena',
+                    columns: { a: 'a', b: 'b' },
+                    weekStartDay: 6,
+                }),
+            ).toBe(
+                `(DATE_DIFF('day', (DATE_TRUNC('week', ("a" - INTERVAL '6' DAY)) + INTERVAL '6' DAY), (DATE_TRUNC('week', ("b" - INTERVAL '6' DAY)) + INTERVAL '6' DAY)) / 7)`,
+            );
+        });
+    });
+
     describe('LAST_DAY', () => {
         const postgresStyleLastDay = `CAST(DATE_TRUNC('month', "order_date") + INTERVAL '1 month' - INTERVAL '1 day' AS DATE)`;
 
@@ -428,6 +516,10 @@ describe('codegen', () => {
             // the Postgres-style INTERVAL '1 month' composition outright.
             ['redshift', 'LAST_DAY("order_date")'],
             ['clickhouse', 'toLastDayOfMonth("order_date")'],
+            // Athena: native LAST_DAY_OF_MONTH (SQL Engine v3 = Trino,
+            // available since Trino 401). Distinct name from the *_DAY
+            // variants above.
+            ['athena', 'LAST_DAY_OF_MONTH("order_date")'],
         ] as const)('%s → %s', (dialect, expected) => {
             expect(
                 compile('=LAST_DAY(order_date)', { dialect, columns }),
@@ -460,6 +552,8 @@ describe('codegen', () => {
             ['clickhouse', 'month', 'toStartOfMonth("order_date")'],
             ['clickhouse', 'quarter', 'toStartOfQuarter("order_date")'],
             ['clickhouse', 'year', 'toStartOfYear("order_date")'],
+            // Athena: ANSI form, same as Postgres.
+            ['athena', 'month', `DATE_TRUNC('month', "order_date")`],
         ] as const)('%s DATE_TRUNC("%s", …) → %s', (dialect, unit, expected) => {
             expect(
                 compile(`=DATE_TRUNC("${unit}", order_date)`, {
@@ -517,6 +611,23 @@ describe('codegen', () => {
                 );
             });
 
+            it('Athena offsets in/out with Trino-flavoured INTERVAL', () => {
+                // Distinct from the Postgres shape: Athena's INTERVAL has
+                // the value quoted and the unit bare (`'6' DAY`, not
+                // `'6 days'`). Mirrors `trinoConfig.getSqlForTruncatedDate`
+                // in `packages/common/src/utils/timeFrames.ts` (Athena maps
+                // to that config because its SQL Engine v3 is Trino).
+                expect(
+                    compile('=DATE_TRUNC("week", order_date)', {
+                        dialect: 'athena',
+                        columns,
+                        weekStartDay: 6,
+                    }),
+                ).toBe(
+                    `(DATE_TRUNC('week', ("order_date" - INTERVAL '6' DAY)) + INTERVAL '6' DAY)`,
+                );
+            });
+
             it('Monday (default) leaves the base form intact on Postgres', () => {
                 expect(
                     compile('=DATE_TRUNC("week", order_date)', {
@@ -539,6 +650,11 @@ describe('codegen', () => {
             ['snowflake', 'DATEADD(MONTH, 3, "order_date")'],
             ['databricks', 'ADD_MONTHS(`order_date`, 3)'],
             ['clickhouse', 'addMonths("order_date", 3)'],
+            // Athena uses date_add(unit, n, x) — function form chosen over
+            // INTERVAL because Athena/Trino don't allow `expr * INTERVAL
+            // '1' DAY` (interval × runtime expr). Function form takes any
+            // int expression for n.
+            ['athena', `DATE_ADD('month', 3, "order_date")`],
         ] as const)('%s → %s', (dialect, expected) => {
             expect(
                 compile('=DATE_ADD(order_date, 3, "month")', {
@@ -647,6 +763,10 @@ describe('codegen', () => {
             // DuckDB + ClickHouse — quoted unit.
             ['duckdb', 'month', `date_diff('month', "a", "b")`],
             ['clickhouse', 'month', `dateDiff('month', "a", "b")`],
+            // Athena: same shape as ClickHouse — quoted unit, function
+            // form. Mirrors `AthenaSqlBuilder.getTimestampDiffSeconds`
+            // which emits `DATE_DIFF('second', start, end)` in production.
+            ['athena', 'month', `DATE_DIFF('month', "a", "b")`],
         ] as const)('%s DATE_DIFF(a, b, "%s") → %s', (dialect, unit, expected) => {
             expect(
                 compile(`=DATE_DIFF(a, b, "${unit}")`, {

--- a/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
+++ b/packages/frontend/src/features/tableCalculation/components/TableCalculationModal.tsx
@@ -146,8 +146,8 @@ const TableCalculationModal: FC<Props> = ({
     const { data: health } = useHealth();
 
     // Formula support is pinned to what the formula package can compile for
-    // this warehouse. The backend mapper throws for unsupported adapters, so
-    // we must not offer the input mode here either.
+    // this warehouse — `SUPPORTED_DIALECTS` is the single source of truth
+    // shared with the backend mapper.
     const isFormulaSupported =
         !!project?.warehouseConnection &&
         (SUPPORTED_DIALECTS as readonly string[]).includes(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -876,6 +876,9 @@ importers:
 
   packages/formula-tests:
     dependencies:
+      '@aws-sdk/client-athena':
+        specifier: 3.1000.0
+        version: 3.1000.0
       '@clickhouse/client':
         specifier: 1.11.1
         version: 1.11.1
@@ -1348,7 +1351,7 @@ importers:
         version: 8.3.4
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2))
+        version: 6.0.1(vite@8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.25.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2))
       csstype:
         specifier: 3.2.3
         version: 3.2.3
@@ -1451,7 +1454,7 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2))
+        version: 6.0.1(vite@8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.25.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2))
       eslint:
         specifier: 8.57.1
         version: 8.57.1
@@ -1559,7 +1562,7 @@ importers:
         version: 19.2.2(@types/react@19.2.2)
       '@vitejs/plugin-react':
         specifier: 6.0.1
-        version: 6.0.1(vite@8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2))
+        version: 6.0.1(vite@8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.25.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2))
       dotenv:
         specifier: 16.6.1
         version: 16.6.1
@@ -9903,15 +9906,6 @@ packages:
   fn.name@1.1.0:
     resolution: {integrity: sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==}
 
-  follow-redirects@1.15.9:
-    resolution: {integrity: sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==}
-    engines: {node: '>=4.0'}
-    peerDependencies:
-      debug: '*'
-    peerDependenciesMeta:
-      debug:
-        optional: true
-
   follow-redirects@1.16.0:
     resolution: {integrity: sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==}
     engines: {node: '>=4.0'}
@@ -16511,7 +16505,7 @@ snapshots:
   '@apm-js-collab/tracing-hooks@0.3.1':
     dependencies:
       '@apm-js-collab/code-transformer': 0.8.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -17427,11 +17421,11 @@ snapshots:
       '@babel/helpers': 7.28.4
       '@babel/parser': 7.29.0
       '@babel/template': 7.27.2
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.28.4(supports-color@5.5.0)
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -17503,7 +17497,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       lodash.debounce: 4.0.8
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -17514,13 +17508,6 @@ snapshots:
   '@babel/helper-member-expression-to-functions@7.28.5':
     dependencies:
       '@babel/traverse': 7.29.0
-      '@babel/types': 7.29.0
-    transitivePeerDependencies:
-      - supports-color
-
-  '@babel/helper-module-imports@7.27.1':
-    dependencies:
-      '@babel/traverse': 7.28.4
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -17542,9 +17529,9 @@ snapshots:
   '@babel/helper-module-transforms@7.28.3(@babel/core@7.28.4)':
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/helper-validator-identifier': 7.28.5
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.28.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -17583,7 +17570,7 @@ snapshots:
 
   '@babel/helper-skip-transparent-expression-wrappers@7.27.1':
     dependencies:
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.28.4(supports-color@5.5.0)
       '@babel/types': 7.29.0
     transitivePeerDependencies:
       - supports-color
@@ -17874,7 +17861,7 @@ snapshots:
       '@babel/core': 7.28.4
       '@babel/helper-compilation-targets': 7.28.6
       '@babel/helper-plugin-utils': 7.28.6
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.28.4(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18249,18 +18236,6 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/types': 7.29.0
 
-  '@babel/traverse@7.28.4':
-    dependencies:
-      '@babel/code-frame': 7.27.1
-      '@babel/generator': 7.28.3
-      '@babel/helper-globals': 7.28.0
-      '@babel/parser': 7.29.0
-      '@babel/template': 7.27.2
-      '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
-    transitivePeerDependencies:
-      - supports-color
-
   '@babel/traverse@7.28.4(supports-color@5.5.0)':
     dependencies:
       '@babel/code-frame': 7.27.1
@@ -18281,7 +18256,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -18514,7 +18489,7 @@ snapshots:
 
   '@emotion/babel-plugin@11.10.6':
     dependencies:
-      '@babel/helper-module-imports': 7.27.1
+      '@babel/helper-module-imports': 7.27.1(supports-color@5.5.0)
       '@babel/runtime': 7.28.6
       '@emotion/hash': 0.9.0
       '@emotion/memoize': 0.8.0
@@ -18756,7 +18731,7 @@ snapshots:
   '@eslint/eslintrc@2.1.4':
     dependencies:
       ajv: 6.12.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       espree: 9.6.1
       globals: 13.24.0
       ignore: 5.3.2
@@ -19099,7 +19074,7 @@ snapshots:
   '@humanwhocodes/config-array@0.13.0':
     dependencies:
       '@humanwhocodes/object-schema': 2.0.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 3.1.2
     transitivePeerDependencies:
       - supports-color
@@ -19479,7 +19454,7 @@ snapshots:
 
   '@kwsites/file-exists@1.1.1':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -20702,7 +20677,7 @@ snapshots:
 
   '@pm2/pm2-version-check@1.0.4':
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -23096,7 +23071,7 @@ snapshots:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.0-beta)
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
     optionalDependencies:
       typescript: 6.0.0-beta
@@ -23109,7 +23084,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(typescript@6.0.0-beta)
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       typescript: 6.0.0-beta
     transitivePeerDependencies:
@@ -23119,7 +23094,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.0-beta)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.0-beta
     transitivePeerDependencies:
       - supports-color
@@ -23128,7 +23103,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -23137,7 +23112,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.0-beta)
       '@typescript-eslint/types': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       typescript: 6.0.0-beta
     transitivePeerDependencies:
       - supports-color
@@ -23178,7 +23153,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/typescript-estree': 7.18.0(typescript@6.0.0-beta)
       '@typescript-eslint/utils': 7.18.0(eslint@8.57.1)(typescript@6.0.0-beta)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       ts-api-utils: 1.4.3(typescript@6.0.0-beta)
     optionalDependencies:
@@ -23191,7 +23166,7 @@ snapshots:
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/typescript-estree': 8.43.0(typescript@6.0.0-beta)
       '@typescript-eslint/utils': 8.43.0(eslint@8.57.1)(typescript@6.0.0-beta)
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       eslint: 8.57.1
       ts-api-utils: 2.4.0(typescript@6.0.0-beta)
       typescript: 6.0.0-beta
@@ -23210,7 +23185,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 5.62.0
       '@typescript-eslint/visitor-keys': 5.62.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.7.3
@@ -23224,7 +23199,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 7.18.0
       '@typescript-eslint/visitor-keys': 7.18.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       globby: 11.1.0
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -23241,7 +23216,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.43.0(typescript@6.0.0-beta)
       '@typescript-eslint/types': 8.43.0
       '@typescript-eslint/visitor-keys': 8.43.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-glob: 3.3.3
       is-glob: 4.0.3
       minimatch: 9.0.5
@@ -23257,7 +23232,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.2
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -23272,7 +23247,7 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.56.1(typescript@6.0.0-beta)
       '@typescript-eslint/types': 8.56.1
       '@typescript-eslint/visitor-keys': 8.56.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       minimatch: 10.2.2
       semver: 7.7.3
       tinyglobby: 0.2.15
@@ -23406,7 +23381,7 @@ snapshots:
 
   '@vercel/oidc@3.1.0': {}
 
-  '@vitejs/plugin-react@6.0.1(vite@8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2))':
+  '@vitejs/plugin-react@6.0.1(vite@8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.25.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       vite: 8.0.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.7.0)(@types/node@24.3.1)(esbuild@0.25.11)(jiti@2.6.1)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2)
@@ -23701,7 +23676,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -24112,7 +24087,7 @@ snapshots:
 
   axios@1.13.5:
     dependencies:
-      follow-redirects: 1.16.0
+      follow-redirects: 1.16.0(debug@4.3.7)
       form-data: 4.0.5
       proxy-from-env: 1.1.0
     transitivePeerDependencies:
@@ -24349,7 +24324,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-errors: 2.0.0
       iconv-lite: 0.7.0
       on-finished: 2.4.1
@@ -25196,7 +25171,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fast-shuffle: 6.1.0
       find-cypress-specs: 1.54.11(@babel/core@7.28.4)
       globby: 11.1.0
@@ -26127,7 +26102,7 @@ snapshots:
       '@es-joy/resolve.exports': 1.2.0
       are-docs-informative: 0.0.2
       comment-parser: 1.4.5
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
       eslint: 8.57.1
       espree: 11.1.0
@@ -26245,7 +26220,7 @@ snapshots:
       ajv: 6.12.6
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       doctrine: 3.0.0
       escape-string-regexp: 4.0.0
       eslint-scope: 7.2.2
@@ -26483,7 +26458,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -26532,7 +26507,7 @@ snapshots:
 
   extrareqp2@1.0.0(debug@4.3.7):
     dependencies:
-      follow-redirects: 1.15.9(debug@4.3.7)
+      follow-redirects: 1.16.0(debug@4.3.7)
     transitivePeerDependencies:
       - debug
 
@@ -26688,7 +26663,7 @@ snapshots:
 
   finalhandler@2.1.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -26702,7 +26677,7 @@ snapshots:
       '@actions/core': 2.0.3
       arg: 5.0.2
       console.table: 0.10.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       find-test-names: 1.29.19(@babel/core@7.28.4)
       minimatch: 10.2.5
       pluralize: 8.0.0
@@ -26726,7 +26701,7 @@ snapshots:
       '@babel/parser': 7.29.0
       '@babel/plugin-syntax-jsx': 7.27.1(@babel/core@7.28.4)
       acorn-walk: 8.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       simple-bin-help: 1.8.0
       tinyglobby: 0.2.15
     transitivePeerDependencies:
@@ -26772,11 +26747,9 @@ snapshots:
 
   fn.name@1.1.0: {}
 
-  follow-redirects@1.15.9(debug@4.3.7):
+  follow-redirects@1.16.0(debug@4.3.7):
     optionalDependencies:
       debug: 4.3.7
-
-  follow-redirects@1.16.0: {}
 
   for-each@0.3.3:
     dependencies:
@@ -27030,7 +27003,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.2.1
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       fs-extra: 11.3.2
     transitivePeerDependencies:
       - supports-color
@@ -27515,14 +27488,14 @@ snapshots:
     dependencies:
       '@tootallnate/once': 2.0.0
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27535,14 +27508,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
   https-proxy-agent@7.0.6:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -27710,7 +27683,7 @@ snapshots:
     dependencies:
       '@ioredis/commands': 1.2.0
       cluster-key-slot: 1.1.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       denque: 2.1.0
       lodash.defaults: 4.2.0
       lodash.isarguments: 3.1.0
@@ -28013,7 +27986,7 @@ snapshots:
 
   istanbul-lib-source-maps@4.0.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       istanbul-lib-coverage: 3.2.0
       source-map: 0.6.1
     transitivePeerDependencies:
@@ -29553,7 +29526,7 @@ snapshots:
 
   micromark@2.11.4:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       parse-entities: 2.0.0
     transitivePeerDependencies:
       - supports-color
@@ -29561,7 +29534,7 @@ snapshots:
   micromark@4.0.1:
     dependencies:
       '@types/debug': 4.1.7
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       decode-named-character-reference: 1.0.2
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.2
@@ -29910,7 +29883,7 @@ snapshots:
 
   nock@13.5.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       json-stringify-safe: 5.0.1
       propagate: 2.0.1
     transitivePeerDependencies:
@@ -30358,7 +30331,7 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       get-uri: 6.0.3
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
@@ -30640,7 +30613,7 @@ snapshots:
 
   pm2-axon-rpc@0.7.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -30648,7 +30621,7 @@ snapshots:
     dependencies:
       amp: 0.3.1
       amp-message: 0.1.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       escape-string-regexp: 4.0.0
     transitivePeerDependencies:
       - supports-color
@@ -30665,7 +30638,7 @@ snapshots:
   pm2-sysmonit@1.2.8:
     dependencies:
       async: 3.2.6
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       pidusage: 2.0.21
       systeminformation: 5.30.7
       tx2: 1.0.5
@@ -30687,7 +30660,7 @@ snapshots:
       commander: 2.15.1
       croner: 4.1.97
       dayjs: 1.11.15
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       enquirer: 2.3.6
       eventemitter2: 5.0.1
       fclone: 1.0.11
@@ -31238,7 +31211,7 @@ snapshots:
   proxy-agent@6.4.0:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       http-proxy-agent: 7.0.2
       https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
@@ -31360,7 +31333,7 @@ snapshots:
   react-docgen@8.0.3:
     dependencies:
       '@babel/core': 7.28.4
-      '@babel/traverse': 7.28.4
+      '@babel/traverse': 7.28.4(supports-color@5.5.0)
       '@babel/types': 7.29.0
       '@types/babel__core': 7.20.5
       '@types/babel__traverse': 7.20.7
@@ -31896,7 +31869,7 @@ snapshots:
 
   require-in-the-middle@5.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -31904,7 +31877,7 @@ snapshots:
 
   require-in-the-middle@7.5.2:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
       resolve: 1.22.11
     transitivePeerDependencies:
@@ -31912,7 +31885,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -32036,7 +32009,7 @@ snapshots:
 
   rollup-plugin-esbuild@6.2.1(esbuild@0.25.11)(rollup@4.60.2):
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       esbuild: 0.25.11
       get-tsconfig: 4.10.1
@@ -32139,7 +32112,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -32278,7 +32251,7 @@ snapshots:
 
   send@1.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -32443,7 +32416,7 @@ snapshots:
     dependencies:
       '@kwsites/file-exists': 1.1.1
       '@kwsites/promise-deferred': 1.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
     transitivePeerDependencies:
       - supports-color
 
@@ -32550,7 +32523,7 @@ snapshots:
   socks-proxy-agent@7.0.0:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -32558,7 +32531,7 @@ snapshots:
   socks-proxy-agent@8.0.2:
     dependencies:
       agent-base: 7.1.3
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       socks: 2.7.3
     transitivePeerDependencies:
       - supports-color
@@ -32602,7 +32575,7 @@ snapshots:
   spec-change@1.11.21:
     dependencies:
       arg: 5.0.2
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       deep-equal: 2.2.3
       dependency-tree: 11.4.0
       lazy-ass: 2.0.3
@@ -34058,7 +34031,7 @@ snapshots:
   vite-node@3.1.1(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 6.4.2(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2)
@@ -34079,7 +34052,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.7.0):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.10(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.7.0)
@@ -34100,7 +34073,7 @@ snapshots:
   vite-node@3.2.4(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2):
     dependencies:
       cac: 6.7.14
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       es-module-lexer: 1.7.0
       pathe: 2.0.3
       vite: 7.1.10(@types/node@24.3.1)(jiti@2.6.1)(lightningcss@1.32.0)(sugarss@5.0.1(postcss@8.5.8))(terser@5.46.1)(tsx@4.19.4)(yaml@2.8.2)
@@ -34136,7 +34109,7 @@ snapshots:
       '@volar/typescript': 2.4.23
       '@vue/language-core': 2.2.0(typescript@6.0.0-beta)
       compare-versions: 6.1.1
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       kolorist: 1.8.0
       local-pkg: 1.1.2
       magic-string: 0.30.21
@@ -34247,7 +34220,7 @@ snapshots:
       '@vitest/spy': 3.1.1
       '@vitest/utils': 3.1.1
       chai: 5.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.2.1
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -34287,7 +34260,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.2.1
       magic-string: 0.30.21
       pathe: 2.0.3
@@ -34329,7 +34302,7 @@ snapshots:
       '@vitest/spy': 3.2.4
       '@vitest/utils': 3.2.4
       chai: 5.2.0
-      debug: 4.4.3(supports-color@8.1.1)
+      debug: 4.4.3(supports-color@5.5.0)
       expect-type: 1.2.1
       magic-string: 0.30.21
       pathe: 2.0.3


### PR DESCRIPTION
## Summary

Adds the `athena` dialect to `@lightdash/formula`. Athena's SQL Engine v3 is Trino, so this introduces a `TRINO_CONFIG` shared with the (forthcoming) `trino` dialect — both dialects map to the same entry, mirroring how `packages/common/src/utils/timeFrames.ts` wires both adapters to a single `trinoConfig`.

Closes one half of ZAP-324. The `trino` dialect lands in a stacked follow-up.

## Why a single shared config

`AthenaSqlBuilder` and `TrinoSqlBuilder` in `packages/warehouses` only diverge at the connection layer. Their SQL emission (escapeString, getIntervalSql, getMetricSql, etc.) is identical because Athena Engine v3 *is* Trino. Two formula-side configs would be a footgun — production treats them as the same engine, and so should we.

## Production parity

Mirrors `AthenaSqlBuilder` in `packages/warehouses` for everything they emit. Where formula goes beyond production (LAST_DAY, DATE_ADD with runtime `n`, DATE_DIFF in calendar units), the shape it emits is consistent with how production *would* write it.

| Concern | Formula codegen | Production (`AthenaSqlBuilder`) |
|---|---|---|
| Identifier quoting | `"x"` | base `getFieldQuoteChar() = '"'` ✅ |
| String escape | `'` doubled, backslashes left literal | base + `replaceAll("'", "''")`. **Diverges deliberately** on backslashes — production doubles them too, but Athena's lexer doesn't unescape backslashes ("Escape codes are not supported in string literals" — Trino docs), so doubling silently corrupts data. Flagged in code comment. |
| AVG | bare `AVG(x)` | `getMetricSql` AVERAGE → base `AVG(${sql})` ✅ |
| ROUND | bare `ROUND(x, n)` | no production helper; native works ✅ |
| CONCAT (≥2 args) | `CONCAT(a, b, …)` | base `concatString` returns `CONCAT(...)` ✅ |
| CONCAT (1 arg) | passes through unchanged | n/a — Athena rejects `CONCAT('x')` outright |
| INTERVAL (week offset) | `INTERVAL '<n>' DAY` | `getIntervalSql(value, unit)` returns `INTERVAL '${value}' ${unit}` ✅ |
| DATE_TRUNC week non-Monday | matches `trinoConfig.getSqlForTruncatedDate` in `timeFrames.ts:382` ✅ |
| DATE_ADD | `DATE_ADD('unit', n, x)` (function form, required because `expr * INTERVAL '1' DAY` isn't allowed) | n/a |
| DATE_DIFF | `DATE_DIFF('unit', start, end)` | `getTimestampDiffSeconds` emits `DATE_DIFF('second', start, end)` — same shape ✅ |
| LAST_DAY | `LAST_DAY_OF_MONTH(x)` (Trino 401+ / Engine v3) | n/a |

## Integration test plumbing

- `formula-tests` adds an Athena connection (`@aws-sdk/client-athena`) + Iceberg seed file.
- `CREATE DATABASE IF NOT EXISTS` runs before the seed so the suite is self-contained against a fresh AWS account / region.
- `FORMULA_TEST_AT_S3_STAGING_DIR` env var is passed as `ResultConfiguration.OutputLocation` per query — the runner doesn't depend on the workgroup having a default output location preconfigured.
- Runner's executor recognises `"true"` / `"false"` strings as booleans during result comparison: Athena's `GetQueryResults` marshals every cell as a `VarCharValue` string, so the existing bool-vs-number bridge wasn't enough.
- Tier 2 picks up `athena`.

## Test plan

- [x] `pnpm -F formula test` — 250/250 (codegen unit tests cover LAST_DAY, DATE_TRUNC w/ non-Monday week, DATE_ADD, DATE_DIFF, CONCAT 2-arg + 1-arg passthrough, AVG, ROUND, single-quote escape)
- [x] `pnpm -F backend test:dev:nowatch -- formulaDialectMapper` — 9/9 (auto-derived from `SUPPORTED_DIALECTS`; `trino` still throws until the stacked PR lands)
- [x] `pnpm -F formula-tests exec tsc --noEmit` — clean
- [x] **`pnpm formula:test:tier2 --warehouse athena`** — **334/334 passing against a real Athena cluster**, including the full date stack (LAST_DAY, DATE_TRUNC month/quarter/year/week, week-Monday + week-Sunday, DATE_TRUNC day, DATE_ADD month/day/week/quarter, DATE_SUB year/week, DATE_DIFF day/month/year/week/week-Sunday/quarter)

## Required env vars

```bash
FORMULA_TEST_AT_ACCESS_KEY_ID=
FORMULA_TEST_AT_SECRET_ACCESS_KEY=
FORMULA_TEST_AT_REGION=
FORMULA_TEST_AT_CATALOG=AwsDataCatalog
FORMULA_TEST_AT_DATABASE=                  # Glue database; created automatically by CREATE DATABASE IF NOT EXISTS
FORMULA_TEST_AT_WORKGROUP=primary          # must have Engine v3 enabled
FORMULA_TEST_AT_S3_BUCKET=
FORMULA_TEST_AT_S3_PREFIX=
FORMULA_TEST_AT_S3_STAGING_DIR=            # s3://bucket/path/ — Athena query result output
```

Refs ZAP-324

🤖 Generated with [Claude Code](https://claude.com/claude-code)
