### PR TITLE
feat(formula): add Trino dialect support

### DIFF
--- a/packages/backend/src/formulaDialectMapper.test.ts
+++ b/packages/backend/src/formulaDialectMapper.test.ts
@@ -14,12 +14,4 @@ describe('mapAdapterToFormulaDialect', () => {
             ).toBe(dialect);
         },
     );
-
-    test('throws for unsupported adapter trino', () => {
-        expect(() =>
-            mapAdapterToFormulaDialect(SupportedDbtAdapter.TRINO),
-        ).toThrow(
-            `Formula table calculations are not yet supported for ${SupportedDbtAdapter.TRINO}`,
-        );
-    });
 });

--- a/packages/backend/src/formulaDialectMapper.ts
+++ b/packages/backend/src/formulaDialectMapper.ts
@@ -36,14 +36,8 @@ export const mapAdapterToFormulaDialect = (
             return 'clickhouse';
         case SupportedDbtAdapter.ATHENA:
             return 'athena';
-        // Trino support follow-up (ZAP-324). The frontend hides the Formula
-        // input mode for unsupported warehouses, but API clients, chart-as-
-        // code YAML, and legacy payloads can still reach this path. Fail
-        // loudly instead of producing broken SQL.
         case SupportedDbtAdapter.TRINO:
-            throw new Error(
-                `Formula table calculations are not yet supported for ${adapter}`,
-            );
+            return 'trino';
         default:
             return assertUnreachable(adapter, `Unknown adapter: ${adapter}`);
     }

--- a/packages/formula-tests/config.ts
+++ b/packages/formula-tests/config.ts
@@ -6,7 +6,8 @@ export type WarehouseType =
     | 'duckdb'
     | 'databricks'
     | 'clickhouse'
-    | 'athena';
+    | 'athena'
+    | 'trino';
 
 export const ALL_WAREHOUSES: WarehouseType[] = [
     'duckdb',
@@ -17,6 +18,7 @@ export const ALL_WAREHOUSES: WarehouseType[] = [
     'databricks',
     'clickhouse',
     'athena',
+    'trino',
 ];
 
 export type Tier = 'fast' | 'tier1' | 'tier2' | 'all';
@@ -24,9 +26,12 @@ export type Tier = 'fast' | 'tier1' | 'tier2' | 'all';
 // Redshift runs in tier1 alongside Postgres: it shares the formula-package
 // codegen with Postgres (empty subclass — zero overrides), so a tier1 run
 // catches shared-path regressions without waiting for cloud-warehouse tiers.
-// Databricks, ClickHouse, Athena run in tier2 alongside BigQuery and
-// Snowflake: cloud / self-hosted warehouses with their own connection
-// latency and infrastructure considerations.
+// Databricks, ClickHouse, Athena, Trino run in tier2 alongside BigQuery
+// and Snowflake: cloud / self-hosted warehouses with their own connection
+// latency and infrastructure considerations. Athena and Trino share a
+// codegen config but each gets its own integration row so any connector-
+// level divergence (Iceberg storage, type marshalling) is caught against
+// the real engine.
 export const TIER_WAREHOUSES: Record<Tier, WarehouseType[]> = {
     fast: ['duckdb'],
     tier1: ['duckdb', 'postgres', 'redshift'],
@@ -36,6 +41,7 @@ export const TIER_WAREHOUSES: Record<Tier, WarehouseType[]> = {
         'databricks',
         'clickhouse',
         'athena',
+        'trino',
     ],
     all: ALL_WAREHOUSES,
 };
@@ -110,6 +116,16 @@ export interface WarehouseConfig {
         // location pre-configured. Format: `s3://bucket/path/`.
         s3StagingDir: string;
     };
+    trino: {
+        host: string;
+        port: number;
+        // `http` for self-hosted clusters / `https` for managed.
+        protocol: 'http' | 'https';
+        user: string;
+        password: string;
+        catalog: string;
+        schema: string;
+    };
 }
 
 export function getWarehouseConfig(): WarehouseConfig {
@@ -167,6 +183,17 @@ export function getWarehouseConfig(): WarehouseConfig {
             s3Bucket: process.env.FORMULA_TEST_AT_S3_BUCKET ?? '',
             s3Prefix: process.env.FORMULA_TEST_AT_S3_PREFIX ?? '',
             s3StagingDir: process.env.FORMULA_TEST_AT_S3_STAGING_DIR ?? '',
+        },
+        trino: {
+            host: process.env.FORMULA_TEST_TR_HOST ?? '',
+            port: parseInt(process.env.FORMULA_TEST_TR_PORT ?? '0', 10),
+            protocol:
+                (process.env.FORMULA_TEST_TR_PROTOCOL as 'http' | 'https') ??
+                'http',
+            user: process.env.FORMULA_TEST_TR_USER ?? '',
+            password: process.env.FORMULA_TEST_TR_PASSWORD ?? '',
+            catalog: process.env.FORMULA_TEST_TR_CATALOG ?? '',
+            schema: process.env.FORMULA_TEST_TR_SCHEMA ?? '',
         },
     };
 }

--- a/packages/formula-tests/fixtures/seed.trino.sql
+++ b/packages/formula-tests/fixtures/seed.trino.sql
@@ -1,0 +1,84 @@
+-- Trino seed. Trino requires explicit type prefixes for DATE / TIMESTAMP /
+-- DECIMAL literals (`DATE '2024-01-15'`, not bare strings) and uses VARCHAR
+-- (no length) rather than VARCHAR(N) for max-length-agnostic strings.
+--
+-- Tables are created in whatever catalog/schema the connection's `catalog`
+-- and `schema` config point at (defaults override-able via FORMULA_TEST_TR_
+-- CATALOG / FORMULA_TEST_TR_SCHEMA). The `memory` connector is the simplest
+-- setup for a CI / test cluster — the same SQL works against the iceberg,
+-- hive, mysql, and postgres connectors.
+
+DROP TABLE IF EXISTS test_orders;
+
+CREATE TABLE test_orders (
+    id INTEGER,
+    order_amount DECIMAL(10,2),
+    tax DECIMAL(10,2),
+    discount DECIMAL(10,2),
+    customer_name VARCHAR,
+    category VARCHAR,
+    order_date DATE,
+    quantity INTEGER,
+    is_returned BOOLEAN
+);
+
+INSERT INTO test_orders VALUES
+(1,  DECIMAL '100.00', DECIMAL '10.00', DECIMAL '5.00',  'Alice',   'Electronics', DATE '2024-01-15', 2,  FALSE),
+(2,  DECIMAL '250.50', DECIMAL '25.05', DECIMAL '12.50', 'Bob',     'Clothing',    DATE '2024-02-20', 1,  FALSE),
+(3,  DECIMAL '75.00',  DECIMAL '7.50',  DECIMAL '0.00',  'Charlie', 'Electronics', DATE '2024-03-10', 3,  TRUE),
+(4,  DECIMAL '500.00', DECIMAL '50.00', DECIMAL '25.00', 'Diana',   'Furniture',   DATE '2024-04-05', 1,  FALSE),
+(5,  DECIMAL '30.00',  DECIMAL '3.00',  DECIMAL '1.50',  'Eve',     'Clothing',    DATE '2024-05-12', 5,  FALSE),
+(6,  DECIMAL '180.00', DECIMAL '18.00', DECIMAL '9.00',  'Frank',   'Electronics', DATE '2024-06-18', 2,  TRUE),
+(7,  DECIMAL '420.00', DECIMAL '42.00', DECIMAL '21.00', 'Grace',   'Furniture',   DATE '2024-07-22', 1,  FALSE),
+(8,  DECIMAL '60.00',  DECIMAL '6.00',  DECIMAL '3.00',  'Henry',   'Clothing',    DATE '2024-08-30', 4,  FALSE),
+(9,  DECIMAL '310.00', DECIMAL '31.00', DECIMAL '15.50', 'Ivy',     'Electronics', DATE '2024-09-14', 2,  FALSE),
+(10, DECIMAL '150.00', DECIMAL '15.00', DECIMAL '7.50',  'Jack',    'Furniture',   DATE '2024-10-01', 3,  TRUE);
+
+DROP TABLE IF EXISTS test_nulls;
+
+CREATE TABLE test_nulls (
+    id INTEGER,
+    val_a DECIMAL(10,2),
+    val_b VARCHAR,
+    val_c INTEGER,
+    val_d DATE
+);
+
+INSERT INTO test_nulls VALUES
+(1, DECIMAL '10.00', 'hello', 100, DATE '2024-01-15'),
+(2, NULL,            'world', 200, NULL),
+(3, DECIMAL '30.00', NULL,    300, DATE '2024-03-10'),
+(4, NULL,            NULL,    400, NULL),
+(5, DECIMAL '50.00', 'test',  500, DATE '2024-05-12');
+
+DROP TABLE IF EXISTS test_window;
+
+CREATE TABLE test_window (
+    id INTEGER,
+    category VARCHAR,
+    amount DECIMAL(10,2),
+    ts TIMESTAMP,
+    rank_val INTEGER
+);
+
+INSERT INTO test_window VALUES
+(1,  'A', DECIMAL '100.00', TIMESTAMP '2024-01-01 10:00:00', 10),
+(2,  'A', DECIMAL '200.00', TIMESTAMP '2024-01-02 10:00:00', 20),
+(3,  'A', DECIMAL '150.00', TIMESTAMP '2024-01-03 10:00:00', 15),
+(4,  'A', DECIMAL '300.00', TIMESTAMP '2024-01-04 10:00:00', 30),
+(5,  'A', DECIMAL '250.00', TIMESTAMP '2024-01-05 10:00:00', 25),
+(6,  'B', DECIMAL '50.00',  TIMESTAMP '2024-01-01 11:00:00', 5),
+(7,  'B', DECIMAL '75.00',  TIMESTAMP '2024-01-02 11:00:00', 8),
+(8,  'B', DECIMAL '60.00',  TIMESTAMP '2024-01-03 11:00:00', 6),
+(9,  'B', DECIMAL '90.00',  TIMESTAMP '2024-01-04 11:00:00', 9),
+(10, 'B', DECIMAL '80.00',  TIMESTAMP '2024-01-05 11:00:00', 7),
+(11, 'C', DECIMAL '500.00', TIMESTAMP '2024-01-01 12:00:00', 50),
+(12, 'C', DECIMAL '400.00', TIMESTAMP '2024-01-02 12:00:00', 40),
+(13, 'C', DECIMAL '450.00', TIMESTAMP '2024-01-03 12:00:00', 45),
+(14, 'C', DECIMAL '350.00', TIMESTAMP '2024-01-04 12:00:00', 35),
+(15, 'C', DECIMAL '550.00', TIMESTAMP '2024-01-05 12:00:00', 55),
+(16, 'D', DECIMAL '10.00',  TIMESTAMP '2024-01-01 13:00:00', 1),
+(17, 'D', DECIMAL '20.00',  TIMESTAMP '2024-01-02 13:00:00', 2),
+(18, 'D', DECIMAL '15.00',  TIMESTAMP '2024-01-03 13:00:00', 3),
+(19, 'D', DECIMAL '25.00',  TIMESTAMP '2024-01-04 13:00:00', 4),
+(20, 'D', DECIMAL '30.00',  TIMESTAMP '2024-01-05 13:00:00', 5);

--- a/packages/formula-tests/package.json
+++ b/packages/formula-tests/package.json
@@ -17,6 +17,7 @@
     "@google-cloud/bigquery": "7.9.2",
     "duckdb": "1.4.2",
     "pg": "8.13.1",
+    "trino-client": "0.2.9",
     "tsx": "4.19.2"
   },
   "devDependencies": {

--- a/packages/formula-tests/runner/warehouse-connections.ts
+++ b/packages/formula-tests/runner/warehouse-connections.ts
@@ -303,6 +303,85 @@ export async function createBigQueryConnection(
     };
 }
 
+export async function createTrinoConnection(
+    config: WarehouseConfig['trino'],
+): Promise<WarehouseConnection> {
+    const missing: string[] = [];
+    if (!config.host) missing.push('FORMULA_TEST_TR_HOST');
+    if (!config.port) missing.push('FORMULA_TEST_TR_PORT');
+    if (!config.user) missing.push('FORMULA_TEST_TR_USER');
+    if (!config.catalog) missing.push('FORMULA_TEST_TR_CATALOG');
+    if (!config.schema) missing.push('FORMULA_TEST_TR_SCHEMA');
+    if (missing.length > 0) {
+        throw new Error(
+            `Trino connection requires the following env vars: ${missing.join(', ')}`,
+        );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const { BasicAuth, Trino } = require('trino-client');
+
+    const client = Trino.create({
+        server: `${config.protocol}://${config.host}:${config.port}`,
+        catalog: config.catalog,
+        schema: config.schema,
+        // trino-client treats `undefined` auth as no auth (anonymous).
+        // Wire BasicAuth only when a password is set so a single-user dev
+        // cluster (no auth) still works.
+        ...(config.password
+            ? { auth: new BasicAuth(config.user, config.password) }
+            : { source: config.user }),
+    });
+
+    // The client returns an Iterator; drain it into an array of plain rows.
+    // Trino's wire format is `{ columns, data }` with parallel column-name
+    // and row arrays — convert each row to a record keyed by column name so
+    // downstream comparators get the same shape as every other warehouse.
+    const execute = async (
+        sql: string,
+    ): Promise<Record<string, any>[]> => {
+        const iter = await client.query(sql);
+        const out: Record<string, any>[] = [];
+        let columns: string[] | undefined;
+        // eslint-disable-next-line no-await-in-loop
+        for await (const result of iter) {
+            if (!columns && result.columns) {
+                columns = result.columns.map(
+                    (c: { name: string }) => c.name,
+                );
+            }
+            if (result.error) {
+                throw new Error(result.error.message);
+            }
+            const data: any[][] = result.data ?? [];
+            for (const row of data) {
+                const obj: Record<string, any> = {};
+                (columns ?? []).forEach((name, i) => {
+                    obj[name] = row[i];
+                });
+                out.push(obj);
+            }
+        }
+        return out;
+    };
+
+    // `Trino.query()` accepts a single statement at a time — multi-
+    // statement seed blobs need splitting, same as Databricks / ClickHouse
+    // / Athena.
+    return {
+        dialect: 'trino',
+        execute,
+        async seed(sql: string) {
+            for (const stmt of splitSqlStatements(sql)) {
+                await execute(stmt);
+            }
+        },
+        async close() {
+            // trino-client has no explicit close — connections are per-query.
+        },
+    };
+}
+
 export async function createAthenaConnection(
     config: WarehouseConfig['athena'],
 ): Promise<WarehouseConnection> {
@@ -503,6 +582,8 @@ export async function createConnection(
             return createClickhouseConnection(config.clickhouse);
         case 'athena':
             return createAthenaConnection(config.athena);
+        case 'trino':
+            return createTrinoConnection(config.trino);
         default: {
             const _exhaustive: never = warehouse;
             throw new Error(`Unknown warehouse: ${warehouse}`);

--- a/packages/formula/src/codegen/dialects.ts
+++ b/packages/formula/src/codegen/dialects.ts
@@ -427,10 +427,11 @@ const CLICKHOUSE_CONFIG: DialectConfig = {
 
 // Trino / Athena config. Athena's SQL Engine v3 is Trino, and
 // `packages/common/src/utils/timeFrames.ts` wires both adapters to the
-// same `trinoConfig`. Currently only `athena` maps to this here; the
-// `trino` dialect lands in a follow-up (ZAP-324) and reuses this entry
-// unchanged. Mirrors `TrinoSqlBuilder` / `AthenaSqlBuilder` in
-// `packages/warehouses` (escapeString, getIntervalSql, getMetricSql, etc.).
+// same `trinoConfig`. Both dialects map to this single entry — keep it
+// that way: any divergence between the two would be a footgun, since
+// production treats them as the same engine. Mirrors `TrinoSqlBuilder` /
+// `AthenaSqlBuilder` in `packages/warehouses` (escapeString,
+// getIntervalSql, getMetricSql, etc.).
 //
 // Key shape divergences from the Postgres family:
 //   - INTERVAL: `INTERVAL '<n>' <UNIT>` (value quoted, unit bare) — not
@@ -485,4 +486,5 @@ export const DIALECTS: Record<Dialect, DialectConfig> = {
     databricks: DATABRICKS_CONFIG,
     clickhouse: CLICKHOUSE_CONFIG,
     athena: TRINO_CONFIG,
+    trino: TRINO_CONFIG,
 };

--- a/packages/formula/src/index.ts
+++ b/packages/formula/src/index.ts
@@ -37,6 +37,7 @@ export const SUPPORTED_DIALECTS = [
     'databricks',
     'clickhouse',
     'athena',
+    'trino',
 ] as const satisfies readonly Dialect[];
 
 type MissingSupportedDialect = Exclude<

--- a/packages/formula/src/types.ts
+++ b/packages/formula/src/types.ts
@@ -19,7 +19,8 @@ export type Dialect =
     | 'duckdb'
     | 'databricks'
     | 'clickhouse'
-    | 'athena';
+    | 'athena'
+    | 'trino';
 
 // Whitelisted units accepted by date functions (DATE_TRUNC today; DATE_ADD,
 // DATE_SUB, DATE_DIFF in follow-up PRs). Validated at parse time so bad units

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -503,6 +503,63 @@ describe('codegen', () => {
         });
     });
 
+    describe('Trino dialect', () => {
+        // Trino reuses the same `TRINO_CONFIG` as Athena (Athena's SQL
+        // Engine v3 is Trino). The Athena describe block above pins the
+        // cross-cutting behaviour against the shared config; this block
+        // adds a parity invariant so the two dialects can never silently
+        // drift in the codegen.
+        it('emits identical SQL to Athena across the date stack', () => {
+            // Don't let the two dialect entries drift accidentally — both
+            // map to the same config and that's how `packages/common/src/
+            // utils/timeFrames.ts` wires them in production.
+            const formulas = [
+                '=LAST_DAY(order_date)',
+                '=DATE_TRUNC("week", order_date)',
+                '=DATE_ADD(order_date, 1, "quarter")',
+                '=DATE_DIFF(order_date, order_date, "month")',
+                '=ROUND(revenue, 2)',
+                '=AVG(revenue)',
+                '=CONCAT(customer_name, " — ", category)',
+            ];
+            for (const formula of formulas) {
+                const trinoSql = compile(formula, {
+                    dialect: 'trino',
+                    columns: {
+                        ...columns,
+                        customer_name: 'name',
+                        category: 'cat',
+                    },
+                });
+                const athenaSql = compile(formula, {
+                    dialect: 'athena',
+                    columns: {
+                        ...columns,
+                        customer_name: 'name',
+                        category: 'cat',
+                    },
+                });
+                expect(trinoSql).toBe(athenaSql);
+            }
+        });
+
+        it('non-Monday weekStartDay parity with Athena', () => {
+            // The composition path also has to agree under non-Monday
+            // weeks — that's where dialect drift would bite hardest.
+            const trinoSql = compile('=DATE_DIFF(a, b, "week")', {
+                dialect: 'trino',
+                columns: { a: 'a', b: 'b' },
+                weekStartDay: 6,
+            });
+            const athenaSql = compile('=DATE_DIFF(a, b, "week")', {
+                dialect: 'athena',
+                columns: { a: 'a', b: 'b' },
+                weekStartDay: 6,
+            });
+            expect(trinoSql).toBe(athenaSql);
+        });
+    });
+
     describe('LAST_DAY', () => {
         const postgresStyleLastDay = `CAST(DATE_TRUNC('month', "order_date") + INTERVAL '1 month' - INTERVAL '1 day' AS DATE)`;
 
@@ -516,10 +573,11 @@ describe('codegen', () => {
             // the Postgres-style INTERVAL '1 month' composition outright.
             ['redshift', 'LAST_DAY("order_date")'],
             ['clickhouse', 'toLastDayOfMonth("order_date")'],
-            // Athena: native LAST_DAY_OF_MONTH (SQL Engine v3 = Trino,
-            // available since Trino 401). Distinct name from the *_DAY
-            // variants above.
+            // Athena (SQL Engine v3 = Trino) and Trino: native
+            // LAST_DAY_OF_MONTH (Trino 401+). Distinct name from the
+            // *_DAY variants above.
             ['athena', 'LAST_DAY_OF_MONTH("order_date")'],
+            ['trino', 'LAST_DAY_OF_MONTH("order_date")'],
         ] as const)('%s → %s', (dialect, expected) => {
             expect(
                 compile('=LAST_DAY(order_date)', { dialect, columns }),
@@ -552,8 +610,9 @@ describe('codegen', () => {
             ['clickhouse', 'month', 'toStartOfMonth("order_date")'],
             ['clickhouse', 'quarter', 'toStartOfQuarter("order_date")'],
             ['clickhouse', 'year', 'toStartOfYear("order_date")'],
-            // Athena: ANSI form, same as Postgres.
+            // Athena / Trino: ANSI form, same as Postgres.
             ['athena', 'month', `DATE_TRUNC('month', "order_date")`],
+            ['trino', 'month', `DATE_TRUNC('month', "order_date")`],
         ] as const)('%s DATE_TRUNC("%s", …) → %s', (dialect, unit, expected) => {
             expect(
                 compile(`=DATE_TRUNC("${unit}", order_date)`, {
@@ -628,6 +687,18 @@ describe('codegen', () => {
                 );
             });
 
+            it('Trino emits the same offset shape as Athena', () => {
+                expect(
+                    compile('=DATE_TRUNC("week", order_date)', {
+                        dialect: 'trino',
+                        columns,
+                        weekStartDay: 6,
+                    }),
+                ).toBe(
+                    `(DATE_TRUNC('week', ("order_date" - INTERVAL '6' DAY)) + INTERVAL '6' DAY)`,
+                );
+            });
+
             it('Monday (default) leaves the base form intact on Postgres', () => {
                 expect(
                     compile('=DATE_TRUNC("week", order_date)', {
@@ -650,11 +721,12 @@ describe('codegen', () => {
             ['snowflake', 'DATEADD(MONTH, 3, "order_date")'],
             ['databricks', 'ADD_MONTHS(`order_date`, 3)'],
             ['clickhouse', 'addMonths("order_date", 3)'],
-            // Athena uses date_add(unit, n, x) — function form chosen over
-            // INTERVAL because Athena/Trino don't allow `expr * INTERVAL
+            // Athena / Trino use date_add(unit, n, x) — function form
+            // chosen over INTERVAL because neither allows `expr * INTERVAL
             // '1' DAY` (interval × runtime expr). Function form takes any
             // int expression for n.
             ['athena', `DATE_ADD('month', 3, "order_date")`],
+            ['trino', `DATE_ADD('month', 3, "order_date")`],
         ] as const)('%s → %s', (dialect, expected) => {
             expect(
                 compile('=DATE_ADD(order_date, 3, "month")', {
@@ -763,10 +835,13 @@ describe('codegen', () => {
             // DuckDB + ClickHouse — quoted unit.
             ['duckdb', 'month', `date_diff('month', "a", "b")`],
             ['clickhouse', 'month', `dateDiff('month', "a", "b")`],
-            // Athena: same shape as ClickHouse — quoted unit, function
-            // form. Mirrors `AthenaSqlBuilder.getTimestampDiffSeconds`
-            // which emits `DATE_DIFF('second', start, end)` in production.
+            // Athena / Trino: same shape as ClickHouse — quoted unit,
+            // function form. Mirrors
+            // `AthenaSqlBuilder.getTimestampDiffSeconds` /
+            // `TrinoSqlBuilder.getTimestampDiffSeconds` which emit
+            // `DATE_DIFF('second', start, end)` in production.
             ['athena', 'month', `DATE_DIFF('month', "a", "b")`],
+            ['trino', 'month', `DATE_DIFF('month', "a", "b")`],
         ] as const)('%s DATE_DIFF(a, b, "%s") → %s', (dialect, unit, expected) => {
             expect(
                 compile(`=DATE_DIFF(a, b, "${unit}")`, {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,6 +897,9 @@ importers:
       pg:
         specifier: 8.13.1
         version: 8.13.1
+      trino-client:
+        specifier: 0.2.9
+        version: 0.2.9
       tsx:
         specifier: 4.19.2
         version: 4.19.2


### PR DESCRIPTION
## Summary

Adds the `trino` dialect to `@lightdash/formula`. Stacked on #22392 (Athena), reusing the same `TRINO_CONFIG` introduced there — both dialects map to a single shared entry, mirroring how `packages/common/src/utils/timeFrames.ts` wires them in production.

Closes ZAP-324 (the second half — first half is the Athena PR).

## Why a single shared config

`AthenaSqlBuilder` and `TrinoSqlBuilder` only diverge at the connection layer; their SQL emission is identical because Athena Engine v3 *is* Trino. Two formula-side configs would be a footgun. This PR adds a parity invariant test that locks the two dialects to identical emission across the date stack — they can't silently drift.

## Production parity

Mirrors `TrinoSqlBuilder` in `packages/warehouses` for everything they emit. Same alignment table as the Athena PR — see #22392 for the line-by-line breakdown.

## Integration test plumbing

- `formula-tests` adds a Trino connection (`trino-client`) + seed file.
- The seed targets the `memory` connector by default (simplest CI / test setup); the same SQL works against `iceberg` / `hive` / `mysql` / `postgres` connectors — verified end-to-end on a real Starburst Galaxy cluster running on the `postgres` connector.
- `BasicAuth` is wired only when `FORMULA_TEST_TR_PASSWORD` is set, so single-user dev clusters with no auth still work.
- Tier 2 picks up `trino`.

## Test plan

- [x] `pnpm -F formula test` — 257/257 (Trino describe block adds two parity invariants: full date stack + non-Monday week DATE_DIFF composition)
- [x] `pnpm -F backend test:dev:nowatch -- formulaDialectMapper` — 9/9 (every `SUPPORTED_DIALECTS` entry now maps cleanly; the throw-on-trino case from #22392 is removed)
- [x] `pnpm -F formula-tests exec tsc --noEmit` — clean
- [x] **`pnpm formula:test:tier2 --warehouse trino`** — **334/334 passing against a real Trino cluster** (Starburst Galaxy, `postgres` connector), including the full date stack: LAST_DAY, DATE_TRUNC month/quarter/year/week, week-Monday + week-Sunday, DATE_TRUNC day, DATE_ADD month/day/week/quarter, DATE_SUB year/week, DATE_DIFF day/month/year/week/week-Sunday/quarter

## Required env vars

```bash
FORMULA_TEST_TR_HOST=
FORMULA_TEST_TR_PORT=
FORMULA_TEST_TR_PROTOCOL=                  # 'http' | 'https'
FORMULA_TEST_TR_USER=
FORMULA_TEST_TR_PASSWORD=                  # leave empty for no-auth dev clusters
FORMULA_TEST_TR_CATALOG=                   # e.g. 'memory' or 'iceberg'
FORMULA_TEST_TR_SCHEMA=                    # e.g. 'formula_tests'
```

Stacked on #22392.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
