### PR TITLE
feat(audit): emit authentication audit events for ITGC compliance

### DIFF
--- a/packages/backend/src/controllers/authentication/strategies/apiKeyStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/apiKeyStrategy.ts
@@ -12,10 +12,17 @@ export const apiKeyPassportStrategy = ({
     new HeaderAPIKeyStrategy(
         { header: 'Authorization', prefix: 'ApiKey ' },
         true,
-        async (token, done) => {
+        async (token, done, req) => {
             try {
-                const user =
-                    await userService.loginWithPersonalAccessToken(token);
+                const user = await userService.loginWithPersonalAccessToken(
+                    token,
+                    req
+                        ? {
+                              ip: req.ip,
+                              userAgent: req.get('user-agent'),
+                          }
+                        : undefined,
+                );
                 return done(null, user);
             } catch {
                 return done(

--- a/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/databricksStrategy.ts
@@ -8,6 +8,7 @@ import {
     ParameterError,
 } from '@lightdash/common';
 import { createHash } from 'crypto';
+import express from 'express';
 import { Strategy as OAuth2Strategy, VerifyCallback } from 'passport-oauth2';
 import { URL } from 'url';
 import { lightdashConfig } from '../../../config/lightdashConfig';
@@ -209,6 +210,12 @@ export const createDatabricksStrategy = ({
                         req.user,
                         undefined,
                         refreshToken,
+                        {
+                            ip: (req as express.Request).ip,
+                            userAgent: (req as express.Request).get(
+                                'user-agent',
+                            ),
+                        },
                     );
                 done(null, user);
             } catch (error) {

--- a/packages/backend/src/controllers/authentication/strategies/googleStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/googleStrategy.ts
@@ -5,6 +5,7 @@ import {
     OpenIdIdentityIssuerType,
     OpenIdUser,
 } from '@lightdash/common';
+import express from 'express';
 import {
     GoogleCallbackParameters,
     Strategy as GoogleStrategy,
@@ -84,6 +85,12 @@ export const googlePassportStrategy: GoogleStrategy | undefined = !(
                           req.user,
                           inviteCode,
                           refreshToken,
+                          {
+                              ip: (req as express.Request).ip,
+                              userAgent: (req as express.Request).get(
+                                  'user-agent',
+                              ),
+                          },
                       );
                   return done(null, user);
               } catch (e) {

--- a/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oidcStrategy.ts
@@ -107,7 +107,16 @@ export const genericOidcHandler =
             if (openIdUser) {
                 const user = await req.services
                     .getUserService()
-                    .loginWithOpenId(openIdUser, req.user, inviteCode);
+                    .loginWithOpenId(
+                        openIdUser,
+                        req.user,
+                        inviteCode,
+                        undefined,
+                        {
+                            ip: req.ip,
+                            userAgent: req.get('user-agent'),
+                        },
+                    );
                 return done(null, user);
             }
             return done(null, false, {

--- a/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/oktaStrategy.ts
@@ -141,7 +141,16 @@ export class OpenIDClientOktaStrategy extends Strategy {
                 if (openIdUser) {
                     const user = await req.services
                         .getUserService()
-                        .loginWithOpenId(openIdUser, req.user, inviteCode);
+                        .loginWithOpenId(
+                            openIdUser,
+                            req.user,
+                            inviteCode,
+                            undefined,
+                            {
+                                ip: req.ip,
+                                userAgent: req.get('user-agent'),
+                            },
+                        );
                     return this.success(user);
                 }
 

--- a/packages/backend/src/controllers/authentication/strategies/passwordStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/passwordStrategy.ts
@@ -10,12 +10,20 @@ export const localPassportStrategy = ({
     userService: UserService;
 }) =>
     new LocalStrategy(
-        { usernameField: 'email', passwordField: 'password' },
-        async (email, password, done) => {
+        {
+            usernameField: 'email',
+            passwordField: 'password',
+            passReqToCallback: true,
+        },
+        async (req, email, password, done) => {
             try {
                 const user = await userService.loginWithPassword(
                     email,
                     password,
+                    {
+                        ip: req.ip,
+                        userAgent: req.get('user-agent'),
+                    },
                 );
                 return done(null, user);
             } catch (e) {

--- a/packages/backend/src/controllers/authentication/strategies/snowflakeStrategy.ts
+++ b/packages/backend/src/controllers/authentication/strategies/snowflakeStrategy.ts
@@ -6,6 +6,7 @@ import {
     OpenIdIdentityIssuerType,
     OpenIdUser,
 } from '@lightdash/common';
+import express from 'express';
 import { Strategy as OAuth2Strategy, VerifyCallback } from 'passport-oauth2';
 import { URL } from 'url';
 import { lightdashConfig } from '../../../config/lightdashConfig';
@@ -85,6 +86,12 @@ export const snowflakePassportStrategy = !(
                           req.user,
                           undefined,
                           refreshToken,
+                          {
+                              ip: (req as express.Request).ip,
+                              userAgent: (req as express.Request).get(
+                                  'user-agent',
+                              ),
+                          },
                       );
                   done(null, user);
                   // Use the generic OIDC handler to process the profile

--- a/packages/backend/src/controllers/impersonationController.ts
+++ b/packages/backend/src/controllers/impersonationController.ts
@@ -43,6 +43,10 @@ export class ImpersonationController extends BaseController {
                 setImpersonation: (data) => {
                     req.session.impersonation = data;
                 },
+                context: {
+                    ip: req.ip,
+                    userAgent: req.get('user-agent'),
+                },
             });
         this.setStatus(200);
         return {
@@ -66,6 +70,10 @@ export class ImpersonationController extends BaseController {
             getImpersonation: () => req.session.impersonation,
             clearImpersonation: () => {
                 delete req.session.impersonation;
+            },
+            context: {
+                ip: req.ip,
+                userAgent: req.get('user-agent'),
             },
         });
         this.setStatus(200);

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -205,12 +205,11 @@ export const authenticateServiceAccount: RequestHandler = async (
         const message = getErrorMessage(error);
         // Avoid double-logging: the explicit-throw branches above already
         // emit a denied audit event with a more specific reason.
-        if (
-            message !== 'No service account token provided' &&
-            message !== 'Invalid service account token. Authentication failed.'
-        ) {
+
+        if (!(error instanceof ServiceAccountAuthError)) {
             logServiceAccountAuthFailure(req, message);
         }
+
         next(new AuthorizationError(message));
     }
 };

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -206,7 +206,7 @@ export const authenticateServiceAccount: RequestHandler = async (
         // Avoid double-logging: the explicit-throw branches above already
         // emit a denied audit event with a more specific reason.
 
-        if (!(error instanceof ServiceAccountAuthError)) {
+        if (!(error instanceof AuthorizationError)) {
             logServiceAccountAuthFailure(req, message);
         }
 

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -11,8 +11,35 @@ import {
 import { RequestHandler } from 'express';
 import { fromServiceAccount } from '../../auth/account/account';
 import { buildAccountExistsWarning } from '../../auth/account/warnAccountExists';
+import {
+    createAuditLogEvent,
+    createUnknownAuthActor,
+} from '../../logging/auditLog';
 import Logger from '../../logging/logger';
+import { logAuditEvent } from '../../logging/winston';
 import { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
+
+const logServiceAccountAuthFailure = (
+    req: { ip?: string; get: (h: string) => string | undefined },
+    reason: string,
+): void => {
+    try {
+        logAuditEvent(
+            createAuditLogEvent(
+                createUnknownAuthActor(),
+                'login',
+                { type: 'ServiceAccount', organizationUuid: 'unknown' },
+                { ip: req.ip, userAgent: req.get('user-agent') },
+                'denied',
+                reason,
+            ),
+        );
+    } catch (err) {
+        Logger.warn('Failed to log service account auth audit event', {
+            error: err instanceof Error ? err.message : String(err),
+        });
+    }
+};
 
 const getRoleForScopes = (scopes: ServiceAccountScope[]) => {
     if (
@@ -102,6 +129,10 @@ export const authenticateServiceAccount: RequestHandler = async (
         const ServiceAccountToken = tokenParts[1];
         // Check if the token is valid
         if (!ServiceAccountToken) {
+            logServiceAccountAuthFailure(
+                req,
+                'No service account token provided',
+            );
             throw new AuthorizationError('No service account token provided');
         }
         // Attach service account serviceAccount to request
@@ -110,6 +141,10 @@ export const authenticateServiceAccount: RequestHandler = async (
             .authenticateServiceAccount(ServiceAccountToken);
 
         if (!serviceAccount) {
+            logServiceAccountAuthFailure(
+                req,
+                'Invalid service account token. Authentication failed.',
+            );
             throw new AuthorizationError(
                 'Invalid service account token. Authentication failed.',
             );
@@ -167,6 +202,15 @@ export const authenticateServiceAccount: RequestHandler = async (
 
         next();
     } catch (error) {
-        next(new AuthorizationError(getErrorMessage(error)));
+        const message = getErrorMessage(error);
+        // Avoid double-logging: the explicit-throw branches above already
+        // emit a denied audit event with a more specific reason.
+        if (
+            message !== 'No service account token provided' &&
+            message !== 'Invalid service account token. Authentication failed.'
+        ) {
+            logServiceAccountAuthFailure(req, message);
+        }
+        next(new AuthorizationError(message));
     }
 };

--- a/packages/backend/src/logging/auditLog.ts
+++ b/packages/backend/src/logging/auditLog.ts
@@ -118,3 +118,16 @@ export const createAuditLogEvent = (
         ruleConditions,
         callStack,
     });
+
+/**
+ * Builds an audit actor for an authentication attempt where the user
+ * could not be resolved (e.g. wrong password, expired/invalid token).
+ * Includes the email when known so failed attempts are still attributable.
+ */
+export const createUnknownAuthActor = (email?: string): AuditActor => ({
+    type: 'session',
+    uuid: 'unknown',
+    email: email ?? '',
+    organizationUuid: 'unknown',
+    organizationRole: 'unknown',
+});

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
@@ -6,7 +6,12 @@ import { fromJwt } from '../../auth/account';
 import { buildAccountExistsWarning } from '../../auth/account/warnAccountExists';
 import { decodeLightdashJwt } from '../../auth/lightdashJwt';
 import { EmbedService } from '../../ee/services/EmbedService/EmbedService';
+import {
+    createAuditLogEvent,
+    createUnknownAuthActor,
+} from '../../logging/auditLog';
 import Logger from '../../logging/logger';
+import { logAuditEvent } from '../../logging/winston';
 
 /**
  * We don't have the parsed routes yet, so we get the path params in a
@@ -101,6 +106,31 @@ export async function jwtAuthMiddleware(
 
         next();
     } catch (error) {
+        try {
+            logAuditEvent(
+                createAuditLogEvent(
+                    createUnknownAuthActor(),
+                    'login',
+                    {
+                        type: 'EmbedJwt',
+                        organizationUuid: 'unknown',
+                        projectUuid: req.project?.projectUuid,
+                    },
+                    { ip: req.ip, userAgent: req.get('user-agent') },
+                    'denied',
+                    error instanceof Error
+                        ? error.message
+                        : 'JWT authentication failed',
+                ),
+            );
+        } catch (auditErr) {
+            Logger.warn('Failed to log JWT auth audit event', {
+                error:
+                    auditErr instanceof Error
+                        ? auditErr.message
+                        : String(auditErr),
+            });
+        }
         next(error);
     }
 }

--- a/packages/backend/src/routers/apiV1Router.ts
+++ b/packages/backend/src/routers/apiV1Router.ts
@@ -21,7 +21,10 @@ import {
     getDatabricksStrategyName,
 } from '../controllers/authentication/strategies/databricksStrategy';
 import { AiAgentService } from '../ee/services/AiAgentService/AiAgentService';
+import { createAuditLogEvent } from '../logging/auditLog';
+import { createActorFromUser } from '../logging/caslAuditWrapper';
 import Logger from '../logging/logger';
+import { logAuditEvent } from '../logging/winston';
 import { UserModel } from '../models/UserModel';
 import { dashboardRouter } from './dashboardRouter';
 import { headlessBrowserRouter } from './headlessBrowser';
@@ -459,6 +462,9 @@ apiV1Router.get(
 );
 
 apiV1Router.get('/logout', (req, res, next) => {
+    const userBeforeLogout = req.user;
+    const { ip } = req;
+    const userAgent = req.get('user-agent');
     req.logout((err) => {
         if (err) {
             return next(err);
@@ -467,6 +473,31 @@ apiV1Router.get('/logout', (req, res, next) => {
             if (err2) {
                 next(err2);
             } else {
+                if (userBeforeLogout?.userUuid) {
+                    try {
+                        logAuditEvent(
+                            createAuditLogEvent(
+                                createActorFromUser(userBeforeLogout),
+                                'logout',
+                                {
+                                    type: 'Session',
+                                    organizationUuid:
+                                        userBeforeLogout.organizationUuid ??
+                                        'unknown',
+                                },
+                                { ip, userAgent },
+                                'allowed',
+                            ),
+                        );
+                    } catch (auditErr) {
+                        Logger.warn('Failed to log logout audit event', {
+                            error:
+                                auditErr instanceof Error
+                                    ? auditErr.message
+                                    : String(auditErr),
+                        });
+                    }
+                }
                 res.json({
                     status: 'ok',
                 });

--- a/packages/backend/src/services/UserService.test.ts
+++ b/packages/backend/src/services/UserService.test.ts
@@ -1,6 +1,7 @@
 import {
     defineUserAbility,
     EmailStatus,
+    NotFoundError,
     OpenIdIdentityIssuerType,
     OrganizationMemberRole,
     ProjectMemberRole,
@@ -10,6 +11,7 @@ import { analyticsMock } from '../analytics/LightdashAnalytics.mock';
 import EmailClient from '../clients/EmailClient/EmailClient';
 import { lightdashConfigMock } from '../config/lightdashConfig.mock';
 import { LightdashConfig } from '../config/parseConfig';
+import * as winston from '../logging/winston';
 import { PersonalAccessTokenModel } from '../models/DashboardModel/PersonalAccessTokenModel';
 import { EmailModel } from '../models/EmailModel';
 import { GroupsModel } from '../models/GroupsModel';
@@ -118,6 +120,10 @@ const createUserService = (lightdashConfig: LightdashConfig) =>
     });
 
 jest.spyOn(analyticsMock, 'track');
+const auditLogSpy = jest
+    .spyOn(winston, 'logAuditEvent')
+    .mockImplementation(() => {});
+
 describe('UserService', () => {
     const userService = createUserService(lightdashConfigMock);
 
@@ -456,6 +462,153 @@ describe('UserService', () => {
             expect(userModel.createUser as jest.Mock).toHaveBeenCalledTimes(0);
             expect(userModel.activateUser as jest.Mock).toHaveBeenCalledTimes(
                 0,
+            );
+        });
+
+        test('should emit allowed audit event on successful OpenID login', async () => {
+            (
+                userModel.findSessionUserByOpenId as jest.Mock
+            ).mockImplementationOnce(async () => sessionUser);
+
+            await userService.loginWithOpenId(openIdUser, undefined, undefined);
+
+            expect(auditLogSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'login',
+                    status: 'allowed',
+                    actor: expect.objectContaining({
+                        uuid: sessionUser.userUuid,
+                        type: 'session',
+                    }),
+                    resource: expect.objectContaining({ type: 'Session' }),
+                }),
+            );
+        });
+
+        test('should emit denied audit event when OpenID provider not allowed', async () => {
+            await expect(
+                userService.loginWithOpenId(
+                    openIdUserWithInvalidIssuer,
+                    undefined,
+                    undefined,
+                ),
+            ).rejects.toThrow();
+
+            expect(auditLogSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'login',
+                    status: 'denied',
+                    actor: expect.objectContaining({ uuid: 'unknown' }),
+                    resource: expect.objectContaining({ type: 'Session' }),
+                }),
+            );
+        });
+    });
+
+    describe('audit events for login failures', () => {
+        test('should emit denied audit event when password is wrong', async () => {
+            const failingUserModel = {
+                ...userModel,
+                getUserByPrimaryEmailAndPassword: jest.fn(async () => {
+                    throw new NotFoundError('wrong password');
+                }),
+            };
+            const service = new UserService({
+                analytics: analyticsMock,
+                lightdashConfig: lightdashConfigMock,
+                inviteLinkModel: inviteLinkModel as unknown as InviteLinkModel,
+                userModel: failingUserModel as unknown as UserModel,
+                groupsModel: {} as GroupsModel,
+                sessionModel: {} as SessionModel,
+                emailModel: emailModel as unknown as EmailModel,
+                openIdIdentityModel:
+                    openIdIdentityModel as unknown as OpenIdIdentityModel,
+                passwordResetLinkModel: {} as PasswordResetLinkModel,
+                emailClient: emailClient as unknown as EmailClient,
+                organizationMemberProfileModel:
+                    {} as OrganizationMemberProfileModel,
+                organizationModel:
+                    organizationModel as unknown as OrganizationModel,
+                personalAccessTokenModel: {} as PersonalAccessTokenModel,
+                organizationAllowedEmailDomainsModel:
+                    {} as OrganizationAllowedEmailDomainsModel,
+                userWarehouseCredentialsModel:
+                    {} as UserWarehouseCredentialsModel,
+                warehouseAvailableTablesModel:
+                    {} as WarehouseAvailableTablesModel,
+                projectModel: projectModel as unknown as ProjectModel,
+            });
+
+            await expect(
+                service.loginWithPassword('user@example.com', 'wrong', {
+                    ip: '127.0.0.1',
+                    userAgent: 'jest',
+                }),
+            ).rejects.toThrow();
+
+            expect(auditLogSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'login',
+                    status: 'denied',
+                    reason: 'Email and password not recognized',
+                    actor: expect.objectContaining({
+                        uuid: 'unknown',
+                        email: 'user@example.com',
+                    }),
+                    context: expect.objectContaining({
+                        ip: '127.0.0.1',
+                        userAgent: 'jest',
+                    }),
+                    resource: expect.objectContaining({ type: 'Session' }),
+                }),
+            );
+        });
+
+        test('should emit denied audit event for unknown personal access token', async () => {
+            const tokenUserModel = {
+                ...userModel,
+                findSessionUserByPersonalAccessToken: jest.fn(
+                    async () => undefined,
+                ),
+            };
+            const service = new UserService({
+                analytics: analyticsMock,
+                lightdashConfig: lightdashConfigMock,
+                inviteLinkModel: inviteLinkModel as unknown as InviteLinkModel,
+                userModel: tokenUserModel as unknown as UserModel,
+                groupsModel: {} as GroupsModel,
+                sessionModel: {} as SessionModel,
+                emailModel: emailModel as unknown as EmailModel,
+                openIdIdentityModel:
+                    openIdIdentityModel as unknown as OpenIdIdentityModel,
+                passwordResetLinkModel: {} as PasswordResetLinkModel,
+                emailClient: emailClient as unknown as EmailClient,
+                organizationMemberProfileModel:
+                    {} as OrganizationMemberProfileModel,
+                organizationModel:
+                    organizationModel as unknown as OrganizationModel,
+                personalAccessTokenModel: {} as PersonalAccessTokenModel,
+                organizationAllowedEmailDomainsModel:
+                    {} as OrganizationAllowedEmailDomainsModel,
+                userWarehouseCredentialsModel:
+                    {} as UserWarehouseCredentialsModel,
+                warehouseAvailableTablesModel:
+                    {} as WarehouseAvailableTablesModel,
+                projectModel: projectModel as unknown as ProjectModel,
+            });
+
+            await expect(
+                service.loginWithPersonalAccessToken('bad-token'),
+            ).rejects.toThrow();
+
+            expect(auditLogSpy).toHaveBeenCalledWith(
+                expect.objectContaining({
+                    action: 'login',
+                    status: 'denied',
+                    resource: expect.objectContaining({
+                        type: 'PersonalAccessToken',
+                    }),
+                }),
             );
         });
     });

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -56,7 +56,19 @@ import refresh from 'passport-oauth2-refresh';
 import { LightdashAnalytics } from '../analytics/LightdashAnalytics';
 import EmailClient from '../clients/EmailClient/EmailClient';
 import { LightdashConfig } from '../config/parseConfig';
+import {
+    createAuditLogEvent,
+    createUnknownAuthActor,
+    type AuditActor,
+    type AuditResource,
+    type AuditStatusType,
+} from '../logging/auditLog';
+import {
+    createActorFromUser,
+    type AuditableUser,
+} from '../logging/caslAuditWrapper';
 import Logger from '../logging/logger';
+import { logAuditEvent } from '../logging/winston';
 import { PersonalAccessTokenModel } from '../models/DashboardModel/PersonalAccessTokenModel';
 import { EmailModel } from '../models/EmailModel';
 import { GroupsModel } from '../models/GroupsModel';
@@ -99,6 +111,64 @@ function isSameMinute(a: Date | null, b: Date): boolean {
     if (!a) return false;
     return Math.floor(a.getTime() / 60000) === Math.floor(b.getTime() / 60000);
 }
+
+export type AuthAuditContext = {
+    ip?: string;
+    userAgent?: string;
+    requestId?: string;
+};
+
+const emitAuthAuditEvent = ({
+    actor,
+    action,
+    resourceType,
+    status,
+    reason,
+    organizationUuid,
+    metadata,
+    context,
+}: {
+    actor: AuditActor;
+    action: 'login' | 'logout' | 'impersonation_start' | 'impersonation_stop';
+    resourceType:
+        | 'Session'
+        | 'PersonalAccessToken'
+        | 'ServiceAccount'
+        | 'EmbedJwt'
+        | 'User';
+    status: AuditStatusType;
+    reason?: string;
+    organizationUuid?: string;
+    metadata?: Record<string, unknown>;
+    context?: AuthAuditContext;
+}): void => {
+    try {
+        const resource: AuditResource = {
+            type: resourceType,
+            organizationUuid: organizationUuid ?? 'unknown',
+            metadata,
+        };
+        const event = createAuditLogEvent(
+            actor,
+            action,
+            resource,
+            {
+                ip: context?.ip,
+                userAgent: context?.userAgent,
+                requestId: context?.requestId,
+            },
+            status,
+            reason,
+        );
+        logAuditEvent(event);
+    } catch (err) {
+        Logger.warn('Failed to log auth audit event', {
+            error: err instanceof Error ? err.message : String(err),
+            action,
+            resourceType,
+        });
+    }
+};
 
 export class UserService extends BaseService {
     private readonly lightdashConfig: LightdashConfig;
@@ -604,6 +674,7 @@ export class UserService extends BaseService {
         authenticatedUser: SessionUser | undefined,
         inviteCode: string | undefined,
         refreshToken?: string,
+        context?: AuthAuditContext,
     ): Promise<SessionUser> {
         this.logger.info(
             `Starting loginWithOpenId - Email: ${
@@ -613,6 +684,45 @@ export class UserService extends BaseService {
             }, Has invite code: ${!!inviteCode}, Is authenticated: ${!!authenticatedUser}`,
         );
 
+        try {
+            const loggedInUser = await this.loginWithOpenIdInner(
+                openIdUser,
+                authenticatedUser,
+                inviteCode,
+                refreshToken,
+            );
+            emitAuthAuditEvent({
+                actor: createActorFromUser(loggedInUser),
+                action: 'login',
+                resourceType: 'Session',
+                status: 'allowed',
+                organizationUuid: loggedInUser.organizationUuid,
+                metadata: { loginProvider: openIdUser.openId.issuerType },
+                context,
+            });
+            return loggedInUser;
+        } catch (e) {
+            emitAuthAuditEvent({
+                actor: createUnknownAuthActor(openIdUser.openId.email),
+                action: 'login',
+                resourceType: 'Session',
+                status: 'denied',
+                reason: e instanceof Error ? e.message : 'OpenID login failure',
+                metadata: {
+                    loginProvider: openIdUser.openId.issuerType,
+                },
+                context,
+            });
+            throw e;
+        }
+    }
+
+    private async loginWithOpenIdInner(
+        openIdUser: OpenIdUser,
+        authenticatedUser: SessionUser | undefined,
+        inviteCode: string | undefined,
+        refreshToken: string | undefined,
+    ): Promise<SessionUser> {
         const openIdSession = await this.userModel.findSessionUserByOpenId(
             openIdUser.openId.issuer,
             openIdUser.openId.subject,
@@ -1102,11 +1212,26 @@ export class UserService extends BaseService {
     async loginWithPassword(
         email: string,
         password: string,
+        context?: AuthAuditContext,
     ): Promise<LightdashUser> {
+        const emitFailure = (reason: string) =>
+            emitAuthAuditEvent({
+                actor: createUnknownAuthActor(email),
+                action: 'login',
+                resourceType: 'Session',
+                status: 'denied',
+                reason,
+                metadata: { loginProvider: 'password' },
+                context,
+            });
+
         if (
             (await this.isLoginMethodAllowed(email, LocalIssuerTypes.EMAIL)) ===
             false
         ) {
+            emitFailure(
+                `User with email ${email} is not allowed to login with password`,
+            );
             throw new ForbiddenError(
                 `User with email ${email} is not allowed to login with password`,
             );
@@ -1143,11 +1268,30 @@ export class UserService extends BaseService {
                     loginProvider: 'password',
                 },
             });
+            emitAuthAuditEvent({
+                actor: createActorFromUser(userWithOrganization),
+                action: 'login',
+                resourceType: 'Session',
+                status: 'allowed',
+                organizationUuid: userWithOrganization.organizationUuid,
+                metadata: { loginProvider: 'password' },
+                context,
+            });
             return user;
         } catch (e) {
             if (e instanceof NotFoundError) {
+                emitFailure('Email and password not recognized');
                 throw new AuthorizationError(
                     'Email and password not recognized',
+                );
+            }
+            if (e instanceof DeactivatedAccountError) {
+                emitFailure('Account is deactivated');
+            } else if (e instanceof ForbiddenError) {
+                emitFailure(e.message);
+            } else {
+                emitFailure(
+                    e instanceof Error ? e.message : 'Unknown login failure',
                 );
             }
             throw e;
@@ -1345,14 +1489,32 @@ export class UserService extends BaseService {
         }
     }
 
-    async loginWithPersonalAccessToken(token: string): Promise<SessionUser> {
+    async loginWithPersonalAccessToken(
+        token: string,
+        context?: AuthAuditContext,
+    ): Promise<SessionUser> {
+        const emitDenied = (reason: string, user?: AuditableUser) =>
+            emitAuthAuditEvent({
+                actor: user
+                    ? createActorFromUser(user)
+                    : createUnknownAuthActor(),
+                action: 'login',
+                resourceType: 'PersonalAccessToken',
+                status: 'denied',
+                reason,
+                organizationUuid: user?.organizationUuid,
+                context,
+            });
+
         const results =
             await this.userModel.findSessionUserByPersonalAccessToken(token);
         if (results === undefined) {
+            emitDenied('Personal access token not recognized');
             throw new AuthorizationError();
         }
         const { user, personalAccessToken } = results;
         if (!user.isActive) {
+            emitDenied('Account is deactivated', user);
             throw new DeactivatedAccountError();
         }
         const auditedAbility = this.createAuditedAbility(user);
@@ -1364,6 +1526,10 @@ export class UserService extends BaseService {
                 }),
             )
         ) {
+            emitDenied(
+                'User lacks permission to login with personal access tokens',
+                user,
+            );
             throw new ForbiddenError(
                 'You do not have permission to login with personal access tokens',
             );
@@ -1384,6 +1550,7 @@ export class UserService extends BaseService {
                     personalAccessToken.uuid,
                 );
             }
+            emitDenied('Personal access token expired', user);
             throw new AuthorizationError();
         }
         // Update last used date (throttled to once per minute)
@@ -2329,6 +2496,7 @@ export class UserService extends BaseService {
             isSessionAuth,
             getImpersonation,
             setImpersonation,
+            context,
         }: {
             isSessionAuth: boolean;
             getImpersonation: () => { targetUserUuid: string } | undefined;
@@ -2338,13 +2506,29 @@ export class UserService extends BaseService {
                 targetUserUuid: string;
                 startedAt: string;
             }) => void;
+            context?: AuthAuditContext;
         },
     ): Promise<void> {
+        const emitDenied = (reason: string, targetOrgUuid?: string) =>
+            emitAuthAuditEvent({
+                actor: createActorFromUser(adminUser),
+                action: 'impersonation_start',
+                resourceType: 'User',
+                status: 'denied',
+                reason,
+                organizationUuid:
+                    targetOrgUuid ?? adminUser.organizationUuid ?? undefined,
+                metadata: { targetUserUuid },
+                context,
+            });
+
         if (!(await this.isImpersonationEnabled(adminUser))) {
+            emitDenied('User impersonation is not enabled');
             throw new ForbiddenError('User impersonation is not enabled');
         }
 
         if (!isSessionAuth) {
+            emitDenied('Impersonation requires session authentication');
             throw new ForbiddenError(
                 'Impersonation requires session authentication',
             );
@@ -2352,6 +2536,9 @@ export class UserService extends BaseService {
 
         // Prevent recursive impersonation
         if (getImpersonation()) {
+            emitDenied(
+                'Cannot start impersonation while already impersonating',
+            );
             throw new ForbiddenError(
                 'Cannot start impersonation while already impersonating',
             );
@@ -2359,6 +2546,7 @@ export class UserService extends BaseService {
 
         // Prevent self-impersonation
         if (adminUser.userUuid === targetUserUuid) {
+            emitDenied('Cannot impersonate yourself');
             throw new ParameterError('Cannot impersonate yourself');
         }
 
@@ -2377,6 +2565,10 @@ export class UserService extends BaseService {
                 }),
             )
         ) {
+            emitDenied(
+                "You don't have permissions to impersonate this user",
+                targetUser.organizationUuid ?? undefined,
+            );
             throw new ForbiddenError(
                 "You don't have permissions to impersonate this user",
             );
@@ -2402,16 +2594,31 @@ export class UserService extends BaseService {
                 organizationUuid: adminUser.organizationUuid!,
             },
         });
+
+        emitAuthAuditEvent({
+            actor: createActorFromUser(adminUser),
+            action: 'impersonation_start',
+            resourceType: 'User',
+            status: 'allowed',
+            organizationUuid:
+                targetUser.organizationUuid ??
+                adminUser.organizationUuid ??
+                undefined,
+            metadata: { targetUserUuid },
+            context,
+        });
     }
 
     async stopImpersonation({
         getImpersonation,
         clearImpersonation,
+        context,
     }: {
         getImpersonation: () =>
             | { adminUserUuid: string; targetUserUuid: string }
             | undefined;
         clearImpersonation: () => void;
+        context?: AuthAuditContext;
     }): Promise<void> {
         const impersonation = getImpersonation();
 
@@ -2437,6 +2644,16 @@ export class UserService extends BaseService {
                 targetUserUuid,
                 organizationUuid: adminUser.organizationUuid!,
             },
+        });
+
+        emitAuthAuditEvent({
+            actor: createActorFromUser(adminUser),
+            action: 'impersonation_stop',
+            resourceType: 'User',
+            status: 'allowed',
+            organizationUuid: adminUser.organizationUuid ?? undefined,
+            metadata: { targetUserUuid },
+            context,
         });
     }
 }

--- a/packages/backend/src/services/UserService.ts
+++ b/packages/backend/src/services/UserService.ts
@@ -1287,12 +1287,12 @@ export class UserService extends BaseService {
             }
             if (e instanceof DeactivatedAccountError) {
                 emitFailure('Account is deactivated');
+            } else if (e instanceof AuthorizationError) {
+                emitFailure('Email and password not recognized');
             } else if (e instanceof ForbiddenError) {
-                emitFailure(e.message);
+                emitFailure('Login not permitted for this account');
             } else {
-                emitFailure(
-                    e instanceof Error ? e.message : 'Unknown login failure',
-                );
+                emitFailure('Login failed');
             }
             throw e;
         }


### PR DESCRIPTION
## Summary

Adds authentication audit logging at the auth boundary (login, logout, impersonation, per-request auth failures) so that successful and rejected access attempts are captured for ITGC compliance. These events sit outside the existing CASL audit wrapper because authentication happens before any CASL permission check.

- **Session lifecycle (success + failure):** password and OpenID login emit \`login\`/Session events; \`/logout\` emits \`logout\`/Session.
- **Per-request auth (failures only):** PAT, service-account bearer, and embed JWT failures emit \`login\` denied events. Successes are not duplicated — the CASL audit wrapper already records the resource access.
- **Impersonation:** \`startImpersonation\`/\`stopImpersonation\` emit \`impersonation_start\`/\`impersonation_stop\` events including denial reasons (feature disabled, not session auth, nested, self, no perms).

Wires \`{ ip, userAgent }\` from each entry point through to the service so the events land with request context.

## Implementation notes

- New helper \`createUnknownAuthActor()\` (in \`logging/auditLog.ts\`) builds the actor for failed-login cases where we know the email but not the user.
- \`UserService\` gets a small private \`emitAuthAuditEvent()\` helper that wraps \`logAuditEvent\` with try/catch so an audit-write failure can never break login.
- All passport strategies updated to forward IP/user-agent. \`localPassportStrategy\` now uses \`passReqToCallback: true\` (already supported by \`@types/passport-local\`).

## Test plan

- [x] \`pnpm -F backend typecheck\` clean
- [x] \`pnpm -F backend lint\` clean
- [x] \`pnpm -F backend test:dev:nowatch\` — 1073 tests pass; new tests cover allowed/denied login events for password and OpenID, and denied PAT auth
- [ ] Manual smoke: log in with password, log in with Google/Okta, log out, fail login with wrong password — confirm audit log entries
- [ ] Manual smoke: start/stop impersonation — confirm allowed and denied events
- [ ] Manual smoke: hit an endpoint with a bogus PAT / Bearer token / embed JWT — confirm denied events