### PR TITLE
feat: add analytics tracking for pre-aggregate routing and materialization events

### DIFF
--- a/packages/backend/src/analytics/LightdashAnalytics.ts
+++ b/packages/backend/src/analytics/LightdashAnalytics.ts
@@ -284,6 +284,44 @@ type QueryErrorEvent = BaseTrack & {
     };
 };
 
+type PreAggregateQueryEvent = BaseTrack & {
+    event: 'pre_aggregate.hit' | 'pre_aggregate.miss';
+    properties: {
+        organizationId: string | undefined;
+        projectId: string;
+        context: QueryExecutionContext;
+        exploreName: string;
+        routingTarget: 'warehouse' | 'pre_aggregate' | 'materialization';
+        routeMode?: 'required' | 'opportunistic';
+        preAggregateName?: string;
+        chartId?: string;
+        dashboardId?: string;
+        missReason?: string;
+    };
+};
+
+type MaterializationEvent = BaseTrack & {
+    event: 'materialization.completed' | 'materialization.failed';
+    properties: {
+        organizationId: string | undefined;
+        materializationUuid: string;
+        projectId: string;
+        preAggregateDefinitionUuid: string;
+        preAggregateName?: string;
+        trigger: string;
+        queryId?: string;
+        materializationStatus?: 'active' | 'superseded' | 'failed';
+        queryStatus?: QueryHistoryStatus;
+        format?: 'jsonl' | 'parquet';
+        rowCount?: number | null;
+        columnCount?: number | null;
+        totalBytes?: number | null;
+        warehouseExecutionTimeMs?: number | null;
+        totalDurationMs: number;
+        errorMessage?: string;
+    };
+};
+
 type QueryPageEvent = BaseTrack & {
     event: 'query_page.fetched';
     properties: {
@@ -1771,6 +1809,8 @@ type TypedEvent =
     | QueryExecutionEvent
     | QueryReadyEvent
     | QueryErrorEvent
+    | PreAggregateQueryEvent
+    | MaterializationEvent
     | QueryPageEvent
     | ResultsCacheCreateEvent
     | ResultsCacheWriteEvent

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.test.ts
@@ -1,13 +1,14 @@
 import {
+    Account,
     QueryExecutionContext,
     QueryHistoryStatus,
-    type Account,
 } from '@lightdash/common';
-import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
+import { analyticsMock } from '../../../analytics/LightdashAnalytics.mock';
+import type { S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { lightdashConfigMock } from '../../../config/lightdashConfig.mock';
-import { type QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
-import { type AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
-import { type PreAggregateModel } from '../../models/PreAggregateModel';
+import type { QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
+import type { AsyncQueryService } from '../../../services/AsyncQueryService/AsyncQueryService';
+import type { PreAggregateModel } from '../../models/PreAggregateModel';
 import { PreAggregateMaterializationService } from './PreAggregateMaterializationService';
 
 describe('PreAggregateMaterializationService', () => {
@@ -45,12 +46,14 @@ describe('PreAggregateMaterializationService', () => {
         preAggregateModel: preAggregateModel as unknown as PreAggregateModel,
         queryHistoryModel: queryHistoryModel as unknown as QueryHistoryModel,
         asyncQueryService: asyncQueryService as unknown as AsyncQueryService,
+        analytics: analyticsMock,
         preAggregateResultsStorageClient:
             preAggregateResultsStorageClient as unknown as S3ResultsFileStorageClient,
     });
 
     beforeEach(() => {
         jest.clearAllMocks();
+        jest.spyOn(analyticsMock, 'trackAccount').mockImplementation();
         preAggregateModel.insertInProgress.mockResolvedValue({
             materializationUuid: 'mat-1',
         });

--- a/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
+++ b/packages/backend/src/ee/services/PreAggregateMaterializationService/PreAggregateMaterializationService.ts
@@ -13,6 +13,7 @@ import {
     type PreAggregateMaterializationTrigger,
 } from '@lightdash/common';
 import * as Sentry from '@sentry/node';
+import { LightdashAnalytics } from '../../../analytics/LightdashAnalytics';
 import { type S3ResultsFileStorageClient } from '../../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { type LightdashConfig } from '../../../config/parseConfig';
 import { type QueryHistoryModel } from '../../../models/QueryHistoryModel/QueryHistoryModel';
@@ -33,6 +34,8 @@ export class PreAggregateMaterializationService extends BaseService {
 
     private readonly asyncQueryService: AsyncQueryService;
 
+    private readonly analytics: LightdashAnalytics;
+
     private readonly prometheusMetrics: PrometheusMetrics | undefined;
 
     private readonly preAggregateResultsStorageClient: S3ResultsFileStorageClient;
@@ -42,6 +45,7 @@ export class PreAggregateMaterializationService extends BaseService {
         preAggregateModel: PreAggregateModel;
         queryHistoryModel: QueryHistoryModel;
         asyncQueryService: AsyncQueryService;
+        analytics: LightdashAnalytics;
         preAggregateResultsStorageClient: S3ResultsFileStorageClient;
         prometheusMetrics?: PrometheusMetrics;
     }) {
@@ -50,6 +54,7 @@ export class PreAggregateMaterializationService extends BaseService {
         this.preAggregateModel = args.preAggregateModel;
         this.queryHistoryModel = args.queryHistoryModel;
         this.asyncQueryService = args.asyncQueryService;
+        this.analytics = args.analytics;
         this.preAggregateResultsStorageClient =
             args.preAggregateResultsStorageClient;
         this.prometheusMetrics = args.prometheusMetrics;
@@ -76,6 +81,73 @@ export class PreAggregateMaterializationService extends BaseService {
         return this.parquetEnabled ? 'parquet' : 'jsonl';
     }
 
+    private trackMaterializationCompleted(args: {
+        account: Account;
+        materializationUuid: string;
+        queryUuid: string;
+        projectUuid: string;
+        preAggregateDefinitionUuid: string;
+        preAggregateName?: string;
+        trigger: PreAggregateMaterializationTrigger;
+        status: 'active' | 'superseded';
+        format: 'jsonl' | 'parquet';
+        rowCount: number | null | undefined;
+        columnCount: number | null;
+        totalBytes: number | null | undefined;
+        warehouseExecutionTimeMs: number | null | undefined;
+        totalDurationMs: number;
+    }): void {
+        this.analytics.trackAccount(args.account, {
+            event: 'materialization.completed',
+            properties: {
+                organizationId: args.account.organization?.organizationUuid,
+                materializationUuid: args.materializationUuid,
+                queryId: args.queryUuid,
+                projectId: args.projectUuid,
+                preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
+                preAggregateName: args.preAggregateName,
+                trigger: args.trigger,
+                materializationStatus: args.status,
+                format: args.format,
+                rowCount: args.rowCount,
+                columnCount: args.columnCount,
+                totalBytes: args.totalBytes,
+                warehouseExecutionTimeMs: args.warehouseExecutionTimeMs,
+                totalDurationMs: args.totalDurationMs,
+            },
+        });
+    }
+
+    private trackMaterializationFailed(args: {
+        account: Account;
+        materializationUuid: string;
+        projectUuid: string;
+        preAggregateDefinitionUuid: string;
+        preAggregateName?: string;
+        trigger: PreAggregateMaterializationTrigger;
+        totalDurationMs: number;
+        errorMessage: string;
+        queryUuid?: string;
+        queryStatus?: QueryHistoryStatus;
+    }): void {
+        this.analytics.trackAccount(args.account, {
+            event: 'materialization.failed',
+            properties: {
+                organizationId: args.account.organization?.organizationUuid,
+                materializationUuid: args.materializationUuid,
+                queryId: args.queryUuid,
+                projectId: args.projectUuid,
+                preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
+                preAggregateName: args.preAggregateName,
+                trigger: args.trigger,
+                materializationStatus: 'failed',
+                queryStatus: args.queryStatus,
+                totalDurationMs: args.totalDurationMs,
+                errorMessage: args.errorMessage,
+            },
+        });
+    }
+
     async materializePreAggregate(args: {
         account: Account;
         projectUuid: string;
@@ -87,6 +159,7 @@ export class PreAggregateMaterializationService extends BaseService {
         queryUuid?: string;
     }> {
         let materializationUuid: string | undefined;
+        let preAggregateName: string | undefined;
         const startTime = Date.now();
 
         try {
@@ -101,6 +174,7 @@ export class PreAggregateMaterializationService extends BaseService {
                     `Pre-aggregate definition "${args.preAggregateDefinitionUuid}" was not found`,
                 );
             }
+            preAggregateName = definition.preAggregateDefinition.name;
 
             this.logger.info(
                 `Starting pre-aggregate materialization for definition ${args.preAggregateDefinitionUuid}`,
@@ -122,11 +196,22 @@ export class PreAggregateMaterializationService extends BaseService {
 
             const { materializationMetricQuery } = definition;
             if (!materializationMetricQuery) {
+                const errorMessage =
+                    definition.materializationQueryError ||
+                    'Pre-aggregate definition is missing materialization query';
                 await this.preAggregateModel.markFailed({
                     materializationUuid,
-                    errorMessage:
-                        definition.materializationQueryError ||
-                        'Pre-aggregate definition is missing materialization query',
+                    errorMessage,
+                });
+                this.trackMaterializationFailed({
+                    account: args.account,
+                    materializationUuid,
+                    projectUuid: args.projectUuid,
+                    preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
+                    preAggregateName,
+                    trigger: args.trigger,
+                    totalDurationMs: Date.now() - startTime,
+                    errorMessage,
                 });
 
                 return {
@@ -268,6 +353,18 @@ export class PreAggregateMaterializationService extends BaseService {
                 });
 
                 const durationMs = Date.now() - startTime;
+                this.trackMaterializationFailed({
+                    account: args.account,
+                    materializationUuid,
+                    queryUuid,
+                    projectUuid: args.projectUuid,
+                    preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
+                    preAggregateName,
+                    trigger: args.trigger,
+                    queryStatus: queryHistory.status,
+                    totalDurationMs: durationMs,
+                    errorMessage,
+                });
                 this.prometheusMetrics?.preAggregateMaterializationCounter?.inc(
                     { status: 'failed', trigger: args.trigger },
                 );
@@ -297,6 +394,19 @@ export class PreAggregateMaterializationService extends BaseService {
 
                 await this.preAggregateModel.markFailed({
                     materializationUuid,
+                    errorMessage:
+                        'Materialization query completed without a persisted results file',
+                });
+                this.trackMaterializationFailed({
+                    account: args.account,
+                    materializationUuid,
+                    queryUuid,
+                    projectUuid: args.projectUuid,
+                    preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
+                    preAggregateName,
+                    trigger: args.trigger,
+                    queryStatus: queryHistory.status,
+                    totalDurationMs: Date.now() - startTime,
                     errorMessage:
                         'Materialization query completed without a persisted results file',
                 });
@@ -440,6 +550,22 @@ export class PreAggregateMaterializationService extends BaseService {
                     this.getMaterializationFormat(),
                 );
             }
+            this.trackMaterializationCompleted({
+                account: args.account,
+                materializationUuid,
+                queryUuid,
+                projectUuid: args.projectUuid,
+                preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
+                preAggregateName,
+                trigger: args.trigger,
+                status,
+                format: this.getMaterializationFormat(),
+                rowCount: queryHistory.totalRowCount,
+                columnCount,
+                totalBytes,
+                warehouseExecutionTimeMs: queryHistory.warehouseExecutionTimeMs,
+                totalDurationMs: durationMs,
+            });
 
             return {
                 materializationUuid,
@@ -471,12 +597,23 @@ export class PreAggregateMaterializationService extends BaseService {
             );
 
             if (materializationUuid) {
+                const errorMessage =
+                    error instanceof Error
+                        ? error.message
+                        : 'Unknown materialization error';
                 await this.preAggregateModel.markFailed({
                     materializationUuid,
-                    errorMessage:
-                        error instanceof Error
-                            ? error.message
-                            : 'Unknown materialization error',
+                    errorMessage,
+                });
+                this.trackMaterializationFailed({
+                    account: args.account,
+                    materializationUuid,
+                    projectUuid: args.projectUuid,
+                    preAggregateDefinitionUuid: args.preAggregateDefinitionUuid,
+                    preAggregateName,
+                    trigger: args.trigger,
+                    totalDurationMs: durationMs,
+                    errorMessage,
                 });
 
                 return {

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.test.ts
@@ -1,31 +1,31 @@
 import { Ability } from '@casl/ability';
 import {
     AnyType,
+    CreateWarehouseCredentials,
     DimensionType,
+    ExecuteAsyncQueryRequestParams,
     ExploreType,
     FilterOperator,
     ForbiddenError,
     NotFoundError,
+    PossibleAbilities,
     QueryExecutionContext,
+    QueryHistory,
     QueryHistoryStatus,
+    ResultColumns,
     VizAggregationOptions,
     VizIndexType,
+    WarehouseClient,
     WarehouseTypes,
-    type CreateWarehouseCredentials,
-    type ExecuteAsyncQueryRequestParams,
-    type PossibleAbilities,
-    type QueryHistory,
-    type ResultColumns,
-    type WarehouseClient,
 } from '@lightdash/common';
-import { type SshTunnel } from '@lightdash/warehouses';
+import type { SshTunnel } from '@lightdash/warehouses';
 import { Readable } from 'stream';
 import { analyticsMock } from '../../analytics/LightdashAnalytics.mock';
 import type { S3CacheClient } from '../../clients/Aws/S3CacheClient';
 import EmailClient from '../../clients/EmailClient/EmailClient';
-import { type FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
+import type { FileStorageClient } from '../../clients/FileStorage/FileStorageClient';
 import type { INatsClient } from '../../clients/NatsClient';
-import { type S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
+import type { S3ResultsFileStorageClient } from '../../clients/ResultsFileStorageClients/S3ResultsFileStorageClient';
 import { lightdashConfigMock } from '../../config/lightdashConfig.mock';
 import type { LightdashConfig } from '../../config/parseConfig';
 import type { PreAggregateModel } from '../../ee/models/PreAggregateModel';

--- a/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
+++ b/packages/backend/src/services/AsyncQueryService/AsyncQueryService.ts
@@ -298,6 +298,46 @@ export class AsyncQueryService extends ProjectService {
         this.preAggregateStrategy.recordStats(params);
     }
 
+    private trackPreAggregateRoutingEvent({
+        account,
+        projectUuid,
+        context,
+        exploreName,
+        routingTarget,
+        preAggregateMetadata,
+        preAggregationRoute,
+        chartId,
+        dashboardId,
+    }: {
+        account: Account;
+        projectUuid: string;
+        context: QueryExecutionContext;
+        exploreName: string;
+        routingTarget: 'warehouse' | 'pre_aggregate' | 'materialization';
+        preAggregateMetadata: NonNullable<CacheMetadata['preAggregate']>;
+        preAggregationRoute?: PreAggregationRoute;
+        chartId?: string;
+        dashboardId?: string;
+    }): void {
+        this.analytics.trackAccount(account, {
+            event: preAggregateMetadata.hit
+                ? 'pre_aggregate.hit'
+                : 'pre_aggregate.miss',
+            properties: {
+                organizationId: account.organization?.organizationUuid,
+                projectId: projectUuid,
+                context,
+                exploreName,
+                routingTarget,
+                routeMode: preAggregationRoute?.mode,
+                preAggregateName: preAggregateMetadata.name,
+                chartId,
+                dashboardId,
+                missReason: preAggregateMetadata.reason?.reason,
+            },
+        });
+    }
+
     async cleanupPreAggregateDailyStats(
         retentionDays: number,
     ): Promise<number> {
@@ -4046,6 +4086,19 @@ export class AsyncQueryService extends ProjectService {
                 routingDecision.preAggregateMetadata.hit,
                 routingDecision.preAggregateMetadata.reason?.reason,
             );
+            this.trackPreAggregateRoutingEvent({
+                account,
+                projectUuid,
+                context,
+                exploreName: explore.name,
+                routingTarget: routingDecision.target,
+                preAggregateMetadata: routingDecision.preAggregateMetadata,
+                preAggregationRoute:
+                    routingDecision.target === 'pre_aggregate'
+                        ? routingDecision.route
+                        : undefined,
+                chartId: savedChart.uuid,
+            });
         }
 
         this.recordPreAggregateStats({
@@ -4351,6 +4404,20 @@ export class AsyncQueryService extends ProjectService {
                 routingDecision.preAggregateMetadata.hit,
                 routingDecision.preAggregateMetadata.reason?.reason,
             );
+            this.trackPreAggregateRoutingEvent({
+                account,
+                projectUuid,
+                context,
+                exploreName: explore.name,
+                routingTarget: routingDecision.target,
+                preAggregateMetadata: routingDecision.preAggregateMetadata,
+                preAggregationRoute:
+                    routingDecision.target === 'pre_aggregate'
+                        ? routingDecision.route
+                        : undefined,
+                chartId: savedChart.uuid,
+                dashboardId: dashboardUuid,
+            });
         }
 
         this.recordPreAggregateStats({

--- a/packages/backend/src/services/ServiceRepository.ts
+++ b/packages/backend/src/services/ServiceRepository.ts
@@ -557,6 +557,7 @@ export class ServiceRepository
                     preAggregateModel: this.models.getPreAggregateModel(),
                     queryHistoryModel: this.models.getQueryHistoryModel(),
                     asyncQueryService: this.getAsyncQueryService(),
+                    analytics: this.context.lightdashAnalytics,
                     preAggregateResultsStorageClient:
                         this.clients.getPreAggregateResultsFileStorageClient(),
                     prometheusMetrics: this.prometheusMetrics,


### PR DESCRIPTION
Closes:

### Description:

Adds analytics tracking for pre-aggregate query routing and materialization lifecycle events.

Two new analytics event types are introduced:

- `pre_aggregate.hit` / `pre_aggregate.miss` — fired when a query is routed through the pre-aggregation system, capturing details such as the routing target (`warehouse`, `pre_aggregate`, or `materialization`), route mode, explore name, chart/dashboard context, and the reason for a cache miss.

- `materialization.completed` / `materialization.failed` — fired at the end of a materialization attempt, capturing details such as trigger type, format, row/column counts, byte size, warehouse execution time, total duration, and error messages on failure.

Tracking is emitted at all relevant exit points in `PreAggregateMaterializationService` (missing query definition, query failure, missing results file, successful completion, and unexpected errors) and at the routing decision point in `AsyncQueryService` for both chart and dashboard query paths. The `LightdashAnalytics` instance is injected into `PreAggregateMaterializationService` via its constructor and wired up through `ServiceRepository`.