### PR TITLE
fix: swallow DB errors in `FeatureFlagModel` for non-UUID userUuids

### DIFF
--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.test.ts
@@ -7,9 +7,17 @@ import { FeatureFlagModel } from './FeatureFlagModel';
 // Minimal stub — tests below don't exercise the database layer
 const databaseStub = {} as Knex;
 
-const buildModel = (configOverrides: Partial<LightdashConfig> = {}) =>
+// Throws on any query — used to verify DB errors are swallowed by the model
+const throwingDatabase = (() => {
+    throw new Error('invalid input syntax for type uuid');
+}) as unknown as Knex;
+
+const buildModel = (
+    configOverrides: Partial<LightdashConfig> = {},
+    database: Knex = databaseStub,
+) =>
     new FeatureFlagModel({
-        database: databaseStub,
+        database,
         lightdashConfig: {
             ...lightdashConfigMock,
             enabledFeatureFlags: new Set<string>(),
@@ -98,6 +106,48 @@ describe('FeatureFlagModel', () => {
             });
 
             expect(result.enabled).toBe(false);
+        });
+    });
+
+    describe('database error resilience', () => {
+        // Reproduces the embed-account regression: a non-UUID userUuid
+        // (e.g. `external::…`) makes Postgres throw 22P02 on the override
+        // lookup. The model must swallow that and resolve to disabled
+        // rather than 500ing.
+        it('does not throw when EnableTimezoneSupport DB lookup fails', async () => {
+            const model = buildModel({}, throwingDatabase);
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableTimezoneSupport,
+                user: {
+                    userUuid: 'external::not-a-uuid',
+                    organizationUuid: 'org-uuid',
+                    organizationName: 'Org',
+                },
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.EnableTimezoneSupport,
+                enabled: false,
+            });
+        });
+
+        it('does not throw when EnableDataApps DB lookup fails', async () => {
+            const model = buildModel({}, throwingDatabase);
+
+            const result = await model.get({
+                featureFlagId: FeatureFlags.EnableDataApps,
+                user: {
+                    userUuid: 'external::not-a-uuid',
+                    organizationUuid: 'org-uuid',
+                    organizationName: 'Org',
+                },
+            });
+
+            expect(result).toEqual({
+                id: FeatureFlags.EnableDataApps,
+                enabled: false,
+            });
         });
     });
 });

--- a/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
+++ b/packages/backend/src/models/FeatureFlagModel/FeatureFlagModel.ts
@@ -78,15 +78,9 @@ export class FeatureFlagModel {
         }
 
         // 3. Check database (user override > org override > flag default)
-        try {
-            const dbResult = await this.getFromDatabase(args);
-            if (dbResult !== null) {
-                return dbResult;
-            }
-        } catch (e) {
-            Logger.warn(
-                `Failed to check feature flag ${args.featureFlagId} from database, falling through to PostHog: ${e}`,
-            );
+        const dbResult = await this.tryGetFromDatabase(args);
+        if (dbResult !== null) {
+            return dbResult;
         }
 
         // 4. Fallback to PostHog (temporary, will be removed after migration)
@@ -391,7 +385,7 @@ export class FeatureFlagModel {
         if (this.lightdashConfig.query.enableTimezoneSupport) {
             return { id: args.featureFlagId, enabled: true };
         }
-        const dbResult = await this.getFromDatabase(args);
+        const dbResult = await this.tryGetFromDatabase(args);
         return dbResult ?? { id: args.featureFlagId, enabled: false };
     }
 
@@ -401,9 +395,21 @@ export class FeatureFlagModel {
         if (this.lightdashConfig.appRuntime.enabled) {
             return { id: args.featureFlagId, enabled: true };
         }
-        // Fall through to database check (pass full args for user/org override resolution)
-        const dbResult = await this.getFromDatabase(args);
+        const dbResult = await this.tryGetFromDatabase(args);
         return dbResult ?? { id: args.featureFlagId, enabled: false };
+    }
+
+    private async tryGetFromDatabase(
+        args: FeatureFlagLogicArgs,
+    ): Promise<FeatureFlag | null> {
+        try {
+            return await this.getFromDatabase(args);
+        } catch (e) {
+            Logger.warn(
+                `Failed to check feature flag ${args.featureFlagId} from database, falling through: ${e}`,
+            );
+            return null;
+        }
     }
 
     private async getFromDatabase(


### PR DESCRIPTION
### Description:

Fixes a regression affecting embed accounts where a non-UUID `userUuid` (e.g. `external::…`) causes Postgres to throw a `22P02` invalid UUID syntax error during feature flag database lookups. Previously, this would result in a 500 error rather than gracefully resolving the flag as disabled.

The fix extracts the database error handling into a shared `tryGetFromDatabase` helper that catches any database errors, logs a warning, and returns `null` (resolving to disabled) instead of propagating the exception. This replaces the previously inconsistent error handling where some code paths had try/catch and others did not.

Tests have been added to verify that `EnableTimezoneSupport` and `EnableDataApps` flag lookups both return `enabled: false` rather than throwing when the database layer fails.