### PR TITLE
fix: render invalid filter operator as removable warning instead of crashing

### DIFF
--- a/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
+++ b/packages/frontend/src/components/common/Filters/FilterRuleForm.tsx
@@ -105,7 +105,19 @@ const FilterRuleForm: FC<Props> = memo(
         const isFieldSelectDisabled =
             !isEditMode || (isRequired && availableFields.length <= 1);
 
+        const isOperatorValid = useMemo(
+            () =>
+                filterOperatorOptions.some(
+                    (o) => o.value === filterRule.operator,
+                ),
+            [filterOperatorOptions, filterRule.operator],
+        );
+
         if (!activeField) {
+            return null;
+        }
+
+        if (!isOperatorValid) {
             return null;
         }
 

--- a/packages/frontend/src/components/common/Filters/index.tsx
+++ b/packages/frontend/src/components/common/Filters/index.tsx
@@ -2,7 +2,9 @@ import {
     addFilterRule,
     deleteFilterRuleFromGroup,
     getFiltersFromGroup,
+    getFilterTypeFromItem,
     getItemId,
+    getItemLabelWithoutTableName,
     getTotalFilterRules,
     hasNestedGroups,
     isAndFilterGroup,
@@ -37,6 +39,7 @@ import FieldSelect from '../FieldSelect';
 import MantineIcon from '../MantineIcon';
 import { FILTER_SELECT_LIMIT } from './constants';
 import FilterGroupForm from './FilterGroupForm';
+import { getFilterOperatorOptions } from './FilterInputs/utils';
 import SimplifiedFilterGroupForm from './SimplifiedFilterGroupForm';
 import useFiltersContext from './useFiltersContext';
 
@@ -46,17 +49,49 @@ type Props = {
     isEditMode: boolean;
 };
 
+type InvalidFilterRule =
+    | { reason: 'unknown_field'; rule: FilterRule }
+    | {
+          reason: 'invalid_operator';
+          rule: FilterRule;
+          fieldLabel: string;
+      };
+
 const getInvalidFilterRules = (
     fields: FieldWithSuggestions[],
     filterRules: FilterRule[],
-) =>
-    filterRules.reduce<FilterRule[]>((accumulator, filterRule) => {
+): InvalidFilterRule[] =>
+    filterRules.reduce<InvalidFilterRule[]>((accumulator, filterRule) => {
         const fieldInRule = fields.find(
             (field) => getItemId(field) === filterRule.target.fieldId,
         );
 
         if (!fieldInRule) {
-            return [...accumulator, filterRule];
+            return [
+                ...accumulator,
+                { reason: 'unknown_field', rule: filterRule },
+            ];
+        }
+
+        if (!isFilterableField(fieldInRule)) {
+            return accumulator;
+        }
+
+        const filterType = getFilterTypeFromItem(fieldInRule);
+        const validOperators = getFilterOperatorOptions(
+            filterType,
+            fieldInRule,
+        ).map((option) => option.value);
+
+        if (!validOperators.includes(filterRule.operator)) {
+            return [
+                ...accumulator,
+                {
+                    reason: 'invalid_operator',
+                    rule: filterRule,
+                    fieldLabel: getItemLabelWithoutTableName(fieldInRule),
+                },
+            ];
         }
 
         return accumulator;
@@ -303,9 +338,9 @@ const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
 
             {hasInvalidFilterRules && (
                 <Stack gap="xs" pl={showSimplifiedForm ? undefined : 36}>
-                    {invalidFilterRules.map((rule) => (
+                    {invalidFilterRules.map((entry) => (
                         <Group
-                            key={rule.id}
+                            key={entry.rule.id}
                             gap="xs"
                             px="xs"
                             h={30}
@@ -320,10 +355,26 @@ const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
                                 color="yellow.6"
                             />
                             <Text c="yellow.6" fz="xs" style={{ flex: 1 }}>
-                                Tried to reference field with unknown id:{' '}
-                                <Code fw={500} fz="xs">
-                                    {rule.target.fieldId}
-                                </Code>
+                                {entry.reason === 'unknown_field' ? (
+                                    <>
+                                        Tried to reference field with unknown
+                                        id:{' '}
+                                        <Code fw={500} fz="xs">
+                                            {entry.rule.target.fieldId}
+                                        </Code>
+                                    </>
+                                ) : (
+                                    <>
+                                        Filter on{' '}
+                                        <Code fw={500} fz="xs">
+                                            {entry.fieldLabel}
+                                        </Code>{' '}
+                                        uses an invalid operator:{' '}
+                                        <Code fw={500} fz="xs">
+                                            {entry.rule.operator}
+                                        </Code>
+                                    </>
+                                )}
                             </Text>
                             <ActionIcon
                                 variant="subtle"
@@ -333,7 +384,7 @@ const FiltersForm: FC<Props> = memo(({ filters, setFilters, isEditMode }) => {
                                     updateFiltersFromGroup(
                                         deleteFilterRuleFromGroup(
                                             rootFilterGroup,
-                                            rule.id,
+                                            entry.rule.id,
                                         ),
                                     )
                                 }


### PR DESCRIPTION
Closes: https://linear.app/lightdash/issue/PROD-7152/explore-page-errors-if-filter-has-unsupported-operator

## Summary

When a chart's saved filter has an operator that isn't valid for the field's type (e.g. a `STRING` dimension with `lessThan`), opening the **Filters** section in the explore view crashed the entire right-hand panel with `NotImplementedError: Filter type string with operator lessThan is not implemented`.

This mirrors the existing **unknown field id** pattern: detect the bad rule in `getInvalidFilterRules`, render it in the yellow warning callout with an X to delete it, and skip rendering the rule's input in `FilterRuleForm` so the throw site is never reached.

- `getInvalidFilterRules` now returns a discriminated union (`unknown_field | invalid_operator`) using `getFilterOperatorOptions` as the single source of truth for operator validity — same source the operator dropdown uses.
- The yellow callout now dispatches on `reason`: `Filter on <field label> uses an invalid operator: <operator>` for the new case, original copy preserved for unknown-field.
- `FilterRuleForm` early-returns `null` when the rule's operator isn't in `filterOperatorOptions`, just like it already does for `!activeField`.

The throw in `getPlaceholderByFilterTypeAndOperator.ts` is intentionally left in place as a regression tripwire — it's now unreachable through the form path.

### Before

<img width="2894" height="1820" alt="CleanShot 2026-04-27 at 14 24 53@2x" src="https://github.com/user-attachments/assets/9c42802f-c9b7-4230-b528-b54a21acd873" />

### After

<img width="2890" height="1820" alt="CleanShot 2026-04-27 at 14 34 25@2x" src="https://github.com/user-attachments/assets/c30bb2ec-047e-47db-acf7-78d0bab36e65" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)