### PR TITLE
fix(backend): populate audit log request context (ip, userAgent, requestId)

### DIFF
--- a/packages/backend/src/auth/account/index.ts
+++ b/packages/backend/src/auth/account/index.ts
@@ -1,1 +1,2 @@
 export { fromJwt, fromSession } from './account';
+export { requestContextFromExpress } from './requestContext';

--- a/packages/backend/src/auth/account/requestContext.ts
+++ b/packages/backend/src/auth/account/requestContext.ts
@@ -1,0 +1,19 @@
+import type { AccountRequestContext } from '@lightdash/common';
+import type { Request } from 'express';
+
+const headerToString = (
+    value: string | string[] | undefined,
+): string | undefined => {
+    if (Array.isArray(value)) return value[0];
+    return value;
+};
+
+export const requestContextFromExpress = (
+    req: Request,
+): AccountRequestContext => ({
+    ip: req.ip,
+    userAgent: headerToString(req.headers['user-agent']),
+    requestId:
+        headerToString(req.headers['x-request-id']) ??
+        headerToString(req.headers['x-amzn-trace-id']),
+});

--- a/packages/backend/src/controllers/authentication/middlewares.ts
+++ b/packages/backend/src/controllers/authentication/middlewares.ts
@@ -12,6 +12,7 @@ import { ErrorRequestHandler, Request, RequestHandler } from 'express';
 import passport from 'passport';
 import { URL } from 'url';
 import { fromApiKey, fromOauth } from '../../auth/account/account';
+import { requestContextFromExpress } from '../../auth/account/requestContext';
 import { buildAccountExistsWarning } from '../../auth/account/warnAccountExists';
 import { lightdashConfig } from '../../config/lightdashConfig';
 import { authenticateServiceAccount } from '../../ee/authentication';
@@ -74,10 +75,13 @@ export const allowOauthAuthentication: RequestHandler = (req, res, next) => {
                             req.account?.authentication?.type,
                         );
                     }
+                    req.user = user;
                     if (user) {
                         req.account = fromOauth(user, token);
+                        const requestContext = requestContextFromExpress(req);
+                        req.account.requestContext = requestContext;
+                        req.user!.requestContext = requestContext;
                     }
-                    req.user = user;
                     next();
                 })
                 .catch((userError) => {
@@ -133,6 +137,9 @@ export const allowApiKeyAuthentication: RequestHandler = (req, res, next) => {
                             req.user!,
                             req.headers.authorization || '',
                         );
+                        const requestContext = requestContextFromExpress(req);
+                        req.account.requestContext = requestContext;
+                        req.user.requestContext = requestContext;
                     }
                     next();
                 },
@@ -166,10 +173,13 @@ export const allowApiKeyAuthentication: RequestHandler = (req, res, next) => {
                             req.account?.authentication?.type,
                         );
                     }
+                    req.user = user;
                     if (user) {
                         req.account = fromOauth(user, token);
+                        const requestContext = requestContextFromExpress(req);
+                        req.account.requestContext = requestContext;
+                        req.user!.requestContext = requestContext;
                     }
-                    req.user = user;
                     next();
                 })
                 .catch((userError) => {

--- a/packages/backend/src/ee/authentication/middlewares.ts
+++ b/packages/backend/src/ee/authentication/middlewares.ts
@@ -10,6 +10,7 @@ import {
 } from '@lightdash/common';
 import { RequestHandler } from 'express';
 import { fromServiceAccount } from '../../auth/account/account';
+import { requestContextFromExpress } from '../../auth/account/requestContext';
 import { buildAccountExistsWarning } from '../../auth/account/warnAccountExists';
 import Logger from '../../logging/logger';
 import { ServiceAccountService } from '../services/ServiceAccountService/ServiceAccountService';
@@ -164,6 +165,9 @@ export const authenticateServiceAccount: RequestHandler = async (
             );
         }
         req.account = fromServiceAccount(req.user!, token);
+        const requestContext = requestContextFromExpress(req);
+        req.account.requestContext = requestContext;
+        req.user.requestContext = requestContext;
 
         next();
     } catch (error) {

--- a/packages/backend/src/middlewares/accountMiddleware/sessionAccountMiddleware.ts
+++ b/packages/backend/src/middlewares/accountMiddleware/sessionAccountMiddleware.ts
@@ -2,6 +2,7 @@
 // This rule is failing in CI but passes locally
 import { NextFunction, Request, Response } from 'express';
 import * as Account from '../../auth/account';
+import { requestContextFromExpress } from '../../auth/account/requestContext';
 import Logger from '../../logging/logger';
 
 /**
@@ -29,6 +30,9 @@ export function sessionAccountMiddleware(
 
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
     req.account = Account.fromSession(req.user, req.headers.cookie || '');
+    const requestContext = requestContextFromExpress(req);
+    req.account.requestContext = requestContext;
+    req.user.requestContext = requestContext;
 
     next();
 }

--- a/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
+++ b/packages/backend/src/middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts
@@ -3,6 +3,7 @@
 import { JWT_HEADER_NAME, NotFoundError } from '@lightdash/common';
 import { NextFunction, Request, Response } from 'express';
 import { fromJwt } from '../../auth/account';
+import { requestContextFromExpress } from '../../auth/account/requestContext';
 import { buildAccountExistsWarning } from '../../auth/account/warnAccountExists';
 import { decodeLightdashJwt } from '../../auth/lightdashJwt';
 import { EmbedService } from '../../ee/services/EmbedService/EmbedService';
@@ -91,6 +92,7 @@ export async function jwtAuthMiddleware(
             projectUuid,
             embedToken,
         );
+        req.account.requestContext = requestContextFromExpress(req);
 
         // Not the greatest, but passport expects this to return a typeguard: this is AuthenticatedRequest.
         // AuthenticatedRequest is not defined and TS won't let us use `this` in a typeguard outside of a class.

--- a/packages/backend/src/services/BaseService.ts
+++ b/packages/backend/src/services/BaseService.ts
@@ -94,10 +94,17 @@ export abstract class BaseService {
             this.logger.debug('Creating audited ability', {
                 accountType: accountOrUser.authentication.type,
             });
+            const { requestContext } = accountOrUser;
             return new CaslAuditWrapper(
                 accountOrUser.user.ability,
                 accountOrUser,
-                { callStack, auditLogger: logAuditEvent },
+                {
+                    callStack,
+                    auditLogger: logAuditEvent,
+                    ip: requestContext?.ip,
+                    userAgent: requestContext?.userAgent,
+                    requestId: requestContext?.requestId,
+                },
             );
         }
 
@@ -105,9 +112,13 @@ export abstract class BaseService {
         this.logger.debug('Creating audited ability', {
             accountType: 'session-user',
         });
+        const { requestContext } = accountOrUser;
         return new CaslAuditWrapper(accountOrUser.ability, accountOrUser, {
             callStack,
             auditLogger: logAuditEvent,
+            ip: requestContext?.ip,
+            userAgent: requestContext?.userAgent,
+            requestId: requestContext?.requestId,
         });
     }
 

--- a/packages/common/src/types/auth.ts
+++ b/packages/common/src/types/auth.ts
@@ -131,12 +131,23 @@ export type AccountOrganization = Partial<
 >;
 
 /**
+ * Per-request metadata captured by the auth middleware. Used by the audit log
+ * to record the IP, user agent and request id alongside permission checks.
+ */
+export type AccountRequestContext = {
+    ip?: string;
+    userAgent?: string;
+    requestId?: string;
+};
+
+/**
  * Base account interface that all account types extend
  */
 export type BaseAccount = {
     organization: AccountOrganization;
     authentication: Authentication;
     user: AccountUser;
+    requestContext?: AccountRequestContext;
 };
 
 type BaseAccountWithHelpers = BaseAccount & AccountHelpers;

--- a/packages/common/src/types/user.ts
+++ b/packages/common/src/types/user.ts
@@ -75,6 +75,16 @@ export interface LightdashUserWithAbilityRules extends LightdashUser {
 
 export interface SessionUser extends LightdashUserWithAbilityRules {
     ability: MemberAbility;
+    /**
+     * Per-request metadata (IP, user agent, request id) populated by the auth
+     * middleware. Used by the audit log; intentionally not persisted in the
+     * session store.
+     */
+    requestContext?: {
+        ip?: string;
+        userAgent?: string;
+        requestId?: string;
+    };
 }
 
 export interface UpdatedByUser {


### PR DESCRIPTION
## Summary

- `BaseService.createAuditedAbility` never forwarded request metadata to `CaslAuditWrapper`, so every CASL audit event was logging `context: { ip: undefined, userAgent: undefined, requestId: undefined }` — even though the wrapper has supported those fields all along (the unit tests in `caslAuditWrapper.test.ts` assert on them).
- Wire the data through by attaching an optional `requestContext` to `Account` (`BaseAccount`) and `SessionUser`, populated by each auth middleware from the Express request, and read by `BaseService` when building the audited ability.

## Why

Audit events are the primary signal for compliance and incident review of CASL permission decisions. Logging `undefined` for ip/userAgent/requestId on every event makes the trail effectively useless for tracing who did what from where, and makes it impossible to correlate audit lines with HTTP request logs (Winston attaches `requestId` to those). This was a latent bug — the schema, wrapper, and tests all expect populated context, only the call site in `BaseService` was dropping it.

## Approach

Considered an `AsyncLocalStorage`-based per-request store (zero changes to service signatures, automatic propagation), but ultimately preferred attaching `requestContext` to the existing identity objects we already pass into services. It's a smaller, more explicit surface and keeps the audit metadata co-located with the actor, with no new global mechanism.

### Wiring

- `packages/common/src/types/auth.ts` — new `AccountRequestContext` and optional `requestContext` on `BaseAccount` (flows to every `Account` variant).
- `packages/common/src/types/user.ts` — same optional field on `SessionUser` (the legacy path still in use across many services). It's deliberately not persisted in the session store.
- `packages/backend/src/auth/account/requestContext.ts` (new) — `requestContextFromExpress(req)` helper that pulls `req.ip`, `user-agent`, and `x-request-id` / `x-amzn-trace-id`.
- Auth middlewares populate **both** `req.account.requestContext` and `req.user.requestContext` after constructing the account, so legacy `SessionUser` callers see it too:
  - `middlewares/accountMiddleware/sessionAccountMiddleware.ts` (session)
  - `controllers/authentication/middlewares.ts` (OAuth — both `allowOauthAuthentication` and `allowApiKeyAuthentication`, plus PAT)
  - `ee/authentication/middlewares.ts` (service account)
  - `middlewares/jwtAuthMiddleware/jwtAuthMiddleware.ts` (JWT/embed — only `req.account`, since this path doesn't set `req.user`)
- `services/BaseService.ts` — `createAuditedAbility` reads `requestContext` off the account or legacy `SessionUser` and forwards `ip`/`userAgent`/`requestId` to `CaslAuditWrapper`.

## Non-request callers

`Account.fromSession(sessionUser)` is also called from non-HTTP paths — scheduler tasks, internal SDK invocations from `AiAgentService`/`AiService`/`AppGenerateService`/etc. Those intentionally don't set `requestContext`, so their audit events keep logging `undefined` context. That's the correct semantic: there's no HTTP request behind a Graphile worker job.

## Test plan

- [ ] Hit any endpoint that triggers a CASL check (e.g. `GET /api/v1/aiAgents/:uuid`) and confirm the audit log entry now shows populated `context.ip` / `context.userAgent` / `context.requestId`.
- [ ] Confirm scheduler-driven jobs (e.g. scheduled delivery) still emit audit events with empty context (no regression).
- [ ] Confirm `caslAuditWrapper.test.ts` still passes (it already asserts on these fields).

🤖 Generated with [Claude Code](https://claude.com/claude-code)