### PR TITLE
fix: adopt SCIM orphan users instead of wiping openid_identity on 409

### DIFF
--- a/examples/api/scim.http
+++ b/examples/api/scim.http
@@ -34,6 +34,50 @@ Authorization: Bearer scim_9d95455ef43b7dd9077d9001e1c5b112
 }
 
 
+### --- BUG REPRO: SCIM 409 wipes openid_identity for orphan users ---
+# An "orphan" is a user with verified email + openid_identity but NO organization_membership
+# (e.g. created by OIDC JIT when auto-join conditions failed).
+# When SCIM POST /Users runs for that email, ScimService.createUser deletes the openid_identity
+# row outside any transaction (ScimService.ts:470), then userModel.createUser throws
+# AlreadyExistsError on the global email check (UserModel.ts:756). The 409 returns to Okta
+# but the openid wipe is NOT rolled back. Okta retries forever.
+#
+# Steps to reproduce locally:
+#   1) Pick an email below, e.g. orphan-repro@example.com
+#   2) Seed the orphan in psql:
+#        BEGIN;
+#        INSERT INTO users (first_name, last_name, is_active)
+#          VALUES ('Orphan', 'Repro', true) RETURNING user_id \gset
+#        INSERT INTO emails (user_id, email, is_primary, is_verified)
+#          VALUES (:'user_id', 'orphan-repro@example.com', true, true);
+#        INSERT INTO openid_identities (issuer, subject, user_id, email, issuer_type)
+#          VALUES ('https://example.okta.com', 'okta-sub-' || :'user_id',
+#                  :'user_id', 'orphan-repro@example.com', 'okta');
+#        COMMIT;
+#   3) Confirm: has_membership=f, has_openid=t (the pre-bug state).
+#   4) Send the POST below. Expected: 409. Then re-check the DB — has_openid is now f.
+
+POST http://localhost:8080/api/v1/scim/v2/Users
+Content-Type: application/json
+Authorization: Bearer scim_9d95455ef43b7dd9077d9001e1c5b112
+
+{
+    "schemas": ["urn:ietf:params:scim:schemas:core:2.0:User"],
+    "userName": "orphan-repro@example.com",
+    "name": {
+        "givenName": "Orphan",
+        "familyName": "Repro"
+    },
+    "active": true,
+    "emails": [
+        {
+            "value": "orphan-repro@example.com",
+            "primary": true
+        }
+    ]
+}
+
+
 ### Update user userName (PUT - full replacement)
 PUT http://localhost:8080/api/v1/scim/v2/Users/fdc58e24-906e-4813-a7e7-8522424cb2ce
 Content-Type: application/json

--- a/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.mock.ts
@@ -86,6 +86,7 @@ const organizationMemberProfileModelMock = {
 
 // Mock user model
 const userModelMock = {
+    findUserByEmail: jest.fn().mockResolvedValue(undefined),
     createUser: jest.fn().mockResolvedValue({
         userId: 1,
         userUuid: mockUser.userUuid,

--- a/packages/backend/src/ee/services/ScimService/ScimService.test.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.test.ts
@@ -256,6 +256,84 @@ describe('ScimService', () => {
             });
         });
 
+        test('should adopt orphan user (verified email but no organization) instead of creating', async () => {
+            const orphanUser = {
+                ...mockUser,
+                userUuid: 'orphan-uuid',
+                email: 'orphan@example.com',
+                organizationUuid: undefined, // orphan: no org membership
+            } as unknown as LightdashUser;
+            const {
+                userModel,
+                organizationMemberProfileModel,
+                openIdIdentityModel,
+            } = ScimServiceArgumentsMock;
+            (userModel.findUserByEmail as jest.Mock).mockResolvedValueOnce(
+                orphanUser,
+            );
+
+            const scimUser = {
+                schemas: [ScimSchemaType.USER],
+                userName: 'orphan@example.com',
+                name: { givenName: 'Orphan', familyName: 'User' },
+                active: true,
+                emails: [{ value: 'orphan@example.com', primary: true }],
+            };
+
+            await service.createUser({
+                user: scimUser,
+                organizationUuid: 'org-uuid',
+            });
+
+            // Adoption: existing user joined to org, no new user created,
+            // openid_identity rows are NOT wiped.
+            expect(userModel.createUser).not.toHaveBeenCalled();
+            expect(
+                openIdIdentityModel.deleteIdentitiesByEmail,
+            ).not.toHaveBeenCalled();
+            expect(
+                organizationMemberProfileModel.createOrganizationMembershipByUuid,
+            ).toHaveBeenCalledWith({
+                organizationUuid: 'org-uuid',
+                userUuid: 'orphan-uuid',
+                role: OrganizationMemberRole.MEMBER,
+            });
+        });
+
+        test('should throw 409 (and NOT wipe openid) when user already belongs to an organization', async () => {
+            const userWithOrg = {
+                ...mockUser,
+                email: 'existing@example.com',
+                organizationUuid: 'some-org-uuid',
+            } as unknown as LightdashUser;
+            const { userModel, openIdIdentityModel } = ScimServiceArgumentsMock;
+            (userModel.findUserByEmail as jest.Mock).mockResolvedValueOnce(
+                userWithOrg,
+            );
+
+            const scimUser = {
+                schemas: [ScimSchemaType.USER],
+                userName: 'existing@example.com',
+                name: { givenName: 'Existing', familyName: 'User' },
+                active: true,
+                emails: [{ value: 'existing@example.com', primary: true }],
+            };
+
+            await expect(
+                service.createUser({
+                    user: scimUser,
+                    organizationUuid: 'org-uuid',
+                }),
+            ).rejects.toThrow(/already in use/);
+
+            // The bug: previously, openid was deleted before the throw.
+            // After the fix, no deletion occurs.
+            expect(
+                openIdIdentityModel.deleteIdentitiesByEmail,
+            ).not.toHaveBeenCalled();
+            expect(userModel.createUser).not.toHaveBeenCalled();
+        });
+
         test('should throw error when invalid role is provided in extension schema', async () => {
             // Create a SCIM user with an invalid role in the extension schema
             const scimUser = {

--- a/packages/backend/src/ee/services/ScimService/ScimService.ts
+++ b/packages/backend/src/ee/services/ScimService/ScimService.ts
@@ -464,20 +464,46 @@ export class ScimService extends BaseService {
                 ScimService.validateRolesArray(user.roles, validRoleValues);
             }
             const email = ScimService.getScimUserEmail(user);
-            // Delete any existing openid identities for this email to prevent login conflicts
-            // This handles the case where a user's email changed via SCIM and an old
-            // openid identity record exists pointing to a deactivated account
-            await this.deleteOpenIdIdentitiesForUser({ email });
 
-            const dbUser = await this.userModel.createUser(
-                {
-                    email,
-                    firstName: user.name?.givenName || '',
-                    lastName: user.name?.familyName || '',
-                    password: user.password || '',
-                },
-                user.active,
-            );
+            // If a user already exists with this email, decide whether to adopt
+            // or reject. Orphan users (verified email but no organization
+            // membership, e.g. created by OIDC JIT when auto-join conditions
+            // failed) are adopted — mirrors UserService.createPendingUserAndInviteLink.
+            // Without this, the AlreadyExistsError thrown below would also leave
+            // openid_identity rows wiped (deleteOpenIdIdentitiesForUser is not
+            // transactional with userModel.createUser), breaking the user's SSO.
+            const existingUser = await this.userModel.findUserByEmail(email);
+            if (existingUser?.organizationUuid) {
+                throw new AlreadyExistsError(`Email ${email} already in use`);
+            }
+
+            let dbUser: LightdashUser;
+            if (existingUser) {
+                this.logger.info(
+                    'SCIM: Adopting orphan user (verified email, no org)',
+                    {
+                        organizationUuid,
+                        userUuid: existingUser.userUuid,
+                        email,
+                    },
+                );
+                dbUser = existingUser;
+            } else {
+                // Delete any existing openid identities for this email to prevent login conflicts
+                // This handles the case where a user's email changed via SCIM and an old
+                // openid identity record exists pointing to a deactivated account
+                await this.deleteOpenIdIdentitiesForUser({ email });
+
+                dbUser = await this.userModel.createUser(
+                    {
+                        email,
+                        firstName: user.name?.givenName || '',
+                        lastName: user.name?.familyName || '',
+                        password: user.password || '',
+                    },
+                    user.active,
+                );
+            }
             // Extract role from extension schema if available
             const extensionData = user[ScimSchemaType.LIGHTDASH_USER_EXTENSION];
             let role = OrganizationMemberRole.MEMBER; // Default role


### PR DESCRIPTION
Closes:  https://github.com/lightdash/lightdash/issues/22402

Before
<img width="1268" height="473" alt="CleanShot 2026-04-27 at 16 19 01" src="https://github.com/user-attachments/assets/673e0d38-17f2-49be-a979-247b153fc911" />


After
<img width="1313" height="499" alt="CleanShot 2026-04-27 at 16 30 20" src="https://github.com/user-attachments/assets/3dbcb570-e763-4b94-8f44-5abb55782777" />


### Description:

Fixes a bug where SCIM `POST /Users` would permanently wipe a user's `openid_identity` rows when the request resulted in a 409 conflict, breaking SSO for affected users.

The root cause was that `deleteOpenIdIdentitiesForUser` was called before `userModel.createUser`, with no transaction wrapping both operations. If `createUser` threw an `AlreadyExistsError` (e.g. for a user with a verified email but no organization membership — an "orphan" created by OIDC JIT when auto-join conditions failed), the OpenID identity deletion was not rolled back. Okta would then retry the SCIM request indefinitely, never succeeding, while the user could no longer log in via SSO.

The fix introduces an upfront lookup via `findUserByEmail` before any destructive operations:

- If the email belongs to a user **with** an existing organization membership, a 409 is returned immediately — no OpenID identities are touched.
- If the email belongs to an **orphan** user (verified email, no organization membership), the user is adopted into the SCIM-provisioned organization directly, mirroring the behavior of `UserService.createPendingUserAndInviteLink`. No new user is created and no OpenID identities are deleted.
- Only for genuinely new emails does the original flow (delete stale OpenID identities, then create user) proceed.

Tests are added covering both the orphan adoption path and the 409-without-OpenID-wipe path. A reproduction script is also included in `examples/api/scim.http` with seeding instructions to verify the bug locally.