### PR TITLE
chore: remove `WorkerQueryExecution` feature flag

### DIFF
--- a/packages/common/src/types/featureFlags.ts
+++ b/packages/common/src/types/featureFlags.ts
@@ -48,11 +48,6 @@ export enum FeatureFlags {
     AiCustomViz = 'ai-custom-viz',
 
     /**
-     * Use workers for async query execution
-     */
-    WorkerQueryExecution = 'worker-query-execution',
-
-    /**
      * Enable SQL pivot results conversion to PivotData format
      */
     UseSqlPivotResults = 'use-sql-pivot-results',


### PR DESCRIPTION
Closes:

### Description:
Removes the `WorkerQueryExecution` feature flag (`worker-query-execution`), which was used to enable workers for async query execution.