### PR TITLE
feat(formula-tests): wire Snowflake into the integration runner

### DIFF
--- a/packages/formula-tests/config.ts
+++ b/packages/formula-tests/config.ts
@@ -69,9 +69,24 @@ export interface WarehouseConfig {
     };
     snowflake: {
         account: string;
-        username: string;
-        password: string;
+        user: string;
+        // Role used for the connection. Mirrors `SnowflakeWarehouseClient`'s
+        // `credentials.role`. SYSADMIN works in our staging account.
+        role: string;
+        // PEM-encoded private key for SNOWFLAKE_JWT key-pair auth — matches
+        // production's `SnowflakeWarehouseClient` private-key path. Pass the
+        // full multi-line PEM (begin/end markers included) through the env
+        // var; quoting it preserves newlines.
+        privateKey: string;
+        // Passphrase for the private key. Empty string if the key is
+        // unencrypted.
+        privateKeyPass: string;
         database: string;
+        // The runner runs `CREATE SCHEMA IF NOT EXISTS` for this schema
+        // before seeding, so a fresh value works without manual setup. The
+        // seed only ever creates / drops `test_orders` / `test_nulls` /
+        // `test_window`, so an existing schema with no name collisions is
+        // also safe.
         schema: string;
         warehouse: string;
     };
@@ -152,10 +167,13 @@ export function getWarehouseConfig(): WarehouseConfig {
         },
         snowflake: {
             account: process.env.FORMULA_TEST_SF_ACCOUNT ?? '',
-            username: process.env.FORMULA_TEST_SF_USERNAME ?? '',
-            password: process.env.FORMULA_TEST_SF_PASSWORD ?? '',
+            user: process.env.FORMULA_TEST_SF_USER ?? '',
+            role: process.env.FORMULA_TEST_SF_ROLE ?? '',
+            privateKey: process.env.FORMULA_TEST_SF_PRIVATE_KEY ?? '',
+            privateKeyPass:
+                process.env.FORMULA_TEST_SF_PRIVATE_KEY_PASS ?? '',
             database: process.env.FORMULA_TEST_SF_DATABASE ?? '',
-            schema: process.env.FORMULA_TEST_SF_SCHEMA ?? 'FORMULA_TESTS',
+            schema: process.env.FORMULA_TEST_SF_SCHEMA ?? '',
             warehouse: process.env.FORMULA_TEST_SF_WAREHOUSE ?? '',
         },
         duckdb: {},

--- a/packages/formula-tests/package.json
+++ b/packages/formula-tests/package.json
@@ -17,6 +17,7 @@
     "@google-cloud/bigquery": "7.9.2",
     "duckdb": "1.4.2",
     "pg": "8.13.1",
+    "snowflake-sdk": "2.3.4",
     "trino-client": "0.2.9",
     "tsx": "4.19.2"
   },

--- a/packages/formula-tests/runner/warehouse-connections.ts
+++ b/packages/formula-tests/runner/warehouse-connections.ts
@@ -303,6 +303,127 @@ export async function createBigQueryConnection(
     };
 }
 
+export async function createSnowflakeConnection(
+    config: WarehouseConfig['snowflake'],
+): Promise<WarehouseConnection> {
+    const missing: string[] = [];
+    if (!config.account) missing.push('FORMULA_TEST_SF_ACCOUNT');
+    if (!config.user) missing.push('FORMULA_TEST_SF_USER');
+    if (!config.role) missing.push('FORMULA_TEST_SF_ROLE');
+    if (!config.privateKey) missing.push('FORMULA_TEST_SF_PRIVATE_KEY');
+    if (!config.database) missing.push('FORMULA_TEST_SF_DATABASE');
+    if (!config.schema) missing.push('FORMULA_TEST_SF_SCHEMA');
+    if (!config.warehouse) missing.push('FORMULA_TEST_SF_WAREHOUSE');
+    if (missing.length > 0) {
+        throw new Error(
+            `Snowflake connection requires the following env vars: ${missing.join(', ')}`,
+        );
+    }
+
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const snowflake = require('snowflake-sdk');
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const crypto = require('crypto');
+
+    // Mirrors `SnowflakeWarehouseClient`'s SNOWFLAKE_JWT path: when a
+    // passphrase is set, decrypt the PEM and re-export as PKCS8 so the
+    // driver gets an unencrypted key. When unencrypted, pass through.
+    const privateKey = config.privateKeyPass
+        ? crypto
+              .createPrivateKey({
+                  key: config.privateKey,
+                  format: 'pem',
+                  passphrase: config.privateKeyPass,
+              })
+              .export({ format: 'pem', type: 'pkcs8' })
+              .toString()
+        : config.privateKey;
+
+    const connection = snowflake.createConnection({
+        account: config.account,
+        username: config.user,
+        role: config.role,
+        privateKey,
+        authenticator: 'SNOWFLAKE_JWT',
+        database: config.database,
+        schema: config.schema,
+        warehouse: config.warehouse,
+    });
+
+    await new Promise<void>((resolve, reject) => {
+        connection.connect((err: Error | null) => {
+            if (err) reject(err);
+            else resolve();
+        });
+    });
+
+    const execute = (sql: string): Promise<Record<string, any>[]> =>
+        new Promise((resolve, reject) => {
+            connection.execute({
+                sqlText: sql,
+                // The driver naively counts `;` characters in `sqlText` and
+                // rejects anything beyond `MULTI_STATEMENT_COUNT` (default
+                // 1) — including a `;` inside a single-quoted string
+                // literal, which trips formula tests that probe SQL
+                // injection guards. `0` means "any number of statements"
+                // and lets quoted `;` round-trip cleanly. We still call
+                // `execute()` once per statement at seed time, so this
+                // doesn't widen the multi-statement attack surface.
+                parameters: { MULTI_STATEMENT_COUNT: 0 },
+                complete: (
+                    err: Error | null,
+                    _stmt: unknown,
+                    rows: Record<string, any>[] | undefined,
+                ) => {
+                    if (err) reject(err);
+                    else resolve(rows ?? []);
+                },
+            });
+        });
+
+    // Snowflake folds unquoted identifiers to UPPERCASE at CREATE time,
+    // but the formula codegen emits `"order_amount"` (lowercase quoted)
+    // which then fails to resolve. Setting this to TRUE makes quoted-
+    // identifier resolution case-insensitive, matching every other
+    // warehouse's behaviour.
+    //
+    // Deliberate divergence from production: `SnowflakeWarehouseClient.
+    // prepareWarehouse` hardcodes this to FALSE for casing strictness. We
+    // diverge here because the test runner controls both ends — the seed
+    // creates uppercase columns and the codegen quotes lowercase, so
+    // strictness would force every test case to special-case Snowflake.
+    // Production users who want this behaviour set it on their Snowflake
+    // account directly.
+    await execute(
+        'ALTER SESSION SET QUOTED_IDENTIFIERS_IGNORE_CASE = TRUE',
+    );
+
+    // The Snowflake nodejs driver doesn't accept multi-statement SQL by
+    // default (would require `MULTI_STATEMENT_COUNT` session parameter), so
+    // split the seed and run each statement individually — same approach
+    // as Databricks / ClickHouse / Athena / Trino.
+    return {
+        dialect: 'snowflake',
+        execute,
+        async seed(sql: string) {
+            // Auto-create the test schema so the runner is self-contained.
+            // SYSADMIN has the privilege; idempotent on re-runs.
+            await execute(
+                `CREATE SCHEMA IF NOT EXISTS ${config.database}.${config.schema}`,
+            );
+            await execute(`USE SCHEMA ${config.database}.${config.schema}`);
+            for (const stmt of splitSqlStatements(sql)) {
+                await execute(stmt);
+            }
+        },
+        async close() {
+            await new Promise<void>((resolve) => {
+                connection.destroy(() => resolve());
+            });
+        },
+    };
+}
+
 export async function createTrinoConnection(
     config: WarehouseConfig['trino'],
 ): Promise<WarehouseConnection> {
@@ -575,7 +696,7 @@ export async function createConnection(
         case 'bigquery':
             return createBigQueryConnection(config.bigquery);
         case 'snowflake':
-            throw new Error('Snowflake connection not yet implemented');
+            return createSnowflakeConnection(config.snowflake);
         case 'databricks':
             return createDatabricksConnection(config.databricks);
         case 'clickhouse':

--- a/packages/formula/src/codegen/dialects.ts
+++ b/packages/formula/src/codegen/dialects.ts
@@ -244,6 +244,11 @@ const REDSHIFT_CONFIG: DialectConfig = {
 // columns. Unit names line up with BigQuery's bare identifiers.
 const SNOWFLAKE_CONFIG: DialectConfig = {
     quoteIdentifier: doubleQuoteIdentifier,
+    // Snowflake's string lexer interprets backslash escapes (`\0`, `\n`,
+    // `\'`) inside literals, so any `\` from user input must be doubled to
+    // round-trip cleanly — mirrors `SnowflakeSqlBuilder.escapeString` (it
+    // inherits the base which already doubles backslashes).
+    generateStringLiteral: ansiQuoteWithEscapedBackslashesStringLiteral,
     generateDateAdd: (unit, date, n) =>
         `DATEADD(${SQL_DATE_UNIT_IDENTIFIERS[unit]}, ${n}, ${date})`,
     generateDateDiff: (unit, start, end) =>

--- a/packages/formula/tests/codegen.test.ts
+++ b/packages/formula/tests/codegen.test.ts
@@ -349,6 +349,24 @@ describe('codegen', () => {
         });
     });
 
+    describe('Snowflake dialect', () => {
+        it('escapes single quotes by doubling and doubles backslashes', () => {
+            // Snowflake's string lexer interprets `\0`, `\n`, `\'` etc. as
+            // escape sequences inside literals — backslashes from user
+            // input must be doubled to round-trip cleanly. Mirrors
+            // `SnowflakeSqlBuilder.escapeString` (inherits the base which
+            // already doubles backslashes).
+            expect(
+                compile(`=IF(region = "O'Brien\\path", 1, 0)`, {
+                    dialect: 'snowflake',
+                    columns: { region: 'region' },
+                }),
+            ).toBe(
+                `CASE WHEN ("region" = 'O''Brien\\\\path') THEN 1 ELSE 0 END`,
+            );
+        });
+    });
+
     describe('Databricks dialect', () => {
         it('emits bare aggregates with backtick quoting by default', () => {
             expect(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -897,6 +897,9 @@ importers:
       pg:
         specifier: 8.13.1
         version: 8.13.1
+      snowflake-sdk:
+        specifier: 2.3.4
+        version: 2.3.4(asn1.js@5.4.1)(encoding@0.1.13)
       trino-client:
         specifier: 0.2.9
         version: 0.2.9


### PR DESCRIPTION
## Summary

Replaces the `throw 'Snowflake connection not yet implemented'` stub in `formula-tests` with a full key-pair-auth Snowflake connection that mirrors the SNOWFLAKE_JWT path in `SnowflakeWarehouseClient`.

Closes [ZAP-339](https://linear.app/lightdash/issue/ZAP-339/wire-snowflake-into-the-formula-tests-runner).

## What it does

| Concern | Implementation | Production parity |
|---|---|---|
| Auth | SNOWFLAKE_JWT key-pair, PKCS8 re-export when passphrase set | Line-for-line equivalent to `SnowflakeWarehouseClient.ts:265-286` |
| Connection options | `account` / `username` / `role` / `privateKey` / `authenticator` / `database` / `schema` / `warehouse` | Same shape as `SnowflakeWarehouseClient` |
| String escape | `generateStringLiteral: ansiQuoteWithEscapedBackslashesStringLiteral` (doubles `'` AND `\`) on `SNOWFLAKE_CONFIG` | Mirrors `SnowflakeSqlBuilder.escapeString` |
| Schema bootstrap | `CREATE SCHEMA IF NOT EXISTS` + `USE SCHEMA` before seed statements | Self-contained, no manual setup |
| `MULTI_STATEMENT_COUNT` | Set to `0` per `execute()` call | The driver naively counts `;` in `sqlText` and rejects anything past 1 — including `;` inside string literals. SQLi-test queries with `';--` patterns trip this otherwise. We still call `execute()` once per statement at seed time. |
| `QUOTED_IDENTIFIERS_IGNORE_CASE` | Set to `TRUE` on session | **Deliberate divergence** from production's `prepareWarehouse` (which forces `FALSE`). Snowflake folds unquoted identifiers to UPPERCASE at CREATE time, but the formula codegen emits `"order_amount"` (lowercase quoted) — so without this, every column reference fails to resolve. Test runner only; production keeps strict casing. |

## Required env vars

```bash
FORMULA_TEST_SF_ACCOUNT=
FORMULA_TEST_SF_USER=
FORMULA_TEST_SF_ROLE=
FORMULA_TEST_SF_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----
... (full PEM, multi-line) ...
-----END PRIVATE KEY-----"
FORMULA_TEST_SF_PRIVATE_KEY_PASS=         # empty if key is unencrypted
FORMULA_TEST_SF_DATABASE=
FORMULA_TEST_SF_SCHEMA=                   # auto-created via CREATE SCHEMA IF NOT EXISTS
FORMULA_TEST_SF_WAREHOUSE=
```

## Test plan

- [x] `pnpm -F formula test` — 258/258 (Snowflake describe block adds a string-escape lock-in test mirroring `SnowflakeSqlBuilder.escapeString`)
- [x] `pnpm -F formula-tests exec tsc --noEmit` — clean
- [x] `pnpm formula:test:fast` — 334/334 (DuckDB unaffected)
- [x] **`pnpm formula:test:tier2 --warehouse snowflake`** — **334/334 passing against the staging Snowflake account**, including the full date stack (LAST_DAY, DATE_TRUNC month/quarter/year/week + week-Monday + week-Sunday + day, DATE_ADD month/day/week/quarter, DATE_SUB year/week, DATE_DIFF day/month/year/week/week-Sunday/quarter), null handling, window functions, and SQL-injection edge cases.

## Discovery story

- 0/334 → 157/334 (made the connection work)
- → 330/334 (`QUOTED_IDENTIFIERS_IGNORE_CASE` for the lowercase identifier issue)
- → 334/334 (backslash-aware string escape + `MULTI_STATEMENT_COUNT=0` for SQLi tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
